### PR TITLE
Fix #481: add per-node hide/show controls on canvas

### DIFF
--- a/PLANNED_FEATURE_ROADMAP_CANVAS.md
+++ b/PLANNED_FEATURE_ROADMAP_CANVAS.md
@@ -79,7 +79,7 @@
 ### 2. Canvas Navigation & Controls
 
 #### Node Visibility Controls 📋 PLANNED
-- 📋 [TODO] Hide/show individual nodes
+- ✅ Hide/show individual nodes
 - 📋 [TODO] Hide all nodes except selected
 - 📋 [TODO] Hide by criteria:
   - [TODO] Hide all empty classes (no properties)
@@ -91,7 +91,6 @@
 
 | Ticket | Feature Description            |
 |--------|--------------------------------|
-| #481   | Hide/show individual nodes     |
 | #482   | Hide all nodes except selected |
 | #483   | Hide by criteria               |
 | #484   | "Ghosts mode" for hidden nodes |

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.8.42",
+  "version": "0.8.43",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -38,6 +38,7 @@ Bug Fixes:
   - Now handles multiple saved layouts per version
   - Adds auto-save layout changes every 30 seconds (configurable)
   - Adds the ability to save custom layout names per version
+  - Introduces the ability to hide/show individual nodes
 - Project form:
   - Now includes the metadata section
   - Moved AI Assistant here

