### PR TITLE
Fix #856 — Amber default-diff hint in dialog headers

### DIFF
--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.8.64",
+  "version": "0.8.65",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -5,6 +5,7 @@ We continue to improve the platform based on your feedback with improvements and
 ---
 
 Improvements:
+- Studio: the amber “differs from defaults” hint appears in the dialog header next to the title for class and property editors so it stays visible (#856)
 - Canvas: class node color, icon, hide, and delete controls appear in a compact bar attached to the upper-right outside the card while hovering (or while a popover is open) (#853)
 - Canvas: class node property rows show the type chip by default; hovering a row swaps it for edit and remove actions on the right (#854)
 - Canvas: nested groups up to three levels — drag group frames into each other, breadcrumb navigation and drill-in control, nested export/bulk/delete-all include descendant groups (#155)

--- a/objectified-ui/src/app/components/ade/studio/ClassEditDialog.tsx
+++ b/objectified-ui/src/app/components/ade/studio/ClassEditDialog.tsx
@@ -1440,8 +1440,8 @@ const ClassEditDialog = ({ open, onClose, editingClassData, nodes, isReadOnly = 
         aria-describedby={undefined}
       >
         <DialogHeader className="px-6 py-4 border-b border-gray-200 dark:border-gray-700 shrink-0">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-3">
+          <div className="flex flex-wrap items-start justify-between gap-x-4 gap-y-2">
+            <div className="flex items-center gap-3 flex-wrap min-w-0">
               {showAIChatMode ? (
                 <>
                   <Button
@@ -1483,6 +1483,11 @@ const ClassEditDialog = ({ open, onClose, editingClassData, nodes, isReadOnly = 
                 </span>
               )}
             </div>
+            {!showAIChatMode && (
+              <p className="text-xs text-amber-700 dark:text-amber-300 shrink-0 max-w-md sm:text-right">
+                Amber-highlighted sections indicate values that differ from defaults.
+              </p>
+            )}
           </div>
         </DialogHeader>
 
@@ -1633,7 +1638,7 @@ const ClassEditDialog = ({ open, onClose, editingClassData, nodes, isReadOnly = 
         ) : (
         <>
         <Tabs value={activeTab} onValueChange={setActiveTab} className="flex-1 flex flex-col overflow-hidden">
-          <div className="flex flex-nowrap items-center justify-between gap-4 border-b border-gray-200 dark:border-gray-700 px-6 shrink-0">
+          <div className="flex flex-nowrap items-center border-b border-gray-200 dark:border-gray-700 px-6 shrink-0">
             <TabsList className="h-auto p-0 rounded-none bg-transparent justify-start gap-0 -ml-2 shrink-0">
               <TabsTrigger
               value="edit"
@@ -1660,9 +1665,6 @@ const ClassEditDialog = ({ open, onClose, editingClassData, nodes, isReadOnly = 
               Example
             </TabsTrigger>
             </TabsList>
-            <p className="text-xs text-amber-700 dark:text-amber-300 shrink-0 py-3 whitespace-nowrap">
-              Amber-highlighted sections indicate values that differ from defaults.
-            </p>
           </div>
 
           {/* Edit Tab */}

--- a/objectified-ui/src/app/components/ade/studio/ClassEditDialog.tsx
+++ b/objectified-ui/src/app/components/ade/studio/ClassEditDialog.tsx
@@ -1439,7 +1439,7 @@ const ClassEditDialog = ({ open, onClose, editingClassData, nodes, isReadOnly = 
         showCloseButton={true}
         aria-describedby={undefined}
       >
-        <DialogHeader className="px-6 py-4 border-b border-gray-200 dark:border-gray-700 shrink-0">
+        <DialogHeader className="pl-6 pr-10 py-4 border-b border-gray-200 dark:border-gray-700 shrink-0">
           <div className="flex flex-wrap items-start justify-between gap-x-4 gap-y-2">
             <div className="flex items-center gap-3 flex-wrap min-w-0">
               {showAIChatMode ? (

--- a/objectified-ui/src/app/components/ade/studio/ClassPropertyEditDialog.tsx
+++ b/objectified-ui/src/app/components/ade/studio/ClassPropertyEditDialog.tsx
@@ -964,12 +964,15 @@ export default function ClassPropertyEditDialog({ open, onClose, editingClassPro
         aria-describedby={undefined}
       >
         <DialogHeader className="px-6 py-4 border-b border-gray-200 dark:border-gray-700 shrink-0">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-3">
+          <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-2">
+            <div className="flex items-center gap-3 min-w-0">
               <DialogTitle className="text-lg font-semibold">
                 Edit Property in Class
               </DialogTitle>
             </div>
+            <p className="text-xs text-amber-700 dark:text-amber-300 shrink-0 max-w-md sm:text-right">
+              Amber-highlighted sections indicate values that differ from defaults.
+            </p>
           </div>
         </DialogHeader>
 
@@ -1529,6 +1532,7 @@ export default function ClassPropertyEditDialog({ open, onClose, editingClassPro
                       }}
                       showMetadata={false}
                       showTitle={false}
+                      showHint={false}
                       size="small"
                       nestedProperties={
                         baseType === 'object'

--- a/objectified-ui/src/app/components/ade/studio/ClassPropertyEditDialog.tsx
+++ b/objectified-ui/src/app/components/ade/studio/ClassPropertyEditDialog.tsx
@@ -963,7 +963,7 @@ export default function ClassPropertyEditDialog({ open, onClose, editingClassPro
         showCloseButton={true}
         aria-describedby={undefined}
       >
-        <DialogHeader className="px-6 py-4 border-b border-gray-200 dark:border-gray-700 shrink-0">
+        <DialogHeader className="pl-6 pr-10 py-4 border-b border-gray-200 dark:border-gray-700 shrink-0">
           <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-2">
             <div className="flex items-center gap-3 min-w-0">
               <DialogTitle className="text-lg font-semibold">

--- a/objectified-ui/src/app/components/ade/studio/PropertyDialog.tsx
+++ b/objectified-ui/src/app/components/ade/studio/PropertyDialog.tsx
@@ -1101,7 +1101,7 @@ export const PropertyDialog: React.FC<PropertyDialogProps> = ({
         showCloseButton={true}
         aria-describedby={undefined}
       >
-        <DialogHeader className="px-6 py-4 border-b border-gray-200 dark:border-gray-700 shrink-0">
+        <DialogHeader className="pl-6 pr-10 py-4 border-b border-gray-200 dark:border-gray-700 shrink-0">
           <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-2">
             <div className="flex items-center gap-3 min-w-0">
               <DialogTitle className="text-lg font-semibold">

--- a/objectified-ui/src/app/components/ade/studio/PropertyDialog.tsx
+++ b/objectified-ui/src/app/components/ade/studio/PropertyDialog.tsx
@@ -1102,17 +1102,20 @@ export const PropertyDialog: React.FC<PropertyDialogProps> = ({
         aria-describedby={undefined}
       >
         <DialogHeader className="px-6 py-4 border-b border-gray-200 dark:border-gray-700 shrink-0">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-3">
+          <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-2">
+            <div className="flex items-center gap-3 min-w-0">
               <DialogTitle className="text-lg font-semibold">
                 {mode === 'add' ? 'Add Property' : 'Edit Property'}
               </DialogTitle>
             </div>
+            <p className="text-xs text-amber-700 dark:text-amber-300 shrink-0 max-w-md sm:text-right">
+              Amber-highlighted sections indicate values that differ from defaults.
+            </p>
           </div>
         </DialogHeader>
 
         <Tabs value={viewMode} onValueChange={(v) => setViewMode(v as 'form' | 'json')} className="flex-1 flex flex-col overflow-hidden">
-          <div className="flex items-center justify-between gap-4 border-b border-gray-200 dark:border-gray-700 px-6 shrink-0">
+          <div className="flex items-center border-b border-gray-200 dark:border-gray-700 px-6 shrink-0">
             <TabsList className="h-auto p-0 rounded-none bg-transparent justify-start gap-0 -ml-2">
               <TabsTrigger
               value="form"
@@ -1127,9 +1130,6 @@ export const PropertyDialog: React.FC<PropertyDialogProps> = ({
               JSON
             </TabsTrigger>
             </TabsList>
-            <p className="text-xs text-amber-700 dark:text-amber-300 shrink-0 py-3">
-              Amber-highlighted sections indicate values that differ from defaults.
-            </p>
           </div>
 
           {/* Form Tab */}


### PR DESCRIPTION
## Problem Statement

Users and teams need **fix #856 — amber default-diff hint in dialog headers** within the Objectified platform. Today this capability is missing or only partially implemented, which blocks dashboard workflows and creates inconsistency across tenants and projects.

## Solution / Scope

Implement **Fix #856 — Amber default-diff hint in dialog headers** as part of **Dashboard**. KPIs, primitives browser, project overview, quick actions.

**Post-MVP** (prioritize after MVP slice) candidacy.

```mermaid
flowchart TB
  CP[Control Panel] --> KPIs[Stats cards]
  CP --> Primitives[Primitives list]
  CP --> Projects[Recent projects]
  CP --> Actions[Quick actions]
```

## Acceptance Criteria

- [ ] Feature behaves as described for: Fix #856 — Amber default-diff hint in dialog headers
- [ ] Unit/integration tests cover happy path and primary error cases
- [ ] UI (if applicable) matches existing ADE patterns (Tailwind 4, Radix, Lucide)
- [ ] REST endpoints (if applicable) follow `/v1/{{feature}}/{{tenant_slug}}/...` conventions
- [ ] Documented in issue/PR; no regressions to existing schema/version flows

## Parallelism / Dependencies

- **Can run in parallel:** Yes
- **Blockers:** None identified; validate against current codebase before starting

## Technical Stack

- **Modules:** objectified-rest
- **Stack:** Next.js ADE dashboard, control panel components, REST stats APIs
- **Labels:** ``

---

**Epic:** [[Epic] Dashboard & Control Panel](https://github.com/objectified-project/objectified/issues/3493)
**Issue:** #860 · **Area:** Dashboard · **Roadmap batch:** legacy #64–#879 enrichment