### PR TITLE
Fix #156 — Group-level export, duplicate, and bulk operations

### DIFF
--- a/PLANNED_FEATURE_ROADMAP_CANVAS.md
+++ b/PLANNED_FEATURE_ROADMAP_CANVAS.md
@@ -84,9 +84,12 @@
   - ✅ Alt+Shift+[ / Alt+Shift+] — collapse all / expand all groups
   - ✅ Collapsed state persisted per user per version (localStorage)
 - 📋 [TODO] Nested groups for hierarchical organization (max 3 levels)
-- ✅ Group-level operations:
+- ✅ Group-level operations (#156):
   - ✅ Move entire group with one drag
   - ✅ Delete all classes in a group
+  - ✅ Export group as OpenAPI JSON/YAML (includes transitive `components.schemas` refs)
+  - ✅ Duplicate group (copies classes, rewrites refs within the group, new group frame)
+  - ✅ Bulk edits: description prefix/suffix, assign tag, set/clear read-only on top-level properties
 - ✅ Named groups with descriptions and metadata
 - ✅ Visual styling options:
   - ✅ Rounded rectangle containers with subtle shadows
@@ -95,10 +98,9 @@
   - ✅ Optional group icons from icon library
 - ✅ Group object is drag-and-drop to the canvas
 
-| Ticket | Feature                                                             |
-|--------|---------------------------------------------------------------------|
-| #155   | Nested groups for hierarchical organization                         |
-| #156   | Group-level operations: move, delete, export, duplicate, bulk edit  |
+| Ticket | Feature                                                                   |
+|--------|-------------------------------------------------------------------------------|
+| #155   | Nested groups for hierarchical organization                                  |
 
 ---
 

--- a/objectified-ui/lib/db/helper.ts
+++ b/objectified-ui/lib/db/helper.ts
@@ -611,6 +611,261 @@ export async function copyClassesFromVersion(sourceVersionId: string, targetVers
   }
 }
 
