### PR TITLE
Collapsible canvas groups (#154)

### DIFF
--- a/PLANNED_FEATURE_ROADMAP_CANVAS.md
+++ b/PLANNED_FEATURE_ROADMAP_CANVAS.md
@@ -79,10 +79,10 @@
 - ✅ Moving a group moves all contained classes together
 - ✅ Nodes stay within group when partially overlapping - only ungroup when completely outside
 - ✅ Grouped nodes are locked to group bounds during dragging - cannot escape unless dragged completely outside
-- 📋 [TODO] Collapsible groups to reduce canvas clutter
-  - 📋 [TODO] Click to collapse: shows only group title and count
-  - 📋 [TODO] Expand/collapse all groups with keyboard shortcut
-  - 📋 [TODO] Remember collapsed state per user
+- ✅ Collapsible groups to reduce canvas clutter (#154)
+  - ✅ Click chevron to collapse: compact frame with title and class count
+  - ✅ Alt+Shift+[ / Alt+Shift+] — collapse all / expand all groups
+  - ✅ Collapsed state persisted per user per version (localStorage)
 - 📋 [TODO] Nested groups for hierarchical organization (max 3 levels)
 - ✅ Group-level operations:
   - ✅ Move entire group with one drag
@@ -97,7 +97,6 @@
 
 | Ticket | Feature                                                             |
 |--------|---------------------------------------------------------------------|
-| #154   | Collapsible groups to reduce canvas clutter                         |
 | #155   | Nested groups for hierarchical organization                         |
 | #156   | Group-level operations: move, delete, export, duplicate, bulk edit  |
 

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.8.56",
+  "version": "0.8.57",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -5,6 +5,7 @@ We continue to improve the platform based on your feedback with improvements and
 ---
 
 Improvements:
+- Canvas: groups can collapse to a compact title bar (chevron); Alt+Shift+[ / ] collapse or expand all; your choices are remembered per version (#154)
 - Canvas: presentation mode — save viewport slides, present in fullscreen with speaker notes, timer, and keyboard controls (#517)
 - Canvas: layout auto-save uses a steady timer while edits are pending so saves occur every 30 seconds (or your chosen interval) without resetting on each move (#315)
 - Canvas: schema timeline panel shows class count, relationships, and complexity across project versions (#323)

--- a/objectified-ui/src/app/ade/studio/editor/page.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/page.tsx
@@ -1461,10 +1461,15 @@ const StudioContent = () => {
     }
   }, [isolateSelectionEnabled, selectedNodeIds.length]);
 
+  // #154: Class node IDs hidden because they belong to a collapsed group — shared between displayNodes and displayEdges
+  const classIdsHiddenByCollapse = useMemo(
+    () => getClassIdsInCollapsedGroups(groups, collapsedGroupIds),
+    [groups, collapsedGroupIds],
+  );
+
   // Compute nodes with search and/or focus mode styling applied (#471: use preview nodes when in layout preview)
   const displayNodes = useMemo(() => {
     let result = layoutPreviewNodes ?? nodes;
-    const classIdsHiddenByCollapse = getClassIdsInCollapsedGroups(groups, collapsedGroupIds);
 
     // #481 + #483: Manual hide, empty/unconnected/deprecated/group criteria — group frame if any member visible
     // #484: Optional ghosts mode — keep hidden nodes on canvas with semi-transparent styling
@@ -1660,34 +1665,43 @@ const StudioContent = () => {
       });
     }
 
-    // #154: Compact group node frame and wire collapse toggle into group UI
-    if (collapsedGroupIds.size > 0) {
-      result = result.map((node) => {
-        if (node.type !== 'groupNode' || !collapsedGroupIds.has(node.id)) return node;
-        const z = node.style?.zIndex ?? -1;
-        return {
-          ...node,
-          width: COLLAPSED_GROUP_FRAME_WIDTH,
-          height: COLLAPSED_GROUP_FRAME_HEIGHT,
-          style: {
-            ...node.style,
-            width: COLLAPSED_GROUP_FRAME_WIDTH,
-            height: COLLAPSED_GROUP_FRAME_HEIGHT,
-            zIndex: z,
+    // #154: Wire collapse toggle and collapsed state into all group nodes; compact frame for collapsed ones
+    result = result.map((node) => {
+      if (node.type !== 'groupNode') return node;
+
+      const isCollapsed = collapsedGroupIds.has(node.id);
+      const z = node.style?.zIndex ?? -1;
+
+      return {
+        ...node,
+        ...(isCollapsed
+          ? {
+              width: COLLAPSED_GROUP_FRAME_WIDTH,
+              height: COLLAPSED_GROUP_FRAME_HEIGHT,
+            }
+          : {}),
+        style: {
+          ...node.style,
+          ...(isCollapsed
+            ? {
+                width: COLLAPSED_GROUP_FRAME_WIDTH,
+                height: COLLAPSED_GROUP_FRAME_HEIGHT,
+              }
+            : {}),
+          zIndex: z,
+        },
+        data: {
+          ...(node.data as object),
+          collapsed: isCollapsed,
+          onToggleCollapse: () => {
+            toggleGroupCollapsedRef.current(node.id);
           },
-          data: {
-            ...(node.data as object),
-            collapsed: true,
-            onToggleCollapse: () => {
-              toggleGroupCollapsedRef.current(node.id);
-            },
-          },
-        };
-      });
-    }
+        },
+      };
+    });
 
     return result;
-  }, [nodes, layoutPreviewNodes, visibleClassIdsAfterHideCriteria, allBaseClassNodeIds, nodeGhostsModeEnabled, isolateSelectionEnabled, selectedNodeIds, groups, collapsedGroupIds, canvasSearchQuery, canvasSearchOpen, matchingNodeIds, focusModeEnabled, focusModeFocusedSet, showDependencyOverlay, dependencyView, dependencyFocalNodeId, dependencyUpstreamIds, dependencyDownstreamIds, dependencyPathChain, nodesWithDependencyIds, dependencyDepthMap, circularNodeIdsSet, impactAnalysisMode, impactAnalysisSourceId, affectedClassIds]);
+  }, [nodes, layoutPreviewNodes, visibleClassIdsAfterHideCriteria, allBaseClassNodeIds, nodeGhostsModeEnabled, isolateSelectionEnabled, selectedNodeIds, groups, collapsedGroupIds, classIdsHiddenByCollapse, canvasSearchQuery, canvasSearchOpen, matchingNodeIds, focusModeEnabled, focusModeFocusedSet, showDependencyOverlay, dependencyView, dependencyFocalNodeId, dependencyUpstreamIds, dependencyDownstreamIds, dependencyPathChain, nodesWithDependencyIds, dependencyDepthMap, circularNodeIdsSet, impactAnalysisMode, impactAnalysisSourceId, affectedClassIds]);
 
   // Compute edges with search and/or focus mode styling applied
   const displayEdges = useMemo(() => {
@@ -1711,7 +1725,6 @@ const StudioContent = () => {
       );
     }
 
-    const classIdsHiddenByCollapse = getClassIdsInCollapsedGroups(groups, collapsedGroupIds);
     if (classIdsHiddenByCollapse.size > 0) {
       result = result.filter(
         (edge) =>
@@ -1819,7 +1832,7 @@ const StudioContent = () => {
     }
 
     return result;
-  }, [edges, visibleClassIdsAfterHideCriteria, allBaseClassNodeIds, nodeGhostsModeEnabled, isolateSelectionEnabled, selectedNodeIds, groups, collapsedGroupIds, canvasSearchQuery, canvasSearchOpen, matchingNodeIds, focusModeEnabled, focusModeFocusedSet, showDependencyOverlay, dependencyView, dependencyFocalNodeId, dependencyUpstreamIds, dependencyDownstreamIds, dependencyPathChain, dependencyEdgeIds, circularEdgeIds, impactAnalysisMode, impactAnalysisSourceId, affectedClassIds]);
+  }, [edges, visibleClassIdsAfterHideCriteria, allBaseClassNodeIds, nodeGhostsModeEnabled, isolateSelectionEnabled, selectedNodeIds, groups, classIdsHiddenByCollapse, canvasSearchQuery, canvasSearchOpen, matchingNodeIds, focusModeEnabled, focusModeFocusedSet, showDependencyOverlay, dependencyView, dependencyFocalNodeId, dependencyUpstreamIds, dependencyDownstreamIds, dependencyPathChain, dependencyEdgeIds, circularEdgeIds, impactAnalysisMode, impactAnalysisSourceId, affectedClassIds]);
 
   // #349: Apply hover highlight to the hovered edge (thicker stroke, higher zIndex)
   const edgesWithHover = useMemo(() => {

--- a/objectified-ui/src/app/ade/studio/editor/page.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/page.tsx
@@ -139,6 +139,12 @@ import {
   groupNodeIdIsVisible,
 } from '@/app/utils/canvas-display-visibility';
 import {
+  collapsePrefsStorageKey,
+  getClassIdsInCollapsedGroups,
+  COLLAPSED_GROUP_FRAME_WIDTH,
+  COLLAPSED_GROUP_FRAME_HEIGHT,
+} from '@/app/utils/canvas-group-collapse';
+import {
   edgeBelongsOnCanvas,
   ghostEdgeClassName,
   ghostNodeClassName,
@@ -396,6 +402,70 @@ const StudioContent = () => {
       return next;
     });
   }, []);
