### PR TITLE
Fix #315 — steady canvas layout auto-save (30s while pending)

### DIFF
--- a/PLANNED_FEATURE_ROADMAP_CANVAS.md
+++ b/PLANNED_FEATURE_ROADMAP_CANVAS.md
@@ -33,7 +33,6 @@
 
 | Ticket | Feature                                        |
 |--------|------------------------------------------------|
-| #315   | Canvas auto-save of layout                     |
 | #316   | Export/import canvas layouts                   |
 
 #### Layout Snapshots ✅ BASIC (named layouts)

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.8.53",
+  "version": "0.8.54",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -5,6 +5,7 @@ We continue to improve the platform based on your feedback with improvements and
 ---
 
 Improvements:
+- Canvas: layout auto-save uses a steady timer while edits are pending so saves occur every 30 seconds (or your chosen interval) without resetting on each move (#315)
 - Canvas: schema timeline panel shows class count, relationships, and complexity across project versions (#323)
 - Canvas: named layout saves store a PNG snapshot for thumbnail preview in the layout menu
 - Canvas: export and import canvas layouts as versioned JSON (share across versions and projects)

--- a/objectified-ui/src/app/ade/studio/editor/page.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/page.tsx
@@ -116,6 +116,7 @@ import {
   updateClassPositionInGroup,
   isTenantAdmin
 } from '../../../../../lib/db/helper';
+import { mapEdgesForLayoutSave, mapNodesForLayoutSave } from '../lib/canvasLayoutPayload';
 import {
   deleteClassWithSession,
   updateClassCanvasMetadataWithSession,
@@ -492,6 +493,21 @@ const StudioContent = () => {
   // #471: Preview layout suggestions before applying
   const [layoutPreviewNodes, setLayoutPreviewNodes] = useState<Node[] | null>(null);
   const [layoutPreviewLabel, setLayoutPreviewLabel] = useState<string>('');
+
+  /** Latest canvas state for auto-save; avoids resetting the interval on every node/edge update (#315). */
+  const nodesForAutoSaveRef = useRef(nodes);
+  const edgesForAutoSaveRef = useRef(edges);
+  const groupsForAutoSaveRef = useRef(groups);
+  const autoSavePendingRef = useRef(autoSavePending);
+  const layoutPreviewNodesForAutoSaveRef = useRef(layoutPreviewNodes);
+
+  useEffect(() => {
+    nodesForAutoSaveRef.current = nodes;
+    edgesForAutoSaveRef.current = edges;
+    groupsForAutoSaveRef.current = groups;
+    autoSavePendingRef.current = autoSavePending;
+    layoutPreviewNodesForAutoSaveRef.current = layoutPreviewNodes;
+  }, [nodes, edges, groups, autoSavePending, layoutPreviewNodes]);
 
   // Canvas search state
   const [canvasSearchQuery, setCanvasSearchQuery] = useState('');
@@ -3456,30 +3472,8 @@ const StudioContent = () => {
       // Get current viewport
       const viewport = getViewport();
 
-      // Extract node positions and dimensions
-      const nodeData = nodes.map(node => ({
-        id: node.id,
-        type: node.type,
-        position: node.position,
-        dimensions: {
-          width: node.measured?.width || node.width || node.style?.width,
-          height: node.measured?.height || node.height || node.style?.height
-        },
-        data: node.type === 'groupNode' ? {
-          name: node.data.name,
-          color: node.data.color,
-          nodeIds: node.data.nodeIds
-        } : undefined
-      }));
-
-      // Extract edge data
-      const edgeData = edges.map(edge => ({
-        id: edge.id,
-        source: edge.source,
-        target: edge.target,
-        sourceHandle: edge.sourceHandle,
-        targetHandle: edge.targetHandle
-      }));
+      const nodeData = mapNodesForLayoutSave(nodes);
+      const edgeData = mapEdgesForLayoutSave(edges);
 
       // Save selected named layout to database
       const result = await saveNamedCanvasLayout(
@@ -3635,11 +3629,11 @@ const StudioContent = () => {
   const autoSaveDefaultLayout = useCallback(async () => {
     if (
       !autoSaveLayoutEnabled ||
-      !autoSavePending ||
+      !autoSavePendingRef.current ||
       isReadOnly ||
       !selectedVersionId ||
       !currentUserId ||
-      layoutPreviewNodes ||
+      layoutPreviewNodesForAutoSaveRef.current ||
       autoSaveInFlightRef.current
     ) {
       return;
@@ -3648,27 +3642,8 @@ const StudioContent = () => {
     autoSaveInFlightRef.current = true;
     try {
       const viewport = getViewport();
-      const nodeData = nodes.map(node => ({
-        id: node.id,
-        type: node.type,
-        position: node.position,
-        dimensions: {
-          width: node.measured?.width || node.width || node.style?.width,
-          height: node.measured?.height || node.height || node.style?.height
-        },
-        data: node.type === 'groupNode' ? {
-          name: node.data.name,
-          color: node.data.color,
-          nodeIds: node.data.nodeIds
-        } : undefined
-      }));
-      const edgeData = edges.map(edge => ({
-        id: edge.id,
-        source: edge.source,
-        target: edge.target,
-        sourceHandle: edge.sourceHandle,
-        targetHandle: edge.targetHandle
-      }));
+      const nodeData = mapNodesForLayoutSave(nodesForAutoSaveRef.current);
+      const edgeData = mapEdgesForLayoutSave(edgesForAutoSaveRef.current);
 
       const result = await saveDefaultCanvasLayout(
         selectedVersionId,
@@ -3676,7 +3651,7 @@ const StudioContent = () => {
         viewport,
         nodeData,
         edgeData,
-        groups
+        groupsForAutoSaveRef.current
       );
       const response = JSON.parse(result);
       if (response.success) {
@@ -3689,15 +3664,10 @@ const StudioContent = () => {
     }
   }, [
     autoSaveLayoutEnabled,
-    autoSavePending,
     isReadOnly,
     selectedVersionId,
     currentUserId,
-    layoutPreviewNodes,
     getViewport,
-    nodes,
-    edges,
-    groups
   ]);
 
   useEffect(() => {

--- a/objectified-ui/src/app/ade/studio/lib/canvasLayoutPayload.ts
+++ b/objectified-ui/src/app/ade/studio/lib/canvasLayoutPayload.ts
@@ -1,0 +1,38 @@
+import type { Edge, Node } from '@xyflow/react';
+
+/**
+ * Serialize React Flow nodes for default/named canvas layout persistence.
+ * Kept in one place for manual save and auto-save (#315).
+ */
+export function mapNodesForLayoutSave(nodes: Node[]) {
+  return nodes.map((node) => ({
+    id: node.id,
+    type: node.type,
+    position: node.position,
+    dimensions: {
+      width: node.measured?.width || node.width || node.style?.width,
+      height: node.measured?.height || node.height || node.style?.height,
+    },
+    data:
+      node.type === 'groupNode'
+        ? {
+            name: node.data.name,
+            color: node.data.color,
+            nodeIds: node.data.nodeIds,
+          }
+        : undefined,
+  }));
+}
+
+/**
+ * Serialize edges for canvas layout persistence.
+ */
+export function mapEdgesForLayoutSave(edges: Edge[]) {
+  return edges.map((edge) => ({
+    id: edge.id,
+    source: edge.source,
+    target: edge.target,
+    sourceHandle: edge.sourceHandle,
+    targetHandle: edge.targetHandle,
+  }));
+}

--- a/objectified-ui/tests/unit/canvasLayoutPayload.test.ts
+++ b/objectified-ui/tests/unit/canvasLayoutPayload.test.ts
@@ -1,0 +1,61 @@
+import type { Edge, Node } from '@xyflow/react';
+import {
+  mapEdgesForLayoutSave,
+  mapNodesForLayoutSave,
+} from '../../src/app/ade/studio/lib/canvasLayoutPayload';
+
+describe('canvasLayoutPayload', () => {
+  it('maps class nodes with dimensions', () => {
+    const nodes = [
+      {
+        id: 'c1',
+        type: 'classNode',
+        position: { x: 1, y: 2 },
+        measured: { width: 100, height: 50 },
+      },
+    ] as Node[];
+    const out = mapNodesForLayoutSave(nodes);
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({
+      id: 'c1',
+      type: 'classNode',
+      position: { x: 1, y: 2 },
+      dimensions: { width: 100, height: 50 },
+    });
+    expect(out[0].data).toBeUndefined();
+  });
+
+  it('maps group nodes with data payload', () => {
+    const nodes = [
+      {
+        id: 'g1',
+        type: 'groupNode',
+        position: { x: 0, y: 0 },
+        data: { name: 'G', color: '#fff', nodeIds: ['a'] },
+      },
+    ] as Node[];
+    const out = mapNodesForLayoutSave(nodes);
+    expect(out[0].data).toEqual({ name: 'G', color: '#fff', nodeIds: ['a'] });
+  });
+
+  it('maps edges with handles', () => {
+    const edges = [
+      {
+        id: 'e1',
+        source: 'a',
+        target: 'b',
+        sourceHandle: 's',
+        targetHandle: 't',
+      },
+    ] as Edge[];
+    expect(mapEdgesForLayoutSave(edges)).toEqual([
+      {
+        id: 'e1',
+        source: 'a',
+        target: 'b',
+        sourceHandle: 's',
+        targetHandle: 't',
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## Problem Statement

Users and teams need **fix #315 — steady canvas layout auto-save (30s while pending)** within the Objectified platform. Today this capability is missing or only partially implemented, which blocks platform workflows and creates inconsistency across tenants and projects.

## Solution / Scope

Implement **Fix #315 — steady canvas layout auto-save (30s while pending)** as part of **Platform**.

**Post-MVP** (prioritize after MVP slice) candidacy.

```mermaid
flowchart LR
  User[User action: Fix #315 — steady canvas layout auto-sav] --> UI[objectified-ui]
  UI --> API[objectified-rest]
  API --> DB[(PostgreSQL)]
```

## Acceptance Criteria

- [ ] Feature behaves as described for: Fix #315 — steady canvas layout auto-save (30s while pending)
- [ ] Unit/integration tests cover happy path and primary error cases
- [ ] UI (if applicable) matches existing ADE patterns (Tailwind 4, Radix, Lucide)
- [ ] REST endpoints (if applicable) follow `/v1/{{feature}}/{{tenant_slug}}/...` conventions
- [ ] Documented in issue/PR; no regressions to existing schema/version flows

## Parallelism / Dependencies

- **Can run in parallel:** Yes
- **Blockers:** None identified; validate against current codebase before starting

## Technical Stack

- **Modules:** objectified-ui, objectified-rest
- **Stack:** Next.js 16, React 19, FastAPI, PostgreSQL
- **Labels:** ``

---
**Issue:** #844 · **Area:** Platform · **Roadmap batch:** legacy #64–#879 enrichment