### PR TITLE
Addresses #167 — Canvas layout JSON export/import

### DIFF
--- a/PLANNED_FEATURE_ROADMAP_CANVAS.md
+++ b/PLANNED_FEATURE_ROADMAP_CANVAS.md
@@ -27,14 +27,12 @@
 - ✅ Auto-save layout changes every 30 seconds (configurable)
 - ✅ Version control for layouts (track layout history) — #165
 - ✅ Default layout setting per user or per team — #166
-- 📋 [TODO] Export layout as JSON for sharing
-- 📋 [TODO] Import layouts from other versions/projects
+- ✅ Export / import layout as versioned JSON — #167
 - 📋 [TODO] Add ability to save layouts with a custom name
 - ✅ Add simple orthagonal edge routing after auto-layout
 
 | Ticket | Feature                                        |
 |--------|------------------------------------------------|
-| #167   | Export/import layouts as JSON                  |
 | #314   | Canvas snapshots                               |
 | #315   | Canvas auto-save of layout                     |
 | #316   | Export/import canvas layouts                   |

--- a/objectified-ui/lib/db/helper.ts
+++ b/objectified-ui/lib/db/helper.ts
@@ -960,6 +960,20 @@ export async function getClassesForVersion(versionId: string) {
   }
 }
 
+/** Class IDs for a version (canvas import: restrict layout JSON to classes that exist here). */
+export async function getClassIdsForVersion(versionId: string) {
+  try {
+    const result = await connectionPool.query(
+      `SELECT id FROM odb.classes WHERE version_id = $1 AND deleted_at IS NULL`,
+      [versionId]
+    );
+    return successResponse({ classIds: result.rows.map((r: { id: string }) => r.id) });
+  } catch (error: any) {
+    console.error('Error fetching class ids for version:', error);
+    return errorResponse(error.message);
+  }
+}
+
 export async function createClass(versionId: string, name: string, description: string | null, schema: any) {
   try {
     if (!name || name.trim().length === 0) {

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.8.50",
+  "version": "0.8.51",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -4,6 +4,9 @@ We continue to improve the platform based on your feedback with improvements and
 
 ---
 
+Improvements:
+- Canvas: export and import canvas layouts as versioned JSON (share across versions and projects)
+
 Bug Fixes:
 - Import now handles paths properly
 - Improved Markdown rendering

--- a/objectified-ui/src/app/ade/studio/editor/page.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/page.tsx
@@ -3693,12 +3693,15 @@ const StudioContent = () => {
       const { layout, layoutNameToSet, clearGroupsWhenEmpty } = options;
 
       if (layout.viewport) {
+        const viewport = layout.viewport;
+        const x =
+          typeof viewport.x === 'number' && Number.isFinite(viewport.x) ? viewport.x : 0;
+        const y =
+          typeof viewport.y === 'number' && Number.isFinite(viewport.y) ? viewport.y : 0;
+        const zoom =
+          typeof viewport.zoom === 'number' && Number.isFinite(viewport.zoom) ? viewport.zoom : 1;
         setViewport(
-          {
-            x: layout.viewport.x ?? 0,
-            y: layout.viewport.y ?? 0,
-            zoom: layout.viewport.zoom ?? 1,
-          },
+          { x, y, zoom },
           { duration: 250 }
         );
       }
@@ -3792,6 +3795,9 @@ const StudioContent = () => {
         }
 
         if (layoutNodes.length > 0) {
+          const layoutNodeMap = new Map<string, any>(
+            layoutNodes.map((n: any) => [n.id, n])
+          );
           setNodes((prevNodes) => {
             const updatedNodes = prevNodes.map((node) => {
               const { measured, width, height, ...restNode } = node as any;
@@ -3806,7 +3812,7 @@ const StudioContent = () => {
                 }
               }
 
-              const savedNode = layoutNodes.find((n: any) => n.id === node.id);
+              const savedNode = layoutNodeMap.get(node.id);
               if (savedNode) {
                 return {
                   ...restNode,
@@ -4053,7 +4059,7 @@ const StudioContent = () => {
         }
 
         const layoutPayload = {
-          viewport: filtered.viewport as { x?: number; y?: number; zoom?: number },
+          viewport: filtered.viewport,
           nodes: filtered.nodes,
         };
 

--- a/objectified-ui/src/app/ade/studio/editor/page.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useState, useEffect, useRef, useMemo } from 'react';
+import { useCallback, useState, useEffect, useRef, useMemo, type ChangeEvent } from 'react';
 import { useSession } from 'next-auth/react';
 import { useSearchParams } from 'next/navigation';
 import dynamic from 'next/dynamic';
@@ -33,6 +33,7 @@ import {
   Wand2,
   Image,
   FileCode,
+  FileJson,
   BarChart3,
   Network,
   Zap,
@@ -108,6 +109,8 @@ import {
   listCanvasLayoutRevisions,
   restoreCanvasLayoutFromRevision,
   getGroupsForVersion,
+  getClassIdsForVersion,
+  syncGroupsForVersion,
   addClassToGroup,
   updateClassPositionInGroup,
   isTenantAdmin
@@ -138,6 +141,11 @@ import {
   ghostNodeClassName,
 } from '@/app/utils/canvas-ghost-mode';
 import { computeLayoutQuality } from '@/app/utils/layout-quality';
+import {
+  buildCanvasLayoutJsonDocument,
+  parseCanvasLayoutJson,
+  filterCanvasLayoutForTargetClasses,
+} from '@/app/utils/canvas-layout-json';
 import { computeSchemaMetrics, getCircularDependencyEdgeIds, getDependencyDepthMap, getAffectedClassIds, getUpstreamClassIds, getDependencyChainNodeAndEdgeIds } from '@/app/utils/schema-metrics';
 import DraggablePanel from '../components/DraggablePanel';
 import MemoryProfiler from '../components/MemoryProfiler';
@@ -468,6 +476,7 @@ const StudioContent = () => {
   const [exportWizardOpen, setExportWizardOpen] = useState(false);
   const [layoutDropdownOpen, setLayoutDropdownOpen] = useState(false);
   const layoutDropdownRef = useRef<HTMLDivElement>(null);
+  const layoutJsonImportInputRef = useRef<HTMLInputElement>(null);
   const [layoutHistoryOpen, setLayoutHistoryOpen] = useState(false);
   const [layoutHistoryRevisions, setLayoutHistoryRevisions] = useState<
     Array<{ id: string; revision: number; created_at: string }>
@@ -3669,6 +3678,184 @@ const StudioContent = () => {
     return () => window.clearInterval(intervalId);
   }, [autoSaveLayoutEnabled, autoSaveLayoutIntervalSeconds, autoSaveDefaultLayout]);
 
+  /**
+   * Shared path for applying saved layout data (DB or JSON import) after groups are in the database.
+   */
+  const applyCanvasLayoutPayload = useCallback(
+    async (options: {
+      layout: {
+        viewport?: { x?: number; y?: number; zoom?: number };
+        nodes?: unknown;
+      };
+      layoutNameToSet?: string;
+      clearGroupsWhenEmpty?: boolean;
+    }) => {
+      const { layout, layoutNameToSet, clearGroupsWhenEmpty } = options;
+
+      if (layout.viewport) {
+        setViewport(
+          {
+            x: layout.viewport.x ?? 0,
+            y: layout.viewport.y ?? 0,
+            zoom: layout.viewport.zoom ?? 1,
+          },
+          { duration: 250 }
+        );
+      }
+
+      let loadedGroups: any[] = [];
+      let classPositionsInGroups: Record<string, { x: number | null; y: number | null }> = {};
+      try {
+        const groupsResult = await getGroupsForVersion(selectedVersionId!);
+        loadedGroups = JSON.parse(groupsResult);
+
+        if (loadedGroups && Array.isArray(loadedGroups) && loadedGroups.length > 0) {
+          loadedGroups.forEach((g: any) => {
+            if (g.classPositions) {
+              Object.assign(classPositionsInGroups, g.classPositions);
+            }
+          });
+
+          const canvasGroups = loadedGroups.map((g: any) => ({
+            id: g.id,
+            name: g.name,
+            description: g.description,
+            color: g.color,
+            position: g.position,
+            dimensions: g.dimensions,
+            nodeIds: g.nodeIds || [],
+            tags: g.metadata?.tags || [],
+            styleOptions: {
+              borderStyle: g.borderStyle || 'dashed',
+              opacity: g.opacity ?? 1,
+              shadow: g.metadata?.shadow || 'none',
+              icon: g.metadata?.icon || 'folder',
+            },
+          }));
+          setGroups(canvasGroups);
+          loadedGroups = canvasGroups;
+
+          canvasGroups.forEach((group: any) => {
+            groupPositionsRef.current.set(group.id, { x: group.position.x, y: group.position.y });
+          });
+        } else if (clearGroupsWhenEmpty) {
+          setGroups([]);
+          groupPositionsRef.current.clear();
+        }
+      } catch (error) {
+        console.error('Error loading groups:', error);
+      }
+
+      await reloadClasses(false);
+
+      setTimeout(() => {
+        const layoutNodes = Array.isArray(layout.nodes) ? layout.nodes : [];
+        const availableTags = projectTags.map((t) => ({ id: t.id, name: t.tag_name, color: t.tag_color }));
+
+        const groupNodes: Node[] = [];
+        if (loadedGroups && Array.isArray(loadedGroups) && loadedGroups.length > 0) {
+          loadedGroups.forEach((group: any) => {
+            const groupNode: Node = {
+              id: group.id,
+              type: 'groupNode',
+              position: group.position,
+              width: group.dimensions.width,
+              height: group.dimensions.height,
+              style: {
+                width: group.dimensions.width,
+                height: group.dimensions.height,
+                zIndex: -1,
+              },
+              data: {
+                id: group.id,
+                name: group.name,
+                color: group.color,
+                nodeIds: group.nodeIds || [],
+                tags: group.metadata?.tags || [],
+                styleOptions: group.styleOptions,
+                availableTags,
+                onRename: (groupId: string, name: string) => handleGroupRenameRef.current?.(groupId, name),
+                onDelete: (groupId: string) => handleGroupDeleteRef.current?.(groupId),
+                onDeleteAllClassesInGroup: (groupId: string) =>
+                  handleDeleteAllClassesInGroupRef.current?.(groupId),
+                onColorChange: (groupId: string, color: string) =>
+                  handleGroupColorChangeRef.current?.(groupId, color),
+                onStyleChange: (groupId: string, style: any) =>
+                  handleGroupStyleChangeRef.current?.(groupId, style),
+                onTagsChange: (groupId: string, tags: any[]) =>
+                  handleGroupTagsChangeRef.current?.(groupId, tags),
+                isReadOnly,
+              },
+            };
+            groupNodes.push(groupNode);
+          });
+        }
+
+        if (layoutNodes.length > 0) {
+          setNodes((prevNodes) => {
+            const updatedNodes = prevNodes.map((node) => {
+              const { measured, width, height, ...restNode } = node as any;
+
+              if (classPositionsInGroups[node.id]) {
+                const savedPos = classPositionsInGroups[node.id];
+                if (savedPos.x !== null && savedPos.y !== null) {
+                  return {
+                    ...restNode,
+                    position: { x: savedPos.x, y: savedPos.y },
+                  };
+                }
+              }
+
+              const savedNode = layoutNodes.find((n: any) => n.id === node.id);
+              if (savedNode) {
+                return {
+                  ...restNode,
+                  position: savedNode.position,
+                };
+              }
+              return restNode;
+            });
+
+            return [...groupNodes, ...updatedNodes];
+          });
+
+          requestAnimationFrame(() => {
+            setTimeout(() => {
+              layoutNodes.forEach((n: any) => {
+                if (n.id) {
+                  updateNodeInternals(n.id);
+                }
+              });
+            }, 100);
+          });
+        } else {
+          setNodes((prevNodes) => [...groupNodes, ...prevNodes]);
+        }
+
+        triggerSidebarRefresh();
+
+        setIsLoadingCanvas(false);
+        setLoadingMessage('');
+        setLayoutDropdownOpen(false);
+      }, 500);
+
+      if (layoutNameToSet !== undefined) {
+        setSelectedLayoutName(layoutNameToSet);
+      }
+    },
+    [
+      selectedVersionId,
+      reloadClasses,
+      setNodes,
+      setGroups,
+      setViewport,
+      projectTags,
+      isReadOnly,
+      triggerSidebarRefresh,
+      updateNodeInternals,
+    ]
+  );
+
   // Load saved canvas layout
   const handleLoadLayout = useCallback(async () => {
     if (!selectedVersionId || !currentUserId) return;
@@ -3686,7 +3873,6 @@ const StudioContent = () => {
       setLoadingMessage('Loading canvas layout...');
       setIsLoadingCanvas(true);
 
-      // Fetch selected named layout from database
       const result = await getNamedCanvasLayout(selectedVersionId, currentUserId, layoutName);
       const response = JSON.parse(result);
 
@@ -3701,160 +3887,10 @@ const StudioContent = () => {
         return;
       }
 
-      const layout = response.layout;
-
-      // Restore viewport using setViewport for accurate restoration
-      if (layout.viewport) {
-        setViewport({ x: layout.viewport.x, y: layout.viewport.y, zoom: layout.viewport.zoom }, { duration: 250 });
-      }
-
-      // Load groups from dedicated table
-      let loadedGroups: any[] = [];
-      let classPositionsInGroups: Record<string, { x: number | null; y: number | null }> = {};
-      try {
-        const groupsResult = await getGroupsForVersion(selectedVersionId);
-        loadedGroups = JSON.parse(groupsResult);
-
-        if (loadedGroups && Array.isArray(loadedGroups) && loadedGroups.length > 0) {
-          // Extract class positions from all groups
-          loadedGroups.forEach((g: any) => {
-            if (g.classPositions) {
-              Object.assign(classPositionsInGroups, g.classPositions);
-            }
-          });
-
-          // Transform to CanvasGroup format
-          const canvasGroups = loadedGroups.map((g: any) => ({
-            id: g.id,
-            name: g.name,
-            description: g.description,
-            color: g.color,
-            position: g.position,
-            dimensions: g.dimensions,
-            nodeIds: g.nodeIds || [],
-            tags: g.metadata?.tags || [],
-            styleOptions: {
-              borderStyle: g.borderStyle || 'dashed',
-              opacity: g.opacity ?? 1,
-              shadow: g.metadata?.shadow || 'none',
-              icon: g.metadata?.icon || 'folder'
-            }
-          }));
-          setGroups(canvasGroups);
-          loadedGroups = canvasGroups;
-
-          // Initialize group positions ref for delta tracking during drag
-          canvasGroups.forEach((group: any) => {
-            groupPositionsRef.current.set(group.id, { x: group.position.x, y: group.position.y });
-          });
-        }
-      } catch (error) {
-        console.error('Error loading groups:', error);
-      }
-
-      // Restore nodes - need to reload classes and apply saved positions
-      await reloadClasses(false);
-
-      // After classes are loaded, apply saved positions and create group nodes
-      setTimeout(() => {
-        const availableTags = projectTags.map(t => ({ id: t.id, name: t.tag_name, color: t.tag_color }));
-
-        // Create group nodes from loaded groups
-        const groupNodes: Node[] = [];
-        if (loadedGroups && Array.isArray(loadedGroups) && loadedGroups.length > 0) {
-          loadedGroups.forEach((group: any) => {
-            const groupNode: Node = {
-              id: group.id,
-              type: 'groupNode',
-              position: group.position,
-              width: group.dimensions.width,
-              height: group.dimensions.height,
-              style: {
-                width: group.dimensions.width,
-                height: group.dimensions.height,
-                zIndex: -1
-              },
-              data: {
-                id: group.id,
-                name: group.name,
-                color: group.color,
-                nodeIds: group.nodeIds || [],
-                tags: group.metadata?.tags || [],
-                styleOptions: group.styleOptions,
-                availableTags,
-                onRename: (groupId: string, name: string) => handleGroupRenameRef.current?.(groupId, name),
-                onDelete: (groupId: string) => handleGroupDeleteRef.current?.(groupId),
-                onDeleteAllClassesInGroup: (groupId: string) => handleDeleteAllClassesInGroupRef.current?.(groupId),
-                onColorChange: (groupId: string, color: string) => handleGroupColorChangeRef.current?.(groupId, color),
-                onStyleChange: (groupId: string, style: any) => handleGroupStyleChangeRef.current?.(groupId, style),
-                onTagsChange: (groupId: string, tags: any[]) => handleGroupTagsChangeRef.current?.(groupId, tags),
-                isReadOnly
-              }
-            };
-            groupNodes.push(groupNode);
-          });
-        }
-
-        if (layout.nodes && Array.isArray(layout.nodes)) {
-          setNodes(prevNodes => {
-            // Map existing nodes to update positions
-            const updatedNodes = prevNodes.map(node => {
-              // Clear measured property to force React Flow to remeasure
-              const { measured, width, height, ...restNode } = node as any;
-
-              // First check if this node is in a group and has saved position
-              if (classPositionsInGroups[node.id]) {
-                const savedPos = classPositionsInGroups[node.id];
-                if (savedPos.x !== null && savedPos.y !== null) {
-                  return {
-                    ...restNode,
-                    position: { x: savedPos.x, y: savedPos.y }
-                  };
-                }
-              }
-
-              // Otherwise use position from layout.nodes
-              // Note: We intentionally do NOT restore saved dimensions
-              // because the node content may have changed since the layout was saved
-              const savedNode = layout.nodes.find((n: any) => n.id === node.id);
-              if (savedNode) {
-                return {
-                  ...restNode,
-                  position: savedNode.position
-                };
-              }
-              return restNode;
-            });
-
-            // Add group nodes at the beginning (behind other nodes due to zIndex: -1)
-            return [...groupNodes, ...updatedNodes];
-          });
-
-          // After nodes are set, update internals for all class nodes to recalculate handle positions
-          // This is needed because the node sizes may differ from when they were saved
-          requestAnimationFrame(() => {
-            setTimeout(() => {
-              layout.nodes.forEach((n: any) => {
-                if (n.id) {
-                  updateNodeInternals(n.id);
-                }
-              });
-            }, 100);
-          });
-        } else {
-          // If no saved nodes, just add group nodes
-          setNodes(prevNodes => [...groupNodes, ...prevNodes]);
-        }
-
-        // Trigger sidebar refresh to update groups list
-        triggerSidebarRefresh();
-
-        setIsLoadingCanvas(false);
-        setLoadingMessage('');
-        setLayoutDropdownOpen(false);
-      }, 500);
-
-      setSelectedLayoutName(layoutName);
+      await applyCanvasLayoutPayload({
+        layout: response.layout,
+        layoutNameToSet: layoutName,
+      });
     } catch (error) {
       console.error('Error loading canvas layout:', error);
       await alertDialog({
@@ -3865,7 +3901,188 @@ const StudioContent = () => {
       setLoadingMessage('');
       setLayoutDropdownOpen(false);
     }
-  }, [selectedVersionId, currentUserId, selectedLayoutName, reloadClasses, setNodes, setGroups, setViewport, alertDialog, projectTags, isReadOnly, triggerSidebarRefresh, updateNodeInternals]);
+  }, [selectedVersionId, currentUserId, selectedLayoutName, reloadClasses, alertDialog, applyCanvasLayoutPayload]);
+
+  const handleExportLayoutJson = useCallback(() => {
+    if (!selectedVersionId) return;
+    const viewport = getViewport();
+    const nodeData = nodes.map((node) => ({
+      id: node.id,
+      type: node.type,
+      position: node.position,
+      dimensions: {
+        width: node.measured?.width || node.width || node.style?.width,
+        height: node.measured?.height || node.height || node.style?.height,
+      },
+      data:
+        node.type === 'groupNode'
+          ? {
+              name: node.data.name,
+              color: node.data.color,
+              nodeIds: node.data.nodeIds,
+            }
+          : undefined,
+    }));
+    const edgeData = edges.map((edge) => ({
+      id: edge.id,
+      source: edge.source,
+      target: edge.target,
+      sourceHandle: edge.sourceHandle,
+      targetHandle: edge.targetHandle,
+    }));
+    const doc = buildCanvasLayoutJsonDocument({
+      layoutName: selectedLayoutName.trim() || undefined,
+      viewport,
+      nodes: nodeData,
+      edges: edgeData,
+      groups,
+      gridSettings: {
+        size: gridSize,
+        snapToGrid,
+        showGrid,
+        gridStyle,
+      },
+      generator: { name: 'objectified-ui' },
+    });
+    const blob = new Blob([JSON.stringify(doc, null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    const base =
+      selectedLayoutName
+        .trim()
+        .replace(/[^a-zA-Z0-9-_]+/g, '-')
+        .replace(/^-+|-+$/g, '') || 'canvas-layout';
+    a.href = url;
+    a.download = `${base}-${new Date().toISOString().slice(0, 10)}.json`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  }, [
+    selectedVersionId,
+    getViewport,
+    nodes,
+    edges,
+    groups,
+    selectedLayoutName,
+    gridSize,
+    snapToGrid,
+    showGrid,
+    gridStyle,
+  ]);
+
+  const handleImportLayoutJsonPick = useCallback(() => {
+    layoutJsonImportInputRef.current?.click();
+  }, []);
+
+  const handleImportLayoutJsonSelected = useCallback(
+    async (e: ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      e.target.value = '';
+      if (!file || !selectedVersionId || !currentUserId || isReadOnly) return;
+
+      let text: string;
+      try {
+        text = await file.text();
+      } catch {
+        await alertDialog({ message: 'Could not read the file.', variant: 'error' });
+        return;
+      }
+
+      let parsedJson: unknown;
+      try {
+        parsedJson = JSON.parse(text);
+      } catch {
+        await alertDialog({ message: 'The file is not valid JSON.', variant: 'error' });
+        return;
+      }
+
+      const parsed = parseCanvasLayoutJson(parsedJson);
+      if (!parsed.ok) {
+        await alertDialog({ message: parsed.error, variant: 'error' });
+        return;
+      }
+
+      const ok = await confirmDialog({
+        title: 'Import layout from JSON',
+        message:
+          'Replace the current canvas with this layout? Class positions apply only to classes that exist in this version. Groups and viewport will match the file after import.',
+      });
+      if (!ok) return;
+
+      try {
+        setLoadingMessage('Importing layout...');
+        setIsLoadingCanvas(true);
+
+        const idsRes = await getClassIdsForVersion(selectedVersionId);
+        const idsParsed = JSON.parse(idsRes);
+        if (!idsParsed.success || !Array.isArray(idsParsed.classIds)) {
+          await alertDialog({
+            message: idsParsed.error || 'Could not load classes for this version.',
+            variant: 'error',
+          });
+          setIsLoadingCanvas(false);
+          setLoadingMessage('');
+          return;
+        }
+
+        const validIds = new Set<string>(idsParsed.classIds);
+        const filtered = filterCanvasLayoutForTargetClasses(parsed.doc, validIds);
+
+        const syncRes = await syncGroupsForVersion(
+          selectedVersionId,
+          filtered.groups,
+          filtered.nodePositions
+        );
+        const syncParsed = JSON.parse(syncRes);
+        if (!syncParsed.success) {
+          await alertDialog({
+            message: syncParsed.error || 'Failed to sync groups for this layout.',
+            variant: 'error',
+          });
+          setIsLoadingCanvas(false);
+          setLoadingMessage('');
+          return;
+        }
+
+        if (filtered.droppedClassCount > 0) {
+          await alertDialog({
+            message: `${filtered.droppedClassCount} class(es) from the file are not in this version and were skipped.`,
+            variant: 'warning',
+          });
+        }
+
+        const layoutPayload = {
+          viewport: filtered.viewport as { x?: number; y?: number; zoom?: number },
+          nodes: filtered.nodes,
+        };
+
+        await applyCanvasLayoutPayload({
+          layout: layoutPayload,
+          layoutNameToSet: parsed.doc.layoutName?.trim() || selectedLayoutName,
+          clearGroupsWhenEmpty: true,
+        });
+      } catch (err) {
+        console.error('Error importing layout JSON:', err);
+        await alertDialog({
+          message: 'An error occurred while importing the layout.',
+          variant: 'error',
+        });
+        setIsLoadingCanvas(false);
+        setLoadingMessage('');
+        setLayoutDropdownOpen(false);
+      }
+    },
+    [
+      selectedVersionId,
+      currentUserId,
+      isReadOnly,
+      alertDialog,
+      confirmDialog,
+      applyCanvasLayoutPayload,
+      selectedLayoutName,
+    ]
+  );
 
   const handleRestoreLayoutRevision = useCallback(
     async (revisionId: string) => {
@@ -6978,6 +7195,14 @@ const StudioContent = () => {
             {/* Layout Control Button */}
             <Panel position="top-right" className="bg-white/95 dark:bg-gray-800/95 backdrop-blur-sm rounded-xl shadow-lg border border-gray-200/80 dark:border-gray-700/80" style={{ marginRight: '60px' }}>
               <div className="relative" ref={layoutDropdownRef}>
+                <input
+                  ref={layoutJsonImportInputRef}
+                  type="file"
+                  accept="application/json,.json"
+                  className="hidden"
+                  aria-hidden
+                  onChange={(e) => void handleImportLayoutJsonSelected(e)}
+                />
                 <button
                   onClick={() => setLayoutDropdownOpen(!layoutDropdownOpen)}
                   className={`p-2 text-sm font-medium rounded-lg border transition-all duration-200 shadow-sm hover:shadow-md ${
@@ -7065,6 +7290,39 @@ const StudioContent = () => {
                         </div>
                         <p className="text-xs text-gray-500 dark:text-gray-400 mt-2">
                           Type a custom name or pick a suggestion. Save and load multiple layouts per version.
+                        </p>
+                        <div className="grid grid-cols-2 gap-2 mt-3">
+                          <button
+                            type="button"
+                            onClick={handleExportLayoutJson}
+                            disabled={!selectedVersionId}
+                            className={`px-3 py-2 text-sm font-medium rounded-lg transition-all duration-200 flex items-center justify-center gap-2 ${
+                              selectedVersionId
+                                ? 'bg-slate-50 dark:bg-slate-900/30 text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-900/50 border border-slate-200 dark:border-slate-700'
+                                : 'bg-gray-100 dark:bg-gray-700 text-gray-400 cursor-not-allowed border border-gray-200 dark:border-gray-600'
+                            }`}
+                            title="Download the current canvas layout as versioned JSON"
+                          >
+                            <Download className="w-4 h-4" />
+                            <span>Export JSON</span>
+                          </button>
+                          <button
+                            type="button"
+                            onClick={handleImportLayoutJsonPick}
+                            disabled={isReadOnly || !selectedVersionId || !currentUserId}
+                            className={`px-3 py-2 text-sm font-medium rounded-lg transition-all duration-200 flex items-center justify-center gap-2 ${
+                              !isReadOnly && selectedVersionId && currentUserId
+                                ? 'bg-slate-50 dark:bg-slate-900/30 text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-900/50 border border-slate-200 dark:border-slate-700'
+                                : 'bg-gray-100 dark:bg-gray-700 text-gray-400 cursor-not-allowed border border-gray-200 dark:border-gray-600'
+                            }`}
+                            title="Apply a layout from a JSON file exported from Objectified"
+                          >
+                            <FileJson className="w-4 h-4" />
+                            <span>Import JSON</span>
+                          </button>
+                        </div>
+                        <p className="text-xs text-gray-500 dark:text-gray-400 mt-2">
+                          Versioned JSON for sharing layouts across versions and projects. Import applies only classes that exist in this version.
                         </p>
                         <div className="mt-3 pt-3 border-t border-gray-200 dark:border-gray-700 space-y-2">
                           <p className="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">

--- a/objectified-ui/src/app/utils/canvas-layout-json.ts
+++ b/objectified-ui/src/app/utils/canvas-layout-json.ts
@@ -9,7 +9,7 @@ export type CanvasLayoutJsonDocument = {
   /** ISO 8601 timestamp */
   exportedAt: string;
   layoutName?: string;
-  viewport: unknown;
+  viewport: { x: number; y: number; zoom: number };
   nodes: unknown[];
   edges: unknown[];
   groups?: unknown[];
@@ -21,7 +21,7 @@ export type CanvasLayoutJsonDocument = {
 
 export function buildCanvasLayoutJsonDocument(params: {
   layoutName?: string;
-  viewport: unknown;
+  viewport: { x: number; y: number; zoom: number };
   nodes: unknown[];
   edges: unknown[];
   groups?: unknown[];
@@ -65,6 +65,10 @@ export function parseCanvasLayoutJson(
   if (o.viewport === null || typeof o.viewport !== 'object' || Array.isArray(o.viewport)) {
     return { ok: false, error: 'Missing or invalid viewport.' };
   }
+  const vp = o.viewport as Record<string, unknown>;
+  const vpX = typeof vp.x === 'number' && Number.isFinite(vp.x) ? vp.x : 0;
+  const vpY = typeof vp.y === 'number' && Number.isFinite(vp.y) ? vp.y : 0;
+  const vpZoom = typeof vp.zoom === 'number' && Number.isFinite(vp.zoom) ? vp.zoom : 1;
 
   if (!Array.isArray(o.nodes)) {
     return { ok: false, error: 'Missing or invalid nodes array.' };
@@ -81,7 +85,7 @@ export function parseCanvasLayoutJson(
   const doc: CanvasLayoutJsonDocument = {
     formatVersion: CANVAS_LAYOUT_JSON_FORMAT_VERSION,
     exportedAt: o.exportedAt,
-    viewport: o.viewport,
+    viewport: { x: vpX, y: vpY, zoom: vpZoom },
     nodes: o.nodes,
     edges: o.edges,
     ...(Array.isArray(o.groups) ? { groups: o.groups } : {}),
@@ -101,9 +105,9 @@ export function parseCanvasLayoutJson(
 }
 
 export type FilteredCanvasLayoutForImport = {
-  viewport: unknown;
-  /** Class nodes only (group nodes stripped); positions applied to matching classes */
-  nodes: unknown[];
+  viewport: { x: number; y: number; zoom: number };
+  /** Class nodes only (group nodes stripped); sanitized to {id, position} */
+  nodes: { id: string; position: { x: number; y: number } }[];
   edges: unknown[];
   /** Groups with nodeIds restricted to classes present in this version */
   groups: unknown[];
@@ -145,10 +149,13 @@ export function filterCanvasLayoutForTargetClasses(
     const n = item as { id: string; position?: { x?: unknown; y?: unknown } };
     const x = n.position?.x;
     const y = n.position?.y;
-    if (typeof x === 'number' && typeof y === 'number') {
+    if (typeof x === 'number' && Number.isFinite(x) && typeof y === 'number' && Number.isFinite(y)) {
       nodePositions[n.id] = { x, y };
     }
   });
+
+  /** Sanitized class nodes: only id + validated position; nodes with invalid positions are dropped. */
+  const sanitizedNodes = Object.entries(nodePositions).map(([id, position]) => ({ id, position }));
 
   const rawEdges = Array.isArray(doc.edges) ? doc.edges : [];
   const filteredEdges = rawEdges.filter((e) => {
@@ -175,7 +182,7 @@ export function filterCanvasLayoutForTargetClasses(
 
   return {
     viewport: doc.viewport,
-    nodes: filteredNodes,
+    nodes: sanitizedNodes,
     edges: filteredEdges,
     groups: filteredGroups,
     nodePositions,

--- a/objectified-ui/src/app/utils/canvas-layout-json.ts
+++ b/objectified-ui/src/app/utils/canvas-layout-json.ts
@@ -1,0 +1,184 @@
+/**
+ * Canvas layout JSON interchange format (versioned for compatibility across app and project copies).
+ */
+
+export const CANVAS_LAYOUT_JSON_FORMAT_VERSION = 1 as const;
+
+export type CanvasLayoutJsonDocument = {
+  formatVersion: typeof CANVAS_LAYOUT_JSON_FORMAT_VERSION;
+  /** ISO 8601 timestamp */
+  exportedAt: string;
+  layoutName?: string;
+  viewport: unknown;
+  nodes: unknown[];
+  edges: unknown[];
+  groups?: unknown[];
+  gridSettings?: unknown;
+  minimapSettings?: unknown;
+  /** Producer metadata (optional) */
+  generator?: { name: string; version?: string };
+};
+
+export function buildCanvasLayoutJsonDocument(params: {
+  layoutName?: string;
+  viewport: unknown;
+  nodes: unknown[];
+  edges: unknown[];
+  groups?: unknown[];
+  gridSettings?: unknown;
+  minimapSettings?: unknown;
+  generator?: { name: string; version?: string };
+}): CanvasLayoutJsonDocument {
+  return {
+    formatVersion: CANVAS_LAYOUT_JSON_FORMAT_VERSION,
+    exportedAt: new Date().toISOString(),
+    ...(params.layoutName?.trim() ? { layoutName: params.layoutName.trim() } : {}),
+    viewport: params.viewport,
+    nodes: params.nodes,
+    edges: params.edges,
+    ...(params.groups !== undefined ? { groups: params.groups } : {}),
+    ...(params.gridSettings !== undefined ? { gridSettings: params.gridSettings } : {}),
+    ...(params.minimapSettings !== undefined ? { minimapSettings: params.minimapSettings } : {}),
+    ...(params.generator ? { generator: params.generator } : {}),
+  };
+}
+
+export function parseCanvasLayoutJson(
+  raw: unknown
+): { ok: true; doc: CanvasLayoutJsonDocument } | { ok: false; error: string } {
+  if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) {
+    return { ok: false, error: 'File must contain a JSON object.' };
+  }
+  const o = raw as Record<string, unknown>;
+
+  if (o.formatVersion !== CANVAS_LAYOUT_JSON_FORMAT_VERSION) {
+    return {
+      ok: false,
+      error: `Unsupported formatVersion: ${String(o.formatVersion)} (expected ${CANVAS_LAYOUT_JSON_FORMAT_VERSION}).`,
+    };
+  }
+
+  if (typeof o.exportedAt !== 'string' || !o.exportedAt.trim()) {
+    return { ok: false, error: 'Missing or invalid exportedAt.' };
+  }
+
+  if (o.viewport === null || typeof o.viewport !== 'object' || Array.isArray(o.viewport)) {
+    return { ok: false, error: 'Missing or invalid viewport.' };
+  }
+
+  if (!Array.isArray(o.nodes)) {
+    return { ok: false, error: 'Missing or invalid nodes array.' };
+  }
+
+  if (!Array.isArray(o.edges)) {
+    return { ok: false, error: 'Missing or invalid edges array.' };
+  }
+
+  if (o.groups !== undefined && !Array.isArray(o.groups)) {
+    return { ok: false, error: 'Invalid groups: expected an array when present.' };
+  }
+
+  const doc: CanvasLayoutJsonDocument = {
+    formatVersion: CANVAS_LAYOUT_JSON_FORMAT_VERSION,
+    exportedAt: o.exportedAt,
+    viewport: o.viewport,
+    nodes: o.nodes,
+    edges: o.edges,
+    ...(Array.isArray(o.groups) ? { groups: o.groups } : {}),
+    ...(o.gridSettings !== undefined ? { gridSettings: o.gridSettings } : {}),
+    ...(o.minimapSettings !== undefined ? { minimapSettings: o.minimapSettings } : {}),
+    ...(typeof o.layoutName === 'string' && o.layoutName.trim() ? { layoutName: o.layoutName.trim() } : {}),
+    ...(o.generator !== undefined &&
+    o.generator !== null &&
+    typeof o.generator === 'object' &&
+    !Array.isArray(o.generator) &&
+    typeof (o.generator as { name?: unknown }).name === 'string'
+      ? { generator: o.generator as { name: string; version?: string } }
+      : {}),
+  };
+
+  return { ok: true, doc };
+}
+
+export type FilteredCanvasLayoutForImport = {
+  viewport: unknown;
+  /** Class nodes only (group nodes stripped); positions applied to matching classes */
+  nodes: unknown[];
+  edges: unknown[];
+  /** Groups with nodeIds restricted to classes present in this version */
+  groups: unknown[];
+  nodePositions: Record<string, { x: number; y: number }>;
+  droppedClassCount: number;
+};
+
+/**
+ * Restricts an imported document to class IDs that exist in the target version.
+ * Drops group nodes from `nodes` (groups are restored from DB after sync).
+ */
+export function filterCanvasLayoutForTargetClasses(
+  doc: CanvasLayoutJsonDocument,
+  validClassIds: Set<string>
+): FilteredCanvasLayoutForImport {
+  const rawNodes = Array.isArray(doc.nodes) ? doc.nodes : [];
+  let droppedClassCount = 0;
+
+  const filteredNodes = rawNodes.filter((item) => {
+    if (!item || typeof item !== 'object' || Array.isArray(item)) {
+      return false;
+    }
+    const n = item as { id?: unknown; type?: unknown };
+    if (n.type === 'groupNode') {
+      return false;
+    }
+    if (typeof n.id !== 'string') {
+      return false;
+    }
+    if (!validClassIds.has(n.id)) {
+      droppedClassCount += 1;
+      return false;
+    }
+    return true;
+  });
+
+  const nodePositions: Record<string, { x: number; y: number }> = {};
+  filteredNodes.forEach((item) => {
+    const n = item as { id: string; position?: { x?: unknown; y?: unknown } };
+    const x = n.position?.x;
+    const y = n.position?.y;
+    if (typeof x === 'number' && typeof y === 'number') {
+      nodePositions[n.id] = { x, y };
+    }
+  });
+
+  const rawEdges = Array.isArray(doc.edges) ? doc.edges : [];
+  const filteredEdges = rawEdges.filter((e) => {
+    if (!e || typeof e !== 'object' || Array.isArray(e)) return false;
+    const edge = e as { source?: unknown; target?: unknown };
+    return (
+      typeof edge.source === 'string' &&
+      typeof edge.target === 'string' &&
+      validClassIds.has(edge.source) &&
+      validClassIds.has(edge.target)
+    );
+  });
+
+  const rawGroups = Array.isArray(doc.groups) ? doc.groups : [];
+  const filteredGroups = rawGroups
+    .filter((g) => g && typeof g === 'object' && !Array.isArray(g))
+    .map((g) => {
+      const gr = g as { nodeIds?: unknown };
+      const nodeIds = Array.isArray(gr.nodeIds)
+        ? gr.nodeIds.filter((id): id is string => typeof id === 'string' && validClassIds.has(id))
+        : [];
+      return { ...gr, nodeIds };
+    });
+
+  return {
+    viewport: doc.viewport,
+    nodes: filteredNodes,
+    edges: filteredEdges,
+    groups: filteredGroups,
+    nodePositions,
+    droppedClassCount,
+  };
+}

--- a/objectified-ui/tests/canvas-layout-json.test.ts
+++ b/objectified-ui/tests/canvas-layout-json.test.ts
@@ -39,6 +39,37 @@ describe('canvas-layout-json', () => {
     if (r.ok) {
       expect(r.doc.formatVersion).toBe(1);
       expect(r.doc.exportedAt).toBe('2026-03-29T12:00:00.000Z');
+      expect(r.doc.viewport).toEqual({ x: 0, y: 0, zoom: 1 });
+    }
+  });
+
+  test('parseCanvasLayoutJson coerces non-finite viewport values to defaults', () => {
+    const raw = {
+      formatVersion: 1,
+      exportedAt: '2026-03-29T12:00:00.000Z',
+      viewport: { x: 'bad', y: NaN, zoom: Infinity },
+      nodes: [],
+      edges: [],
+    };
+    const r = parseCanvasLayoutJson(raw);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.doc.viewport).toEqual({ x: 0, y: 0, zoom: 1 });
+    }
+  });
+
+  test('parseCanvasLayoutJson coerces missing viewport fields to defaults', () => {
+    const raw = {
+      formatVersion: 1,
+      exportedAt: '2026-03-29T12:00:00.000Z',
+      viewport: {},
+      nodes: [],
+      edges: [],
+    };
+    const r = parseCanvasLayoutJson(raw);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.doc.viewport).toEqual({ x: 0, y: 0, zoom: 1 });
     }
   });
 
@@ -73,12 +104,31 @@ describe('canvas-layout-json', () => {
     const valid = new Set(['keep']);
     const filtered = filterCanvasLayoutForTargetClasses(doc, valid);
     expect(filtered.nodes).toHaveLength(1);
-    expect((filtered.nodes[0] as { id: string }).id).toBe('keep');
+    expect(filtered.nodes[0].id).toBe('keep');
+    expect(filtered.nodes[0].position).toEqual({ x: 10, y: 20 });
     expect(filtered.droppedClassCount).toBe(1);
     expect(filtered.nodePositions.keep).toEqual({ x: 10, y: 20 });
     expect(filtered.edges).toHaveLength(1);
     expect((filtered.edges[0] as { source: string; target: string }).source).toBe('keep');
     expect((filtered.edges[0] as { source: string; target: string }).target).toBe('keep');
     expect((filtered.groups[0] as { nodeIds: string[] }).nodeIds).toEqual(['keep']);
+  });
+
+  test('filterCanvasLayoutForTargetClasses drops nodes with invalid positions', () => {
+    const doc = buildCanvasLayoutJsonDocument({
+      viewport: { x: 0, y: 0, zoom: 1 },
+      nodes: [
+        { id: 'valid', type: 'classNode', position: { x: 5, y: 10 } },
+        { id: 'bad-pos', type: 'classNode', position: { x: 'oops', y: 0 } },
+        { id: 'no-pos', type: 'classNode' },
+      ],
+      edges: [],
+    });
+    const valid = new Set(['valid', 'bad-pos', 'no-pos']);
+    const filtered = filterCanvasLayoutForTargetClasses(doc, valid);
+    // Only 'valid' has a valid numeric position
+    expect(filtered.nodes).toHaveLength(1);
+    expect(filtered.nodes[0].id).toBe('valid');
+    expect(filtered.nodePositions).toEqual({ valid: { x: 5, y: 10 } });
   });
 });

--- a/objectified-ui/tests/canvas-layout-json.test.ts
+++ b/objectified-ui/tests/canvas-layout-json.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from '@jest/globals';
+import {
+  buildCanvasLayoutJsonDocument,
+  CANVAS_LAYOUT_JSON_FORMAT_VERSION,
+  filterCanvasLayoutForTargetClasses,
+  parseCanvasLayoutJson,
+} from '../src/app/utils/canvas-layout-json';
+
+describe('canvas-layout-json', () => {
+  test('buildCanvasLayoutJsonDocument includes format version and required fields', () => {
+    const doc = buildCanvasLayoutJsonDocument({
+      layoutName: 'Dev',
+      viewport: { x: 1, y: 2, zoom: 0.5 },
+      nodes: [{ id: 'a', type: 'classNode' }],
+      edges: [{ id: 'e1', source: 'a', target: 'b' }],
+      groups: [{ id: 'g1', name: 'G', nodeIds: ['a'], position: { x: 0, y: 0 }, dimensions: { width: 100, height: 100 } }],
+      gridSettings: { size: 20, snapToGrid: true, showGrid: true, gridStyle: 'dots' },
+      generator: { name: 'objectified-ui' },
+    });
+    expect(doc.formatVersion).toBe(CANVAS_LAYOUT_JSON_FORMAT_VERSION);
+    expect(doc.layoutName).toBe('Dev');
+    expect(doc.exportedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    expect(doc.nodes).toHaveLength(1);
+    expect(doc.edges).toHaveLength(1);
+    expect(doc.groups).toHaveLength(1);
+    expect(doc.generator?.name).toBe('objectified-ui');
+  });
+
+  test('parseCanvasLayoutJson accepts valid v1 document', () => {
+    const raw = {
+      formatVersion: 1,
+      exportedAt: '2026-03-29T12:00:00.000Z',
+      viewport: { x: 0, y: 0, zoom: 1 },
+      nodes: [],
+      edges: [],
+    };
+    const r = parseCanvasLayoutJson(raw);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.doc.formatVersion).toBe(1);
+      expect(r.doc.exportedAt).toBe('2026-03-29T12:00:00.000Z');
+    }
+  });
+
+  test('parseCanvasLayoutJson rejects wrong format version', () => {
+    const r = parseCanvasLayoutJson({
+      formatVersion: 99,
+      exportedAt: '2026-03-29T12:00:00.000Z',
+      viewport: {},
+      nodes: [],
+      edges: [],
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.error).toContain('formatVersion');
+    }
+  });
+
+  test('filterCanvasLayoutForTargetClasses drops unknown class ids and group nodes', () => {
+    const doc = buildCanvasLayoutJsonDocument({
+      viewport: { x: 0, y: 0, zoom: 1 },
+      nodes: [
+        { id: 'keep', type: 'classNode', position: { x: 10, y: 20 } },
+        { id: 'drop', type: 'classNode', position: { x: 1, y: 2 } },
+        { id: 'g-old', type: 'groupNode', position: { x: 0, y: 0 } },
+      ],
+      edges: [
+        { id: 'e1', source: 'keep', target: 'drop' },
+        { id: 'e2', source: 'keep', target: 'keep' },
+      ],
+      groups: [{ id: 'g1', name: 'G', nodeIds: ['keep', 'drop'], position: { x: 0, y: 0 }, dimensions: { width: 1, height: 1 } }],
+    });
+    const valid = new Set(['keep']);
+    const filtered = filterCanvasLayoutForTargetClasses(doc, valid);
+    expect(filtered.nodes).toHaveLength(1);
+    expect((filtered.nodes[0] as { id: string }).id).toBe('keep');
+    expect(filtered.droppedClassCount).toBe(1);
+    expect(filtered.nodePositions.keep).toEqual({ x: 10, y: 20 });
+    expect(filtered.edges).toHaveLength(1);
+    expect((filtered.edges[0] as { source: string; target: string }).source).toBe('keep');
+    expect((filtered.edges[0] as { source: string; target: string }).target).toBe('keep');
+    expect((filtered.groups[0] as { nodeIds: string[] }).nodeIds).toEqual(['keep']);
+  });
+});

--- a/objectified-ui/tests/canvas-layout-named.test.ts
+++ b/objectified-ui/tests/canvas-layout-named.test.ts
@@ -465,4 +465,22 @@ describe('Database Helper - default named canvas layout preference', () => {
       ['tenant-1', 'user-1']
     );
   });
+
+  test('getClassIdsForVersion returns ids for non-deleted classes in version', async () => {
+    const { getClassIdsForVersion } = await import('../lib/db/helper');
+
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: 'class-a' }, { id: 'class-b' }],
+    });
+
+    const result = await getClassIdsForVersion('version-1');
+    const parsed = JSON.parse(result);
+
+    expect(parsed.success).toBe(true);
+    expect(parsed.classIds).toEqual(['class-a', 'class-b']);
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining('FROM odb.classes'),
+      ['version-1']
+    );
+  });
 });


### PR DESCRIPTION
## Problem Statement

Users and teams need **addresses #167 — canvas layout json export/import** within the Objectified platform. Today this capability is missing or only partially implemented, which blocks platform workflows and creates inconsistency across tenants and projects.

## Solution / Scope

Implement **Addresses #167 — Canvas layout JSON export/import** as part of **Platform**.

**Post-MVP** (prioritize after MVP slice) candidacy.

```mermaid
flowchart LR
  User[User action: Addresses #167 — Canvas layout JSON expo] --> UI[objectified-ui]
  UI --> API[objectified-rest]
  API --> DB[(PostgreSQL)]
```

## Acceptance Criteria

- [ ] Feature behaves as described for: Addresses #167 — Canvas layout JSON export/import
- [ ] Unit/integration tests cover happy path and primary error cases
- [ ] UI (if applicable) matches existing ADE patterns (Tailwind 4, Radix, Lucide)
- [ ] REST endpoints (if applicable) follow `/v1/{{feature}}/{{tenant_slug}}/...` conventions
- [ ] Documented in issue/PR; no regressions to existing schema/version flows

## Parallelism / Dependencies

- **Can run in parallel:** Yes
- **Blockers:** None identified; validate against current codebase before starting

## Technical Stack

- **Modules:** objectified-ui, objectified-rest
- **Stack:** Next.js 16, React 19, FastAPI, PostgreSQL
- **Labels:** ``

---
**Issue:** #840 · **Area:** Platform · **Roadmap batch:** legacy #64–#879 enrichment