### PR TITLE
Fix #849 — Sidebar group delete persists layout

### DIFF
--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.8.69",
+  "version": "0.8.70",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.8.68",
+  "version": "0.8.69",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -20,6 +20,7 @@ Improvements:
 - Canvas: layout import and named layout load restore edge handle routing when saved edge IDs match the canvas (#316)
 
 Bug Fixes:
+- Studio: deleting a group from the sidebar now removes it from the list and persists like canvas delete (nested frames, layout save) (#849)
 - Studio: property editor XML section and object min/max properties use the same card, typography, and helper text patterns as the class form (#852)
 - Canvas: empty group frames from drag-to-canvas now appear (visibility treated empty leaf groups as visible) (#848)
 - Import now handles paths properly

--- a/objectified-ui/src/app/ade/studio/StudioContext.tsx
+++ b/objectified-ui/src/app/ade/studio/StudioContext.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { createContext, useContext, useState, useEffect, useCallback, ReactNode } from 'react';
+import React, { createContext, useContext, useState, useEffect, useCallback, ReactNode, Dispatch, SetStateAction } from 'react';
 
 // Group style options
 export interface GroupStyleOptions {
@@ -150,6 +150,9 @@ interface StudioContextType {
   /** Called to delete all classes contained in a group (registered by editor). */
   deleteAllClassesInGroupFn: ((groupId: string, classIds?: string[], groupName?: string) => Promise<void>) | null;
   setDeleteAllClassesInGroupFn: (fn: ((groupId: string, classIds?: string[], groupName?: string) => Promise<void>) | null) => void;
+  /** Full group delete from sidebar: nested subtree, canvas nodes, layout persistence (registered by editor). */
+  deleteGroupFn: ((groupId: string) => Promise<void>) | null;
+  setDeleteGroupFn: Dispatch<SetStateAction<((groupId: string) => Promise<void>) | null>>;
   addNodeToGroup: (groupId: string, nodeId: string) => void;
   removeNodeFromGroup: (groupId: string, nodeId: string) => void;
   // Search history
@@ -448,6 +451,7 @@ export function StudioProvider({ children }: { children: ReactNode }) {
   };
 
   const [deleteAllClassesInGroupFn, setDeleteAllClassesInGroupFn] = useState<((groupId: string, classIds?: string[], groupName?: string) => Promise<void>) | null>(null);
+  const [deleteGroupFn, setDeleteGroupFn] = useState<((groupId: string) => Promise<void>) | null>(null);
 
   const addNodeToGroup = (groupId: string, nodeId: string) => {
     setGroups(prev => prev.map(g => {
@@ -524,6 +528,8 @@ export function StudioProvider({ children }: { children: ReactNode }) {
       deleteGroup,
       deleteAllClassesInGroupFn,
       setDeleteAllClassesInGroupFn,
+      deleteGroupFn,
+      setDeleteGroupFn,
       addNodeToGroup,
       removeNodeFromGroup,
       searchHistoryCount,

--- a/objectified-ui/src/app/ade/studio/editor/page.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useState, useEffect, useRef, useMemo, type ChangeEvent } from 'react';
+import { useCallback, useState, useEffect, useRef, useMemo, type ChangeEvent, type SetStateAction } from 'react';
 import { useSession } from 'next-auth/react';
 import { useSearchParams } from 'next/navigation';
 import dynamic from 'next/dynamic';
@@ -305,6 +305,7 @@ const StudioContent = () => {
     updateGroup,
     deleteGroup: deleteGroupFromContext,
     setDeleteAllClassesInGroupFn,
+    setDeleteGroupFn,
     setSearchHistoryCount,
     setClearSearchHistoryFn,
     setCanvasPresentationMode,
@@ -4006,6 +4007,16 @@ const StudioContent = () => {
     );
     return () => setDeleteAllClassesInGroupFn(null);
   }, [setDeleteAllClassesInGroupFn]);
+
+  // Register group delete for sidebar (persists layout, removes nested subtree + group nodes)
+  useEffect(() => {
+    const register: SetStateAction<((groupId: string) => Promise<void>) | null> = () =>
+      async (groupId: string) => {
+        await handleGroupDeleteRef.current?.(groupId);
+      };
+    setDeleteGroupFn(register);
+    return () => setDeleteGroupFn(null);
+  }, [setDeleteGroupFn]);
 
   // Create a new group at a specific position (for drag-and-drop)
   const handleCreateGroupAtPosition = useCallback(async (dropPosition: { x: number; y: number }) => {

--- a/objectified-ui/src/app/ade/studio/layout.tsx
+++ b/objectified-ui/src/app/ade/studio/layout.tsx
@@ -49,7 +49,7 @@ function StudioLayoutContent({ children }: Readonly<{ children: React.ReactNode 
     createGroupFn,
     clickToFocusEnabled,
     groups,
-    deleteGroup,
+    deleteGroupFn,
     updateGroup,
     canvasPresentationMode,
   } = useStudio();
@@ -345,19 +345,15 @@ function StudioLayoutContent({ children }: Readonly<{ children: React.ReactNode 
         return;
       }
 
-      const group = groups.find(g => g.id === groupId);
-      const confirmed = await confirmDialog({
-        title: 'Delete Group',
-        message: `Are you sure you want to delete the group "${group?.name || 'this group'}"? The classes inside will not be deleted.`,
+      if (deleteGroupFn) {
+        await deleteGroupFn(groupId);
+        return;
+      }
+
+      await alertDialog({
+        message: 'Canvas editor is still loading. Please try again in a moment.',
         variant: 'warning',
-        confirmLabel: 'Delete Group',
-        cancelLabel: 'Cancel',
       });
-
-      if (!confirmed) return;
-
-      deleteGroup(groupId);
-      triggerCanvasRefresh();
     },
     onGroupDeleteAllClasses: async (groupId) => {
       if (isReadOnly) return;

--- a/objectified-ui/src/app/components/ade/studio/StudioSideNav.tsx
+++ b/objectified-ui/src/app/components/ade/studio/StudioSideNav.tsx
@@ -3,7 +3,7 @@
 
 import React, { useState } from 'react';
 import * as Tabs from '@radix-ui/react-tabs';
-import { Search, Plus, Pencil, Trash2, Trash2 as DeleteSweep, Upload, Library, ChevronDown, ChevronUp, Eye, EyeOff } from 'lucide-react';
+import { Search, Plus, Pencil, Trash2, FileX, Upload, Library, ChevronDown, ChevronUp, Eye, EyeOff } from 'lucide-react';
 import { getPropertiesForClass } from '../../../../../lib/db/helper';
 import { useDarkMode } from '@/app/hooks/useDarkMode';
 
@@ -708,7 +708,7 @@ const StudioSideNav: React.FC<StudioSideNavProps> = ({
                                 title="Delete all classes in group"
                                 className="p-1.5 rounded hover:bg-amber-500/10 hover:text-amber-500"
                               >
-                                <DeleteSweep className="w-4 h-4" />
+                                <FileX className="w-4 h-4" />
                               </button>
                             )}
                             <button


### PR DESCRIPTION
## Problem Statement

Users and teams need **fix #849 — sidebar group delete persists layout** within the Objectified platform. Today this capability is missing or only partially implemented, which blocks dashboard workflows and creates inconsistency across tenants and projects.

## Solution / Scope

Implement **Fix #849 — Sidebar group delete persists layout** as part of **Dashboard**. KPIs, primitives browser, project overview, quick actions.

**Post-MVP** (prioritize after MVP slice) candidacy.

```mermaid
flowchart TB
  CP[Control Panel] --> KPIs[Stats cards]
  CP --> Primitives[Primitives list]
  CP --> Projects[Recent projects]
  CP --> Actions[Quick actions]
```

## Acceptance Criteria

- [ ] Feature behaves as described for: Fix #849 — Sidebar group delete persists layout
- [ ] Unit/integration tests cover happy path and primary error cases
- [ ] UI (if applicable) matches existing ADE patterns (Tailwind 4, Radix, Lucide)
- [ ] REST endpoints (if applicable) follow `/v1/{{feature}}/{{tenant_slug}}/...` conventions
- [ ] Documented in issue/PR; no regressions to existing schema/version flows

## Parallelism / Dependencies

- **Can run in parallel:** Yes
- **Blockers:** None identified; validate against current codebase before starting

## Technical Stack

- **Modules:** objectified-rest
- **Stack:** Next.js ADE dashboard, control panel components, REST stats APIs
- **Labels:** ``

---

**Epic:** [[Epic] Dashboard & Control Panel](https://github.com/objectified-project/objectified/issues/3493)
**Issue:** #863 · **Area:** Dashboard · **Roadmap batch:** legacy #64–#879 enrichment