+/** Rewrite `#/components/schemas/{Name}` refs when duplicating a set of classes with new names (#156). */
+function rewriteOpenApiRefsInValue(value: unknown, oldNameToNewName: Map<string, string>): unknown {
+  if (value === null || value === undefined) return value;
+  if (Array.isArray(value)) {
+    return value.map((item) => rewriteOpenApiRefsInValue(item, oldNameToNewName));
+  }
+  if (typeof value === 'object') {
+    const obj = value as Record<string, unknown>;
+    const out: Record<string, unknown> = { ...obj };
+    if (typeof out['$ref'] === 'string') {
+      const ref = out['$ref'] as string;
+      const prefix = '#/components/schemas/';
+      if (ref.startsWith(prefix)) {
+        const oldName = ref.slice(prefix.length);
+        const newName = oldNameToNewName.get(oldName);
+        if (newName) {
+          out['$ref'] = `${prefix}${newName}`;
+        }
+      }
+    }
+    for (const key of Object.keys(out)) {
+      if (key === '$ref') continue;
+      out[key] = rewriteOpenApiRefsInValue(out[key], oldNameToNewName);
+    }
+    return out;
+  }
+  return value;
+}
+
+function makeUniqueCopyName(stem: string, taken: Set<string>): string {
+  const base = stem.trim() || 'Class';
+  let candidate = `${base} Copy`;
+  let n = 2;
+  while (taken.has(candidate)) {
+    candidate = `${base} Copy ${n}`;
+    n += 1;
+  }
+  taken.add(candidate);
+  return candidate;
+}
+
+/**
+ * Deep-duplicate classes in the same version (new rows, new names, refs between them rewritten).
+ * Used for "duplicate group" on the canvas (#156).
+ */
+export async function duplicateClassesInGroup(versionId: string, sourceClassIds: string[]) {
+  try {
+    const uniqueIds = [...new Set((sourceClassIds || []).filter(Boolean))];
+    if (uniqueIds.length === 0) {
+      return JSON.stringify({ success: true, idMap: {} });
+    }
+
+    const classesResult = await connectionPool.query(
+      `SELECT id, name, description, schema, enabled
+       FROM odb.classes
+       WHERE version_id = $1 AND deleted_at IS NULL AND id = ANY($2::uuid[])`,
+      [versionId, uniqueIds]
+    );
+
+    if (classesResult.rowCount !== uniqueIds.length) {
+      return JSON.stringify({
+        success: false,
+        error: 'One or more classes were not found in this version.',
+      });
+    }
+
+    const existingNamesResult = await connectionPool.query(
+      `SELECT name FROM odb.classes WHERE version_id = $1 AND deleted_at IS NULL`,
+      [versionId]
+    );
+    const takenNames = new Set<string>(
+      existingNamesResult.rows.map((r: { name: string }) => r.name)
+    );
+
+    const rows = classesResult.rows as Array<{
+      id: string;
+      name: string;
+      description: string | null;
+      schema: unknown;
+      enabled: boolean;
+    }>;
+
+    const oldNameToNewName = new Map<string, string>();
+    for (const row of rows) {
+      const newName = makeUniqueCopyName(row.name, takenNames);
+      oldNameToNewName.set(row.name, newName);
+    }
+
+    const idMap: Record<string, string> = {};
+
+    for (const row of rows) {
+      const newName = oldNameToNewName.get(row.name)!;
+      let schemaObj =
+        typeof row.schema === 'string' ? JSON.parse(row.schema) : row.schema || {};
+      schemaObj = rewriteOpenApiRefsInValue(schemaObj, oldNameToNewName) as Record<string, unknown>;
+
+      const insertResult = await connectionPool.query(
+        `INSERT INTO odb.classes (version_id, name, description, schema, enabled, canvas_metadata)
+         VALUES ($1, $2, $3, $4, $5, $6)
+         RETURNING id`,
+        [
+          versionId,
+          newName,
+          row.description,
+          JSON.stringify(schemaObj),
+          row.enabled ?? true,
+          null,
+        ]
+      );
+
+      const newId = insertResult.rows[0].id as string;
+      idMap[row.id] = newId;
+
+      const originalPropertiesResult = await connectionPool.query(
+        `SELECT id, property_id, name, description, data, parent_id
+         FROM odb.class_properties
+         WHERE class_id = $1
+         ORDER BY parent_id NULLS FIRST, name ASC`,
+        [row.id]
+      );
+
+      const allProperties = originalPropertiesResult.rows;
+      const oldToNewIdMap = new Map<string, string>();
+      const processedIds = new Set<string>();
+
+      const copyPropertiesRecursively = async (parentId: string | null) => {
+        const propsAtThisLevel = allProperties.filter(
+          (p: any) =>
+            (p.parent_id === parentId || (p.parent_id === null && parentId === null)) &&
+            !processedIds.has(p.id)
+        );
+
+        for (const prop of propsAtThisLevel) {
+          const newParentId = prop.parent_id ? oldToNewIdMap.get(prop.parent_id) || null : null;
+          let dataVal: unknown = prop.data;
+          if (typeof dataVal === 'string') {
+            try {
+              dataVal = JSON.parse(dataVal);
+            } catch {
+              /* keep primitive string data as-is */
+            }
+          }
+          if (dataVal !== null && typeof dataVal === 'object') {
+            dataVal = rewriteOpenApiRefsInValue(dataVal, oldNameToNewName);
+          }
+
+          const dataForInsert =
+            typeof dataVal === 'string' ? dataVal : JSON.stringify(dataVal ?? {});
+
+          const insertProp = await connectionPool.query(
+            `INSERT INTO odb.class_properties (class_id, property_id, name, description, data, parent_id)
+             VALUES ($1, $2, $3, $4, $5, $6)
+             RETURNING id`,
+            [newId, prop.property_id, prop.name, prop.description, dataForInsert, newParentId]
+          );
+
+          const newPropId = insertProp.rows[0].id as string;
+          oldToNewIdMap.set(prop.id, newPropId);
+          processedIds.add(prop.id);
+          await copyPropertiesRecursively(prop.id);
+        }
+      };
+
+      await copyPropertiesRecursively(null);
+
+      await connectionPool.query(
+        `INSERT INTO odb.class_tags (class_id, tag_id)
+         SELECT $1, tag_id FROM odb.class_tags WHERE class_id = $2
+         ON CONFLICT (class_id, tag_id) DO NOTHING`,
+        [newId, row.id]
+      );
+    }
+
+    return JSON.stringify({ success: true, idMap });
+  } catch (error: any) {
+    console.error('duplicateClassesInGroup:', error);
+    return JSON.stringify({ success: false, error: error.message });
+  }
+}
+
+/**
+ * Apply bulk metadata / tag / top-level property flag changes to many classes (#156).
+ */
+export async function bulkApplyEditsToGroupClasses(
+  classIds: string[],
+  options: {
+    descriptionPrefix?: string;
+    descriptionSuffix?: string;
+    tagId?: string;
+    topLevelPropertyReadOnly?: boolean;
+  }
+) {
+  try {
+    const uniqueIds = [...new Set((classIds || []).filter(Boolean))];
+    if (uniqueIds.length === 0) {
+      return JSON.stringify({ success: true });
+    }
+
+    const prefix = options.descriptionPrefix ?? '';
+    const suffix = options.descriptionSuffix ?? '';
+
+    if (prefix !== '' || suffix !== '') {
+      for (const classId of uniqueIds) {
+        const r = await connectionPool.query(
+          `SELECT id, name, description, schema FROM odb.classes WHERE id = $1 AND deleted_at IS NULL`,
+          [classId]
+        );
+        if (r.rowCount === 0) continue;
+        const row = r.rows[0];
+        const desc = `${prefix}${row.description || ''}${suffix}`;
+        const schema = typeof row.schema === 'string' ? JSON.parse(row.schema) : row.schema;
+        await updateClass(row.id, row.name, desc.trim() === '' ? null : desc, schema);
+      }
+    }
+
+    if (options.tagId) {
+      for (const classId of uniqueIds) {
+        await assignTagToClass(classId, options.tagId);
+      }
+    }
+
+    if (typeof options.topLevelPropertyReadOnly === 'boolean') {
+      const ro = options.topLevelPropertyReadOnly;
+      for (const classId of uniqueIds) {
+        const props = await connectionPool.query(
+          `SELECT id, data FROM odb.class_properties WHERE class_id = $1 AND parent_id IS NULL`,
+          [classId]
+        );
+        for (const p of props.rows) {
+          let data: Record<string, unknown>;
+          try {
+            data =
+              typeof p.data === 'string'
+                ? JSON.parse(p.data || '{}')
+                : { ...(p.data as object) };
+          } catch {
+            data = {};
+          }
+          if (ro) data.readOnly = true;
+          else delete data.readOnly;
+          await connectionPool.query(`UPDATE odb.class_properties SET data = $1 WHERE id = $2`, [
+            JSON.stringify(data),
+            p.id,
+          ]);
+        }
+      }
+    }
+
+    return JSON.stringify({ success: true });
+  } catch (error: any) {
+    console.error('bulkApplyEditsToGroupClasses:', error);
+    return JSON.stringify({ success: false, error: error.message });
+  }
+}
+
 export async function createVersion(projectId: string, creatorId: string, versionId: string | null, description: string, changeLog: string, sourceVersionId?: string | null, bumpStrategy?: 'patch' | 'minor') {
   try {
     let finalVersionId = versionId;

--- a/objectified-ui/lib/db/helper.ts
+++ b/objectified-ui/lib/db/helper.ts
@@ -657,13 +657,17 @@ function makeUniqueCopyName(stem: string, taken: Set<string>): string {
  * Used for "duplicate group" on the canvas (#156).
  */
 export async function duplicateClassesInGroup(versionId: string, sourceClassIds: string[]) {
+  const client = await connectionPool.connect();
   try {
     const uniqueIds = [...new Set((sourceClassIds || []).filter(Boolean))];
     if (uniqueIds.length === 0) {
+      client.release();
       return JSON.stringify({ success: true, idMap: {} });
     }
 
-    const classesResult = await connectionPool.query(
+    await client.query('BEGIN');
+
+    const classesResult = await client.query(
       `SELECT id, name, description, schema, enabled
        FROM odb.classes
        WHERE version_id = $1 AND deleted_at IS NULL AND id = ANY($2::uuid[])`,
@@ -671,13 +675,14 @@ export async function duplicateClassesInGroup(versionId: string, sourceClassIds:
     );
 
     if (classesResult.rowCount !== uniqueIds.length) {
+      await client.query('ROLLBACK');
       return JSON.stringify({
         success: false,
         error: 'One or more classes were not found in this version.',
       });
     }
 
-    const existingNamesResult = await connectionPool.query(
+    const existingNamesResult = await client.query(
       `SELECT name FROM odb.classes WHERE version_id = $1 AND deleted_at IS NULL`,
       [versionId]
     );
@@ -707,7 +712,7 @@ export async function duplicateClassesInGroup(versionId: string, sourceClassIds:
         typeof row.schema === 'string' ? JSON.parse(row.schema) : row.schema || {};
       schemaObj = rewriteOpenApiRefsInValue(schemaObj, oldNameToNewName) as Record<string, unknown>;
 
-      const insertResult = await connectionPool.query(
+      const insertResult = await client.query(
         `INSERT INTO odb.classes (version_id, name, description, schema, enabled, canvas_metadata)
          VALUES ($1, $2, $3, $4, $5, $6)
          RETURNING id`,
@@ -724,7 +729,7 @@ export async function duplicateClassesInGroup(versionId: string, sourceClassIds:
       const newId = insertResult.rows[0].id as string;
       idMap[row.id] = newId;
 
-      const originalPropertiesResult = await connectionPool.query(
+      const originalPropertiesResult = await client.query(
         `SELECT id, property_id, name, description, data, parent_id
          FROM odb.class_properties
          WHERE class_id = $1
@@ -760,7 +765,7 @@ export async function duplicateClassesInGroup(versionId: string, sourceClassIds:
           const dataForInsert =
             typeof dataVal === 'string' ? dataVal : JSON.stringify(dataVal ?? {});
 
-          const insertProp = await connectionPool.query(
+          const insertProp = await client.query(
             `INSERT INTO odb.class_properties (class_id, property_id, name, description, data, parent_id)
              VALUES ($1, $2, $3, $4, $5, $6)
              RETURNING id`,
@@ -776,7 +781,7 @@ export async function duplicateClassesInGroup(versionId: string, sourceClassIds:
 
       await copyPropertiesRecursively(null);
 
-      await connectionPool.query(
+      await client.query(
         `INSERT INTO odb.class_tags (class_id, tag_id)
          SELECT $1, tag_id FROM odb.class_tags WHERE class_id = $2
          ON CONFLICT (class_id, tag_id) DO NOTHING`,
@@ -784,17 +789,23 @@ export async function duplicateClassesInGroup(versionId: string, sourceClassIds:
       );
     }
 
+    await client.query('COMMIT');
     return JSON.stringify({ success: true, idMap });
   } catch (error: any) {
+    await client.query('ROLLBACK');
     console.error('duplicateClassesInGroup:', error);
     return JSON.stringify({ success: false, error: error.message });
+  } finally {
+    client.release();
   }
 }
 
 /**
  * Apply bulk metadata / tag / top-level property flag changes to many classes (#156).
+ * `versionId` is required so the function validates that all class IDs belong to that version.
  */
 export async function bulkApplyEditsToGroupClasses(
+  versionId: string,
   classIds: string[],
   options: {
     descriptionPrefix?: string;
@@ -809,11 +820,22 @@ export async function bulkApplyEditsToGroupClasses(
       return JSON.stringify({ success: true });
     }
 
+    // Validate that all requested IDs belong to the given version
+    const ownedResult = await connectionPool.query(
+      `SELECT id FROM odb.classes WHERE version_id = $1 AND deleted_at IS NULL AND id = ANY($2::uuid[])`,
+      [versionId, uniqueIds]
+    );
+    const ownedIds = new Set<string>(ownedResult.rows.map((r: { id: string }) => r.id));
+    const validIds = uniqueIds.filter((id) => ownedIds.has(id));
+    if (validIds.length === 0) {
+      return JSON.stringify({ success: false, error: 'No valid class IDs for this version.' });
+    }
+
     const prefix = options.descriptionPrefix ?? '';
     const suffix = options.descriptionSuffix ?? '';
 
     if (prefix !== '' || suffix !== '') {
-      for (const classId of uniqueIds) {
+      for (const classId of validIds) {
         const r = await connectionPool.query(
           `SELECT id, name, description, schema FROM odb.classes WHERE id = $1 AND deleted_at IS NULL`,
           [classId]
@@ -827,35 +849,42 @@ export async function bulkApplyEditsToGroupClasses(
     }
 
     if (options.tagId) {
-      for (const classId of uniqueIds) {
+      for (const classId of validIds) {
         await assignTagToClass(classId, options.tagId);
       }
     }
 
     if (typeof options.topLevelPropertyReadOnly === 'boolean') {
       const ro = options.topLevelPropertyReadOnly;
-      for (const classId of uniqueIds) {
-        const props = await connectionPool.query(
-          `SELECT id, data FROM odb.class_properties WHERE class_id = $1 AND parent_id IS NULL`,
-          [classId]
-        );
-        for (const p of props.rows) {
-          let data: Record<string, unknown>;
-          try {
-            data =
-              typeof p.data === 'string'
-                ? JSON.parse(p.data || '{}')
-                : { ...(p.data as object) };
-          } catch {
-            data = {};
+      await connectionPool.query('BEGIN');
+      try {
+        for (const classId of validIds) {
+          const props = await connectionPool.query(
+            `SELECT id, data FROM odb.class_properties WHERE class_id = $1 AND parent_id IS NULL`,
+            [classId]
+          );
+          for (const p of props.rows) {
+            let data: Record<string, unknown>;
+            try {
+              data =
+                typeof p.data === 'string'
+                  ? JSON.parse(p.data || '{}')
+                  : { ...(p.data as object) };
+            } catch {
+              data = {};
+            }
+            if (ro) data.readOnly = true;
+            else delete data.readOnly;
+            await connectionPool.query(`UPDATE odb.class_properties SET data = $1 WHERE id = $2`, [
+              JSON.stringify(data),
+              p.id,
+            ]);
           }
-          if (ro) data.readOnly = true;
-          else delete data.readOnly;
-          await connectionPool.query(`UPDATE odb.class_properties SET data = $1 WHERE id = $2`, [
-            JSON.stringify(data),
-            p.id,
-          ]);
         }
+        await connectionPool.query('COMMIT');
+      } catch (e) {
+        await connectionPool.query('ROLLBACK');
+        throw e;
       }
     }
 

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.8.57",
+  "version": "0.8.58",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.8.58",
+  "version": "0.8.59",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -5,6 +5,7 @@ We continue to improve the platform based on your feedback with improvements and
 ---
 
 Improvements:
+- Canvas: group toolbar — export the group’s schemas as OpenAPI JSON or YAML (with referenced types), duplicate the whole group into a new frame, and apply bulk class updates (description prefix/suffix, tag, top-level read-only) (#156)
 - Canvas: groups can collapse to a compact title bar (chevron); Alt+Shift+[ / ] collapse or expand all; your choices are remembered per version (#154)
 - Canvas: presentation mode — save viewport slides, present in fullscreen with speaker notes, timer, and keyboard controls (#517)
 - Canvas: layout auto-save uses a steady timer while edits are pending so saves occur every 30 seconds (or your chosen interval) without resetting on each move (#315)

--- a/objectified-ui/src/app/ade/studio/editor/page.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/page.tsx
@@ -2064,13 +2064,11 @@ const StudioContent = () => {
       setLoadingMessage('Updating nodes and edges...');
 
       // Preserve group frame nodes across refresh; merge class nodes by position (#156).
-      let existingPositions = new Map<string, { x: number; y: number }>();
-      let savedGroupNodes: Node[] = [];
-      setNodes((currentNodes) => {
-        savedGroupNodes = currentNodes.filter((n) => n.type === 'groupNode');
-        existingPositions = new Map(currentNodes.map(n => [n.id, n.position]));
-        return currentNodes;
-      });
+      const currentNodes = getNodes();
+      const savedGroupNodes: Node[] = currentNodes.filter((n) => n.type === 'groupNode');
+      const existingPositions = new Map<string, { x: number; y: number }>(
+        currentNodes.map((n) => [n.id, n.position])
+      );
 
       const newNodes = await classesToNodes(classesWithProperties);
       // Restore positions from existing nodes
@@ -2090,7 +2088,7 @@ const StudioContent = () => {
       setIsLoadingCanvas(false);
       setLoadingMessage('');
     }
-  }, [selectedVersionId, projects, versions]);
+  }, [selectedVersionId, projects, versions, getNodes]);
 
   // Helper to update only a single class node without reloading the entire canvas
   const updateSingleClassNode = useCallback(async (classId: string) => {
@@ -2780,33 +2778,42 @@ const StudioContent = () => {
     async (groupId: string, nodeIds: string[], groupName: string, format: 'json' | 'yaml') => {
       void groupId;
       if (!selectedVersionId || nodeIds.length === 0) return;
-      const res = await getClassesWithPropertiesAndTagsWithSession(selectedVersionId);
-      if (!res.success || !res.classes) {
-        await alertDialog({
-          message: res.error || 'Failed to load classes for export.',
-          variant: 'error',
+      try {
+        const res = await getClassesWithPropertiesAndTagsWithSession(selectedVersionId);
+        if (!res.success || !res.classes) {
+          await alertDialog({
+            message: res.error || 'Failed to load classes for export.',
+            variant: 'error',
+          });
+          return;
+        }
+        const expanded = expandClassesForGroupExport(nodeIds, res.classes);
+        if (expanded.length === 0) {
+          await alertDialog({ message: 'No classes in this group to export.', variant: 'warning' });
+          return;
+        }
+        const project = projects.find((p) => p.id === selectedProjectId);
+        const ver = versions.find((v) => v.id === selectedVersionId);
+        const specJson = await generateOpenApiSpec(expanded, {
+          projectName: project?.name ? `${project.name} — ${groupName}` : groupName,
+          version: ver?.version_id ?? '1.0.0',
+          description: `OpenAPI components for canvas group "${groupName}" (Objectified export).`,
         });
-        return;
-      }
-      const expanded = expandClassesForGroupExport(nodeIds, res.classes);
-      if (expanded.length === 0) {
-        await alertDialog({ message: 'No classes in this group to export.', variant: 'warning' });
-        return;
-      }
-      const project = projects.find((p) => p.id === selectedProjectId);
-      const ver = versions.find((v) => v.id === selectedVersionId);
-      const specJson = await generateOpenApiSpec(expanded, {
-        projectName: project?.name ? `${project.name} — ${groupName}` : groupName,
-        version: ver?.version_id ?? '1.0.0',
-        description: `OpenAPI components for canvas group "${groupName}" (Objectified export).`,
-      });
-      const safe = groupName.replace(/[^\w\-]+/g, '-').toLowerCase().slice(0, 80) || 'group';
-      if (format === 'yaml') {
-        const doc = JSON.parse(specJson);
-        const yaml = YAML.stringify(doc, { lineWidth: 0, aliasDuplicateObjects: false } as any);
-        downloadTextFile(`${safe}-openapi.yaml`, yaml, 'text/yaml');
-      } else {
-        downloadTextFile(`${safe}-openapi.json`, specJson, 'application/json');
+        const safe = groupName.replace(/[^\w\-]+/g, '-').toLowerCase().slice(0, 80) || 'group';
+        if (format === 'yaml') {
+          const doc = JSON.parse(specJson);
+          const yaml = YAML.stringify(doc, { lineWidth: 0, aliasDuplicateObjects: false } as any);
+          downloadTextFile(`${safe}-openapi.yaml`, yaml, 'text/yaml');
+        } else {
+          downloadTextFile(`${safe}-openapi.json`, specJson, 'application/json');
+        }
+      } catch (err: unknown) {
+        console.error('Failed to export group schema:', err);
+        const message =
+          err instanceof Error
+            ? `Failed to export group schema: ${err.message}`
+            : 'Failed to export group schema due to an unexpected error.';
+        await alertDialog({ message, variant: 'error' });
       }
     },
     [selectedVersionId, selectedProjectId, projects, versions, alertDialog]
@@ -2846,7 +2853,7 @@ const StudioContent = () => {
       });
       if (!ok) throw new Error('cancelled');
 
-      const raw = await bulkApplyEditsToGroupClasses(nodeIds, {
+      const raw = await bulkApplyEditsToGroupClasses(selectedVersionId!, nodeIds, {
         descriptionPrefix:
           options.descriptionPrefix && options.descriptionPrefix.trim().length > 0
             ? options.descriptionPrefix
@@ -2870,7 +2877,7 @@ const StudioContent = () => {
       triggerSidebarRefresh();
       await alertDialog({ message: 'Bulk changes applied to all classes in this group.', variant: 'success' });
     },
-    [isReadOnly, confirmDialog, alertDialog, reloadClasses, triggerSidebarRefresh]
+    [isReadOnly, selectedVersionId, confirmDialog, alertDialog, reloadClasses, triggerSidebarRefresh]
   );
 
   const handleDuplicateGroup = useCallback(

--- a/objectified-ui/src/app/ade/studio/editor/page.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/page.tsx
@@ -115,8 +115,11 @@ import {
   syncGroupsForVersion,
   addClassToGroup,
   updateClassPositionInGroup,
-  isTenantAdmin
+  isTenantAdmin,
+  duplicateClassesInGroup,
+  bulkApplyEditsToGroupClasses,
 } from '../../../../../lib/db/helper';
+import { expandClassesForGroupExport, downloadTextFile } from '@/app/utils/group-schema-export';
 import { mapEdgesForLayoutSave, mapNodesForLayoutSave } from '../lib/canvasLayoutPayload';
 import {
   deleteClassWithSession,
@@ -358,7 +361,7 @@ const StudioContent = () => {
   const [nodes, setNodes, onNodesChange] = useNodesState<Node>([]);
   const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>([]);
   const [isAnimating, setIsAnimating] = useState<boolean>(false);
-  const { fitView, setCenter, getViewport, setViewport, getNodes } = useReactFlow();
+  const { fitView, setCenter, getViewport, setViewport, getNodes, getEdges } = useReactFlow();
   const updateNodeInternals = useUpdateNodeInternals();
 
   // Zoom level state for level-of-detail rendering
@@ -793,6 +796,25 @@ const StudioContent = () => {
   const handleGroupRenameRef = useRef<any>(null);
   const handleGroupDeleteRef = useRef<any>(null);
   const handleDeleteAllClassesInGroupRef = useRef<any>(null);
+  const handleExportGroupSchemaRef = useRef<
+    ((groupId: string, nodeIds: string[], groupName: string, format: 'json' | 'yaml') => Promise<void>) | null
+  >(null);
+  const handleDuplicateGroupRef = useRef<
+    ((groupId: string, nodeIds: string[], groupName: string) => Promise<void>) | null
+  >(null);
+  const handleBulkEditGroupClassesRef = useRef<
+    ((
+      groupId: string,
+      nodeIds: string[],
+      groupName: string,
+      options: {
+        descriptionPrefix?: string;
+        descriptionSuffix?: string;
+        tagId?: string;
+        topLevelPropertyReadOnly?: boolean;
+      }
+    ) => Promise<void>) | null
+  >(null);
   const handleGroupColorChangeRef = useRef<any>(null);
   const handleGroupStyleChangeRef = useRef<any>(null);
   const handleGroupTagsChangeRef = useRef<any>(null);
@@ -2041,11 +2063,13 @@ const StudioContent = () => {
 
       setLoadingMessage('Updating nodes and edges...');
 
-      // Get existing positions using functional setState
+      // Preserve group frame nodes across refresh; merge class nodes by position (#156).
       let existingPositions = new Map<string, { x: number; y: number }>();
+      let savedGroupNodes: Node[] = [];
       setNodes((currentNodes) => {
+        savedGroupNodes = currentNodes.filter((n) => n.type === 'groupNode');
         existingPositions = new Map(currentNodes.map(n => [n.id, n.position]));
-        return currentNodes; // No change yet
+        return currentNodes;
       });
 
       const newNodes = await classesToNodes(classesWithProperties);
@@ -2056,7 +2080,7 @@ const StudioContent = () => {
           node.position = existingPos;
         }
       });
-      const finalNodes = newNodes;
+      const finalNodes = [...savedGroupNodes, ...newNodes];
       const newEdges = createAllEdges(classesWithProperties);
       setEdges(newEdges);
       setNodes(finalNodes);
@@ -2752,6 +2776,303 @@ const StudioContent = () => {
     triggerSidebarRefresh();
   }, [isReadOnly, groups, confirmDialog, alertDialog, deleteClassWithSession, reloadClasses, triggerSidebarRefresh]);
 
+  const handleExportGroupSchema = useCallback(
+    async (groupId: string, nodeIds: string[], groupName: string, format: 'json' | 'yaml') => {
+      void groupId;
+      if (!selectedVersionId || nodeIds.length === 0) return;
+      const res = await getClassesWithPropertiesAndTagsWithSession(selectedVersionId);
+      if (!res.success || !res.classes) {
+        await alertDialog({
+          message: res.error || 'Failed to load classes for export.',
+          variant: 'error',
+        });
+        return;
+      }
+      const expanded = expandClassesForGroupExport(nodeIds, res.classes);
+      if (expanded.length === 0) {
+        await alertDialog({ message: 'No classes in this group to export.', variant: 'warning' });
+        return;
+      }
+      const project = projects.find((p) => p.id === selectedProjectId);
+      const ver = versions.find((v) => v.id === selectedVersionId);
+      const specJson = await generateOpenApiSpec(expanded, {
+        projectName: project?.name ? `${project.name} — ${groupName}` : groupName,
+        version: ver?.version_id ?? '1.0.0',
+        description: `OpenAPI components for canvas group "${groupName}" (Objectified export).`,
+      });
+      const safe = groupName.replace(/[^\w\-]+/g, '-').toLowerCase().slice(0, 80) || 'group';
+      if (format === 'yaml') {
+        const doc = JSON.parse(specJson);
+        const yaml = YAML.stringify(doc, { lineWidth: 0, aliasDuplicateObjects: false } as any);
+        downloadTextFile(`${safe}-openapi.yaml`, yaml, 'text/yaml');
+      } else {
+        downloadTextFile(`${safe}-openapi.json`, specJson, 'application/json');
+      }
+    },
+    [selectedVersionId, selectedProjectId, projects, versions, alertDialog]
+  );
+
+  const handleBulkEditGroupClasses = useCallback(
+    async (
+      groupId: string,
+      nodeIds: string[],
+      groupName: string,
+      options: {
+        descriptionPrefix?: string;
+        descriptionSuffix?: string;
+        tagId?: string;
+        topLevelPropertyReadOnly?: boolean;
+      }
+    ) => {
+      void groupId;
+      if (isReadOnly || nodeIds.length === 0) return;
+      const hasText =
+        (options.descriptionPrefix && options.descriptionPrefix.trim().length > 0) ||
+        (options.descriptionSuffix && options.descriptionSuffix.trim().length > 0);
+      const hasTag = Boolean(options.tagId && options.tagId.trim().length > 0);
+      const hasReadOnly = typeof options.topLevelPropertyReadOnly === 'boolean';
+      if (!hasText && !hasTag && !hasReadOnly) {
+        await alertDialog({
+          message: 'Choose at least one change: description prefix/suffix, tag, or read-only.',
+          variant: 'warning',
+        });
+        throw new Error('No bulk changes selected.');
+      }
+      const ok = await confirmDialog({
+        title: 'Apply to all classes in group',
+        message: `Update ${nodeIds.length} class(es) in "${groupName}"?`,
+        confirmLabel: 'Apply',
+        cancelLabel: 'Cancel',
+      });
+      if (!ok) throw new Error('cancelled');
+
+      const raw = await bulkApplyEditsToGroupClasses(nodeIds, {
+        descriptionPrefix:
+          options.descriptionPrefix && options.descriptionPrefix.trim().length > 0
+            ? options.descriptionPrefix
+            : undefined,
+        descriptionSuffix:
+          options.descriptionSuffix && options.descriptionSuffix.trim().length > 0
+            ? options.descriptionSuffix
+            : undefined,
+        tagId: hasTag ? options.tagId : undefined,
+        topLevelPropertyReadOnly: hasReadOnly ? options.topLevelPropertyReadOnly : undefined,
+      });
+      const parsed = typeof raw === 'string' ? JSON.parse(raw) : raw;
+      if (!parsed.success) {
+        await alertDialog({
+          message: parsed.error || 'Bulk update failed.',
+          variant: 'error',
+        });
+        throw new Error(parsed.error || 'Bulk update failed.');
+      }
+      await reloadClasses(true);
+      triggerSidebarRefresh();
+      await alertDialog({ message: 'Bulk changes applied to all classes in this group.', variant: 'success' });
+    },
+    [isReadOnly, confirmDialog, alertDialog, reloadClasses, triggerSidebarRefresh]
+  );
+
+  const handleDuplicateGroup = useCallback(
+    async (sourceGroupId: string, nodeIds: string[], sourceGroupName: string) => {
+      if (isReadOnly || !selectedVersionId || nodeIds.length === 0) return;
+
+      const ok = await confirmDialog({
+        title: 'Duplicate group',
+        message: `Create copies of all ${nodeIds.length} class(es) in "${sourceGroupName}" in a new group? References between these classes will target the duplicated types.`,
+        confirmLabel: 'Duplicate',
+        cancelLabel: 'Cancel',
+      });
+      if (!ok) return;
+
+      const sourceGroup = groups.find((g) => g.id === sourceGroupId);
+      const idSet = new Set(nodeIds);
+      const oldPositions = new Map<string, { x: number; y: number }>();
+      getNodes().forEach((n) => {
+        if (idSet.has(n.id)) oldPositions.set(n.id, { ...n.position });
+      });
+
+      const dupRaw = await duplicateClassesInGroup(selectedVersionId, nodeIds);
+      const dup = typeof dupRaw === 'string' ? JSON.parse(dupRaw) : dupRaw;
+      if (!dup.success) {
+        await alertDialog({
+          message: dup.error || 'Could not duplicate classes.',
+          variant: 'error',
+        });
+        return;
+      }
+      const idMap: Record<string, string> = dup.idMap || {};
+      const OFFSET = 56;
+
+      let newGroupName = `${sourceGroupName} Copy`;
+      let suffix = 2;
+      while (groups.some((g) => g.name === newGroupName)) {
+        newGroupName = `${sourceGroupName} Copy ${suffix++}`;
+      }
+
+      const newGroupId = generateGroupId();
+      const basePos = sourceGroup?.position || { x: 120, y: 120 };
+      const newGroup = {
+        id: newGroupId,
+        name: newGroupName,
+        color: sourceGroup?.color || GROUP_COLORS[0].name,
+        nodeIds: nodeIds.map((oid) => idMap[oid]).filter(Boolean) as string[],
+        position: { x: basePos.x + OFFSET, y: basePos.y + OFFSET },
+        dimensions: sourceGroup?.dimensions || { width: 400, height: 300 },
+        styleOptions:
+          sourceGroup?.styleOptions ||
+          ({
+            borderStyle: 'dashed' as const,
+            opacity: 1,
+            shadow: 'none' as const,
+            icon: 'folder',
+          } as const),
+        description: sourceGroup?.description,
+        tags: sourceGroup?.tags,
+      };
+
+      const nextGroups = [...groups, newGroup];
+      addGroup(newGroup);
+      groupPositionsRef.current.set(newGroupId, { ...newGroup.position });
+
+      const availableTags = projectTags.map((t) => ({
+        id: t.id,
+        name: t.tag_name,
+        color: t.tag_color,
+      }));
+
+      const newGroupFlowNode: Node = {
+        id: newGroupId,
+        type: 'groupNode',
+        position: newGroup.position,
+        width: newGroup.dimensions.width,
+        height: newGroup.dimensions.height,
+        style: {
+          width: newGroup.dimensions.width,
+          height: newGroup.dimensions.height,
+          zIndex: -1,
+        },
+        data: {
+          id: newGroupId,
+          name: newGroup.name,
+          color: newGroup.color,
+          nodeIds: newGroup.nodeIds,
+          tags: newGroup.tags,
+          styleOptions: newGroup.styleOptions,
+          availableTags,
+          onRename: (gid: string, name: string) => handleGroupRenameRef.current?.(gid, name),
+          onDelete: (gid: string) => handleGroupDeleteRef.current?.(gid),
+          onDeleteAllClassesInGroup: (gid: string, cids?: string[], gn?: string) =>
+            handleDeleteAllClassesInGroupRef.current?.(gid, cids, gn),
+          onExportGroupSchema: (gid: string, cids: string[], gn: string, fmt: 'json' | 'yaml') =>
+            handleExportGroupSchemaRef.current?.(gid, cids, gn, fmt),
+          onDuplicateGroup: (gid: string, cids: string[], gn: string) =>
+            handleDuplicateGroupRef.current?.(gid, cids, gn),
+          onBulkEditGroupClasses: (
+            gid: string,
+            cids: string[],
+            gn: string,
+            opts: {
+              descriptionPrefix?: string;
+              descriptionSuffix?: string;
+              tagId?: string;
+              topLevelPropertyReadOnly?: boolean;
+            }
+          ) => handleBulkEditGroupClassesRef.current?.(gid, cids, gn, opts),
+          onColorChange: (gid: string, color: string) => handleGroupColorChangeRef.current?.(gid, color),
+          onStyleChange: (gid: string, style: any) => handleGroupStyleChangeRef.current?.(gid, style),
+          onTagsChange: (gid: string, t: any[]) => handleGroupTagsChangeRef.current?.(gid, t),
+          isReadOnly,
+        },
+      };
+
+      setNodes((prev) => [newGroupFlowNode, ...prev]);
+
+      await reloadClasses(true);
+
+      setNodes((prev) =>
+        prev.map((node) => {
+          if (node.type === 'groupNode') return node;
+          for (const oid of nodeIds) {
+            if (node.id === idMap[oid] && oldPositions.has(oid)) {
+              const op = oldPositions.get(oid)!;
+              return {
+                ...node,
+                position: { x: op.x + OFFSET, y: op.y + OFFSET },
+              };
+            }
+          }
+          return node;
+        })
+      );
+
+      for (const oid of nodeIds) {
+        const nid = idMap[oid];
+        const op = oldPositions.get(oid);
+        if (nid && op) {
+          void updateClassCanvasMetadataWithSession(nid, {
+            position: { x: op.x + OFFSET, y: op.y + OFFSET },
+          });
+        }
+      }
+
+      if (selectedVersionId && currentUserId) {
+        try {
+          const viewport = getViewport();
+          const flowNodes = getNodes();
+          const flowEdges = getEdges();
+          const nodeData = flowNodes.map((node) => ({
+            id: node.id,
+            type: node.type,
+            position: node.position,
+            dimensions: {
+              width: (node as any).measured?.width || (node as any).width || (node.style as any)?.width,
+              height: (node as any).measured?.height || (node as any).height || (node.style as any)?.height,
+            },
+          }));
+          const edgeData = flowEdges.map((edge) => ({
+            id: edge.id,
+            source: edge.source,
+            target: edge.target,
+          }));
+          await saveDefaultCanvasLayout(
+            selectedVersionId,
+            currentUserId,
+            viewport,
+            nodeData,
+            edgeData,
+            nextGroups
+          );
+        } catch (e) {
+          console.error('Failed to save layout after duplicate group:', e);
+        }
+      }
+
+      await alertDialog({
+        message: `Duplicated ${nodeIds.length} class(es) into "${newGroupName}".`,
+        variant: 'success',
+      });
+      triggerSidebarRefresh();
+    },
+    [
+      isReadOnly,
+      selectedVersionId,
+      groups,
+      confirmDialog,
+      alertDialog,
+      getNodes,
+      getEdges,
+      getViewport,
+      addGroup,
+      generateGroupId,
+      reloadClasses,
+      setNodes,
+      projectTags,
+      currentUserId,
+      triggerSidebarRefresh,
+    ]
+  );
+
   // Handle group color change
   const handleGroupColorChange = useCallback(async (groupId: string, newColor: string) => {
     if (isReadOnly) return;
@@ -2919,6 +3240,9 @@ const StudioContent = () => {
   handleGroupRenameRef.current = handleGroupRename;
   handleGroupDeleteRef.current = handleGroupDelete;
   handleDeleteAllClassesInGroupRef.current = handleDeleteAllClassesInGroup;
+  handleExportGroupSchemaRef.current = handleExportGroupSchema;
+  handleDuplicateGroupRef.current = handleDuplicateGroup;
+  handleBulkEditGroupClassesRef.current = handleBulkEditGroupClasses;
   handleGroupColorChangeRef.current = handleGroupColorChange;
   handleGroupStyleChangeRef.current = handleGroupStyleChange;
 
@@ -3377,6 +3701,12 @@ const StudioContent = () => {
       }
     };
 
+    const createGroupAvailableTags = projectTags.map((t) => ({
+      id: t.id,
+      name: t.tag_name,
+      color: t.tag_color,
+    }));
+
     // Add group to context
     addGroup(newGroup);
 
@@ -3401,9 +3731,25 @@ const StudioContent = () => {
         color: newGroup.color,
         nodeIds: newGroup.nodeIds,
         styleOptions: newGroup.styleOptions,
+        availableTags: createGroupAvailableTags,
         onRename: handleGroupRename,
         onDelete: handleGroupDelete,
         onDeleteAllClassesInGroup: handleDeleteAllClassesInGroup,
+        onExportGroupSchema: (gid: string, cids: string[], gn: string, fmt: 'json' | 'yaml') =>
+          handleExportGroupSchemaRef.current?.(gid, cids, gn, fmt),
+        onDuplicateGroup: (gid: string, cids: string[], gn: string) =>
+          handleDuplicateGroupRef.current?.(gid, cids, gn),
+        onBulkEditGroupClasses: (
+          gid: string,
+          cids: string[],
+          gn: string,
+          opts: {
+            descriptionPrefix?: string;
+            descriptionSuffix?: string;
+            tagId?: string;
+            topLevelPropertyReadOnly?: boolean;
+          }
+        ) => handleBulkEditGroupClassesRef.current?.(gid, cids, gn, opts),
         onColorChange: handleGroupColorChange,
         onStyleChange: handleGroupStyleChange,
         isReadOnly: isReadOnly
@@ -3448,7 +3794,7 @@ const StudioContent = () => {
       }
     }
 
-  }, [groups, isReadOnly, addGroup, generateGroupId, setNodes, getViewport, handleGroupRename, handleGroupDelete, handleDeleteAllClassesInGroup, handleGroupColorChange, handleGroupStyleChange, selectedVersionId, currentUserId, nodes, edges]);
+  }, [groups, isReadOnly, addGroup, generateGroupId, setNodes, getViewport, handleGroupRename, handleGroupDelete, handleDeleteAllClassesInGroup, handleGroupColorChange, handleGroupStyleChange, selectedVersionId, currentUserId, nodes, edges, projectTags]);
 
   // Register handleCreateGroup function in context for sidebar access
   useEffect(() => {
@@ -3498,6 +3844,12 @@ const StudioContent = () => {
       }
     };
 
+    const createGroupAtDropAvailableTags = projectTags.map((t) => ({
+      id: t.id,
+      name: t.tag_name,
+      color: t.tag_color,
+    }));
+
     // Add group to context
     addGroup(newGroup);
 
@@ -3522,9 +3874,25 @@ const StudioContent = () => {
         color: newGroup.color,
         nodeIds: newGroup.nodeIds,
         styleOptions: newGroup.styleOptions,
+        availableTags: createGroupAtDropAvailableTags,
         onRename: handleGroupRename,
         onDelete: handleGroupDelete,
         onDeleteAllClassesInGroup: handleDeleteAllClassesInGroup,
+        onExportGroupSchema: (gid: string, cids: string[], gn: string, fmt: 'json' | 'yaml') =>
+          handleExportGroupSchemaRef.current?.(gid, cids, gn, fmt),
+        onDuplicateGroup: (gid: string, cids: string[], gn: string) =>
+          handleDuplicateGroupRef.current?.(gid, cids, gn),
+        onBulkEditGroupClasses: (
+          gid: string,
+          cids: string[],
+          gn: string,
+          opts: {
+            descriptionPrefix?: string;
+            descriptionSuffix?: string;
+            tagId?: string;
+            topLevelPropertyReadOnly?: boolean;
+          }
+        ) => handleBulkEditGroupClassesRef.current?.(gid, cids, gn, opts),
         onColorChange: handleGroupColorChange,
         onStyleChange: handleGroupStyleChange,
         isReadOnly: isReadOnly
@@ -3568,7 +3936,7 @@ const StudioContent = () => {
       }
     }
 
-  }, [groups, isReadOnly, addGroup, generateGroupId, setNodes, getViewport, handleGroupRename, handleGroupDelete, handleDeleteAllClassesInGroup, handleGroupColorChange, handleGroupStyleChange, selectedVersionId, currentUserId, nodes, edges]);
+  }, [groups, isReadOnly, addGroup, generateGroupId, setNodes, getViewport, handleGroupRename, handleGroupDelete, handleDeleteAllClassesInGroup, handleGroupColorChange, handleGroupStyleChange, selectedVersionId, currentUserId, nodes, edges, projectTags]);
 
   // Register handleCreateGroupAtPosition function in context for drag-and-drop access
   useEffect(() => {
@@ -4148,8 +4516,23 @@ const StudioContent = () => {
                 availableTags,
                 onRename: (groupId: string, name: string) => handleGroupRenameRef.current?.(groupId, name),
                 onDelete: (groupId: string) => handleGroupDeleteRef.current?.(groupId),
-                onDeleteAllClassesInGroup: (groupId: string) =>
-                  handleDeleteAllClassesInGroupRef.current?.(groupId),
+                onDeleteAllClassesInGroup: (gid: string, cids?: string[], gn?: string) =>
+                  handleDeleteAllClassesInGroupRef.current?.(gid, cids, gn),
+                onExportGroupSchema: (gid: string, cids: string[], gn: string, fmt: 'json' | 'yaml') =>
+                  handleExportGroupSchemaRef.current?.(gid, cids, gn, fmt),
+                onDuplicateGroup: (gid: string, cids: string[], gn: string) =>
+                  handleDuplicateGroupRef.current?.(gid, cids, gn),
+                onBulkEditGroupClasses: (
+                  gid: string,
+                  cids: string[],
+                  gn: string,
+                  opts: {
+                    descriptionPrefix?: string;
+                    descriptionSuffix?: string;
+                    tagId?: string;
+                    topLevelPropertyReadOnly?: boolean;
+                  }
+                ) => handleBulkEditGroupClassesRef.current?.(gid, cids, gn, opts),
                 onColorChange: (groupId: string, color: string) =>
                   handleGroupColorChangeRef.current?.(groupId, color),
                 onStyleChange: (groupId: string, style: any) =>
@@ -5345,7 +5728,23 @@ const StudioContent = () => {
                   availableTags,
                   onRename: (groupId: string, name: string) => handleGroupRenameRef.current?.(groupId, name),
                   onDelete: (groupId: string) => handleGroupDeleteRef.current?.(groupId),
-                  onDeleteAllClassesInGroup: (groupId: string) => handleDeleteAllClassesInGroupRef.current?.(groupId),
+                  onDeleteAllClassesInGroup: (gid: string, cids?: string[], gn?: string) =>
+                    handleDeleteAllClassesInGroupRef.current?.(gid, cids, gn),
+                  onExportGroupSchema: (gid: string, cids: string[], gn: string, fmt: 'json' | 'yaml') =>
+                    handleExportGroupSchemaRef.current?.(gid, cids, gn, fmt),
+                  onDuplicateGroup: (gid: string, cids: string[], gn: string) =>
+                    handleDuplicateGroupRef.current?.(gid, cids, gn),
+                  onBulkEditGroupClasses: (
+                    gid: string,
+                    cids: string[],
+                    gn: string,
+                    opts: {
+                      descriptionPrefix?: string;
+                      descriptionSuffix?: string;
+                      tagId?: string;
+                      topLevelPropertyReadOnly?: boolean;
+                    }
+                  ) => handleBulkEditGroupClassesRef.current?.(gid, cids, gn, opts),
                   onColorChange: (groupId: string, color: string) => handleGroupColorChangeRef.current?.(groupId, color),
                   onStyleChange: (groupId: string, style: any) => handleGroupStyleChangeRef.current?.(groupId, style),
                   onTagsChange: (groupId: string, tags: any[]) => handleGroupTagsChangeRef.current?.(groupId, tags),

--- a/objectified-ui/src/app/components/ade/studio/GroupBulkEditDialog.tsx
+++ b/objectified-ui/src/app/components/ade/studio/GroupBulkEditDialog.tsx
@@ -1,0 +1,176 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/app/components/ui/Dialog';
+import { Button } from '@/app/components/ui/Button';
+import { Input } from '@/app/components/ui/Input';
+import { Label } from '@/app/components/ui/Label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/app/components/ui/Select';
+
+export interface GroupBulkEditTagOption {
+  id: string;
+  name: string;
+  color?: string;
+}
+
+export interface GroupBulkEditSubmitPayload {
+  descriptionPrefix?: string;
+  descriptionSuffix?: string;
+  tagId?: string;
+  topLevelPropertyReadOnly?: boolean;
+}
+
+interface GroupBulkEditDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  groupName: string;
+  classCount: number;
+  availableTags: GroupBulkEditTagOption[];
+  onSubmit: (payload: GroupBulkEditSubmitPayload) => Promise<void>;
+}
+
+export default function GroupBulkEditDialog({
+  open,
+  onOpenChange,
+  groupName,
+  classCount,
+  availableTags,
+  onSubmit,
+}: GroupBulkEditDialogProps) {
+  const [descriptionPrefix, setDescriptionPrefix] = useState('');
+  const [descriptionSuffix, setDescriptionSuffix] = useState('');
+  const [tagChoice, setTagChoice] = useState<string>('__none__');
+  const [readOnlyMode, setReadOnlyMode] = useState<'skip' | 'true' | 'false'>('skip');
+  const [submitting, setSubmitting] = useState(false);
+
+  const reset = useCallback(() => {
+    setDescriptionPrefix('');
+    setDescriptionSuffix('');
+    setTagChoice('__none__');
+    setReadOnlyMode('skip');
+  }, []);
+
+  const handleClose = useCallback(
+    (next: boolean) => {
+      if (!next) reset();
+      onOpenChange(next);
+    },
+    [onOpenChange, reset]
+  );
+
+  const handleApply = useCallback(async () => {
+    setSubmitting(true);
+    try {
+      const payload: GroupBulkEditSubmitPayload = {};
+      if (descriptionPrefix.trim()) payload.descriptionPrefix = descriptionPrefix.trim();
+      if (descriptionSuffix.trim()) payload.descriptionSuffix = descriptionSuffix.trim();
+      if (tagChoice && tagChoice !== '__none__') payload.tagId = tagChoice;
+      if (readOnlyMode === 'true') payload.topLevelPropertyReadOnly = true;
+      if (readOnlyMode === 'false') payload.topLevelPropertyReadOnly = false;
+      await onSubmit(payload);
+      reset();
+      onOpenChange(false);
+    } catch {
+      /* Parent shows alert; keep dialog open */
+    } finally {
+      setSubmitting(false);
+    }
+  }, [
+    descriptionPrefix,
+    descriptionSuffix,
+    tagChoice,
+    readOnlyMode,
+    onSubmit,
+    reset,
+    onOpenChange,
+  ]);
+
+  return (
+    <Dialog open={open} onOpenChange={handleClose}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Bulk edit classes in &ldquo;{groupName}&rdquo;</DialogTitle>
+          <p className="text-sm text-gray-600 dark:text-gray-400">
+            Apply metadata changes to all {classCount} class{classCount === 1 ? '' : 'es'} in this
+            group (top-level properties only for read-only).
+          </p>
+        </DialogHeader>
+        <div className="space-y-4 py-2">
+          <div className="space-y-2">
+            <Label htmlFor="bulk-desc-prefix">Description prefix</Label>
+            <Input
+              id="bulk-desc-prefix"
+              value={descriptionPrefix}
+              onChange={(e) => setDescriptionPrefix(e.target.value)}
+              placeholder="Optional text before existing description"
+              disabled={submitting}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="bulk-desc-suffix">Description suffix</Label>
+            <Input
+              id="bulk-desc-suffix"
+              value={descriptionSuffix}
+              onChange={(e) => setDescriptionSuffix(e.target.value)}
+              placeholder="Optional text after existing description"
+              disabled={submitting}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label>Assign tag</Label>
+            <Select value={tagChoice} onValueChange={setTagChoice} disabled={submitting}>
+              <SelectTrigger>
+                <SelectValue placeholder="No tag" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="__none__">No tag change</SelectItem>
+                {availableTags.map((t) => (
+                  <SelectItem key={t.id} value={t.id}>
+                    {t.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-2">
+            <Label>Top-level properties read-only</Label>
+            <Select
+              value={readOnlyMode}
+              onValueChange={(v) => setReadOnlyMode(v as 'skip' | 'true' | 'false')}
+              disabled={submitting}
+            >
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="skip">Do not change</SelectItem>
+                <SelectItem value="true">Set read-only</SelectItem>
+                <SelectItem value="false">Clear read-only</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+        <DialogFooter className="gap-2 sm:gap-0">
+          <Button type="button" variant="outline" onClick={() => handleClose(false)} disabled={submitting}>
+            Cancel
+          </Button>
+          <Button type="button" onClick={() => void handleApply()} disabled={submitting}>
+            {submitting ? 'Applying…' : 'Apply to all'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/objectified-ui/src/app/components/ade/studio/GroupNode.tsx
+++ b/objectified-ui/src/app/components/ade/studio/GroupNode.tsx
@@ -1,15 +1,16 @@
 'use client';
 
 import React, { memo, useState, useCallback } from 'react';
-import { NodeProps, NodeResizer, useReactFlow } from '@xyflow/react';
+import { NodeProps, NodeResizer } from '@xyflow/react';
 import {
   Folder, Edit2, Trash2, X, Check, Palette, Settings,
   Box, Layers, Database, Shield, Users, Zap, Globe, Lock,
   FileText, Tag, Star, Heart, Flag, Bookmark, Archive, Package,
-  FileX, ChevronRight, ChevronDown,
+  FileX, ChevronRight, ChevronDown, Download, FileJson, FileCode2, Copy, SlidersHorizontal,
 } from 'lucide-react';
 import * as Popover from '@radix-ui/react-popover';
 import { COLLAPSED_GROUP_FRAME_WIDTH, COLLAPSED_GROUP_FRAME_HEIGHT } from '@/app/utils/canvas-group-collapse';
+import GroupBulkEditDialog, { type GroupBulkEditTagOption } from './GroupBulkEditDialog';
 
 // Available group icons
 export const GROUP_ICONS = [
@@ -102,6 +103,29 @@ export interface GroupNodeData {
   onRename?: (groupId: string, newName: string) => void;
   onDelete?: (groupId: string) => void;
   onDeleteAllClassesInGroup?: (groupId: string, classIds?: string[], groupName?: string) => void;
+  /** Export OpenAPI schema for group members + transitive refs (#156). */
+  onExportGroupSchema?: (
+    groupId: string,
+    nodeIds: string[],
+    groupName: string,
+    format: 'json' | 'yaml'
+  ) => void | Promise<void>;
+  /** Duplicate all classes in the group into a new group (#156). */
+  onDuplicateGroup?: (groupId: string, nodeIds: string[], groupName: string) => void | Promise<void>;
+  /** Bulk metadata / tags / top-level readOnly (#156). */
+  onBulkEditGroupClasses?: (
+    groupId: string,
+    nodeIds: string[],
+    groupName: string,
+    options: {
+      descriptionPrefix?: string;
+      descriptionSuffix?: string;
+      tagId?: string;
+      topLevelPropertyReadOnly?: boolean;
+    }
+  ) => void | Promise<void>;
+  /** Project tags for bulk assign */
+  availableTags?: GroupBulkEditTagOption[];
   onColorChange?: (groupId: string, newColor: string) => void;
   onStyleChange?: (groupId: string, styleOptions: GroupStyleOptions) => void;
   isReadOnly?: boolean;
@@ -116,7 +140,8 @@ const GroupNode = memo(({ id, data, selected }: NodeProps) => {
   const [editName, setEditName] = useState(groupData.name);
   const [colorPickerOpen, setColorPickerOpen] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
-  const { getNodes } = useReactFlow();
+  const [exportPopoverOpen, setExportPopoverOpen] = useState(false);
+  const [bulkDialogOpen, setBulkDialogOpen] = useState(false);
 
   // Get color configuration
   const colorConfig = GROUP_COLORS.find(c => c.name === groupData.color) || GROUP_COLORS[0];
@@ -182,6 +207,43 @@ const GroupNode = memo(({ id, data, selected }: NodeProps) => {
     if (groupData.isReadOnly) return;
     groupData.onDeleteAllClassesInGroup?.(groupData.id, groupData.nodeIds, groupData.name);
   }, [groupData]);
+
+  const runExportSchema = useCallback(
+    async (format: 'json' | 'yaml', e: React.MouseEvent) => {
+      e.stopPropagation();
+      if (groupData.isReadOnly || nodeCount === 0) return;
+      setExportPopoverOpen(false);
+      await groupData.onExportGroupSchema?.(groupData.id, groupData.nodeIds, groupData.name, format);
+    },
+    [groupData, nodeCount]
+  );
+
+  const handleDuplicateGroupClick = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      if (groupData.isReadOnly || nodeCount === 0) return;
+      void groupData.onDuplicateGroup?.(groupData.id, groupData.nodeIds, groupData.name);
+    },
+    [groupData, nodeCount]
+  );
+
+  const handleOpenBulk = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (groupData.isReadOnly || nodeCount === 0) return;
+    setBulkDialogOpen(true);
+  }, [groupData, nodeCount]);
+
+  const handleBulkSubmit = useCallback(
+    async (options: {
+      descriptionPrefix?: string;
+      descriptionSuffix?: string;
+      tagId?: string;
+      topLevelPropertyReadOnly?: boolean;
+    }) => {
+      await groupData.onBulkEditGroupClasses?.(groupData.id, groupData.nodeIds, groupData.name, options);
+    },
+    [groupData]
+  );
 
   const handleColorChange = useCallback((colorName: string) => {
     if (groupData.isReadOnly) return;
@@ -468,6 +530,79 @@ const GroupNode = memo(({ id, data, selected }: NodeProps) => {
                 <Edit2 className="h-3.5 w-3.5" />
               </button>
 
+              {/* Export OpenAPI (JSON/YAML) — group + transitive schema deps (#156) */}
+              {nodeCount > 0 && (
+                <Popover.Root open={exportPopoverOpen} onOpenChange={setExportPopoverOpen}>
+                  <Popover.Trigger asChild>
+                    <button
+                      type="button"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        e.preventDefault();
+                        setExportPopoverOpen((v) => !v);
+                      }}
+                      onMouseDown={(e) => e.stopPropagation()}
+                      className={`p-1 rounded transition-colors ${useLightText ? 'hover:bg-white/30' : 'hover:bg-white/50 dark:hover:bg-gray-700/50'}`}
+                      title="Export group as OpenAPI schema file"
+                    >
+                      <Download className="h-3.5 w-3.5" />
+                    </button>
+                  </Popover.Trigger>
+                  <Popover.Portal>
+                    <Popover.Content
+                      className="z-[9999] bg-white dark:bg-gray-800 rounded-lg shadow-xl border border-gray-200 dark:border-gray-700 p-2 min-w-[160px]"
+                      sideOffset={5}
+                      onOpenAutoFocus={(e) => e.preventDefault()}
+                      onClick={(e) => e.stopPropagation()}
+                    >
+                      <button
+                        type="button"
+                        className="flex items-center gap-2 w-full text-left text-sm px-2 py-1.5 rounded hover:bg-gray-100 dark:hover:bg-gray-700 text-gray-900 dark:text-gray-100"
+                        onClick={(e) => void runExportSchema('json', e)}
+                      >
+                        <FileJson className="h-4 w-4 shrink-0" />
+                        OpenAPI JSON
+                      </button>
+                      <button
+                        type="button"
+                        className="flex items-center gap-2 w-full text-left text-sm px-2 py-1.5 rounded hover:bg-gray-100 dark:hover:bg-gray-700 text-gray-900 dark:text-gray-100"
+                        onClick={(e) => void runExportSchema('yaml', e)}
+                      >
+                        <FileCode2 className="h-4 w-4 shrink-0" />
+                        OpenAPI YAML
+                      </button>
+                      <Popover.Arrow className="fill-white dark:fill-gray-800" />
+                    </Popover.Content>
+                  </Popover.Portal>
+                </Popover.Root>
+              )}
+
+              {/* Duplicate entire group (#156) */}
+              {nodeCount > 0 && (
+                <button
+                  onClick={handleDuplicateGroupClick}
+                  onMouseDown={(e) => e.stopPropagation()}
+                  onPointerDown={(e) => e.stopPropagation()}
+                  className={`p-1 rounded transition-colors ${useLightText ? 'hover:bg-white/30' : 'hover:bg-white/50 dark:hover:bg-gray-700/50'}`}
+                  title="Duplicate group (all classes)"
+                >
+                  <Copy className="h-3.5 w-3.5" />
+                </button>
+              )}
+
+              {/* Bulk edit classes (#156) */}
+              {nodeCount > 0 && (
+                <button
+                  onClick={handleOpenBulk}
+                  onMouseDown={(e) => e.stopPropagation()}
+                  onPointerDown={(e) => e.stopPropagation()}
+                  className={`p-1 rounded transition-colors ${useLightText ? 'hover:bg-white/30' : 'hover:bg-white/50 dark:hover:bg-gray-700/50'}`}
+                  title="Bulk edit all classes in group"
+                >
+                  <SlidersHorizontal className="h-3.5 w-3.5" />
+                </button>
+              )}
+
               {/* Delete all classes in group (only when group has classes) */}
               {nodeCount > 0 && (
                 <button
@@ -501,6 +636,15 @@ const GroupNode = memo(({ id, data, selected }: NodeProps) => {
           </div>
         )}
       </div>
+
+      <GroupBulkEditDialog
+        open={bulkDialogOpen}
+        onOpenChange={setBulkDialogOpen}
+        groupName={groupData.name}
+        classCount={nodeCount}
+        availableTags={groupData.availableTags || []}
+        onSubmit={handleBulkSubmit}
+      />
     </>
   );
 });

--- a/objectified-ui/src/app/utils/group-schema-export.ts
+++ b/objectified-ui/src/app/utils/group-schema-export.ts
@@ -1,4 +1,4 @@
-import { findReferencedClasses } from '@/app/utils/openapi';
+import { findReferencedClasses } from '@/app/utils/openapi-schema-refs';
 
 /**
  * Collect every class in `allClasses` that is in `rootClassIds` or referenced from them

--- a/objectified-ui/src/app/utils/group-schema-export.ts
+++ b/objectified-ui/src/app/utils/group-schema-export.ts
@@ -1,0 +1,62 @@
+import { findReferencedClasses } from '@/app/utils/openapi';
+
+/**
+ * Collect every class in `allClasses` that is in `rootClassIds` or referenced from them
+ * (transitive `#/components/schemas/X` closure). Used for group OpenAPI export (#156).
+ */
+export function expandClassesForGroupExport(rootClassIds: string[], allClasses: any[]): any[] {
+  const byId = new Map<string, any>((allClasses || []).map((c) => [c.id, c]));
+  const included = new Set<string>();
+
+  for (const id of rootClassIds) {
+    if (byId.has(id)) included.add(id);
+  }
+
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const id of Array.from(included)) {
+      const cls = byId.get(id);
+      if (!cls) continue;
+      const refs = new Set<string>();
+
+      try {
+        const schema = typeof cls.schema === 'string' ? JSON.parse(cls.schema) : cls.schema;
+        if (schema) findReferencedClasses(schema, refs);
+      } catch {
+        /* ignore */
+      }
+
+      for (const p of cls.properties || []) {
+        try {
+          const d = typeof p.data === 'string' ? JSON.parse(p.data) : p.data;
+          if (d) findReferencedClasses(d, refs);
+        } catch {
+          /* ignore */
+        }
+      }
+
+      for (const refName of refs) {
+        const dep = (allClasses || []).find((c: any) => c.name === refName);
+        if (dep && !included.has(dep.id)) {
+          included.add(dep.id);
+          changed = true;
+        }
+      }
+    }
+  }
+
+  return (allClasses || []).filter((c) => included.has(c.id));
+}
+
+export function downloadTextFile(filename: string, content: string, mimeType: string) {
+  const blob = new Blob([content], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}

--- a/objectified-ui/src/app/utils/group-schema-export.ts
+++ b/objectified-ui/src/app/utils/group-schema-export.ts
@@ -12,6 +12,8 @@ export function expandClassesForGroupExport(rootClassIds: string[], allClasses: 
     if (byId.has(id)) included.add(id);
   }
 
+  const byName = new Map<string, any>((allClasses || []).map((c) => [c.name, c]));
+
   let changed = true;
   while (changed) {
     changed = false;
@@ -37,7 +39,7 @@ export function expandClassesForGroupExport(rootClassIds: string[], allClasses: 
       }
 
       for (const refName of refs) {
-        const dep = (allClasses || []).find((c: any) => c.name === refName);
+        const dep = byName.get(refName);
         if (dep && !included.has(dep.id)) {
           included.add(dep.id);
           changed = true;

--- a/objectified-ui/src/app/utils/openapi-schema-refs.ts
+++ b/objectified-ui/src/app/utils/openapi-schema-refs.ts
@@ -1,0 +1,31 @@
+/**
+ * Pure helpers for walking JSON Schema / OpenAPI schema objects and collecting
+ * `#/components/schemas/...` ref targets. Kept separate from openapi.ts so Jest
+ * and lightweight callers avoid the Handlebars template loader (#156).
+ */
+
+export function extractClassNameFromRef(ref: string): string | null {
+  if (!ref) return null;
+
+  if (ref.includes('/')) {
+    const parts = ref.split('/');
+    return parts[parts.length - 1] || null;
+  }
+  return ref;
+}
+
+/** Recursively finds all class names referenced in a schema object via $ref */
+export function findReferencedClasses(obj: any, refs: Set<string>): void {
+  if (!obj || typeof obj !== 'object') return;
+
+  if (obj.$ref && typeof obj.$ref === 'string') {
+    const className = extractClassNameFromRef(obj.$ref);
+    if (className) refs.add(className);
+  }
+
+  for (const key in obj) {
+    if (Object.prototype.hasOwnProperty.call(obj, key)) {
+      findReferencedClasses(obj[key], refs);
+    }
+  }
+}

--- a/objectified-ui/src/app/utils/openapi.ts
+++ b/objectified-ui/src/app/utils/openapi.ts
@@ -8,41 +8,9 @@
 
 import { renderTemplate } from './template-loader';
 import { getOpenAPIVersionConfig, DEFAULT_OPENAPI_VERSION } from './openapi-versions';
+import { extractClassNameFromRef, findReferencedClasses } from './openapi-schema-refs';
 
-/**
- * Extracts class name from a JSON Schema $ref string
- * @param ref - The $ref string (e.g., "#/components/schemas/Person")
- * @returns The class name or null if not found
- */
-export function extractClassNameFromRef(ref: string): string | null {
-  if (!ref) return null;
-
-  if (ref.includes('/')) {
-    const parts = ref.split('/');
-    return parts[parts.length - 1] || null;
-  }
-  return ref;
-}
-
-/**
- * Recursively finds all class names referenced in a schema object via $ref
- * @param obj - The schema object to search
- * @param refs - Set to accumulate found class names
- */
-export function findReferencedClasses(obj: any, refs: Set<string>): void {
-  if (!obj || typeof obj !== 'object') return;
-
-  if (obj.$ref && typeof obj.$ref === 'string') {
-    const className = extractClassNameFromRef(obj.$ref);
-    if (className) refs.add(className);
-  }
-
-  for (const key in obj) {
-    if (obj.hasOwnProperty(key)) {
-      findReferencedClasses(obj[key], refs);
-    }
-  }
-}
+export { extractClassNameFromRef, findReferencedClasses };
 
 /**
  * Builds property schema with nested children for object types

--- a/objectified-ui/tests/db/helper-group-operations.test.ts
+++ b/objectified-ui/tests/db/helper-group-operations.test.ts
@@ -1,0 +1,266 @@
+/**
+ * Unit tests for group-level helper functions (#156):
+ * - duplicateClassesInGroup
+ * - bulkApplyEditsToGroupClasses
+ */
+
+import { describe, test, expect, jest, beforeEach } from '@jest/globals';
+
+// Mock the database connection pool
+jest.mock('../../lib/db/db', () => ({
+  query: jest.fn(),
+  connect: jest.fn(),
+}));
+
+// Mock auth/server-session so 'use server' functions can be imported in tests
+jest.mock('../../lib/auth/server-session', () => ({
+  getAuthSession: jest.fn().mockResolvedValue({ user: { id: 'test-user' } }),
+}));
+
+describe('duplicateClassesInGroup', () => {
+  let mockDb: any;
+  let mockClient: any;
+
+  beforeEach(() => {
+    jest.resetModules();
+    mockDb = require('../../lib/db/db');
+    mockClient = {
+      query: jest.fn(),
+      release: jest.fn(),
+    };
+    mockDb.connect = jest.fn().mockResolvedValue(mockClient);
+    mockDb.query = jest.fn();
+  });
+
+  test('returns empty idMap for empty sourceClassIds', async () => {
+    const { duplicateClassesInGroup } = await import('../../lib/db/helper');
+    const result = JSON.parse(await duplicateClassesInGroup('ver-1', []));
+    expect(result.success).toBe(true);
+    expect(result.idMap).toEqual({});
+    // Should NOT begin a transaction for empty input
+    expect(mockClient.query).not.toHaveBeenCalled();
+  });
+
+  test('returns error when class not found in version', async () => {
+    const { duplicateClassesInGroup } = await import('../../lib/db/helper');
+
+    // BEGIN, then classesResult returns 0 rows (mismatch)
+    mockClient.query
+      .mockResolvedValueOnce(undefined) // BEGIN
+      .mockResolvedValueOnce({ rowCount: 0, rows: [] }); // SELECT classes
+
+    const result = JSON.parse(await duplicateClassesInGroup('ver-1', ['missing-id']));
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/not found/i);
+    // Should ROLLBACK on mismatch
+    expect(mockClient.query).toHaveBeenCalledWith('ROLLBACK');
+  });
+
+  test('duplicates a single class with properties and commits', async () => {
+    const { duplicateClassesInGroup } = await import('../../lib/db/helper');
+
+    mockClient.query
+      .mockResolvedValueOnce(undefined) // BEGIN
+      .mockResolvedValueOnce({         // SELECT classes
+        rowCount: 1,
+        rows: [{ id: 'c1', name: 'Foo', description: 'desc', schema: '{"type":"object"}', enabled: true }],
+      })
+      .mockResolvedValueOnce({ rows: [{ name: 'Foo' }] }) // SELECT existing names
+      .mockResolvedValueOnce({ rows: [{ id: 'c2' }] })   // INSERT new class
+      .mockResolvedValueOnce({ rows: [] })                 // SELECT class_properties
+      .mockResolvedValueOnce(undefined)                    // INSERT class_tags
+      .mockResolvedValueOnce(undefined);                   // COMMIT
+
+    const result = JSON.parse(await duplicateClassesInGroup('ver-1', ['c1']));
+    expect(result.success).toBe(true);
+    expect(result.idMap['c1']).toBe('c2');
+    expect(mockClient.query).toHaveBeenCalledWith('COMMIT');
+    expect(mockClient.release).toHaveBeenCalled();
+  });
+
+  test('rewrites $ref in property data to new class names', async () => {
+    const { duplicateClassesInGroup } = await import('../../lib/db/helper');
+
+    mockClient.query
+      .mockResolvedValueOnce(undefined) // BEGIN
+      .mockResolvedValueOnce({         // SELECT classes (two classes: Foo and Bar)
+        rowCount: 2,
+        rows: [
+          { id: 'c1', name: 'Foo', description: null, schema: '{}', enabled: true },
+          { id: 'c2', name: 'Bar', description: null, schema: '{}', enabled: true },
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [{ name: 'Foo' }, { name: 'Bar' }] }) // existing names
+      // Insert Foo Copy
+      .mockResolvedValueOnce({ rows: [{ id: 'c3' }] })
+      // SELECT properties for c1 (one property referencing Bar)
+      .mockResolvedValueOnce({
+        rows: [{ id: 'p1', property_id: null, name: 'ref', description: null,
+                 data: JSON.stringify({ $ref: '#/components/schemas/Bar' }), parent_id: null }],
+      })
+      // INSERT property copy
+      .mockResolvedValueOnce({ rows: [{ id: 'p2' }] })
+      // INSERT class_tags for c1
+      .mockResolvedValueOnce(undefined)
+      // Insert Bar Copy
+      .mockResolvedValueOnce({ rows: [{ id: 'c4' }] })
+      // SELECT properties for c2 (no properties)
+      .mockResolvedValueOnce({ rows: [] })
+      // INSERT class_tags for c2
+      .mockResolvedValueOnce(undefined)
+      // COMMIT
+      .mockResolvedValueOnce(undefined);
+
+    const result = JSON.parse(await duplicateClassesInGroup('ver-1', ['c1', 'c2']));
+    expect(result.success).toBe(true);
+    expect(result.idMap['c1']).toBe('c3');
+    expect(result.idMap['c2']).toBe('c4');
+
+    // Find the INSERT property call and verify the $ref was rewritten
+    const insertPropCall = mockClient.query.mock.calls.find(
+      (c: any[]) => typeof c[0] === 'string' && c[0].includes('INSERT INTO odb.class_properties')
+    );
+    expect(insertPropCall).toBeDefined();
+    const insertedData = JSON.parse(insertPropCall![1][4]);
+    expect(insertedData.$ref).toContain('Bar Copy');
+  });
+
+  test('rolls back and returns error on database failure', async () => {
+    const { duplicateClassesInGroup } = await import('../../lib/db/helper');
+
+    mockClient.query
+      .mockResolvedValueOnce(undefined) // BEGIN
+      .mockRejectedValueOnce(new Error('DB error')); // SELECT classes throws
+
+    const result = JSON.parse(await duplicateClassesInGroup('ver-1', ['c1']));
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('DB error');
+    expect(mockClient.query).toHaveBeenCalledWith('ROLLBACK');
+    expect(mockClient.release).toHaveBeenCalled();
+  });
+});
+
+describe('bulkApplyEditsToGroupClasses', () => {
+  let mockDb: any;
+
+  beforeEach(() => {
+    jest.resetModules();
+    mockDb = require('../../lib/db/db');
+    mockDb.query = jest.fn();
+    mockDb.connect = jest.fn();
+  });
+
+  test('returns success for empty classIds', async () => {
+    const { bulkApplyEditsToGroupClasses } = await import('../../lib/db/helper');
+    const result = JSON.parse(await bulkApplyEditsToGroupClasses('ver-1', [], {}));
+    expect(result.success).toBe(true);
+    expect(mockDb.query).not.toHaveBeenCalled();
+  });
+
+  test('rejects class IDs that do not belong to the version', async () => {
+    const { bulkApplyEditsToGroupClasses } = await import('../../lib/db/helper');
+
+    // Ownership check returns empty (no classes belong to version)
+    mockDb.query.mockResolvedValueOnce({ rows: [] });
+
+    const result = JSON.parse(
+      await bulkApplyEditsToGroupClasses('ver-1', ['c1', 'c2'], { descriptionPrefix: 'prefix-' })
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/No valid class IDs/i);
+  });
+
+  test('applies description prefix/suffix only to valid (owned) classes', async () => {
+    const { bulkApplyEditsToGroupClasses } = await import('../../lib/db/helper');
+
+    // Ownership check: c1 is owned, c2 is not
+    mockDb.query
+      .mockResolvedValueOnce({ rows: [{ id: 'c1' }] })   // ownership check
+      .mockResolvedValueOnce({                             // SELECT class for c1
+        rowCount: 1,
+        rows: [{ id: 'c1', name: 'Foo', description: 'original', schema: '{"type":"object"}' }],
+      })
+      // updateClass internals: SELECT old name, UPDATE, SELECT updated refs…
+      .mockResolvedValue({ rows: [{ id: 'c1', name: 'Foo', version_id: 'ver-1' }] });
+
+    const result = JSON.parse(
+      await bulkApplyEditsToGroupClasses('ver-1', ['c1', 'c2'], { descriptionPrefix: '[TEST] ' })
+    );
+    expect(result.success).toBe(true);
+    // Only 1 class was valid (c1); ownership query should have been called
+    const ownershipCall = mockDb.query.mock.calls[0];
+    expect(ownershipCall[0]).toContain('version_id = $1');
+  });
+
+  test('wraps readOnly updates in a transaction (BEGIN/COMMIT)', async () => {
+    const { bulkApplyEditsToGroupClasses } = await import('../../lib/db/helper');
+
+    mockDb.query
+      .mockResolvedValueOnce({ rows: [{ id: 'c1' }] })  // ownership
+      .mockResolvedValueOnce(undefined)                   // BEGIN
+      .mockResolvedValueOnce({                            // SELECT class_properties
+        rows: [{ id: 'p1', data: '{"type":"string"}' }],
+      })
+      .mockResolvedValueOnce(undefined)                   // UPDATE class_properties
+      .mockResolvedValueOnce(undefined);                  // COMMIT
+
+    const result = JSON.parse(
+      await bulkApplyEditsToGroupClasses('ver-1', ['c1'], { topLevelPropertyReadOnly: true })
+    );
+    expect(result.success).toBe(true);
+
+    const calls = mockDb.query.mock.calls.map((c: any[]) => c[0]);
+    expect(calls).toContain('BEGIN');
+    expect(calls).toContain('COMMIT');
+
+    // Verify readOnly was set in the UPDATE
+    const updateCall = mockDb.query.mock.calls.find(
+      (c: any[]) => typeof c[0] === 'string' && c[0].includes('UPDATE odb.class_properties')
+    );
+    expect(updateCall).toBeDefined();
+    const updatedData = JSON.parse(updateCall![1][0]);
+    expect(updatedData.readOnly).toBe(true);
+  });
+
+  test('rolls back readOnly updates on failure', async () => {
+    const { bulkApplyEditsToGroupClasses } = await import('../../lib/db/helper');
+
+    mockDb.query
+      .mockResolvedValueOnce({ rows: [{ id: 'c1' }] }) // ownership
+      .mockResolvedValueOnce(undefined)                  // BEGIN
+      .mockRejectedValueOnce(new Error('DB failure'));   // SELECT class_properties throws
+
+    const result = JSON.parse(
+      await bulkApplyEditsToGroupClasses('ver-1', ['c1'], { topLevelPropertyReadOnly: false })
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('DB failure');
+
+    const calls = mockDb.query.mock.calls.map((c: any[]) => c[0]);
+    expect(calls).toContain('ROLLBACK');
+  });
+
+  test('removes readOnly flag when topLevelPropertyReadOnly is false', async () => {
+    const { bulkApplyEditsToGroupClasses } = await import('../../lib/db/helper');
+
+    mockDb.query
+      .mockResolvedValueOnce({ rows: [{ id: 'c1' }] })
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce({
+        rows: [{ id: 'p1', data: '{"type":"string","readOnly":true}' }],
+      })
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(undefined);
+
+    const result = JSON.parse(
+      await bulkApplyEditsToGroupClasses('ver-1', ['c1'], { topLevelPropertyReadOnly: false })
+    );
+    expect(result.success).toBe(true);
+
+    const updateCall = mockDb.query.mock.calls.find(
+      (c: any[]) => typeof c[0] === 'string' && c[0].includes('UPDATE odb.class_properties')
+    );
+    const updatedData = JSON.parse(updateCall![1][0]);
+    expect(updatedData.readOnly).toBeUndefined();
+  });
+});

--- a/objectified-ui/tests/unit/group-schema-export.test.ts
+++ b/objectified-ui/tests/unit/group-schema-export.test.ts
@@ -1,0 +1,30 @@
+import { expandClassesForGroupExport } from '../../src/app/utils/group-schema-export';
+
+describe('expandClassesForGroupExport (#156)', () => {
+  test('includes only roots when there are no refs', () => {
+    const all = [
+      { id: 'a', name: 'A', schema: { type: 'object' }, properties: [] },
+      { id: 'b', name: 'B', schema: { type: 'object' }, properties: [] },
+    ];
+    expect(expandClassesForGroupExport(['a'], all)).toHaveLength(1);
+    expect(expandClassesForGroupExport(['a'], all)[0].id).toBe('a');
+  });
+
+  test('pulls in transitively referenced classes', () => {
+    const all = [
+      {
+        id: 'a',
+        name: 'A',
+        schema: { type: 'object' },
+        properties: [{ data: { $ref: '#/components/schemas/B' } }],
+      },
+      { id: 'b', name: 'B', schema: { type: 'object' }, properties: [] },
+      { id: 'c', name: 'C', schema: { type: 'object' }, properties: [] },
+    ];
+    const expanded = expandClassesForGroupExport(['a'], all);
+    const ids = new Set(expanded.map((c) => c.id));
+    expect(ids.has('a')).toBe(true);
+    expect(ids.has('b')).toBe(true);
+    expect(ids.has('c')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem Statement

Users and teams need **fix #156 — group-level export, duplicate, and bulk operations** within the Objectified platform. Today this capability is missing or only partially implemented, which blocks platform workflows and creates inconsistency across tenants and projects.

## Solution / Scope

Implement **Fix #156 — Group-level export, duplicate, and bulk operations** as part of **Platform**.

**Post-MVP** (prioritize after MVP slice) candidacy.

```mermaid
flowchart LR
  User[User action: Fix #156 — Group-level export, duplicate] --> UI[objectified-ui]
  UI --> API[objectified-rest]
  API --> DB[(PostgreSQL)]
```

## Acceptance Criteria

- [ ] Feature behaves as described for: Fix #156 — Group-level export, duplicate, and bulk operations
- [ ] Unit/integration tests cover happy path and primary error cases
- [ ] UI (if applicable) matches existing ADE patterns (Tailwind 4, Radix, Lucide)
- [ ] REST endpoints (if applicable) follow `/v1/{{feature}}/{{tenant_slug}}/...` conventions
- [ ] Documented in issue/PR; no regressions to existing schema/version flows

## Parallelism / Dependencies

- **Can run in parallel:** Yes
- **Blockers:** None identified; validate against current codebase before starting

## Technical Stack

- **Modules:** objectified-ui, objectified-rest
- **Stack:** Next.js 16, React 19, FastAPI, PostgreSQL
- **Labels:** ``

---
**Issue:** #850 · **Area:** Platform · **Roadmap batch:** legacy #64–#879 enrichment