### PR TITLE
Fix #485 — Show all nodes (quick restore canvas visibility)

### DIFF
--- a/PLANNED_FEATURE_ROADMAP_CANVAS.md
+++ b/PLANNED_FEATURE_ROADMAP_CANVAS.md
@@ -87,11 +87,7 @@
   - Hide deprecated classes
   - Hide by group membership
 - ✅ "Ghosts mode": Show hidden nodes as semi-transparent
-- 📋 [TODO] Quick restore hidden nodes
-
-| Ticket | Feature Description            |
-|--------|--------------------------------|
-| #485   | Quick restore hidden nodes     |
+- ✅ Quick restore: **Show all nodes** in View Mode clears manual hides, filters, ghosts, isolate, and focus
 
 ---
 

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.8.47",
+  "version": "0.8.48",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -21,6 +21,7 @@ Bug Fixes:
 - Improved layout of the linked accounts page
   - Linked accounts page is slightly wider matching those of other dashboard layouts
   - Provider cards now show PAT hints so users can match the PATs that were assigned
+- Canvas **View mode** menu includes **Show all nodes** to restore full visibility after manual hides, filters, ghosts, isolate selection, or focus mode
 - Improvements in the canvas
   - Class node customization form is slightly more compact
   - Class and Properties forms now have tabs instead of button groupings

--- a/objectified-ui/src/app/ade/studio/editor/page.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/page.tsx
@@ -55,7 +55,8 @@ import {
   BoxSelect,
   Braces,
   Ban,
-  Ghost
+  Ghost,
+  Undo2
 } from 'lucide-react';
 import * as Select from '@radix-ui/react-select';
 import * as ToggleGroup from '@radix-ui/react-toggle-group';
@@ -117,6 +118,7 @@ import { applyEdgeStyling } from '@/app/utils/edge-styling';
 import { computeCanvasSuggestions } from '@/app/utils/canvas-suggestions';
 import { getVisibleNodeIdsForIsolateSelection } from '@/app/utils/canvas-node-visibility';
 import {
+  hasActiveCanvasVisibilityRestrictions,
   computeClassIdsPassingHideCriteria,
   groupNodeIdIsVisible,
 } from '@/app/utils/canvas-display-visibility';
@@ -339,6 +341,30 @@ const StudioContent = () => {
 
   // #482: Hide all class nodes except the current selection (and group frames that contain them)
   const [isolateSelectionEnabled, setIsolateSelectionEnabled] = useState(false);
+
+  const canvasVisibilityRestricted = useMemo(
+    () =>
+      hasActiveCanvasVisibilityRestrictions({
+        manualHiddenNodeCount: hiddenNodeIds.size,
+        hideEmptyClasses,
+        hideUnconnectedClasses: showOnlyConnectedNodes,
+        hideDeprecatedClasses,
+        hiddenGroupIdsCount: hiddenCanvasGroupIds.size,
+        nodeGhostsModeEnabled,
+        isolateSelectionEnabled,
+        focusModeEnabled,
+      }),
+    [
+      hiddenNodeIds,
+      hideEmptyClasses,
+      showOnlyConnectedNodes,
+      hideDeprecatedClasses,
+      hiddenCanvasGroupIds,
+      nodeGhostsModeEnabled,
+      isolateSelectionEnabled,
+      focusModeEnabled,
+    ]
+  );
 
   // Spacing indicators state
   const [spacingIndicators, setSpacingIndicators] = useState<{
@@ -1431,6 +1457,20 @@ const StudioContent = () => {
       }
       return next;
     });
+  }, []);
+
+  /** #485: One action to clear manual hides, hide filters, ghosts, isolate, and focus mode. */
+  const restoreCanvasVisibility = useCallback(() => {
+    setHiddenNodeIdsState(new Set());
+    setHideEmptyClasses(false);
+    setHideDeprecatedClasses(false);
+    setShowOnlyConnectedNodes(false);
+    setHiddenCanvasGroupIds(new Set());
+    setNodeGhostsModeEnabled(false);
+    setIsolateSelectionEnabled(false);
+    setFocusModeEnabled(false);
+    setFocusModeGroupId(null);
+    setFocusModeDegree(1);
   }, []);
 
   // Register zoomToClass function in context on mount
