### PR TITLE
Addresses #165 — Canvas layout revision history and restore

### DIFF
--- a/PLANNED_FEATURE_ROADMAP_CANVAS.md
+++ b/PLANNED_FEATURE_ROADMAP_CANVAS.md
@@ -25,7 +25,7 @@
     - "Logical Layout" - grouped by business domain
     - "Dependency Layout" - organized by relationships
 - ✅ Auto-save layout changes every 30 seconds (configurable)
-- 📋 [TODO] Version control for layouts (track layout history)
+- ✅ Version control for layouts (track layout history) — #165
 - 📋 [TODO] Default layout setting per user or per team
 - 📋 [TODO] Export layout as JSON for sharing
 - 📋 [TODO] Import layouts from other versions/projects
@@ -34,7 +34,6 @@
 
 | Ticket | Feature                                        |
 |--------|------------------------------------------------|
-| #165   | Version control for layouts                    |
 | #166   | Default layout setting per user or per team    |
 | #167   | Export/import layouts as JSON                  |
 | #314   | Canvas snapshots                               |

--- a/objectified-db/scripts/20260329-150000.sql
+++ b/objectified-db/scripts/20260329-150000.sql
@@ -1,0 +1,26 @@
+-- Canvas layout revision history (named layout saves)
+-- Stores prior snapshots before each named-layout update for restore/version history.
+
+SET search_path TO odb, public;
+
+CREATE TABLE IF NOT EXISTS canvas_layout_revisions (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    canvas_layout_id UUID NOT NULL REFERENCES canvas_layouts(id) ON DELETE CASCADE,
+    revision INTEGER NOT NULL,
+    viewport JSONB,
+    nodes JSONB,
+    edges JSONB,
+    grid_settings JSONB,
+    minimap_settings JSONB,
+    created_by UUID REFERENCES users(id) ON DELETE SET NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT canvas_layout_revisions_unique_rev UNIQUE (canvas_layout_id, revision)
+);
+
+CREATE INDEX IF NOT EXISTS idx_canvas_layout_revisions_layout_id
+    ON canvas_layout_revisions(canvas_layout_id);
+CREATE INDEX IF NOT EXISTS idx_canvas_layout_revisions_created_at
+    ON canvas_layout_revisions(created_at DESC);
+
+COMMENT ON TABLE canvas_layout_revisions IS 'Point-in-time snapshots of canvas_layouts rows before named-layout updates; capped per layout in application code';
+COMMENT ON COLUMN canvas_layout_revisions.revision IS 'Monotonic per canvas_layout_id; higher is newer snapshot of the prior state';

--- a/objectified-ui/lib/db/helper.ts
+++ b/objectified-ui/lib/db/helper.ts
@@ -3135,11 +3135,15 @@ export async function saveNamedCanvasLayout(
     }
 
     if (existingResult.rowCount > 0) {
-      return updateCanvasLayout(existingResult.rows[0].id, {
-        viewport,
-        nodes,
-        edges: edges || []
-      });
+      return updateCanvasLayout(
+        existingResult.rows[0].id,
+        {
+          viewport,
+          nodes,
+          edges: edges || []
+        },
+        { recordRevision: true, revisionUserId: userId }
+      );
     }
 
     return createCanvasLayout(
@@ -3213,8 +3217,12 @@ export async function createCanvasLayout(
   }
 }
 
