### PR TITLE
Canvas: floating group edit toolbar on hover (#859)

### DIFF
--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.8.65",
+  "version": "0.8.66",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -5,6 +5,7 @@ We continue to improve the platform based on your feedback with improvements and
 ---
 
 Improvements:
+- Canvas: group edit controls (style, color, rename, export, duplicate, bulk, delete) sit in a compact floating card above the frame (`-top-6`, `right: -2px`) so the title row stays readable on hover or when selected (#859)
 - Studio: the amber “differs from defaults” hint appears in the dialog header next to the title for class and property editors so it stays visible (#856)
 - Canvas: class node color, icon, hide, and delete controls appear in a compact bar attached to the upper-right outside the card while hovering (or while a popover is open) (#853)
 - Canvas: class node property rows show the type chip by default; hovering a row swaps it for edit and remove actions on the right (#854)

--- a/objectified-ui/src/app/components/ade/studio/GroupNode.tsx
+++ b/objectified-ui/src/app/components/ade/studio/GroupNode.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { memo, useState, useCallback } from 'react';
+import React, { memo, useState, useCallback, useMemo } from 'react';
 import { NodeProps, NodeResizer } from '@xyflow/react';
 import {
   Folder, Edit2, Trash2, X, Check, Palette, Settings,
@@ -147,6 +147,27 @@ const GroupNode = memo(({ id, data, selected }: NodeProps) => {
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [exportPopoverOpen, setExportPopoverOpen] = useState(false);
   const [bulkDialogOpen, setBulkDialogOpen] = useState(false);
+  const [isFrameHovered, setIsFrameHovered] = useState(false);
+
+  const showFloatingToolbar = useMemo(
+    () =>
+      !groupData.isReadOnly &&
+      !isEditing &&
+      (selected ||
+        isFrameHovered ||
+        settingsOpen ||
+        colorPickerOpen ||
+        exportPopoverOpen),
+    [
+      groupData.isReadOnly,
+      isEditing,
+      selected,
+      isFrameHovered,
+      settingsOpen,
+      colorPickerOpen,
+      exportPopoverOpen,
+    ]
+  );
 
   // Get color configuration
   const colorConfig = GROUP_COLORS.find(c => c.name === groupData.color) || GROUP_COLORS[0];
@@ -279,8 +300,9 @@ const GroupNode = memo(({ id, data, selected }: NodeProps) => {
       />
 
       <div
+        data-testid="group-node-surface"
         className={`
-          w-full h-full rounded-2xl border-2 transition-all duration-200
+          relative w-full h-full rounded-2xl border-2 transition-all duration-200
           ${borderStyleClass} ${colorConfig.border} ${shadowClass}
           ${selected ? 'ring-2 ring-indigo-500 ring-offset-2 dark:ring-offset-gray-900' : ''}
           ${groupData.isHighlighted ? 'ring-4 ring-green-500 ring-offset-4 dark:ring-offset-gray-900 scale-[1.02] border-green-500 dark:border-green-400' : ''}
@@ -290,6 +312,8 @@ const GroupNode = memo(({ id, data, selected }: NodeProps) => {
           minHeight: isCollapsed ? COLLAPSED_GROUP_FRAME_HEIGHT : 150,
           backgroundColor: `${colorConfig.hex}${Math.round(styleOptions.opacity * 25.5).toString(16).padStart(2, '0')}`
         }}
+        onMouseEnter={() => setIsFrameHovered(true)}
+        onMouseLeave={() => setIsFrameHovered(false)}
       >
         {/* Group Header */}
         <div
@@ -373,10 +397,24 @@ const GroupNode = memo(({ id, data, selected }: NodeProps) => {
               <span className="text-xs opacity-70">({nodeCount})</span>
             </>
           )}
+        </div>
 
-          {/* Actions (visible when selected and not editing) */}
-          {selected && !isEditing && !groupData.isReadOnly && (
-            <div className={`flex items-center gap-1 ml-2 pl-2 border-l ${useLightText ? 'border-white/30' : 'border-current/20'}`}>
+        {/* Floating toolbar: outside the title pill, top -24px / right -2px (#859) */}
+        {showFloatingToolbar && (
+          <div
+            role="toolbar"
+            aria-label="Group edit actions"
+            className={`
+              absolute -top-6 right-[-2px] z-20 flex max-w-[min(100%,calc(100vw-2rem))] flex-wrap items-center gap-1 rounded-lg border px-1.5 py-1
+              ${shadowClass || 'shadow-md'}
+              ${colorConfig.border} ${textColorClass}
+            `}
+            style={{
+              backgroundColor: `${colorConfig.hex}${Math.round(Math.min(styleOptions.opacity + 0.3, 1) * 255).toString(16).padStart(2, '0')}`
+            }}
+            onMouseDown={(e) => e.stopPropagation()}
+            onPointerDown={(e) => e.stopPropagation()}
+          >
               {/* Settings popover */}
               <Popover.Root open={settingsOpen} onOpenChange={setSettingsOpen}>
                 <Popover.Trigger asChild>
@@ -646,9 +684,8 @@ const GroupNode = memo(({ id, data, selected }: NodeProps) => {
               >
                 <Trash2 className="h-3.5 w-3.5" />
               </button>
-            </div>
-          )}
-        </div>
+          </div>
+        )}
 
         {/* Description (if any) */}
         {groupData.description && !isCollapsed && (

--- a/objectified-ui/src/app/components/ade/studio/GroupNode.tsx
+++ b/objectified-ui/src/app/components/ade/studio/GroupNode.tsx
@@ -420,6 +420,7 @@ const GroupNode = memo(({ id, data, selected }: NodeProps) => {
                 <Popover.Trigger asChild>
                   <button
                     type="button"
+                    aria-label="Style settings"
                     onClick={(e) => {
                       e.stopPropagation();
                       e.preventDefault();
@@ -540,6 +541,7 @@ const GroupNode = memo(({ id, data, selected }: NodeProps) => {
                 <Popover.Trigger asChild>
                   <button
                     type="button"
+                    aria-label="Change color"
                     onClick={(e) => {
                       e.stopPropagation();
                       e.preventDefault();
@@ -583,6 +585,7 @@ const GroupNode = memo(({ id, data, selected }: NodeProps) => {
                 onClick={handleStartEdit}
                 onMouseDown={(e) => e.stopPropagation()}
                 onPointerDown={(e) => e.stopPropagation()}
+                aria-label="Rename group"
                 className={`p-1 rounded transition-colors ${useLightText ? 'hover:bg-white/30' : 'hover:bg-white/50 dark:hover:bg-gray-700/50'}`}
                 title="Rename group"
               >
@@ -595,6 +598,7 @@ const GroupNode = memo(({ id, data, selected }: NodeProps) => {
                   <Popover.Trigger asChild>
                     <button
                       type="button"
+                      aria-label="Export group as OpenAPI schema file"
                       onClick={(e) => {
                         e.stopPropagation();
                         e.preventDefault();
@@ -642,6 +646,7 @@ const GroupNode = memo(({ id, data, selected }: NodeProps) => {
                   onClick={handleDuplicateGroupClick}
                   onMouseDown={(e) => e.stopPropagation()}
                   onPointerDown={(e) => e.stopPropagation()}
+                  aria-label="Duplicate group (all classes)"
                   className={`p-1 rounded transition-colors ${useLightText ? 'hover:bg-white/30' : 'hover:bg-white/50 dark:hover:bg-gray-700/50'}`}
                   title="Duplicate group (all classes)"
                 >
@@ -655,6 +660,7 @@ const GroupNode = memo(({ id, data, selected }: NodeProps) => {
                   onClick={handleOpenBulk}
                   onMouseDown={(e) => e.stopPropagation()}
                   onPointerDown={(e) => e.stopPropagation()}
+                  aria-label="Bulk edit all classes in group"
                   className={`p-1 rounded transition-colors ${useLightText ? 'hover:bg-white/30' : 'hover:bg-white/50 dark:hover:bg-gray-700/50'}`}
                   title="Bulk edit all classes in group"
                 >
@@ -668,6 +674,7 @@ const GroupNode = memo(({ id, data, selected }: NodeProps) => {
                   onClick={handleDeleteAllClassesInGroup}
                   onMouseDown={(e) => e.stopPropagation()}
                   onPointerDown={(e) => e.stopPropagation()}
+                  aria-label="Delete all classes in group"
                   className={`p-1 rounded transition-colors ${useLightText ? 'hover:bg-amber-400/40 text-amber-200' : 'hover:bg-amber-100 dark:hover:bg-amber-900/30 text-amber-600 dark:text-amber-400'}`}
                   title="Delete all classes in group"
                 >
@@ -679,6 +686,7 @@ const GroupNode = memo(({ id, data, selected }: NodeProps) => {
                 onClick={handleDelete}
                 onMouseDown={(e) => e.stopPropagation()}
                 onPointerDown={(e) => e.stopPropagation()}
+                aria-label="Delete group"
                 className={`p-1 rounded transition-colors ${useLightText ? 'hover:bg-red-400/40 text-red-200' : 'hover:bg-red-100 dark:hover:bg-red-900/30 text-red-600 dark:text-red-400'}`}
                 title="Delete group"
               >

--- a/objectified-ui/tests/unit/GroupNode-toolbar.test.tsx
+++ b/objectified-ui/tests/unit/GroupNode-toolbar.test.tsx
@@ -1,0 +1,61 @@
+/**
+ * Group canvas node: floating edit toolbar (#859).
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ReactFlowProvider } from '@xyflow/react';
+
+import GroupNode, { type GroupNodeData } from '../../src/app/components/ade/studio/GroupNode';
+
+jest.mock('../../src/app/components/ade/studio/GroupBulkEditDialog', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+const baseData: GroupNodeData = {
+  id: 'g1',
+  name: 'Alpha Group',
+  color: 'indigo',
+  nodeIds: ['n1'],
+};
+
+function renderGroup(overrides?: Partial<GroupNodeData>, selected = false) {
+  const data = { ...baseData, ...overrides };
+  return render(
+    <ReactFlowProvider>
+      <GroupNode
+        id="g1"
+        type="groupNode"
+        data={data as unknown as Record<string, unknown>}
+        selected={selected}
+      />
+    </ReactFlowProvider>
+  );
+}
+
+describe('GroupNode floating toolbar', () => {
+  it('does not show style controls when the frame is not hovered or selected', () => {
+    renderGroup(undefined, false);
+    expect(screen.queryByTitle('Style settings')).not.toBeInTheDocument();
+  });
+
+  it('shows style controls when hovering the group surface', () => {
+    renderGroup(undefined, false);
+    const surface = screen.getByTestId('group-node-surface');
+    fireEvent.mouseEnter(surface);
+    expect(screen.getByTitle('Style settings')).toBeInTheDocument();
+    expect(screen.getByTitle('Change color')).toBeInTheDocument();
+  });
+
+  it('shows style controls when selected even without hover', () => {
+    renderGroup(undefined, true);
+    expect(screen.getByTitle('Style settings')).toBeInTheDocument();
+  });
+
+  it('hides toolbar in read-only mode', () => {
+    renderGroup({ isReadOnly: true }, true);
+    expect(screen.queryByTitle('Style settings')).not.toBeInTheDocument();
+  });
+});

--- a/objectified-ui/tests/unit/GroupNode-toolbar.test.tsx
+++ b/objectified-ui/tests/unit/GroupNode-toolbar.test.tsx
@@ -14,6 +14,13 @@ jest.mock('../../src/app/components/ade/studio/GroupBulkEditDialog', () => ({
   default: () => null,
 }));
 
+// Radix UI popovers use ResizeObserver internally; provide a no-op stub for jsdom.
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
 const baseData: GroupNodeData = {
   id: 'g1',
   name: 'Alpha Group',
@@ -57,5 +64,31 @@ describe('GroupNode floating toolbar', () => {
   it('hides toolbar in read-only mode', () => {
     renderGroup({ isReadOnly: true }, true);
     expect(screen.queryByTitle('Style settings')).not.toBeInTheDocument();
+  });
+
+  it('toolbar buttons have accessible aria-labels', () => {
+    renderGroup(undefined, true);
+    expect(screen.getByRole('button', { name: 'Style settings' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Change color' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Rename group' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Delete group' })).toBeInTheDocument();
+  });
+
+  it('toolbar stays visible after mouseLeave while the settings popover is open', () => {
+    renderGroup(undefined, false);
+    const surface = screen.getByTestId('group-node-surface');
+
+    // Hover the surface to reveal the toolbar
+    fireEvent.mouseEnter(surface);
+    expect(screen.getByTitle('Style settings')).toBeInTheDocument();
+
+    // Open the "Style settings" popover
+    fireEvent.click(screen.getByTitle('Style settings'));
+
+    // Simulate the cursor leaving the group surface (e.g., moving into the popover portal)
+    fireEvent.mouseLeave(surface);
+
+    // Toolbar must remain because the popover is still open
+    expect(screen.getByTitle('Style settings')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Problem Statement

Users and teams need **canvas: floating group edit toolbar on hover (#859)** within the Objectified platform. Today this capability is missing or only partially implemented, which blocks dashboard workflows and creates inconsistency across tenants and projects.

## Solution / Scope

Implement **Canvas: floating group edit toolbar on hover (#859)** as part of **Dashboard**. KPIs, primitives browser, project overview, quick actions.

**Post-MVP** (prioritize after MVP slice) candidacy.

```mermaid
flowchart TB
  CP[Control Panel] --> KPIs[Stats cards]
  CP --> Primitives[Primitives list]
  CP --> Projects[Recent projects]
  CP --> Actions[Quick actions]
```

## Acceptance Criteria

- [ ] Feature behaves as described for: Canvas: floating group edit toolbar on hover (#859)
- [ ] Unit/integration tests cover happy path and primary error cases
- [ ] UI (if applicable) matches existing ADE patterns (Tailwind 4, Radix, Lucide)
- [ ] REST endpoints (if applicable) follow `/v1/{{feature}}/{{tenant_slug}}/...` conventions
- [ ] Documented in issue/PR; no regressions to existing schema/version flows

## Parallelism / Dependencies

- **Can run in parallel:** Yes
- **Blockers:** None identified; validate against current codebase before starting

## Technical Stack

- **Modules:** objectified-rest
- **Stack:** Next.js ADE dashboard, control panel components, REST stats APIs
- **Labels:** ``

---

**Epic:** [[Epic] Dashboard & Control Panel](https://github.com/objectified-project/objectified/issues/3493)
**Issue:** #861 · **Area:** Dashboard · **Roadmap batch:** legacy #64–#879 enrichment