### PR TITLE
Fix #314 — Canvas PNG snapshots for named layouts

### DIFF
--- a/PLANNED_FEATURE_ROADMAP_CANVAS.md
+++ b/PLANNED_FEATURE_ROADMAP_CANVAS.md
@@ -33,11 +33,11 @@
 
 | Ticket | Feature                                        |
 |--------|------------------------------------------------|
-| #314   | Canvas snapshots                               |
 | #315   | Canvas auto-save of layout                     |
 | #316   | Export/import canvas layouts                   |
 
-#### Layout Snapshots 📋 PLANNED
+#### Layout Snapshots ✅ BASIC (named layouts)
+- ✅ PNG snapshot stored with each named layout save; thumbnail preview when picking a layout name (#314)
 - 📋 [TODO] Take quick snapshots of current layout
 - 📋 [TODO] Thumbnail preview of each snapshot
 - 📋 [TODO] Restore any snapshot with one click

--- a/objectified-db/scripts/20260329-170000.sql
+++ b/objectified-db/scripts/20260329-170000.sql
@@ -1,0 +1,8 @@
+-- Canvas layout PNG snapshot (thumbnail) stored with named layouts for UI reference
+
+SET search_path TO odb, public;
+
+ALTER TABLE canvas_layouts
+    ADD COLUMN IF NOT EXISTS snapshot_image BYTEA;
+
+COMMENT ON COLUMN canvas_layouts.snapshot_image IS 'Optional PNG bytes captured from the canvas when the layout was saved; used for thumbnails and reference';

--- a/objectified-ui/lib/db/helper.ts
+++ b/objectified-ui/lib/db/helper.ts
@@ -12,6 +12,12 @@ const successResponse = (data: any = {}) => JSON.stringify({ success: true, ...d
 
 /** Max PNG size for canvas layout snapshots (~512 KiB). */
 const MAX_CANVAS_LAYOUT_SNAPSHOT_BYTES = 512 * 1024;
+/** Max base64-encoded length corresponding to MAX_CANVAS_LAYOUT_SNAPSHOT_BYTES. */
+const MAX_CANVAS_LAYOUT_SNAPSHOT_BASE64_CHARS = Math.ceil(MAX_CANVAS_LAYOUT_SNAPSHOT_BYTES / 3) * 4;
+/** Full 8-byte PNG file signature. */
+const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+/** 4-byte ASCII chunk type for the required IHDR chunk (first chunk in every PNG). */
+const PNG_IHDR_TYPE = Buffer.from([0x49, 0x48, 0x44, 0x52]);
 
 function parseLayoutSnapshotBase64(
   snapshotPngBase64: string
@@ -20,6 +26,10 @@ function parseLayoutSnapshotBase64(
   if (raw.startsWith('data:image')) {
     const comma = raw.indexOf(',');
     if (comma !== -1) raw = raw.slice(comma + 1);
+  }
+  // Reject oversized payloads before decoding to avoid large allocations.
+  if (raw.length > MAX_CANVAS_LAYOUT_SNAPSHOT_BASE64_CHARS) {
+    return { ok: false, error: 'Layout snapshot exceeds maximum size' };
   }
   let buf: Buffer;
   try {
@@ -33,7 +43,12 @@ function parseLayoutSnapshotBase64(
   if (buf.length > MAX_CANVAS_LAYOUT_SNAPSHOT_BYTES) {
     return { ok: false, error: 'Layout snapshot exceeds maximum size' };
   }
-  if (buf[0] !== 0x89 || buf[1] !== 0x50 || buf[2] !== 0x4e || buf[3] !== 0x47) {
+  // Validate full 8-byte PNG signature: \x89PNG\r\n\x1A\n
+  if (buf.length < 8 || !buf.subarray(0, 8).equals(PNG_SIGNATURE)) {
+    return { ok: false, error: 'Layout snapshot must be a PNG image' };
+  }
+  // Basic PNG structure check: first chunk (at offset 12) must be IHDR
+  if (buf.length < 24 || !buf.subarray(12, 16).equals(PNG_IHDR_TYPE)) {
     return { ok: false, error: 'Layout snapshot must be a PNG image' };
   }
   return { ok: true, buffer: buf };

--- a/objectified-ui/lib/db/helper.ts
+++ b/objectified-ui/lib/db/helper.ts
@@ -10,6 +10,42 @@ const crypto = require('crypto');
 const errorResponse = (error: string) => JSON.stringify({ success: false, error });
 const successResponse = (data: any = {}) => JSON.stringify({ success: true, ...data });
 
+/** Max PNG size for canvas layout snapshots (~512 KiB). */
+const MAX_CANVAS_LAYOUT_SNAPSHOT_BYTES = 512 * 1024;
+
+function parseLayoutSnapshotBase64(
+  snapshotPngBase64: string
+): { ok: true; buffer: Buffer } | { ok: false; error: string } {
+  let raw = snapshotPngBase64.trim();
+  if (raw.startsWith('data:image')) {
+    const comma = raw.indexOf(',');
+    if (comma !== -1) raw = raw.slice(comma + 1);
+  }
+  let buf: Buffer;
+  try {
+    buf = Buffer.from(raw, 'base64');
+  } catch {
+    return { ok: false, error: 'Invalid layout snapshot encoding' };
+  }
+  if (buf.length === 0) {
+    return { ok: false, error: 'Layout snapshot is empty' };
+  }
+  if (buf.length > MAX_CANVAS_LAYOUT_SNAPSHOT_BYTES) {
+    return { ok: false, error: 'Layout snapshot exceeds maximum size' };
+  }
+  if (buf[0] !== 0x89 || buf[1] !== 0x50 || buf[2] !== 0x4e || buf[3] !== 0x47) {
+    return { ok: false, error: 'Layout snapshot must be a PNG image' };
+  }
+  return { ok: true, buffer: buf };
+}
+
+/** Strip BYTEA from layout rows before JSON serialization (Buffers are not JSON-safe). */
+function layoutRowWithoutBinarySnapshot(row: any) {
+  if (!row) return row;
+  const { snapshot_image: _s, ...rest } = row;
+  return rest;
+}
+
 export const getUserByEmail = async (emailAddress: string) =>
   connectionPool.query('SELECT * FROM odb.users WHERE email = $1', [emailAddress]);
 
@@ -3219,7 +3255,7 @@ export async function clearTenantCanvasLayoutDefaultName(
 export async function getNamedCanvasLayoutsForVersion(versionId: string, userId?: string) {
   try {
     const result = await connectionPool.query(
-      `SELECT id, version_id, user_id, name, is_default, created_at, updated_at
+      `SELECT id, version_id, user_id, name, is_default, snapshot_image, created_at, updated_at
        FROM odb.canvas_layouts
        WHERE version_id = $1
          AND name IS NOT NULL
@@ -3235,9 +3271,14 @@ export async function getNamedCanvasLayoutsForVersion(versionId: string, userId?
       const normalizedName = row.name.trim();
       if (!normalizedName) return;
       if (!byName.has(normalizedName)) {
+        const snapshotImageBase64 =
+          row.snapshot_image && Buffer.isBuffer(row.snapshot_image)
+            ? row.snapshot_image.toString('base64')
+            : undefined;
         byName.set(normalizedName, {
-          ...row,
-          name: normalizedName
+          ...layoutRowWithoutBinarySnapshot(row),
+          name: normalizedName,
+          ...(snapshotImageBase64 ? { snapshotImageBase64 } : {})
         });
       }
     });
@@ -3261,7 +3302,7 @@ export async function getNamedCanvasLayout(versionId: string, userId: string | n
 
     const result = await connectionPool.query(
       `SELECT id, version_id, user_id, name, is_default, viewport, nodes, edges,
-              grid_settings, minimap_settings, metadata, created_at, updated_at
+              grid_settings, minimap_settings, metadata, snapshot_image, created_at, updated_at
        FROM odb.canvas_layouts
        WHERE version_id = $1
          AND name = $2
@@ -3275,7 +3316,17 @@ export async function getNamedCanvasLayout(versionId: string, userId: string | n
       return successResponse({ layout: null });
     }
 
-    return successResponse({ layout: result.rows[0] });
+    const raw = result.rows[0];
+    const snapshotImageBase64 =
+      raw.snapshot_image && Buffer.isBuffer(raw.snapshot_image)
+        ? raw.snapshot_image.toString('base64')
+        : undefined;
+    return successResponse({
+      layout: {
+        ...layoutRowWithoutBinarySnapshot(raw),
+        ...(snapshotImageBase64 ? { snapshotImageBase64 } : {})
+      }
+    });
   } catch (error: any) {
     console.error('Error fetching named canvas layout:', error);
     return errorResponse(error.message);
@@ -3292,12 +3343,22 @@ export async function saveNamedCanvasLayout(
   viewport: any,
   nodes: any,
   edges?: any,
-  groups?: any
+  groups?: any,
+  snapshotPngBase64?: string
 ) {
   try {
     const nameValue = name.trim();
     if (!nameValue) {
       return errorResponse('Layout name is required');
+    }
+
+    let snapshotBuffer: Buffer | undefined;
+    if (snapshotPngBase64 !== undefined && snapshotPngBase64.trim() !== '') {
+      const parsed = parseLayoutSnapshotBase64(snapshotPngBase64);
+      if (!parsed.ok) {
+        return errorResponse(parsed.error);
+      }
+      snapshotBuffer = parsed.buffer;
     }
 
     const existingResult = await connectionPool.query(
@@ -3327,13 +3388,22 @@ export async function saveNamedCanvasLayout(
     }
 
     if (existingResult.rowCount > 0) {
+      const updates: {
+        viewport: any;
+        nodes: any;
+        edges: any;
+        snapshotImage?: Buffer;
+      } = {
+        viewport,
+        nodes,
+        edges: edges || []
+      };
+      if (snapshotBuffer !== undefined) {
+        updates.snapshotImage = snapshotBuffer;
+      }
       return updateCanvasLayout(
         existingResult.rows[0].id,
-        {
-          viewport,
-          nodes,
-          edges: edges || []
-        },
+        updates,
         { recordRevision: true, revisionUserId: userId }
       );
     }
@@ -3349,7 +3419,8 @@ export async function saveNamedCanvasLayout(
       null,
       { enabled: true, size: 20, snapToGrid: true, showGrid: true },
       { enabled: true, position: 'bottom-right', size: 'medium' },
-      {}
+      {},
+      snapshotBuffer ?? null
     );
   } catch (error: any) {
     console.error('Error saving named canvas layout:', error);
@@ -3371,7 +3442,8 @@ export async function createCanvasLayout(
   groups: any,
   gridSettings: any,
   minimapSettings: any,
-  metadata: any
+  metadata: any,
+  snapshotImage?: Buffer | null
 ) {
   try {
     // If setting as default, unset other defaults for this version/user combination
@@ -3393,16 +3465,17 @@ export async function createCanvasLayout(
 
     const result = await connectionPool.query(
       `INSERT INTO odb.canvas_layouts 
-       (version_id, user_id, name, is_default, viewport, nodes, edges, grid_settings, minimap_settings, metadata)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+       (version_id, user_id, name, is_default, viewport, nodes, edges, grid_settings, minimap_settings, metadata, snapshot_image)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
        RETURNING id, version_id, user_id, name, is_default, viewport, nodes, edges,
                  grid_settings, minimap_settings, metadata, created_at, updated_at`,
       [versionId, userId, name, isDefault,
        JSON.stringify(viewport), JSON.stringify(nodes), JSON.stringify(edges),
-       JSON.stringify(gridSettings), JSON.stringify(minimapSettings), JSON.stringify(metadata)]
+       JSON.stringify(gridSettings), JSON.stringify(minimapSettings), JSON.stringify(metadata),
+       snapshotImage ?? null]
     );
 
-    return successResponse({ layout: result.rows[0] });
+    return successResponse({ layout: layoutRowWithoutBinarySnapshot(result.rows[0]) });
   } catch (error: any) {
     console.error('Error creating canvas layout:', error);
     return errorResponse(error.message);
@@ -3429,6 +3502,7 @@ export async function updateCanvasLayout(
     gridSettings?: any;
     minimapSettings?: any;
     metadata?: any;
+    snapshotImage?: Buffer;
   },
   options?: {
     recordRevision?: boolean;
@@ -3557,6 +3631,10 @@ export async function updateCanvasLayout(
       setClauses.push(`metadata = $${paramIndex++}`);
       values.push(JSON.stringify(updates.metadata));
     }
+    if (updates.snapshotImage !== undefined) {
+      setClauses.push(`snapshot_image = $${paramIndex++}`);
+      values.push(updates.snapshotImage);
+    }
 
     if (setClauses.length === 0) {
       await client.query('ROLLBACK');
@@ -3575,7 +3653,7 @@ export async function updateCanvasLayout(
     );
 
     await client.query('COMMIT');
-    return successResponse({ layout: result.rows[0] });
+    return successResponse({ layout: layoutRowWithoutBinarySnapshot(result.rows[0]) });
   } catch (error: any) {
     try { await client.query('ROLLBACK'); } catch {}
     console.error('Error updating canvas layout:', error);

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.8.51",
+  "version": "0.8.52",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -5,6 +5,7 @@ We continue to improve the platform based on your feedback with improvements and
 ---
 
 Improvements:
+- Canvas: named layout saves store a PNG snapshot for thumbnail preview in the layout menu
 - Canvas: export and import canvas layouts as versioned JSON (share across versions and projects)
 
 Bug Fixes:

--- a/objectified-ui/src/app/ade/studio/editor/page.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/page.tsx
@@ -147,6 +147,7 @@ import {
   filterCanvasLayoutForTargetClasses,
 } from '@/app/utils/canvas-layout-json';
 import { computeSchemaMetrics, getCircularDependencyEdgeIds, getDependencyDepthMap, getAffectedClassIds, getUpstreamClassIds, getDependencyChainNodeAndEdgeIds } from '@/app/utils/schema-metrics';
+import { toPng } from 'html-to-image';
 import DraggablePanel from '../components/DraggablePanel';
 import MemoryProfiler from '../components/MemoryProfiler';
 import SchemaMetricsPanel from '../components/SchemaMetricsPanel';
@@ -457,6 +458,9 @@ const StudioContent = () => {
   const [hasExistingLayout, setHasExistingLayout] = useState(false);
   const [selectedLayoutName, setSelectedLayoutName] = useState('Development Layout');
   const [availableLayoutNames, setAvailableLayoutNames] = useState<string[]>(BUILTIN_LAYOUT_NAMES);
+  /** Data URLs for saved layout snapshots keyed by trimmed layout name */
+  const [namedLayoutSnapshotDataUrls, setNamedLayoutSnapshotDataUrls] = useState<Record<string, string>>({});
+  const canvasCaptureAreaRef = useRef<HTMLDivElement>(null);
   const selectedLayoutNameRef = useRef(selectedLayoutName);
   const [autoSavePending, setAutoSavePending] = useState(false);
   const autoSaveInFlightRef = useRef(false);
@@ -3425,6 +3429,26 @@ const StudioContent = () => {
       setLoadingMessage('Saving canvas layout...');
       setIsLoadingCanvas(true);
 
+      let snapshotDataUrl: string | undefined;
+      let snapshotBase64ForServer: string | undefined;
+      const captureEl = canvasCaptureAreaRef.current;
+      if (captureEl) {
+        try {
+          const dataUrl = await toPng(captureEl, {
+            pixelRatio: 0.45,
+            cacheBust: true,
+            backgroundColor: isDark ? '#111827' : '#f8fafc',
+          });
+          const comma = dataUrl.indexOf(',');
+          if (comma !== -1 && dataUrl.slice(0, comma).includes('image/png')) {
+            snapshotDataUrl = dataUrl;
+            snapshotBase64ForServer = dataUrl.slice(comma + 1);
+          }
+        } catch (snapErr) {
+          console.warn('Canvas snapshot capture failed:', snapErr);
+        }
+      }
+
       // Get current viewport
       const viewport = getViewport();
 
@@ -3461,13 +3485,17 @@ const StudioContent = () => {
         viewport,
         nodeData,
         edgeData,
-        groups
+        groups,
+        snapshotBase64ForServer
       );
 
       const response = JSON.parse(result);
 
       if (response.success) {
         setSelectedLayoutName(layoutName);
+        if (snapshotDataUrl) {
+          setNamedLayoutSnapshotDataUrls((prev) => ({ ...prev, [layoutName]: snapshotDataUrl }));
+        }
         // Show "Saved" state temporarily
         setLayoutSaved(true);
         setHasExistingLayout(true);
@@ -3494,7 +3522,7 @@ const StudioContent = () => {
       setIsLoadingCanvas(false);
       setLoadingMessage('');
     }
-  }, [isReadOnly, selectedVersionId, currentUserId, selectedLayoutName, nodes, edges, groups, getViewport, alertDialog]);
+  }, [isReadOnly, selectedVersionId, currentUserId, selectedLayoutName, nodes, edges, groups, getViewport, alertDialog, isDark]);
 
   const handleSetMyDefaultLayoutName = useCallback(async () => {
     if (isReadOnly || !selectedVersionId || !currentUserId) return;
@@ -5131,6 +5159,7 @@ const StudioContent = () => {
       if (!selectedVersionId || !currentUserId) {
         setHasExistingLayout(false);
         setAvailableLayoutNames(BUILTIN_LAYOUT_NAMES);
+        setNamedLayoutSnapshotDataUrls({});
         return;
       }
 
@@ -5147,6 +5176,15 @@ const StudioContent = () => {
           Array.from(new Set([...BUILTIN_LAYOUT_NAMES, ...dbLayoutNames]))
         );
 
+        const snapMap: Record<string, string> = {};
+        for (const layout of allLayoutsResponse.layouts || []) {
+          const n = typeof layout.name === 'string' ? layout.name.trim() : '';
+          if (n && layout.snapshotImageBase64) {
+            snapMap[n] = `data:image/png;base64,${layout.snapshotImageBase64}`;
+          }
+        }
+        setNamedLayoutSnapshotDataUrls(snapMap);
+
         const trimmedSelection = selectedLayoutName.trim();
         const hasExistingLayoutForSelection =
           !!trimmedSelection &&
@@ -5158,6 +5196,7 @@ const StudioContent = () => {
         console.error('Error checking layout existence:', error);
         setHasExistingLayout(false);
         setAvailableLayoutNames(BUILTIN_LAYOUT_NAMES);
+        setNamedLayoutSnapshotDataUrls({});
       }
     };
 
@@ -6115,7 +6154,8 @@ const StudioContent = () => {
               </Panel>
             )}
 
-            <ReactFlow
+            <div ref={canvasCaptureAreaRef} className="absolute inset-0 w-full h-full min-h-0">
+              <ReactFlow
               nodes={displayNodes}
               edges={edgesWithHover}
               nodeTypes={nodeTypes}
@@ -7252,6 +7292,18 @@ const StudioContent = () => {
                               <option key={layoutName} value={layoutName} />
                             ))}
                           </datalist>
+                          {namedLayoutSnapshotDataUrls[selectedLayoutName.trim()] ? (
+                            <div className="mt-2 flex items-start gap-2">
+                              <img
+                                src={namedLayoutSnapshotDataUrls[selectedLayoutName.trim()]}
+                                alt=""
+                                className="h-16 w-28 shrink-0 rounded-md border border-gray-200 dark:border-gray-600 object-cover bg-gray-100 dark:bg-gray-800"
+                              />
+                              <span className="text-xs text-gray-500 dark:text-gray-400 leading-snug pt-0.5">
+                                Saved canvas preview for this layout name
+                              </span>
+                            </div>
+                          ) : null}
                         </div>
                         <div className="grid grid-cols-2 gap-2">
                           <button
@@ -7610,7 +7662,8 @@ const StudioContent = () => {
               )}
             </Panel>
 
-          </ReactFlow>
+              </ReactFlow>
+            </div>
 
           {/* Draggable panels (outside ReactFlow so position:fixed is viewport-relative) */}
           {schemaMetricsOpen && (

--- a/objectified-ui/tests/canvas-layout-named.test.ts
+++ b/objectified-ui/tests/canvas-layout-named.test.ts
@@ -214,6 +214,67 @@ describe('Database Helper - Named Canvas Layouts', () => {
     expect(mockQuery).not.toHaveBeenCalled();
   });
 
+  test('saveNamedCanvasLayout rejects oversized layout snapshot', async () => {
+    const { saveNamedCanvasLayout } = await import('../lib/db/helper');
+
+    // Construct a base64 string that exceeds the snapshot size cap when decoded (~1 MiB).
+    const largeBase64 = Buffer.alloc(1024 * 1024).toString('base64');
+
+    const result = await saveNamedCanvasLayout(
+      'version-1',
+      'user-1',
+      'My Layout',
+      { x: 0, y: 0, zoom: 1 },
+      [{ id: 'node-1', type: 'classNode', position: { x: 1, y: 2 } }],
+      [],
+      undefined,
+      largeBase64
+    );
+    const parsed = JSON.parse(result);
+
+    expect(parsed.success).toBe(false);
+    expect(parsed.error).toBe('Layout snapshot exceeds maximum size');
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  test('saveNamedCanvasLayout accepts minimal valid PNG layout snapshot', async () => {
+    const { saveNamedCanvasLayout } = await import('../lib/db/helper');
+
+    // 1x1 transparent PNG (well-known minimal valid PNG)
+    const minimalPngBase64 =
+      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Y9VZwAAAABJRU5ErkJggg==';
+
+    mockQuery
+      .mockResolvedValueOnce({ rowCount: 0, rows: [] }) // existing layout lookup
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 'layout-with-snapshot-1', name: 'My Layout' }] }); // INSERT RETURNING
+
+    const result = await saveNamedCanvasLayout(
+      'version-1',
+      'user-1',
+      'My Layout',
+      { x: 0, y: 0, zoom: 1 },
+      [{ id: 'node-1', type: 'classNode', position: { x: 1, y: 2 } }],
+      [],
+      undefined,
+      minimalPngBase64
+    );
+    const parsed = JSON.parse(result);
+
+    expect(parsed.success).toBe(true);
+    expect(parsed.layout.id).toBe('layout-with-snapshot-1');
+
+    // Ensure the INSERT query was called and included a snapshot image argument.
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining('INSERT INTO odb.canvas_layouts'),
+      expect.arrayContaining([
+        'version-1',
+        'user-1',
+        'My Layout',
+        expect.any(Buffer), // snapshot_image
+      ])
+    );
+  });
+
   test('saveNamedCanvasLayout creates shared layout when userId is null and trims name', async () => {
     const { saveNamedCanvasLayout } = await import('../lib/db/helper');
 

--- a/objectified-ui/tests/canvas-layout-named.test.ts
+++ b/objectified-ui/tests/canvas-layout-named.test.ts
@@ -204,6 +204,7 @@ describe('Database Helper - Named Canvas Layouts', () => {
       { x: 0, y: 0, zoom: 1 },
       [{ id: 'node-1', type: 'classNode', position: { x: 1, y: 2 } }],
       [],
+      undefined,
       'YQ=='
     );
     const parsed = JSON.parse(result);

--- a/objectified-ui/tests/canvas-layout-named.test.ts
+++ b/objectified-ui/tests/canvas-layout-named.test.ts
@@ -194,6 +194,25 @@ describe('Database Helper - Named Canvas Layouts', () => {
     expect(mockQuery).not.toHaveBeenCalled();
   });
 
+  test('saveNamedCanvasLayout rejects invalid layout snapshot bytes', async () => {
+    const { saveNamedCanvasLayout } = await import('../lib/db/helper');
+
+    const result = await saveNamedCanvasLayout(
+      'version-1',
+      'user-1',
+      'My Layout',
+      { x: 0, y: 0, zoom: 1 },
+      [{ id: 'node-1', type: 'classNode', position: { x: 1, y: 2 } }],
+      [],
+      'YQ=='
+    );
+    const parsed = JSON.parse(result);
+
+    expect(parsed.success).toBe(false);
+    expect(parsed.error).toBe('Layout snapshot must be a PNG image');
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
   test('saveNamedCanvasLayout creates shared layout when userId is null and trims name', async () => {
     const { saveNamedCanvasLayout } = await import('../lib/db/helper');
 


### PR DESCRIPTION
## Problem Statement

Users and teams need **fix #314 — canvas png snapshots for named layouts** within the Objectified platform. Today this capability is missing or only partially implemented, which blocks platform workflows and creates inconsistency across tenants and projects.

## Solution / Scope

Implement **Fix #314 — Canvas PNG snapshots for named layouts** as part of **Platform**.

**Post-MVP** (prioritize after MVP slice) candidacy.

```mermaid
flowchart LR
  User[User action: Fix #314 — Canvas PNG snapshots for name] --> UI[objectified-ui]
  UI --> API[objectified-rest]
  API --> DB[(PostgreSQL)]
```

## Acceptance Criteria

- [ ] Feature behaves as described for: Fix #314 — Canvas PNG snapshots for named layouts
- [ ] Unit/integration tests cover happy path and primary error cases
- [ ] UI (if applicable) matches existing ADE patterns (Tailwind 4, Radix, Lucide)
- [ ] REST endpoints (if applicable) follow `/v1/{{feature}}/{{tenant_slug}}/...` conventions
- [ ] Documented in issue/PR; no regressions to existing schema/version flows

## Parallelism / Dependencies

- **Can run in parallel:** Yes
- **Blockers:** None identified; validate against current codebase before starting

## Technical Stack

- **Modules:** objectified-ui, objectified-rest
- **Stack:** Next.js 16, React 19, FastAPI, PostgreSQL
- **Labels:** ``

---
**Issue:** #841 · **Area:** Platform · **Roadmap batch:** legacy #64–#879 enrichment