+/** Max prior snapshots kept per layout row (named saves only; default auto-save does not record). */
+const CANVAS_LAYOUT_REVISION_RETAIN = 50;
+
 /**
  * Update an existing canvas layout
+ * @param options.recordRevision When true and layout fields change, stores the previous row in canvas_layout_revisions (named layout saves).
  */
 export async function updateCanvasLayout(
   layoutId: string,
@@ -3227,20 +3235,73 @@ export async function updateCanvasLayout(
     gridSettings?: any;
     minimapSettings?: any;
     metadata?: any;
+  },
+  options?: {
+    recordRevision?: boolean;
+    revisionUserId?: string | null;
   }
 ) {
   try {
-    // Get current layout to check version_id and user_id
-    const currentResult = await connectionPool.query(
-      `SELECT version_id, user_id FROM odb.canvas_layouts WHERE id = $1`,
-      [layoutId]
-    );
+    const recordRevision = options?.recordRevision === true;
+    const revisionUserId = options?.revisionUserId ?? null;
+
+    const shouldSnapshotPriorLayout =
+      recordRevision &&
+      (updates.viewport !== undefined ||
+        updates.nodes !== undefined ||
+        updates.edges !== undefined ||
+        updates.gridSettings !== undefined ||
+        updates.minimapSettings !== undefined);
+
+    const currentResult = shouldSnapshotPriorLayout
+      ? await connectionPool.query(`SELECT * FROM odb.canvas_layouts WHERE id = $1`, [layoutId])
+      : await connectionPool.query(
+          `SELECT version_id, user_id FROM odb.canvas_layouts WHERE id = $1`,
+          [layoutId]
+        );
 
     if (currentResult.rowCount === 0) {
       return errorResponse('Layout not found');
     }
 
-    const { version_id, user_id } = currentResult.rows[0];
+    const currentRow = currentResult.rows[0];
+
+    if (shouldSnapshotPriorLayout) {
+      const maxRevResult = await connectionPool.query(
+        `SELECT COALESCE(MAX(revision), 0) AS n FROM odb.canvas_layout_revisions WHERE canvas_layout_id = $1`,
+        [layoutId]
+      );
+      const nextRevision = Number(maxRevResult.rows[0].n) + 1;
+
+      await connectionPool.query(
+        `INSERT INTO odb.canvas_layout_revisions
+         (canvas_layout_id, revision, viewport, nodes, edges, grid_settings, minimap_settings, created_by)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+        [
+          layoutId,
+          nextRevision,
+          currentRow.viewport,
+          currentRow.nodes,
+          currentRow.edges,
+          currentRow.grid_settings,
+          currentRow.minimap_settings,
+          revisionUserId
+        ]
+      );
+
+      await connectionPool.query(
+        `DELETE FROM odb.canvas_layout_revisions
+         WHERE canvas_layout_id = $1
+           AND revision < (
+             SELECT COALESCE(MAX(revision), 0) - $2
+             FROM odb.canvas_layout_revisions
+             WHERE canvas_layout_id = $1
+           )`,
+        [layoutId, CANVAS_LAYOUT_REVISION_RETAIN - 1]
+      );
+    }
+
+    const { version_id, user_id } = currentRow;
 
     // If setting as default, unset other defaults
     if (updates.isDefault) {
@@ -3315,6 +3376,65 @@ export async function updateCanvasLayout(
     return successResponse({ layout: result.rows[0] });
   } catch (error: any) {
     console.error('Error updating canvas layout:', error);
+    return errorResponse(error.message);
+  }
+}
+
+/**
+ * List prior snapshots for a named layout (newest first).
+ */
+export async function listCanvasLayoutRevisions(layoutId: string, limit: number = 50) {
+  try {
+    const cap = Math.min(Math.max(1, limit), 100);
+    const result = await connectionPool.query(
+      `SELECT id, canvas_layout_id, revision, created_at, created_by
+       FROM odb.canvas_layout_revisions
+       WHERE canvas_layout_id = $1
+       ORDER BY revision DESC
+       LIMIT $2`,
+      [layoutId, cap]
+    );
+    return successResponse({ revisions: result.rows });
+  } catch (error: any) {
+    console.error('Error listing canvas layout revisions:', error);
+    return errorResponse(error.message);
+  }
+}
+
+/**
+ * Restore a canvas layout from a stored revision (records current state as a new revision first).
+ */
+export async function restoreCanvasLayoutFromRevision(
+  layoutId: string,
+  revisionId: string,
+  userId: string | null
+) {
+  try {
+    const revResult = await connectionPool.query(
+      `SELECT r.viewport, r.nodes, r.edges, r.grid_settings, r.minimap_settings
+       FROM odb.canvas_layout_revisions r
+       WHERE r.id = $1 AND r.canvas_layout_id = $2`,
+      [revisionId, layoutId]
+    );
+
+    if (revResult.rowCount === 0) {
+      return errorResponse('Revision not found');
+    }
+
+    const row = revResult.rows[0];
+    return updateCanvasLayout(
+      layoutId,
+      {
+        viewport: row.viewport,
+        nodes: row.nodes,
+        edges: row.edges,
+        gridSettings: row.grid_settings,
+        minimapSettings: row.minimap_settings
+      },
+      { recordRevision: true, revisionUserId: userId }
+    );
+  } catch (error: any) {
+    console.error('Error restoring canvas layout revision:', error);
     return errorResponse(error.message);
   }
 }

--- a/objectified-ui/lib/db/helper.ts
+++ b/objectified-ui/lib/db/helper.ts
@@ -3221,8 +3221,10 @@ export async function createCanvasLayout(
 const CANVAS_LAYOUT_REVISION_RETAIN = 50;
 
 /**
- * Update an existing canvas layout
- * @param options.recordRevision When true and layout fields change, stores the previous row in canvas_layout_revisions (named layout saves).
+ * Update an existing canvas layout.
+ * @param options.recordRevision When true, stores the previous row snapshot in canvas_layout_revisions
+ *   (used for named layout saves). A revision is recorded whenever spatial layout fields are provided,
+ *   regardless of whether the values have actually changed.
  */
 export async function updateCanvasLayout(
   layoutId: string,
@@ -3241,6 +3243,7 @@ export async function updateCanvasLayout(
     revisionUserId?: string | null;
   }
 ) {
+  const client = await connectionPool.connect();
   try {
     const recordRevision = options?.recordRevision === true;
     const revisionUserId = options?.revisionUserId ?? null;
@@ -3253,27 +3256,32 @@ export async function updateCanvasLayout(
         updates.gridSettings !== undefined ||
         updates.minimapSettings !== undefined);
 
-    const currentResult = shouldSnapshotPriorLayout
-      ? await connectionPool.query(`SELECT * FROM odb.canvas_layouts WHERE id = $1`, [layoutId])
-      : await connectionPool.query(
-          `SELECT version_id, user_id FROM odb.canvas_layouts WHERE id = $1`,
-          [layoutId]
-        );
+    await client.query('BEGIN');
+
+    // Lock the layout row for the duration of the transaction so concurrent saves
+    // for the same layout cannot race on the revision counter.
+    const currentResult = await client.query(
+      `SELECT * FROM odb.canvas_layouts WHERE id = $1 FOR UPDATE`,
+      [layoutId]
+    );
 
     if (currentResult.rowCount === 0) {
+      await client.query('ROLLBACK');
       return errorResponse('Layout not found');
     }
 
     const currentRow = currentResult.rows[0];
 
     if (shouldSnapshotPriorLayout) {
-      const maxRevResult = await connectionPool.query(
+      // MAX(revision) is safe here because the canvas_layouts row is locked above,
+      // preventing any concurrent transaction from inserting a revision for this layout.
+      const maxRevResult = await client.query(
         `SELECT COALESCE(MAX(revision), 0) AS n FROM odb.canvas_layout_revisions WHERE canvas_layout_id = $1`,
         [layoutId]
       );
       const nextRevision = Number(maxRevResult.rows[0].n) + 1;
 
-      await connectionPool.query(
+      await client.query(
         `INSERT INTO odb.canvas_layout_revisions
          (canvas_layout_id, revision, viewport, nodes, edges, grid_settings, minimap_settings, created_by)
          VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
@@ -3289,7 +3297,7 @@ export async function updateCanvasLayout(
         ]
       );
 
-      await connectionPool.query(
+      await client.query(
         `DELETE FROM odb.canvas_layout_revisions
          WHERE canvas_layout_id = $1
            AND revision < (
@@ -3306,13 +3314,13 @@ export async function updateCanvasLayout(
     // If setting as default, unset other defaults
     if (updates.isDefault) {
       if (user_id) {
-        await connectionPool.query(
+        await client.query(
           `UPDATE odb.canvas_layouts SET is_default = false 
            WHERE version_id = $1 AND user_id = $2 AND is_default = true AND id != $3`,
           [version_id, user_id, layoutId]
         );
       } else {
-        await connectionPool.query(
+        await client.query(
           `UPDATE odb.canvas_layouts SET is_default = false 
            WHERE version_id = $1 AND user_id IS NULL AND is_default = true AND id != $2`,
           [version_id, layoutId]
@@ -3359,12 +3367,13 @@ export async function updateCanvasLayout(
     }
 
     if (setClauses.length === 0) {
+      await client.query('ROLLBACK');
       return errorResponse('No updates provided');
     }
 
     values.push(layoutId);
 
-    const result = await connectionPool.query(
+    const result = await client.query(
       `UPDATE odb.canvas_layouts 
        SET ${setClauses.join(', ')}
        WHERE id = $${paramIndex}
@@ -3373,26 +3382,40 @@ export async function updateCanvasLayout(
       values
     );
 
+    await client.query('COMMIT');
     return successResponse({ layout: result.rows[0] });
   } catch (error: any) {
+    try { await client.query('ROLLBACK'); } catch {}
     console.error('Error updating canvas layout:', error);
     return errorResponse(error.message);
+  } finally {
+    client.release();
   }
 }
 
 /**
  * List prior snapshots for a named layout (newest first).
+ * Access is restricted to layouts that belong to `versionId` and are owned by
+ * `userId` or are shared (user_id IS NULL).
  */
-export async function listCanvasLayoutRevisions(layoutId: string, limit: number = 50) {
+export async function listCanvasLayoutRevisions(
+  layoutId: string,
+  versionId: string,
+  userId: string | null,
+  limit: number = 50
+) {
   try {
     const cap = Math.min(Math.max(1, limit), 100);
     const result = await connectionPool.query(
-      `SELECT id, canvas_layout_id, revision, created_at, created_by
-       FROM odb.canvas_layout_revisions
-       WHERE canvas_layout_id = $1
-       ORDER BY revision DESC
-       LIMIT $2`,
-      [layoutId, cap]
+      `SELECT r.id, r.canvas_layout_id, r.revision, r.created_at, r.created_by
+       FROM odb.canvas_layout_revisions r
+       JOIN odb.canvas_layouts cl ON cl.id = r.canvas_layout_id
+       WHERE r.canvas_layout_id = $1
+         AND cl.version_id = $2
+         AND (cl.user_id = $3 OR cl.user_id IS NULL)
+       ORDER BY r.revision DESC
+       LIMIT $4`,
+      [layoutId, versionId, userId, cap]
     );
     return successResponse({ revisions: result.rows });
   } catch (error: any) {
@@ -3403,18 +3426,25 @@ export async function listCanvasLayoutRevisions(layoutId: string, limit: number 
 
 /**
  * Restore a canvas layout from a stored revision (records current state as a new revision first).
+ * Access is restricted to layouts that belong to `versionId` and are owned by
+ * `userId` or are shared (user_id IS NULL).
  */
 export async function restoreCanvasLayoutFromRevision(
   layoutId: string,
   revisionId: string,
+  versionId: string,
   userId: string | null
 ) {
   try {
     const revResult = await connectionPool.query(
       `SELECT r.viewport, r.nodes, r.edges, r.grid_settings, r.minimap_settings
        FROM odb.canvas_layout_revisions r
-       WHERE r.id = $1 AND r.canvas_layout_id = $2`,
-      [revisionId, layoutId]
+       JOIN odb.canvas_layouts cl ON cl.id = r.canvas_layout_id
+       WHERE r.id = $1
+         AND r.canvas_layout_id = $2
+         AND cl.version_id = $3
+         AND (cl.user_id = $4 OR cl.user_id IS NULL)`,
+      [revisionId, layoutId, versionId, userId]
     );
 
     if (revResult.rowCount === 0) {

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.8.48",
+  "version": "0.8.49",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -37,6 +37,7 @@ Bug Fixes:
   - Renaming a property no longer rearranges the entire canvas
   - Adding a reference to a class no longer rearranges the entire canvas
   - Now handles multiple saved layouts per version
+  - Named layout saves keep version history with restore (up to 50 prior states per layout)
   - Adds auto-save layout changes every 30 seconds (configurable)
   - Adds the ability to save custom layout names per version
   - Adds view mode to show and hide all nodes except selected

--- a/objectified-ui/src/app/ade/studio/editor/page.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/page.tsx
@@ -3762,6 +3762,7 @@ const StudioContent = () => {
         const restoreRes = await restoreCanvasLayoutFromRevision(
           layoutParsed.layout.id,
           revisionId,
+          selectedVersionId,
           currentUserId
         );
         const restoreParsed = JSON.parse(restoreRes);
@@ -3819,7 +3820,7 @@ const StudioContent = () => {
           }
           return;
         }
-        const revRes = await listCanvasLayoutRevisions(parsed.layout.id);
+        const revRes = await listCanvasLayoutRevisions(parsed.layout.id, selectedVersionId, currentUserId);
         const revParsed = JSON.parse(revRes);
         if (!cancelled && revParsed.success) {
           setLayoutHistoryRevisions(revParsed.revisions || []);
@@ -6913,6 +6914,8 @@ const StudioContent = () => {
                           <button
                             type="button"
                             onClick={() => setLayoutHistoryOpen((open) => !open)}
+                            aria-expanded={layoutHistoryOpen}
+                            aria-controls="layout-history-panel"
                             className="flex w-full items-center justify-between gap-2 text-left text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400"
                           >
                             <span className="flex items-center gap-1.5">
@@ -6926,7 +6929,7 @@ const StudioContent = () => {
                             )}
                           </button>
                           {layoutHistoryOpen && (
-                            <div className="mt-2 max-h-40 space-y-1 overflow-y-auto">
+                            <div id="layout-history-panel" className="mt-2 max-h-40 space-y-1 overflow-y-auto">
                               {layoutHistoryLoading && (
                                 <p className="text-xs text-gray-500 dark:text-gray-400">Loading history…</p>
                               )}

--- a/objectified-ui/src/app/ade/studio/editor/page.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/page.tsx
@@ -98,6 +98,8 @@ import {
   getNamedCanvasLayout,
   getNamedCanvasLayoutsForVersion,
   saveNamedCanvasLayout,
+  listCanvasLayoutRevisions,
+  restoreCanvasLayoutFromRevision,
   getGroupsForVersion,
   addClassToGroup,
   updateClassPositionInGroup
@@ -431,6 +433,11 @@ const StudioContent = () => {
   const [exportWizardOpen, setExportWizardOpen] = useState(false);
   const [layoutDropdownOpen, setLayoutDropdownOpen] = useState(false);
   const layoutDropdownRef = useRef<HTMLDivElement>(null);
+  const [layoutHistoryOpen, setLayoutHistoryOpen] = useState(false);
+  const [layoutHistoryRevisions, setLayoutHistoryRevisions] = useState<
+    Array<{ id: string; revision: number; created_at: string }>
+  >([]);
+  const [layoutHistoryLoading, setLayoutHistoryLoading] = useState(false);
 
   // #471: Preview layout suggestions before applying
   const [layoutPreviewNodes, setLayoutPreviewNodes] = useState<Node[] | null>(null);
@@ -3721,6 +3728,124 @@ const StudioContent = () => {
     }
   }, [selectedVersionId, currentUserId, selectedLayoutName, reloadClasses, setNodes, setGroups, setViewport, alertDialog, projectTags, isReadOnly, triggerSidebarRefresh, updateNodeInternals]);
 
+  const handleRestoreLayoutRevision = useCallback(
+    async (revisionId: string) => {
+      if (!selectedVersionId || !currentUserId || isReadOnly) return;
+      const layoutName = selectedLayoutName.trim();
+      if (!layoutName) {
+        await alertDialog({
+          message: 'Please enter a layout name that matches a saved layout.',
+          variant: 'warning',
+        });
+        return;
+      }
+      const ok = await confirmDialog({
+        title: 'Restore layout version',
+        message:
+          'Replace the current canvas with this saved version? Your current layout is stored in history first.',
+      });
+      if (!ok) return;
+      try {
+        setLoadingMessage('Restoring layout...');
+        setIsLoadingCanvas(true);
+        const layoutRes = await getNamedCanvasLayout(selectedVersionId, currentUserId, layoutName);
+        const layoutParsed = JSON.parse(layoutRes);
+        if (!layoutParsed.success || !layoutParsed.layout) {
+          await alertDialog({
+            message: `No saved "${layoutName}" found for this version`,
+            variant: 'warning',
+          });
+          setIsLoadingCanvas(false);
+          setLoadingMessage('');
+          return;
+        }
+        const restoreRes = await restoreCanvasLayoutFromRevision(
+          layoutParsed.layout.id,
+          revisionId,
+          currentUserId
+        );
+        const restoreParsed = JSON.parse(restoreRes);
+        if (!restoreParsed.success) {
+          await alertDialog({
+            message: restoreParsed.error || 'Could not restore this version',
+            variant: 'error',
+          });
+          setIsLoadingCanvas(false);
+          setLoadingMessage('');
+          return;
+        }
+        await handleLoadLayout();
+      } catch (error) {
+        console.error('Error restoring layout revision:', error);
+        await alertDialog({
+          message: 'An error occurred while restoring the layout',
+          variant: 'error',
+        });
+        setIsLoadingCanvas(false);
+        setLoadingMessage('');
+      }
+    },
+    [
+      selectedVersionId,
+      currentUserId,
+      isReadOnly,
+      selectedLayoutName,
+      confirmDialog,
+      alertDialog,
+      handleLoadLayout,
+    ]
+  );
+
+  useEffect(() => {
+    if (!layoutHistoryOpen || !layoutDropdownOpen || !selectedVersionId || !currentUserId) {
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      setLayoutHistoryLoading(true);
+      try {
+        const name = selectedLayoutName.trim();
+        if (!name) {
+          if (!cancelled) {
+            setLayoutHistoryRevisions([]);
+          }
+          return;
+        }
+        const layoutRes = await getNamedCanvasLayout(selectedVersionId, currentUserId, name);
+        const parsed = JSON.parse(layoutRes);
+        if (!parsed.success || !parsed.layout) {
+          if (!cancelled) {
+            setLayoutHistoryRevisions([]);
+          }
+          return;
+        }
+        const revRes = await listCanvasLayoutRevisions(parsed.layout.id);
+        const revParsed = JSON.parse(revRes);
+        if (!cancelled && revParsed.success) {
+          setLayoutHistoryRevisions(revParsed.revisions || []);
+        }
+      } catch (error) {
+        console.error('Error loading layout history:', error);
+        if (!cancelled) {
+          setLayoutHistoryRevisions([]);
+        }
+      } finally {
+        if (!cancelled) {
+          setLayoutHistoryLoading(false);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    layoutHistoryOpen,
+    layoutDropdownOpen,
+    selectedVersionId,
+    currentUserId,
+    selectedLayoutName,
+  ]);
+
   // #471: Preview layout before applying — compute layout and show preview (do not commit)
   const handlePreviewLayout = useCallback((direction: 'TB' | 'LR') => {
     if (nodes.length === 0) return;
@@ -4343,6 +4468,12 @@ const StudioContent = () => {
     return () => {
       document.removeEventListener('mousedown', handleClickOutside);
     };
+  }, [layoutDropdownOpen]);
+
+  useEffect(() => {
+    if (!layoutDropdownOpen) {
+      setLayoutHistoryOpen(false);
+    }
   }, [layoutDropdownOpen]);
 
   // Load versions when project is selected
@@ -6778,6 +6909,57 @@ const StudioContent = () => {
                         <p className="text-xs text-gray-500 dark:text-gray-400 mt-2">
                           Type a custom name or pick a suggestion. Save and load multiple layouts per version.
                         </p>
+                        <div className="mt-3 pt-3 border-t border-gray-200 dark:border-gray-700">
+                          <button
+                            type="button"
+                            onClick={() => setLayoutHistoryOpen((open) => !open)}
+                            className="flex w-full items-center justify-between gap-2 text-left text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400"
+                          >
+                            <span className="flex items-center gap-1.5">
+                              <History className="h-3.5 w-3.5 shrink-0" aria-hidden />
+                              Layout history
+                            </span>
+                            {layoutHistoryOpen ? (
+                              <ChevronUp className="h-4 w-4 shrink-0" aria-hidden />
+                            ) : (
+                              <ChevronDown className="h-4 w-4 shrink-0" aria-hidden />
+                            )}
+                          </button>
+                          {layoutHistoryOpen && (
+                            <div className="mt-2 max-h-40 space-y-1 overflow-y-auto">
+                              {layoutHistoryLoading && (
+                                <p className="text-xs text-gray-500 dark:text-gray-400">Loading history…</p>
+                              )}
+                              {!layoutHistoryLoading && layoutHistoryRevisions.length === 0 && (
+                                <p className="text-xs text-gray-500 dark:text-gray-400">
+                                  No prior versions yet. Each named save stores the previous state (up to 50).
+                                </p>
+                              )}
+                              {!layoutHistoryLoading &&
+                                layoutHistoryRevisions.map((rev) => (
+                                  <div
+                                    key={rev.id}
+                                    className="flex items-center justify-between gap-2 rounded-md py-1 text-xs"
+                                  >
+                                    <span className="min-w-0 truncate text-gray-600 dark:text-gray-300">
+                                      Rev {rev.revision} ·{' '}
+                                      {typeof rev.created_at === 'string'
+                                        ? new Date(rev.created_at).toLocaleString()
+                                        : ''}
+                                    </span>
+                                    <button
+                                      type="button"
+                                      disabled={isReadOnly}
+                                      onClick={() => void handleRestoreLayoutRevision(rev.id)}
+                                      className="shrink-0 rounded border border-indigo-200 px-2 py-0.5 text-indigo-700 transition-colors hover:bg-indigo-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-indigo-700 dark:text-indigo-300 dark:hover:bg-indigo-950/40"
+                                    >
+                                      Restore
+                                    </button>
+                                  </div>
+                                ))}
+                            </div>
+                          )}
+                        </div>
                       </div>
 
                       {/* Divider */}

--- a/objectified-ui/tests/canvas-layout-named.test.ts
+++ b/objectified-ui/tests/canvas-layout-named.test.ts
@@ -113,7 +113,23 @@ describe('Database Helper - Named Canvas Layouts', () => {
 
     mockQuery
       .mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 'layout-1' }] }) // existing lookup
-      .mockResolvedValueOnce({ rowCount: 1, rows: [{ version_id: 'version-1', user_id: 'user-1' }] }) // update lookup
+      .mockResolvedValueOnce({
+        rowCount: 1,
+        rows: [
+          {
+            version_id: 'version-1',
+            user_id: 'user-1',
+            viewport: { x: 0, y: 0, zoom: 1 },
+            nodes: [],
+            edges: [],
+            grid_settings: {},
+            minimap_settings: {}
+          }
+        ]
+      }) // full row for revision snapshot
+      .mockResolvedValueOnce({ rows: [{ n: 0 }] }) // max revision
+      .mockResolvedValueOnce({ rowCount: 1 }) // insert revision
+      .mockResolvedValueOnce({ rowCount: 0 }) // prune old revisions
       .mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 'layout-1', name: 'Dependency Layout' }] }); // update return
 
     const result = await saveNamedCanvasLayout(
@@ -206,7 +222,23 @@ describe('Database Helper - Named Canvas Layouts', () => {
 
     mockQuery
       .mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 'layout-shared-1' }] }) // existing lookup
-      .mockResolvedValueOnce({ rowCount: 1, rows: [{ version_id: 'version-1', user_id: null }] }) // update lookup
+      .mockResolvedValueOnce({
+        rowCount: 1,
+        rows: [
+          {
+            version_id: 'version-1',
+            user_id: null,
+            viewport: { x: 0, y: 0, zoom: 1 },
+            nodes: [],
+            edges: [],
+            grid_settings: {},
+            minimap_settings: {}
+          }
+        ]
+      }) // full row for revision snapshot
+      .mockResolvedValueOnce({ rows: [{ n: 2 }] }) // max revision
+      .mockResolvedValueOnce({ rowCount: 1 }) // insert revision
+      .mockResolvedValueOnce({ rowCount: 0 }) // prune
       .mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 'layout-shared-1', name: 'Shared Layout' }] }); // update return
 
     const result = await saveNamedCanvasLayout(

--- a/objectified-ui/tests/canvas-layout-revisions.test.ts
+++ b/objectified-ui/tests/canvas-layout-revisions.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, jest, test } from '@jest/globals';
+
+jest.mock('../lib/db/db', () => ({
+  query: jest.fn(),
+}));
+
+jest.mock('bcrypt', () => ({
+  compare: jest.fn(),
+  hash: jest.fn(),
+}));
+
+jest.mock('crypto', () => ({
+  randomBytes: jest.fn(() => Buffer.from('test-api-key-data')),
+}));
+
+describe('Database Helper - Canvas layout revisions', () => {
+  let mockQuery: jest.Mock<any>;
+
+  beforeEach(() => {
+    const db = require('../lib/db/db');
+    mockQuery = db.query as jest.Mock;
+    mockQuery.mockReset();
+  });
+
+  test('listCanvasLayoutRevisions returns revisions ordered newest first', async () => {
+    const { listCanvasLayoutRevisions } = await import('../lib/db/helper');
+
+    mockQuery.mockResolvedValue({
+      rows: [
+        { id: 'r2', canvas_layout_id: 'layout-1', revision: 2, created_at: '2026-01-01T00:00:00Z', created_by: 'u1' },
+        { id: 'r1', canvas_layout_id: 'layout-1', revision: 1, created_at: '2025-12-01T00:00:00Z', created_by: 'u1' },
+      ],
+    });
+
+    const result = await listCanvasLayoutRevisions('layout-1', 50);
+    const parsed = JSON.parse(result);
+
+    expect(parsed.success).toBe(true);
+    expect(parsed.revisions).toHaveLength(2);
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining('ORDER BY revision DESC'),
+      ['layout-1', 50]
+    );
+  });
+
+  test('restoreCanvasLayoutFromRevision applies snapshot and records prior state', async () => {
+    const { restoreCanvasLayoutFromRevision } = await import('../lib/db/helper');
+
+    const priorSnapshot = {
+      viewport: { x: 0, y: 0, zoom: 1 },
+      nodes: [{ id: 'n1' }],
+      edges: [],
+      grid_settings: {},
+      minimap_settings: {},
+    };
+
+    mockQuery
+      .mockResolvedValueOnce({
+        rowCount: 1,
+        rows: [priorSnapshot],
+      }) // revision row
+      .mockResolvedValueOnce({
+        rowCount: 1,
+        rows: [
+          {
+            version_id: 'version-1',
+            user_id: 'user-1',
+            viewport: { x: 10, y: 10, zoom: 0.5 },
+            nodes: [{ id: 'n2' }],
+            edges: [],
+            grid_settings: {},
+            minimap_settings: {},
+          },
+        ],
+      }) // SELECT * before update
+      .mockResolvedValueOnce({ rows: [{ n: 3 }] })
+      .mockResolvedValueOnce({ rowCount: 1 })
+      .mockResolvedValueOnce({ rowCount: 0 })
+      .mockResolvedValueOnce({
+        rowCount: 1,
+        rows: [{ id: 'layout-1', viewport: priorSnapshot.viewport, nodes: priorSnapshot.nodes }],
+      });
+
+    const result = await restoreCanvasLayoutFromRevision('layout-1', 'rev-uuid', 'user-1');
+    const parsed = JSON.parse(result);
+
+    expect(parsed.success).toBe(true);
+    expect(mockQuery).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining('FROM odb.canvas_layout_revisions r'),
+      ['rev-uuid', 'layout-1']
+    );
+  });
+});


### PR DESCRIPTION
## Problem Statement

Users and teams need **addresses #165 — canvas layout revision history and restore** within the Objectified platform. Today this capability is missing or only partially implemented, which blocks platform workflows and creates inconsistency across tenants and projects.

## Solution / Scope

Implement **Addresses #165 — Canvas layout revision history and restore** as part of **Platform**.

**Post-MVP** (prioritize after MVP slice) candidacy.

```mermaid
flowchart LR
  User[User action: Addresses #165 — Canvas layout revision ] --> UI[objectified-ui]
  UI --> API[objectified-rest]
  API --> DB[(PostgreSQL)]
```

## Acceptance Criteria

- [ ] Feature behaves as described for: Addresses #165 — Canvas layout revision history and restore
- [ ] Unit/integration tests cover happy path and primary error cases
- [ ] UI (if applicable) matches existing ADE patterns (Tailwind 4, Radix, Lucide)
- [ ] REST endpoints (if applicable) follow `/v1/{{feature}}/{{tenant_slug}}/...` conventions
- [ ] Documented in issue/PR; no regressions to existing schema/version flows

## Parallelism / Dependencies

- **Can run in parallel:** Yes
- **Blockers:** None identified; validate against current codebase before starting

## Technical Stack

- **Modules:** objectified-ui, objectified-rest
- **Stack:** Next.js 16, React 19, FastAPI, PostgreSQL
- **Labels:** ``

---
**Issue:** #838 · **Area:** Platform · **Roadmap batch:** legacy #64–#879 enrichment