### PR TITLE
Addresses #482 — Selected-only canvas visibility (hide unselected nodes)

### DIFF
--- a/PLANNED_FEATURE_ROADMAP_CANVAS.md
+++ b/PLANNED_FEATURE_ROADMAP_CANVAS.md
@@ -80,7 +80,7 @@
 
 #### Node Visibility Controls 📋 PLANNED
 - ✅ Hide/show individual nodes
-- 📋 [TODO] Hide all nodes except selected
+- ✅ Hide all nodes except selected
 - 📋 [TODO] Hide by criteria:
   - [TODO] Hide all empty classes (no properties)
   - [TODO] Hide all classes without relationships
@@ -91,7 +91,6 @@
 
 | Ticket | Feature Description            |
 |--------|--------------------------------|
-| #482   | Hide all nodes except selected |
 | #483   | Hide by criteria               |
 | #484   | "Ghosts mode" for hidden nodes |
 | #485   | Quick restore hidden nodes     |

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.8.43",
+  "version": "0.8.44",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -38,6 +38,7 @@ Bug Fixes:
   - Now handles multiple saved layouts per version
   - Adds auto-save layout changes every 30 seconds (configurable)
   - Adds the ability to save custom layout names per version
+  - Adds view mode to show and hide all nodes except selected
   - Introduces the ability to hide/show individual nodes
 - Project form:
   - Now includes the metadata section

--- a/objectified-ui/src/app/ade/studio/editor/page.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/page.tsx
@@ -51,7 +51,8 @@ import {
   SlidersHorizontal,
   ArrowUp,
   ArrowDown,
-  Route
+  Route,
+  BoxSelect
 } from 'lucide-react';
 import * as Select from '@radix-ui/react-select';
 import * as ToggleGroup from '@radix-ui/react-toggle-group';
@@ -111,6 +112,7 @@ import { applyAutoLayout } from '@/app/utils/canvas-auto-layout';
 import { getCanvasBackgroundStyle } from '@/app/utils/canvas-background-style';
 import { applyEdgeStyling } from '@/app/utils/edge-styling';
 import { computeCanvasSuggestions } from '@/app/utils/canvas-suggestions';
+import { getVisibleNodeIdsForIsolateSelection } from '@/app/utils/canvas-node-visibility';
 import { computeLayoutQuality } from '@/app/utils/layout-quality';
 import { computeSchemaMetrics, getCircularDependencyEdgeIds, getDependencyDepthMap, getAffectedClassIds, getUpstreamClassIds, getDependencyChainNodeAndEdgeIds } from '@/app/utils/schema-metrics';
 import DraggablePanel from '../components/DraggablePanel';
