### PR TITLE
Addresses #164 — configurable canvas layout auto-save interval

### DIFF
--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.8.41",
+  "version": "0.8.42",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/src/app/ade/studio/StudioContext.tsx
+++ b/objectified-ui/src/app/ade/studio/StudioContext.tsx
@@ -118,6 +118,11 @@ interface StudioContextType {
   // Smart guides
   smartGuidesEnabled: boolean;
   setSmartGuidesEnabled: (enabled: boolean) => void;
+  // Auto-save layout settings
+  autoSaveLayoutEnabled: boolean;
+  setAutoSaveLayoutEnabled: (enabled: boolean) => void;
+  autoSaveLayoutIntervalSeconds: number;
+  setAutoSaveLayoutIntervalSeconds: (seconds: number) => void;
   // Edge styling
   edgeStyling: EdgeStylingOptions;
   setEdgeStyling: (options: EdgeStylingOptions) => void;
@@ -216,6 +221,23 @@ export function StudioProvider({ children }: { children: ReactNode }) {
       return saved ? JSON.parse(saved) : true; // Default to enabled
     }
     return true;
+  });
+  const [autoSaveLayoutEnabled, setAutoSaveLayoutEnabled] = useState<boolean>(() => {
+    if (typeof window !== 'undefined') {
+      const saved = localStorage.getItem('autoSaveLayoutEnabled');
+      return saved ? JSON.parse(saved) : true;
+    }
+    return true;
+  });
+  const [autoSaveLayoutIntervalSeconds, setAutoSaveLayoutIntervalSeconds] = useState<number>(() => {
+    if (typeof window !== 'undefined') {
+      const saved = localStorage.getItem('autoSaveLayoutIntervalSeconds');
+      const parsed = saved ? parseInt(saved, 10) : 30;
+      if (Number.isFinite(parsed)) {
+        return Math.min(300, Math.max(10, parsed));
+      }
+    }
+    return 30;
   });
 
   const [edgeStyling, setEdgeStyling] = useState<EdgeStylingOptions>(() => {
@@ -345,6 +367,16 @@ export function StudioProvider({ children }: { children: ReactNode }) {
       localStorage.setItem('smartGuidesEnabled', JSON.stringify(smartGuidesEnabled));
     }
   }, [smartGuidesEnabled]);
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('autoSaveLayoutEnabled', JSON.stringify(autoSaveLayoutEnabled));
+    }
+  }, [autoSaveLayoutEnabled]);
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('autoSaveLayoutIntervalSeconds', String(autoSaveLayoutIntervalSeconds));
+    }
+  }, [autoSaveLayoutIntervalSeconds]);
 
   useEffect(() => {
     if (typeof window !== 'undefined') {
@@ -446,6 +478,10 @@ export function StudioProvider({ children }: { children: ReactNode }) {
       setExportGridOverride,
       smartGuidesEnabled,
       setSmartGuidesEnabled,
+      autoSaveLayoutEnabled,
+      setAutoSaveLayoutEnabled,
+      autoSaveLayoutIntervalSeconds,
+      setAutoSaveLayoutIntervalSeconds,
       edgeStyling,
       setEdgeStyling,
       edgeRouting,

--- a/objectified-ui/src/app/ade/studio/StudioContext.tsx
+++ b/objectified-ui/src/app/ade/studio/StudioContext.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
+import React, { createContext, useContext, useState, useEffect, useCallback, ReactNode } from 'react';
 
 // Group style options
 export interface GroupStyleOptions {
@@ -225,11 +225,18 @@ export function StudioProvider({ children }: { children: ReactNode }) {
   const [autoSaveLayoutEnabled, setAutoSaveLayoutEnabled] = useState<boolean>(() => {
     if (typeof window !== 'undefined') {
       const saved = localStorage.getItem('autoSaveLayoutEnabled');
-      return saved ? JSON.parse(saved) : true;
+      if (saved) {
+        try {
+          return JSON.parse(saved);
+        } catch (e) {
+          console.error('Failed to parse autoSaveLayoutEnabled from localStorage:', e);
+          return true;
+        }
+      }
     }
     return true;
   });
-  const [autoSaveLayoutIntervalSeconds, setAutoSaveLayoutIntervalSeconds] = useState<number>(() => {
+  const [autoSaveLayoutIntervalSeconds, setAutoSaveLayoutIntervalSecondsRaw] = useState<number>(() => {
     if (typeof window !== 'undefined') {
       const saved = localStorage.getItem('autoSaveLayoutIntervalSeconds');
       const parsed = saved ? parseInt(saved, 10) : 30;
@@ -239,6 +246,9 @@ export function StudioProvider({ children }: { children: ReactNode }) {
     }
     return 30;
   });
+  const setAutoSaveLayoutIntervalSeconds = useCallback((seconds: number) => {
+    setAutoSaveLayoutIntervalSecondsRaw(Math.min(300, Math.max(10, seconds)));
+  }, []);
 
   const [edgeStyling, setEdgeStyling] = useState<EdgeStylingOptions>(() => {
     const defaults: EdgeStylingOptions = {

--- a/objectified-ui/src/app/ade/studio/components/CanvasSettingsDialog.tsx
+++ b/objectified-ui/src/app/ade/studio/components/CanvasSettingsDialog.tsx
@@ -192,6 +192,8 @@ interface CanvasSettingsDialogProps {
   clickToFocusEnabled: boolean;
   snapToGrid: boolean;
   smartGuidesEnabled: boolean;
+  autoSaveLayoutEnabled: boolean;
+  autoSaveLayoutIntervalSeconds: number;
   showGrid: boolean;
   gridSize: number;
   gridStyle: 'dots' | 'lines' | 'cross';
@@ -204,6 +206,8 @@ interface CanvasSettingsDialogProps {
     clickToFocusEnabled: boolean;
     snapToGrid: boolean;
     smartGuidesEnabled: boolean;
+    autoSaveLayoutEnabled: boolean;
+    autoSaveLayoutIntervalSeconds: number;
     showGrid: boolean;
     gridSize: number;
     gridStyle: 'dots' | 'lines' | 'cross';
@@ -241,6 +245,8 @@ export default function CanvasSettingsDialog({
   clickToFocusEnabled,
   snapToGrid,
   smartGuidesEnabled,
+  autoSaveLayoutEnabled,
+  autoSaveLayoutIntervalSeconds,
   showGrid,
   gridSize,
   gridStyle,
@@ -256,6 +262,8 @@ export default function CanvasSettingsDialog({
   const [localClickToFocus, setLocalClickToFocus] = React.useState(clickToFocusEnabled);
   const [localSnapToGrid, setLocalSnapToGrid] = React.useState(snapToGrid);
   const [localSmartGuides, setLocalSmartGuides] = React.useState(smartGuidesEnabled);
+  const [localAutoSaveLayoutEnabled, setLocalAutoSaveLayoutEnabled] = React.useState(autoSaveLayoutEnabled);
+  const [localAutoSaveLayoutIntervalSeconds, setLocalAutoSaveLayoutIntervalSeconds] = React.useState(autoSaveLayoutIntervalSeconds);
   const [localShowGrid, setLocalShowGrid] = React.useState(showGrid);
   const [localGridSize, setLocalGridSize] = React.useState(gridSize);
   const [localGridStyle, setLocalGridStyle] = React.useState(gridStyle);
@@ -270,6 +278,8 @@ export default function CanvasSettingsDialog({
       setLocalClickToFocus(clickToFocusEnabled);
       setLocalSnapToGrid(snapToGrid);
       setLocalSmartGuides(smartGuidesEnabled);
+      setLocalAutoSaveLayoutEnabled(autoSaveLayoutEnabled);
+      setLocalAutoSaveLayoutIntervalSeconds(autoSaveLayoutIntervalSeconds);
       setLocalShowGrid(showGrid);
       setLocalGridSize(gridSize);
       setLocalGridStyle(gridStyle);
@@ -278,13 +288,15 @@ export default function CanvasSettingsDialog({
       setLocalEdgeRouting(edgeRouting);
       setLocalEdgeAnimation(edgeAnimation);
     }
-  }, [open, clickToFocusEnabled, snapToGrid, smartGuidesEnabled, showGrid, gridSize, gridStyle, canvasBackground, edgeStyling, edgeRouting, edgeAnimation]);
+  }, [open, clickToFocusEnabled, snapToGrid, smartGuidesEnabled, autoSaveLayoutEnabled, autoSaveLayoutIntervalSeconds, showGrid, gridSize, gridStyle, canvasBackground, edgeStyling, edgeRouting, edgeAnimation]);
 
   const handleSave = () => {
     onSave({
       clickToFocusEnabled: localClickToFocus,
       snapToGrid: localSnapToGrid,
       smartGuidesEnabled: localSmartGuides,
+      autoSaveLayoutEnabled: localAutoSaveLayoutEnabled,
+      autoSaveLayoutIntervalSeconds: localAutoSaveLayoutIntervalSeconds,
       showGrid: localShowGrid,
       gridSize: localGridSize,
       gridStyle: localGridStyle,
@@ -456,6 +468,42 @@ export default function CanvasSettingsDialog({
                       className="w-4 h-4 text-indigo-500 rounded focus:ring-indigo-500"
                     />
                   </label>
+                  <label className="flex items-center justify-between p-3 bg-gray-50 dark:bg-gray-800/50 rounded-lg cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-700/50 transition-colors">
+                    <div className="flex items-center gap-3">
+                      <svg className="w-4 h-4 text-gray-600 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+                      </svg>
+                      <span className="text-sm text-gray-700 dark:text-gray-300">Auto-save Layout</span>
+                    </div>
+                    <input
+                      type="checkbox"
+                      checked={localAutoSaveLayoutEnabled}
+                      onChange={(e) => setLocalAutoSaveLayoutEnabled(e.target.checked)}
+                      className="w-4 h-4 text-indigo-500 rounded focus:ring-indigo-500"
+                    />
+                  </label>
+                  <div className="p-3 bg-gray-50 dark:bg-gray-800/50 rounded-lg">
+                    <div className="flex items-center justify-between mb-2">
+                      <span className="text-sm text-gray-700 dark:text-gray-300">Auto-save Interval</span>
+                      <span className="text-xs px-2 py-0.5 rounded bg-indigo-100 dark:bg-indigo-900 text-indigo-700 dark:text-indigo-300 font-medium">
+                        {localAutoSaveLayoutIntervalSeconds}s
+                      </span>
+                    </div>
+                    <input
+                      type="range"
+                      min="10"
+                      max="300"
+                      step="5"
+                      value={localAutoSaveLayoutIntervalSeconds}
+                      disabled={!localAutoSaveLayoutEnabled}
+                      onChange={(e) => setLocalAutoSaveLayoutIntervalSeconds(Number(e.target.value))}
+                      className="w-full h-2 bg-gray-200 dark:bg-gray-700 rounded-lg appearance-none cursor-pointer accent-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed"
+                    />
+                    <div className="flex justify-between text-xs text-gray-500 dark:text-gray-400 mt-1">
+                      <span>10s</span>
+                      <span>300s</span>
+                    </div>
+                  </div>
                 </div>
               </div>
 

--- a/objectified-ui/src/app/ade/studio/components/StudioHeader.tsx
+++ b/objectified-ui/src/app/ade/studio/components/StudioHeader.tsx
@@ -58,6 +58,10 @@ export default function StudioHeader({ onProjectTagsLoaded }: StudioHeaderProps)
     setCanvasBackground,
     smartGuidesEnabled,
     setSmartGuidesEnabled,
+    autoSaveLayoutEnabled,
+    setAutoSaveLayoutEnabled,
+    autoSaveLayoutIntervalSeconds,
+    setAutoSaveLayoutIntervalSeconds,
     edgeStyling,
     setEdgeStyling,
     edgeRouting,
@@ -88,6 +92,8 @@ export default function StudioHeader({ onProjectTagsLoaded }: StudioHeaderProps)
     clickToFocusEnabled: boolean;
     snapToGrid: boolean;
     smartGuidesEnabled: boolean;
+    autoSaveLayoutEnabled: boolean;
+    autoSaveLayoutIntervalSeconds: number;
     showGrid: boolean;
     gridSize: number;
     gridStyle: 'dots' | 'lines' | 'cross';
@@ -104,6 +110,10 @@ export default function StudioHeader({ onProjectTagsLoaded }: StudioHeaderProps)
 
     setSmartGuidesEnabled(settings.smartGuidesEnabled);
     localStorage.setItem('smartGuidesEnabled', JSON.stringify(settings.smartGuidesEnabled));
+    setAutoSaveLayoutEnabled(settings.autoSaveLayoutEnabled);
+    localStorage.setItem('autoSaveLayoutEnabled', JSON.stringify(settings.autoSaveLayoutEnabled));
+    setAutoSaveLayoutIntervalSeconds(settings.autoSaveLayoutIntervalSeconds);
+    localStorage.setItem('autoSaveLayoutIntervalSeconds', String(settings.autoSaveLayoutIntervalSeconds));
 
     setShowGrid(settings.showGrid);
     localStorage.setItem('showGrid', JSON.stringify(settings.showGrid));
@@ -125,7 +135,7 @@ export default function StudioHeader({ onProjectTagsLoaded }: StudioHeaderProps)
 
     setEdgeAnimation(settings.edgeAnimation);
     localStorage.setItem('edgeAnimation', settings.edgeAnimation);
-  }, [setClickToFocusEnabled, setSnapToGrid, setSmartGuidesEnabled, setShowGrid, setGridSize, setGridStyle, setCanvasBackground, setEdgeStyling, setEdgeRouting, setEdgeAnimation]);
+  }, [setClickToFocusEnabled, setSnapToGrid, setSmartGuidesEnabled, setAutoSaveLayoutEnabled, setAutoSaveLayoutIntervalSeconds, setShowGrid, setGridSize, setGridStyle, setCanvasBackground, setEdgeStyling, setEdgeRouting, setEdgeAnimation]);
 
   // Sync local state with context
   React.useEffect(() => {
@@ -394,6 +404,8 @@ export default function StudioHeader({ onProjectTagsLoaded }: StudioHeaderProps)
               clickToFocusEnabled={clickToFocusEnabled}
               snapToGrid={snapToGrid}
               smartGuidesEnabled={smartGuidesEnabled}
+              autoSaveLayoutEnabled={autoSaveLayoutEnabled}
+              autoSaveLayoutIntervalSeconds={autoSaveLayoutIntervalSeconds}
               showGrid={showGrid}
               gridSize={gridSize}
               gridStyle={gridStyle}

--- a/objectified-ui/src/app/ade/studio/editor/page.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/page.tsx
@@ -224,6 +224,8 @@ const StudioContent = () => {
     exportGridOverride,
     smartGuidesEnabled,
     setSmartGuidesEnabled,
+    autoSaveLayoutEnabled,
+    autoSaveLayoutIntervalSeconds,
     canvasBackground,
     groups,
     setGroups,
@@ -344,6 +346,7 @@ const StudioContent = () => {
   const [selectedLayoutName, setSelectedLayoutName] = useState('Development Layout');
   const [availableLayoutNames, setAvailableLayoutNames] = useState<string[]>(BUILTIN_LAYOUT_NAMES);
   const selectedLayoutNameRef = useRef(selectedLayoutName);
+  const [autoSavePending, setAutoSavePending] = useState(false);
 
   // Track whether this is the first load for a given version (to apply saved layout only once)
   const initialLayoutAppliedRef = useRef<string | null>(null);
@@ -351,6 +354,10 @@ const StudioContent = () => {
   useEffect(() => {
     selectedLayoutNameRef.current = selectedLayoutName;
   }, [selectedLayoutName]);
+
+  useEffect(() => {
+    setAutoSavePending(false);
+  }, [selectedVersionId]);
 
   // Export wizard state
   const [exportWizardOpen, setExportWizardOpen] = useState(false);
@@ -2871,6 +2878,9 @@ const StudioContent = () => {
 
   // Custom onNodesChange that syncs group positions/dimensions, moves children, and constrains grouped nodes
   const handleNodesChange = useCallback((changes: any[]) => {
+    if (changes.length > 0) {
+      setAutoSavePending(true);
+    }
     // Track group position changes to move their child nodes
     const groupDeltas: Map<string, { dx: number; dy: number }> = new Map();
 
@@ -3010,6 +3020,13 @@ const StudioContent = () => {
     }
   }, [onNodesChange, nodes, groups, updateGroup, setNodes]);
 
+  const handleEdgesChange = useCallback((changes: any[]) => {
+    if (changes.length > 0) {
+      setAutoSavePending(true);
+    }
+    onEdgesChange(changes);
+  }, [onEdgesChange]);
+
   // ============================================================================
   // END GROUP MANAGEMENT HANDLERS
   // ============================================================================
@@ -3105,6 +3122,80 @@ const StudioContent = () => {
       setLoadingMessage('');
     }
   }, [isReadOnly, selectedVersionId, currentUserId, selectedLayoutName, nodes, edges, groups, getViewport, alertDialog]);
+
+  const autoSaveDefaultLayout = useCallback(async () => {
+    if (
+      !autoSaveLayoutEnabled ||
+      !autoSavePending ||
+      isReadOnly ||
+      !selectedVersionId ||
+      !currentUserId ||
+      layoutPreviewNodes
+    ) {
+      return;
+    }
+
+    try {
+      const viewport = getViewport();
+      const nodeData = nodes.map(node => ({
+        id: node.id,
+        type: node.type,
+        position: node.position,
+        dimensions: {
+          width: node.measured?.width || node.width || node.style?.width,
+          height: node.measured?.height || node.height || node.style?.height
+        },
+        data: node.type === 'groupNode' ? {
+          name: node.data.name,
+          color: node.data.color,
+          nodeIds: node.data.nodeIds
+        } : undefined
+      }));
+      const edgeData = edges.map(edge => ({
+        id: edge.id,
+        source: edge.source,
+        target: edge.target,
+        sourceHandle: edge.sourceHandle,
+        targetHandle: edge.targetHandle
+      }));
+
+      const result = await saveDefaultCanvasLayout(
+        selectedVersionId,
+        currentUserId,
+        viewport,
+        nodeData,
+        edgeData,
+        groups
+      );
+      const response = JSON.parse(result);
+      if (response.success) {
+        setAutoSavePending(false);
+      }
+    } catch (error) {
+      console.error('Failed to auto-save layout:', error);
+    }
+  }, [
+    autoSaveLayoutEnabled,
+    autoSavePending,
+    isReadOnly,
+    selectedVersionId,
+    currentUserId,
+    layoutPreviewNodes,
+    getViewport,
+    nodes,
+    edges,
+    groups
+  ]);
+
+  useEffect(() => {
+    if (!autoSaveLayoutEnabled || autoSaveLayoutIntervalSeconds < 10) return;
+
+    const intervalId = window.setInterval(() => {
+      void autoSaveDefaultLayout();
+    }, autoSaveLayoutIntervalSeconds * 1000);
+
+    return () => window.clearInterval(intervalId);
+  }, [autoSaveLayoutEnabled, autoSaveLayoutIntervalSeconds, autoSaveDefaultLayout]);
 
   // Load saved canvas layout
   const handleLoadLayout = useCallback(async () => {
@@ -4401,6 +4492,7 @@ const StudioContent = () => {
         }
         // Default behavior for other connections (e.g., composition edges if we enable manual linking)
         setEdges((eds) => addEdge(params, eds));
+        setAutoSavePending(true);
       } catch (e) {
         console.error('onConnect failed:', e);
       }
@@ -5184,7 +5276,7 @@ const StudioContent = () => {
               minZoom={0.1}
               maxZoom={2}
               onNodesChange={handleNodesChange}
-              onEdgesChange={onEdgesChange}
+              onEdgesChange={handleEdgesChange}
               onConnect={onConnect}
               onNodeClick={onNodeClick}
               onEdgeClick={onEdgeClick}
@@ -5196,6 +5288,7 @@ const StudioContent = () => {
               onDragOver={handleCanvasDragOver}
               onDrop={handleCanvasDrop}
               onMove={(_, viewport) => setZoomLevel(viewport.zoom)}
+              onMoveEnd={() => setAutoSavePending(true)}
               snapToGrid={snapToGrid}
               snapGrid={[gridSize, gridSize]}
               fitView

--- a/objectified-ui/src/app/ade/studio/editor/page.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/page.tsx
@@ -347,6 +347,7 @@ const StudioContent = () => {
   const [availableLayoutNames, setAvailableLayoutNames] = useState<string[]>(BUILTIN_LAYOUT_NAMES);
   const selectedLayoutNameRef = useRef(selectedLayoutName);
   const [autoSavePending, setAutoSavePending] = useState(false);
+  const autoSaveInFlightRef = useRef(false);
 
   // Track whether this is the first load for a given version (to apply saved layout only once)
   const initialLayoutAppliedRef = useRef<string | null>(null);
@@ -2878,7 +2879,14 @@ const StudioContent = () => {
 
   // Custom onNodesChange that syncs group positions/dimensions, moves children, and constrains grouped nodes
   const handleNodesChange = useCallback((changes: any[]) => {
-    if (changes.length > 0) {
+    const shouldTriggerAutoSave = changes.some((change: any) =>
+      change.type === 'position' ||
+      change.type === 'dimensions' ||
+      change.type === 'add' ||
+      change.type === 'remove'
+    );
+
+    if (shouldTriggerAutoSave) {
       setAutoSavePending(true);
     }
     // Track group position changes to move their child nodes
@@ -3021,7 +3029,24 @@ const StudioContent = () => {
   }, [onNodesChange, nodes, groups, updateGroup, setNodes]);
 
   const handleEdgesChange = useCallback((changes: any[]) => {
-    if (changes.length > 0) {
+    const hasLayoutAffectingChange = changes.some((change) => {
+      if (!change || typeof change !== 'object') return false;
+
+      if (change.type === 'add' || change.type === 'remove') {
+        return true;
+      }
+
+      if (change.type === 'update') {
+        const update = (change as any).update;
+        if (update && typeof update === 'object' && update.type === 'replace') {
+          return true;
+        }
+      }
+
+      return false;
+    });
+
+    if (hasLayoutAffectingChange) {
       setAutoSavePending(true);
     }
     onEdgesChange(changes);
@@ -3130,11 +3155,13 @@ const StudioContent = () => {
       isReadOnly ||
       !selectedVersionId ||
       !currentUserId ||
-      layoutPreviewNodes
+      layoutPreviewNodes ||
+      autoSaveInFlightRef.current
     ) {
       return;
     }
 
+    autoSaveInFlightRef.current = true;
     try {
       const viewport = getViewport();
       const nodeData = nodes.map(node => ({
@@ -3173,6 +3200,8 @@ const StudioContent = () => {
       }
     } catch (error) {
       console.error('Failed to auto-save layout:', error);
+    } finally {
+      autoSaveInFlightRef.current = false;
     }
   }, [
     autoSaveLayoutEnabled,

--- a/objectified-ui/src/app/ade/studio/editor/page.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/page.tsx
@@ -2879,12 +2879,15 @@ const StudioContent = () => {
 
   // Custom onNodesChange that syncs group positions/dimensions, moves children, and constrains grouped nodes
   const handleNodesChange = useCallback((changes: any[]) => {
-    const shouldTriggerAutoSave = changes.some((change: any) =>
-      change.type === 'position' ||
-      change.type === 'dimensions' ||
-      change.type === 'add' ||
-      change.type === 'remove'
-    );
+    const shouldTriggerAutoSave = changes.some((change: any) => {
+      if (!change || typeof change !== 'object') return false;
+      return (
+        change.type === 'position' ||
+        change.type === 'dimensions' ||
+        change.type === 'add' ||
+        change.type === 'remove'
+      );
+    });
 
     if (shouldTriggerAutoSave) {
       setAutoSavePending(true);


### PR DESCRIPTION
## Problem Statement

Users and teams need **addresses #164 — configurable canvas layout auto-save interval** within the Objectified platform. Today this capability is missing or only partially implemented, which blocks platform workflows and creates inconsistency across tenants and projects.

## Solution / Scope

Implement **Addresses #164 — configurable canvas layout auto-save interval** as part of **Platform**.

**Post-MVP** (prioritize after MVP slice) candidacy.

```mermaid
flowchart LR
  User[User action: Addresses #164 — configurable canvas lay] --> UI[objectified-ui]
  UI --> API[objectified-rest]
  API --> DB[(PostgreSQL)]
```

## Acceptance Criteria

- [ ] Feature behaves as described for: Addresses #164 — configurable canvas layout auto-save interval
- [ ] Unit/integration tests cover happy path and primary error cases
- [ ] UI (if applicable) matches existing ADE patterns (Tailwind 4, Radix, Lucide)
- [ ] REST endpoints (if applicable) follow `/v1/{{feature}}/{{tenant_slug}}/...` conventions
- [ ] Documented in issue/PR; no regressions to existing schema/version flows

## Parallelism / Dependencies

- **Can run in parallel:** Yes
- **Blockers:** None identified; validate against current codebase before starting

## Technical Stack

- **Modules:** objectified-ui, objectified-rest
- **Stack:** Next.js 16, React 19, FastAPI, PostgreSQL
- **Labels:** ``

---
**Issue:** #830 · **Area:** Platform · **Roadmap batch:** legacy #64–#879 enrichment