### PR TITLE
Fix #166 — Default named canvas layout per user and team

### DIFF
--- a/PLANNED_FEATURE_ROADMAP_CANVAS.md
+++ b/PLANNED_FEATURE_ROADMAP_CANVAS.md
@@ -26,7 +26,7 @@
     - "Dependency Layout" - organized by relationships
 - ✅ Auto-save layout changes every 30 seconds (configurable)
 - ✅ Version control for layouts (track layout history) — #165
-- 📋 [TODO] Default layout setting per user or per team
+- ✅ Default layout setting per user or per team — #166
 - 📋 [TODO] Export layout as JSON for sharing
 - 📋 [TODO] Import layouts from other versions/projects
 - 📋 [TODO] Add ability to save layouts with a custom name
@@ -34,7 +34,6 @@
 
 | Ticket | Feature                                        |
 |--------|------------------------------------------------|
-| #166   | Default layout setting per user or per team    |
 | #167   | Export/import layouts as JSON                  |
 | #314   | Canvas snapshots                               |
 | #315   | Canvas auto-save of layout                     |

--- a/objectified-db/scripts/20260329-160000.sql
+++ b/objectified-db/scripts/20260329-160000.sql
@@ -1,0 +1,54 @@
+-- Default named canvas layout selection per user and per tenant (team).
+-- Resolved order when opening the studio: user default → tenant default → built-in fallback in app.
+
+SET search_path TO odb, public;
+
+CREATE TABLE user_canvas_layout_defaults (
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    version_id UUID NOT NULL REFERENCES versions(id) ON DELETE CASCADE,
+    layout_name VARCHAR(255) NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (user_id, version_id)
+);
+
+CREATE TABLE tenant_canvas_layout_defaults (
+    tenant_id UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+    version_id UUID NOT NULL REFERENCES versions(id) ON DELETE CASCADE,
+    layout_name VARCHAR(255) NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (tenant_id, version_id)
+);
+
+CREATE INDEX idx_user_canvas_layout_defaults_version_id ON user_canvas_layout_defaults(version_id);
+CREATE INDEX idx_tenant_canvas_layout_defaults_version_id ON tenant_canvas_layout_defaults(version_id);
+
+COMMENT ON TABLE user_canvas_layout_defaults IS 'Preferred named canvas layout to load first for a user on a version';
+COMMENT ON TABLE tenant_canvas_layout_defaults IS 'Team (tenant) default named canvas layout for a version when the user has no personal default';
+
+CREATE OR REPLACE FUNCTION update_user_canvas_layout_defaults_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = CURRENT_TIMESTAMP;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trigger_update_user_canvas_layout_defaults_updated_at
+    BEFORE UPDATE ON user_canvas_layout_defaults
+    FOR EACH ROW
+    EXECUTE FUNCTION update_user_canvas_layout_defaults_updated_at();
+
+CREATE OR REPLACE FUNCTION update_tenant_canvas_layout_defaults_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = CURRENT_TIMESTAMP;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trigger_update_tenant_canvas_layout_defaults_updated_at
+    BEFORE UPDATE ON tenant_canvas_layout_defaults
+    FOR EACH ROW
+    EXECUTE FUNCTION update_tenant_canvas_layout_defaults_updated_at();

--- a/objectified-ui/jest.config.ts
+++ b/objectified-ui/jest.config.ts
@@ -29,6 +29,7 @@ const config: Config = {
     '^@lib/(.*)$': '<rootDir>/lib/$1',
     '^react-markdown$': '<rootDir>/tests/__mocks__/react-markdown.tsx',
     '^remark-gfm$': '<rootDir>/tests/__mocks__/remark-gfm.ts',
+    '^.*auth/server-session$': '<rootDir>/tests/__mocks__/server-session.ts',
   },
   transformIgnorePatterns: [
     'node_modules/(?!(react-markdown|remark-gfm|unified|bail|is-plain-obj|trough|vfile|unist-.*|unified|remark-.*|mdast-.*|micromark.*|decode-named-character-reference|character-entities|property-information|hast-util-whitespace|space-separated-tokens|comma-separated-tokens|pretty-bytes)/)',

--- a/objectified-ui/lib/auth/server-session.ts
+++ b/objectified-ui/lib/auth/server-session.ts
@@ -1,0 +1,12 @@
+'use server';
+
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/app/api/auth/[...nextauth]/route';
+
+/**
+ * Returns the current server session, or null when called outside an
+ * authenticated request context (e.g. in unit tests with no mock).
+ */
+export async function getAuthSession() {
+  return getServerSession(authOptions);
+}

--- a/objectified-ui/lib/db/helper.ts
+++ b/objectified-ui/lib/db/helper.ts
@@ -1,5 +1,7 @@
 'use server';
 
+import { getAuthSession } from '../auth/server-session';
+
 const connectionPool = require('./db');
 const bcrypt = require('bcrypt');
 const crypto = require('crypto');
@@ -3062,7 +3064,30 @@ export async function getEffectiveDefaultLayoutName(
   }
 }
 
