### PR TITLE
Fix #163: handle multiple saved layouts per version

### DIFF
--- a/objectified-ui/lib/db/helper.ts
+++ b/objectified-ui/lib/db/helper.ts
@@ -3027,8 +3027,7 @@ export async function getDefaultCanvasLayout(versionId: string, userId?: string)
 export async function getNamedCanvasLayoutsForVersion(versionId: string, userId?: string) {
   try {
     const result = await connectionPool.query(
-      `SELECT id, version_id, user_id, name, is_default, viewport, nodes, edges,
-              grid_settings, minimap_settings, metadata, created_at, updated_at
+      `SELECT id, version_id, user_id, name, is_default, created_at, updated_at
        FROM odb.canvas_layouts
        WHERE version_id = $1
          AND name IS NOT NULL

--- a/objectified-ui/lib/db/helper.ts
+++ b/objectified-ui/lib/db/helper.ts
@@ -3032,6 +3032,7 @@ export async function getNamedCanvasLayoutsForVersion(versionId: string, userId?
        FROM odb.canvas_layouts
        WHERE version_id = $1
          AND name IS NOT NULL
+         AND is_default = false
          AND (user_id = $2 OR user_id IS NULL)
        ORDER BY name ASC, (user_id = $2) DESC, updated_at DESC`,
       [versionId, userId || null]

--- a/objectified-ui/lib/db/helper.ts
+++ b/objectified-ui/lib/db/helper.ts
@@ -3033,15 +3033,20 @@ export async function getNamedCanvasLayoutsForVersion(versionId: string, userId?
          AND name IS NOT NULL
          AND is_default = false
          AND (user_id = $2 OR user_id IS NULL)
-       ORDER BY name ASC, (user_id = $2) DESC, updated_at DESC`,
+       ORDER BY name ASC, (user_id = $2) DESC NULLS LAST, updated_at DESC`,
       [versionId, userId || null]
     );
 
     const byName = new Map<string, any>();
     result.rows.forEach((row: any) => {
-      if (!row.name) return;
-      if (!byName.has(row.name)) {
-        byName.set(row.name, row);
+      if (!row.name || typeof row.name !== 'string') return;
+      const normalizedName = row.name.trim();
+      if (!normalizedName) return;
+      if (!byName.has(normalizedName)) {
+        byName.set(normalizedName, {
+          ...row,
+          name: normalizedName
+        });
       }
     });
 
@@ -3057,6 +3062,11 @@ export async function getNamedCanvasLayoutsForVersion(versionId: string, userId?
  */
 export async function getNamedCanvasLayout(versionId: string, userId: string | null, name: string) {
   try {
+    const nameValue = name.trim();
+    if (!nameValue) {
+      return successResponse({ layout: null });
+    }
+
     const result = await connectionPool.query(
       `SELECT id, version_id, user_id, name, is_default, viewport, nodes, edges,
               grid_settings, minimap_settings, metadata, created_at, updated_at
@@ -3064,9 +3074,9 @@ export async function getNamedCanvasLayout(versionId: string, userId: string | n
        WHERE version_id = $1
          AND name = $2
          AND (user_id = $3 OR user_id IS NULL)
-       ORDER BY (user_id = $3) DESC, updated_at DESC
+       ORDER BY (user_id = $3) DESC NULLS LAST, updated_at DESC
        LIMIT 1`,
-      [versionId, name, userId]
+      [versionId, nameValue, userId]
     );
 
     if (result.rowCount === 0) {
@@ -3118,7 +3128,12 @@ export async function saveNamedCanvasLayout(
         });
       }
       const syncResult = await syncGroupsForVersion(versionId, groups, nodePositions);
-      try {
+      const parsedSyncResult = JSON.parse(syncResult);
+      if (!parsedSyncResult.success) {
+        return errorResponse(parsedSyncResult.error || 'Failed to sync groups for layout save');
+      }
+    }
+
     if (existingResult.rowCount > 0) {
       return updateCanvasLayout(existingResult.rows[0].id, {
         viewport,

--- a/objectified-ui/lib/db/helper.ts
+++ b/objectified-ui/lib/db/helper.ts
@@ -3103,7 +3103,7 @@ export async function saveNamedCanvasLayout(
       `SELECT id FROM odb.canvas_layouts
        WHERE version_id = $1
          AND name = $2
-         AND user_id = $3
+         AND user_id IS NOT DISTINCT FROM $3
        LIMIT 1`,
       [versionId, nameValue, userId]
     );

--- a/objectified-ui/lib/db/helper.ts
+++ b/objectified-ui/lib/db/helper.ts
@@ -3118,7 +3118,19 @@ export async function saveNamedCanvasLayout(
           }
         });
       }
-      await syncGroupsForVersion(versionId, groups, nodePositions);
+      const syncResult = await syncGroupsForVersion(versionId, groups, nodePositions);
+      try {
+        const parsedSyncResult = JSON.parse(syncResult);
+        if (!parsedSyncResult || parsedSyncResult.success !== true) {
+          const message =
+            parsedSyncResult && typeof parsedSyncResult.error === 'string'
+              ? parsedSyncResult.error
+              : 'Failed to sync groups for canvas layout';
+          return errorResponse(message);
+        }
+      } catch (e: any) {
+        return errorResponse('Failed to sync groups for canvas layout');
+      }
     }
 
     if (existingResult.rowCount > 0) {

--- a/objectified-ui/lib/db/helper.ts
+++ b/objectified-ui/lib/db/helper.ts
@@ -3021,6 +3021,133 @@ export async function getDefaultCanvasLayout(versionId: string, userId?: string)
 }
 
 /**
+ * Get all named canvas layouts for a version, preferring user-specific layouts.
+ * Returns at most one layout per name.
+ */
+export async function getNamedCanvasLayoutsForVersion(versionId: string, userId?: string) {
+  try {
+    const result = await connectionPool.query(
+      `SELECT id, version_id, user_id, name, is_default, viewport, nodes, edges,
+              grid_settings, minimap_settings, metadata, created_at, updated_at
+       FROM odb.canvas_layouts
+       WHERE version_id = $1
+         AND name IS NOT NULL
+         AND (user_id = $2 OR user_id IS NULL)
+       ORDER BY name ASC, (user_id = $2) DESC, updated_at DESC`,
+      [versionId, userId || null]
+    );
+
+    const byName = new Map<string, any>();
+    result.rows.forEach((row: any) => {
+      if (!row.name) return;
+      if (!byName.has(row.name)) {
+        byName.set(row.name, row);
+      }
+    });
+
+    return successResponse({ layouts: Array.from(byName.values()) });
+  } catch (error: any) {
+    console.error('Error fetching named canvas layouts:', error);
+    return errorResponse(error.message);
+  }
+}
+
+/**
+ * Get a named canvas layout for a version, preferring user-specific layout.
+ */
+export async function getNamedCanvasLayout(versionId: string, userId: string | null, name: string) {
+  try {
+    const result = await connectionPool.query(
+      `SELECT id, version_id, user_id, name, is_default, viewport, nodes, edges,
+              grid_settings, minimap_settings, metadata, created_at, updated_at
+       FROM odb.canvas_layouts
+       WHERE version_id = $1
+         AND name = $2
+         AND (user_id = $3 OR user_id IS NULL)
+       ORDER BY (user_id = $3) DESC, updated_at DESC
+       LIMIT 1`,
+      [versionId, name, userId]
+    );
+
+    if (result.rowCount === 0) {
+      return successResponse({ layout: null });
+    }
+
+    return successResponse({ layout: result.rows[0] });
+  } catch (error: any) {
+    console.error('Error fetching named canvas layout:', error);
+    return errorResponse(error.message);
+  }
+}
+
+/**
+ * Save or update a named canvas layout for a version.
+ */
+export async function saveNamedCanvasLayout(
+  versionId: string,
+  userId: string | null,
+  name: string,
+  viewport: any,
+  nodes: any,
+  edges?: any,
+  groups?: any
+) {
+  try {
+    const nameValue = name.trim();
+    if (!nameValue) {
+      return errorResponse('Layout name is required');
+    }
+
+    const existingResult = await connectionPool.query(
+      `SELECT id FROM odb.canvas_layouts
+       WHERE version_id = $1
+         AND name = $2
+         AND user_id = $3
+       LIMIT 1`,
+      [versionId, nameValue, userId]
+    );
+
+    // Keep group storage behavior aligned with default layout saves.
+    if (groups && Array.isArray(groups)) {
+      const nodePositions: Record<string, { x: number; y: number }> = {};
+      if (nodes && Array.isArray(nodes)) {
+        nodes.forEach((node: any) => {
+          if (node.id && node.position && node.type !== 'groupNode') {
+            nodePositions[node.id] = { x: node.position.x, y: node.position.y };
+          }
+        });
+      }
+      await syncGroupsForVersion(versionId, groups, nodePositions);
+    }
+
+    if (existingResult.rowCount > 0) {
+      return updateCanvasLayout(existingResult.rows[0].id, {
+        viewport,
+        nodes,
+        edges: edges || []
+      });
+    }
+
+    return createCanvasLayout(
+      versionId,
+      userId,
+      nameValue,
+      false,
+      viewport,
+      nodes,
+      edges || [],
+      null,
+      { enabled: true, size: 20, snapToGrid: true, showGrid: true },
+      { enabled: true, position: 'bottom-right', size: 'medium' },
+      {}
+    );
+  } catch (error: any) {
+    console.error('Error saving named canvas layout:', error);
+    return errorResponse(error.message);
+  }
+}
+
+/**
  * Create a new canvas layout
  */
 export async function createCanvasLayout(

--- a/objectified-ui/lib/db/helper.ts
+++ b/objectified-ui/lib/db/helper.ts
@@ -3120,19 +3120,6 @@ export async function saveNamedCanvasLayout(
       }
       const syncResult = await syncGroupsForVersion(versionId, groups, nodePositions);
       try {
-        const parsedSyncResult = JSON.parse(syncResult);
-        if (!parsedSyncResult || parsedSyncResult.success !== true) {
-          const message =
-            parsedSyncResult && typeof parsedSyncResult.error === 'string'
-              ? parsedSyncResult.error
-              : 'Failed to sync groups for canvas layout';
-          return errorResponse(message);
-        }
-      } catch (e: any) {
-        return errorResponse('Failed to sync groups for canvas layout');
-      }
-    }
-
     if (existingResult.rowCount > 0) {
       return updateCanvasLayout(existingResult.rows[0].id, {
         viewport,

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.8.36",
+  "version": "0.8.37",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/src/app/ade/studio/editor/page.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/page.tsx
@@ -343,9 +343,14 @@ const StudioContent = () => {
   const [hasExistingLayout, setHasExistingLayout] = useState(false);
   const [selectedLayoutName, setSelectedLayoutName] = useState('Development Layout');
   const [availableLayoutNames, setAvailableLayoutNames] = useState<string[]>(BUILTIN_LAYOUT_NAMES);
+  const selectedLayoutNameRef = useRef(selectedLayoutName);
 
   // Track whether this is the first load for a given version (to apply saved layout only once)
   const initialLayoutAppliedRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    selectedLayoutNameRef.current = selectedLayoutName;
+  }, [selectedLayoutName]);
 
   // Export wizard state
   const [exportWizardOpen, setExportWizardOpen] = useState(false);
@@ -4091,7 +4096,12 @@ const StudioContent = () => {
         if (isFirstLoad && currentUserId) {
           try {
             setLoadingMessage('Checking for saved layout...');
-            const layoutResult = await getNamedCanvasLayout(selectedVersionId, currentUserId, selectedLayoutName);
+            const layoutNameForInitialLoad = selectedLayoutNameRef.current;
+            const layoutResult = await getNamedCanvasLayout(
+              selectedVersionId,
+              currentUserId,
+              layoutNameForInitialLoad
+            );
             const layoutResponse = JSON.parse(layoutResult);
 
             if (layoutResponse.success && layoutResponse.layout) {
@@ -4162,7 +4172,7 @@ const StudioContent = () => {
     };
 
     loadClasses();
-  }, [selectedVersionId, selectedProjectId, canvasRefreshKey, projects, versions, currentUserId, selectedLayoutName, projectTags, isReadOnly, updateNodeInternals, setViewport]);
+  }, [selectedVersionId, selectedProjectId, canvasRefreshKey, projects, versions, currentUserId, projectTags, isReadOnly, updateNodeInternals, setViewport]);
 
   // Check layout availability when version or selected layout changes
   useEffect(() => {
@@ -6140,10 +6150,14 @@ const StudioContent = () => {
                           Canvas Layout
                         </h4>
                         <div className="mb-3">
-                          <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1">
+                          <label
+                            htmlFor="layout-name-select"
+                            className="block text-xs text-gray-500 dark:text-gray-400 mb-1"
+                          >
                             Layout Name
                           </label>
                           <select
+                            id="layout-name-select"
                             value={selectedLayoutName}
                             onChange={(e) => setSelectedLayoutName(e.target.value)}
                             className="w-full px-2.5 py-2 text-sm rounded-lg border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-700/50 text-gray-700 dark:text-gray-200 focus:outline-none focus:ring-2 focus:ring-indigo-500"

--- a/objectified-ui/src/app/ade/studio/editor/page.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/page.tsx
@@ -4174,17 +4174,24 @@ const StudioContent = () => {
       }
 
       try {
-        const [allLayoutsResult, selectedLayoutResult] = await Promise.all([
-          getNamedCanvasLayoutsForVersion(selectedVersionId, currentUserId),
-          getNamedCanvasLayout(selectedVersionId, currentUserId, selectedLayoutName)
-        ]);
+        const allLayoutsResult = await getNamedCanvasLayoutsForVersion(
+          selectedVersionId,
+          currentUserId
+        );
         const allLayoutsResponse = JSON.parse(allLayoutsResult);
-        const selectedLayoutResponse = JSON.parse(selectedLayoutResult);
         const dbLayoutNames = (allLayoutsResponse.layouts || [])
           .map((layout: any) => layout.name)
           .filter((name: string | null): name is string => Boolean(name));
-        setAvailableLayoutNames(Array.from(new Set([...BUILTIN_LAYOUT_NAMES, ...dbLayoutNames])));
-        setHasExistingLayout(selectedLayoutResponse.success && selectedLayoutResponse.layout !== null);
+        setAvailableLayoutNames(
+          Array.from(new Set([...BUILTIN_LAYOUT_NAMES, ...dbLayoutNames]))
+        );
+
+        const hasExistingLayoutForSelection =
+          !!selectedLayoutName &&
+          (allLayoutsResponse.layouts || []).some(
+            (layout: any) => layout.name === selectedLayoutName
+          );
+        setHasExistingLayout(hasExistingLayoutForSelection);
       } catch (error) {
         console.error('Error checking layout existence:', error);
         setHasExistingLayout(false);

--- a/objectified-ui/src/app/ade/studio/editor/page.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/page.tsx
@@ -4169,7 +4169,7 @@ const StudioContent = () => {
     const checkLayoutExists = async () => {
       if (!selectedVersionId || !currentUserId) {
         setHasExistingLayout(false);
-        setAvailableLayoutNames([]);
+        setAvailableLayoutNames(BUILTIN_LAYOUT_NAMES);
         return;
       }
 

--- a/objectified-ui/src/app/ade/studio/editor/page.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/page.tsx
@@ -90,7 +90,9 @@ import {
   updateClassPropertyRef,
   getTagsForProject,
   saveDefaultCanvasLayout,
-  getDefaultCanvasLayout,
+  getNamedCanvasLayout,
+  getNamedCanvasLayoutsForVersion,
+  saveNamedCanvasLayout,
   getGroupsForVersion,
   addClassToGroup,
   updateClassPositionInGroup
@@ -131,6 +133,10 @@ const Editor = dynamic(() => import('@monaco-editor/react'), {
 });
 
 const StudioContent = () => {
+  const BUILTIN_LAYOUT_NAMES = useMemo(
+    () => ['Development Layout', 'Presentation Layout', 'Logical Layout', 'Dependency Layout'],
+    []
+  );
   const { data: session } = useSession();
   const searchParams = useSearchParams();
 
@@ -335,6 +341,8 @@ const StudioContent = () => {
   // Layout saved state
   const [layoutSaved, setLayoutSaved] = useState(false);
   const [hasExistingLayout, setHasExistingLayout] = useState(false);
+  const [selectedLayoutName, setSelectedLayoutName] = useState('Development Layout');
+  const [availableLayoutNames, setAvailableLayoutNames] = useState<string[]>(BUILTIN_LAYOUT_NAMES);
 
   // Track whether this is the first load for a given version (to apply saved layout only once)
   const initialLayoutAppliedRef = useRef<string | null>(null);
@@ -3041,10 +3049,11 @@ const StudioContent = () => {
         targetHandle: edge.targetHandle
       }));
 
-      // Save to database
-      const result = await saveDefaultCanvasLayout(
+      // Save selected named layout to database
+      const result = await saveNamedCanvasLayout(
         selectedVersionId,
         currentUserId,
+        selectedLayoutName,
         viewport,
         nodeData,
         edgeData,
@@ -3057,6 +3066,10 @@ const StudioContent = () => {
         // Show "Saved" state temporarily
         setLayoutSaved(true);
         setHasExistingLayout(true);
+        setAvailableLayoutNames(prev => {
+          if (prev.includes(selectedLayoutName)) return prev;
+          return [...prev, selectedLayoutName];
+        });
         setTimeout(() => {
           setLayoutSaved(false);
         }, 2000);
@@ -3076,7 +3089,7 @@ const StudioContent = () => {
       setIsLoadingCanvas(false);
       setLoadingMessage('');
     }
-  }, [isReadOnly, selectedVersionId, currentUserId, nodes, edges, groups, getViewport, alertDialog]);
+  }, [isReadOnly, selectedVersionId, currentUserId, selectedLayoutName, nodes, edges, groups, getViewport, alertDialog]);
 
   // Load saved canvas layout
   const handleLoadLayout = useCallback(async () => {
@@ -3086,13 +3099,13 @@ const StudioContent = () => {
       setLoadingMessage('Loading canvas layout...');
       setIsLoadingCanvas(true);
 
-      // Fetch saved layout from database
-      const result = await getDefaultCanvasLayout(selectedVersionId, currentUserId);
+      // Fetch selected named layout from database
+      const result = await getNamedCanvasLayout(selectedVersionId, currentUserId, selectedLayoutName);
       const response = JSON.parse(result);
 
       if (!response.success || !response.layout) {
         await alertDialog({
-          message: 'No saved layout found for this version',
+          message: `No saved "${selectedLayoutName}" found for this version`,
           variant: 'warning',
         });
         setIsLoadingCanvas(false);
@@ -3264,7 +3277,7 @@ const StudioContent = () => {
       setLoadingMessage('');
       setLayoutDropdownOpen(false);
     }
-  }, [selectedVersionId, currentUserId, reloadClasses, setNodes, setGroups, setViewport, alertDialog, projectTags, isReadOnly, triggerSidebarRefresh, updateNodeInternals]);
+  }, [selectedVersionId, currentUserId, selectedLayoutName, reloadClasses, setNodes, setGroups, setViewport, alertDialog, projectTags, isReadOnly, triggerSidebarRefresh, updateNodeInternals]);
 
   // #471: Preview layout before applying — compute layout and show preview (do not commit)
   const handlePreviewLayout = useCallback((direction: 'TB' | 'LR') => {
@@ -4074,11 +4087,11 @@ const StudioContent = () => {
           return node;
         });
 
-        // On first load, check if there's a saved layout and apply it
+        // On first load, check if selected layout exists and apply it
         if (isFirstLoad && currentUserId) {
           try {
             setLoadingMessage('Checking for saved layout...');
-            const layoutResult = await getDefaultCanvasLayout(selectedVersionId, currentUserId);
+            const layoutResult = await getNamedCanvasLayout(selectedVersionId, currentUserId, selectedLayoutName);
             const layoutResponse = JSON.parse(layoutResult);
 
             if (layoutResponse.success && layoutResponse.layout) {
@@ -4149,28 +4162,38 @@ const StudioContent = () => {
     };
 
     loadClasses();
-  }, [selectedVersionId, selectedProjectId, canvasRefreshKey, projects, versions, currentUserId, projectTags, isReadOnly, updateNodeInternals, setViewport]);
+  }, [selectedVersionId, selectedProjectId, canvasRefreshKey, projects, versions, currentUserId, selectedLayoutName, projectTags, isReadOnly, updateNodeInternals, setViewport]);
 
-  // Check if a saved layout exists when version changes
+  // Check layout availability when version or selected layout changes
   useEffect(() => {
     const checkLayoutExists = async () => {
       if (!selectedVersionId || !currentUserId) {
         setHasExistingLayout(false);
+        setAvailableLayoutNames([]);
         return;
       }
 
       try {
-        const result = await getDefaultCanvasLayout(selectedVersionId, currentUserId);
-        const response = JSON.parse(result);
-        setHasExistingLayout(response.success && response.layout !== null);
+        const [allLayoutsResult, selectedLayoutResult] = await Promise.all([
+          getNamedCanvasLayoutsForVersion(selectedVersionId, currentUserId),
+          getNamedCanvasLayout(selectedVersionId, currentUserId, selectedLayoutName)
+        ]);
+        const allLayoutsResponse = JSON.parse(allLayoutsResult);
+        const selectedLayoutResponse = JSON.parse(selectedLayoutResult);
+        const dbLayoutNames = (allLayoutsResponse.layouts || [])
+          .map((layout: any) => layout.name)
+          .filter((name: string | null): name is string => Boolean(name));
+        setAvailableLayoutNames(Array.from(new Set([...BUILTIN_LAYOUT_NAMES, ...dbLayoutNames])));
+        setHasExistingLayout(selectedLayoutResponse.success && selectedLayoutResponse.layout !== null);
       } catch (error) {
         console.error('Error checking layout existence:', error);
         setHasExistingLayout(false);
+        setAvailableLayoutNames(BUILTIN_LAYOUT_NAMES);
       }
     };
 
     checkLayoutExists();
-  }, [selectedVersionId, currentUserId]);
+  }, [selectedVersionId, currentUserId, selectedLayoutName, BUILTIN_LAYOUT_NAMES]);
 
   // Regenerate edges when edge styling or routing preferences change
   useEffect(() => {
@@ -6109,6 +6132,22 @@ const StudioContent = () => {
                         <h4 className="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider mb-3">
                           Canvas Layout
                         </h4>
+                        <div className="mb-3">
+                          <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1">
+                            Layout Name
+                          </label>
+                          <select
+                            value={selectedLayoutName}
+                            onChange={(e) => setSelectedLayoutName(e.target.value)}
+                            className="w-full px-2.5 py-2 text-sm rounded-lg border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-700/50 text-gray-700 dark:text-gray-200 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                          >
+                            {availableLayoutNames.map((layoutName) => (
+                              <option key={layoutName} value={layoutName}>
+                                {layoutName}
+                              </option>
+                            ))}
+                          </select>
+                        </div>
                         <div className="grid grid-cols-2 gap-2">
                           <button
                             onClick={handleSaveLayout}
@@ -6151,7 +6190,7 @@ const StudioContent = () => {
                           </button>
                         </div>
                         <p className="text-xs text-gray-500 dark:text-gray-400 mt-2">
-                          Save or load your canvas layout per version
+                          Save and load multiple named layouts per version
                         </p>
                       </div>
 

--- a/objectified-ui/tests/canvas-layout-named.test.ts
+++ b/objectified-ui/tests/canvas-layout-named.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, jest, test } from '@jest/globals';
+
+jest.mock('../lib/db/db', () => ({
+  query: jest.fn(),
+}));
+
+jest.mock('bcrypt', () => ({
+  compare: jest.fn(),
+  hash: jest.fn(),
+}));
+
+jest.mock('crypto', () => ({
+  randomBytes: jest.fn(() => Buffer.from('test-api-key-data')),
+}));
+
+describe('Database Helper - Named Canvas Layouts', () => {
+  let mockQuery: jest.Mock;
+
+  beforeEach(() => {
+    const db = require('../lib/db/db');
+    mockQuery = db.query as jest.Mock;
+    mockQuery.mockReset();
+  });
+
+  test('getNamedCanvasLayoutsForVersion deduplicates names and prefers user layouts', async () => {
+    const { getNamedCanvasLayoutsForVersion } = await import('../lib/db/helper');
+
+    mockQuery.mockResolvedValue({
+      rows: [
+        { id: 'u1', name: 'Development Layout', user_id: 'user-1' },
+        { id: 's1', name: 'Development Layout', user_id: null },
+        { id: 's2', name: 'Presentation Layout', user_id: null },
+      ]
+    });
+
+    const result = await getNamedCanvasLayoutsForVersion('version-1', 'user-1');
+    const parsed = JSON.parse(result);
+
+    expect(parsed.success).toBe(true);
+    expect(parsed.layouts).toHaveLength(2);
+    expect(parsed.layouts[0].name).toBe('Development Layout');
+    expect(parsed.layouts[0].id).toBe('u1');
+  });
+
+  test('getNamedCanvasLayout returns null when no named layout exists', async () => {
+    const { getNamedCanvasLayout } = await import('../lib/db/helper');
+
+    mockQuery.mockResolvedValue({ rowCount: 0, rows: [] });
+
+    const result = await getNamedCanvasLayout('version-1', 'user-1', 'Logical Layout');
+    const parsed = JSON.parse(result);
+
+    expect(parsed.success).toBe(true);
+    expect(parsed.layout).toBeNull();
+  });
+
+  test('saveNamedCanvasLayout updates existing named layout', async () => {
+    const { saveNamedCanvasLayout } = await import('../lib/db/helper');
+
+    mockQuery
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 'layout-1' }] }) // existing lookup
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ version_id: 'version-1', user_id: 'user-1' }] }) // update lookup
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 'layout-1', name: 'Dependency Layout' }] }); // update return
+
+    const result = await saveNamedCanvasLayout(
+      'version-1',
+      'user-1',
+      'Dependency Layout',
+      { x: 0, y: 0, zoom: 1 },
+      [{ id: 'node-1', type: 'classNode', position: { x: 1, y: 2 } }],
+      []
+    );
+    const parsed = JSON.parse(result);
+
+    expect(parsed.success).toBe(true);
+    expect(parsed.layout.id).toBe('layout-1');
+  });
+
+  test('saveNamedCanvasLayout creates layout when missing', async () => {
+    const { saveNamedCanvasLayout } = await import('../lib/db/helper');
+
+    mockQuery
+      .mockResolvedValueOnce({ rowCount: 0, rows: [] }) // existing lookup
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 'layout-2', name: 'Presentation Layout' }] }); // create return
+
+    const result = await saveNamedCanvasLayout(
+      'version-1',
+      'user-1',
+      'Presentation Layout',
+      { x: 0, y: 0, zoom: 1 },
+      [{ id: 'node-1', type: 'classNode', position: { x: 1, y: 2 } }],
+      []
+    );
+    const parsed = JSON.parse(result);
+
+    expect(parsed.success).toBe(true);
+    expect(parsed.layout.name).toBe('Presentation Layout');
+  });
+});

--- a/objectified-ui/tests/canvas-layout-named.test.ts
+++ b/objectified-ui/tests/canvas-layout-named.test.ts
@@ -14,7 +14,7 @@ jest.mock('crypto', () => ({
 }));
 
 describe('Database Helper - Named Canvas Layouts', () => {
-  let mockQuery: jest.Mock;
+  let mockQuery: jest.Mock<any>;
 
   beforeEach(() => {
     const db = require('../lib/db/db');
@@ -40,6 +40,30 @@ describe('Database Helper - Named Canvas Layouts', () => {
     expect(parsed.layouts).toHaveLength(2);
     expect(parsed.layouts[0].name).toBe('Development Layout');
     expect(parsed.layouts[0].id).toBe('u1');
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining('ORDER BY name ASC, (user_id = $2) DESC NULLS LAST, updated_at DESC'),
+      ['version-1', 'user-1']
+    );
+  });
+
+  test('getNamedCanvasLayoutsForVersion normalizes whitespace before de-duplication', async () => {
+    const { getNamedCanvasLayoutsForVersion } = await import('../lib/db/helper');
+
+    mockQuery.mockResolvedValue({
+      rows: [
+        { id: 'u1', name: '  Development Layout  ', user_id: 'user-1' },
+        { id: 's1', name: 'Development Layout', user_id: null },
+        { id: 's2', name: '   ', user_id: null },
+      ]
+    });
+
+    const result = await getNamedCanvasLayoutsForVersion('version-1', 'user-1');
+    const parsed = JSON.parse(result);
+
+    expect(parsed.success).toBe(true);
+    expect(parsed.layouts).toHaveLength(1);
+    expect(parsed.layouts[0].id).toBe('u1');
+    expect(parsed.layouts[0].name).toBe('Development Layout');
   });
 
   test('getNamedCanvasLayout returns null when no named layout exists', async () => {
@@ -52,6 +76,36 @@ describe('Database Helper - Named Canvas Layouts', () => {
 
     expect(parsed.success).toBe(true);
     expect(parsed.layout).toBeNull();
+  });
+
+  test('getNamedCanvasLayout trims requested name before querying', async () => {
+    const { getNamedCanvasLayout } = await import('../lib/db/helper');
+
+    mockQuery.mockResolvedValue({
+      rowCount: 1,
+      rows: [{ id: 'layout-1', name: 'Development Layout' }]
+    });
+
+    const result = await getNamedCanvasLayout('version-1', 'user-1', '  Development Layout  ');
+    const parsed = JSON.parse(result);
+
+    expect(parsed.success).toBe(true);
+    expect(parsed.layout.id).toBe('layout-1');
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining('ORDER BY (user_id = $3) DESC NULLS LAST, updated_at DESC'),
+      ['version-1', 'Development Layout', 'user-1']
+    );
+  });
+
+  test('getNamedCanvasLayout returns null for blank name after trim', async () => {
+    const { getNamedCanvasLayout } = await import('../lib/db/helper');
+
+    const result = await getNamedCanvasLayout('version-1', 'user-1', '   ');
+    const parsed = JSON.parse(result);
+
+    expect(parsed.success).toBe(true);
+    expect(parsed.layout).toBeNull();
+    expect(mockQuery).not.toHaveBeenCalled();
   });
 
   test('saveNamedCanvasLayout updates existing named layout', async () => {
@@ -95,5 +149,82 @@ describe('Database Helper - Named Canvas Layouts', () => {
 
     expect(parsed.success).toBe(true);
     expect(parsed.layout.name).toBe('Presentation Layout');
+  });
+
+  test('saveNamedCanvasLayout rejects blank layout name after trim', async () => {
+    const { saveNamedCanvasLayout } = await import('../lib/db/helper');
+
+    const result = await saveNamedCanvasLayout(
+      'version-1',
+      'user-1',
+      '   ',
+      { x: 0, y: 0, zoom: 1 },
+      [{ id: 'node-1', type: 'classNode', position: { x: 1, y: 2 } }],
+      []
+    );
+    const parsed = JSON.parse(result);
+
+    expect(parsed.success).toBe(false);
+    expect(parsed.error).toBe('Layout name is required');
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  test('saveNamedCanvasLayout creates shared layout when userId is null and trims name', async () => {
+    const { saveNamedCanvasLayout } = await import('../lib/db/helper');
+
+    mockQuery
+      .mockResolvedValueOnce({ rowCount: 0, rows: [] }) // existing lookup
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 'layout-shared-1', name: 'Shared Layout' }] }); // create return
+
+    const result = await saveNamedCanvasLayout(
+      'version-1',
+      null,
+      '  Shared Layout  ',
+      { x: 0, y: 0, zoom: 1 },
+      [{ id: 'node-1', type: 'classNode', position: { x: 1, y: 2 } }],
+      []
+    );
+    const parsed = JSON.parse(result);
+
+    expect(parsed.success).toBe(true);
+    expect(parsed.layout.id).toBe('layout-shared-1');
+
+    expect(mockQuery).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining('user_id IS NOT DISTINCT FROM $3'),
+      ['version-1', 'Shared Layout', null]
+    );
+    expect(mockQuery).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining('INSERT INTO odb.canvas_layouts'),
+      expect.arrayContaining(['version-1', null, 'Shared Layout'])
+    );
+  });
+
+  test('saveNamedCanvasLayout updates existing shared layout when userId is null', async () => {
+    const { saveNamedCanvasLayout } = await import('../lib/db/helper');
+
+    mockQuery
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 'layout-shared-1' }] }) // existing lookup
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ version_id: 'version-1', user_id: null }] }) // update lookup
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 'layout-shared-1', name: 'Shared Layout' }] }); // update return
+
+    const result = await saveNamedCanvasLayout(
+      'version-1',
+      null,
+      'Shared Layout',
+      { x: 0, y: 0, zoom: 1 },
+      [{ id: 'node-1', type: 'classNode', position: { x: 1, y: 2 } }],
+      []
+    );
+    const parsed = JSON.parse(result);
+
+    expect(parsed.success).toBe(true);
+    expect(parsed.layout.id).toBe('layout-shared-1');
+    expect(mockQuery).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining('user_id IS NOT DISTINCT FROM $3'),
+      ['version-1', 'Shared Layout', null]
+    );
   });
 });


### PR DESCRIPTION
## Problem Statement

Users and teams need **fix #163: handle multiple saved layouts per version** within the Objectified platform. Today this capability is missing or only partially implemented, which blocks platform workflows and creates inconsistency across tenants and projects.

## Solution / Scope

Implement **Fix #163: handle multiple saved layouts per version** as part of **Platform**.

**Post-MVP** (prioritize after MVP slice) candidacy.

```mermaid
flowchart LR
  User[User action: Fix #163: handle multiple saved layouts ] --> UI[objectified-ui]
  UI --> API[objectified-rest]
  API --> DB[(PostgreSQL)]
```

## Acceptance Criteria

- [ ] Feature behaves as described for: Fix #163: handle multiple saved layouts per version
- [ ] Unit/integration tests cover happy path and primary error cases
- [ ] UI (if applicable) matches existing ADE patterns (Tailwind 4, Radix, Lucide)
- [ ] REST endpoints (if applicable) follow `/v1/{{feature}}/{{tenant_slug}}/...` conventions
- [ ] Documented in issue/PR; no regressions to existing schema/version flows

## Parallelism / Dependencies

- **Can run in parallel:** Yes
- **Blockers:** None identified; validate against current codebase before starting

## Technical Stack

- **Modules:** objectified-ui, objectified-rest
- **Stack:** Next.js 16, React 19, FastAPI, PostgreSQL
- **Labels:** ``

---
**Issue:** #824 · **Area:** Platform · **Roadmap batch:** legacy #64–#879 enrichment