### PR TITLE
Fix #478 - add class drop ghost preview

### DIFF
--- a/PLANNED_FEATURE_ROADMAP_CANVAS.md
+++ b/PLANNED_FEATURE_ROADMAP_CANVAS.md
@@ -99,16 +99,6 @@
 | #484   | "Ghosts mode" for hidden nodes |
 | #485   | Quick restore hidden nodes     |
 
-#### Visual Feedback
-- ✅ **Dropzone highlighting**: Visual cues for valid drop targets
-- 📋 [TODO] **Ghost preview**: Show preview while dragging
-- ✅ **Invalid drop indicator**: Clear feedback for invalid drops
-- ✅ **Snap indicators**: Show snap points during drag
-
-| Ticket | Feature Description                              |
-|--------|--------------------------------------------------|
-| #478   | Show ghost preview of node while dragging        |
-
 ---
 
 ### 3. Node Grouping & Organization
@@ -330,3 +320,9 @@
 
 #### Schema Metrics Dashboard 📋 PLANNED
 - 📋 [TODO] Trend indicators (improving/declining metrics)
+
+#### Visual Feedback
+- ✅ **Dropzone highlighting**: Visual cues for valid drop targets
+- ✅ **Ghost preview**: Show preview while dragging
+- ✅ **Invalid drop indicator**: Clear feedback for invalid drops
+- ✅ **Snap indicators**: Show snap points during drag

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.8.37",
+  "version": "0.8.38",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -30,6 +30,7 @@ Bug Fixes:
   - Class nodes show the name of the singular reference - arrays were already correct
   - Class form was displaying a prompt for dependent schemas - this has been corrected
   - Class template library form is wider to show better detail
+  - Class nodes show ghost preview of node while dragging
   - Property template button now appears properly when in dark mode
   - Property template form is also now wider to show better detail
   - Renaming a property no longer rearranges the entire canvas

--- a/objectified-ui/src/app/components/ade/studio/ClassNode.tsx
+++ b/objectified-ui/src/app/components/ade/studio/ClassNode.tsx
@@ -924,8 +924,13 @@ function ClassNode({ id, data, selected }: NodeProps) {
       setGhostPreview(null);
       return;
     }
+    const name = String(payload.property.name).trim();
+    if (!name) {
+      setGhostPreview(null);
+      return;
+    }
     setGhostPreview({
-      name: payload.property.name,
+      name,
       typeLabel: getDropPreviewPropertyType(payload.property),
       parentId,
     });

--- a/objectified-ui/src/app/components/ade/studio/ClassNode.tsx
+++ b/objectified-ui/src/app/components/ade/studio/ClassNode.tsx
@@ -344,6 +344,15 @@ type ClassNodeTheme = {
   labelMultiLine?: boolean;
 };
 
+type DragPayload = {
+  type?: string;
+  property?: {
+    name?: string;
+    type?: string;
+    data?: any;
+  };
+};
+
 // Border options for node style (#342) — includes 1.5 to match default
 const BORDER_WIDTH_OPTIONS = [1, 2, 3, 4, 5] as const;
 const BORDER_STYLE_OPTIONS: Array<{ name: NodeBorderStyle; label: string }> = [
@@ -427,6 +436,38 @@ function themeFromPrimaryColor(primaryHex: string): Omit<ClassNodeTheme, 'icon'>
   };
 }
 