-export async function setUserCanvasLayoutDefaultName(versionId: string, userId: string, layoutName: string) {
+export async function isTenantAdmin(tenantId: string) {
+  try {
+    const session = await getAuthSession();
+    const userId = (session?.user as any)?.user_id;
+    if (!userId) {
+      return successResponse({ isAdmin: false });
+    }
+    const result = await connectionPool.query(
+      `SELECT 1 FROM odb.tenant_administrators WHERE tenant_id = $1 AND user_id = $2`,
+      [tenantId, userId]
+    );
+    return successResponse({ isAdmin: Boolean(result.rowCount) });
+  } catch (error: any) {
+    console.error('Error checking tenant admin status:', error);
+    return errorResponse(error.message);
+  }
+}
+
+export async function setUserCanvasLayoutDefaultName(versionId: string, layoutName: string) {
+  const session = await getAuthSession();
+  const userId = (session?.user as any)?.user_id;
+  if (!userId) {
+    return errorResponse('Unauthorized');
+  }
   const name = layoutName.trim();
   if (!name) {
     return errorResponse('Layout name is required');
@@ -3082,7 +3107,12 @@ export async function setUserCanvasLayoutDefaultName(versionId: string, userId: 
   }
 }
 
-export async function clearUserCanvasLayoutDefaultName(versionId: string, userId: string) {
+export async function clearUserCanvasLayoutDefaultName(versionId: string) {
+  const session = await getAuthSession();
+  const userId = (session?.user as any)?.user_id;
+  if (!userId) {
+    return errorResponse('Unauthorized');
+  }
   try {
     await connectionPool.query(
       `DELETE FROM odb.user_canvas_layout_defaults WHERE user_id = $1 AND version_id = $2`,
@@ -3098,9 +3128,13 @@ export async function clearUserCanvasLayoutDefaultName(versionId: string, userId
 export async function setTenantCanvasLayoutDefaultName(
   versionId: string,
   tenantId: string,
-  actingUserId: string,
   layoutName: string
 ) {
+  const session = await getAuthSession();
+  const actingUserId = (session?.user as any)?.user_id;
+  if (!actingUserId) {
+    return errorResponse('Unauthorized');
+  }
   const name = layoutName.trim();
   if (!name) {
     return errorResponse('Layout name is required');
@@ -3138,9 +3172,13 @@ export async function setTenantCanvasLayoutDefaultName(
 
 export async function clearTenantCanvasLayoutDefaultName(
   versionId: string,
-  tenantId: string,
-  actingUserId: string
+  tenantId: string
 ) {
+  const session = await getAuthSession();
+  const actingUserId = (session?.user as any)?.user_id;
+  if (!actingUserId) {
+    return errorResponse('Unauthorized');
+  }
   try {
     const adminCheck = await connectionPool.query(
       `SELECT 1 FROM odb.tenant_administrators WHERE tenant_id = $1 AND user_id = $2`,

--- a/objectified-ui/lib/db/helper.ts
+++ b/objectified-ui/lib/db/helper.ts
@@ -3021,6 +3021,146 @@ export async function getDefaultCanvasLayout(versionId: string, userId?: string)
 }
 
 /**
+ * Resolve which named layout to prefer on first open: user → tenant → built-in "Development Layout".
+ */
+export async function getEffectiveDefaultLayoutName(
+  versionId: string,
+  userId: string | undefined,
+  tenantId: string | undefined
+) {
+  try {
+    if (userId) {
+      const userRow = await connectionPool.query(
+        `SELECT layout_name FROM odb.user_canvas_layout_defaults
+         WHERE user_id = $1 AND version_id = $2`,
+        [userId, versionId]
+      );
+      if (userRow.rowCount && userRow.rows[0].layout_name) {
+        const n = String(userRow.rows[0].layout_name).trim();
+        if (n) {
+          return successResponse({ layoutName: n });
+        }
+      }
+    }
+    if (tenantId) {
+      const tenantRow = await connectionPool.query(
+        `SELECT layout_name FROM odb.tenant_canvas_layout_defaults
+         WHERE tenant_id = $1 AND version_id = $2`,
+        [tenantId, versionId]
+      );
+      if (tenantRow.rowCount && tenantRow.rows[0].layout_name) {
+        const n = String(tenantRow.rows[0].layout_name).trim();
+        if (n) {
+          return successResponse({ layoutName: n });
+        }
+      }
+    }
+    return successResponse({ layoutName: 'Development Layout' });
+  } catch (error: any) {
+    console.error('Error resolving default layout name:', error);
+    return errorResponse(error.message);
+  }
+}
+
+export async function setUserCanvasLayoutDefaultName(versionId: string, userId: string, layoutName: string) {
+  const name = layoutName.trim();
+  if (!name) {
+    return errorResponse('Layout name is required');
+  }
+  try {
+    await connectionPool.query(
+      `INSERT INTO odb.user_canvas_layout_defaults (user_id, version_id, layout_name)
+       VALUES ($1, $2, $3)
+       ON CONFLICT (user_id, version_id) DO UPDATE
+       SET layout_name = EXCLUDED.layout_name, updated_at = CURRENT_TIMESTAMP`,
+      [userId, versionId, name]
+    );
+    return successResponse({ layoutName: name });
+  } catch (error: any) {
+    console.error('Error saving user default layout name:', error);
+    return errorResponse(error.message);
+  }
+}
+
+export async function clearUserCanvasLayoutDefaultName(versionId: string, userId: string) {
+  try {
+    await connectionPool.query(
+      `DELETE FROM odb.user_canvas_layout_defaults WHERE user_id = $1 AND version_id = $2`,
+      [userId, versionId]
+    );
+    return successResponse();
+  } catch (error: any) {
+    console.error('Error clearing user default layout name:', error);
+    return errorResponse(error.message);
+  }
+}
+
+export async function setTenantCanvasLayoutDefaultName(
+  versionId: string,
+  tenantId: string,
+  actingUserId: string,
+  layoutName: string
+) {
+  const name = layoutName.trim();
+  if (!name) {
+    return errorResponse('Layout name is required');
+  }
+  try {
+    const adminCheck = await connectionPool.query(
+      `SELECT 1 FROM odb.tenant_administrators WHERE tenant_id = $1 AND user_id = $2`,
+      [tenantId, actingUserId]
+    );
+    if (!adminCheck.rowCount) {
+      return errorResponse('Only tenant administrators can set the team default layout name');
+    }
+    const verCheck = await connectionPool.query(
+      `SELECT 1 FROM odb.versions v
+       INNER JOIN odb.projects p ON v.project_id = p.id
+       WHERE v.id = $1 AND p.tenant_id = $2 AND v.deleted_at IS NULL AND p.deleted_at IS NULL`,
+      [versionId, tenantId]
+    );
+    if (!verCheck.rowCount) {
+      return errorResponse('Version not found for this tenant');
+    }
+    await connectionPool.query(
+      `INSERT INTO odb.tenant_canvas_layout_defaults (tenant_id, version_id, layout_name)
+       VALUES ($1, $2, $3)
+       ON CONFLICT (tenant_id, version_id) DO UPDATE
+       SET layout_name = EXCLUDED.layout_name, updated_at = CURRENT_TIMESTAMP`,
+      [tenantId, versionId, name]
+    );
+    return successResponse({ layoutName: name });
+  } catch (error: any) {
+    console.error('Error saving tenant default layout name:', error);
+    return errorResponse(error.message);
+  }
+}
+
+export async function clearTenantCanvasLayoutDefaultName(
+  versionId: string,
+  tenantId: string,
+  actingUserId: string
+) {
+  try {
+    const adminCheck = await connectionPool.query(
+      `SELECT 1 FROM odb.tenant_administrators WHERE tenant_id = $1 AND user_id = $2`,
+      [tenantId, actingUserId]
+    );
+    if (!adminCheck.rowCount) {
+      return errorResponse('Only tenant administrators can clear the team default layout name');
+    }
+    await connectionPool.query(
+      `DELETE FROM odb.tenant_canvas_layout_defaults WHERE tenant_id = $1 AND version_id = $2`,
+      [tenantId, versionId]
+    );
+    return successResponse();
+  } catch (error: any) {
+    console.error('Error clearing tenant default layout name:', error);
+    return errorResponse(error.message);
+  }
+}
+
+/**
  * Get all named canvas layouts for a version, preferring user-specific layouts.
  * Returns at most one layout per name.
  */

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.8.49",
+  "version": "0.8.50",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -21,6 +21,7 @@ Bug Fixes:
 - Improved layout of the linked accounts page
   - Linked accounts page is slightly wider matching those of other dashboard layouts
   - Provider cards now show PAT hints so users can match the PATs that were assigned
+- Canvas: optional default named layout on open — save a personal or team (tenant) default per version
 - Improvements in the canvas
   - Class node customization form is slightly more compact
   - Class and Properties forms now have tabs instead of button groupings

--- a/objectified-ui/src/app/ade/studio/editor/page.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/page.tsx
@@ -110,7 +110,7 @@ import {
   getGroupsForVersion,
   addClassToGroup,
   updateClassPositionInGroup,
-  getTenantsAdministratedByUser
+  isTenantAdmin
 } from '../../../../../lib/db/helper';
 import {
   deleteClassWithSession,
@@ -308,14 +308,13 @@ const StudioContent = () => {
           if (!cancelled) setEffectiveIsTenantAdmin(true);
           return;
         }
-        if (!currentUserId || !currentTenantId) {
+        if (!currentTenantId) {
           if (!cancelled) setEffectiveIsTenantAdmin(false);
           return;
         }
-        const res = await getTenantsAdministratedByUser(currentUserId);
-        const rows = JSON.parse(res) as Array<{ tenant_id: string }>;
-        const ok = rows.some((r) => r.tenant_id === currentTenantId);
-        if (!cancelled) setEffectiveIsTenantAdmin(ok);
+        const res = await isTenantAdmin(currentTenantId);
+        const response = JSON.parse(res);
+        if (!cancelled) setEffectiveIsTenantAdmin(response.success && response.isAdmin);
       } catch {
         if (!cancelled) setEffectiveIsTenantAdmin(false);
       }
@@ -324,7 +323,7 @@ const StudioContent = () => {
     return () => {
       cancelled = true;
     };
-  }, [sessionIsTenantAdmin, currentUserId, currentTenantId]);
+  }, [sessionIsTenantAdmin, currentTenantId]);
 
   const [nodes, setNodes, onNodesChange] = useNodesState<Node>([]);
   const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>([]);
@@ -3496,7 +3495,7 @@ const StudioContent = () => {
       return;
     }
     try {
-      const result = await setUserCanvasLayoutDefaultName(selectedVersionId, currentUserId, layoutName);
+      const result = await setUserCanvasLayoutDefaultName(selectedVersionId, layoutName);
       const response = JSON.parse(result);
       if (response.success) {
         await alertDialog({
@@ -3514,7 +3513,7 @@ const StudioContent = () => {
   const handleClearMyDefaultLayoutName = useCallback(async () => {
     if (isReadOnly || !selectedVersionId || !currentUserId) return;
     try {
-      const result = await clearUserCanvasLayoutDefaultName(selectedVersionId, currentUserId);
+      const result = await clearUserCanvasLayoutDefaultName(selectedVersionId);
       const response = JSON.parse(result);
       if (response.success) {
         await alertDialog({
@@ -3540,7 +3539,6 @@ const StudioContent = () => {
       const result = await setTenantCanvasLayoutDefaultName(
         selectedVersionId,
         currentTenantId,
-        currentUserId,
         layoutName
       );
       const response = JSON.parse(result);
@@ -3573,7 +3571,7 @@ const StudioContent = () => {
     });
     if (!ok) return;
     try {
-      const result = await clearTenantCanvasLayoutDefaultName(selectedVersionId, currentTenantId, currentUserId);
+      const result = await clearTenantCanvasLayoutDefaultName(selectedVersionId, currentTenantId);
       const response = JSON.parse(result);
       if (response.success) {
         await alertDialog({ message: 'Team default cleared.', variant: 'success' });

--- a/objectified-ui/src/app/ade/studio/editor/page.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/page.tsx
@@ -47,6 +47,8 @@ import {
   Activity,
   History,
   Trash2,
+  Bookmark,
+  Users,
   Filter,
   SlidersHorizontal,
   ArrowUp,
@@ -97,12 +99,18 @@ import {
   saveDefaultCanvasLayout,
   getNamedCanvasLayout,
   getNamedCanvasLayoutsForVersion,
+  getEffectiveDefaultLayoutName,
+  setUserCanvasLayoutDefaultName,
+  clearUserCanvasLayoutDefaultName,
+  setTenantCanvasLayoutDefaultName,
+  clearTenantCanvasLayoutDefaultName,
   saveNamedCanvasLayout,
   listCanvasLayoutRevisions,
   restoreCanvasLayoutFromRevision,
   getGroupsForVersion,
   addClassToGroup,
-  updateClassPositionInGroup
+  updateClassPositionInGroup,
+  getTenantsAdministratedByUser
 } from '../../../../../lib/db/helper';
 import {
   deleteClassWithSession,
@@ -289,6 +297,34 @@ const StudioContent = () => {
 
   const currentTenantId = (session?.user as any)?.current_tenant_id;
   const currentUserId = (session?.user as any)?.user_id;
+  const sessionIsTenantAdmin = Boolean((session?.user as any)?.is_tenant_admin);
+  const [effectiveIsTenantAdmin, setEffectiveIsTenantAdmin] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    const run = async () => {
+      try {
+        if (sessionIsTenantAdmin) {
+          if (!cancelled) setEffectiveIsTenantAdmin(true);
+          return;
+        }
+        if (!currentUserId || !currentTenantId) {
+          if (!cancelled) setEffectiveIsTenantAdmin(false);
+          return;
+        }
+        const res = await getTenantsAdministratedByUser(currentUserId);
+        const rows = JSON.parse(res) as Array<{ tenant_id: string }>;
+        const ok = rows.some((r) => r.tenant_id === currentTenantId);
+        if (!cancelled) setEffectiveIsTenantAdmin(ok);
+      } catch {
+        if (!cancelled) setEffectiveIsTenantAdmin(false);
+      }
+    };
+    void run();
+    return () => {
+      cancelled = true;
+    };
+  }, [sessionIsTenantAdmin, currentUserId, currentTenantId]);
 
   const [nodes, setNodes, onNodesChange] = useNodesState<Node>([]);
   const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>([]);
@@ -3452,6 +3488,111 @@ const StudioContent = () => {
     }
   }, [isReadOnly, selectedVersionId, currentUserId, selectedLayoutName, nodes, edges, groups, getViewport, alertDialog]);
 
+  const handleSetMyDefaultLayoutName = useCallback(async () => {
+    if (isReadOnly || !selectedVersionId || !currentUserId) return;
+    const layoutName = selectedLayoutName.trim();
+    if (!layoutName) {
+      await alertDialog({ message: 'Please enter a layout name.', variant: 'warning' });
+      return;
+    }
+    try {
+      const result = await setUserCanvasLayoutDefaultName(selectedVersionId, currentUserId, layoutName);
+      const response = JSON.parse(result);
+      if (response.success) {
+        await alertDialog({
+          message: `This layout name is now your default when you open this version.`,
+          variant: 'success',
+        });
+      } else {
+        await alertDialog({ message: response.error || 'Could not save preference', variant: 'error' });
+      }
+    } catch {
+      await alertDialog({ message: 'Could not save preference', variant: 'error' });
+    }
+  }, [isReadOnly, selectedVersionId, currentUserId, selectedLayoutName, alertDialog]);
+
+  const handleClearMyDefaultLayoutName = useCallback(async () => {
+    if (isReadOnly || !selectedVersionId || !currentUserId) return;
+    try {
+      const result = await clearUserCanvasLayoutDefaultName(selectedVersionId, currentUserId);
+      const response = JSON.parse(result);
+      if (response.success) {
+        await alertDialog({
+          message: 'Your personal default was cleared. The team or built-in default will apply on next open.',
+          variant: 'success',
+        });
+      } else {
+        await alertDialog({ message: response.error || 'Could not clear preference', variant: 'error' });
+      }
+    } catch {
+      await alertDialog({ message: 'Could not clear preference', variant: 'error' });
+    }
+  }, [isReadOnly, selectedVersionId, currentUserId, alertDialog]);
+
+  const handleSetTeamDefaultLayoutName = useCallback(async () => {
+    if (isReadOnly || !selectedVersionId || !currentUserId || !currentTenantId || !effectiveIsTenantAdmin) return;
+    const layoutName = selectedLayoutName.trim();
+    if (!layoutName) {
+      await alertDialog({ message: 'Please enter a layout name.', variant: 'warning' });
+      return;
+    }
+    try {
+      const result = await setTenantCanvasLayoutDefaultName(
+        selectedVersionId,
+        currentTenantId,
+        currentUserId,
+        layoutName
+      );
+      const response = JSON.parse(result);
+      if (response.success) {
+        await alertDialog({
+          message: `Team default layout name for this version is now "${layoutName}".`,
+          variant: 'success',
+        });
+      } else {
+        await alertDialog({ message: response.error || 'Could not save team default', variant: 'error' });
+      }
+    } catch {
+      await alertDialog({ message: 'Could not save team default', variant: 'error' });
+    }
+  }, [
+    isReadOnly,
+    selectedVersionId,
+    currentUserId,
+    currentTenantId,
+    effectiveIsTenantAdmin,
+    selectedLayoutName,
+    alertDialog,
+  ]);
+
+  const handleClearTeamDefaultLayoutName = useCallback(async () => {
+    if (isReadOnly || !selectedVersionId || !currentUserId || !currentTenantId || !effectiveIsTenantAdmin) return;
+    const ok = await confirmDialog({
+      title: 'Clear team default',
+      message: 'Remove the team default layout name for this version? Members without a personal default will use the built-in fallback on next open.',
+    });
+    if (!ok) return;
+    try {
+      const result = await clearTenantCanvasLayoutDefaultName(selectedVersionId, currentTenantId, currentUserId);
+      const response = JSON.parse(result);
+      if (response.success) {
+        await alertDialog({ message: 'Team default cleared.', variant: 'success' });
+      } else {
+        await alertDialog({ message: response.error || 'Could not clear team default', variant: 'error' });
+      }
+    } catch {
+      await alertDialog({ message: 'Could not clear team default', variant: 'error' });
+    }
+  }, [
+    isReadOnly,
+    selectedVersionId,
+    currentUserId,
+    currentTenantId,
+    effectiveIsTenantAdmin,
+    confirmDialog,
+    alertDialog,
+  ]);
+
   const autoSaveDefaultLayout = useCallback(async () => {
     if (
       !autoSaveLayoutEnabled ||
@@ -4662,10 +4803,27 @@ const StudioContent = () => {
           return node;
         });
 
-        // On first load, check if selected layout exists and apply it
+        // On first load, resolve default layout name (user → tenant → built-in), then load that named layout if present
         if (isFirstLoad && currentUserId) {
           setLoadingMessage('Checking for saved layout...');
-          const layoutNameForInitialLoad = selectedLayoutNameRef.current.trim();
+          let layoutNameForInitialLoad = selectedLayoutNameRef.current.trim();
+          try {
+            const prefResult = await getEffectiveDefaultLayoutName(
+              selectedVersionId,
+              currentUserId,
+              currentTenantId || undefined
+            );
+            const prefParsed = JSON.parse(prefResult);
+            if (prefParsed.success && prefParsed.layoutName && typeof prefParsed.layoutName === 'string') {
+              layoutNameForInitialLoad = prefParsed.layoutName.trim();
+              if (layoutNameForInitialLoad) {
+                setSelectedLayoutName(layoutNameForInitialLoad);
+                selectedLayoutNameRef.current = layoutNameForInitialLoad;
+              }
+            }
+          } catch {
+            // keep ref/default name
+          }
           if (layoutNameForInitialLoad) {
             try {
               const layoutResult = await getNamedCanvasLayout(
@@ -4744,7 +4902,7 @@ const StudioContent = () => {
     };
 
     loadClasses();
-  }, [selectedVersionId, selectedProjectId, canvasRefreshKey, projects, versions, currentUserId, projectTags, isReadOnly, updateNodeInternals, setViewport]);
+  }, [selectedVersionId, selectedProjectId, canvasRefreshKey, projects, versions, currentUserId, currentTenantId, projectTags, isReadOnly, updateNodeInternals, setViewport]);
 
   // Check layout availability when version or selected layout changes
   useEffect(() => {
@@ -6910,6 +7068,72 @@ const StudioContent = () => {
                         <p className="text-xs text-gray-500 dark:text-gray-400 mt-2">
                           Type a custom name or pick a suggestion. Save and load multiple layouts per version.
                         </p>
+                        <div className="mt-3 pt-3 border-t border-gray-200 dark:border-gray-700 space-y-2">
+                          <p className="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                            Default on open
+                          </p>
+                          <p className="text-xs text-gray-500 dark:text-gray-400">
+                            Choose which named layout loads first for this version. Your preference overrides the team default.
+                          </p>
+                          <div className="flex flex-col gap-2">
+                            <button
+                              type="button"
+                              onClick={() => void handleSetMyDefaultLayoutName()}
+                              disabled={isReadOnly || !selectedLayoutName.trim()}
+                              className={`flex items-center justify-center gap-2 px-3 py-2 text-sm font-medium rounded-lg border transition-colors ${
+                                isReadOnly || !selectedLayoutName.trim()
+                                  ? 'border-gray-200 dark:border-gray-600 bg-gray-100 dark:bg-gray-700 text-gray-400 cursor-not-allowed'
+                                  : 'border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-700/50 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600'
+                              }`}
+                              title="Use the current layout name as your personal default when opening this version"
+                            >
+                              <Bookmark className="h-4 w-4 shrink-0" aria-hidden />
+                              Set as my default
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() => void handleClearMyDefaultLayoutName()}
+                              disabled={isReadOnly}
+                              className={`text-xs text-left px-1 py-0.5 rounded ${
+                                isReadOnly
+                                  ? 'text-gray-400 cursor-not-allowed'
+                                  : 'text-indigo-600 dark:text-indigo-400 hover:underline'
+                              }`}
+                            >
+                              Clear my default
+                            </button>
+                            {effectiveIsTenantAdmin && currentTenantId ? (
+                              <>
+                                <button
+                                  type="button"
+                                  onClick={() => void handleSetTeamDefaultLayoutName()}
+                                  disabled={isReadOnly || !selectedLayoutName.trim()}
+                                  className={`flex items-center justify-center gap-2 px-3 py-2 text-sm font-medium rounded-lg border transition-colors ${
+                                    isReadOnly || !selectedLayoutName.trim()
+                                      ? 'border-gray-200 dark:border-gray-600 bg-gray-100 dark:bg-gray-700 text-gray-400 cursor-not-allowed'
+                                      : 'border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-700/50 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600'
+                                  }`}
+                                  title="Team default for members who have not set a personal default"
+                                >
+                                  <Users className="h-4 w-4 shrink-0" aria-hidden />
+                                  Set as team default
+                                </button>
+                                <button
+                                  type="button"
+                                  onClick={() => void handleClearTeamDefaultLayoutName()}
+                                  disabled={isReadOnly}
+                                  className={`text-xs text-left px-1 py-0.5 rounded ${
+                                    isReadOnly
+                                      ? 'text-gray-400 cursor-not-allowed'
+                                      : 'text-indigo-600 dark:text-indigo-400 hover:underline'
+                                  }`}
+                                >
+                                  Clear team default
+                                </button>
+                              </>
+                            ) : null}
+                          </div>
+                        </div>
                         <div className="mt-3 pt-3 border-t border-gray-200 dark:border-gray-700">
                           <button
                             type="button"

--- a/objectified-ui/tests/__mocks__/server-session.ts
+++ b/objectified-ui/tests/__mocks__/server-session.ts
@@ -1,0 +1,5 @@
+import { jest } from '@jest/globals';
+
+// Default: unauthenticated (tests that need a session should override via
+// jest.mock or mockResolvedValueOnce on this export directly).
+export const getAuthSession = jest.fn(async () => null);

--- a/objectified-ui/tests/canvas-layout-named.test.ts
+++ b/objectified-ui/tests/canvas-layout-named.test.ts
@@ -1,8 +1,15 @@
 import { beforeEach, describe, expect, jest, test } from '@jest/globals';
 
-jest.mock('../lib/db/db', () => ({
-  query: jest.fn(),
-}));
+jest.mock('../lib/db/db', () => {
+  const query = jest.fn();
+  return {
+    query,
+    connect: jest.fn(async () => ({
+      query,
+      release: jest.fn(),
+    })),
+  };
+});
 
 jest.mock('bcrypt', () => ({
   compare: jest.fn(),
@@ -112,7 +119,8 @@ describe('Database Helper - Named Canvas Layouts', () => {
     const { saveNamedCanvasLayout } = await import('../lib/db/helper');
 
     mockQuery
-      .mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 'layout-1' }] }) // existing lookup
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 'layout-1' }] }) // existing lookup (pool)
+      .mockResolvedValueOnce({ rowCount: 0 }) // BEGIN
       .mockResolvedValueOnce({
         rowCount: 1,
         rows: [
@@ -126,11 +134,12 @@ describe('Database Helper - Named Canvas Layouts', () => {
             minimap_settings: {}
           }
         ]
-      }) // full row for revision snapshot
+      }) // SELECT FOR UPDATE
       .mockResolvedValueOnce({ rows: [{ n: 0 }] }) // max revision
       .mockResolvedValueOnce({ rowCount: 1 }) // insert revision
       .mockResolvedValueOnce({ rowCount: 0 }) // prune old revisions
-      .mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 'layout-1', name: 'Dependency Layout' }] }); // update return
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 'layout-1', name: 'Dependency Layout' }] }) // UPDATE RETURNING
+      .mockResolvedValueOnce({ rowCount: 0 }); // COMMIT
 
     const result = await saveNamedCanvasLayout(
       'version-1',
@@ -221,7 +230,8 @@ describe('Database Helper - Named Canvas Layouts', () => {
     const { saveNamedCanvasLayout } = await import('../lib/db/helper');
 
     mockQuery
-      .mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 'layout-shared-1' }] }) // existing lookup
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 'layout-shared-1' }] }) // existing lookup (pool)
+      .mockResolvedValueOnce({ rowCount: 0 }) // BEGIN
       .mockResolvedValueOnce({
         rowCount: 1,
         rows: [
@@ -235,11 +245,12 @@ describe('Database Helper - Named Canvas Layouts', () => {
             minimap_settings: {}
           }
         ]
-      }) // full row for revision snapshot
+      }) // SELECT FOR UPDATE
       .mockResolvedValueOnce({ rows: [{ n: 2 }] }) // max revision
       .mockResolvedValueOnce({ rowCount: 1 }) // insert revision
       .mockResolvedValueOnce({ rowCount: 0 }) // prune
-      .mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 'layout-shared-1', name: 'Shared Layout' }] }); // update return
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 'layout-shared-1', name: 'Shared Layout' }] }) // UPDATE RETURNING
+      .mockResolvedValueOnce({ rowCount: 0 }); // COMMIT
 
     const result = await saveNamedCanvasLayout(
       'version-1',
@@ -258,5 +269,96 @@ describe('Database Helper - Named Canvas Layouts', () => {
       expect.stringContaining('user_id IS NOT DISTINCT FROM $3'),
       ['version-1', 'Shared Layout', null]
     );
+  });
+});
+
+describe('Database Helper - default named canvas layout preference', () => {
+  let mockQuery: jest.Mock<any>;
+
+  beforeEach(() => {
+    const db = require('../lib/db/db');
+    mockQuery = db.query as jest.Mock;
+    mockQuery.mockReset();
+  });
+
+  test('getEffectiveDefaultLayoutName returns user default when present', async () => {
+    const { getEffectiveDefaultLayoutName } = await import('../lib/db/helper');
+
+    mockQuery.mockResolvedValueOnce({
+      rowCount: 1,
+      rows: [{ layout_name: '  Presentation Layout  ' }]
+    });
+
+    const result = await getEffectiveDefaultLayoutName('version-1', 'user-1', 'tenant-1');
+    const parsed = JSON.parse(result);
+
+    expect(parsed.success).toBe(true);
+    expect(parsed.layoutName).toBe('Presentation Layout');
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+  });
+
+  test('getEffectiveDefaultLayoutName falls back to tenant when user has no row', async () => {
+    const { getEffectiveDefaultLayoutName } = await import('../lib/db/helper');
+
+    mockQuery
+      .mockResolvedValueOnce({ rowCount: 0, rows: [] })
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ layout_name: 'Logical Layout' }] });
+
+    const result = await getEffectiveDefaultLayoutName('version-1', 'user-1', 'tenant-1');
+    const parsed = JSON.parse(result);
+
+    expect(parsed.success).toBe(true);
+    expect(parsed.layoutName).toBe('Logical Layout');
+  });
+
+  test('getEffectiveDefaultLayoutName uses built-in fallback when no preferences', async () => {
+    const { getEffectiveDefaultLayoutName } = await import('../lib/db/helper');
+
+    mockQuery
+      .mockResolvedValueOnce({ rowCount: 0, rows: [] })
+      .mockResolvedValueOnce({ rowCount: 0, rows: [] });
+
+    const result = await getEffectiveDefaultLayoutName('version-1', 'user-1', 'tenant-1');
+    const parsed = JSON.parse(result);
+
+    expect(parsed.success).toBe(true);
+    expect(parsed.layoutName).toBe('Development Layout');
+  });
+
+  test('setTenantCanvasLayoutDefaultName rejects when user is not tenant admin', async () => {
+    const { setTenantCanvasLayoutDefaultName } = await import('../lib/db/helper');
+
+    mockQuery.mockResolvedValueOnce({ rowCount: 0, rows: [] });
+
+    const result = await setTenantCanvasLayoutDefaultName(
+      'version-1',
+      'tenant-1',
+      'user-1',
+      'Presentation Layout'
+    );
+    const parsed = JSON.parse(result);
+
+    expect(parsed.success).toBe(false);
+    expect(parsed.error).toContain('administrators');
+  });
+
+  test('setTenantCanvasLayoutDefaultName inserts when admin and version belongs to tenant', async () => {
+    const { setTenantCanvasLayoutDefaultName } = await import('../lib/db/helper');
+
+    mockQuery
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ '?column?': 1 }] })
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ '?column?': 1 }] })
+      .mockResolvedValueOnce({ rowCount: 1, rows: [] });
+
+    const result = await setTenantCanvasLayoutDefaultName(
+      'version-1',
+      'tenant-1',
+      'admin-1',
+      'Dependency Layout'
+    );
+    const parsed = JSON.parse(result);
+
+    expect(parsed.success).toBe(true);
+    expect(mockQuery).toHaveBeenCalledTimes(3);
   });
 });

