### PR TITLE
Addresses #483 — Hide canvas nodes by criteria

### DIFF
--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.8.44",
+  "version": "0.8.45",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/src/app/ade/studio/editor/page.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/page.tsx
@@ -314,7 +314,6 @@ const StudioContent = () => {
   const [hideEmptyClasses, setHideEmptyClasses] = useState(false);
   const [hideDeprecatedClasses, setHideDeprecatedClasses] = useState(false);
   const [hiddenCanvasGroupIds, setHiddenCanvasGroupIds] = useState<Set<string>>(new Set());
-  const [hideGroupMembersFlyoutHovered, setHideGroupMembersFlyoutHovered] = useState(false);
 
   const getHideCriteriaStorageKey = useCallback((versionId: string) => `studio:canvasHideCriteria:${versionId}`, []);
 
@@ -1042,9 +1041,10 @@ const StudioContent = () => {
     let result = layoutPreviewNodes ?? nodes;
 
     // #481 + #483: Manual hide, empty/unconnected/deprecated/group criteria — group frame if any member visible
+    const groupMap = new Map(groups.map((g) => [g.id, g]));
     result = result.filter((node) => {
       if (node.type === 'groupNode') {
-        const g = groups.find((gr) => gr.id === node.id);
+        const g = groupMap.get(node.id);
         return g ? groupNodeIdIsVisible(g, visibleClassIdsAfterHideCriteria) : false;
       }
       return visibleClassIdsAfterHideCriteria.has(node.id);
@@ -1448,6 +1448,8 @@ const StudioContent = () => {
       setHideDeprecatedClasses(false);
       setShowOnlyConnectedNodes(false);
       setHiddenCanvasGroupIds(new Set());
+      // Remove corrupt or unparsable hide-criteria from storage so it doesn't cause repeated parse failures
+      localStorage.removeItem(key);
     }
     skipNextHideCriteriaPersistRef.current = true;
   }, [selectedVersionId, getHideCriteriaStorageKey]);
@@ -6170,44 +6172,42 @@ const StudioContent = () => {
                         <Ban className="h-4 w-4 shrink-0" />
                         <span>Deprecated classes</span>
                       </DropdownMenu.CheckboxItem>
-                      <div
-                        className="relative rounded-md"
-                        onMouseEnter={() => setHideGroupMembersFlyoutHovered(true)}
-                        onMouseLeave={() => setHideGroupMembersFlyoutHovered(false)}
-                      >
-                        <div className="flex items-center gap-3 px-3 py-2 text-sm rounded-md outline-none cursor-pointer text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700">
+                      <DropdownMenu.Sub>
+                        <DropdownMenu.SubTrigger className="flex items-center gap-3 px-3 py-2 text-sm rounded-md outline-none cursor-pointer text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 data-[state=open]:bg-gray-100 dark:data-[state=open]:bg-gray-700">
                           <Folder className="h-4 w-4 shrink-0" />
                           <span>Hide group members</span>
                           <ChevronRight className="h-4 w-4 ml-auto shrink-0" />
-                        </div>
-                        {hideGroupMembersFlyoutHovered && (
-                          <div className="absolute left-full top-0 ml-0.5 min-w-[200px] max-w-[260px] rounded-lg shadow-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 py-1 z-10 overflow-x-hidden">
-                            {groups.length === 0 ? (
-                              <div className="px-3 py-2 text-sm text-gray-500 dark:text-gray-400">No groups</div>
-                            ) : (
-                              <div className="max-h-[240px] overflow-y-auto overflow-x-hidden">
-                                {groups.map((g) => (
-                                  <button
-                                    key={g.id}
-                                    type="button"
-                                    className="w-full min-w-0 flex items-center gap-2 px-3 py-2 text-sm text-left text-gray-700 dark:text-gray-300 rounded-md hover:bg-gray-100 dark:hover:bg-gray-700 outline-none mx-0.5"
-                                    onClick={(e) => {
-                                      e.preventDefault();
-                                      toggleHiddenCanvasGroup(g.id);
-                                    }}
-                                  >
-                                    <span className="inline-flex w-5 shrink-0 items-center justify-center text-indigo-600 dark:text-indigo-400">
-                                      {hiddenCanvasGroupIds.has(g.id) ? <Check className="h-4 w-4" /> : null}
-                                    </span>
-                                    <span className="truncate min-w-0">{g.name}</span>
-                                    <span className="text-xs text-gray-400 tabular-nums shrink-0">({g.nodeIds.length})</span>
-                                  </button>
-                                ))}
-                              </div>
-                            )}
-                          </div>
-                        )}
-                      </div>
+                        </DropdownMenu.SubTrigger>
+                        <DropdownMenu.SubContent
+                          className="min-w-[200px] max-w-[260px] rounded-lg shadow-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 py-1 z-50 overflow-x-hidden"
+                          sideOffset={4}
+                          alignOffset={-4}
+                        >
+                          {groups.length === 0 ? (
+                            <div className="px-3 py-2 text-sm text-gray-500 dark:text-gray-400">No groups</div>
+                          ) : (
+                            <div className="max-h-[240px] overflow-y-auto overflow-x-hidden">
+                              {groups.map((g) => (
+                                <button
+                                  key={g.id}
+                                  type="button"
+                                  className="w-full min-w-0 flex items-center gap-2 px-3 py-2 text-sm text-left text-gray-700 dark:text-gray-300 rounded-md hover:bg-gray-100 dark:hover:bg-gray-700 outline-none mx-0.5"
+                                  onClick={(e) => {
+                                    e.preventDefault();
+                                    toggleHiddenCanvasGroup(g.id);
+                                  }}
+                                >
+                                  <span className="inline-flex w-5 shrink-0 items-center justify-center text-indigo-600 dark:text-indigo-400">
+                                    {hiddenCanvasGroupIds.has(g.id) ? <Check className="h-4 w-4" /> : null}
+                                  </span>
+                                  <span className="truncate min-w-0">{g.name}</span>
+                                  <span className="text-xs text-gray-400 tabular-nums shrink-0">({g.nodeIds.length})</span>
+                                </button>
+                              ))}
+                            </div>
+                          )}
+                        </DropdownMenu.SubContent>
+                      </DropdownMenu.Sub>
                       <DropdownMenu.Separator className="h-px bg-gray-200 dark:bg-gray-700 my-1" />
                       <DropdownMenu.CheckboxItem
                         checked={isolateSelectionEnabled}

--- a/objectified-ui/src/app/ade/studio/editor/page.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/page.tsx
@@ -52,7 +52,9 @@ import {
   ArrowUp,
   ArrowDown,
   Route,
-  BoxSelect
+  BoxSelect,
+  Braces,
+  Ban
 } from 'lucide-react';
 import * as Select from '@radix-ui/react-select';
 import * as ToggleGroup from '@radix-ui/react-toggle-group';
@@ -113,6 +115,10 @@ import { getCanvasBackgroundStyle } from '@/app/utils/canvas-background-style';
 import { applyEdgeStyling } from '@/app/utils/edge-styling';
 import { computeCanvasSuggestions } from '@/app/utils/canvas-suggestions';
 import { getVisibleNodeIdsForIsolateSelection } from '@/app/utils/canvas-node-visibility';
+import {
+  computeClassIdsPassingHideCriteria,
+  groupNodeIdIsVisible,
+} from '@/app/utils/canvas-display-visibility';
 import { computeLayoutQuality } from '@/app/utils/layout-quality';
 import { computeSchemaMetrics, getCircularDependencyEdgeIds, getDependencyDepthMap, getAffectedClassIds, getUpstreamClassIds, getDependencyChainNodeAndEdgeIds } from '@/app/utils/schema-metrics';
 import DraggablePanel from '../components/DraggablePanel';
@@ -304,6 +310,25 @@ const StudioContent = () => {
 
   // #488: Show only connected nodes (hide nodes with no edges)
   const [showOnlyConnectedNodes, setShowOnlyConnectedNodes] = useState(false);
+  // #483: Additional hide criteria (persisted per version with showOnlyConnectedNodes)
+  const [hideEmptyClasses, setHideEmptyClasses] = useState(false);
+  const [hideDeprecatedClasses, setHideDeprecatedClasses] = useState(false);
+  const [hiddenCanvasGroupIds, setHiddenCanvasGroupIds] = useState<Set<string>>(new Set());
+  const [hideGroupMembersFlyoutHovered, setHideGroupMembersFlyoutHovered] = useState(false);
+
+  const getHideCriteriaStorageKey = useCallback((versionId: string) => `studio:canvasHideCriteria:${versionId}`, []);
+
+  const toggleHiddenCanvasGroup = useCallback((groupId: string) => {
+    setHiddenCanvasGroupIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(groupId)) next.delete(groupId);
+      else next.add(groupId);
+      return next;
+    });
+  }, []);
+
+  /** Avoid clobbering localStorage on hydrate: save effect runs after load in the same tick. */
+  const skipNextHideCriteriaPersistRef = useRef(false);
 
   // #482: Hide all class nodes except the current selection (and group frames that contain them)
   const [isolateSelectionEnabled, setIsolateSelectionEnabled] = useState(false);
@@ -884,6 +909,34 @@ const StudioContent = () => {
     return set;
   }, [edges]);
 
