### PR TITLE
Fixes #316 — Canvas layout import/export: edge handle restore & DRY export

### DIFF
--- a/PLANNED_FEATURE_ROADMAP_CANVAS.md
+++ b/PLANNED_FEATURE_ROADMAP_CANVAS.md
@@ -31,10 +31,6 @@
 - 📋 [TODO] Add ability to save layouts with a custom name
 - ✅ Add simple orthagonal edge routing after auto-layout
 
-| Ticket | Feature                                        |
-|--------|------------------------------------------------|
-| #316   | Export/import canvas layouts                   |
-
 #### Layout Snapshots ✅ BASIC (named layouts)
 - ✅ PNG snapshot stored with each named layout save; thumbnail preview when picking a layout name (#314)
 - 📋 [TODO] Take quick snapshots of current layout

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.8.54",
+  "version": "0.8.55",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -9,6 +9,7 @@ Improvements:
 - Canvas: schema timeline panel shows class count, relationships, and complexity across project versions (#323)
 - Canvas: named layout saves store a PNG snapshot for thumbnail preview in the layout menu
 - Canvas: export and import canvas layouts as versioned JSON (share across versions and projects)
+- Canvas: layout import and named layout load restore edge handle routing when saved edge IDs match the canvas (#316)
 
 Bug Fixes:
 - Import now handles paths properly

--- a/objectified-ui/src/app/ade/studio/editor/page.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/page.tsx
@@ -147,6 +147,7 @@ import {
   buildCanvasLayoutJsonDocument,
   parseCanvasLayoutJson,
   filterCanvasLayoutForTargetClasses,
+  mergeSavedEdgeHandles,
 } from '@/app/utils/canvas-layout-json';
 import { computeSchemaMetrics, getCircularDependencyEdgeIds, getDependencyDepthMap, getAffectedClassIds, getUpstreamClassIds, getDependencyChainNodeAndEdgeIds } from '@/app/utils/schema-metrics';
 import { toPng } from 'html-to-image';
@@ -3688,6 +3689,7 @@ const StudioContent = () => {
       layout: {
         viewport?: { x?: number; y?: number; zoom?: number };
         nodes?: unknown;
+        edges?: unknown;
       };
       layoutNameToSet?: string;
       clearGroupsWhenEmpty?: boolean;
@@ -3842,6 +3844,10 @@ const StudioContent = () => {
 
         triggerSidebarRefresh();
 
+        if (Array.isArray(layout.edges) && layout.edges.length > 0) {
+          setEdges((eds) => mergeSavedEdgeHandles(eds, layout.edges as unknown[]));
+        }
+
         setIsLoadingCanvas(false);
         setLoadingMessage('');
         setLayoutDropdownOpen(false);
@@ -3855,6 +3861,7 @@ const StudioContent = () => {
       selectedVersionId,
       reloadClasses,
       setNodes,
+      setEdges,
       setGroups,
       setViewport,
       projectTags,
@@ -3914,30 +3921,8 @@ const StudioContent = () => {
   const handleExportLayoutJson = useCallback(() => {
     if (!selectedVersionId) return;
     const viewport = getViewport();
-    const nodeData = nodes.map((node) => ({
-      id: node.id,
-      type: node.type,
-      position: node.position,
-      dimensions: {
-        width: node.measured?.width || node.width || node.style?.width,
-        height: node.measured?.height || node.height || node.style?.height,
-      },
-      data:
-        node.type === 'groupNode'
-          ? {
-              name: node.data.name,
-              color: node.data.color,
-              nodeIds: node.data.nodeIds,
-            }
-          : undefined,
-    }));
-    const edgeData = edges.map((edge) => ({
-      id: edge.id,
-      source: edge.source,
-      target: edge.target,
-      sourceHandle: edge.sourceHandle,
-      targetHandle: edge.targetHandle,
-    }));
+    const nodeData = mapNodesForLayoutSave(nodes);
+    const edgeData = mapEdgesForLayoutSave(edges);
     const doc = buildCanvasLayoutJsonDocument({
       layoutName: selectedLayoutName.trim() || undefined,
       viewport,
@@ -4063,6 +4048,7 @@ const StudioContent = () => {
         const layoutPayload = {
           viewport: filtered.viewport,
           nodes: filtered.nodes,
+          edges: filtered.edges,
         };
 
         await applyCanvasLayoutPayload({

--- a/objectified-ui/src/app/utils/canvas-layout-json.ts
+++ b/objectified-ui/src/app/utils/canvas-layout-json.ts
@@ -2,6 +2,8 @@
  * Canvas layout JSON interchange format (versioned for compatibility across app and project copies).
  */
 
+import type { Edge } from '@xyflow/react';
+
 export const CANVAS_LAYOUT_JSON_FORMAT_VERSION = 1 as const;
 
 export type CanvasLayoutJsonDocument = {
@@ -188,4 +190,36 @@ export function filterCanvasLayoutForTargetClasses(
     nodePositions,
     droppedClassCount,
   };
+}
+
+/**
+ * After the canvas rebuilds edges from schema, overlay handle IDs from an imported or saved layout
+ * so routing matches the exported file when edge IDs still match.
+ */
+export function mergeSavedEdgeHandles(
+  currentEdges: Edge[],
+  savedEdges: unknown[] | undefined
+): Edge[] {
+  if (!savedEdges?.length) {
+    return currentEdges;
+  }
+  const byId = new Map<string, { sourceHandle?: string; targetHandle?: string }>();
+  for (const raw of savedEdges) {
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) continue;
+    const e = raw as Record<string, unknown>;
+    if (typeof e.id !== 'string') continue;
+    const overlay: { sourceHandle?: string; targetHandle?: string } = {};
+    if (typeof e.sourceHandle === 'string') overlay.sourceHandle = e.sourceHandle;
+    if (typeof e.targetHandle === 'string') overlay.targetHandle = e.targetHandle;
+    if (Object.keys(overlay).length === 0) continue;
+    byId.set(e.id, overlay);
+  }
+  if (byId.size === 0) {
+    return currentEdges;
+  }
+  return currentEdges.map((edge) => {
+    const o = byId.get(edge.id);
+    if (!o) return edge;
+    return { ...edge, ...o };
+  });
 }

--- a/objectified-ui/tests/canvas-layout-json.test.ts
+++ b/objectified-ui/tests/canvas-layout-json.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, test } from '@jest/globals';
+import type { Edge } from '@xyflow/react';
 import {
   buildCanvasLayoutJsonDocument,
   CANVAS_LAYOUT_JSON_FORMAT_VERSION,
   filterCanvasLayoutForTargetClasses,
+  mergeSavedEdgeHandles,
   parseCanvasLayoutJson,
 } from '../src/app/utils/canvas-layout-json';
 
@@ -130,5 +132,33 @@ describe('canvas-layout-json', () => {
     expect(filtered.nodes).toHaveLength(1);
     expect(filtered.nodes[0].id).toBe('valid');
     expect(filtered.nodePositions).toEqual({ valid: { x: 5, y: 10 } });
+  });
+
+  test('mergeSavedEdgeHandles overlays handles by edge id', () => {
+    const current: Edge[] = [
+      {
+        id: 'e1',
+        source: 'a',
+        target: 'b',
+        sourceHandle: 'old-src',
+        targetHandle: 'old-tgt',
+      } as Edge,
+    ];
+    const merged = mergeSavedEdgeHandles(current, [
+      { id: 'e1', sourceHandle: 'new-src', targetHandle: 'new-tgt' },
+    ]);
+    expect(merged[0].sourceHandle).toBe('new-src');
+    expect(merged[0].targetHandle).toBe('new-tgt');
+  });
+
+  test('mergeSavedEdgeHandles ignores entries without string handles', () => {
+    const current: Edge[] = [{ id: 'e1', source: 'a', target: 'b' } as Edge];
+    expect(mergeSavedEdgeHandles(current, [{ id: 'e1', sourceHandle: 1 }])).toEqual(current);
+  });
+
+  test('mergeSavedEdgeHandles returns current when saved is empty', () => {
+    const current: Edge[] = [{ id: 'e1', source: 'a', target: 'b' } as Edge];
+    expect(mergeSavedEdgeHandles(current, [])).toEqual(current);
+    expect(mergeSavedEdgeHandles(current, undefined)).toEqual(current);
   });
 });


### PR DESCRIPTION
## Problem Statement

Users and teams need **fixes #316 — canvas layout import/export: edge handle restore & dry export** within the Objectified platform. Today this capability is missing or only partially implemented, which blocks platform workflows and creates inconsistency across tenants and projects.

## Solution / Scope

Implement **Fixes #316 — Canvas layout import/export: edge handle restore & DRY export** as part of **Platform**.

**Post-MVP** (prioritize after MVP slice) candidacy.

```mermaid
flowchart LR
  User[User action: Fixes #316 — Canvas layout import/export] --> UI[objectified-ui]
  UI --> API[objectified-rest]
  API --> DB[(PostgreSQL)]
```

## Acceptance Criteria

- [ ] Feature behaves as described for: Fixes #316 — Canvas layout import/export: edge handle restore & DRY export
- [ ] Unit/integration tests cover happy path and primary error cases
- [ ] UI (if applicable) matches existing ADE patterns (Tailwind 4, Radix, Lucide)
- [ ] REST endpoints (if applicable) follow `/v1/{{feature}}/{{tenant_slug}}/...` conventions
- [ ] Documented in issue/PR; no regressions to existing schema/version flows

## Parallelism / Dependencies

- **Can run in parallel:** Yes
- **Blockers:** None identified; validate against current codebase before starting

## Technical Stack

- **Modules:** objectified-ui, objectified-rest
- **Stack:** Next.js 16, React 19, FastAPI, PostgreSQL
- **Labels:** ``

---
**Issue:** #845 · **Area:** Platform · **Roadmap batch:** legacy #64–#879 enrichment