--- a/objectified-ui/tests/canvas-layout-named.test.ts
+++ b/objectified-ui/tests/canvas-layout-named.test.ts
@@ -274,11 +274,20 @@ describe('Database Helper - Named Canvas Layouts', () => {
 
 describe('Database Helper - default named canvas layout preference', () => {
   let mockQuery: jest.Mock<any>;
+  let mockGetAuthSession: jest.Mock<any>;
 
   beforeEach(() => {
     const db = require('../lib/db/db');
     mockQuery = db.query as jest.Mock;
     mockQuery.mockReset();
+
+    // Default session for this describe block: authenticated as user-1
+    const serverSession = require('../lib/auth/server-session');
+    mockGetAuthSession = serverSession.getAuthSession as jest.Mock<any>;
+    mockGetAuthSession.mockReset();
+    mockGetAuthSession.mockResolvedValue({
+      user: { user_id: 'user-1', current_tenant_id: 'tenant-1' },
+    });
   });
 
   test('getEffectiveDefaultLayoutName returns user default when present', async () => {
@@ -333,7 +342,6 @@ describe('Database Helper - default named canvas layout preference', () => {
     const result = await setTenantCanvasLayoutDefaultName(
       'version-1',
       'tenant-1',
-      'user-1',
       'Presentation Layout'
     );
     const parsed = JSON.parse(result);
@@ -353,12 +361,108 @@ describe('Database Helper - default named canvas layout preference', () => {
     const result = await setTenantCanvasLayoutDefaultName(
       'version-1',
       'tenant-1',
-      'admin-1',
       'Dependency Layout'
     );
     const parsed = JSON.parse(result);
 
     expect(parsed.success).toBe(true);
     expect(mockQuery).toHaveBeenCalledTimes(3);
+  });
+
+  test('setUserCanvasLayoutDefaultName rejects when unauthenticated', async () => {
+    mockGetAuthSession.mockResolvedValueOnce(null);
+
+    const { setUserCanvasLayoutDefaultName } = await import('../lib/db/helper');
+
+    const result = await setUserCanvasLayoutDefaultName('version-1', 'Presentation Layout');
+    const parsed = JSON.parse(result);
+
+    expect(parsed.success).toBe(false);
+    expect(parsed.error).toBe('Unauthorized');
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  test('setUserCanvasLayoutDefaultName saves default for authenticated user', async () => {
+    const { setUserCanvasLayoutDefaultName } = await import('../lib/db/helper');
+
+    mockQuery.mockResolvedValueOnce({ rowCount: 1 });
+
+    const result = await setUserCanvasLayoutDefaultName('version-1', 'My Layout');
+    const parsed = JSON.parse(result);
+
+    expect(parsed.success).toBe(true);
+    expect(parsed.layoutName).toBe('My Layout');
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining('user_canvas_layout_defaults'),
+      ['user-1', 'version-1', 'My Layout']
+    );
+  });
+
+  test('clearUserCanvasLayoutDefaultName rejects when unauthenticated', async () => {
+    mockGetAuthSession.mockResolvedValueOnce(null);
+
+    const { clearUserCanvasLayoutDefaultName } = await import('../lib/db/helper');
+
+    const result = await clearUserCanvasLayoutDefaultName('version-1');
+    const parsed = JSON.parse(result);
+
+    expect(parsed.success).toBe(false);
+    expect(parsed.error).toBe('Unauthorized');
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  test('setTenantCanvasLayoutDefaultName rejects when unauthenticated', async () => {
+    mockGetAuthSession.mockResolvedValueOnce(null);
+
+    const { setTenantCanvasLayoutDefaultName } = await import('../lib/db/helper');
+
+    const result = await setTenantCanvasLayoutDefaultName('version-1', 'tenant-1', 'Some Layout');
+    const parsed = JSON.parse(result);
+
+    expect(parsed.success).toBe(false);
+    expect(parsed.error).toBe('Unauthorized');
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  test('clearTenantCanvasLayoutDefaultName rejects when unauthenticated', async () => {
+    mockGetAuthSession.mockResolvedValueOnce(null);
+
+    const { clearTenantCanvasLayoutDefaultName } = await import('../lib/db/helper');
+
+    const result = await clearTenantCanvasLayoutDefaultName('version-1', 'tenant-1');
+    const parsed = JSON.parse(result);
+
+    expect(parsed.success).toBe(false);
+    expect(parsed.error).toBe('Unauthorized');
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  test('isTenantAdmin returns false when unauthenticated', async () => {
+    mockGetAuthSession.mockResolvedValueOnce(null);
+
+    const { isTenantAdmin } = await import('../lib/db/helper');
+
+    const result = await isTenantAdmin('tenant-1');
+    const parsed = JSON.parse(result);
+
+    expect(parsed.success).toBe(true);
+    expect(parsed.isAdmin).toBe(false);
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  test('isTenantAdmin returns true for authenticated admin', async () => {
+    const { isTenantAdmin } = await import('../lib/db/helper');
+
+    mockQuery.mockResolvedValueOnce({ rowCount: 1, rows: [{ '?column?': 1 }] });
+
+    const result = await isTenantAdmin('tenant-1');
+    const parsed = JSON.parse(result);
+
+    expect(parsed.success).toBe(true);
+    expect(parsed.isAdmin).toBe(true);
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining('tenant_administrators'),
+      ['tenant-1', 'user-1']
+    );
   });
 });

--- a/objectified-ui/tests/canvas-layout-revisions.test.ts
+++ b/objectified-ui/tests/canvas-layout-revisions.test.ts
@@ -1,8 +1,15 @@
 import { beforeEach, describe, expect, jest, test } from '@jest/globals';
 
-jest.mock('../lib/db/db', () => ({
-  query: jest.fn(),
-}));
+jest.mock('../lib/db/db', () => {
+  const query = jest.fn();
+  return {
+    query,
+    connect: jest.fn(async () => ({
+      query,
+      release: jest.fn(),
+    })),
+  };
+});
 
 jest.mock('bcrypt', () => ({
   compare: jest.fn(),
@@ -32,14 +39,14 @@ describe('Database Helper - Canvas layout revisions', () => {
       ],
     });
 
-    const result = await listCanvasLayoutRevisions('layout-1', 50);
+    const result = await listCanvasLayoutRevisions('layout-1', 'version-1', 'user-1', 50);
     const parsed = JSON.parse(result);
 
     expect(parsed.success).toBe(true);
     expect(parsed.revisions).toHaveLength(2);
     expect(mockQuery).toHaveBeenCalledWith(
-      expect.stringContaining('ORDER BY revision DESC'),
-      ['layout-1', 50]
+      expect.stringContaining('ORDER BY r.revision DESC'),
+      ['layout-1', 'version-1', 'user-1', 50]
     );
   });
 
@@ -58,7 +65,8 @@ describe('Database Helper - Canvas layout revisions', () => {
       .mockResolvedValueOnce({
         rowCount: 1,
         rows: [priorSnapshot],
-      }) // revision row
+      }) // revision row (pool)
+      .mockResolvedValueOnce({ rowCount: 0 }) // BEGIN
       .mockResolvedValueOnce({
         rowCount: 1,
         rows: [
@@ -72,23 +80,24 @@ describe('Database Helper - Canvas layout revisions', () => {
             minimap_settings: {},
           },
         ],
-      }) // SELECT * before update
+      }) // SELECT FOR UPDATE
       .mockResolvedValueOnce({ rows: [{ n: 3 }] })
       .mockResolvedValueOnce({ rowCount: 1 })
       .mockResolvedValueOnce({ rowCount: 0 })
       .mockResolvedValueOnce({
         rowCount: 1,
         rows: [{ id: 'layout-1', viewport: priorSnapshot.viewport, nodes: priorSnapshot.nodes }],
-      });
+      })
+      .mockResolvedValueOnce({ rowCount: 0 }); // COMMIT
 
-    const result = await restoreCanvasLayoutFromRevision('layout-1', 'rev-uuid', 'user-1');
+    const result = await restoreCanvasLayoutFromRevision('layout-1', 'rev-uuid', 'version-1', 'user-1');
     const parsed = JSON.parse(result);
 
     expect(parsed.success).toBe(true);
     expect(mockQuery).toHaveBeenNthCalledWith(
       1,
       expect.stringContaining('FROM odb.canvas_layout_revisions r'),
-      ['rev-uuid', 'layout-1']
+      ['rev-uuid', 'layout-1', 'version-1', 'user-1']
     );
   });
 });


### PR DESCRIPTION
## Problem Statement

Users and teams need **fix #166 — default named canvas layout per user and team** within the Objectified platform. Today this capability is missing or only partially implemented, which blocks platform workflows and creates inconsistency across tenants and projects.

## Solution / Scope

Implement **Fix #166 — Default named canvas layout per user and team** as part of **Platform**.

**Post-MVP** (prioritize after MVP slice) candidacy.

```mermaid
flowchart LR
  User[User action: Fix #166 — Default named canvas layout p] --> UI[objectified-ui]
  UI --> API[objectified-rest]
  API --> DB[(PostgreSQL)]
```

## Acceptance Criteria

- [ ] Feature behaves as described for: Fix #166 — Default named canvas layout per user and team
- [ ] Unit/integration tests cover happy path and primary error cases
- [ ] UI (if applicable) matches existing ADE patterns (Tailwind 4, Radix, Lucide)
- [ ] REST endpoints (if applicable) follow `/v1/{{feature}}/{{tenant_slug}}/...` conventions
- [ ] Documented in issue/PR; no regressions to existing schema/version flows

## Parallelism / Dependencies

- **Can run in parallel:** Yes
- **Blockers:** None identified; validate against current codebase before starting

## Technical Stack

- **Modules:** objectified-ui, objectified-rest
- **Stack:** Next.js 16, React 19, FastAPI, PostgreSQL
- **Labels:** ``

---
**Issue:** #839 · **Area:** Platform · **Roadmap batch:** legacy #64–#879 enrichment