### PR TITLE
Fix #323 — Schema timeline panel (canvas)

### DIFF
--- a/PLANNED_FEATURE_ROADMAP_CANVAS.md
+++ b/PLANNED_FEATURE_ROADMAP_CANVAS.md
@@ -204,11 +204,7 @@
 - ✅ **Quality score gauge**: Visual score indicator (0-100)
 - ✅ **Complexity charts**: Schema complexity visualization
 - ✅ **Relationship graphs**: Visual dependency maps
-- 📋 [TODO] **Timeline views**: Schema evolution over time
-
-| Ticket | Feature Description                          |
-|--------|----------------------------------------------|
-| #323   | Timeline view of schema changes over time    |
+- ✅ **Timeline views**: Schema evolution over time (#323 — studio canvas schema timeline panel)
 
 ---
 

--- a/objectified-ui/lib/api/rest-client.ts
+++ b/objectified-ui/lib/api/rest-client.ts
@@ -122,13 +122,14 @@ export async function updateClassCanvasMetadataWithSession(
 /**
  * Get classes with properties and tags for a version via REST API
  */
-async function getClassesWithPropertiesAndTags(versionId: string): Promise<{ success: boolean; classes?: any[]; error?: string }> {
+async function getClassesWithPropertiesAndTags(versionId: string, signal?: AbortSignal): Promise<{ success: boolean; classes?: any[]; error?: string }> {
   try {
     const response = await fetch(`/api/classes/version/${versionId}/with-properties-tags`, {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',
       },
+      signal,
     });
 
     if (!response.ok) {
@@ -173,9 +174,10 @@ async function getClassWithPropertiesAndTags(classId: string): Promise<{ success
  * Get classes with properties and tags for a version (convenience wrapper)
  */
 export async function getClassesWithPropertiesAndTagsWithSession(
-  versionId: string
+  versionId: string,
+  signal?: AbortSignal
 ): Promise<{ success: boolean; classes?: any[]; error?: string }> {
-  return getClassesWithPropertiesAndTags(versionId);
+  return getClassesWithPropertiesAndTags(versionId, signal);
 }
 
 /**

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.8.52",
+  "version": "0.8.53",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -5,6 +5,7 @@ We continue to improve the platform based on your feedback with improvements and
 ---
 
 Improvements:
+- Canvas: schema timeline panel shows class count, relationships, and complexity across project versions (#323)
 - Canvas: named layout saves store a PNG snapshot for thumbnail preview in the layout menu
 - Canvas: export and import canvas layouts as versioned JSON (share across versions and projects)
 

--- a/objectified-ui/src/app/ade/studio/components/SchemaTimelinePanel.tsx
+++ b/objectified-ui/src/app/ade/studio/components/SchemaTimelinePanel.tsx
@@ -1,0 +1,329 @@
+'use client';
+
+import * as React from 'react';
+import { History, ChevronDown, ChevronUp, X, Loader2 } from 'lucide-react';
+import { cn } from '../../../../../lib/utils';
+import { getClassesWithPropertiesAndTagsWithSession } from '../../../../../lib/api/rest-client';
+import { computeSchemaMetricsFromClasses } from '@/app/utils/schema-metrics';
+import type { SchemaMetricsResult } from '@/app/utils/schema-metrics';
+
+export interface SchemaTimelineVersion {
+  id: string;
+  version_id: string;
+  description: string;
+  published?: boolean;
+  created_at?: string;
+}
+
+export interface SchemaTimelinePanelProps {
+  versions: SchemaTimelineVersion[];
+  selectedVersionId: string;
+  onSelectVersion?: (versionId: string) => void;
+  onClose?: () => void;
+  isMinimized?: boolean;
+  onMinimizeToggle?: () => void;
+}
+
+type TimelinePoint = {
+  versionId: string;
+  label: string;
+  createdAt: string | null;
+  metrics: SchemaMetricsResult | null;
+  loadError?: string;
+};
+
+const CHART_W = 320;
+const CHART_H = 120;
+const PAD = 8;
+
+function normalizeSeries(values: number[]): number[] {
+  if (values.length === 0) return [];
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const span = max - min;
+  if (span <= 0) return values.map(() => CHART_H / 2);
+  return values.map((v) => PAD + ((v - min) / span) * (CHART_H - 2 * PAD));
+}
+
+function buildPolylinePoints(xs: number[], ys: number[]): string {
+  return xs.map((x, i) => `${x},${ys[i]}`).join(' ');
+}
+
+export default function SchemaTimelinePanel({
+  versions,
+  selectedVersionId,
+  onSelectVersion,
+  onClose,
+  isMinimized = false,
+  onMinimizeToggle,
+}: SchemaTimelinePanelProps) {
+  const [loading, setLoading] = React.useState(false);
+  const [points, setPoints] = React.useState<TimelinePoint[]>([]);
+  const [globalError, setGlobalError] = React.useState<string | null>(null);
+
+  const sortedVersions = React.useMemo(() => {
+    const copy = [...versions];
+    copy.sort((a, b) => {
+      const ta = a.created_at ? new Date(a.created_at).getTime() : 0;
+      const tb = b.created_at ? new Date(b.created_at).getTime() : 0;
+      if (ta !== tb) return ta - tb;
+      return (a.version_id || '').localeCompare(b.version_id || '');
+    });
+    return copy;
+  }, [versions]);
+
+  React.useEffect(() => {
+    if (sortedVersions.length === 0) {
+      setPoints([]);
+      setLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    setLoading(true);
+    setGlobalError(null);
+
+    const run = async () => {
+      const next: TimelinePoint[] = [];
+      try {
+        for (const v of sortedVersions) {
+          const res = await getClassesWithPropertiesAndTagsWithSession(v.id);
+          if (cancelled) return;
+          if (!res.success) {
+            next.push({
+              versionId: v.id,
+              label: v.version_id,
+              createdAt: v.created_at ?? null,
+              metrics: null,
+              loadError: res.error || 'Failed to load',
+            });
+            continue;
+          }
+          try {
+            const metrics = computeSchemaMetricsFromClasses(res.classes || []);
+            next.push({
+              versionId: v.id,
+              label: v.version_id,
+              createdAt: v.created_at ?? null,
+              metrics,
+            });
+          } catch (e) {
+            next.push({
+              versionId: v.id,
+              label: v.version_id,
+              createdAt: v.created_at ?? null,
+              metrics: null,
+              loadError: e instanceof Error ? e.message : 'Metrics error',
+            });
+          }
+        }
+        if (!cancelled) {
+          setPoints(next);
+          setGlobalError(null);
+        }
+      } catch (e) {
+        if (!cancelled) {
+          setGlobalError(e instanceof Error ? e.message : 'Failed to load timeline');
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    run();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [sortedVersions]);
+
+  const chartData = React.useMemo(() => {
+    const ok = points.filter((p) => p.metrics);
+    if (ok.length === 0) return null;
+    const n = ok.length;
+    const xs = ok.map((_, i) => (n === 1 ? CHART_W / 2 : PAD + (i / (n - 1)) * (CHART_W - 2 * PAD)));
+    const classes = ok.map((p) => p.metrics!.classCount);
+    const rel = ok.map((p) => p.metrics!.relationshipCount);
+    const comp = ok.map((p) => p.metrics!.complexityScore);
+    return {
+      xs,
+      yClasses: normalizeSeries(classes),
+      yRel: normalizeSeries(rel),
+      yComp: normalizeSeries(comp),
+      points: ok,
+    };
+  }, [points]);
+
+  if (isMinimized) {
+    return (
+      <button
+        type="button"
+        onClick={onMinimizeToggle}
+        className="bg-white/95 dark:bg-gray-800/95 backdrop-blur-sm rounded-xl shadow-lg border border-gray-200/80 dark:border-gray-700/80 px-3 py-2 flex items-center gap-2 text-sm font-medium text-gray-800 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700/80"
+        title="Expand schema timeline"
+      >
+        <History className="w-4 h-4 text-indigo-500 shrink-0" />
+        <span>Schema timeline</span>
+        <ChevronUp className="w-4 h-4" />
+      </button>
+    );
+  }
+
+  return (
+    <div className="bg-white/95 dark:bg-gray-800/95 backdrop-blur-sm rounded-xl shadow-lg border border-gray-200/80 dark:border-gray-700/80 w-[min(100vw-2rem,22rem)] max-h-[min(90vh,32rem)] flex flex-col overflow-hidden">
+      <div className="flex items-center justify-between gap-2 px-3 py-2 border-b border-gray-200/80 dark:border-gray-700/80 shrink-0">
+        <div className="flex items-center gap-2 min-w-0">
+          <History className="w-4 h-4 text-indigo-500 shrink-0" />
+          <span className="text-sm font-semibold text-gray-800 dark:text-gray-200 truncate">Schema timeline</span>
+        </div>
+        <div className="flex items-center gap-1 shrink-0">
+          {onMinimizeToggle && (
+            <button
+              type="button"
+              onClick={onMinimizeToggle}
+              className="p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-700 text-gray-500"
+              title="Minimize"
+            >
+              <ChevronDown className="w-4 h-4" />
+            </button>
+          )}
+          {onClose && (
+            <button
+              type="button"
+              onClick={onClose}
+              className="p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-700 text-gray-500"
+              title="Close"
+            >
+              <X className="w-4 h-4" />
+            </button>
+          )}
+        </div>
+      </div>
+
+      <div className="p-3 overflow-y-auto flex-1 min-h-0 space-y-3">
+        <p className="text-xs text-gray-500 dark:text-gray-400">
+          Schema size and complexity across each version of this project (oldest → newest).
+        </p>
+
+        {loading && (
+          <div className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-300">
+            <Loader2 className="w-4 h-4 animate-spin text-indigo-500" />
+            Loading versions…
+          </div>
+        )}
+
+        {globalError && (
+          <p className="text-sm text-rose-600 dark:text-rose-400">{globalError}</p>
+        )}
+
+        {!loading && sortedVersions.length === 0 && (
+          <p className="text-sm text-gray-500 dark:text-gray-400">Select a project with versions.</p>
+        )}
+
+        {!loading && chartData && chartData.points.length > 0 && (
+          <div className="rounded-lg border border-gray-200/80 dark:border-gray-700/80 bg-gray-50/80 dark:bg-gray-900/40 p-2">
+            <svg
+              viewBox={`0 0 ${CHART_W} ${CHART_H}`}
+              className="w-full h-auto text-gray-900 dark:text-gray-100"
+              role="img"
+              aria-label="Schema metrics over versions"
+            >
+              <polyline
+                fill="none"
+                stroke="currentColor"
+                className="text-indigo-500"
+                strokeWidth="2"
+                strokeLinejoin="round"
+                strokeLinecap="round"
+                points={buildPolylinePoints(chartData.xs, chartData.yClasses)}
+              />
+              <polyline
+                fill="none"
+                stroke="currentColor"
+                className="text-violet-500"
+                strokeWidth="2"
+                strokeLinejoin="round"
+                strokeLinecap="round"
+                points={buildPolylinePoints(chartData.xs, chartData.yRel)}
+              />
+              <polyline
+                fill="none"
+                stroke="currentColor"
+                className="text-amber-500"
+                strokeWidth="2"
+                strokeLinejoin="round"
+                strokeLinecap="round"
+                points={buildPolylinePoints(chartData.xs, chartData.yComp)}
+              />
+            </svg>
+            <div className="flex flex-wrap gap-x-3 gap-y-1 mt-2 text-[10px] text-gray-600 dark:text-gray-400">
+              <span className="inline-flex items-center gap-1">
+                <span className="inline-block w-2 h-2 rounded-full bg-indigo-500" />
+                Classes
+              </span>
+              <span className="inline-flex items-center gap-1">
+                <span className="inline-block w-2 h-2 rounded-full bg-violet-500" />
+                Relationships
+              </span>
+              <span className="inline-flex items-center gap-1">
+                <span className="inline-block w-2 h-2 rounded-full bg-amber-500" />
+                Complexity
+              </span>
+            </div>
+          </div>
+        )}
+
+        <ul className="space-y-1.5 text-xs">
+          {points.map((p) => {
+            const isSelected = p.versionId === selectedVersionId;
+            const m = p.metrics;
+            return (
+              <li key={p.versionId}>
+                <button
+                  type="button"
+                  disabled={!onSelectVersion}
+                  onClick={() => onSelectVersion?.(p.versionId)}
+                  className={cn(
+                    'w-full text-left rounded-lg px-2 py-1.5 border transition-colors',
+                    isSelected
+                      ? 'border-indigo-300 dark:border-indigo-600 bg-indigo-50/90 dark:bg-indigo-950/40'
+                      : 'border-transparent hover:bg-gray-100 dark:hover:bg-gray-700/60',
+                    onSelectVersion && 'cursor-pointer'
+                  )}
+                >
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="font-medium text-gray-800 dark:text-gray-200 truncate">
+                      v{p.label}
+                      {p.createdAt && (
+                        <span className="font-normal text-gray-500 dark:text-gray-400 ml-1">
+                          · {new Date(p.createdAt).toLocaleDateString()}
+                        </span>
+                      )}
+                    </span>
+                  </div>
+                  {p.loadError && (
+                    <span className="text-rose-600 dark:text-rose-400">{p.loadError}</span>
+                  )}
+                  {m && !p.loadError && (
+                    <div className="text-gray-500 dark:text-gray-400 mt-0.5 tabular-nums">
+                      {m.classCount} classes · {m.relationshipCount} rel · complexity {m.complexityScore}{' '}
+                      <span
+                        className={cn(
+                          m.complexityLabel === 'Low' && 'text-emerald-600 dark:text-emerald-400',
+                          m.complexityLabel === 'Medium' && 'text-amber-600 dark:text-amber-400',
+                          m.complexityLabel === 'High' && 'text-rose-600 dark:text-rose-400'
+                        )}
+                      >
+                        ({m.complexityLabel})
+                      </span>
+                    </div>
+                  )}
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/objectified-ui/src/app/ade/studio/components/SchemaTimelinePanel.tsx
+++ b/objectified-ui/src/app/ade/studio/components/SchemaTimelinePanel.tsx
@@ -42,7 +42,11 @@ function normalizeSeries(values: number[]): number[] {
   const max = Math.max(...values);
   const span = max - min;
   if (span <= 0) return values.map(() => CHART_H / 2);
-  return values.map((v) => PAD + ((v - min) / span) * (CHART_H - 2 * PAD));
+  return values.map((v) => {
+    const t = (v - min) / span; // 0 at min, 1 at max
+    // Invert for SVG: larger values should be nearer the top (smaller y)
+    return PAD + (1 - t) * (CHART_H - 2 * PAD);
+  });
 }
 
 function buildPolylinePoints(xs: number[], ys: number[]): string {
@@ -64,8 +68,10 @@ export default function SchemaTimelinePanel({
   const sortedVersions = React.useMemo(() => {
     const copy = [...versions];
     copy.sort((a, b) => {
-      const ta = a.created_at ? new Date(a.created_at).getTime() : 0;
-      const tb = b.created_at ? new Date(b.created_at).getTime() : 0;
+      const rawA = a.created_at ? Date.parse(a.created_at) : NaN;
+      const rawB = b.created_at ? Date.parse(b.created_at) : NaN;
+      const ta = Number.isFinite(rawA) ? rawA : 0;
+      const tb = Number.isFinite(rawB) ? rawB : 0;
       if (ta !== tb) return ta - tb;
       return (a.version_id || '').localeCompare(b.version_id || '');
     });
@@ -79,7 +85,8 @@ export default function SchemaTimelinePanel({
       return;
     }
 
-    let cancelled = false;
+    const controller = new AbortController();
+    const { signal } = controller;
     setLoading(true);
     setGlobalError(null);
 
@@ -87,8 +94,8 @@ export default function SchemaTimelinePanel({
       const next: TimelinePoint[] = [];
       try {
         for (const v of sortedVersions) {
-          const res = await getClassesWithPropertiesAndTagsWithSession(v.id);
-          if (cancelled) return;
+          const res = await getClassesWithPropertiesAndTagsWithSession(v.id, signal);
+          if (signal.aborted) return;
           if (!res.success) {
             next.push({
               versionId: v.id,
@@ -117,23 +124,23 @@ export default function SchemaTimelinePanel({
             });
           }
         }
-        if (!cancelled) {
+        if (!signal.aborted) {
           setPoints(next);
           setGlobalError(null);
         }
       } catch (e) {
-        if (!cancelled) {
+        if (!signal.aborted) {
           setGlobalError(e instanceof Error ? e.message : 'Failed to load timeline');
         }
       } finally {
-        if (!cancelled) setLoading(false);
+        if (!signal.aborted) setLoading(false);
       }
     };
 
     run();
 
     return () => {
-      cancelled = true;
+      controller.abort();
     };
   }, [sortedVersions]);
 
@@ -294,7 +301,7 @@ export default function SchemaTimelinePanel({
                   <div className="flex items-center justify-between gap-2">
                     <span className="font-medium text-gray-800 dark:text-gray-200 truncate">
                       v{p.label}
-                      {p.createdAt && (
+                      {p.createdAt && Number.isFinite(Date.parse(p.createdAt)) && (
                         <span className="font-normal text-gray-500 dark:text-gray-400 ml-1">
                           · {new Date(p.createdAt).toLocaleDateString()}
                         </span>

--- a/objectified-ui/src/app/ade/studio/editor/components/types.ts
+++ b/objectified-ui/src/app/ade/studio/editor/components/types.ts
@@ -11,6 +11,8 @@ export interface Version {
   version_id: string;
   description: string;
   published: boolean;
+  /** ISO timestamp for timeline / sorting (#323) */
+  created_at?: string;
 }
 
 export type ViewMode = 'canvas' | 'code';

--- a/objectified-ui/src/app/ade/studio/editor/page.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/page.tsx
@@ -59,7 +59,8 @@ import {
   Braces,
   Ban,
   Ghost,
-  Undo2
+  Undo2,
+  TrendingUp
 } from 'lucide-react';
 import * as Select from '@radix-ui/react-select';
 import * as ToggleGroup from '@radix-ui/react-toggle-group';
@@ -151,6 +152,7 @@ import { toPng } from 'html-to-image';
 import DraggablePanel from '../components/DraggablePanel';
 import MemoryProfiler from '../components/MemoryProfiler';
 import SchemaMetricsPanel from '../components/SchemaMetricsPanel';
+import SchemaTimelinePanel from '../components/SchemaTimelinePanel';
 import { useSearchHistory } from '../hooks/useSearchHistory';
 
 // Import extracted components
@@ -526,6 +528,8 @@ const StudioContent = () => {
   const [memoryProfilerMinimized, setMemoryProfilerMinimized] = useState(false);
   const [schemaMetricsOpen, setSchemaMetricsOpen] = useState(false);
   const [schemaMetricsMinimized, setSchemaMetricsMinimized] = useState(false);
+  const [schemaTimelineOpen, setSchemaTimelineOpen] = useState(false);
+  const [schemaTimelineMinimized, setSchemaTimelineMinimized] = useState(false);
 
   // #547: Interactive dependency graph overlay – highlight $ref / allOf/anyOf/oneOf edges, dim the rest
   const [showDependencyOverlay, setShowDependencyOverlay] = useState(() => {
@@ -7651,6 +7655,15 @@ const StudioContent = () => {
                   <BarChart3 className="w-5 h-5" />
                 </button>
               )}
+              {!schemaTimelineOpen && (
+                <button
+                  onClick={() => setSchemaTimelineOpen(true)}
+                  className="p-2 text-sm font-medium rounded-lg border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-700/50 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-600 hover:border-indigo-300 dark:hover:border-indigo-500/50 transition-all duration-200 shadow-sm hover:shadow-md"
+                  title="Schema timeline — evolution across versions"
+                >
+                  <TrendingUp className="w-5 h-5" />
+                </button>
+              )}
               {!memoryProfilerOpen && (
                 <button
                   onClick={() => setMemoryProfilerOpen(true)}
@@ -7694,6 +7707,25 @@ const StudioContent = () => {
                 onClose={() => setMemoryProfilerOpen(false)}
                 isMinimized={memoryProfilerMinimized}
                 onMinimizeToggle={() => setMemoryProfilerMinimized(!memoryProfilerMinimized)}
+              />
+            </DraggablePanel>
+          )}
+          {schemaTimelineOpen && (
+            <DraggablePanel
+              storageKey="schema-timeline-panel"
+              defaultPosition={{ left: 20, top: 280 }}
+            >
+              <SchemaTimelinePanel
+                versions={versions}
+                selectedVersionId={selectedVersionId}
+                onSelectVersion={(versionId) => {
+                  setSelectedVersionId(versionId);
+                  const v = versions.find((x) => x.id === versionId);
+                  setIsReadOnly(v?.published ?? false);
+                }}
+                onClose={() => setSchemaTimelineOpen(false)}
+                isMinimized={schemaTimelineMinimized}
+                onMinimizeToggle={() => setSchemaTimelineMinimized(!schemaTimelineMinimized)}
               />
             </DraggablePanel>
           )}

--- a/objectified-ui/src/app/utils/schema-graph-from-classes.ts
+++ b/objectified-ui/src/app/utils/schema-graph-from-classes.ts
@@ -1,0 +1,299 @@
+/**
+ * Build React Flow nodes and edges from persisted class rows for schema metrics (#323).
+ * Mirrors the studio editor’s dependency graph (property $refs + schema allOf/anyOf/oneOf)
+ * without canvas styling or animation so {@link computeSchemaMetrics} matches the canvas.
+ */
+
+import type { Edge, Node } from '@xyflow/react';
+
+function extractClassNameFromRef(ref: string): string | null {
+  if (ref.includes('/')) {
+    const parts = ref.split('/');
+    return parts[parts.length - 1] || null;
+  }
+  return ref;
+}
+
+const METRIC_EDGE_TYPE = 'default';
+
+function createPropertyRefEdgesForMetrics(classes: any[]): Edge[] {
+  const edges: Edge[] = [];
+  const classNameToId = new Map(classes.map((cls) => [cls.name, cls.id]));
+
+  classes.forEach((cls) => {
+    if (!cls.properties || cls.properties.length === 0) return;
+
+    cls.properties.forEach((prop: any) => {
+      const propData = typeof prop.data === 'string' ? JSON.parse(prop.data) : prop.data;
+      let sourceBaseType = propData.type;
+      if (Array.isArray(propData.type)) {
+        sourceBaseType = propData.type.find((t: string) => t !== 'null');
+      }
+      const isSourceArray = sourceBaseType === 'array';
+
+      const createCompositionEdges = (compositionType: 'allOf' | 'anyOf' | 'oneOf', refs: any[]) => {
+        refs.forEach((item: any, index: number) => {
+          if (item.$ref) {
+            const refClassName = extractClassNameFromRef(item.$ref);
+            if (refClassName && classNameToId.has(refClassName)) {
+              const targetClassId = classNameToId.get(refClassName)!;
+              let edgeColor: string;
+              let strokeDasharray: string;
+              let label: string;
+              if (compositionType === 'allOf') {
+                edgeColor = '#2563eb';
+                strokeDasharray = '0';
+                label = 'allOf';
+              } else if (compositionType === 'anyOf') {
+                edgeColor = '#ea580c';
+                strokeDasharray = '5,5';
+                label = 'anyOf';
+              } else {
+                edgeColor = '#9333ea';
+                strokeDasharray = '2,3';
+                label = 'oneOf';
+              }
+              edges.push({
+                id: `prop-${compositionType}-${cls.id}-${prop.id}-${targetClassId}-${index}`,
+                source: cls.id,
+                sourceHandle: `prop-${prop.id}`,
+                target: targetClassId,
+                type: METRIC_EDGE_TYPE,
+                animated: false,
+                label: `${prop.name} (${label}:${refClassName}${isSourceArray ? '[]' : ''})`,
+                data: { sourceNodeId: cls.id, targetNodeId: targetClassId },
+                style: { stroke: edgeColor, strokeWidth: 3, strokeDasharray },
+                labelStyle: { fill: edgeColor, fontSize: 10, fontWeight: 600 },
+                labelBgStyle: { fill: 'white', fillOpacity: 0.95 },
+                zIndex: 0,
+              });
+            }
+          }
+        });
+      };
+
+      if (propData.allOf && Array.isArray(propData.allOf)) {
+        createCompositionEdges('allOf', propData.allOf);
+        return;
+      }
+      if (propData.anyOf && Array.isArray(propData.anyOf)) {
+        createCompositionEdges('anyOf', propData.anyOf);
+        return;
+      }
+      if (propData.oneOf && Array.isArray(propData.oneOf)) {
+        createCompositionEdges('oneOf', propData.oneOf);
+        return;
+      }
+      if (isSourceArray && propData.items) {
+        if (propData.items.anyOf && Array.isArray(propData.items.anyOf)) {
+          createCompositionEdges('anyOf', propData.items.anyOf);
+          return;
+        }
+        if (propData.items.oneOf && Array.isArray(propData.items.oneOf)) {
+          createCompositionEdges('oneOf', propData.items.oneOf);
+          return;
+        }
+        if (propData.items.allOf && Array.isArray(propData.items.allOf)) {
+          createCompositionEdges('allOf', propData.items.allOf);
+          return;
+        }
+      }
+
+      let refClassName: string | null = null;
+      if (propData.$ref) {
+        refClassName = extractClassNameFromRef(propData.$ref);
+      } else if (sourceBaseType === 'array' && propData.items?.$ref) {
+        refClassName = extractClassNameFromRef(propData.items.$ref);
+      }
+
+      if (refClassName && classNameToId.has(refClassName)) {
+        const targetClassId = classNameToId.get(refClassName)!;
+        const targetClass = classes.find((c) => c.id === targetClassId);
+        let isTargetArray = false;
+        let hasReverseRef = false;
+        if (targetClass && targetClass.properties) {
+          targetClass.properties.forEach((targetProp: any) => {
+            const targetPropData =
+              typeof targetProp.data === 'string' ? JSON.parse(targetProp.data) : targetProp.data;
+            let targetBaseType = targetPropData.type;
+            if (Array.isArray(targetPropData.type)) {
+              targetBaseType = targetPropData.type.find((t: string) => t !== 'null');
+            }
+            const targetRefName = targetPropData.$ref
+              ? extractClassNameFromRef(targetPropData.$ref)
+              : targetBaseType === 'array' && targetPropData.items?.$ref
+                ? extractClassNameFromRef(targetPropData.items.$ref)
+                : null;
+            if (targetRefName === cls.name) {
+              hasReverseRef = true;
+              isTargetArray = targetBaseType === 'array';
+            }
+          });
+        }
+
+        let cardinality: string;
+        let edgeColor: string;
+        let markerStart: any;
+        let markerEnd: any;
+        if (isSourceArray && isTargetArray) {
+          cardinality = 'N:N';
+          edgeColor = '#ec4899';
+          markerStart = { type: 'arrow', color: edgeColor, width: 20, height: 20 };
+          markerEnd = { type: 'arrow', color: edgeColor, width: 20, height: 20 };
+        } else if (isSourceArray && !isTargetArray) {
+          cardinality = hasReverseRef ? '1:N' : 'N:1';
+          edgeColor = '#8b5cf6';
+          markerStart = hasReverseRef
+            ? { type: 'arrowclosed', color: edgeColor, width: 20, height: 20 }
+            : undefined;
+          markerEnd = { type: 'arrow', color: edgeColor, width: 20, height: 20 };
+        } else if (!isSourceArray && isTargetArray) {
+          cardinality = 'N:1';
+          edgeColor = '#f59e0b';
+          markerStart = { type: 'arrow', color: edgeColor, width: 20, height: 20 };
+          markerEnd = { type: 'arrowclosed', color: edgeColor, width: 20, height: 20 };
+        } else {
+          cardinality = hasReverseRef ? '1:1' : '1';
+          edgeColor = '#3b82f6';
+          markerStart = hasReverseRef
+            ? { type: 'arrowclosed', color: edgeColor, width: 20, height: 20 }
+            : undefined;
+          markerEnd = { type: 'arrowclosed', color: edgeColor, width: 20, height: 20 };
+        }
+        edges.push({
+          id: `prop-${cls.id}-${prop.id}-${targetClassId}`,
+          source: cls.id,
+          sourceHandle: `prop-${prop.id}`,
+          target: targetClassId,
+          type: METRIC_EDGE_TYPE,
+          animated: false,
+          label: `${prop.name} (${cardinality})`,
+          data: { sourceNodeId: cls.id, targetNodeId: targetClassId },
+          style: { stroke: edgeColor, strokeWidth: 2 },
+          markerStart,
+          markerEnd,
+          labelStyle: { fill: '#6b7280', fontSize: 11, fontWeight: 500 },
+          labelBgStyle: { fill: 'white', fillOpacity: 0.9 },
+        });
+      }
+    });
+  });
+
+  return edges;
+}
+
+function createCompositionEdgesForMetrics(classes: any[]): Edge[] {
+  const edges: Edge[] = [];
+  const classNameToId = new Map(classes.map((cls) => [cls.name, cls.id]));
+
+  classes.forEach((cls) => {
+    const schema = typeof cls.schema === 'string' ? JSON.parse(cls.schema) : cls.schema;
+    if (!schema) return;
+
+    if (schema.allOf && Array.isArray(schema.allOf)) {
+      schema.allOf.forEach((item: any, index: number) => {
+        if (item.$ref) {
+          const refClassName = extractClassNameFromRef(item.$ref);
+          if (refClassName && classNameToId.has(refClassName)) {
+            const targetId = classNameToId.get(refClassName)!;
+            edges.push({
+              id: `allOf-${cls.id}-${refClassName}-${index}`,
+              source: cls.id,
+              sourceHandle: 'comp-bottom',
+              target: targetId,
+              type: METRIC_EDGE_TYPE,
+              animated: false,
+              label: `allOf:${refClassName}`,
+              data: { sourceNodeId: cls.id, targetNodeId: targetId },
+              style: { stroke: '#2563eb', strokeWidth: 3, strokeDasharray: '0' },
+              markerEnd: { type: 'arrowclosed', color: '#2563eb', width: 15, height: 15 },
+              labelStyle: { fill: '#2563eb', fontSize: 10, fontWeight: 600 },
+              labelBgStyle: { fill: 'white', fillOpacity: 0.95 },
+              zIndex: 0,
+            });
+          }
+        }
+      });
+    }
+
+    if (schema.anyOf && Array.isArray(schema.anyOf)) {
+      schema.anyOf.forEach((item: any, index: number) => {
+        if (item.$ref) {
+          const refClassName = extractClassNameFromRef(item.$ref);
+          if (refClassName && classNameToId.has(refClassName)) {
+            const targetId = classNameToId.get(refClassName)!;
+            edges.push({
+              id: `anyOf-${cls.id}-${refClassName}-${index}`,
+              source: cls.id,
+              sourceHandle: 'comp-bottom',
+              target: targetId,
+              type: METRIC_EDGE_TYPE,
+              animated: false,
+              label: `anyOf:${refClassName}`,
+              data: { sourceNodeId: cls.id, targetNodeId: targetId },
+              style: { stroke: '#ea580c', strokeWidth: 3, strokeDasharray: '5,5' },
+              markerEnd: { type: 'arrowclosed', color: '#ea580c', width: 15, height: 15 },
+              labelStyle: { fill: '#ea580c', fontSize: 10, fontWeight: 600 },
+              labelBgStyle: { fill: 'white', fillOpacity: 0.95 },
+              zIndex: 0,
+            });
+          }
+        }
+      });
+    }
+
+    if (schema.oneOf && Array.isArray(schema.oneOf)) {
+      schema.oneOf.forEach((item: any, index: number) => {
+        if (item.$ref) {
+          const refClassName = extractClassNameFromRef(item.$ref);
+          if (refClassName && classNameToId.has(refClassName)) {
+            const targetId = classNameToId.get(refClassName)!;
+            edges.push({
+              id: `oneOf-${cls.id}-${refClassName}-${index}`,
+              source: cls.id,
+              sourceHandle: 'comp-bottom',
+              target: targetId,
+              type: METRIC_EDGE_TYPE,
+              animated: false,
+              label: `oneOf:${refClassName}`,
+              data: { sourceNodeId: cls.id, targetNodeId: targetId },
+              style: { stroke: '#9333ea', strokeWidth: 3, strokeDasharray: '2,3' },
+              markerEnd: { type: 'arrowclosed', color: '#9333ea', width: 15, height: 15 },
+              labelStyle: { fill: '#9333ea', fontSize: 10, fontWeight: 600 },
+              labelBgStyle: { fill: 'white', fillOpacity: 0.95 },
+            });
+          }
+        }
+      });
+    }
+  });
+
+  return edges;
+}
+
+function classesToMetricNodes(classes: any[]): Node[] {
+  return classes.map((cls) => ({
+    id: cls.id,
+    type: 'classNode',
+    position: { x: 0, y: 0 },
+    data: {
+      id: cls.id,
+      name: cls.name,
+      description: cls.description,
+      properties: cls.properties || [],
+      schema: cls.schema,
+      tags: cls.tags || [],
+      updated_at: cls.updated_at,
+    },
+  }));
+}
+
+/**
+ * Nodes and edges suitable for {@link computeSchemaMetrics} from API class rows.
+ */
+export function buildGraphForSchemaMetrics(classes: any[]): { nodes: Node[]; edges: Edge[] } {
+  const list = Array.isArray(classes) ? classes : [];
+  const nodes = classesToMetricNodes(list);
+  const edges = [...createPropertyRefEdgesForMetrics(list), ...createCompositionEdgesForMetrics(list)];
+  return { nodes, edges };
+}

--- a/objectified-ui/src/app/utils/schema-graph-from-classes.ts
+++ b/objectified-ui/src/app/utils/schema-graph-from-classes.ts
@@ -1,7 +1,7 @@
 /**
  * Build React Flow nodes and edges from persisted class rows for schema metrics (#323).
  * Mirrors the studio editor’s dependency graph (property $refs + schema allOf/anyOf/oneOf)
- * without canvas styling or animation so {@link computeSchemaMetrics} matches the canvas.
+ * for use by {@link computeSchemaMetrics}; output may include visual styling metadata.
  */
 
 import type { Edge, Node } from '@xyflow/react';

--- a/objectified-ui/src/app/utils/schema-metrics.ts
+++ b/objectified-ui/src/app/utils/schema-metrics.ts
@@ -5,6 +5,7 @@
 
 import type { Node, Edge } from '@xyflow/react';
 import { detectNamingConvention } from './naming-conventions';
+import { buildGraphForSchemaMetrics } from './schema-graph-from-classes';
 
 export interface SchemaMetricsResult {
   /** Total number of class nodes (excludes group nodes) */
@@ -406,6 +407,14 @@ function computeNamingCompliance(classNodes: Node[]): NamingComplianceResult {
     classesNonPascal,
     propertiesNonCamel,
   };
+}
+
+/**
+ * Compute schema metrics from persisted class rows (same shape as the studio canvas API) — #323 timeline.
+ */
+export function computeSchemaMetricsFromClasses(classes: unknown[]): SchemaMetricsResult {
+  const { nodes, edges } = buildGraphForSchemaMetrics(classes);
+  return computeSchemaMetrics(nodes, edges);
 }
 
 /**

--- a/objectified-ui/tests/schema-graph-from-classes.test.ts
+++ b/objectified-ui/tests/schema-graph-from-classes.test.ts
@@ -1,0 +1,48 @@
+import { buildGraphForSchemaMetrics } from '@/app/utils/schema-graph-from-classes';
+import { computeSchemaMetricsFromClasses } from '@/app/utils/schema-metrics';
+
+describe('schema-graph-from-classes / computeSchemaMetricsFromClasses', () => {
+  it('builds nodes and dependency edges for metrics', () => {
+    const classes = [
+      { id: 'a', name: 'User', properties: [], schema: {} },
+      {
+        id: 'b',
+        name: 'Post',
+        properties: [
+          {
+            id: 'p1',
+            name: 'author',
+            data: JSON.stringify({ $ref: '#/components/schemas/User' }),
+          },
+        ],
+        schema: {},
+      },
+    ];
+    const { nodes, edges } = buildGraphForSchemaMetrics(classes);
+    expect(nodes).toHaveLength(2);
+    expect(edges.some((e) => e.id.startsWith('prop-'))).toBe(true);
+  });
+
+  it('computes aggregate metrics consistent with graph', () => {
+    const classes = [
+      { id: 'a', name: 'User', properties: [], schema: {} },
+      {
+        id: 'b',
+        name: 'Post',
+        properties: [
+          {
+            id: 'p1',
+            name: 'author',
+            data: JSON.stringify({ $ref: '#/components/schemas/User' }),
+          },
+        ],
+        schema: {},
+      },
+    ];
+    const m = computeSchemaMetricsFromClasses(classes);
+    expect(m.classCount).toBe(2);
+    expect(m.relationshipCount).toBeGreaterThan(0);
+    expect(m.complexityScore).toBeGreaterThanOrEqual(0);
+    expect(m.complexityScore).toBeLessThanOrEqual(100);
+  });
+});


### PR DESCRIPTION
## Problem Statement

Users and teams need **fix #323 — schema timeline panel (canvas)** within the Objectified platform. Today this capability is missing or only partially implemented, which blocks platform workflows and creates inconsistency across tenants and projects.

## Solution / Scope

Implement **Fix #323 — Schema timeline panel (canvas)** as part of **Platform**.

**Post-MVP** (prioritize after MVP slice) candidacy.

```mermaid
flowchart LR
  User[User action: Fix #323 — Schema timeline panel (canvas] --> UI[objectified-ui]
  UI --> API[objectified-rest]
  API --> DB[(PostgreSQL)]
```

## Acceptance Criteria

- [ ] Feature behaves as described for: Fix #323 — Schema timeline panel (canvas)
- [ ] Unit/integration tests cover happy path and primary error cases
- [ ] UI (if applicable) matches existing ADE patterns (Tailwind 4, Radix, Lucide)
- [ ] REST endpoints (if applicable) follow `/v1/{{feature}}/{{tenant_slug}}/...` conventions
- [ ] Documented in issue/PR; no regressions to existing schema/version flows

## Parallelism / Dependencies

- **Can run in parallel:** Yes
- **Blockers:** None identified; validate against current codebase before starting

## Technical Stack

- **Modules:** objectified-ui, objectified-rest
- **Stack:** Next.js 16, React 19, FastAPI, PostgreSQL
- **Labels:** ``

---
**Issue:** #843 · **Area:** Platform · **Roadmap batch:** legacy #64–#879 enrichment