+
+  // #154: Collapsed canvas groups — member classes hidden, compact frame; prefs per user + version
+  const [collapsedGroupIds, setCollapsedGroupIds] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    if (!currentUserId || !selectedVersionId) {
+      setCollapsedGroupIds(new Set());
+      return;
+    }
+    try {
+      const raw = localStorage.getItem(collapsePrefsStorageKey(currentUserId, selectedVersionId));
+      setCollapsedGroupIds(raw ? new Set(JSON.parse(raw) as string[]) : new Set());
+    } catch {
+      setCollapsedGroupIds(new Set());
+    }
+  }, [currentUserId, selectedVersionId]);
+
+  const persistCollapsedGroupIds = useCallback(
+    (next: Set<string>) => {
+      if (!currentUserId || !selectedVersionId) return;
+      try {
+        localStorage.setItem(
+          collapsePrefsStorageKey(currentUserId, selectedVersionId),
+          JSON.stringify([...next])
+        );
+      } catch {
+        /* ignore quota / private mode */
+      }
+    },
+    [currentUserId, selectedVersionId]
+  );
+
+  const toggleGroupCollapsed = useCallback(
+    (groupId: string) => {
+      setCollapsedGroupIds((prev) => {
+        const next = new Set(prev);
+        if (next.has(groupId)) next.delete(groupId);
+        else next.add(groupId);
+        persistCollapsedGroupIds(next);
+        return next;
+      });
+    },
+    [persistCollapsedGroupIds]
+  );
+
+  const collapseAllCanvasGroups = useCallback(() => {
+    if (groups.length === 0) return;
+    const next = new Set(groups.map((g) => g.id));
+    setCollapsedGroupIds(next);
+    persistCollapsedGroupIds(next);
+  }, [groups, persistCollapsedGroupIds]);
+
+  const expandAllCanvasGroups = useCallback(() => {
+    const next = new Set<string>();
+    setCollapsedGroupIds(next);
+    persistCollapsedGroupIds(next);
+  }, [persistCollapsedGroupIds]);
+
+  const toggleGroupCollapsedRef = useRef<(id: string) => void>(() => {});
+  toggleGroupCollapsedRef.current = toggleGroupCollapsed;
+  const collapseAllCanvasGroupsRef = useRef<() => void>(() => {});
+  const expandAllCanvasGroupsRef = useRef<() => void>(() => {});
+  collapseAllCanvasGroupsRef.current = collapseAllCanvasGroups;
+  expandAllCanvasGroupsRef.current = expandAllCanvasGroups;
 
   /** Avoid clobbering localStorage on hydrate: save effect runs after load in the same tick. */
   const skipNextHideCriteriaPersistRef = useRef(false);