+function getBaseTypeFromData(data: any): string | undefined {
+  if (Array.isArray(data?.type)) {
+    return data.type.find((t: string) => t !== 'null');
+  }
+  return data?.type;
+}
+
+export function getDropPreviewPropertyType(property: { type?: string; data?: any } | null | undefined): string {
+  const data = property?.data && typeof property.data === 'string'
+    ? JSON.parse(property.data)
+    : (property?.data || {});
+
+  const baseType = getBaseTypeFromData(data);
+  if (baseType === 'array') {
+    if (data?.items?.$ref) {
+      const refName = String(data.items.$ref).split('/').pop();
+      return `${refName || 'ref'}[]`;
+    }
+    if (data?.items?.type) {
+      return `${data.items.type}[]`;
+    }
+    return 'array';
+  }
+  if (data?.$ref) {
+    return String(data.$ref).split('/').pop() || 'ref';
+  }
+  if (data?.allOf) return 'allOf';
+  if (data?.anyOf) return 'anyOf';
+  if (data?.oneOf) return 'oneOf';
+  return baseType || property?.type || 'object';
+}
+
 type ClassNodeData = {
   id: string;
   name: string;
@@ -474,6 +515,7 @@ function ClassNode({ id, data, selected }: NodeProps) {
   const [dragOverPropertyId, setDragOverPropertyId] = useState<string | null>(null);
   /** #479: Reason string when drop would be invalid (duplicate, read-only, etc.); null when valid or not dragging over */
   const [invalidDropReason, setInvalidDropReason] = useState<string | null>(null);
+  const [ghostPreview, setGhostPreview] = useState<{ name: string; typeLabel: string; parentId: string | null } | null>(null);
   const [localExpandedProperties, setLocalExpandedProperties] = useState<Set<string>>(new Set());
   const [colorPickerOpen, setColorPickerOpen] = useState(false);
   const [iconPickerOpen, setIconPickerOpen] = useState(false);
@@ -857,6 +899,18 @@ function ClassNode({ id, data, selected }: NodeProps) {
     return null;
   };
 
+  const setGhostPreviewFromPayload = (payload: DragPayload | null, parentId: string | null) => {
+    if (payload?.type !== 'property' || !payload.property?.name) {
+      setGhostPreview(null);
+      return;
+    }
+    setGhostPreview({
+      name: payload.property.name,
+      typeLabel: getDropPreviewPropertyType(payload.property),
+      parentId,
+    });
+  };
+
   // DnD Handlers (top-level)
   const handleDragOver = (e: React.DragEvent) => {
     e.preventDefault();
@@ -865,12 +919,14 @@ function ClassNode({ id, data, selected }: NodeProps) {
     // #479: Validate drop (getData may be empty in some browsers until drop)
     try {
       const raw = e.dataTransfer.getData('application/json');
-      const payload = raw ? (JSON.parse(raw) as { type?: string; property?: { name?: string } }) : null;
+      const payload = raw ? (JSON.parse(raw) as DragPayload) : null;
       const reason = validateDrop(null, payload);
       setInvalidDropReason(reason);
       if (reason) e.dataTransfer.dropEffect = 'none';
+      setGhostPreviewFromPayload(payload, null);
     } catch {
       setInvalidDropReason(null);
+      setGhostPreview(null);
     }
   };
 
@@ -880,6 +936,7 @@ function ClassNode({ id, data, selected }: NodeProps) {
     setDragTarget(null);
     setDragOverPropertyId(null);
     setInvalidDropReason(null);
+    setGhostPreview(null);
   };
 
   const handleDrop = (e: React.DragEvent) => {
@@ -888,6 +945,7 @@ function ClassNode({ id, data, selected }: NodeProps) {
     setDragTarget(null);
     setDragOverPropertyId(null);
     setInvalidDropReason(null);
+    setGhostPreview(null);
     if (typedData.isReadOnly) return;
     try {
       const raw = e.dataTransfer.getData('application/json');
@@ -915,24 +973,28 @@ function ClassNode({ id, data, selected }: NodeProps) {
       setDragOverPropertyId(propertyId);
       try {
         const raw = e.dataTransfer.getData('application/json');
-        const payload = raw ? (JSON.parse(raw) as { type?: string; property?: { name?: string } }) : null;
+        const payload = raw ? (JSON.parse(raw) as DragPayload) : null;
         const reason = validateDrop(propertyId, payload);
         setInvalidDropReason(reason);
         if (reason) e.dataTransfer.dropEffect = 'none';
+        setGhostPreviewFromPayload(payload, propertyId);
       } catch {
         setInvalidDropReason(null);
+        setGhostPreview(null);
       }
     } else {
       setDragTarget('node');
       setDragOverPropertyId(null);
       try {
         const raw = e.dataTransfer.getData('application/json');
-        const payload = raw ? (JSON.parse(raw) as { type?: string; property?: { name?: string } }) : null;
+        const payload = raw ? (JSON.parse(raw) as DragPayload) : null;
         const reason = validateDrop(null, payload);
         setInvalidDropReason(reason);
         if (reason) e.dataTransfer.dropEffect = 'none';
+        setGhostPreviewFromPayload(payload, null);
       } catch {
         setInvalidDropReason(null);
+        setGhostPreview(null);
       }
     }
   };
@@ -943,6 +1005,7 @@ function ClassNode({ id, data, selected }: NodeProps) {
     setDragTarget(null);
     setDragOverPropertyId(null);
     setInvalidDropReason(null);
+    setGhostPreview(null);
   };
 
   const handlePropertyDrop = (e: React.DragEvent, parentPropertyId: string) => {
@@ -951,6 +1014,7 @@ function ClassNode({ id, data, selected }: NodeProps) {
     setDragTarget(null);
     setDragOverPropertyId(null);
     setInvalidDropReason(null);
+    setGhostPreview(null);
     if (typedData.isReadOnly) return;
     try {
       const raw = e.dataTransfer.getData('application/json');
@@ -1806,8 +1870,34 @@ function ClassNode({ id, data, selected }: NodeProps) {
           opacity: propertiesOpacity,
           transition: 'opacity 0.2s ease'
         }}>
-          {(topLevel.length > 0 ? topLevel : []).length > 0 ? (
-          topLevel.flatMap((prop, idx) => {
+          {(topLevel.length > 0 ? topLevel : []).length > 0 || (ghostPreview && ghostPreview.parentId === null && !invalidDropReason) ? (
+          <>
+          {ghostPreview && ghostPreview.parentId === null && !invalidDropReason && (
+            <div
+              style={{
+                display: 'grid',
+                gridTemplateColumns: '16px 1fr auto 36px',
+                alignItems: 'center',
+                padding: '5px 10px',
+                background: 'linear-gradient(135deg, #eff6ff 0%, #dbeafe 100%)',
+                borderBottom: '1px dashed #93c5fd',
+                gap: '4px',
+                minHeight: '28px',
+                opacity: 0.95,
+              }}
+              aria-hidden
+            >
+              <div />
+              <div style={{ fontWeight: 500, color: '#1d4ed8', fontSize: '11px', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                {ghostPreview.name}
+              </div>
+              <div style={{ fontSize: '9px', color: '#1e40af', fontFamily: '"SF Mono", Monaco, "Cascadia Code", monospace', whiteSpace: 'nowrap', background: 'rgba(147, 197, 253, 0.35)', padding: '1px 6px', borderRadius: '3px', fontWeight: 500 }}>
+                {ghostPreview.typeLabel}
+              </div>
+              <div style={{ fontSize: '9px', color: '#1d4ed8', textAlign: 'right', paddingRight: '2px', fontStyle: 'italic' }}>preview</div>
+            </div>
+          )}
+          {topLevel.flatMap((prop, idx) => {
             let rowIndex = 0;
             const totalTopLevel = topLevel.length;
             const renderProperty = (p: ClassProperty, depth: number, isLast: boolean = false): React.JSX.Element[] => {
@@ -2034,6 +2124,36 @@ function ClassNode({ id, data, selected }: NodeProps) {
                 </div>
               );
 
+              if (ghostPreview && ghostPreview.parentId === p.id && !invalidDropReason) {
+                row.push(
+                  <div
+                    key={`${p.id}-ghost-preview`}
+                    style={{
+                      display: 'grid',
+                      gridTemplateColumns: '16px 1fr auto 36px',
+                      alignItems: 'center',
+                      padding: '5px 10px',
+                      paddingLeft: `${10 + (depth + 1) * 14}px`,
+                      background: 'linear-gradient(135deg, #eff6ff 0%, #dbeafe 100%)',
+                      borderBottom: '1px dashed #93c5fd',
+                      gap: '4px',
+                      minHeight: '28px',
+                      opacity: 0.95,
+                    }}
+                    aria-hidden
+                  >
+                    <div />
+                    <div style={{ fontWeight: 500, color: '#1d4ed8', fontSize: '11px', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                      {ghostPreview.name}
+                    </div>
+                    <div style={{ fontSize: '9px', color: '#1e40af', fontFamily: '"SF Mono", Monaco, "Cascadia Code", monospace', whiteSpace: 'nowrap', background: 'rgba(147, 197, 253, 0.35)', padding: '1px 6px', borderRadius: '3px', fontWeight: 500 }}>
+                      {ghostPreview.typeLabel}
+                    </div>
+                    <div style={{ fontSize: '9px', color: '#1d4ed8', textAlign: 'right', paddingRight: '2px', fontStyle: 'italic' }}>preview</div>
+                  </div>
+                );
+              }
+
               if (container && isExpanded && children.length > 0) {
                 children.forEach((c, childIdx) => row.push(...renderProperty(c, depth + 1, childIdx === children.length - 1)));
               }
@@ -2042,7 +2162,8 @@ function ClassNode({ id, data, selected }: NodeProps) {
             };
 
             return renderProperty(prop, 0, idx === totalTopLevel - 1);
-          })
+          })}
+          </>
         ) : (
           <div style={{
             padding: '10px 12px',

--- a/objectified-ui/src/app/components/ade/studio/ClassNode.tsx
+++ b/objectified-ui/src/app/components/ade/studio/ClassNode.tsx
@@ -444,27 +444,47 @@ function getBaseTypeFromData(data: any): string | undefined {
 }
 
 export function getDropPreviewPropertyType(property: { type?: string; data?: any } | null | undefined): string {
-  const data = property?.data && typeof property.data === 'string'
-    ? JSON.parse(property.data)
-    : (property?.data || {});
+  // Prefer schema from `property.data` (string or object), but fall back to the
+  // full `property` object so that top-level $ref/items are also supported.
+  let schemaFromData: any | undefined;
 
-  const baseType = getBaseTypeFromData(data);
+  if (property?.data) {
+    if (typeof property.data === 'string') {
+      const trimmed = property.data.trim();
+      if (trimmed) {
+        try {
+          schemaFromData = JSON.parse(trimmed);
+        } catch {
+          // Ignore parse errors and fall back to using the full property object.
+          schemaFromData = undefined;
+        }
+      }
+    } else if (typeof property.data === 'object') {
+      schemaFromData = property.data;
+    }
+  }
+
+  const schema = (schemaFromData && typeof schemaFromData === 'object')
+    ? schemaFromData
+    : (property && typeof property === 'object' ? property : {});
+
+  const baseType = getBaseTypeFromData(schema);
   if (baseType === 'array') {
-    if (data?.items?.$ref) {
-      const refName = String(data.items.$ref).split('/').pop();
+    if (schema?.items?.$ref) {
+      const refName = String(schema.items.$ref).split('/').pop();
       return `${refName || 'ref'}[]`;
     }
-    if (data?.items?.type) {
-      return `${data.items.type}[]`;
+    if (schema?.items?.type) {
+      return `${schema.items.type}[]`;
     }
     return 'array';
   }
-  if (data?.$ref) {
-    return String(data.$ref).split('/').pop() || 'ref';
+  if (schema?.$ref) {
+    return String(schema.$ref).split('/').pop() || 'ref';
   }
-  if (data?.allOf) return 'allOf';
-  if (data?.anyOf) return 'anyOf';
-  if (data?.oneOf) return 'oneOf';
+  if (schema?.allOf) return 'allOf';
+  if (schema?.anyOf) return 'anyOf';
+  if (schema?.oneOf) return 'oneOf';
   return baseType || property?.type || 'object';
 }
 

--- a/objectified-ui/src/app/components/ade/studio/ClassNode.tsx
+++ b/objectified-ui/src/app/components/ade/studio/ClassNode.tsx
@@ -444,9 +444,17 @@ function getBaseTypeFromData(data: any): string | undefined {
 }
 
 export function getDropPreviewPropertyType(property: { type?: string; data?: any } | null | undefined): string {
-  const data = property?.data && typeof property.data === 'string'
-    ? JSON.parse(property.data)
-    : (property?.data || {});
+  // Drag payloads may provide schema either under `data` or directly on the property object.
+  const source = property?.data ?? property;
+  let data: any = source || {};
+  if (typeof source === 'string') {
+    try {
+      data = JSON.parse(source);
+    } catch {
+      // Defensive fallback: malformed drag payload metadata should not crash hover rendering.
+      return property?.type || 'object';
+    }
+  }
 
   const baseType = getBaseTypeFromData(data);
   if (baseType === 'array') {
@@ -455,7 +463,8 @@ export function getDropPreviewPropertyType(property: { type?: string; data?: any
       return `${refName || 'ref'}[]`;
     }
     if (data?.items?.type) {
-      return `${data.items.type}[]`;
+      const itemBaseType = getBaseTypeFromData(data.items);
+      return `${itemBaseType || data.items.type}[]`;
     }
     return 'array';
   }
@@ -516,6 +525,7 @@ function ClassNode({ id, data, selected }: NodeProps) {
   /** #479: Reason string when drop would be invalid (duplicate, read-only, etc.); null when valid or not dragging over */
   const [invalidDropReason, setInvalidDropReason] = useState<string | null>(null);
   const [ghostPreview, setGhostPreview] = useState<{ name: string; typeLabel: string; parentId: string | null } | null>(null);
+  const ghostPreviewKeyRef = useRef<string | null>(null);
   const [localExpandedProperties, setLocalExpandedProperties] = useState<Set<string>>(new Set());
   const [colorPickerOpen, setColorPickerOpen] = useState(false);
   const [iconPickerOpen, setIconPickerOpen] = useState(false);
@@ -901,14 +911,59 @@ function ClassNode({ id, data, selected }: NodeProps) {
 
   const setGhostPreviewFromPayload = (payload: DragPayload | null, parentId: string | null) => {
     if (payload?.type !== 'property' || !payload.property?.name) {
-      setGhostPreview(null);
+      if (ghostPreviewKeyRef.current !== null) {
+        ghostPreviewKeyRef.current = null;
+        setGhostPreview(null);
+      }
       return;
     }
+    const typeLabel = getDropPreviewPropertyType(payload.property);
+    const previewKey = `${parentId ?? 'root'}|${payload.property.name}|${typeLabel}`;
+    if (ghostPreviewKeyRef.current === previewKey) return;
+    ghostPreviewKeyRef.current = previewKey;
     setGhostPreview({
       name: payload.property.name,
-      typeLabel: getDropPreviewPropertyType(payload.property),
+      typeLabel,
       parentId,
     });
+  };
+
+  const clearGhostPreview = () => {
+    if (ghostPreviewKeyRef.current !== null) {
+      ghostPreviewKeyRef.current = null;
+      setGhostPreview(null);
+    }
+  };
+
+  const renderGhostPreviewRow = (key: string, paddingLeft?: string) => {
+    if (!ghostPreview || invalidDropReason) return null;
+    return (
+      <div
+        key={key}
+        style={{
+          display: 'grid',
+          gridTemplateColumns: '16px 1fr auto 36px',
+          alignItems: 'center',
+          padding: '5px 10px',
+          ...(paddingLeft ? { paddingLeft } : {}),
+          background: 'linear-gradient(135deg, #eff6ff 0%, #dbeafe 100%)',
+          borderBottom: '1px dashed #93c5fd',
+          gap: '4px',
+          minHeight: '28px',
+          opacity: 0.95,
+        }}
+        aria-hidden
+      >
+        <div />
+        <div style={{ fontWeight: 500, color: '#1d4ed8', fontSize: '11px', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+          {ghostPreview.name}
+        </div>
+        <div style={{ fontSize: '9px', color: '#1e40af', fontFamily: '"SF Mono", Monaco, "Cascadia Code", monospace', whiteSpace: 'nowrap', background: 'rgba(147, 197, 253, 0.35)', padding: '1px 6px', borderRadius: '3px', fontWeight: 500 }}>
+          {ghostPreview.typeLabel}
+        </div>
+        <div style={{ fontSize: '9px', color: '#1d4ed8', textAlign: 'right', paddingRight: '2px', fontStyle: 'italic' }}>preview</div>
+      </div>
+    );
   };
 
   // DnD Handlers (top-level)
@@ -926,7 +981,7 @@ function ClassNode({ id, data, selected }: NodeProps) {
       setGhostPreviewFromPayload(payload, null);
     } catch {
       setInvalidDropReason(null);
-      setGhostPreview(null);
+      clearGhostPreview();
     }
   };
 
@@ -936,7 +991,7 @@ function ClassNode({ id, data, selected }: NodeProps) {
     setDragTarget(null);
     setDragOverPropertyId(null);
     setInvalidDropReason(null);
-    setGhostPreview(null);
+    clearGhostPreview();
   };
 
   const handleDrop = (e: React.DragEvent) => {
@@ -945,7 +1000,7 @@ function ClassNode({ id, data, selected }: NodeProps) {
     setDragTarget(null);
     setDragOverPropertyId(null);
     setInvalidDropReason(null);
-    setGhostPreview(null);
+    clearGhostPreview();
     if (typedData.isReadOnly) return;
     try {
       const raw = e.dataTransfer.getData('application/json');
@@ -980,7 +1035,7 @@ function ClassNode({ id, data, selected }: NodeProps) {
         setGhostPreviewFromPayload(payload, propertyId);
       } catch {
         setInvalidDropReason(null);
-        setGhostPreview(null);
+        clearGhostPreview();
       }
     } else {
       setDragTarget('node');
@@ -994,7 +1049,7 @@ function ClassNode({ id, data, selected }: NodeProps) {
         setGhostPreviewFromPayload(payload, null);
       } catch {
         setInvalidDropReason(null);
-        setGhostPreview(null);
+        clearGhostPreview();
       }
     }
   };
@@ -1005,7 +1060,7 @@ function ClassNode({ id, data, selected }: NodeProps) {
     setDragTarget(null);
     setDragOverPropertyId(null);
     setInvalidDropReason(null);
-    setGhostPreview(null);
+    clearGhostPreview();
   };
 
   const handlePropertyDrop = (e: React.DragEvent, parentPropertyId: string) => {
@@ -1014,7 +1069,7 @@ function ClassNode({ id, data, selected }: NodeProps) {
     setDragTarget(null);
     setDragOverPropertyId(null);
     setInvalidDropReason(null);
-    setGhostPreview(null);
+    clearGhostPreview();
     if (typedData.isReadOnly) return;
     try {
       const raw = e.dataTransfer.getData('application/json');
@@ -1872,31 +1927,7 @@ function ClassNode({ id, data, selected }: NodeProps) {
         }}>
           {(topLevel.length > 0 ? topLevel : []).length > 0 || (ghostPreview && ghostPreview.parentId === null && !invalidDropReason) ? (
           <>
-          {ghostPreview && ghostPreview.parentId === null && !invalidDropReason && (
-            <div
-              style={{
-                display: 'grid',
-                gridTemplateColumns: '16px 1fr auto 36px',
-                alignItems: 'center',
-                padding: '5px 10px',
-                background: 'linear-gradient(135deg, #eff6ff 0%, #dbeafe 100%)',
-                borderBottom: '1px dashed #93c5fd',
-                gap: '4px',
-                minHeight: '28px',
-                opacity: 0.95,
-              }}
-              aria-hidden
-            >
-              <div />
-              <div style={{ fontWeight: 500, color: '#1d4ed8', fontSize: '11px', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                {ghostPreview.name}
-              </div>
-              <div style={{ fontSize: '9px', color: '#1e40af', fontFamily: '"SF Mono", Monaco, "Cascadia Code", monospace', whiteSpace: 'nowrap', background: 'rgba(147, 197, 253, 0.35)', padding: '1px 6px', borderRadius: '3px', fontWeight: 500 }}>
-                {ghostPreview.typeLabel}
-              </div>
-              <div style={{ fontSize: '9px', color: '#1d4ed8', textAlign: 'right', paddingRight: '2px', fontStyle: 'italic' }}>preview</div>
-            </div>
-          )}
+          {ghostPreview && ghostPreview.parentId === null && renderGhostPreviewRow('root-ghost-preview')}
           {topLevel.flatMap((prop, idx) => {
             let rowIndex = 0;
             const totalTopLevel = topLevel.length;
@@ -2126,31 +2157,7 @@ function ClassNode({ id, data, selected }: NodeProps) {
 
               if (ghostPreview && ghostPreview.parentId === p.id && !invalidDropReason) {
                 row.push(
-                  <div
-                    key={`${p.id}-ghost-preview`}
-                    style={{
-                      display: 'grid',
-                      gridTemplateColumns: '16px 1fr auto 36px',
-                      alignItems: 'center',
-                      padding: '5px 10px',
-                      paddingLeft: `${10 + (depth + 1) * 14}px`,
-                      background: 'linear-gradient(135deg, #eff6ff 0%, #dbeafe 100%)',
-                      borderBottom: '1px dashed #93c5fd',
-                      gap: '4px',
-                      minHeight: '28px',
-                      opacity: 0.95,
-                    }}
-                    aria-hidden
-                  >
-                    <div />
-                    <div style={{ fontWeight: 500, color: '#1d4ed8', fontSize: '11px', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                      {ghostPreview.name}
-                    </div>
-                    <div style={{ fontSize: '9px', color: '#1e40af', fontFamily: '"SF Mono", Monaco, "Cascadia Code", monospace', whiteSpace: 'nowrap', background: 'rgba(147, 197, 253, 0.35)', padding: '1px 6px', borderRadius: '3px', fontWeight: 500 }}>
-                      {ghostPreview.typeLabel}
-                    </div>
-                    <div style={{ fontSize: '9px', color: '#1d4ed8', textAlign: 'right', paddingRight: '2px', fontStyle: 'italic' }}>preview</div>
-                  </div>
+                  renderGhostPreviewRow(`${p.id}-ghost-preview`, `${10 + (depth + 1) * 14}px`) as React.JSX.Element
                 );
               }
 

--- a/objectified-ui/tests/unit/class-node-drop-preview.test.ts
+++ b/objectified-ui/tests/unit/class-node-drop-preview.test.ts
@@ -20,11 +20,48 @@ describe('ClassNode ghost drop preview type', () => {
     ).toBe('User');
   });
 
+  it('renders array reference labels from top-level payload shape', () => {
+    expect(
+      getDropPreviewPropertyType({
+        type: 'array',
+        items: { $ref: '#/components/schemas/OrderLine' },
+      } as any)
+    ).toBe('OrderLine[]');
+  });
+
+  it('renders direct ref labels from top-level payload shape', () => {
+    expect(
+      getDropPreviewPropertyType({
+        $ref: '#/components/schemas/Account',
+      } as any)
+    ).toBe('Account');
+  });
+
   it('falls back to primitive/base type', () => {
     expect(
       getDropPreviewPropertyType({
         data: { type: ['string', 'null'] },
       })
     ).toBe('string');
+  });
+
+  it('normalizes nullable array item type labels', () => {
+    expect(
+      getDropPreviewPropertyType({
+        data: {
+          type: 'array',
+          items: { type: ['string', 'null'] },
+        },
+      })
+    ).toBe('string[]');
+  });
+
+  it('handles malformed string data payloads without throwing', () => {
+    expect(
+      getDropPreviewPropertyType({
+        type: 'number',
+        data: '{"type":"array","items":',
+      })
+    ).toBe('number');
   });
 });

--- a/objectified-ui/tests/unit/class-node-drop-preview.test.ts
+++ b/objectified-ui/tests/unit/class-node-drop-preview.test.ts
@@ -1,0 +1,30 @@
+import { getDropPreviewPropertyType } from '@/app/components/ade/studio/ClassNode';
+
+describe('ClassNode ghost drop preview type', () => {
+  it('renders array reference type labels', () => {
+    expect(
+      getDropPreviewPropertyType({
+        data: {
+          type: 'array',
+          items: { $ref: '#/components/schemas/Address' },
+        },
+      })
+    ).toBe('Address[]');
+  });
+
+  it('renders direct ref labels', () => {
+    expect(
+      getDropPreviewPropertyType({
+        data: { $ref: '#/components/schemas/User' },
+      })
+    ).toBe('User');
+  });
+
+  it('falls back to primitive/base type', () => {
+    expect(
+      getDropPreviewPropertyType({
+        data: { type: ['string', 'null'] },
+      })
+    ).toBe('string');
+  });
+});


### PR DESCRIPTION
## Problem Statement

Users and teams need **fix #478 - add class drop ghost preview** within the Objectified platform. Today this capability is missing or only partially implemented, which blocks platform workflows and creates inconsistency across tenants and projects.

## Solution / Scope

Implement **Fix #478 - add class drop ghost preview** as part of **Platform**.

**Post-MVP** (prioritize after MVP slice) candidacy.

```mermaid
flowchart LR
  User[User action: Fix #478 - add class drop ghost preview] --> UI[objectified-ui]
  UI --> API[objectified-rest]
  API --> DB[(PostgreSQL)]
```

## Acceptance Criteria

- [ ] Feature behaves as described for: Fix #478 - add class drop ghost preview
- [ ] Unit/integration tests cover happy path and primary error cases
- [ ] UI (if applicable) matches existing ADE patterns (Tailwind 4, Radix, Lucide)
- [ ] REST endpoints (if applicable) follow `/v1/{{feature}}/{{tenant_slug}}/...` conventions
- [ ] Documented in issue/PR; no regressions to existing schema/version flows

## Parallelism / Dependencies

- **Can run in parallel:** Yes
- **Blockers:** None identified; validate against current codebase before starting

## Technical Stack

- **Modules:** objectified-ui, objectified-rest
- **Stack:** Next.js 16, React 19, FastAPI, PostgreSQL
- **Labels:** ``

---
**Issue:** #827 · **Area:** Platform · **Roadmap batch:** legacy #64–#879 enrichment