### PR TITLE
Fix #848 — empty canvas group frames visible after drag-drop

### DIFF
--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.8.63",
+  "version": "0.8.64",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -18,6 +18,7 @@ Improvements:
 - Canvas: layout import and named layout load restore edge handle routing when saved edge IDs match the canvas (#316)
 
 Bug Fixes:
+- Canvas: empty group frames from drag-to-canvas now appear (visibility treated empty leaf groups as visible) (#848)
 - Import now handles paths properly
 - Improved Markdown rendering
 - Improved layout of primitives form

--- a/objectified-ui/src/app/utils/canvas-display-visibility.ts
+++ b/objectified-ui/src/app/utils/canvas-display-visibility.ts
@@ -62,7 +62,11 @@ export function computeClassIdsPassingHideCriteria(
   return visible;
 }
 
-/** Group frame is visible if any member class passes criteria or a visible nested child group does (#155). Safe against cycles via a visited set. */
+/**
+ * Group frame is visible if any member class passes criteria or a visible nested child group does (#155).
+ * Empty leaf groups (no members, no child group frames) stay visible so a newly dropped group renders (#848).
+ * Safe against cycles via a visited set.
+ */
 export function groupNodeIdIsVisible(
   group: CanvasGroupForVisibility,
   visibleClassIds: Set<string>,
@@ -80,7 +84,8 @@ export function groupNodeIdIsVisible(
       }
     }
   }
-  return false;
+  const hasChildGroups = allGroups?.some((cg) => cg.parentId === group.id) ?? false;
+  return group.nodeIds.length === 0 && !hasChildGroups;
 }
 
 /**

--- a/objectified-ui/src/app/utils/canvas-display-visibility.ts
+++ b/objectified-ui/src/app/utils/canvas-display-visibility.ts
@@ -77,14 +77,17 @@ export function groupNodeIdIsVisible(
   _visited.add(group.id);
 
   if (group.nodeIds.some((id) => visibleClassIds.has(id))) return true;
+  let hasChildGroups = false;
   if (allGroups) {
     for (const cg of allGroups) {
-      if (cg.parentId === group.id && groupNodeIdIsVisible(cg, visibleClassIds, allGroups, _visited)) {
-        return true;
+      if (cg.parentId === group.id) {
+        hasChildGroups = true;
+        if (groupNodeIdIsVisible(cg, visibleClassIds, allGroups, _visited)) {
+          return true;
+        }
       }
     }
   }
-  const hasChildGroups = allGroups?.some((cg) => cg.parentId === group.id) ?? false;
   return group.nodeIds.length === 0 && !hasChildGroups;
 }
 

--- a/objectified-ui/tests/unit/canvas-display-visibility.test.ts
+++ b/objectified-ui/tests/unit/canvas-display-visibility.test.ts
@@ -114,6 +114,20 @@ describe('canvas-display-visibility (#483)', () => {
     expect(groupNodeIdIsVisible(nested[0], new Set(['c']), nested)).toBe(true);
     expect(groupNodeIdIsVisible(nested[0], new Set(['a']), nested)).toBe(false);
   });
+
+  it('groupNodeIdIsVisible is true for empty leaf group so new frames render (#848)', () => {
+    const empty = { id: 'gNew', nodeIds: [] as string[], parentId: null as string | null };
+    expect(groupNodeIdIsVisible(empty, new Set(), [empty])).toBe(true);
+    expect(groupNodeIdIsVisible(empty, new Set(['x']), [empty])).toBe(true);
+  });
+
+  it('groupNodeIdIsVisible stays false when parent is empty but every nested group is hidden (#848)', () => {
+    const nested = [
+      { id: 'g1', nodeIds: [], parentId: null },
+      { id: 'g2', nodeIds: ['c'], parentId: 'g1' },
+    ];
+    expect(groupNodeIdIsVisible(nested[0], new Set(), nested)).toBe(false);
+  });
 });
 
 const allOff = {


### PR DESCRIPTION
## Problem Statement

Users and teams need **fix #848 — empty canvas group frames visible after drag-drop** within the Objectified platform. Today this capability is missing or only partially implemented, which blocks dashboard workflows and creates inconsistency across tenants and projects.

## Solution / Scope

Implement **Fix #848 — empty canvas group frames visible after drag-drop** as part of **Dashboard**. KPIs, primitives browser, project overview, quick actions.

**Post-MVP** (prioritize after MVP slice) candidacy.

```mermaid
flowchart TB
  CP[Control Panel] --> KPIs[Stats cards]
  CP --> Primitives[Primitives list]
  CP --> Projects[Recent projects]
  CP --> Actions[Quick actions]
```

## Acceptance Criteria

- [ ] Feature behaves as described for: Fix #848 — empty canvas group frames visible after drag-drop
- [ ] Unit/integration tests cover happy path and primary error cases
- [ ] UI (if applicable) matches existing ADE patterns (Tailwind 4, Radix, Lucide)
- [ ] REST endpoints (if applicable) follow `/v1/{{feature}}/{{tenant_slug}}/...` conventions
- [ ] Documented in issue/PR; no regressions to existing schema/version flows

## Parallelism / Dependencies

- **Can run in parallel:** Yes
- **Blockers:** None identified; validate against current codebase before starting

## Technical Stack

- **Modules:** objectified-rest
- **Stack:** Next.js ADE dashboard, control panel components, REST stats APIs
- **Labels:** ``

---

**Epic:** [[Epic] Dashboard & Control Panel](https://github.com/objectified-project/objectified/issues/3493)
**Issue:** #858 · **Area:** Dashboard · **Roadmap batch:** legacy #64–#879 enrichment