@@ -302,6 +304,9 @@ const StudioContent = () => {
 
   // #488: Show only connected nodes (hide nodes with no edges)
   const [showOnlyConnectedNodes, setShowOnlyConnectedNodes] = useState(false);
+
+  // #482: Hide all class nodes except the current selection (and group frames that contain them)
+  const [isolateSelectionEnabled, setIsolateSelectionEnabled] = useState(false);
 
   // Spacing indicators state
   const [spacingIndicators, setSpacingIndicators] = useState<{
@@ -954,10 +959,13 @@ const StudioContent = () => {
         openCanvasSearch();
       }
 
-      // Escape: exit focus mode first, then close search
+      // Escape: exit focus mode, then isolate selection, then close search
       if (e.key === 'Escape') {
         if (focusModeEnabled) {
           exitFocusMode();
+          e.preventDefault();
+        } else if (isolateSelectionEnabled) {
+          setIsolateSelectionEnabled(false);
           e.preventDefault();
         } else if (canvasSearchOpen) {
           closeCanvasSearch();
@@ -967,7 +975,14 @@ const StudioContent = () => {
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [viewMode, canvasSearchOpen, openCanvasSearch, closeCanvasSearch, focusModeEnabled, exitFocusMode]);
+  }, [viewMode, canvasSearchOpen, openCanvasSearch, closeCanvasSearch, focusModeEnabled, exitFocusMode, isolateSelectionEnabled]);
+
+  // #482: Turn off isolate when the class selection is cleared
+  useEffect(() => {
+    if (isolateSelectionEnabled && selectedNodeIds.length === 0) {
+      setIsolateSelectionEnabled(false);
+    }
+  }, [isolateSelectionEnabled, selectedNodeIds.length]);
 
   // Compute nodes with search and/or focus mode styling applied (#471: use preview nodes when in layout preview)
   const displayNodes = useMemo(() => {
@@ -986,6 +1001,12 @@ const StudioContent = () => {
           ? visibleGroupIds.has(node.id)
           : connectedNodeIds.has(node.id)
       );
+    }
+
+    // #482: Show only selected classes and group containers that include them
+    if (isolateSelectionEnabled && selectedNodeIds.length > 0) {
+      const visibleIds = getVisibleNodeIdsForIsolateSelection(groups, new Set(selectedNodeIds));
+      result = result.filter((node) => visibleIds.has(node.id));
     }
 
     // Apply search classes when search is active
@@ -1135,7 +1156,7 @@ const StudioContent = () => {
     }
 
     return result;
-  }, [nodes, layoutPreviewNodes, hiddenNodeIds, showOnlyConnectedNodes, groups, connectedNodeIds, canvasSearchQuery, canvasSearchOpen, matchingNodeIds, focusModeEnabled, focusModeFocusedSet, showDependencyOverlay, dependencyView, dependencyFocalNodeId, dependencyUpstreamIds, dependencyDownstreamIds, dependencyPathChain, nodesWithDependencyIds, dependencyDepthMap, circularNodeIdsSet, impactAnalysisMode, impactAnalysisSourceId, affectedClassIds]);
+  }, [nodes, layoutPreviewNodes, hiddenNodeIds, showOnlyConnectedNodes, isolateSelectionEnabled, selectedNodeIds, groups, connectedNodeIds, canvasSearchQuery, canvasSearchOpen, matchingNodeIds, focusModeEnabled, focusModeFocusedSet, showDependencyOverlay, dependencyView, dependencyFocalNodeId, dependencyUpstreamIds, dependencyDownstreamIds, dependencyPathChain, nodesWithDependencyIds, dependencyDepthMap, circularNodeIdsSet, impactAnalysisMode, impactAnalysisSourceId, affectedClassIds]);
 
   // Compute edges with search and/or focus mode styling applied
   const displayEdges = useMemo(() => {
@@ -1145,6 +1166,13 @@ const StudioContent = () => {
     if (showOnlyConnectedNodes) {
       result = result.filter(
         edge => connectedNodeIds.has(edge.source) && connectedNodeIds.has(edge.target)
+      );
+    }
+
+    if (isolateSelectionEnabled && selectedNodeIds.length > 0) {
+      const visibleIds = getVisibleNodeIdsForIsolateSelection(groups, new Set(selectedNodeIds));
+      result = result.filter(
+        (edge) => visibleIds.has(edge.source) && visibleIds.has(edge.target)
       );
     }
 
@@ -1233,7 +1261,7 @@ const StudioContent = () => {
     }
 
     return result;
-  }, [edges, showOnlyConnectedNodes, connectedNodeIds, canvasSearchQuery, canvasSearchOpen, matchingNodeIds, focusModeEnabled, focusModeFocusedSet, showDependencyOverlay, dependencyView, dependencyFocalNodeId, dependencyUpstreamIds, dependencyDownstreamIds, dependencyPathChain, dependencyEdgeIds, circularEdgeIds, impactAnalysisMode, impactAnalysisSourceId, affectedClassIds]);
+  }, [edges, showOnlyConnectedNodes, isolateSelectionEnabled, selectedNodeIds, groups, connectedNodeIds, canvasSearchQuery, canvasSearchOpen, matchingNodeIds, focusModeEnabled, focusModeFocusedSet, showDependencyOverlay, dependencyView, dependencyFocalNodeId, dependencyUpstreamIds, dependencyDownstreamIds, dependencyPathChain, dependencyEdgeIds, circularEdgeIds, impactAnalysisMode, impactAnalysisSourceId, affectedClassIds]);
 
   // #349: Apply hover highlight to the hovered edge (thicker stroke, higher zIndex)
   const edgesWithHover = useMemo(() => {
@@ -5916,7 +5944,7 @@ const StudioContent = () => {
                   <DropdownMenu.Trigger asChild>
                     <button
                       className={`px-3 py-1.5 text-xs font-medium rounded-lg transition-all duration-200 flex items-center gap-1.5 border ${
-                        focusModeEnabled || showOnlyConnectedNodes
+                        focusModeEnabled || showOnlyConnectedNodes || isolateSelectionEnabled
                           ? 'bg-indigo-100 dark:bg-indigo-900/40 text-indigo-700 dark:text-indigo-300 border-indigo-200 dark:border-indigo-700'
                           : 'bg-gray-50 dark:bg-gray-700 text-gray-700 dark:text-gray-300 border-transparent hover:bg-indigo-50 dark:hover:bg-indigo-900/30 hover:text-indigo-600 dark:hover:text-indigo-400'
                       }`}
@@ -5996,6 +6024,24 @@ const StudioContent = () => {
                         </DropdownMenu.ItemIndicator>
                         <Network className="h-4 w-4 shrink-0" />
                         <span>Connected</span>
+                      </DropdownMenu.CheckboxItem>
+                      <DropdownMenu.CheckboxItem
+                        checked={isolateSelectionEnabled}
+                        disabled={selectedNodeIds.length === 0}
+                        onCheckedChange={(checked) => setIsolateSelectionEnabled(!!checked)}
+                        className="flex items-center gap-3 px-3 py-2 text-sm text-gray-700 dark:text-gray-300 rounded-md outline-none cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-700 data-[highlighted]:bg-gray-100 dark:data-[highlighted]:bg-gray-700 data-[disabled]:opacity-50 data-[disabled]:pointer-events-none"
+                        onSelect={(e) => e.preventDefault()}
+                        title={
+                          selectedNodeIds.length === 0
+                            ? 'Select one or more class nodes on the canvas first'
+                            : 'Show only selected classes (Esc to clear)'
+                        }
+                      >
+                        <DropdownMenu.ItemIndicator className="inline-flex w-5 items-center justify-center">
+                          <Check className="h-4 w-4" />
+                        </DropdownMenu.ItemIndicator>
+                        <BoxSelect className="h-4 w-4 shrink-0" />
+                        <span>Selected only</span>
                       </DropdownMenu.CheckboxItem>
                     </DropdownMenu.Content>
                   </DropdownMenu.Portal>

--- a/objectified-ui/src/app/utils/canvas-node-visibility.ts
+++ b/objectified-ui/src/app/utils/canvas-node-visibility.ts
@@ -1,0 +1,27 @@
+/**
+ * Helpers for ADE studio canvas node/edge visibility (#482 isolate selection, etc.).
+ */
+
+export interface CanvasGroupForVisibility {
+  id: string;
+  nodeIds: string[];
+}
+
+/** Group nodes that contain at least one of the selected class IDs. */
+export function getVisibleGroupIdsForSelectedClasses(
+  groups: CanvasGroupForVisibility[],
+  selectedClassIds: Set<string>
+): Set<string> {
+  return new Set(
+    groups.filter((g) => g.nodeIds.some((id) => selectedClassIds.has(id))).map((g) => g.id)
+  );
+}
+
+/** Build the set of canvas node IDs visible when isolating to the given class selection. */
+export function getVisibleNodeIdsForIsolateSelection(
+  groups: CanvasGroupForVisibility[],
+  selectedClassIds: Set<string>
+): Set<string> {
+  const visibleGroupIds = getVisibleGroupIdsForSelectedClasses(groups, selectedClassIds);
+  return new Set<string>([...selectedClassIds, ...visibleGroupIds]);
+}

--- a/objectified-ui/tests/unit/canvas-node-visibility.test.ts
+++ b/objectified-ui/tests/unit/canvas-node-visibility.test.ts
@@ -1,0 +1,30 @@
+import {
+  getVisibleGroupIdsForSelectedClasses,
+  getVisibleNodeIdsForIsolateSelection,
+} from '@/app/utils/canvas-node-visibility';
+
+describe('canvas-node-visibility (#482)', () => {
+  const groups = [
+    { id: 'g1', nodeIds: ['a', 'b'] },
+    { id: 'g2', nodeIds: ['c'] },
+    { id: 'g3', nodeIds: [] },
+  ];
+
+  it('getVisibleGroupIdsForSelectedClasses returns groups that contain a selected class', () => {
+    expect(getVisibleGroupIdsForSelectedClasses(groups, new Set(['a']))).toEqual(new Set(['g1']));
+    expect(getVisibleGroupIdsForSelectedClasses(groups, new Set(['a', 'c']))).toEqual(
+      new Set(['g1', 'g2'])
+    );
+    expect(getVisibleGroupIdsForSelectedClasses(groups, new Set())).toEqual(new Set());
+    expect(getVisibleGroupIdsForSelectedClasses(groups, new Set(['z']))).toEqual(new Set());
+  });
+
+  it('getVisibleNodeIdsForIsolateSelection unions selected classes and enclosing group ids', () => {
+    expect(getVisibleNodeIdsForIsolateSelection(groups, new Set(['b']))).toEqual(
+      new Set(['b', 'g1'])
+    );
+    expect(getVisibleNodeIdsForIsolateSelection(groups, new Set(['c']))).toEqual(
+      new Set(['c', 'g2'])
+    );
+  });
+});


### PR DESCRIPTION
## Problem Statement

Users and teams need **addresses #482 — selected-only canvas visibility (hide unselected nodes)** within the Objectified platform. Today this capability is missing or only partially implemented, which blocks platform workflows and creates inconsistency across tenants and projects.

**Original request:**

- Add View Mode option 'Selected only' to show selected classes and their group frames
- Filter display edges to endpoints visible under the same rule
- Esc clears isolate after focus mode; auto-clear when selection empties
- Extract getVisibleNodeIdsForIsolateSelection helper with unit tests
- Bump objectified-ui patch version

Made-with: Cursor

## Solution / Scope

Implement **Addresses #482 — Selected-only canvas visibility (hide unselected nodes)** as part of **Platform**.

**Post-MVP** (prioritize after MVP slice) candidacy.

```mermaid
flowchart LR
  User[User action: Addresses #482 — Selected-only canvas vi] --> UI[objectified-ui]
  UI --> API[objectified-rest]
  API --> DB[(PostgreSQL)]
```

## Acceptance Criteria

- [ ] Feature behaves as described for: Addresses #482 — Selected-only canvas visibility (hide unselected nodes)
- [ ] Unit/integration tests cover happy path and primary error cases
- [ ] UI (if applicable) matches existing ADE patterns (Tailwind 4, Radix, Lucide)
- [ ] REST endpoints (if applicable) follow `/v1/{{feature}}/{{tenant_slug}}/...` conventions
- [ ] Documented in issue/PR; no regressions to existing schema/version flows

## Parallelism / Dependencies

- **Can run in parallel:** Yes
- **Blockers:** None identified; validate against current codebase before starting

## Technical Stack

- **Modules:** objectified-ui, objectified-rest
- **Stack:** Next.js 16, React 19, FastAPI, PostgreSQL
- **Labels:** ``

---
**Issue:** #834 · **Area:** Platform · **Roadmap batch:** legacy #64–#879 enrichment