### PR TITLE
Nested canvas groups (max 3 levels) — #155

### DIFF
--- a/PLANNED_FEATURE_ROADMAP_CANVAS.md
+++ b/PLANNED_FEATURE_ROADMAP_CANVAS.md
@@ -83,7 +83,10 @@
   - ✅ Click chevron to collapse: compact frame with title and class count
   - ✅ Alt+Shift+[ / Alt+Shift+] — collapse all / expand all groups
   - ✅ Collapsed state persisted per user per version (localStorage)
-- 📋 [TODO] Nested groups for hierarchical organization (max 3 levels)
+- ✅ Nested groups for hierarchical organization (max 3 levels) (#155):
+  - ✅ Parent groups can contain child group frames; drag a group into another to nest, or out to the canvas to unnest
+  - ✅ Breadcrumb (Canvas → …) when drilling into nested groups; tree icon on the group header enters nested view
+  - ✅ `parent_group_id` on `odb.groups`; sync and load preserve hierarchy
 - ✅ Group-level operations (#156):
   - ✅ Move entire group with one drag
   - ✅ Delete all classes in a group
@@ -97,10 +100,6 @@
   - ✅ Background color/opacity customization
   - ✅ Optional group icons from icon library
 - ✅ Group object is drag-and-drop to the canvas
-
-| Ticket | Feature                                                                   |
-|--------|-------------------------------------------------------------------------------|
-| #155   | Nested groups for hierarchical organization                                  |
 
 ---
 

--- a/objectified-db/scripts/20260329-180000.sql
+++ b/objectified-db/scripts/20260329-180000.sql
@@ -1,0 +1,10 @@
+-- Nested canvas groups (#155): optional parent_group_id, max depth enforced in application (3 levels).
+
+SET search_path TO odb, public;
+
+ALTER TABLE odb.groups
+    ADD COLUMN IF NOT EXISTS parent_group_id UUID REFERENCES odb.groups(id) ON DELETE CASCADE;
+
+CREATE INDEX IF NOT EXISTS idx_groups_parent_group_id ON odb.groups(parent_group_id);
+
+COMMENT ON COLUMN odb.groups.parent_group_id IS 'Parent group for hierarchical nesting; null = top-level. App limits nesting to 3 levels.';

--- a/objectified-ui/lib/db/helper.ts
+++ b/objectified-ui/lib/db/helper.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { getAuthSession } from '../auth/server-session';
+import { sortGroupsParentsBeforeChildren } from '../utils/group-sort';
 
 const connectionPool = require('./db');
 const bcrypt = require('bcrypt');
@@ -4475,23 +4476,6 @@ export async function updateClassPositionInGroup(
  */
 export async function syncGroupsForVersion(versionId: string, groups: any[], nodePositions?: Record<string, { x: number; y: number }>) {
   try {
-    const sortGroupsParentsBeforeChildren = (list: any[]): any[] => {
-      const byId = new Map(list.map((g: any) => [g.id, g]));
-      const memo = new Map<string, number>();
-      const depthKey = (gid: string): number => {
-        if (memo.has(gid)) return memo.get(gid)!;
-        const g = byId.get(gid);
-        if (!g || !g.parentId || !byId.has(g.parentId)) {
-          memo.set(gid, 0);
-          return 0;
-        }
-        const d = 1 + depthKey(g.parentId);
-        memo.set(gid, d);
-        return d;
-      };
-      return [...list].sort((a, b) => depthKey(a.id) - depthKey(b.id));
-    };
-
     // Start a transaction
     await connectionPool.query('BEGIN');
 

--- a/objectified-ui/lib/db/helper.ts
+++ b/objectified-ui/lib/db/helper.ts
@@ -4148,6 +4148,7 @@ export async function getGroupsForVersion(versionId: string) {
       `SELECT g.id, g.version_id, g.name, g.description, g.color,
               g.position_x, g.position_y, g.width, g.height, g.z_index,
               g.is_collapsed, g.is_locked, g.opacity, g.border_style, g.metadata,
+              g.parent_group_id,
               g.created_at, g.updated_at
        FROM odb.groups g
        WHERE g.version_id = $1
@@ -4185,6 +4186,7 @@ export async function getGroupsForVersion(versionId: string) {
         opacity: group.opacity,
         borderStyle: group.border_style,
         metadata: group.metadata,
+        parentId: group.parent_group_id ?? null,
         nodeIds: classesResult.rows.map((c: any) => c.class_id),
         classPositions: classPositions,
         createdAt: group.created_at,
@@ -4282,6 +4284,8 @@ export async function updateGroup(
     opacity?: number;
     borderStyle?: string;
     metadata?: any;
+    /** Set null to make the group top-level (#155). */
+    parentGroupId?: string | null;
   }
 ) {
   try {
@@ -4336,6 +4340,10 @@ export async function updateGroup(
     if (updates.metadata !== undefined) {
       setClauses.push(`metadata = $${paramIndex++}`);
       values.push(JSON.stringify(updates.metadata));
+    }
+    if (updates.parentGroupId !== undefined) {
+      setClauses.push(`parent_group_id = $${paramIndex++}`);
+      values.push(updates.parentGroupId);
     }
 
     if (setClauses.length === 0) {
@@ -4467,6 +4475,23 @@ export async function updateClassPositionInGroup(
  */
 export async function syncGroupsForVersion(versionId: string, groups: any[], nodePositions?: Record<string, { x: number; y: number }>) {
   try {
+    const sortGroupsParentsBeforeChildren = (list: any[]): any[] => {
+      const byId = new Map(list.map((g: any) => [g.id, g]));
+      const memo = new Map<string, number>();
+      const depthKey = (gid: string): number => {
+        if (memo.has(gid)) return memo.get(gid)!;
+        const g = byId.get(gid);
+        if (!g || !g.parentId || !byId.has(g.parentId)) {
+          memo.set(gid, 0);
+          return 0;
+        }
+        const d = 1 + depthKey(g.parentId);
+        memo.set(gid, d);
+        return d;
+      };
+      return [...list].sort((a, b) => depthKey(a.id) - depthKey(b.id));
+    };
+
     // Start a transaction
     await connectionPool.query('BEGIN');
 
@@ -4479,17 +4504,33 @@ export async function syncGroupsForVersion(versionId: string, groups: any[], nod
     // Track mapping from client ID to database ID for returning
     const idMapping: Record<string, string> = {};
 
-    // Insert new groups
-    for (const group of groups) {
+    const sortedGroups = sortGroupsParentsBeforeChildren(groups);
+
+    // Insert new groups (parents before children so parent_group_id resolves)
+    for (const group of sortedGroups) {
       const position = group.position || { x: 0, y: 0 };
       const dimensions = group.dimensions || { width: 200, height: 200 };
+
+      const parentClientId = group.parentId || null;
+      let parentDbId: string | null = null;
+      if (parentClientId) {
+        parentDbId = idMapping[parentClientId] || null;
+        if (!parentDbId) {
+          await connectionPool.query('ROLLBACK');
+          return errorResponse(
+            `Sync: parent group id ${parentClientId} not found or out of order for child ${group.id || group.name}`
+          );
+        }
+      }
+
+      const isCollapsed = group.isCollapsed === true;
 
       // Let database generate UUID - don't use client-side ID
       const groupResult = await connectionPool.query(
         `INSERT INTO odb.groups 
          (version_id, name, description, color, position_x, position_y, width, height, 
-          z_index, opacity, border_style, metadata)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+          z_index, opacity, border_style, metadata, parent_group_id, is_collapsed)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
          RETURNING id`,
         [
           versionId,
@@ -4503,7 +4544,9 @@ export async function syncGroupsForVersion(versionId: string, groups: any[], nod
           group.zIndex || 0,
           group.opacity ?? 1.0,
           group.borderStyle || group.styleOptions?.borderStyle || 'dashed',
-          JSON.stringify(group.metadata || group.styleOptions || {})
+          JSON.stringify(group.metadata || group.styleOptions || {}),
+          parentDbId,
+          isCollapsed
         ]
       );
 

--- a/objectified-ui/lib/utils/group-sort.ts
+++ b/objectified-ui/lib/utils/group-sort.ts
@@ -1,0 +1,42 @@
+/**
+ * Shared topological sorter for canvas group hierarchies.
+ * Used by both the server-side DB sync (lib/db/helper.ts) and the
+ * client-side canvas utility (src/app/utils/canvas-nested-groups.ts).
+ * No React or browser dependencies — safe to import from either context.
+ */
+
+/** Minimal interface required for topological group sorting. */
+export interface GroupSortItem {
+  id: string;
+  parentId?: string | null;
+}
+
+/**
+ * Topologically sort groups so every parent appears before its children (for DB sync inserts).
+ * Safe against cycles: a group involved in a cycle is treated as depth 0 to prevent infinite recursion.
+ */
+export function sortGroupsParentsBeforeChildren<T extends GroupSortItem>(groups: T[]): T[] {
+  const byId = new Map(groups.map((g) => [g.id, g]));
+  const memo = new Map<string, number>();
+  const visiting = new Set<string>();
+
+  function depthKey(gid: string): number {
+    if (memo.has(gid)) return memo.get(gid)!;
+    if (visiting.has(gid)) {
+      // Cycle detected — treat as depth 0 to stop recursion
+      return 0;
+    }
+    const g = byId.get(gid);
+    if (!g || !g.parentId || !byId.has(g.parentId)) {
+      memo.set(gid, 0);
+      return 0;
+    }
+    visiting.add(gid);
+    const d = 1 + depthKey(g.parentId);
+    visiting.delete(gid);
+    memo.set(gid, d);
+    return d;
+  }
+
+  return [...groups].sort((a, b) => depthKey(a.id) - depthKey(b.id));
+}

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.8.59",
+  "version": "0.8.60",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.8.60",
+  "version": "0.8.61",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -5,6 +5,7 @@ We continue to improve the platform based on your feedback with improvements and
 ---
 
 Improvements:
+- Canvas: nested groups up to three levels — drag group frames into each other, breadcrumb navigation and drill-in control, nested export/bulk/delete-all include descendant groups (#155)
 - Canvas: group toolbar — export the group’s schemas as OpenAPI JSON or YAML (with referenced types), duplicate the whole group into a new frame, and apply bulk class updates (description prefix/suffix, tag, top-level read-only) (#156)
 - Canvas: groups can collapse to a compact title bar (chevron); Alt+Shift+[ / ] collapse or expand all; your choices are remembered per version (#154)
 - Canvas: presentation mode — save viewport slides, present in fullscreen with speaker notes, timer, and keyboard controls (#517)

--- a/objectified-ui/src/app/ade/studio/StudioContext.tsx
+++ b/objectified-ui/src/app/ade/studio/StudioContext.tsx
@@ -24,6 +24,8 @@ export interface CanvasGroup {
   description?: string;
   color: string;
   nodeIds: string[];
+  /** Parent canvas group for nesting (#155); omit or null = top-level. */
+  parentId?: string | null;
   tags?: GroupTag[];
   position: { x: number; y: number };
   dimensions: { width: number; height: number };

--- a/objectified-ui/src/app/ade/studio/editor/components/types.ts
+++ b/objectified-ui/src/app/ade/studio/editor/components/types.ts
@@ -34,6 +34,7 @@ export interface CanvasGroup {
   position: { x: number; y: number };
   dimensions: { width: number; height: number };
   nodeIds: string[];
+  parentId?: string | null;
   tags?: any[];
   styleOptions?: GroupStyleOptions;
 }

--- a/objectified-ui/src/app/ade/studio/editor/page.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/page.tsx
@@ -148,6 +148,18 @@ import {
   COLLAPSED_GROUP_FRAME_HEIGHT,
 } from '@/app/utils/canvas-group-collapse';
 import {
+  MAX_CANVAS_GROUP_DEPTH,
+  collectAllNodeIdsInGroupSubtree,
+  collectDescendantGroupIds,
+  collectSubtreeGroupIds,
+  findInnermostGroupAtPosition,
+  getGroupDepth,
+  groupById,
+  isStrictDescendantGroup,
+  wouldNestExceedMaxDepth,
+  type FlowLikeGroupNode,
+} from '@/app/utils/canvas-nested-groups';
+import {
   edgeBelongsOnCanvas,
   ghostEdgeClassName,
   ghostNodeClassName,
@@ -408,6 +420,28 @@ const StudioContent = () => {
 
   // #154: Collapsed canvas groups — member classes hidden, compact frame; prefs per user + version
   const [collapsedGroupIds, setCollapsedGroupIds] = useState<Set<string>>(new Set());
+  /** #155: Breadcrumb / drill path — innermost group id is last; empty = full canvas */
+  const [nestedGroupDrillPath, setNestedGroupDrillPath] = useState<string[]>([]);
+
+  useEffect(() => {
+    setNestedGroupDrillPath([]);
+  }, [selectedVersionId]);
+
+  useEffect(() => {
+    setNestedGroupDrillPath((prev) => {
+      if (prev.length === 0) return prev;
+      const idSet = new Set(groups.map((g) => g.id));
+      let cut = prev.length;
+      for (let i = 0; i < prev.length; i++) {
+        if (!idSet.has(prev[i])) {
+          cut = i;
+          break;
+        }
+      }
+      const next = prev.slice(0, cut);
+      return next.length === prev.length ? prev : next;
+    });
+  }, [groups]);
 
   useEffect(() => {
     if (!currentUserId || !selectedVersionId) {
@@ -818,6 +852,7 @@ const StudioContent = () => {
   const handleGroupColorChangeRef = useRef<any>(null);
   const handleGroupStyleChangeRef = useRef<any>(null);
   const handleGroupTagsChangeRef = useRef<any>(null);
+  const handleDrillIntoNestedGroupRef = useRef<(groupId: string) => void>(() => {});
 
   // Handle toggling property expansion
   const handleTogglePropertyExpansion = useCallback((propertyId: string) => {
@@ -1170,8 +1205,7 @@ const StudioContent = () => {
     if (!focusModeEnabled) return new Set<string>();
     // #490: Focus on group – only show this group's members
     if (focusModeGroupId) {
-      const group = groups.find(g => g.id === focusModeGroupId);
-      return group ? new Set<string>(group.nodeIds) : new Set<string>();
+      return new Set<string>(collectAllNodeIdsInGroupSubtree(focusModeGroupId, groups));
     }
     const classNodeIds = selectedNodeIds.filter(id => {
       const node = nodes.find(n => n.id === id);
@@ -1493,6 +1527,16 @@ const StudioContent = () => {
   const displayNodes = useMemo(() => {
     let result = layoutPreviewNodes ?? nodes;
 
+    if (nestedGroupDrillPath.length > 0) {
+      const focusId = nestedGroupDrillPath[nestedGroupDrillPath.length - 1]!;
+      const visibleGroupIds = collectSubtreeGroupIds(focusId, groups);
+      const visibleClassIds = new Set(collectAllNodeIdsInGroupSubtree(focusId, groups));
+      result = result.filter((node) => {
+        if (node.type === 'groupNode') return visibleGroupIds.has(node.id);
+        return visibleClassIds.has(node.id);
+      });
+    }
+
     // #481 + #483: Manual hide, empty/unconnected/deprecated/group criteria — group frame if any member visible
     // #484: Optional ghosts mode — keep hidden nodes on canvas with semi-transparent styling
     const groupMap = new Map(groups.map((g) => [g.id, g]));
@@ -1500,7 +1544,7 @@ const StudioContent = () => {
       result = result.filter((node) => {
         if (node.type === 'groupNode') {
           const g = groupMap.get(node.id);
-          return g ? groupNodeIdIsVisible(g, allBaseClassNodeIds) : false;
+          return g ? groupNodeIdIsVisible(g, allBaseClassNodeIds, groups) : false;
         }
         return true;
       });
@@ -1511,7 +1555,8 @@ const StudioContent = () => {
           node.type,
           g,
           visibleClassIdsAfterHideCriteria,
-          nodeGhostsModeEnabled
+          nodeGhostsModeEnabled,
+          groups
         );
         if (!ghost) return node;
         const existingClassName = node.className || '';
@@ -1521,7 +1566,7 @@ const StudioContent = () => {
       result = result.filter((node) => {
         if (node.type === 'groupNode') {
           const g = groupMap.get(node.id);
-          return g ? groupNodeIdIsVisible(g, visibleClassIdsAfterHideCriteria) : false;
+          return g ? groupNodeIdIsVisible(g, visibleClassIdsAfterHideCriteria, groups) : false;
         }
         return visibleClassIdsAfterHideCriteria.has(node.id);
       });
@@ -1718,12 +1763,13 @@ const StudioContent = () => {
           onToggleCollapse: () => {
             toggleGroupCollapsedRef.current(node.id);
           },
+          onDrillInto: () => handleDrillIntoNestedGroupRef.current(node.id),
         },
       };
     });
 
     return result;
-  }, [nodes, layoutPreviewNodes, visibleClassIdsAfterHideCriteria, allBaseClassNodeIds, nodeGhostsModeEnabled, isolateSelectionEnabled, selectedNodeIds, groups, collapsedGroupIds, classIdsHiddenByCollapse, canvasSearchQuery, canvasSearchOpen, matchingNodeIds, focusModeEnabled, focusModeFocusedSet, showDependencyOverlay, dependencyView, dependencyFocalNodeId, dependencyUpstreamIds, dependencyDownstreamIds, dependencyPathChain, nodesWithDependencyIds, dependencyDepthMap, circularNodeIdsSet, impactAnalysisMode, impactAnalysisSourceId, affectedClassIds]);
+  }, [nodes, layoutPreviewNodes, nestedGroupDrillPath, visibleClassIdsAfterHideCriteria, allBaseClassNodeIds, nodeGhostsModeEnabled, isolateSelectionEnabled, selectedNodeIds, groups, collapsedGroupIds, classIdsHiddenByCollapse, canvasSearchQuery, canvasSearchOpen, matchingNodeIds, focusModeEnabled, focusModeFocusedSet, showDependencyOverlay, dependencyView, dependencyFocalNodeId, dependencyUpstreamIds, dependencyDownstreamIds, dependencyPathChain, nodesWithDependencyIds, dependencyDepthMap, circularNodeIdsSet, impactAnalysisMode, impactAnalysisSourceId, affectedClassIds]);
 
   // Compute edges with search and/or focus mode styling applied
   const displayEdges = useMemo(() => {
@@ -1751,6 +1797,14 @@ const StudioContent = () => {
       result = result.filter(
         (edge) =>
           !classIdsHiddenByCollapse.has(edge.source) && !classIdsHiddenByCollapse.has(edge.target)
+      );
+    }
+
+    if (nestedGroupDrillPath.length > 0) {
+      const focusId = nestedGroupDrillPath[nestedGroupDrillPath.length - 1]!;
+      const visibleClassIds = new Set(collectAllNodeIdsInGroupSubtree(focusId, groups));
+      result = result.filter(
+        (edge) => visibleClassIds.has(edge.source) && visibleClassIds.has(edge.target)
       );
     }
 
@@ -1854,7 +1908,7 @@ const StudioContent = () => {
     }
 
     return result;
-  }, [edges, visibleClassIdsAfterHideCriteria, allBaseClassNodeIds, nodeGhostsModeEnabled, isolateSelectionEnabled, selectedNodeIds, groups, classIdsHiddenByCollapse, canvasSearchQuery, canvasSearchOpen, matchingNodeIds, focusModeEnabled, focusModeFocusedSet, showDependencyOverlay, dependencyView, dependencyFocalNodeId, dependencyUpstreamIds, dependencyDownstreamIds, dependencyPathChain, dependencyEdgeIds, circularEdgeIds, impactAnalysisMode, impactAnalysisSourceId, affectedClassIds]);
+  }, [edges, visibleClassIdsAfterHideCriteria, allBaseClassNodeIds, nodeGhostsModeEnabled, isolateSelectionEnabled, selectedNodeIds, groups, classIdsHiddenByCollapse, nestedGroupDrillPath, canvasSearchQuery, canvasSearchOpen, matchingNodeIds, focusModeEnabled, focusModeFocusedSet, showDependencyOverlay, dependencyView, dependencyFocalNodeId, dependencyUpstreamIds, dependencyDownstreamIds, dependencyPathChain, dependencyEdgeIds, circularEdgeIds, impactAnalysisMode, impactAnalysisSourceId, affectedClassIds]);
 
   // #349: Apply hover highlight to the hovered edge (thicker stroke, higher zIndex)
   const edgesWithHover = useMemo(() => {
@@ -2676,10 +2730,15 @@ const StudioContent = () => {
   const handleGroupDelete = useCallback(async (groupId: string) => {
     if (isReadOnly) return;
 
-    const group = groups.find(g => g.id === groupId);
+    const group = groups.find((g) => g.id === groupId);
+    const subtree = collectSubtreeGroupIds(groupId, groups);
+    const subtreeCount = subtree.size;
     const confirmed = await confirmDialog({
       title: 'Delete Group',
-      message: `Are you sure you want to delete the group "${group?.name || 'this group'}"? The classes inside will not be deleted.`,
+      message:
+        subtreeCount > 1
+          ? `Delete "${group?.name || 'this group'}" and ${subtreeCount - 1} nested group frame(s)? Classes on the canvas are not deleted.`
+          : `Are you sure you want to delete the group "${group?.name || 'this group'}"? The classes inside will not be deleted.`,
       variant: 'warning',
       confirmLabel: 'Delete Group',
       cancelLabel: 'Cancel',
@@ -2687,20 +2746,26 @@ const StudioContent = () => {
 
     if (!confirmed) return;
 
-    // Remove from context
-    deleteGroupFromContext(groupId);
+    const byIdDel = groupById(groups);
+    const sortedToRemove = Array.from(subtree).sort(
+      (a, b) => getGroupDepth(b, byIdDel) - getGroupDepth(a, byIdDel)
+    );
+    for (const id of sortedToRemove) {
+      deleteGroupFromContext(id);
+      groupPositionsRef.current.delete(id);
+    }
 
-    // Clean up group position tracking
-    groupPositionsRef.current.delete(groupId);
+    setNodes((prevNodes) =>
+      prevNodes.filter((node) => !(node.type === 'groupNode' && subtree.has(node.id)))
+    );
 
-    // Remove group node from canvas
-    setNodes(prevNodes => prevNodes.filter(node => node.id !== groupId));
+    setNestedGroupDrillPath((prev) => prev.filter((id) => !subtree.has(id)));
 
     // Auto-save to database
     if (selectedVersionId && currentUserId) {
       try {
         const viewport = getViewport();
-        const nodeData = nodes.filter(n => n.id !== groupId && n.type !== 'groupNode').map(node => ({
+        const nodeData = nodes.filter((n) => !subtree.has(n.id) && n.type !== 'groupNode').map((node) => ({
           id: node.id,
           position: node.position,
           dimensions: node.style ? { width: node.style.width, height: node.style.height } : undefined
@@ -2711,8 +2776,7 @@ const StudioContent = () => {
           target: edge.target
         }));
 
-        // Exclude the deleted group
-        const updatedGroups = groups.filter(g => g.id !== groupId);
+        const updatedGroups = groups.filter((g) => !subtree.has(g.id));
 
         await saveDefaultCanvasLayout(
           selectedVersionId,
@@ -2732,13 +2796,14 @@ const StudioContent = () => {
   // Optional classIdsFromNode/groupNameFromNode come from the group node so we don't rely on groups state being in sync
   const handleDeleteAllClassesInGroup = useCallback(async (
     groupId: string,
-    classIdsFromNode?: string[],
+    _classIdsFromNode?: string[],
     groupNameFromNode?: string
   ) => {
     if (isReadOnly) return;
 
-    const group = groups.find(g => g.id === groupId);
-    const classIds = (classIdsFromNode?.length ? classIdsFromNode : group?.nodeIds) || [];
+    const group = groups.find((g) => g.id === groupId);
+    const classIds = collectAllNodeIdsInGroupSubtree(groupId, groups);
+    const directCount = group?.nodeIds?.length ?? 0;
     const groupName = groupNameFromNode ?? group?.name ?? 'this group';
 
     if (classIds.length === 0) {
@@ -2747,7 +2812,9 @@ const StudioContent = () => {
 
     const confirmed = await confirmDialog({
       title: 'Delete All Classes in Group',
-      message: `Are you sure you want to delete all ${classIds.length} class${classIds.length === 1 ? '' : 'es'} in "${groupName}"? This action cannot be undone.`,
+      message: `Are you sure you want to delete all ${classIds.length} class${classIds.length === 1 ? '' : 'es'} in "${groupName}"${
+        classIds.length > directCount ? ' (including classes in nested group frames)' : ''
+      }? This action cannot be undone.`,
       variant: 'danger',
       confirmLabel: 'Delete All',
       cancelLabel: 'Cancel',
@@ -2776,8 +2843,10 @@ const StudioContent = () => {
 
   const handleExportGroupSchema = useCallback(
     async (groupId: string, nodeIds: string[], groupName: string, format: 'json' | 'yaml') => {
-      void groupId;
-      if (!selectedVersionId || nodeIds.length === 0) return;
+      if (!selectedVersionId) return;
+      const rootIds = collectAllNodeIdsInGroupSubtree(groupId, groups);
+      const exportIds = rootIds.length > 0 ? rootIds : nodeIds;
+      if (exportIds.length === 0) return;
       try {
         const res = await getClassesWithPropertiesAndTagsWithSession(selectedVersionId);
         if (!res.success || !res.classes) {
@@ -2787,7 +2856,7 @@ const StudioContent = () => {
           });
           return;
         }
-        const expanded = expandClassesForGroupExport(nodeIds, res.classes);
+        const expanded = expandClassesForGroupExport(exportIds, res.classes);
         if (expanded.length === 0) {
           await alertDialog({ message: 'No classes in this group to export.', variant: 'warning' });
           return;
@@ -2816,7 +2885,7 @@ const StudioContent = () => {
         await alertDialog({ message, variant: 'error' });
       }
     },
-    [selectedVersionId, selectedProjectId, projects, versions, alertDialog]
+    [selectedVersionId, selectedProjectId, projects, versions, alertDialog, groups]
   );
 
   const handleBulkEditGroupClasses = useCallback(
@@ -2831,8 +2900,10 @@ const StudioContent = () => {
         topLevelPropertyReadOnly?: boolean;
       }
     ) => {
-      void groupId;
-      if (isReadOnly || nodeIds.length === 0) return;
+      if (isReadOnly) return;
+      const bulkIds = collectAllNodeIdsInGroupSubtree(groupId, groups);
+      const targetIds = bulkIds.length > 0 ? bulkIds : nodeIds;
+      if (targetIds.length === 0) return;
       const hasText =
         (options.descriptionPrefix && options.descriptionPrefix.trim().length > 0) ||
         (options.descriptionSuffix && options.descriptionSuffix.trim().length > 0);
@@ -2847,13 +2918,13 @@ const StudioContent = () => {
       }
       const ok = await confirmDialog({
         title: 'Apply to all classes in group',
-        message: `Update ${nodeIds.length} class(es) in "${groupName}"?`,
+        message: `Update ${targetIds.length} class(es) in "${groupName}"${bulkIds.length > nodeIds.length ? ' (includes nested groups)' : ''}?`,
         confirmLabel: 'Apply',
         cancelLabel: 'Cancel',
       });
       if (!ok) throw new Error('cancelled');
 
-      const raw = await bulkApplyEditsToGroupClasses(selectedVersionId!, nodeIds, {
+      const raw = await bulkApplyEditsToGroupClasses(selectedVersionId!, targetIds, {
         descriptionPrefix:
           options.descriptionPrefix && options.descriptionPrefix.trim().length > 0
             ? options.descriptionPrefix
@@ -2877,7 +2948,7 @@ const StudioContent = () => {
       triggerSidebarRefresh();
       await alertDialog({ message: 'Bulk changes applied to all classes in this group.', variant: 'success' });
     },
-    [isReadOnly, selectedVersionId, confirmDialog, alertDialog, reloadClasses, triggerSidebarRefresh]
+    [isReadOnly, selectedVersionId, confirmDialog, alertDialog, reloadClasses, triggerSidebarRefresh, groups]
   );
 
   const handleDuplicateGroup = useCallback(
@@ -2923,6 +2994,7 @@ const StudioContent = () => {
         id: newGroupId,
         name: newGroupName,
         color: sourceGroup?.color || GROUP_COLORS[0].name,
+        parentId: null as string | null,
         nodeIds: nodeIds.map((oid) => idMap[oid]).filter(Boolean) as string[],
         position: { x: basePos.x + OFFSET, y: basePos.y + OFFSET },
         dimensions: sourceGroup?.dimensions || { width: 400, height: 300 },
@@ -2989,6 +3061,8 @@ const StudioContent = () => {
           onColorChange: (gid: string, color: string) => handleGroupColorChangeRef.current?.(gid, color),
           onStyleChange: (gid: string, style: any) => handleGroupStyleChangeRef.current?.(gid, style),
           onTagsChange: (gid: string, t: any[]) => handleGroupTagsChangeRef.current?.(gid, t),
+          parentId: null,
+          onDrillInto: () => handleDrillIntoNestedGroupRef.current(newGroupId),
           isReadOnly,
         },
       };
@@ -3242,6 +3316,10 @@ const StudioContent = () => {
     }
   }, [isReadOnly, updateGroup, setNodes, selectedVersionId, currentUserId, getViewport, nodes, edges, groups]);
 
+  const handleDrillIntoNestedGroup = useCallback((groupId: string) => {
+    setNestedGroupDrillPath((prev) => [...prev, groupId]);
+  }, []);
+
   // Assign current handlers to refs for use in effects
   handleGroupTagsChangeRef.current = handleGroupTagsChange;
   handleGroupRenameRef.current = handleGroupRename;
@@ -3252,6 +3330,7 @@ const StudioContent = () => {
   handleBulkEditGroupClassesRef.current = handleBulkEditGroupClasses;
   handleGroupColorChangeRef.current = handleGroupColorChange;
   handleGroupStyleChangeRef.current = handleGroupStyleChange;
+  handleDrillIntoNestedGroupRef.current = handleDrillIntoNestedGroup;
 
   // State for drag-over highlighting
   const [dragOverGroupId, setDragOverGroupId] = useState<string | null>(null);
@@ -3359,22 +3438,12 @@ const StudioContent = () => {
     return true;
   }, [isReadOnly, groups, confirmDialog, updateGroup, setNodes]);
 
-  // Find which group a position is inside of
+  // Innermost group frame containing (x,y) — #155 nesting uses smallest overlapping frame
   const findGroupAtPosition = useCallback((x: number, y: number, excludeGroupId?: string): string | null => {
-    const groupNodes = nodes.filter(n => n.type === 'groupNode' && n.id !== excludeGroupId);
-
-    for (const groupNode of groupNodes) {
-      const groupX = groupNode.position.x;
-      const groupY = groupNode.position.y;
-      // Use measured dimensions first (updated after resize), then style, then default
-      const groupWidth = (groupNode.measured?.width as number) || (groupNode.style?.width as number) || 400;
-      const groupHeight = (groupNode.measured?.height as number) || (groupNode.style?.height as number) || 300;
-
-      if (x >= groupX && x <= groupX + groupWidth && y >= groupY && y <= groupY + groupHeight) {
-        return groupNode.id;
-      }
-    }
-    return null;
+    const groupFlowNodes = nodes.filter((n) => n.type === 'groupNode') as FlowLikeGroupNode[];
+    const exclude = new Set<string>();
+    if (excludeGroupId) exclude.add(excludeGroupId);
+    return findInnermostGroupAtPosition(x, y, groupFlowNodes, exclude);
   }, [nodes]);
 
   // Find which group a node currently belongs to
@@ -3389,9 +3458,34 @@ const StudioContent = () => {
 
   // Handle node drag - check if over a group for visual feedback and calculate smart guides
   const handleNodeDrag = useCallback((event: React.MouseEvent, node: Node) => {
-    if (isReadOnly || node.type === 'groupNode') {
+    if (isReadOnly) {
       setDragOverGroupId(null);
       setGuides({ horizontal: [], vertical: [] });
+      return;
+    }
+
+    if (node.type === 'groupNode') {
+      setGuides({ horizontal: [], vertical: [] });
+      const desc = collectDescendantGroupIds(node.id, groups);
+      const exclude = new Set<string>([node.id, ...desc]);
+      const groupFlowNodes = nodes.filter((n) => n.type === 'groupNode') as FlowLikeGroupNode[];
+      const nodeWidth = (node.measured?.width as number) || (node.width as number) || 400;
+      const nodeHeight = (node.measured?.height as number) || (node.height as number) || 300;
+      const cx = node.position.x + nodeWidth / 2;
+      const cy = node.position.y + nodeHeight / 2;
+      const target = findInnermostGroupAtPosition(cx, cy, groupFlowNodes, exclude);
+      const byId = groupById(groups);
+      const currentParent = groups.find((g) => g.id === node.id)?.parentId ?? null;
+      let showTarget: string | null = null;
+      if (target) {
+        if (
+          !isStrictDescendantGroup(node.id, target, byId) &&
+          !wouldNestExceedMaxDepth(node.id, target, groups)
+        ) {
+          if (target !== currentParent) showTarget = target;
+        }
+      }
+      setDragOverGroupId(showTarget);
       return;
     }
 
@@ -3487,7 +3581,7 @@ const StudioContent = () => {
     });
 
     setGuides({ horizontal: newHorizontalGuides, vertical: newVerticalGuides });
-  }, [isReadOnly, findGroupAtPosition, nodes, smartGuidesEnabled]);
+  }, [isReadOnly, findGroupAtPosition, nodes, smartGuidesEnabled, groups]);
 
   // Check if a node is completely outside a group's bounds
   const isNodeCompletelyOutsideGroup = useCallback((node: Node, groupId: string): boolean => {
@@ -3523,7 +3617,83 @@ const StudioContent = () => {
     setDragOverGroupId(null);
     setGuides({ horizontal: [], vertical: [] }); // Clear smart guides
 
-    if (isReadOnly || node.type === 'groupNode') return;
+    if (isReadOnly) return;
+
+    // #155: Nest or unnest group frames by dropping inside another group or on empty canvas
+    if (node.type === 'groupNode') {
+      const movingId = node.id;
+      const desc = collectDescendantGroupIds(movingId, groups);
+      const exclude = new Set<string>([movingId, ...desc]);
+      const groupFlowNodes = nodes.filter((n) => n.type === 'groupNode') as FlowLikeGroupNode[];
+      const nodeWidth = (node.measured?.width as number) || (node.width as number) || 400;
+      const nodeHeight = (node.measured?.height as number) || (node.height as number) || 300;
+      const cx = node.position.x + nodeWidth / 2;
+      const cy = node.position.y + nodeHeight / 2;
+      const targetParentId = findInnermostGroupAtPosition(cx, cy, groupFlowNodes, exclude);
+      const currentParent = groups.find((g) => g.id === movingId)?.parentId ?? null;
+      const newParent = targetParentId ?? null;
+      const byId = groupById(groups);
+
+      if (
+        newParent &&
+        (isStrictDescendantGroup(movingId, newParent, byId) ||
+          wouldNestExceedMaxDepth(movingId, newParent, groups))
+      ) {
+        await alertDialog({
+          message: isStrictDescendantGroup(movingId, newParent, byId)
+            ? 'A group cannot be placed inside its own descendant.'
+            : `Groups can nest at most ${MAX_CANVAS_GROUP_DEPTH} levels deep.`,
+          variant: 'warning',
+        });
+        return;
+      }
+
+      if (newParent === currentParent) return;
+
+      updateGroup(movingId, { parentId: newParent });
+      setNodes((prev) =>
+        prev.map((n) => {
+          if (n.id === movingId && n.type === 'groupNode') {
+            return { ...n, data: { ...(n.data as object), parentId: newParent } };
+          }
+          return n;
+        })
+      );
+
+      if (selectedVersionId && currentUserId) {
+        try {
+          const viewport = getViewport();
+          const nodeData = nodes.map((nd) => ({
+            id: nd.id,
+            type: nd.type,
+            position: nd.position,
+            dimensions: {
+              width: (nd as any).measured?.width || (nd as any).width || (nd.style as any)?.width,
+              height: (nd as any).measured?.height || (nd as any).height || (nd.style as any)?.height,
+            },
+          }));
+          const edgeData = edges.map((edge) => ({
+            id: edge.id,
+            source: edge.source,
+            target: edge.target,
+          }));
+          const updatedGroups = groups.map((g) =>
+            g.id === movingId ? { ...g, parentId: newParent } : g
+          );
+          await saveDefaultCanvasLayout(
+            selectedVersionId,
+            currentUserId,
+            viewport,
+            nodeData,
+            edgeData,
+            updatedGroups
+          );
+        } catch (error) {
+          console.error('Failed to save after nesting change:', error);
+        }
+      }
+      return;
+    }
 
     // Get node dimensions and center
     const nodeWidth = (node.measured?.width as number) || (node.width as number) || 260;
@@ -3644,7 +3814,25 @@ const StudioContent = () => {
         console.error('Error updating class position in group:', error);
       }
     }
-  }, [isReadOnly, findNodeGroup, findGroupAtPosition, handleAddNodeToGroup, handleRemoveNodeFromGroup, groups, confirmDialog, updateGroup, setNodes, nodes, isNodeCompletelyOutsideGroup]);
+  }, [
+    isReadOnly,
+    findNodeGroup,
+    findGroupAtPosition,
+    handleAddNodeToGroup,
+    handleRemoveNodeFromGroup,
+    groups,
+    confirmDialog,
+    alertDialog,
+    updateGroup,
+    setNodes,
+    nodes,
+    edges,
+    isNodeCompletelyOutsideGroup,
+    selectedVersionId,
+    currentUserId,
+    getViewport,
+    saveDefaultCanvasLayout,
+  ]);
 
   // Handle canvas drag over - allow dropping groups; show dropzone when dragging new-group
   const handleCanvasDragOver = useCallback((event: React.DragEvent) => {
@@ -3738,6 +3926,7 @@ const StudioContent = () => {
         color: newGroup.color,
         nodeIds: newGroup.nodeIds,
         styleOptions: newGroup.styleOptions,
+        parentId: null,
         availableTags: createGroupAvailableTags,
         onRename: handleGroupRename,
         onDelete: handleGroupDelete,
@@ -3759,6 +3948,7 @@ const StudioContent = () => {
         ) => handleBulkEditGroupClassesRef.current?.(gid, cids, gn, opts),
         onColorChange: handleGroupColorChange,
         onStyleChange: handleGroupStyleChange,
+        onDrillInto: () => handleDrillIntoNestedGroupRef.current(groupId),
         isReadOnly: isReadOnly
       }
     };
@@ -3881,6 +4071,7 @@ const StudioContent = () => {
         color: newGroup.color,
         nodeIds: newGroup.nodeIds,
         styleOptions: newGroup.styleOptions,
+        parentId: null,
         availableTags: createGroupAtDropAvailableTags,
         onRename: handleGroupRename,
         onDelete: handleGroupDelete,
@@ -3902,6 +4093,7 @@ const StudioContent = () => {
         ) => handleBulkEditGroupClassesRef.current?.(gid, cids, gn, opts),
         onColorChange: handleGroupColorChange,
         onStyleChange: handleGroupStyleChange,
+        onDrillInto: () => handleDrillIntoNestedGroupRef.current(groupId),
         isReadOnly: isReadOnly
       }
     };
@@ -4056,8 +4248,49 @@ const StudioContent = () => {
       if (change.type === 'position' && change.position) {
         const node = nodes.find(n => n.id === change.id);
 
-        // Skip group nodes - they can move freely
-        if (node?.type === 'groupNode') return change;
+        // #155: Nested group frames stay within parent bounds (same rules as class nodes)
+        if (node?.type === 'groupNode') {
+          const selfGroup = groups.find((g) => g.id === change.id);
+          const pgId = selfGroup?.parentId;
+          if (!pgId) return change;
+          const parentGn = nodes.find((n) => n.id === pgId && n.type === 'groupNode');
+          if (!parentGn) return change;
+          const nodeWidth = (node?.measured?.width as number) || (node?.width as number) || 400;
+          const nodeHeight = (node?.measured?.height as number) || (node?.height as number) || 300;
+          const groupX = parentGn.position.x;
+          const groupY = parentGn.position.y;
+          const groupWidth =
+            (parentGn.measured?.width as number) || (parentGn.style?.width as number) || 400;
+          const groupHeight =
+            (parentGn.measured?.height as number) || (parentGn.style?.height as number) || 300;
+          const nodeLeft = change.position.x;
+          const nodeRight = change.position.x + nodeWidth;
+          const nodeTop = change.position.y;
+          const nodeBottom = change.position.y + nodeHeight;
+          const groupLeft = groupX;
+          const groupRight = groupX + groupWidth;
+          const groupTop = groupY;
+          const groupBottom = groupY + groupHeight;
+          const isCompletelyOutside =
+            nodeRight < groupLeft ||
+            nodeLeft > groupRight ||
+            nodeBottom < groupTop ||
+            nodeTop > groupBottom;
+          if (isCompletelyOutside && change.dragging) return change;
+          if (isCompletelyOutside && !change.dragging) return change;
+          const constrainedX = Math.max(
+            groupX,
+            Math.min(change.position.x, groupX + groupWidth - nodeWidth)
+          );
+          const constrainedY = Math.max(
+            groupY,
+            Math.min(change.position.y, groupY + groupHeight - nodeHeight)
+          );
+          return {
+            ...change,
+            position: { x: constrainedX, y: constrainedY },
+          };
+        }
 
         // Check if this node belongs to a group
         const parentGroup = groups.find(g => g.nodeIds.includes(change.id));
@@ -4116,15 +4349,29 @@ const StudioContent = () => {
     // Apply the constrained changes
     onNodesChange(constrainedChanges);
 
-    // Move child nodes when their parent group moves
+    // Move child class nodes and nested group frames when a parent group moves (#155)
     if (groupDeltas.size > 0) {
+      const byId = groupById(groups);
       setNodes((prevNodes) => {
         return prevNodes.map((node) => {
-          if (node.type === 'groupNode') return node;
+          if (node.type === 'groupNode') {
+            for (const [movedGid, delta] of groupDeltas) {
+              if (node.id === movedGid) continue;
+              if (isStrictDescendantGroup(movedGid, node.id, byId)) {
+                return {
+                  ...node,
+                  position: {
+                    x: node.position.x + delta.dx,
+                    y: node.position.y + delta.dy,
+                  },
+                };
+              }
+            }
+            return node;
+          }
 
-          // Check if this node is in any moved group
           for (const [groupId, delta] of groupDeltas) {
-            const group = groups.find(g => g.id === groupId);
+            const group = groups.find((g) => g.id === groupId);
             if (group && group.nodeIds.includes(node.id)) {
               return {
                 ...node,
@@ -4471,6 +4718,7 @@ const StudioContent = () => {
             position: g.position,
             dimensions: g.dimensions,
             nodeIds: g.nodeIds || [],
+            parentId: g.parentId ?? null,
             tags: g.metadata?.tags || [],
             styleOptions: {
               borderStyle: g.borderStyle || 'dashed',
@@ -4518,6 +4766,7 @@ const StudioContent = () => {
                 name: group.name,
                 color: group.color,
                 nodeIds: group.nodeIds || [],
+                parentId: group.parentId ?? null,
                 tags: group.metadata?.tags || [],
                 styleOptions: group.styleOptions,
                 availableTags,
@@ -4546,6 +4795,7 @@ const StudioContent = () => {
                   handleGroupStyleChangeRef.current?.(groupId, style),
                 onTagsChange: (groupId: string, tags: any[]) =>
                   handleGroupTagsChangeRef.current?.(groupId, tags),
+                onDrillInto: () => handleDrillIntoNestedGroupRef.current(group.id),
                 isReadOnly,
               },
             };
@@ -5691,6 +5941,7 @@ const StudioContent = () => {
               position: g.position,
               dimensions: g.dimensions,
               nodeIds: g.nodeIds || [],
+              parentId: g.parentId ?? null,
               tags: g.metadata?.tags || [],
               styleOptions: {
                 borderStyle: g.borderStyle || 'dashed',
@@ -5725,6 +5976,7 @@ const StudioContent = () => {
                   name: group.name,
                   color: group.color,
                   nodeIds: group.nodeIds || [],
+                  parentId: group.parentId ?? null,
                   tags: group.metadata?.tags || [],
                   styleOptions: {
                     borderStyle: group.borderStyle || 'dashed',
@@ -5755,6 +6007,7 @@ const StudioContent = () => {
                   onColorChange: (groupId: string, color: string) => handleGroupColorChangeRef.current?.(groupId, color),
                   onStyleChange: (groupId: string, style: any) => handleGroupStyleChangeRef.current?.(groupId, style),
                   onTagsChange: (groupId: string, tags: any[]) => handleGroupTagsChangeRef.current?.(groupId, tags),
+                  onDrillInto: () => handleDrillIntoNestedGroupRef.current(group.id),
                   isReadOnly
                 }
               };
@@ -6989,6 +7242,41 @@ const StudioContent = () => {
                 })}
               </defs>
             </svg>
+            {nestedGroupDrillPath.length > 0 && (
+              <Panel
+                position="top-left"
+                className="!mt-12 ml-2 z-[1002] max-w-[min(100vw-2rem,28rem)]"
+              >
+                <nav
+                  aria-label="Nested groups"
+                  className="flex flex-wrap items-center gap-1 rounded-lg border border-gray-200/80 dark:border-gray-600 bg-white/95 dark:bg-gray-800/95 px-2 py-1.5 text-xs shadow-md backdrop-blur-sm"
+                >
+                  <button
+                    type="button"
+                    className="rounded px-1.5 py-0.5 font-medium text-indigo-600 dark:text-indigo-400 hover:bg-indigo-50 dark:hover:bg-indigo-900/40"
+                    onClick={() => setNestedGroupDrillPath([])}
+                  >
+                    Canvas
+                  </button>
+                  {nestedGroupDrillPath.map((gid, idx) => {
+                    const g = groups.find((x) => x.id === gid);
+                    const label = g?.name ?? gid;
+                    return (
+                      <span key={`${gid}-${idx}`} className="flex items-center gap-1 text-gray-500 dark:text-gray-400">
+                        <ChevronRight className="h-3 w-3 shrink-0" />
+                        <button
+                          type="button"
+                          className="max-w-[10rem] truncate rounded px-1.5 py-0.5 text-left text-gray-800 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700"
+                          onClick={() => setNestedGroupDrillPath((p) => p.slice(0, idx + 1))}
+                        >
+                          {label}
+                        </button>
+                      </span>
+                    );
+                  })}
+                </nav>
+              </Panel>
+            )}
             {/* #349: Edge hover tooltip */}
             {hoveredEdgeId && edgeTooltipPosition && (() => {
               const hoveredEdge = displayEdges.find((e) => e.id === hoveredEdgeId);

--- a/objectified-ui/src/app/ade/studio/editor/page.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/page.tsx
@@ -4358,11 +4358,15 @@ const StudioContent = () => {
             for (const [movedGid, delta] of groupDeltas) {
               if (node.id === movedGid) continue;
               if (isStrictDescendantGroup(movedGid, node.id, byId)) {
+                const newX = node.position.x + delta.dx;
+                const newY = node.position.y + delta.dy;
+                // Keep groupPositionsRef in sync so the next drag computes correct deltas
+                groupPositionsRef.current.set(node.id, { x: newX, y: newY });
                 return {
                   ...node,
                   position: {
-                    x: node.position.x + delta.dx,
-                    y: node.position.y + delta.dy,
+                    x: newX,
+                    y: newY,
                   },
                 };
               }

--- a/objectified-ui/src/app/ade/studio/lib/canvasLayoutPayload.ts
+++ b/objectified-ui/src/app/ade/studio/lib/canvasLayoutPayload.ts
@@ -19,6 +19,7 @@ export function mapNodesForLayoutSave(nodes: Node[]) {
             name: node.data.name,
             color: node.data.color,
             nodeIds: node.data.nodeIds,
+            parentId: (node.data as { parentId?: string | null }).parentId ?? null,
           }
         : undefined,
   }));

--- a/objectified-ui/src/app/components/ade/studio/GroupNode.tsx
+++ b/objectified-ui/src/app/components/ade/studio/GroupNode.tsx
@@ -7,6 +7,7 @@ import {
   Box, Layers, Database, Shield, Users, Zap, Globe, Lock,
   FileText, Tag, Star, Heart, Flag, Bookmark, Archive, Package,
   FileX, ChevronRight, ChevronDown, Download, FileJson, FileCode2, Copy, SlidersHorizontal,
+  ListTree,
 } from 'lucide-react';
 import * as Popover from '@radix-ui/react-popover';
 import { COLLAPSED_GROUP_FRAME_WIDTH, COLLAPSED_GROUP_FRAME_HEIGHT } from '@/app/utils/canvas-group-collapse';
@@ -132,6 +133,10 @@ export interface GroupNodeData {
   /** Canvas frame is collapsed to title + count only (#154). */
   collapsed?: boolean;
   onToggleCollapse?: () => void;
+  /** #155: Parent group id if nested */
+  parentId?: string | null;
+  /** #155: Drill into group (breadcrumb navigation) */
+  onDrillInto?: (groupId: string) => void;
 }
 
 const GroupNode = memo(({ id, data, selected }: NodeProps) => {
@@ -316,6 +321,22 @@ const GroupNode = memo(({ id, data, selected }: NodeProps) => {
               <ChevronDown className="h-4 w-4" />
             )}
           </button>
+          {groupData.onDrillInto && !groupData.isReadOnly && (
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                e.preventDefault();
+                groupData.onDrillInto?.(groupData.id);
+              }}
+              onPointerDown={(e) => e.stopPropagation()}
+              className={`p-0.5 rounded shrink-0 transition-colors ${useLightText ? 'hover:bg-white/25' : 'hover:bg-white/50 dark:hover:bg-gray-700/50'}`}
+              title="Nested view — focus breadcrumb on this group"
+              aria-label="Drill into nested group"
+            >
+              <ListTree className="h-4 w-4" />
+            </button>
+          )}
           <IconComponent className="h-4 w-4" />
 
           {isEditing ? (

--- a/objectified-ui/src/app/components/ade/studio/GroupNode.tsx
+++ b/objectified-ui/src/app/components/ade/studio/GroupNode.tsx
@@ -167,6 +167,8 @@ const GroupNode = memo(({ id, data, selected }: NodeProps) => {
   // Get shadow class
   const shadowClass = SHADOW_OPTIONS.find(s => s.name === styleOptions.shadow)?.class || '';
 
+  const nodeCount = groupData.nodeIds?.length || 0;
+
   const handleStartEdit = useCallback((e: React.MouseEvent) => {
     e.stopPropagation();
     if (groupData.isReadOnly) return;
@@ -263,8 +265,6 @@ const GroupNode = memo(({ id, data, selected }: NodeProps) => {
     groupData.onStyleChange?.(groupData.id, newOptions);
   }, [groupData, styleOptions]);
 
-  // Count nodes in this group
-  const nodeCount = groupData.nodeIds?.length || 0;
   const isCollapsed = Boolean(groupData.collapsed);
 
   return (

--- a/objectified-ui/src/app/components/ade/studio/GroupNode.tsx
+++ b/objectified-ui/src/app/components/ade/studio/GroupNode.tsx
@@ -321,7 +321,7 @@ const GroupNode = memo(({ id, data, selected }: NodeProps) => {
               <ChevronDown className="h-4 w-4" />
             )}
           </button>
-          {groupData.onDrillInto && !groupData.isReadOnly && (
+          {groupData.onDrillInto && (
             <button
               type="button"
               onClick={(e) => {

--- a/objectified-ui/src/app/utils/canvas-display-visibility.ts
+++ b/objectified-ui/src/app/utils/canvas-display-visibility.ts
@@ -62,16 +62,20 @@ export function computeClassIdsPassingHideCriteria(
   return visible;
 }
 
-/** Group frame is visible if any member class passes criteria or a visible nested child group does (#155). */
+/** Group frame is visible if any member class passes criteria or a visible nested child group does (#155). Safe against cycles via a visited set. */
 export function groupNodeIdIsVisible(
   group: CanvasGroupForVisibility,
   visibleClassIds: Set<string>,
-  allGroups?: CanvasGroupForVisibility[]
+  allGroups?: CanvasGroupForVisibility[],
+  _visited: Set<string> = new Set()
 ): boolean {
+  if (_visited.has(group.id)) return false; // cycle guard
+  _visited.add(group.id);
+
   if (group.nodeIds.some((id) => visibleClassIds.has(id))) return true;
   if (allGroups) {
     for (const cg of allGroups) {
-      if (cg.parentId === group.id && groupNodeIdIsVisible(cg, visibleClassIds, allGroups)) {
+      if (cg.parentId === group.id && groupNodeIdIsVisible(cg, visibleClassIds, allGroups, _visited)) {
         return true;
       }
     }

--- a/objectified-ui/src/app/utils/canvas-display-visibility.ts
+++ b/objectified-ui/src/app/utils/canvas-display-visibility.ts
@@ -29,9 +29,19 @@ export function computeClassIdsPassingHideCriteria(
   connectedNodeIds: Set<string>,
   criteria: CanvasHideCriteriaInput
 ): Set<string> {
+  const byId = new Map(groups.map((g) => [g.id, g]));
   const inHiddenGroups = new Set<string>();
+  const underHiddenBranch = (groupId: string): boolean => {
+    let cur = byId.get(groupId);
+    while (cur) {
+      if (criteria.hiddenGroupIds.has(cur.id)) return true;
+      if (!cur.parentId) break;
+      cur = byId.get(cur.parentId);
+    }
+    return false;
+  };
   for (const g of groups) {
-    if (criteria.hiddenGroupIds.has(g.id)) {
+    if (underHiddenBranch(g.id)) {
       for (const id of g.nodeIds) {
         inHiddenGroups.add(id);
       }
@@ -52,12 +62,21 @@ export function computeClassIdsPassingHideCriteria(
   return visible;
 }
 
-/** Group frame is visible if at least one member class passes criteria. */
+/** Group frame is visible if any member class passes criteria or a visible nested child group does (#155). */
 export function groupNodeIdIsVisible(
   group: CanvasGroupForVisibility,
-  visibleClassIds: Set<string>
+  visibleClassIds: Set<string>,
+  allGroups?: CanvasGroupForVisibility[]
 ): boolean {
-  return group.nodeIds.some((id) => visibleClassIds.has(id));
+  if (group.nodeIds.some((id) => visibleClassIds.has(id))) return true;
+  if (allGroups) {
+    for (const cg of allGroups) {
+      if (cg.parentId === group.id && groupNodeIdIsVisible(cg, visibleClassIds, allGroups)) {
+        return true;
+      }
+    }
+  }
+  return false;
 }
 
 /**

--- a/objectified-ui/src/app/utils/canvas-ghost-mode.ts
+++ b/objectified-ui/src/app/utils/canvas-ghost-mode.ts
@@ -42,12 +42,13 @@ export function ghostNodeClassName(
   nodeType: string | undefined,
   group: CanvasGroupForVisibility | undefined,
   visibleClassIds: Set<string>,
-  nodeGhostsModeEnabled: boolean
+  nodeGhostsModeEnabled: boolean,
+  allGroups?: CanvasGroupForVisibility[]
 ): string {
   if (!nodeGhostsModeEnabled) return '';
   if (nodeType === 'groupNode') {
     if (!group) return '';
-    return groupNodeIdIsVisible(group, visibleClassIds) ? '' : 'canvas-node-ghost';
+    return groupNodeIdIsVisible(group, visibleClassIds, allGroups) ? '' : 'canvas-node-ghost';
   }
   return visibleClassIds.has(nodeId) ? '' : 'canvas-node-ghost';
 }

--- a/objectified-ui/src/app/utils/canvas-group-collapse.ts
+++ b/objectified-ui/src/app/utils/canvas-group-collapse.ts
@@ -9,14 +9,24 @@ export function collapsePrefsStorageKey(userId: string, versionId: string): stri
   return `ade.canvasGroupCollapsed:v1:${userId}:${versionId}`;
 }
 
-/** Class node IDs that belong to at least one collapsed group. */
+/** Class node IDs that belong to a collapsed group or a descendant group under a collapsed ancestor (#155). */
 export function getClassIdsInCollapsedGroups(
-  groups: { id: string; nodeIds: string[] }[],
+  groups: { id: string; nodeIds: string[]; parentId?: string | null }[],
   collapsedGroupIds: Set<string>
 ): Set<string> {
+  const byId = new Map(groups.map((g) => [g.id, g]));
+  const hasCollapsedAncestor = (groupId: string): boolean => {
+    let cur = byId.get(groupId);
+    while (cur) {
+      if (collapsedGroupIds.has(cur.id)) return true;
+      if (!cur.parentId) break;
+      cur = byId.get(cur.parentId);
+    }
+    return false;
+  };
   const ids = new Set<string>();
   for (const g of groups) {
-    if (!collapsedGroupIds.has(g.id)) continue;
+    if (!hasCollapsedAncestor(g.id)) continue;
     for (const id of g.nodeIds) {
       ids.add(id);
     }

--- a/objectified-ui/src/app/utils/canvas-nested-groups.ts
+++ b/objectified-ui/src/app/utils/canvas-nested-groups.ts
@@ -3,6 +3,7 @@
  */
 
 import type { CanvasGroup } from '@/app/ade/studio/StudioContext';
+export { sortGroupsParentsBeforeChildren } from '@lib/utils/group-sort';
 
 /** Allowed group depths: level 1 (root) … level 3 (deepest). */
 export const MAX_CANVAS_GROUP_DEPTH = 3;
@@ -11,23 +12,29 @@ export function groupById(groups: CanvasGroup[]): Map<string, CanvasGroup> {
   return new Map(groups.map((g) => [g.id, g]));
 }
 
-/** Depth 1 = top-level (no parent). */
+/** Depth 1 = top-level (no parent). Safe against cycles via a visited set. */
 export function getGroupDepth(groupId: string, byId: Map<string, CanvasGroup>): number {
   let depth = 1;
   let cur = byId.get(groupId);
+  const visited = new Set<string>();
+  visited.add(groupId);
   while (cur?.parentId) {
+    if (visited.has(cur.parentId)) break; // cycle guard
+    visited.add(cur.parentId);
     depth += 1;
     cur = byId.get(cur.parentId);
   }
   return depth;
 }
 
-/** Longest chain of child groups strictly below `groupId` (edge count to deepest descendant group). */
-export function maxChildGroupChainLength(groupId: string, groups: CanvasGroup[]): number {
+/** Longest chain of child groups strictly below `groupId` (edge count to deepest descendant group). Safe against cycles via a visited set. */
+export function maxChildGroupChainLength(groupId: string, groups: CanvasGroup[], _visited: Set<string> = new Set()): number {
+  if (_visited.has(groupId)) return 0; // cycle guard
+  _visited.add(groupId);
   let maxBelow = 0;
   for (const g of groups) {
     if (g.parentId === groupId) {
-      maxBelow = Math.max(maxBelow, 1 + maxChildGroupChainLength(g.id, groups));
+      maxBelow = Math.max(maxBelow, 1 + maxChildGroupChainLength(g.id, groups, _visited));
     }
   }
   return maxBelow;
@@ -49,15 +56,19 @@ export function wouldNestExceedMaxDepth(
   return baseDepth + tail > maxDepth;
 }
 
-/** True if `maybeDescendantId` is a strict descendant group of `ancestorId` (walks parent chain from the former). */
+/** True if `maybeDescendantId` is a strict descendant group of `ancestorId` (walks parent chain from the former). Safe against cycles via a visited set. */
 export function isStrictDescendantGroup(
   ancestorId: string,
   maybeDescendantId: string,
   byId: Map<string, CanvasGroup>
 ): boolean {
   let cur = byId.get(maybeDescendantId);
+  const visited = new Set<string>();
+  visited.add(maybeDescendantId);
   while (cur?.parentId) {
     if (cur.parentId === ancestorId) return true;
+    if (visited.has(cur.parentId)) break; // cycle guard
+    visited.add(cur.parentId);
     cur = byId.get(cur.parentId);
   }
   return false;
@@ -152,26 +163,4 @@ export function findInnermostGroupAtPosition(
     }
   }
   return best?.id ?? null;
-}
-
-/**
- * Topologically sort groups so every parent appears before its children (for DB sync inserts).
- */
-export function sortGroupsParentsBeforeChildren(groups: CanvasGroup[]): CanvasGroup[] {
-  const byId = groupById(groups);
-  const memo = new Map<string, number>();
-
-  function depthKey(gid: string): number {
-    if (memo.has(gid)) return memo.get(gid)!;
-    const g = byId.get(gid);
-    if (!g || !g.parentId || !byId.has(g.parentId)) {
-      memo.set(gid, 0);
-      return 0;
-    }
-    const d = 1 + depthKey(g.parentId);
-    memo.set(gid, d);
-    return d;
-  }
-
-  return [...groups].sort((a, b) => depthKey(a.id) - depthKey(b.id));
 }

--- a/objectified-ui/src/app/utils/canvas-nested-groups.ts
+++ b/objectified-ui/src/app/utils/canvas-nested-groups.ts
@@ -1,0 +1,177 @@
+/**
+ * Nested canvas groups (#155): hierarchy helpers, depth limits, subtree collection.
+ */
+
+import type { CanvasGroup } from '@/app/ade/studio/StudioContext';
+
+/** Allowed group depths: level 1 (root) … level 3 (deepest). */
+export const MAX_CANVAS_GROUP_DEPTH = 3;
+
+export function groupById(groups: CanvasGroup[]): Map<string, CanvasGroup> {
+  return new Map(groups.map((g) => [g.id, g]));
+}
+
+/** Depth 1 = top-level (no parent). */
+export function getGroupDepth(groupId: string, byId: Map<string, CanvasGroup>): number {
+  let depth = 1;
+  let cur = byId.get(groupId);
+  while (cur?.parentId) {
+    depth += 1;
+    cur = byId.get(cur.parentId);
+  }
+  return depth;
+}
+
+/** Longest chain of child groups strictly below `groupId` (edge count to deepest descendant group). */
+export function maxChildGroupChainLength(groupId: string, groups: CanvasGroup[]): number {
+  let maxBelow = 0;
+  for (const g of groups) {
+    if (g.parentId === groupId) {
+      maxBelow = Math.max(maxBelow, 1 + maxChildGroupChainLength(g.id, groups));
+    }
+  }
+  return maxBelow;
+}
+
+/**
+ * After move, deepest group depth in this subtree would be:
+ * newDepth(moved) + maxChildGroupChainLength(moved).
+ */
+export function wouldNestExceedMaxDepth(
+  movingGroupId: string,
+  newParentId: string | null | undefined,
+  groups: CanvasGroup[],
+  maxDepth: number = MAX_CANVAS_GROUP_DEPTH
+): boolean {
+  const byId = groupById(groups);
+  const baseDepth = newParentId ? getGroupDepth(newParentId, byId) + 1 : 1;
+  const tail = maxChildGroupChainLength(movingGroupId, groups);
+  return baseDepth + tail > maxDepth;
+}
+
+/** True if `maybeDescendantId` is a strict descendant group of `ancestorId` (walks parent chain from the former). */
+export function isStrictDescendantGroup(
+  ancestorId: string,
+  maybeDescendantId: string,
+  byId: Map<string, CanvasGroup>
+): boolean {
+  let cur = byId.get(maybeDescendantId);
+  while (cur?.parentId) {
+    if (cur.parentId === ancestorId) return true;
+    cur = byId.get(cur.parentId);
+  }
+  return false;
+}
+
+/** All strict descendant group ids (not including rootId). */
+export function collectDescendantGroupIds(rootId: string, groups: CanvasGroup[]): Set<string> {
+  const out = new Set<string>();
+  const visit = (id: string) => {
+    for (const g of groups) {
+      if (g.parentId === id && !out.has(g.id)) {
+        out.add(g.id);
+        visit(g.id);
+      }
+    }
+  };
+  visit(rootId);
+  return out;
+}
+
+/** Subtree: root + all descendant groups. */
+export function collectSubtreeGroupIds(rootId: string, groups: CanvasGroup[]): Set<string> {
+  const desc = collectDescendantGroupIds(rootId, groups);
+  desc.add(rootId);
+  return desc;
+}
+
+/** Every class id assigned to this group or a descendant group (deduped). */
+export function collectAllNodeIdsInGroupSubtree(groupId: string, groups: CanvasGroup[]): string[] {
+  const ids = collectSubtreeGroupIds(groupId, groups);
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const g of groups) {
+    if (!ids.has(g.id)) continue;
+    for (const nid of g.nodeIds || []) {
+      if (!seen.has(nid)) {
+        seen.add(nid);
+        out.push(nid);
+      }
+    }
+  }
+  return out;
+}
+
+export type FlowLikeGroupNode = {
+  id: string;
+  type?: string;
+  position: { x: number; y: number };
+  measured?: { width?: number; height?: number };
+  width?: number | string;
+  height?: number | string;
+  style?: { width?: number | string; height?: number | string };
+};
+
+function numDim(v: number | string | undefined, fallback: number): number {
+  if (v === undefined) return fallback;
+  if (typeof v === 'number' && Number.isFinite(v)) return v;
+  const n = typeof v === 'string' ? parseFloat(v) : NaN;
+  return Number.isFinite(n) ? n : fallback;
+}
+
+export function getGroupNodeBounds(node: FlowLikeGroupNode): {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  area: number;
+} {
+  const width = numDim(node.measured?.width ?? node.width ?? node.style?.width, 400);
+  const height = numDim(node.measured?.height ?? node.height ?? node.style?.height, 300);
+  return { x: node.position.x, y: node.position.y, width, height, area: width * height };
+}
+
+/**
+ * Among group frames whose bounds contain (x,y), return the id of the smallest area
+ * (innermost when frames overlap). Excludes `excludeIds`.
+ */
+export function findInnermostGroupAtPosition(
+  x: number,
+  y: number,
+  groupFlowNodes: ReadonlyArray<FlowLikeGroupNode>,
+  excludeIds: Set<string>
+): string | null {
+  let best: { id: string; area: number } | null = null;
+  for (const n of groupFlowNodes) {
+    if (n.type !== 'groupNode' || excludeIds.has(n.id)) continue;
+    const b = getGroupNodeBounds(n);
+    const inside = x >= b.x && x <= b.x + b.width && y >= b.y && y <= b.y + b.height;
+    if (!inside) continue;
+    if (!best || b.area < best.area) {
+      best = { id: n.id, area: b.area };
+    }
+  }
+  return best?.id ?? null;
+}
+
+/**
+ * Topologically sort groups so every parent appears before its children (for DB sync inserts).
+ */
+export function sortGroupsParentsBeforeChildren(groups: CanvasGroup[]): CanvasGroup[] {
+  const byId = groupById(groups);
+  const memo = new Map<string, number>();
+
+  function depthKey(gid: string): number {
+    if (memo.has(gid)) return memo.get(gid)!;
+    const g = byId.get(gid);
+    if (!g || !g.parentId || !byId.has(g.parentId)) {
+      memo.set(gid, 0);
+      return 0;
+    }
+    const d = 1 + depthKey(g.parentId);
+    memo.set(gid, d);
+    return d;
+  }
+
+  return [...groups].sort((a, b) => depthKey(a.id) - depthKey(b.id));
+}

--- a/objectified-ui/src/app/utils/canvas-node-visibility.ts
+++ b/objectified-ui/src/app/utils/canvas-node-visibility.ts
@@ -5,16 +5,26 @@
 export interface CanvasGroupForVisibility {
   id: string;
   nodeIds: string[];
+  parentId?: string | null;
 }
 
-/** Group nodes that contain at least one of the selected class IDs. */
+/** Group nodes that contain at least one of the selected class IDs (includes ancestor frames for nesting #155). */
 export function getVisibleGroupIdsForSelectedClasses(
   groups: CanvasGroupForVisibility[],
   selectedClassIds: Set<string>
 ): Set<string> {
-  return new Set(
-    groups.filter((g) => g.nodeIds.some((id) => selectedClassIds.has(id))).map((g) => g.id)
-  );
+  const byId = new Map(groups.map((g) => [g.id, g]));
+  const out = new Set<string>();
+  for (const g of groups) {
+    if (!g.nodeIds.some((id) => selectedClassIds.has(id))) continue;
+    let cur: CanvasGroupForVisibility | undefined = g;
+    while (cur) {
+      out.add(cur.id);
+      if (!cur.parentId) break;
+      cur = byId.get(cur.parentId);
+    }
+  }
+  return out;
 }
 
 /** Build the set of canvas node IDs visible when isolating to the given class selection. */

--- a/objectified-ui/tests/unit/canvas-display-visibility.test.ts
+++ b/objectified-ui/tests/unit/canvas-display-visibility.test.ts
@@ -74,6 +74,21 @@ describe('canvas-display-visibility (#483)', () => {
     ).toEqual(new Set(['c', 'd']));
   });
 
+  it('hiddenGroupIds on ancestor removes members of nested groups (#155)', () => {
+    const nested = [
+      { id: 'g1', nodeIds: ['a'], parentId: null as string | null },
+      { id: 'g2', nodeIds: ['c'], parentId: 'g1' },
+    ];
+    expect(
+      computeClassIdsPassingHideCriteria(nodes, nested, connected, {
+        hideEmptyClasses: false,
+        hideUnconnectedClasses: false,
+        hideDeprecatedClasses: false,
+        hiddenGroupIds: new Set(['g1']),
+      })
+    ).toEqual(new Set(['d']));
+  });
+
   it('combines criteria as AND across rules', () => {
     expect(
       computeClassIdsPassingHideCriteria(nodes, groups, connected, {
@@ -89,6 +104,15 @@ describe('canvas-display-visibility (#483)', () => {
     expect(groupNodeIdIsVisible(groups[0], new Set(['a']))).toBe(true);
     expect(groupNodeIdIsVisible(groups[0], new Set(['c']))).toBe(false);
     expect(groupNodeIdIsVisible(groups[1], new Set(['c']))).toBe(true);
+  });
+
+  it('groupNodeIdIsVisible considers visible members in nested child groups (#155)', () => {
+    const nested = [
+      { id: 'g1', nodeIds: [], parentId: null },
+      { id: 'g2', nodeIds: ['c'], parentId: 'g1' },
+    ];
+    expect(groupNodeIdIsVisible(nested[0], new Set(['c']), nested)).toBe(true);
+    expect(groupNodeIdIsVisible(nested[0], new Set(['a']), nested)).toBe(false);
   });
 });
 

--- a/objectified-ui/tests/unit/canvas-display-visibility.test.ts
+++ b/objectified-ui/tests/unit/canvas-display-visibility.test.ts
@@ -76,7 +76,7 @@ describe('canvas-display-visibility (#483)', () => {
 
   it('hiddenGroupIds on ancestor removes members of nested groups (#155)', () => {
     const nested = [
-      { id: 'g1', nodeIds: ['a'], parentId: null as string | null },
+      { id: 'g1', nodeIds: ['a', 'b'], parentId: null as string | null },
       { id: 'g2', nodeIds: ['c'], parentId: 'g1' },
     ];
     expect(

--- a/objectified-ui/tests/unit/canvas-group-collapse.test.ts
+++ b/objectified-ui/tests/unit/canvas-group-collapse.test.ts
@@ -14,6 +14,14 @@ describe('canvas-group-collapse', () => {
     expect(getClassIdsInCollapsedGroups(groups, new Set()).size).toBe(0);
   });
 
+  it('getClassIdsInCollapsedGroups includes nested groups under a collapsed ancestor (#155)', () => {
+    const groups = [
+      { id: 'parent', nodeIds: ['1'], parentId: null },
+      { id: 'child', nodeIds: ['2'], parentId: 'parent' },
+    ];
+    expect([...getClassIdsInCollapsedGroups(groups, new Set(['parent']))].sort()).toEqual(['1', '2']);
+  });
+
   it('collapsePrefsStorageKey encodes user and version', () => {
     expect(collapsePrefsStorageKey('user-1', 'ver-2')).toBe(
       'ade.canvasGroupCollapsed:v1:user-1:ver-2'

--- a/objectified-ui/tests/unit/canvas-nested-groups.test.ts
+++ b/objectified-ui/tests/unit/canvas-nested-groups.test.ts
@@ -1,0 +1,90 @@
+import {
+  MAX_CANVAS_GROUP_DEPTH,
+  collectAllNodeIdsInGroupSubtree,
+  collectDescendantGroupIds,
+  collectSubtreeGroupIds,
+  findInnermostGroupAtPosition,
+  getGroupDepth,
+  groupById,
+  isStrictDescendantGroup,
+  maxChildGroupChainLength,
+  sortGroupsParentsBeforeChildren,
+  wouldNestExceedMaxDepth,
+} from '@/app/utils/canvas-nested-groups';
+import type { CanvasGroup } from '@/app/ade/studio/StudioContext';
+
+describe('canvas-nested-groups (#155)', () => {
+  const tree: CanvasGroup[] = [
+    { id: 'r', name: 'R', color: 'blue', nodeIds: ['a'], parentId: null, position: { x: 0, y: 0 }, dimensions: { width: 400, height: 300 } },
+    { id: 'c1', name: 'C1', color: 'blue', nodeIds: ['b'], parentId: 'r', position: { x: 0, y: 0 }, dimensions: { width: 200, height: 200 } },
+    { id: 'c2', name: 'C2', color: 'blue', nodeIds: [], parentId: 'c1', position: { x: 0, y: 0 }, dimensions: { width: 100, height: 100 } },
+  ];
+
+  it('getGroupDepth counts from root', () => {
+    const byId = groupById(tree);
+    expect(getGroupDepth('r', byId)).toBe(1);
+    expect(getGroupDepth('c1', byId)).toBe(2);
+    expect(getGroupDepth('c2', byId)).toBe(3);
+  });
+
+  it('maxChildGroupChainLength measures edges below a node', () => {
+    expect(maxChildGroupChainLength('c2', tree)).toBe(0);
+    expect(maxChildGroupChainLength('c1', tree)).toBe(1);
+    expect(maxChildGroupChainLength('r', tree)).toBe(2);
+  });
+
+  it('wouldNestExceedMaxDepth allows three levels and rejects a fourth', () => {
+    expect(wouldNestExceedMaxDepth('c2', null, tree)).toBe(false);
+    const chain3: CanvasGroup[] = [
+      { id: 'g1', name: '', color: 'x', nodeIds: [], parentId: null, position: { x: 0, y: 0 }, dimensions: { width: 1, height: 1 } },
+      { id: 'g2', name: '', color: 'x', nodeIds: [], parentId: 'g1', position: { x: 0, y: 0 }, dimensions: { width: 1, height: 1 } },
+      { id: 'g3', name: '', color: 'x', nodeIds: [], parentId: 'g2', position: { x: 0, y: 0 }, dimensions: { width: 1, height: 1 } },
+    ];
+    const leaf: CanvasGroup = {
+      id: 'leaf',
+      name: '',
+      color: 'x',
+      nodeIds: [],
+      parentId: null,
+      position: { x: 0, y: 0 },
+      dimensions: { width: 1, height: 1 },
+    };
+    expect(wouldNestExceedMaxDepth('leaf', 'g3', [...chain3, leaf])).toBe(true);
+  });
+
+  it('isStrictDescendantGroup detects ancestry', () => {
+    const byId = groupById(tree);
+    expect(isStrictDescendantGroup('r', 'c1', byId)).toBe(true);
+    expect(isStrictDescendantGroup('r', 'c2', byId)).toBe(true);
+    expect(isStrictDescendantGroup('c1', 'r', byId)).toBe(false);
+    expect(isStrictDescendantGroup('c2', 'c1', byId)).toBe(true);
+  });
+
+  it('collectDescendantGroupIds and collectSubtreeGroupIds', () => {
+    expect([...collectDescendantGroupIds('r', tree)].sort()).toEqual(['c1', 'c2']);
+    expect([...collectSubtreeGroupIds('r', tree)].sort()).toEqual(['c1', 'c2', 'r']);
+  });
+
+  it('collectAllNodeIdsInGroupSubtree dedupes class ids', () => {
+    expect(collectAllNodeIdsInGroupSubtree('r', tree).sort()).toEqual(['a', 'b']);
+  });
+
+  it('sortGroupsParentsBeforeChildren orders parents first', () => {
+    const shuffled = [tree[2], tree[0], tree[1]];
+    const sorted = sortGroupsParentsBeforeChildren(shuffled);
+    expect(sorted.map((g) => g.id)).toEqual(['r', 'c1', 'c2']);
+  });
+
+  it('findInnermostGroupAtPosition picks smallest containing frame', () => {
+    const nodes = [
+      { id: 'big', type: 'groupNode' as const, position: { x: 0, y: 0 }, style: { width: 400, height: 300 } },
+      { id: 'small', type: 'groupNode' as const, position: { x: 50, y: 50 }, style: { width: 80, height: 60 } },
+    ];
+    expect(findInnermostGroupAtPosition(90, 80, nodes, new Set())).toBe('small');
+    expect(findInnermostGroupAtPosition(5, 5, nodes, new Set(['small']))).toBe('big');
+  });
+
+  it('MAX_CANVAS_GROUP_DEPTH is 3', () => {
+    expect(MAX_CANVAS_GROUP_DEPTH).toBe(3);
+  });
+});

--- a/objectified-ui/tests/unit/canvas-nested-groups.test.ts
+++ b/objectified-ui/tests/unit/canvas-nested-groups.test.ts
@@ -57,7 +57,7 @@ describe('canvas-nested-groups (#155)', () => {
     expect(isStrictDescendantGroup('r', 'c1', byId)).toBe(true);
     expect(isStrictDescendantGroup('r', 'c2', byId)).toBe(true);
     expect(isStrictDescendantGroup('c1', 'r', byId)).toBe(false);
-    expect(isStrictDescendantGroup('c2', 'c1', byId)).toBe(true);
+    expect(isStrictDescendantGroup('c1', 'c2', byId)).toBe(true);
   });
 
   it('collectDescendantGroupIds and collectSubtreeGroupIds', () => {

--- a/objectified-ui/tests/unit/canvas-node-visibility.test.ts
+++ b/objectified-ui/tests/unit/canvas-node-visibility.test.ts
@@ -27,4 +27,14 @@ describe('canvas-node-visibility (#482)', () => {
       new Set(['c', 'g2'])
     );
   });
+
+  it('getVisibleNodeIdsForIsolateSelection includes ancestor frames for nested groups (#155)', () => {
+    const nested = [
+      { id: 'g1', nodeIds: ['a'], parentId: null as string | null },
+      { id: 'g2', nodeIds: ['c'], parentId: 'g1' },
+    ];
+    expect(getVisibleNodeIdsForIsolateSelection(nested, new Set(['c']))).toEqual(
+      new Set(['c', 'g2', 'g1'])
+    );
+  });
 });

--- a/objectified-ui/tests/unit/canvasLayoutPayload.test.ts
+++ b/objectified-ui/tests/unit/canvasLayoutPayload.test.ts
@@ -35,7 +35,12 @@ describe('canvasLayoutPayload', () => {
       },
     ] as Node[];
     const out = mapNodesForLayoutSave(nodes);
-    expect(out[0].data).toEqual({ name: 'G', color: '#fff', nodeIds: ['a'] });
+    expect(out[0].data).toEqual({
+      name: 'G',
+      color: '#fff',
+      nodeIds: ['a'],
+      parentId: null,
+    });
   });
 
   it('maps edges with handles', () => {


### PR DESCRIPTION
## Problem Statement

Users and teams need **nested canvas groups (max 3 levels) — #155** within the Objectified platform. Today this capability is missing or only partially implemented, which blocks platform workflows and creates inconsistency across tenants and projects.

## Solution / Scope

Implement **Nested canvas groups (max 3 levels) — #155** as part of **Platform**.

**Post-MVP** (prioritize after MVP slice) candidacy.

```mermaid
flowchart LR
  User[User action: Nested canvas groups (max 3 levels) — #1] --> UI[objectified-ui]
  UI --> API[objectified-rest]
  API --> DB[(PostgreSQL)]
```

## Acceptance Criteria

- [ ] Feature behaves as described for: Nested canvas groups (max 3 levels) — #155
- [ ] Unit/integration tests cover happy path and primary error cases
- [ ] UI (if applicable) matches existing ADE patterns (Tailwind 4, Radix, Lucide)
- [ ] REST endpoints (if applicable) follow `/v1/{{feature}}/{{tenant_slug}}/...` conventions
- [ ] Documented in issue/PR; no regressions to existing schema/version flows

## Parallelism / Dependencies

- **Can run in parallel:** Yes
- **Blockers:** None identified; validate against current codebase before starting

## Technical Stack

- **Modules:** objectified-ui, objectified-rest
- **Stack:** Next.js 16, React 19, FastAPI, PostgreSQL
- **Labels:** ``

---
**Issue:** #851 · **Area:** Platform · **Roadmap batch:** legacy #64–#879 enrichment