+  // #483: Class IDs visible after manual per-node hide and hide criteria
+  const visibleClassIdsAfterHideCriteria = useMemo(() => {
+    const baseNodes = layoutPreviewNodes ?? nodes;
+    const classNodes = baseNodes.filter((n) => n.type !== 'groupNode');
+    const passing = computeClassIdsPassingHideCriteria(
+      classNodes,
+      groups,
+      connectedNodeIds,
+      {
+        hideEmptyClasses,
+        hideUnconnectedClasses: showOnlyConnectedNodes,
+        hideDeprecatedClasses,
+        hiddenGroupIds: hiddenCanvasGroupIds,
+      }
+    );
+    return new Set([...passing].filter((id) => !hiddenNodeIds.has(id)));
+  }, [
+    layoutPreviewNodes,
+    nodes,
+    groups,
+    connectedNodeIds,
+    hideEmptyClasses,
+    showOnlyConnectedNodes,
+    hideDeprecatedClasses,
+    hiddenCanvasGroupIds,
+    hiddenNodeIds,
+  ]);
+
   // Focus mode: focused set = either group members (#490) or selection + neighbors up to degree (BFS)
   const focusModeFocusedSet = useMemo(() => {
     if (!focusModeEnabled) return new Set<string>();
@@ -988,20 +1041,14 @@ const StudioContent = () => {
   const displayNodes = useMemo(() => {
     let result = layoutPreviewNodes ?? nodes;
 
-    // #481: Hide individually toggled nodes from canvas display
-    result = result.filter((node) => node.type === 'groupNode' || !hiddenNodeIds.has(node.id));
-
-    // #488: Show only nodes that have at least one connection (hide isolated nodes)
-    if (showOnlyConnectedNodes) {
-      const visibleGroupIds = new Set(
-        groups.filter(g => g.nodeIds.some(id => connectedNodeIds.has(id))).map(g => g.id)
-      );
-      result = result.filter(node =>
-        node.type === 'groupNode'
-          ? visibleGroupIds.has(node.id)
-          : connectedNodeIds.has(node.id)
-      );
-    }
+    // #481 + #483: Manual hide, empty/unconnected/deprecated/group criteria — group frame if any member visible
+    result = result.filter((node) => {
+      if (node.type === 'groupNode') {
+        const g = groups.find((gr) => gr.id === node.id);
+        return g ? groupNodeIdIsVisible(g, visibleClassIdsAfterHideCriteria) : false;
+      }
+      return visibleClassIdsAfterHideCriteria.has(node.id);
+    });
 
     // #482: Show only selected classes and group containers that include them
     if (isolateSelectionEnabled && selectedNodeIds.length > 0) {
@@ -1156,18 +1203,18 @@ const StudioContent = () => {
     }
 
     return result;
-  }, [nodes, layoutPreviewNodes, hiddenNodeIds, showOnlyConnectedNodes, isolateSelectionEnabled, selectedNodeIds, groups, connectedNodeIds, canvasSearchQuery, canvasSearchOpen, matchingNodeIds, focusModeEnabled, focusModeFocusedSet, showDependencyOverlay, dependencyView, dependencyFocalNodeId, dependencyUpstreamIds, dependencyDownstreamIds, dependencyPathChain, nodesWithDependencyIds, dependencyDepthMap, circularNodeIdsSet, impactAnalysisMode, impactAnalysisSourceId, affectedClassIds]);
+  }, [nodes, layoutPreviewNodes, visibleClassIdsAfterHideCriteria, isolateSelectionEnabled, selectedNodeIds, groups, canvasSearchQuery, canvasSearchOpen, matchingNodeIds, focusModeEnabled, focusModeFocusedSet, showDependencyOverlay, dependencyView, dependencyFocalNodeId, dependencyUpstreamIds, dependencyDownstreamIds, dependencyPathChain, nodesWithDependencyIds, dependencyDepthMap, circularNodeIdsSet, impactAnalysisMode, impactAnalysisSourceId, affectedClassIds]);
 
   // Compute edges with search and/or focus mode styling applied
   const displayEdges = useMemo(() => {
     let result = edges;
 
-    // #488: Show only edges between visible (connected) nodes when filter is on
-    if (showOnlyConnectedNodes) {
-      result = result.filter(
-        edge => connectedNodeIds.has(edge.source) && connectedNodeIds.has(edge.target)
-      );
-    }
+    // #483 / #488: Only edges between class nodes that remain visible after hide criteria
+    result = result.filter(
+      (edge) =>
+        visibleClassIdsAfterHideCriteria.has(edge.source) &&
+        visibleClassIdsAfterHideCriteria.has(edge.target)
+    );
 
     if (isolateSelectionEnabled && selectedNodeIds.length > 0) {
       const visibleIds = getVisibleNodeIdsForIsolateSelection(groups, new Set(selectedNodeIds));
@@ -1261,7 +1308,7 @@ const StudioContent = () => {
     }
 
     return result;
-  }, [edges, showOnlyConnectedNodes, isolateSelectionEnabled, selectedNodeIds, groups, connectedNodeIds, canvasSearchQuery, canvasSearchOpen, matchingNodeIds, focusModeEnabled, focusModeFocusedSet, showDependencyOverlay, dependencyView, dependencyFocalNodeId, dependencyUpstreamIds, dependencyDownstreamIds, dependencyPathChain, dependencyEdgeIds, circularEdgeIds, impactAnalysisMode, impactAnalysisSourceId, affectedClassIds]);
+  }, [edges, visibleClassIdsAfterHideCriteria, isolateSelectionEnabled, selectedNodeIds, groups, canvasSearchQuery, canvasSearchOpen, matchingNodeIds, focusModeEnabled, focusModeFocusedSet, showDependencyOverlay, dependencyView, dependencyFocalNodeId, dependencyUpstreamIds, dependencyDownstreamIds, dependencyPathChain, dependencyEdgeIds, circularEdgeIds, impactAnalysisMode, impactAnalysisSourceId, affectedClassIds]);
 
   // #349: Apply hover highlight to the hovered edge (thicker stroke, higher zIndex)
   const edgesWithHover = useMemo(() => {
@@ -1367,6 +1414,68 @@ const StudioContent = () => {
     localStorage.setItem(key, JSON.stringify(ids));
   }, [hiddenNodeIds, selectedVersionId, getHiddenNodesStorageKey, setHiddenClassIds]);
 
+  useEffect(() => {
+    if (!selectedVersionId) {
+      setHideEmptyClasses(false);
+      setHideDeprecatedClasses(false);
+      setShowOnlyConnectedNodes(false);
+      setHiddenCanvasGroupIds(new Set());
+      skipNextHideCriteriaPersistRef.current = false;
+      return;
+    }
+    const key = getHideCriteriaStorageKey(selectedVersionId);
+    try {
+      const raw = localStorage.getItem(key);
+      const parsed = raw ? JSON.parse(raw) : null;
+      if (parsed && typeof parsed === 'object') {
+        setHideEmptyClasses(!!(parsed as { hideEmpty?: boolean }).hideEmpty);
+        setHideDeprecatedClasses(!!(parsed as { hideDeprecated?: boolean }).hideDeprecated);
+        setShowOnlyConnectedNodes(!!(parsed as { hideUnconnected?: boolean }).hideUnconnected);
+        const gids = (parsed as { hiddenGroupIds?: unknown }).hiddenGroupIds;
+        setHiddenCanvasGroupIds(
+          Array.isArray(gids)
+            ? new Set(gids.filter((x): x is string => typeof x === 'string'))
+            : new Set()
+        );
+      } else {
+        setHideEmptyClasses(false);
+        setHideDeprecatedClasses(false);
+        setShowOnlyConnectedNodes(false);
+        setHiddenCanvasGroupIds(new Set());
+      }
+    } catch {
+      setHideEmptyClasses(false);
+      setHideDeprecatedClasses(false);
+      setShowOnlyConnectedNodes(false);
+      setHiddenCanvasGroupIds(new Set());
+    }
+    skipNextHideCriteriaPersistRef.current = true;
+  }, [selectedVersionId, getHideCriteriaStorageKey]);
+
+  useEffect(() => {
+    if (!selectedVersionId) return;
+    if (skipNextHideCriteriaPersistRef.current) {
+      skipNextHideCriteriaPersistRef.current = false;
+      return;
+    }
+    const key = getHideCriteriaStorageKey(selectedVersionId);
+    localStorage.setItem(
+      key,
+      JSON.stringify({
+        hideEmpty: hideEmptyClasses,
+        hideDeprecated: hideDeprecatedClasses,
+        hideUnconnected: showOnlyConnectedNodes,
+        hiddenGroupIds: Array.from(hiddenCanvasGroupIds),
+      })
+    );
+  }, [
+    hideEmptyClasses,
+    hideDeprecatedClasses,
+    showOnlyConnectedNodes,
+    hiddenCanvasGroupIds,
+    selectedVersionId,
+    getHideCriteriaStorageKey,
+  ]);
 
   // Helper to reload classes for current selectedVersionId (used after edits)
   const reloadClasses = useCallback(async (applyLayout = false) => {
@@ -5944,7 +6053,12 @@ const StudioContent = () => {
                   <DropdownMenu.Trigger asChild>
                     <button
                       className={`px-3 py-1.5 text-xs font-medium rounded-lg transition-all duration-200 flex items-center gap-1.5 border ${
-                        focusModeEnabled || showOnlyConnectedNodes || isolateSelectionEnabled
+                        focusModeEnabled ||
+                        showOnlyConnectedNodes ||
+                        isolateSelectionEnabled ||
+                        hideEmptyClasses ||
+                        hideDeprecatedClasses ||
+                        hiddenCanvasGroupIds.size > 0
                           ? 'bg-indigo-100 dark:bg-indigo-900/40 text-indigo-700 dark:text-indigo-300 border-indigo-200 dark:border-indigo-700'
                           : 'bg-gray-50 dark:bg-gray-700 text-gray-700 dark:text-gray-300 border-transparent hover:bg-indigo-50 dark:hover:bg-indigo-900/30 hover:text-indigo-600 dark:hover:text-indigo-400'
                       }`}
@@ -6013,18 +6127,88 @@ const StudioContent = () => {
                           </div>
                         )}
                       </div>
+                      <DropdownMenu.Separator className="h-px bg-gray-200 dark:bg-gray-700 my-1" />
+                      <div className="px-3 py-1.5 text-[10px] font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                        Hide on canvas
+                      </div>
+                      <DropdownMenu.CheckboxItem
+                        checked={hideEmptyClasses}
+                        onCheckedChange={(checked) => setHideEmptyClasses(!!checked)}
+                        className="flex items-center gap-3 px-3 py-2 text-sm text-gray-700 dark:text-gray-300 rounded-md outline-none cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-700 data-[highlighted]:bg-gray-100 dark:data-[highlighted]:bg-gray-700"
+                        onSelect={(e) => e.preventDefault()}
+                        title="Hide classes that have no properties"
+                      >
+                        <DropdownMenu.ItemIndicator className="inline-flex w-5 items-center justify-center">
+                          <Check className="h-4 w-4" />
+                        </DropdownMenu.ItemIndicator>
+                        <Braces className="h-4 w-4 shrink-0" />
+                        <span>Empty classes</span>
+                      </DropdownMenu.CheckboxItem>
                       <DropdownMenu.CheckboxItem
                         checked={showOnlyConnectedNodes}
                         onCheckedChange={(checked) => setShowOnlyConnectedNodes(!!checked)}
                         className="flex items-center gap-3 px-3 py-2 text-sm text-gray-700 dark:text-gray-300 rounded-md outline-none cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-700 data-[highlighted]:bg-gray-100 dark:data-[highlighted]:bg-gray-700"
                         onSelect={(e) => e.preventDefault()}
+                        title="Hide classes with no relationships (no edges on the canvas)"
                       >
                         <DropdownMenu.ItemIndicator className="inline-flex w-5 items-center justify-center">
                           <Check className="h-4 w-4" />
                         </DropdownMenu.ItemIndicator>
                         <Network className="h-4 w-4 shrink-0" />
-                        <span>Connected</span>
+                        <span>Unconnected classes</span>
                       </DropdownMenu.CheckboxItem>
+                      <DropdownMenu.CheckboxItem
+                        checked={hideDeprecatedClasses}
+                        onCheckedChange={(checked) => setHideDeprecatedClasses(!!checked)}
+                        className="flex items-center gap-3 px-3 py-2 text-sm text-gray-700 dark:text-gray-300 rounded-md outline-none cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-700 data-[highlighted]:bg-gray-100 dark:data-[highlighted]:bg-gray-700"
+                        onSelect={(e) => e.preventDefault()}
+                        title="Hide classes marked deprecated in schema"
+                      >
+                        <DropdownMenu.ItemIndicator className="inline-flex w-5 items-center justify-center">
+                          <Check className="h-4 w-4" />
+                        </DropdownMenu.ItemIndicator>
+                        <Ban className="h-4 w-4 shrink-0" />
+                        <span>Deprecated classes</span>
+                      </DropdownMenu.CheckboxItem>
+                      <div
+                        className="relative rounded-md"
+                        onMouseEnter={() => setHideGroupMembersFlyoutHovered(true)}
+                        onMouseLeave={() => setHideGroupMembersFlyoutHovered(false)}
+                      >
+                        <div className="flex items-center gap-3 px-3 py-2 text-sm rounded-md outline-none cursor-pointer text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700">
+                          <Folder className="h-4 w-4 shrink-0" />
+                          <span>Hide group members</span>
+                          <ChevronRight className="h-4 w-4 ml-auto shrink-0" />
+                        </div>
+                        {hideGroupMembersFlyoutHovered && (
+                          <div className="absolute left-full top-0 ml-0.5 min-w-[200px] max-w-[260px] rounded-lg shadow-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 py-1 z-10 overflow-x-hidden">
+                            {groups.length === 0 ? (
+                              <div className="px-3 py-2 text-sm text-gray-500 dark:text-gray-400">No groups</div>
+                            ) : (
+                              <div className="max-h-[240px] overflow-y-auto overflow-x-hidden">
+                                {groups.map((g) => (
+                                  <button
+                                    key={g.id}
+                                    type="button"
+                                    className="w-full min-w-0 flex items-center gap-2 px-3 py-2 text-sm text-left text-gray-700 dark:text-gray-300 rounded-md hover:bg-gray-100 dark:hover:bg-gray-700 outline-none mx-0.5"
+                                    onClick={(e) => {
+                                      e.preventDefault();
+                                      toggleHiddenCanvasGroup(g.id);
+                                    }}
+                                  >
+                                    <span className="inline-flex w-5 shrink-0 items-center justify-center text-indigo-600 dark:text-indigo-400">
+                                      {hiddenCanvasGroupIds.has(g.id) ? <Check className="h-4 w-4" /> : null}
+                                    </span>
+                                    <span className="truncate min-w-0">{g.name}</span>
+                                    <span className="text-xs text-gray-400 tabular-nums shrink-0">({g.nodeIds.length})</span>
+                                  </button>
+                                ))}
+                              </div>
+                            )}
+                          </div>
+                        )}
+                      </div>
+                      <DropdownMenu.Separator className="h-px bg-gray-200 dark:bg-gray-700 my-1" />
                       <DropdownMenu.CheckboxItem
                         checked={isolateSelectionEnabled}
                         disabled={selectedNodeIds.length === 0}

--- a/objectified-ui/src/app/utils/canvas-display-visibility.ts
+++ b/objectified-ui/src/app/utils/canvas-display-visibility.ts
@@ -1,0 +1,61 @@
+/**
+ * Canvas display visibility (#483): which class nodes remain visible after hide criteria.
+ */
+
+import type { CanvasGroupForVisibility } from '@/app/utils/canvas-node-visibility';
+
+export interface CanvasClassNodeShape {
+  id: string;
+  type?: string;
+  data?: {
+    properties?: unknown[] | null;
+    schema?: { deprecated?: boolean } | null;
+  };
+}
+
+export interface CanvasHideCriteriaInput {
+  hideEmptyClasses: boolean;
+  /** When true, hide class nodes that have no incident edges (same as "Connected" view filter). */
+  hideUnconnectedClasses: boolean;
+  hideDeprecatedClasses: boolean;
+  /** Group IDs whose member class nodes should be hidden. */
+  hiddenGroupIds: Set<string>;
+}
+
+/** Class node IDs that should still appear on the canvas (before per-node manual hide). */
+export function computeClassIdsPassingHideCriteria(
+  classNodes: CanvasClassNodeShape[],
+  groups: CanvasGroupForVisibility[],
+  connectedNodeIds: Set<string>,
+  criteria: CanvasHideCriteriaInput
+): Set<string> {
+  const inHiddenGroups = new Set<string>();
+  for (const g of groups) {
+    if (criteria.hiddenGroupIds.has(g.id)) {
+      for (const id of g.nodeIds) {
+        inHiddenGroups.add(id);
+      }
+    }
+  }
+
+  const visible = new Set<string>();
+  for (const node of classNodes) {
+    if (node.type === 'groupNode') continue;
+    const props = node.data?.properties;
+    const propCount = Array.isArray(props) ? props.length : 0;
+    if (criteria.hideEmptyClasses && propCount === 0) continue;
+    if (criteria.hideUnconnectedClasses && !connectedNodeIds.has(node.id)) continue;
+    if (criteria.hideDeprecatedClasses && node.data?.schema?.deprecated === true) continue;
+    if (inHiddenGroups.has(node.id)) continue;
+    visible.add(node.id);
+  }
+  return visible;
+}
+
+/** Group frame is visible if at least one member class passes criteria. */
+export function groupNodeIdIsVisible(
+  group: CanvasGroupForVisibility,
+  visibleClassIds: Set<string>
+): boolean {
+  return group.nodeIds.some((id) => visibleClassIds.has(id));
+}

--- a/objectified-ui/tests/unit/canvas-display-visibility.test.ts
+++ b/objectified-ui/tests/unit/canvas-display-visibility.test.ts
@@ -1,0 +1,92 @@
+import {
+  computeClassIdsPassingHideCriteria,
+  groupNodeIdIsVisible,
+} from '@/app/utils/canvas-display-visibility';
+
+describe('canvas-display-visibility (#483)', () => {
+  const groups = [
+    { id: 'g1', nodeIds: ['a', 'b'] },
+    { id: 'g2', nodeIds: ['c'] },
+  ];
+
+  const nodes = [
+    { id: 'a', data: { properties: [{ name: 'x' }], schema: {} } },
+    { id: 'b', data: { properties: [], schema: {} } },
+    { id: 'c', data: { properties: [{ name: 'y' }], schema: { deprecated: true } } },
+    { id: 'd', data: { properties: [{ name: 'z' }], schema: {} } },
+  ];
+
+  const connected = new Set(['a', 'b', 'c']);
+
+  it('returns all class ids when no criteria enabled', () => {
+    expect(
+      computeClassIdsPassingHideCriteria(nodes, groups, connected, {
+        hideEmptyClasses: false,
+        hideUnconnectedClasses: false,
+        hideDeprecatedClasses: false,
+        hiddenGroupIds: new Set(),
+      })
+    ).toEqual(new Set(['a', 'b', 'c', 'd']));
+  });
+
+  it('hideEmptyClasses removes property-less classes', () => {
+    expect(
+      computeClassIdsPassingHideCriteria(nodes, groups, connected, {
+        hideEmptyClasses: true,
+        hideUnconnectedClasses: false,
+        hideDeprecatedClasses: false,
+        hiddenGroupIds: new Set(),
+      })
+    ).toEqual(new Set(['a', 'c', 'd']));
+  });
+
+  it('hideUnconnectedClasses removes nodes not in connected set', () => {
+    expect(
+      computeClassIdsPassingHideCriteria(nodes, groups, connected, {
+        hideEmptyClasses: false,
+        hideUnconnectedClasses: true,
+        hideDeprecatedClasses: false,
+        hiddenGroupIds: new Set(),
+      })
+    ).toEqual(new Set(['a', 'b', 'c']));
+  });
+
+  it('hideDeprecatedClasses removes schema.deprecated', () => {
+    expect(
+      computeClassIdsPassingHideCriteria(nodes, groups, connected, {
+        hideEmptyClasses: false,
+        hideUnconnectedClasses: false,
+        hideDeprecatedClasses: true,
+        hiddenGroupIds: new Set(),
+      })
+    ).toEqual(new Set(['a', 'b', 'd']));
+  });
+
+  it('hiddenGroupIds removes members of those groups', () => {
+    expect(
+      computeClassIdsPassingHideCriteria(nodes, groups, connected, {
+        hideEmptyClasses: false,
+        hideUnconnectedClasses: false,
+        hideDeprecatedClasses: false,
+        hiddenGroupIds: new Set(['g1']),
+      })
+    ).toEqual(new Set(['c', 'd']));
+  });
+
+  it('combines criteria as AND across rules', () => {
+    expect(
+      computeClassIdsPassingHideCriteria(nodes, groups, connected, {
+        hideEmptyClasses: true,
+        hideUnconnectedClasses: true,
+        hideDeprecatedClasses: true,
+        hiddenGroupIds: new Set(),
+      })
+    ).toEqual(new Set(['a']));
+  });
+
+  it('groupNodeIdIsVisible is true when any member is visible', () => {
+    expect(groupNodeIdIsVisible(groups[0], new Set(['a']))).toBe(true);
+    expect(groupNodeIdIsVisible(groups[0], new Set(['c']))).toBe(false);
+    expect(groupNodeIdIsVisible(groups[1], new Set(['c']))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Problem Statement

Users and teams need **addresses #483 — hide canvas nodes by criteria** within the Objectified platform. Today this capability is missing or only partially implemented, which blocks platform workflows and creates inconsistency across tenants and projects.

## Solution / Scope

Implement **Addresses #483 — Hide canvas nodes by criteria** as part of **Platform**.

**Post-MVP** (prioritize after MVP slice) candidacy.

```mermaid
flowchart LR
  User[User action: Addresses #483 — Hide canvas nodes by cr] --> UI[objectified-ui]
  UI --> API[objectified-rest]
  API --> DB[(PostgreSQL)]
```

## Acceptance Criteria

- [ ] Feature behaves as described for: Addresses #483 — Hide canvas nodes by criteria
- [ ] Unit/integration tests cover happy path and primary error cases
- [ ] UI (if applicable) matches existing ADE patterns (Tailwind 4, Radix, Lucide)
- [ ] REST endpoints (if applicable) follow `/v1/{{feature}}/{{tenant_slug}}/...` conventions
- [ ] Documented in issue/PR; no regressions to existing schema/version flows

## Parallelism / Dependencies

- **Can run in parallel:** Yes
- **Blockers:** None identified; validate against current codebase before starting

## Technical Stack

- **Modules:** objectified-ui, objectified-rest
- **Stack:** Next.js 16, React 19, FastAPI, PostgreSQL
- **Labels:** ``

---
**Issue:** #835 · **Area:** Platform · **Roadmap batch:** legacy #64–#879 enrichment