@@ -1355,6 +1425,19 @@ const StudioContent = () => {
           closeCanvasSearch();
         }
       }
+
+      // #154: Alt+Shift+[ collapse all groups; Alt+Shift+] expand all
+      if (e.altKey && e.shiftKey && !e.ctrlKey && !e.metaKey && (e.key === '[' || e.key === ']')) {
+        const el = e.target as HTMLElement | null;
+        if (el?.closest('input, textarea, [contenteditable="true"]')) return;
+        if (groups.length === 0) return;
+        e.preventDefault();
+        if (e.key === '[') {
+          collapseAllCanvasGroupsRef.current();
+        } else {
+          expandAllCanvasGroupsRef.current();
+        }
+      }
     };
 
     window.addEventListener('keydown', handleKeyDown);
@@ -1368,6 +1451,7 @@ const StudioContent = () => {
     exitFocusMode,
     isolateSelectionEnabled,
     canvasPresentationActive,
+    groups.length,
   ]);
 
   // #482: Turn off isolate when the class selection is cleared
@@ -1380,6 +1464,7 @@ const StudioContent = () => {
   // Compute nodes with search and/or focus mode styling applied (#471: use preview nodes when in layout preview)
   const displayNodes = useMemo(() => {
     let result = layoutPreviewNodes ?? nodes;
+    const classIdsHiddenByCollapse = getClassIdsInCollapsedGroups(groups, collapsedGroupIds);
 
     // #481 + #483: Manual hide, empty/unconnected/deprecated/group criteria — group frame if any member visible
     // #484: Optional ghosts mode — keep hidden nodes on canvas with semi-transparent styling
@@ -1419,6 +1504,14 @@ const StudioContent = () => {
     if (isolateSelectionEnabled && selectedNodeIds.length > 0) {
       const visibleIds = getVisibleNodeIdsForIsolateSelection(groups, new Set(selectedNodeIds));
       result = result.filter((node) => visibleIds.has(node.id));
+    }
+
+    // #154: Hide member class nodes for collapsed groups (compact frame applied below)
+    if (classIdsHiddenByCollapse.size > 0) {
+      result = result.filter((node) => {
+        if (node.type === 'groupNode') return true;
+        return !classIdsHiddenByCollapse.has(node.id);
+      });
     }
 
     // Apply search classes when search is active
@@ -1567,8 +1660,34 @@ const StudioContent = () => {
       });
     }
 
+    // #154: Compact group node frame and wire collapse toggle into group UI
+    if (collapsedGroupIds.size > 0) {
+      result = result.map((node) => {
+        if (node.type !== 'groupNode' || !collapsedGroupIds.has(node.id)) return node;
+        const z = node.style?.zIndex ?? -1;
+        return {
+          ...node,
+          width: COLLAPSED_GROUP_FRAME_WIDTH,
+          height: COLLAPSED_GROUP_FRAME_HEIGHT,
+          style: {
+            ...node.style,
+            width: COLLAPSED_GROUP_FRAME_WIDTH,
+            height: COLLAPSED_GROUP_FRAME_HEIGHT,
+            zIndex: z,
+          },
+          data: {
+            ...(node.data as object),
+            collapsed: true,
+            onToggleCollapse: () => {
+              toggleGroupCollapsedRef.current(node.id);
+            },
+          },
+        };
+      });
+    }
+
     return result;
-  }, [nodes, layoutPreviewNodes, visibleClassIdsAfterHideCriteria, allBaseClassNodeIds, nodeGhostsModeEnabled, isolateSelectionEnabled, selectedNodeIds, groups, canvasSearchQuery, canvasSearchOpen, matchingNodeIds, focusModeEnabled, focusModeFocusedSet, showDependencyOverlay, dependencyView, dependencyFocalNodeId, dependencyUpstreamIds, dependencyDownstreamIds, dependencyPathChain, nodesWithDependencyIds, dependencyDepthMap, circularNodeIdsSet, impactAnalysisMode, impactAnalysisSourceId, affectedClassIds]);
+  }, [nodes, layoutPreviewNodes, visibleClassIdsAfterHideCriteria, allBaseClassNodeIds, nodeGhostsModeEnabled, isolateSelectionEnabled, selectedNodeIds, groups, collapsedGroupIds, canvasSearchQuery, canvasSearchOpen, matchingNodeIds, focusModeEnabled, focusModeFocusedSet, showDependencyOverlay, dependencyView, dependencyFocalNodeId, dependencyUpstreamIds, dependencyDownstreamIds, dependencyPathChain, nodesWithDependencyIds, dependencyDepthMap, circularNodeIdsSet, impactAnalysisMode, impactAnalysisSourceId, affectedClassIds]);
 
   // Compute edges with search and/or focus mode styling applied
   const displayEdges = useMemo(() => {
@@ -1589,6 +1708,14 @@ const StudioContent = () => {
       const visibleIds = getVisibleNodeIdsForIsolateSelection(groups, new Set(selectedNodeIds));
       result = result.filter(
         (edge) => visibleIds.has(edge.source) && visibleIds.has(edge.target)
+      );
+    }
+
+    const classIdsHiddenByCollapse = getClassIdsInCollapsedGroups(groups, collapsedGroupIds);
+    if (classIdsHiddenByCollapse.size > 0) {
+      result = result.filter(
+        (edge) =>
+          !classIdsHiddenByCollapse.has(edge.source) && !classIdsHiddenByCollapse.has(edge.target)
       );
     }
 
@@ -1692,7 +1819,7 @@ const StudioContent = () => {
     }
 
     return result;
-  }, [edges, visibleClassIdsAfterHideCriteria, allBaseClassNodeIds, nodeGhostsModeEnabled, isolateSelectionEnabled, selectedNodeIds, groups, canvasSearchQuery, canvasSearchOpen, matchingNodeIds, focusModeEnabled, focusModeFocusedSet, showDependencyOverlay, dependencyView, dependencyFocalNodeId, dependencyUpstreamIds, dependencyDownstreamIds, dependencyPathChain, dependencyEdgeIds, circularEdgeIds, impactAnalysisMode, impactAnalysisSourceId, affectedClassIds]);
+  }, [edges, visibleClassIdsAfterHideCriteria, allBaseClassNodeIds, nodeGhostsModeEnabled, isolateSelectionEnabled, selectedNodeIds, groups, collapsedGroupIds, canvasSearchQuery, canvasSearchOpen, matchingNodeIds, focusModeEnabled, focusModeFocusedSet, showDependencyOverlay, dependencyView, dependencyFocalNodeId, dependencyUpstreamIds, dependencyDownstreamIds, dependencyPathChain, dependencyEdgeIds, circularEdgeIds, impactAnalysisMode, impactAnalysisSourceId, affectedClassIds]);
 
   // #349: Apply hover highlight to the hovered edge (thicker stroke, higher zIndex)
   const edgesWithHover = useMemo(() => {

--- a/objectified-ui/src/app/components/ade/studio/GroupNode.tsx
+++ b/objectified-ui/src/app/components/ade/studio/GroupNode.tsx
@@ -9,6 +9,7 @@ import {
   FileX, ChevronRight, ChevronDown,
 } from 'lucide-react';
 import * as Popover from '@radix-ui/react-popover';
+import { COLLAPSED_GROUP_FRAME_WIDTH, COLLAPSED_GROUP_FRAME_HEIGHT } from '@/app/utils/canvas-group-collapse';
 
 // Available group icons
 export const GROUP_ICONS = [
@@ -218,8 +219,8 @@ const GroupNode = memo(({ id, data, selected }: NodeProps) => {
           ${groupData.isHighlighted ? 'ring-4 ring-green-500 ring-offset-4 dark:ring-offset-gray-900 scale-[1.02] border-green-500 dark:border-green-400' : ''}
         `}
         style={{
-          minWidth: isCollapsed ? 120 : 200,
-          minHeight: isCollapsed ? 40 : 150,
+          minWidth: isCollapsed ? COLLAPSED_GROUP_FRAME_WIDTH : 200,
+          minHeight: isCollapsed ? COLLAPSED_GROUP_FRAME_HEIGHT : 150,
           backgroundColor: `${colorConfig.hex}${Math.round(styleOptions.opacity * 25.5).toString(16).padStart(2, '0')}`
         }}
       >

--- a/objectified-ui/src/app/components/ade/studio/GroupNode.tsx
+++ b/objectified-ui/src/app/components/ade/studio/GroupNode.tsx
@@ -6,7 +6,7 @@ import {
   Folder, Edit2, Trash2, X, Check, Palette, Settings,
   Box, Layers, Database, Shield, Users, Zap, Globe, Lock,
   FileText, Tag, Star, Heart, Flag, Bookmark, Archive, Package,
-  FileX
+  FileX, ChevronRight, ChevronDown,
 } from 'lucide-react';
 import * as Popover from '@radix-ui/react-popover';
 
@@ -104,6 +104,9 @@ export interface GroupNodeData {
   onColorChange?: (groupId: string, newColor: string) => void;
   onStyleChange?: (groupId: string, styleOptions: GroupStyleOptions) => void;
   isReadOnly?: boolean;
+  /** Canvas frame is collapsed to title + count only (#154). */
+  collapsed?: boolean;
+  onToggleCollapse?: () => void;
 }
 
 const GroupNode = memo(({ id, data, selected }: NodeProps) => {
@@ -194,6 +197,7 @@ const GroupNode = memo(({ id, data, selected }: NodeProps) => {
 
   // Count nodes in this group
   const nodeCount = groupData.nodeIds?.length || 0;
+  const isCollapsed = Boolean(groupData.collapsed);
 
   return (
     <>
@@ -201,7 +205,7 @@ const GroupNode = memo(({ id, data, selected }: NodeProps) => {
       <NodeResizer
         minWidth={200}
         minHeight={150}
-        isVisible={selected && !groupData.isReadOnly}
+        isVisible={selected && !groupData.isReadOnly && !isCollapsed}
         lineClassName="!border-indigo-400"
         handleClassName="!w-3 !h-3 !bg-indigo-500 !border-2 !border-white !rounded"
       />
@@ -214,8 +218,8 @@ const GroupNode = memo(({ id, data, selected }: NodeProps) => {
           ${groupData.isHighlighted ? 'ring-4 ring-green-500 ring-offset-4 dark:ring-offset-gray-900 scale-[1.02] border-green-500 dark:border-green-400' : ''}
         `}
         style={{
-          minWidth: 200,
-          minHeight: 150,
+          minWidth: isCollapsed ? 120 : 200,
+          minHeight: isCollapsed ? 40 : 150,
           backgroundColor: `${colorConfig.hex}${Math.round(styleOptions.opacity * 25.5).toString(16).padStart(2, '0')}`
         }}
       >
@@ -230,6 +234,25 @@ const GroupNode = memo(({ id, data, selected }: NodeProps) => {
             backgroundColor: `${colorConfig.hex}${Math.round(Math.min(styleOptions.opacity + 0.3, 1) * 255).toString(16).padStart(2, '0')}`
           }}
         >
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              e.preventDefault();
+              groupData.onToggleCollapse?.();
+            }}
+            onPointerDown={(e) => e.stopPropagation()}
+            className={`p-0.5 rounded shrink-0 -ml-0.5 transition-colors ${useLightText ? 'hover:bg-white/25' : 'hover:bg-white/50 dark:hover:bg-gray-700/50'}`}
+            title={isCollapsed ? 'Expand group (show classes)' : 'Collapse group (hide classes)'}
+            aria-expanded={!isCollapsed}
+            aria-label={isCollapsed ? 'Expand group' : 'Collapse group'}
+          >
+            {isCollapsed ? (
+              <ChevronRight className="h-4 w-4" />
+            ) : (
+              <ChevronDown className="h-4 w-4" />
+            )}
+          </button>
           <IconComponent className="h-4 w-4" />
 
           {isEditing ? (
@@ -471,7 +494,7 @@ const GroupNode = memo(({ id, data, selected }: NodeProps) => {
         </div>
 
         {/* Description (if any) */}
-        {groupData.description && (
+        {groupData.description && !isCollapsed && (
           <div className={`absolute bottom-2 left-4 right-4 text-xs ${textColorClass} opacity-70 truncate`}>
             {groupData.description}
           </div>

--- a/objectified-ui/src/app/utils/canvas-group-collapse.ts
+++ b/objectified-ui/src/app/utils/canvas-group-collapse.ts
@@ -1,0 +1,25 @@
+/**
+ * Canvas group collapse (#154): compact group frames and hide member class nodes.
+ */
+
+export const COLLAPSED_GROUP_FRAME_WIDTH = 240;
+export const COLLAPSED_GROUP_FRAME_HEIGHT = 56;
+
+export function collapsePrefsStorageKey(userId: string, versionId: string): string {
+  return `ade.canvasGroupCollapsed:v1:${userId}:${versionId}`;
+}
+
+/** Class node IDs that belong to at least one collapsed group. */
+export function getClassIdsInCollapsedGroups(
+  groups: { id: string; nodeIds: string[] }[],
+  collapsedGroupIds: Set<string>
+): Set<string> {
+  const ids = new Set<string>();
+  for (const g of groups) {
+    if (!collapsedGroupIds.has(g.id)) continue;
+    for (const id of g.nodeIds) {
+      ids.add(id);
+    }
+  }
+  return ids;
+}

--- a/objectified-ui/tests/unit/canvas-group-collapse.test.ts
+++ b/objectified-ui/tests/unit/canvas-group-collapse.test.ts
@@ -1,0 +1,22 @@
+import {
+  collapsePrefsStorageKey,
+  getClassIdsInCollapsedGroups,
+} from '@/app/utils/canvas-group-collapse';
+
+describe('canvas-group-collapse', () => {
+  it('getClassIdsInCollapsedGroups returns members of collapsed groups only', () => {
+    const groups = [
+      { id: 'a', nodeIds: ['1', '2'] },
+      { id: 'b', nodeIds: ['3'] },
+    ];
+    expect([...getClassIdsInCollapsedGroups(groups, new Set(['a']))].sort()).toEqual(['1', '2']);
+    expect(getClassIdsInCollapsedGroups(groups, new Set(['a', 'b'])).size).toBe(3);
+    expect(getClassIdsInCollapsedGroups(groups, new Set()).size).toBe(0);
+  });
+
+  it('collapsePrefsStorageKey encodes user and version', () => {
+    expect(collapsePrefsStorageKey('user-1', 'ver-2')).toBe(
+      'ade.canvasGroupCollapsed:v1:user-1:ver-2'
+    );
+  });
+});


### PR DESCRIPTION
## Problem Statement

Users and teams need **collapsible canvas groups (#154)** within the Objectified platform. Today this capability is missing or only partially implemented, which blocks platform workflows and creates inconsistency across tenants and projects.

## Solution / Scope

Implement **Collapsible canvas groups (#154)** as part of **Platform**.

**Post-MVP** (prioritize after MVP slice) candidacy.

```mermaid
flowchart LR
  User[User action: Collapsible canvas groups (#154)] --> UI[objectified-ui]
  UI --> API[objectified-rest]
  API --> DB[(PostgreSQL)]
```

## Acceptance Criteria

- [ ] Feature behaves as described for: Collapsible canvas groups (#154)
- [ ] Unit/integration tests cover happy path and primary error cases
- [ ] UI (if applicable) matches existing ADE patterns (Tailwind 4, Radix, Lucide)
- [ ] REST endpoints (if applicable) follow `/v1/{{feature}}/{{tenant_slug}}/...` conventions
- [ ] Documented in issue/PR; no regressions to existing schema/version flows

## Parallelism / Dependencies

- **Can run in parallel:** Yes
- **Blockers:** None identified; validate against current codebase before starting

## Technical Stack

- **Modules:** objectified-ui, objectified-rest
- **Stack:** Next.js 16, React 19, FastAPI, PostgreSQL
- **Labels:** ``

---
**Issue:** #847 · **Area:** Platform · **Roadmap batch:** legacy #64–#879 enrichment