--- a/objectified-ui/src/app/ade/studio/StudioContext.tsx
+++ b/objectified-ui/src/app/ade/studio/StudioContext.tsx
@@ -95,6 +95,10 @@ interface StudioContextType {
   setIsReadOnly: (value: boolean) => void;
   zoomToClassFn: ((classId: string) => void) | null;
   setZoomToClassFn: (fn: ((classId: string) => void) | null) => void;
+  toggleClassVisibilityFn: ((classId: string, visible?: boolean) => void) | null;
+  setToggleClassVisibilityFn: (fn: ((classId: string, visible?: boolean) => void) | null) => void;
+  hiddenClassIds: string[];
+  setHiddenClassIds: (ids: string[]) => void;
   createGroupFn: (() => void) | null;
   setCreateGroupFn: (fn: (() => void) | null) => void;
   createGroupAtPositionFn: ((position: { x: number; y: number }) => void) | null;
@@ -162,6 +166,8 @@ export function StudioProvider({ children }: { children: ReactNode }) {
   const [sidebarRefreshKey, setSidebarRefreshKey] = useState<number>(0);
   const [isReadOnly, setIsReadOnly] = useState<boolean>(false);
   const [zoomToClassFn, setZoomToClassFn] = useState<((classId: string) => void) | null>(null);
+  const [toggleClassVisibilityFn, setToggleClassVisibilityFn] = useState<((classId: string, visible?: boolean) => void) | null>(null);
+  const [hiddenClassIds, setHiddenClassIds] = useState<string[]>([]);
   const [createGroupFn, setCreateGroupFn] = useState<(() => void) | null>(null);
   const [createGroupAtPositionFn, setCreateGroupAtPositionFn] = useState<((position: { x: number; y: number }) => void) | null>(null);
   const [clickToFocusEnabled, setClickToFocusEnabled] = useState<boolean>(() => {
@@ -468,6 +474,10 @@ export function StudioProvider({ children }: { children: ReactNode }) {
       setIsReadOnly,
       zoomToClassFn,
       setZoomToClassFn,
+      toggleClassVisibilityFn,
+      setToggleClassVisibilityFn,
+      hiddenClassIds,
+      setHiddenClassIds,
       createGroupFn,
       setCreateGroupFn,
       createGroupAtPositionFn,

--- a/objectified-ui/src/app/ade/studio/editor/page.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/page.tsx
@@ -209,6 +209,8 @@ const StudioContent = () => {
     isReadOnly,
     setIsReadOnly,
     setZoomToClassFn,
+    setToggleClassVisibilityFn,
+    setHiddenClassIds,
     setCreateGroupFn,
     setCreateGroupAtPositionFn,
     clickToFocusEnabled,
@@ -252,6 +254,8 @@ const StudioContent = () => {
   const selectedVersionId = contextVersionId || '';
   const setSelectedProjectId = setContextProjectId;
   const setSelectedVersionId = setContextVersionId;
+  const [hiddenNodeIds, setHiddenNodeIdsState] = useState<Set<string>>(new Set());
+  const getHiddenNodesStorageKey = useCallback((versionId: string) => `studio:hiddenNodes:${versionId}`, []);
 
   const [isLoadingProjects, setIsLoadingProjects] = useState(false);
   const [isLoadingVersions, setIsLoadingVersions] = useState(false);
@@ -969,6 +973,9 @@ const StudioContent = () => {
   const displayNodes = useMemo(() => {
     let result = layoutPreviewNodes ?? nodes;
 
+    // #481: Hide individually toggled nodes from canvas display
+    result = result.filter((node) => node.type === 'groupNode' || !hiddenNodeIds.has(node.id));
+
     // #488: Show only nodes that have at least one connection (hide isolated nodes)
     if (showOnlyConnectedNodes) {
       const visibleGroupIds = new Set(
@@ -1128,7 +1135,7 @@ const StudioContent = () => {
     }
 
     return result;
-  }, [nodes, layoutPreviewNodes, showOnlyConnectedNodes, groups, connectedNodeIds, canvasSearchQuery, canvasSearchOpen, matchingNodeIds, focusModeEnabled, focusModeFocusedSet, showDependencyOverlay, dependencyView, dependencyFocalNodeId, dependencyUpstreamIds, dependencyDownstreamIds, dependencyPathChain, nodesWithDependencyIds, dependencyDepthMap, circularNodeIdsSet, impactAnalysisMode, impactAnalysisSourceId, affectedClassIds]);
+  }, [nodes, layoutPreviewNodes, hiddenNodeIds, showOnlyConnectedNodes, groups, connectedNodeIds, canvasSearchQuery, canvasSearchOpen, matchingNodeIds, focusModeEnabled, focusModeFocusedSet, showDependencyOverlay, dependencyView, dependencyFocalNodeId, dependencyUpstreamIds, dependencyDownstreamIds, dependencyPathChain, nodesWithDependencyIds, dependencyDepthMap, circularNodeIdsSet, impactAnalysisMode, impactAnalysisSourceId, affectedClassIds]);
 
   // Compute edges with search and/or focus mode styling applied
   const displayEdges = useMemo(() => {
@@ -1281,11 +1288,56 @@ const StudioContent = () => {
     setCenter(x, y, { zoom: targetZoom, duration: 250 });
   }, [setCenter, getViewport]);
 
+  const setClassVisibility = useCallback((classId: string, visible?: boolean) => {
+    setHiddenNodeIdsState((prev) => {
+      const next = new Set(prev);
+      const shouldHide = visible === undefined ? !next.has(classId) : !visible;
+      if (shouldHide) {
+        next.add(classId);
+      } else {
+        next.delete(classId);
+      }
+      return next;
+    });
+  }, []);
+
   // Register zoomToClass function in context on mount
   useEffect(() => {
     setZoomToClassFn(() => zoomToClass);
     return () => setZoomToClassFn(null);
   }, [zoomToClass, setZoomToClassFn]);
+
+  useEffect(() => {
+    setToggleClassVisibilityFn(() => setClassVisibility);
+    return () => setToggleClassVisibilityFn(null);
+  }, [setClassVisibility, setToggleClassVisibilityFn]);
+
+  useEffect(() => {
+    if (!selectedVersionId) {
+      setHiddenNodeIdsState(new Set());
+      setHiddenClassIds([]);
+      return;
+    }
+    const key = getHiddenNodesStorageKey(selectedVersionId);
+    try {
+      const raw = localStorage.getItem(key);
+      const parsed = raw ? JSON.parse(raw) : [];
+      const ids = Array.isArray(parsed) ? parsed.filter((id) => typeof id === 'string') : [];
+      setHiddenNodeIdsState(new Set(ids));
+      setHiddenClassIds(ids);
+    } catch {
+      setHiddenNodeIdsState(new Set());
+      setHiddenClassIds([]);
+    }
+  }, [selectedVersionId, getHiddenNodesStorageKey, setHiddenClassIds]);
+
+  useEffect(() => {
+    const ids = Array.from(hiddenNodeIds);
+    setHiddenClassIds(ids);
+    if (!selectedVersionId) return;
+    const key = getHiddenNodesStorageKey(selectedVersionId);
+    localStorage.setItem(key, JSON.stringify(ids));
+  }, [hiddenNodeIds, selectedVersionId, getHiddenNodesStorageKey, setHiddenClassIds]);
 
 
   // Helper to reload classes for current selectedVersionId (used after edits)
@@ -3587,6 +3639,7 @@ const StudioContent = () => {
           onClassDelete: (...args: any[]) => handleClassDeleteRef.current?.(...args),
           onCreateReference: (...args: any[]) => handleCreateReferenceRef.current?.(...args),
           onThemeChange: (...args: any[]) => handleThemeChangeRef.current?.(...args),
+          onToggleVisibility: (classId: string, visible?: boolean) => setClassVisibility(classId, visible),
           isReadOnly: isReadOnly,
           expandedProperties: globalExpandedProperties,
           onTogglePropertyExpansion: (...args: any[]) => handleTogglePropertyExpansionRef.current?.(...args),

--- a/objectified-ui/src/app/ade/studio/layout.tsx
+++ b/objectified-ui/src/app/ade/studio/layout.tsx
@@ -36,7 +36,7 @@ function StudioLayoutContent({ children }: Readonly<{ children: React.ReactNode 
   const pathname = usePathname();
   const currentTenantId = (session?.user as any)?.current_tenant_id;
   const currentUserId = (session?.user as any)?.user_id;
-  const { selectedProjectId, selectedVersionId, triggerCanvasRefresh, triggerSidebarRefresh, sidebarRefreshKey, isReadOnly, zoomToClassFn, createGroupFn, clickToFocusEnabled, groups, deleteGroup, updateGroup } = useStudio();
+  const { selectedProjectId, selectedVersionId, triggerCanvasRefresh, triggerSidebarRefresh, sidebarRefreshKey, isReadOnly, zoomToClassFn, toggleClassVisibilityFn, hiddenClassIds, createGroupFn, clickToFocusEnabled, groups, deleteGroup, updateGroup } = useStudio();
 
   // Check if we're on the code or paths view - hide sidebar for these views
   const isCodeView = pathname?.includes('/code') || pathname?.includes('/paths');
@@ -306,6 +306,10 @@ function StudioLayoutContent({ children }: Readonly<{ children: React.ReactNode 
         zoomToClassFn(classItem.id);
       }
     },
+    onClassVisibilityToggle: (classId, visible) => {
+      toggleClassVisibilityFn?.(classId, visible);
+      triggerCanvasRefresh();
+    },
     onPropertyAdd: handlePropertyAdd, onPropertyEdit: handlePropertyEdit, onPropertyDelete: handlePropertyDelete, onPropertyTemplates: handlePropertyTemplates,
     onPropertySelect: (propertyItem) => console.log('Property selected:', propertyItem),
     onGroupAdd: () => {
@@ -416,6 +420,7 @@ function StudioLayoutContent({ children }: Readonly<{ children: React.ReactNode 
         {/* Only show sidebar for canvas/editor view, not for code view */}
         {!isCodeView && currentTenantId && selectedProjectId && selectedVersionId && (
           <StudioSideNav classes={classes} properties={properties} groups={sidebarGroups} callbacks={callbacks} refreshKey={refreshKey}
+                         hiddenClassIds={hiddenClassIds}
                          selectedProjectId={selectedProjectId} selectedVersionId={selectedVersionId} isReadOnly={isReadOnly} />
         )}
 

--- a/objectified-ui/src/app/components/ade/studio/ClassNode.tsx
+++ b/objectified-ui/src/app/components/ade/studio/ClassNode.tsx
@@ -503,6 +503,7 @@ type ClassNodeData = {
   onClassDelete?: (classId: string, className: string) => void;
   onCreateReference?: (classOrCompositeId: string) => void;
   onThemeChange?: (classId: string, theme: ClassNodeTheme) => void;
+  onToggleVisibility?: (classId: string, visible?: boolean) => void;
   isReadOnly?: boolean;
   expandedProperties?: Set<string>; // Global expanded properties state
   onTogglePropertyExpansion?: (propertyId: string) => void; // Callback to toggle property expansion
@@ -1805,6 +1806,40 @@ function ClassNode({ id, data, selected }: NodeProps) {
                 </Popover.Content>
               </Popover.Portal>
             </Popover.Root>
+
+            {/* Hide node button (#481) */}
+            <button
+              style={{
+                background: 'rgba(255, 255, 255, 0.12)',
+                border: '1px solid rgba(255, 255, 255, 0.18)',
+                borderRadius: '5px',
+                padding: '4px',
+                cursor: 'pointer',
+                color: 'rgba(255, 255, 255, 0.9)',
+                fontSize: '12px',
+                lineHeight: 1,
+                transition: 'all 0.15s ease',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                flexShrink: 0,
+              }}
+              onClick={(e) => {
+                e.stopPropagation();
+                typedData.onToggleVisibility?.(typedData.id, false);
+              }}
+              onMouseEnter={(e) => {
+                e.currentTarget.style.background = 'rgba(37, 99, 235, 0.8)';
+                e.currentTarget.style.borderColor = 'rgba(37, 99, 235, 0.9)';
+              }}
+              onMouseLeave={(e) => {
+                e.currentTarget.style.background = 'rgba(255, 255, 255, 0.12)';
+                e.currentTarget.style.borderColor = 'rgba(255, 255, 255, 0.18)';
+              }}
+              title="Hide class"
+            >
+              <EyeOff size={12} />
+            </button>
 
             {/* Delete button */}
             <button

--- a/objectified-ui/src/app/components/ade/studio/StudioSideNav.tsx
+++ b/objectified-ui/src/app/components/ade/studio/StudioSideNav.tsx
@@ -3,7 +3,7 @@
 
 import React, { useState } from 'react';
 import * as Tabs from '@radix-ui/react-tabs';
-import { Search, Plus, Pencil, Trash2, Trash2 as DeleteSweep, Upload, Library, ChevronDown, ChevronUp } from 'lucide-react';
+import { Search, Plus, Pencil, Trash2, Trash2 as DeleteSweep, Upload, Library, ChevronDown, ChevronUp, Eye, EyeOff } from 'lucide-react';
 import { getPropertiesForClass } from '../../../../../lib/db/helper';
 import { useDarkMode } from '@/app/hooks/useDarkMode';
 
@@ -55,6 +55,7 @@ export interface StudioSideNavCallbacks {
   onClassEdit?: (classItem: ClassItem) => void;
   onClassDelete?: (classId: string) => void;
   onClassSelect?: (classItem: ClassItem) => void;
+  onClassVisibilityToggle?: (classId: string, visible?: boolean) => void;
   onClassImport?: () => void;
   onClassTemplates?: () => void;
 
@@ -88,6 +89,7 @@ interface StudioSideNavProps {
   selectedProjectId?: string | null; // Currently selected project from canvas
   selectedVersionId?: string | null; // Currently selected version from canvas
   isReadOnly?: boolean; // Whether the current version is published (read-only)
+  hiddenClassIds?: string[];
   // classWarnings?: Record<string, boolean>; // removed, computed locally
   [key: string]: any; // allow future, non-breaking props from parent
 }
@@ -101,6 +103,7 @@ const StudioSideNav: React.FC<StudioSideNavProps> = ({
   selectedProjectId = null,
   selectedVersionId = null,
   isReadOnly = false,
+  hiddenClassIds = [],
 }) => {
   // Dark mode detection using shared hook
   const isDark = useDarkMode();
@@ -331,7 +334,9 @@ const StudioSideNav: React.FC<StudioSideNavProps> = ({
                   </div>
                 ) : (
                   <ul className="py-1 space-y-1 list-none p-0 m-0">
-                    {filteredClasses.map((classItem) => (
+                    {filteredClasses.map((classItem) => {
+                      const isHidden = hiddenClassIds.includes(classItem.id);
+                      return (
                       <li key={classItem.id} className="mb-1 flex items-stretch rounded-lg group">
                         <button
                           type="button"
@@ -340,7 +345,7 @@ const StudioSideNav: React.FC<StudioSideNavProps> = ({
                             selectedClassId === classItem.id
                               ? 'bg-indigo-500/10 border-l-[3px] border-indigo-500 hover:bg-indigo-500/15'
                               : 'hover:bg-indigo-500/5 border-l-[3px] border-transparent'
-                          }`}
+                          } ${isHidden ? 'opacity-60' : ''}`}
                         >
                           <span className="flex items-center gap-1.5 min-w-0">
                             <span
@@ -359,8 +364,19 @@ const StudioSideNav: React.FC<StudioSideNavProps> = ({
                           {classItem.description && (
                             <span className="block text-xs truncate mt-0.5 text-slate-500 dark:text-slate-400">{classItem.description}</span>
                           )}
+                          {isHidden && (
+                            <span className="block text-[10px] mt-0.5 text-slate-500 dark:text-slate-400">Hidden on canvas</span>
+                          )}
                         </button>
                         <div className="flex items-center gap-0.5 opacity-60 group-hover:opacity-100">
+                          <button
+                            type="button"
+                            onClick={(e) => { e.stopPropagation(); callbacks.onClassVisibilityToggle?.(classItem.id, isHidden); }}
+                            title={isHidden ? 'Show class on canvas' : 'Hide class on canvas'}
+                            className="p-1.5 rounded hover:bg-slate-500/10 hover:text-slate-600 dark:hover:text-slate-300"
+                          >
+                            {isHidden ? <Eye className="w-4 h-4" /> : <EyeOff className="w-4 h-4" />}
+                          </button>
                           <button
                             type="button"
                             disabled={!selectedVersionId || isReadOnly}
@@ -381,7 +397,8 @@ const StudioSideNav: React.FC<StudioSideNavProps> = ({
                           </button>
                         </div>
                       </li>
-                    ))}
+                      );
+                    })}
                   </ul>
                 )}
               </div>


### PR DESCRIPTION
## Problem Statement

Users and teams need **fix #481: add per-node hide/show controls on canvas** within the Objectified platform. Today this capability is missing or only partially implemented, which blocks platform workflows and creates inconsistency across tenants and projects.

## Solution / Scope

Implement **Fix #481: add per-node hide/show controls on canvas** as part of **Platform**.

**Post-MVP** (prioritize after MVP slice) candidacy.

```mermaid
flowchart LR
  User[User action: Fix #481: add per-node hide/show control] --> UI[objectified-ui]
  UI --> API[objectified-rest]
  API --> DB[(PostgreSQL)]
```

## Acceptance Criteria

- [ ] Feature behaves as described for: Fix #481: add per-node hide/show controls on canvas
- [ ] Unit/integration tests cover happy path and primary error cases
- [ ] UI (if applicable) matches existing ADE patterns (Tailwind 4, Radix, Lucide)
- [ ] REST endpoints (if applicable) follow `/v1/{{feature}}/{{tenant_slug}}/...` conventions
- [ ] Documented in issue/PR; no regressions to existing schema/version flows

## Parallelism / Dependencies

- **Can run in parallel:** Yes
- **Blockers:** None identified; validate against current codebase before starting

## Technical Stack

- **Modules:** objectified-ui, objectified-rest
- **Stack:** Next.js 16, React 19, FastAPI, PostgreSQL
- **Labels:** ``

---
**Issue:** #832 · **Area:** Platform · **Roadmap batch:** legacy #64–#879 enrichment