@@ -6128,13 +6168,7 @@ const StudioContent = () => {
                   <DropdownMenu.Trigger asChild>
                     <button
                       className={`px-3 py-1.5 text-xs font-medium rounded-lg transition-all duration-200 flex items-center gap-1.5 border ${
-                        focusModeEnabled ||
-                        showOnlyConnectedNodes ||
-                        isolateSelectionEnabled ||
-                        hideEmptyClasses ||
-                        hideDeprecatedClasses ||
-                        hiddenCanvasGroupIds.size > 0 ||
-                        nodeGhostsModeEnabled
+                        canvasVisibilityRestricted
                           ? 'bg-indigo-100 dark:bg-indigo-900/40 text-indigo-700 dark:text-indigo-300 border-indigo-200 dark:border-indigo-700'
                           : 'bg-gray-50 dark:bg-gray-700 text-gray-700 dark:text-gray-300 border-transparent hover:bg-indigo-50 dark:hover:bg-indigo-900/30 hover:text-indigo-600 dark:hover:text-indigo-400'
                       }`}
@@ -6314,6 +6348,16 @@ const StudioContent = () => {
                         <BoxSelect className="h-4 w-4 shrink-0" />
                         <span>Selected only</span>
                       </DropdownMenu.CheckboxItem>
+                      <DropdownMenu.Separator className="h-px bg-gray-200 dark:bg-gray-700 my-1" />
+                      <DropdownMenu.Item
+                        className="flex items-center gap-3 px-3 py-2 text-sm text-gray-700 dark:text-gray-300 rounded-md outline-none cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-700 data-[highlighted]:bg-gray-100 dark:data-[highlighted]:bg-gray-700 data-[disabled]:opacity-40 data-[disabled]:pointer-events-none"
+                        disabled={!canvasVisibilityRestricted}
+                        title="Show every class again: clear manual hides, hide filters, node ghosts, isolate selection, and focus mode"
+                        onSelect={() => restoreCanvasVisibility()}
+                      >
+                        <Undo2 className="h-4 w-4 shrink-0" />
+                        <span>Show all nodes</span>
+                      </DropdownMenu.Item>
                     </DropdownMenu.Content>
                   </DropdownMenu.Portal>
                 </DropdownMenu.Root>

--- a/objectified-ui/src/app/utils/canvas-display-visibility.ts
+++ b/objectified-ui/src/app/utils/canvas-display-visibility.ts
@@ -59,3 +59,29 @@ export function groupNodeIdIsVisible(
 ): boolean {
   return group.nodeIds.some((id) => visibleClassIds.has(id));
 }
+
+/**
+ * True when any canvas visibility control is active (#485).
+ * Used to enable “show all nodes” / highlight View Mode when something is restricting visibility.
+ */
+export function hasActiveCanvasVisibilityRestrictions(params: {
+  manualHiddenNodeCount: number;
+  hideEmptyClasses: boolean;
+  hideUnconnectedClasses: boolean;
+  hideDeprecatedClasses: boolean;
+  hiddenGroupIdsCount: number;
+  nodeGhostsModeEnabled: boolean;
+  isolateSelectionEnabled: boolean;
+  focusModeEnabled: boolean;
+}): boolean {
+  return (
+    params.manualHiddenNodeCount > 0 ||
+    params.hideEmptyClasses ||
+    params.hideUnconnectedClasses ||
+    params.hideDeprecatedClasses ||
+    params.hiddenGroupIdsCount > 0 ||
+    params.nodeGhostsModeEnabled ||
+    params.isolateSelectionEnabled ||
+    params.focusModeEnabled
+  );
+}

--- a/objectified-ui/tests/unit/canvas-display-visibility.test.ts
+++ b/objectified-ui/tests/unit/canvas-display-visibility.test.ts
@@ -1,6 +1,7 @@
 import {
   computeClassIdsPassingHideCriteria,
   groupNodeIdIsVisible,
+  hasActiveCanvasVisibilityRestrictions,
 } from '@/app/utils/canvas-display-visibility';
 
 describe('canvas-display-visibility (#483)', () => {
@@ -88,5 +89,33 @@ describe('canvas-display-visibility (#483)', () => {
     expect(groupNodeIdIsVisible(groups[0], new Set(['a']))).toBe(true);
     expect(groupNodeIdIsVisible(groups[0], new Set(['c']))).toBe(false);
     expect(groupNodeIdIsVisible(groups[1], new Set(['c']))).toBe(true);
+  });
+});
+
+const allOff = {
+  manualHiddenNodeCount: 0,
+  hideEmptyClasses: false,
+  hideUnconnectedClasses: false,
+  hideDeprecatedClasses: false,
+  hiddenGroupIdsCount: 0,
+  nodeGhostsModeEnabled: false,
+  isolateSelectionEnabled: false,
+  focusModeEnabled: false,
+};
+
+describe('hasActiveCanvasVisibilityRestrictions (#485)', () => {
+  it('is false when nothing restricts visibility', () => {
+    expect(hasActiveCanvasVisibilityRestrictions(allOff)).toBe(false);
+  });
+
+  it('is true when any restriction is on', () => {
+    expect(hasActiveCanvasVisibilityRestrictions({ ...allOff, manualHiddenNodeCount: 1 })).toBe(true);
+    expect(hasActiveCanvasVisibilityRestrictions({ ...allOff, hideEmptyClasses: true })).toBe(true);
+    expect(hasActiveCanvasVisibilityRestrictions({ ...allOff, hideUnconnectedClasses: true })).toBe(true);
+    expect(hasActiveCanvasVisibilityRestrictions({ ...allOff, hideDeprecatedClasses: true })).toBe(true);
+    expect(hasActiveCanvasVisibilityRestrictions({ ...allOff, hiddenGroupIdsCount: 1 })).toBe(true);
+    expect(hasActiveCanvasVisibilityRestrictions({ ...allOff, nodeGhostsModeEnabled: true })).toBe(true);
+    expect(hasActiveCanvasVisibilityRestrictions({ ...allOff, isolateSelectionEnabled: true })).toBe(true);
+    expect(hasActiveCanvasVisibilityRestrictions({ ...allOff, focusModeEnabled: true })).toBe(true);
   });
 });


### PR DESCRIPTION
## Problem Statement

Users and teams need **fix #485 — show all nodes (quick restore canvas visibility)** within the Objectified platform. Today this capability is missing or only partially implemented, which blocks platform workflows and creates inconsistency across tenants and projects.

## Solution / Scope

Implement **Fix #485 — Show all nodes (quick restore canvas visibility)** as part of **Platform**.

**Post-MVP** (prioritize after MVP slice) candidacy.

```mermaid
flowchart LR
  User[User action: Fix #485 — Show all nodes (quick restore] --> UI[objectified-ui]
  UI --> API[objectified-rest]
  API --> DB[(PostgreSQL)]
```

## Acceptance Criteria

- [ ] Feature behaves as described for: Fix #485 — Show all nodes (quick restore canvas visibility)
- [ ] Unit/integration tests cover happy path and primary error cases
- [ ] UI (if applicable) matches existing ADE patterns (Tailwind 4, Radix, Lucide)
- [ ] REST endpoints (if applicable) follow `/v1/{{feature}}/{{tenant_slug}}/...` conventions
- [ ] Documented in issue/PR; no regressions to existing schema/version flows

## Parallelism / Dependencies

- **Can run in parallel:** Yes
- **Blockers:** None identified; validate against current codebase before starting

## Technical Stack

- **Modules:** objectified-ui, objectified-rest
- **Stack:** Next.js 16, React 19, FastAPI, PostgreSQL
- **Labels:** ``

---
**Issue:** #837 · **Area:** Platform · **Roadmap batch:** legacy #64–#879 enrichment