### PR TITLE
Class node property rows: show edit/delete on hover (#854)

### DIFF
--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.8.61",
+  "version": "0.8.62",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -5,6 +5,7 @@ We continue to improve the platform based on your feedback with improvements and
 ---
 
 Improvements:
+- Canvas: class node property rows show the type chip by default; hovering a row swaps it for edit and remove actions on the right (#854)
 - Canvas: nested groups up to three levels — drag group frames into each other, breadcrumb navigation and drill-in control, nested export/bulk/delete-all include descendant groups (#155)
 - Canvas: group toolbar — export the group’s schemas as OpenAPI JSON or YAML (with referenced types), duplicate the whole group into a new frame, and apply bulk class updates (description prefix/suffix, tag, top-level read-only) (#156)
 - Canvas: groups can collapse to a compact title bar (chevron); Alt+Shift+[ / ] collapse or expand all; your choices are remembered per version (#154)

--- a/objectified-ui/src/app/components/ade/studio/ClassNode.tsx
+++ b/objectified-ui/src/app/components/ade/studio/ClassNode.tsx
@@ -2146,6 +2146,8 @@ function ClassNode({ id, data, selected }: NodeProps) {
                               e.currentTarget.style.background = 'transparent';
                               e.currentTarget.style.color = '#94a3b8';
                             }}
+                            type="button"
+                            aria-label="Edit property"
                             title="Edit property"
                           >
                             <Edit size={11} />
@@ -2184,6 +2186,8 @@ function ClassNode({ id, data, selected }: NodeProps) {
                               e.currentTarget.style.background = 'transparent';
                               e.currentTarget.style.color = '#94a3b8';
                             }}
+                            type="button"
+                            aria-label="Remove property from class"
                             title="Remove property from class"
                           >
                             <Trash2 size={11} />

--- a/objectified-ui/src/app/components/ade/studio/ClassNode.tsx
+++ b/objectified-ui/src/app/components/ade/studio/ClassNode.tsx
@@ -543,6 +543,8 @@ function ClassNode({ id, data, selected }: NodeProps) {
   const [colorPickerOpen, setColorPickerOpen] = useState(false);
   const [iconPickerOpen, setIconPickerOpen] = useState(false);
   const [iconSearchQuery, setIconSearchQuery] = useState('');
+  /** #854: Property row shows type by default; edit/delete replace type on hover (editable canvas only). */
+  const [hoveredPropertyRowId, setHoveredPropertyRowId] = useState<string | null>(null);
   const nodeRef = useRef<HTMLDivElement>(null);
 
   // Use ResizeObserver to detect when the node's actual DOM size changes
@@ -1997,6 +1999,9 @@ function ClassNode({ id, data, selected }: NodeProps) {
               const currentIndex = rowIndex++;
               const isRequired = p.data?.required;
               const isDeprecated = parseData(p)?.deprecated;
+              const canShowPropertyActions =
+                !typedData.isReadOnly && !!(typedData.onPropertyEdit || typedData.onPropertyDelete);
+              const showPropertyRowActions = canShowPropertyActions && hoveredPropertyRowId === p.id;
 
               const row: React.JSX.Element[] = [];
               row.push(
@@ -2007,7 +2012,7 @@ function ClassNode({ id, data, selected }: NodeProps) {
                   onDrop={container && !typedData.isReadOnly ? (e) => handlePropertyDrop(e, p.id) : undefined}
                   style={{
                     display: 'grid',
-                    gridTemplateColumns: '16px 1fr auto 36px',
+                    gridTemplateColumns: '16px 1fr auto',
                     alignItems: 'center',
                     padding: '5px 10px',
                     paddingLeft: `${10 + depth * 14}px`,
@@ -2024,11 +2029,13 @@ function ClassNode({ id, data, selected }: NodeProps) {
                     minHeight: '28px',
                   }}
                   onMouseEnter={(e) => {
+                    setHoveredPropertyRowId(p.id);
                     if (!isInDropZone) {
                       e.currentTarget.style.background = '#f8fafc';
                     }
                   }}
                   onMouseLeave={(e) => {
+                    setHoveredPropertyRowId((prev) => (prev === p.id ? null : prev));
                     if (!isInDropZone) {
                       e.currentTarget.style.background = 'transparent';
                     }
@@ -2105,90 +2112,102 @@ function ClassNode({ id, data, selected }: NodeProps) {
                     )}
                   </div>
 
-                  <div style={{
-                    fontSize: '9px',
-                    color: '#64748b',
-                    fontFamily: '"SF Mono", Monaco, "Cascadia Code", monospace',
-                    whiteSpace: 'nowrap',
-                    background: '#f1f5f9',
-                    padding: '1px 6px',
-                    borderRadius: '3px',
-                    fontWeight: 500,
-                    letterSpacing: '-0.02em',
-                  }}>
-                    {getPropertyType(p)}
+                  <div
+                    style={{
+                      display: 'flex',
+                      justifyContent: 'flex-end',
+                      alignItems: 'center',
+                      gap: '4px',
+                      minWidth: 0,
+                    }}
+                  >
+                    {showPropertyRowActions ? (
+                      <div style={{ display: 'flex', gap: '2px', justifyContent: 'flex-end' }}>
+                        {typedData.onPropertyEdit && (
+                          <button
+                            onClick={(e) => { e.stopPropagation(); typedData.onPropertyEdit!(typedData.id, p); }}
+                            style={{
+                              background: 'transparent',
+                              border: 'none',
+                              cursor: 'pointer',
+                              padding: '3px',
+                              borderRadius: '3px',
+                              color: '#94a3b8',
+                              display: 'flex',
+                              alignItems: 'center',
+                              justifyContent: 'center',
+                              transition: 'all 0.12s ease',
+                            }}
+                            onMouseEnter={(e) => {
+                              e.currentTarget.style.background = '#e0e7ff';
+                              e.currentTarget.style.color = '#6366f1';
+                            }}
+                            onMouseLeave={(e) => {
+                              e.currentTarget.style.background = 'transparent';
+                              e.currentTarget.style.color = '#94a3b8';
+                            }}
+                            title="Edit property"
+                          >
+                            <Edit size={11} />
+                          </button>
+                        )}
+                        {typedData.onPropertyDelete && (
+                          <button
+                            onClick={async (e) => {
+                              e.stopPropagation();
+                              const confirmed = await confirmDialog({
+                                title: 'Remove Property',
+                                message: `Remove "${p.name}" from this class?`,
+                                variant: 'warning',
+                                confirmLabel: 'Remove',
+                                cancelLabel: 'Cancel',
+                              });
+                              if (confirmed) typedData.onPropertyDelete!(typedData.id, p.id);
+                            }}
+                            style={{
+                              background: 'transparent',
+                              border: 'none',
+                              cursor: 'pointer',
+                              padding: '3px',
+                              borderRadius: '3px',
+                              color: '#94a3b8',
+                              display: 'flex',
+                              alignItems: 'center',
+                              justifyContent: 'center',
+                              transition: 'all 0.12s ease',
+                            }}
+                            onMouseEnter={(e) => {
+                              e.currentTarget.style.background = '#fee2e2';
+                              e.currentTarget.style.color = '#ef4444';
+                            }}
+                            onMouseLeave={(e) => {
+                              e.currentTarget.style.background = 'transparent';
+                              e.currentTarget.style.color = '#94a3b8';
+                            }}
+                            title="Remove property from class"
+                          >
+                            <Trash2 size={11} />
+                          </button>
+                        )}
+                      </div>
+                    ) : (
+                      <div
+                        style={{
+                          fontSize: '9px',
+                          color: '#64748b',
+                          fontFamily: '"SF Mono", Monaco, "Cascadia Code", monospace',
+                          whiteSpace: 'nowrap',
+                          background: '#f1f5f9',
+                          padding: '1px 6px',
+                          borderRadius: '3px',
+                          fontWeight: 500,
+                          letterSpacing: '-0.02em',
+                        }}
+                      >
+                        {getPropertyType(p)}
+                      </div>
+                    )}
                   </div>
-
-                  {!typedData.isReadOnly && (
-                    <div style={{ display: 'flex', gap: '2px', justifyContent: 'flex-end' }}>
-                      {typedData.onPropertyEdit && (
-                        <button
-                          onClick={(e) => { e.stopPropagation(); typedData.onPropertyEdit!(typedData.id, p); }}
-                          style={{
-                            background: 'transparent',
-                            border: 'none',
-                            cursor: 'pointer',
-                            padding: '3px',
-                            borderRadius: '3px',
-                            color: '#94a3b8',
-                            display: 'flex',
-                            alignItems: 'center',
-                            justifyContent: 'center',
-                            transition: 'all 0.12s ease',
-                          }}
-                          onMouseEnter={(e) => {
-                            e.currentTarget.style.background = '#e0e7ff';
-                            e.currentTarget.style.color = '#6366f1';
-                          }}
-                          onMouseLeave={(e) => {
-                            e.currentTarget.style.background = 'transparent';
-                            e.currentTarget.style.color = '#94a3b8';
-                          }}
-                          title="Edit property"
-                        >
-                          <Edit size={11} />
-                        </button>
-                      )}
-                      {typedData.onPropertyDelete && (
-                        <button
-                          onClick={async (e) => {
-                            e.stopPropagation();
-                            const confirmed = await confirmDialog({
-                              title: 'Remove Property',
-                              message: `Remove "${p.name}" from this class?`,
-                              variant: 'warning',
-                              confirmLabel: 'Remove',
-                              cancelLabel: 'Cancel',
-                            });
-                            if (confirmed) typedData.onPropertyDelete!(typedData.id, p.id);
-                          }}
-                          style={{
-                            background: 'transparent',
-                            border: 'none',
-                            cursor: 'pointer',
-                            padding: '3px',
-                            borderRadius: '3px',
-                            color: '#94a3b8',
-                            display: 'flex',
-                            alignItems: 'center',
-                            justifyContent: 'center',
-                            transition: 'all 0.12s ease',
-                          }}
-                          onMouseEnter={(e) => {
-                            e.currentTarget.style.background = '#fee2e2';
-                            e.currentTarget.style.color = '#ef4444';
-                          }}
-                          onMouseLeave={(e) => {
-                            e.currentTarget.style.background = 'transparent';
-                            e.currentTarget.style.color = '#94a3b8';
-                          }}
-                          title="Remove property from class"
-                        >
-                          <Trash2 size={11} />
-                        </button>
-                      )}
-                    </div>
-                  )}
 
                   {/* Property reference handle: only show for properties with $ref */}
                   {hasRef(p) && (

--- a/package.json
+++ b/package.json
@@ -14,6 +14,6 @@
   ],
   "packageManager": "yarn@4.12.0",
   "devDependencies": {
-    "turbo": "^2.8.21"
+    "turbo": "^2.9.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3549,44 +3549,44 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@turbo/darwin-64@npm:2.8.21":
-  version: 2.8.21
-  resolution: "@turbo/darwin-64@npm:2.8.21"
+"@turbo/darwin-64@npm:2.9.1":
+  version: 2.9.1
+  resolution: "@turbo/darwin-64@npm:2.9.1"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@turbo/darwin-arm64@npm:2.8.21":
-  version: 2.8.21
-  resolution: "@turbo/darwin-arm64@npm:2.8.21"
+"@turbo/darwin-arm64@npm:2.9.1":
+  version: 2.9.1
+  resolution: "@turbo/darwin-arm64@npm:2.9.1"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@turbo/linux-64@npm:2.8.21":
-  version: 2.8.21
-  resolution: "@turbo/linux-64@npm:2.8.21"
+"@turbo/linux-64@npm:2.9.1":
+  version: 2.9.1
+  resolution: "@turbo/linux-64@npm:2.9.1"
   conditions: os=linux & cpu=x64
   languageName: node
   linkType: hard
 
-"@turbo/linux-arm64@npm:2.8.21":
-  version: 2.8.21
-  resolution: "@turbo/linux-arm64@npm:2.8.21"
+"@turbo/linux-arm64@npm:2.9.1":
+  version: 2.9.1
+  resolution: "@turbo/linux-arm64@npm:2.9.1"
   conditions: os=linux & cpu=arm64
   languageName: node
   linkType: hard
 
-"@turbo/windows-64@npm:2.8.21":
-  version: 2.8.21
-  resolution: "@turbo/windows-64@npm:2.8.21"
+"@turbo/windows-64@npm:2.9.1":
+  version: 2.9.1
+  resolution: "@turbo/windows-64@npm:2.9.1"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
-"@turbo/windows-arm64@npm:2.8.21":
-  version: 2.8.21
-  resolution: "@turbo/windows-arm64@npm:2.8.21"
+"@turbo/windows-arm64@npm:2.9.1":
+  version: 2.9.1
+  resolution: "@turbo/windows-arm64@npm:2.9.1"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
@@ -10488,7 +10488,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "objectified@workspace:."
   dependencies:
-    turbo: "npm:^2.8.21"
+    turbo: "npm:^2.9.1"
   languageName: unknown
   linkType: soft
 
@@ -12527,16 +12527,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"turbo@npm:^2.8.21":
-  version: 2.8.21
-  resolution: "turbo@npm:2.8.21"
+"turbo@npm:^2.9.1":
+  version: 2.9.1
+  resolution: "turbo@npm:2.9.1"
   dependencies:
-    "@turbo/darwin-64": "npm:2.8.21"
-    "@turbo/darwin-arm64": "npm:2.8.21"
-    "@turbo/linux-64": "npm:2.8.21"
-    "@turbo/linux-arm64": "npm:2.8.21"
-    "@turbo/windows-64": "npm:2.8.21"
-    "@turbo/windows-arm64": "npm:2.8.21"
+    "@turbo/darwin-64": "npm:2.9.1"
+    "@turbo/darwin-arm64": "npm:2.9.1"
+    "@turbo/linux-64": "npm:2.9.1"
+    "@turbo/linux-arm64": "npm:2.9.1"
+    "@turbo/windows-64": "npm:2.9.1"
+    "@turbo/windows-arm64": "npm:2.9.1"
   dependenciesMeta:
     "@turbo/darwin-64":
       optional: true
@@ -12552,7 +12552,7 @@ __metadata:
       optional: true
   bin:
     turbo: bin/turbo
-  checksum: 10c0/1afaf399d50d26ab1b81b61c3709e7cb13573c23b2e2052edd100e74eddd592f6d8736bfde8bb7cf689f3129b9334f987d586e3aa5f6a88d92f79e42935708bc
+  checksum: 10c0/c474a2dbdc60534a66ce7e0dafa49cd21269334e8420cbae5026e4d99af5d5bcb5b1cfdb243deac61d41ff80b9fc0c42efc2b048241ae7753df961cb12c4c3d0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Problem Statement

Users and teams need **class node property rows: show edit/delete on hover (#854)** within the Objectified platform. Today this capability is missing or only partially implemented, which blocks dashboard workflows and creates inconsistency across tenants and projects.

## Solution / Scope

Implement **Class node property rows: show edit/delete on hover (#854)** as part of **Dashboard**. KPIs, primitives browser, project overview, quick actions.

**Post-MVP** (prioritize after MVP slice) candidacy.

```mermaid
flowchart TB
  CP[Control Panel] --> KPIs[Stats cards]
  CP --> Primitives[Primitives list]
  CP --> Projects[Recent projects]
  CP --> Actions[Quick actions]
```

## Acceptance Criteria

- [ ] Feature behaves as described for: Class node property rows: show edit/delete on hover (#854)
- [ ] Unit/integration tests cover happy path and primary error cases
- [ ] UI (if applicable) matches existing ADE patterns (Tailwind 4, Radix, Lucide)
- [ ] REST endpoints (if applicable) follow `/v1/{{feature}}/{{tenant_slug}}/...` conventions
- [ ] Documented in issue/PR; no regressions to existing schema/version flows

## Parallelism / Dependencies

- **Can run in parallel:** Yes
- **Blockers:** None identified; validate against current codebase before starting

## Technical Stack

- **Modules:** objectified-rest
- **Stack:** Next.js ADE dashboard, control panel components, REST stats APIs
- **Labels:** ``

---

**Epic:** [[Epic] Dashboard & Control Panel](https://github.com/objectified-project/objectified/issues/3493)
**Issue:** #855 · **Area:** Dashboard · **Roadmap batch:** legacy #64–#879 enrichment