### PR TITLE
Canvas layout auto-save in layout menu (#831)

### DIFF
--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.8.72",
+  "version": "0.8.73",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -5,6 +5,7 @@ We continue to improve the platform based on your feedback with improvements and
 ---
 
 Improvements:
+- Canvas: layout auto-save interval and on/off switch moved into the layout menu; auto-save stays off by default and is only available after you have saved a layout for the current name (#831)
 - Canvas: Expand, Collapse, Search, View Mode, and Tags live in a left slide-out drawer opened from the **Tools** control in the upper-left (#842)
 - Canvas: group edit controls (style, color, rename, export, duplicate, bulk, delete) sit in a compact floating card above the frame (`-top-6`, `right: -2px`) so the title row stays readable on hover or when selected (#859)
 - Studio: the amber “differs from defaults” hint appears in the dialog header next to the title for class and property editors so it stays visible (#856)

--- a/objectified-ui/src/app/ade/studio/StudioContext.tsx
+++ b/objectified-ui/src/app/ade/studio/StudioContext.tsx
@@ -244,11 +244,11 @@ export function StudioProvider({ children }: { children: ReactNode }) {
           return JSON.parse(saved);
         } catch (e) {
           console.error('Failed to parse autoSaveLayoutEnabled from localStorage:', e);
-          return true;
+          return false;
         }
       }
     }
-    return true;
+    return false;
   });
   const [autoSaveLayoutIntervalSeconds, setAutoSaveLayoutIntervalSecondsRaw] = useState<number>(() => {
     if (typeof window !== 'undefined') {

--- a/objectified-ui/src/app/ade/studio/components/CanvasSettingsDialog.tsx
+++ b/objectified-ui/src/app/ade/studio/components/CanvasSettingsDialog.tsx
@@ -192,8 +192,6 @@ interface CanvasSettingsDialogProps {
   clickToFocusEnabled: boolean;
   snapToGrid: boolean;
   smartGuidesEnabled: boolean;
-  autoSaveLayoutEnabled: boolean;
-  autoSaveLayoutIntervalSeconds: number;
   showGrid: boolean;
   gridSize: number;
   gridStyle: 'dots' | 'lines' | 'cross';
@@ -206,8 +204,6 @@ interface CanvasSettingsDialogProps {
     clickToFocusEnabled: boolean;
     snapToGrid: boolean;
     smartGuidesEnabled: boolean;
-    autoSaveLayoutEnabled: boolean;
-    autoSaveLayoutIntervalSeconds: number;
     showGrid: boolean;
     gridSize: number;
     gridStyle: 'dots' | 'lines' | 'cross';
@@ -245,8 +241,6 @@ export default function CanvasSettingsDialog({
   clickToFocusEnabled,
   snapToGrid,
   smartGuidesEnabled,
-  autoSaveLayoutEnabled,
-  autoSaveLayoutIntervalSeconds,
   showGrid,
   gridSize,
   gridStyle,
@@ -262,8 +256,6 @@ export default function CanvasSettingsDialog({
   const [localClickToFocus, setLocalClickToFocus] = React.useState(clickToFocusEnabled);
   const [localSnapToGrid, setLocalSnapToGrid] = React.useState(snapToGrid);
   const [localSmartGuides, setLocalSmartGuides] = React.useState(smartGuidesEnabled);
-  const [localAutoSaveLayoutEnabled, setLocalAutoSaveLayoutEnabled] = React.useState(autoSaveLayoutEnabled);
-  const [localAutoSaveLayoutIntervalSeconds, setLocalAutoSaveLayoutIntervalSeconds] = React.useState(autoSaveLayoutIntervalSeconds);
   const [localShowGrid, setLocalShowGrid] = React.useState(showGrid);
   const [localGridSize, setLocalGridSize] = React.useState(gridSize);
   const [localGridStyle, setLocalGridStyle] = React.useState(gridStyle);
@@ -278,8 +270,6 @@ export default function CanvasSettingsDialog({
       setLocalClickToFocus(clickToFocusEnabled);
       setLocalSnapToGrid(snapToGrid);
       setLocalSmartGuides(smartGuidesEnabled);
-      setLocalAutoSaveLayoutEnabled(autoSaveLayoutEnabled);
-      setLocalAutoSaveLayoutIntervalSeconds(autoSaveLayoutIntervalSeconds);
       setLocalShowGrid(showGrid);
       setLocalGridSize(gridSize);
       setLocalGridStyle(gridStyle);
@@ -288,15 +278,13 @@ export default function CanvasSettingsDialog({
       setLocalEdgeRouting(edgeRouting);
       setLocalEdgeAnimation(edgeAnimation);
     }
-  }, [open, clickToFocusEnabled, snapToGrid, smartGuidesEnabled, autoSaveLayoutEnabled, autoSaveLayoutIntervalSeconds, showGrid, gridSize, gridStyle, canvasBackground, edgeStyling, edgeRouting, edgeAnimation]);
+  }, [open, clickToFocusEnabled, snapToGrid, smartGuidesEnabled, showGrid, gridSize, gridStyle, canvasBackground, edgeStyling, edgeRouting, edgeAnimation]);
 
   const handleSave = () => {
     onSave({
       clickToFocusEnabled: localClickToFocus,
       snapToGrid: localSnapToGrid,
       smartGuidesEnabled: localSmartGuides,
-      autoSaveLayoutEnabled: localAutoSaveLayoutEnabled,
-      autoSaveLayoutIntervalSeconds: localAutoSaveLayoutIntervalSeconds,
       showGrid: localShowGrid,
       gridSize: localGridSize,
       gridStyle: localGridStyle,
@@ -468,42 +456,6 @@ export default function CanvasSettingsDialog({
                       className="w-4 h-4 text-indigo-500 rounded focus:ring-indigo-500"
                     />
                   </label>
-                  <label className="flex items-center justify-between p-3 bg-gray-50 dark:bg-gray-800/50 rounded-lg cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-700/50 transition-colors">
-                    <div className="flex items-center gap-3">
-                      <svg className="w-4 h-4 text-gray-600 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
-                      </svg>
-                      <span className="text-sm text-gray-700 dark:text-gray-300">Auto-save Layout</span>
-                    </div>
-                    <input
-                      type="checkbox"
-                      checked={localAutoSaveLayoutEnabled}
-                      onChange={(e) => setLocalAutoSaveLayoutEnabled(e.target.checked)}
-                      className="w-4 h-4 text-indigo-500 rounded focus:ring-indigo-500"
-                    />
-                  </label>
-                  <div className="p-3 bg-gray-50 dark:bg-gray-800/50 rounded-lg">
-                    <div className="flex items-center justify-between mb-2">
-                      <span className="text-sm text-gray-700 dark:text-gray-300">Auto-save Interval</span>
-                      <span className="text-xs px-2 py-0.5 rounded bg-indigo-100 dark:bg-indigo-900 text-indigo-700 dark:text-indigo-300 font-medium">
-                        {localAutoSaveLayoutIntervalSeconds}s
-                      </span>
-                    </div>
-                    <input
-                      type="range"
-                      min="10"
-                      max="300"
-                      step="5"
-                      value={localAutoSaveLayoutIntervalSeconds}
-                      disabled={!localAutoSaveLayoutEnabled}
-                      onChange={(e) => setLocalAutoSaveLayoutIntervalSeconds(Number(e.target.value))}
-                      className="w-full h-2 bg-gray-200 dark:bg-gray-700 rounded-lg appearance-none cursor-pointer accent-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed"
-                    />
-                    <div className="flex justify-between text-xs text-gray-500 dark:text-gray-400 mt-1">
-                      <span>10s</span>
-                      <span>300s</span>
-                    </div>
-                  </div>
                 </div>
               </div>
 

--- a/objectified-ui/src/app/ade/studio/components/StudioHeader.tsx
+++ b/objectified-ui/src/app/ade/studio/components/StudioHeader.tsx
@@ -58,10 +58,6 @@ export default function StudioHeader({ onProjectTagsLoaded }: StudioHeaderProps)
     setCanvasBackground,
     smartGuidesEnabled,
     setSmartGuidesEnabled,
-    autoSaveLayoutEnabled,
-    setAutoSaveLayoutEnabled,
-    autoSaveLayoutIntervalSeconds,
-    setAutoSaveLayoutIntervalSeconds,
     edgeStyling,
     setEdgeStyling,
     edgeRouting,
@@ -92,8 +88,6 @@ export default function StudioHeader({ onProjectTagsLoaded }: StudioHeaderProps)
     clickToFocusEnabled: boolean;
     snapToGrid: boolean;
     smartGuidesEnabled: boolean;
-    autoSaveLayoutEnabled: boolean;
-    autoSaveLayoutIntervalSeconds: number;
     showGrid: boolean;
     gridSize: number;
     gridStyle: 'dots' | 'lines' | 'cross';
@@ -110,10 +104,6 @@ export default function StudioHeader({ onProjectTagsLoaded }: StudioHeaderProps)
 
     setSmartGuidesEnabled(settings.smartGuidesEnabled);
     localStorage.setItem('smartGuidesEnabled', JSON.stringify(settings.smartGuidesEnabled));
-    setAutoSaveLayoutEnabled(settings.autoSaveLayoutEnabled);
-    localStorage.setItem('autoSaveLayoutEnabled', JSON.stringify(settings.autoSaveLayoutEnabled));
-    setAutoSaveLayoutIntervalSeconds(settings.autoSaveLayoutIntervalSeconds);
-    localStorage.setItem('autoSaveLayoutIntervalSeconds', String(settings.autoSaveLayoutIntervalSeconds));
 
     setShowGrid(settings.showGrid);
     localStorage.setItem('showGrid', JSON.stringify(settings.showGrid));
@@ -135,7 +125,7 @@ export default function StudioHeader({ onProjectTagsLoaded }: StudioHeaderProps)
 
     setEdgeAnimation(settings.edgeAnimation);
     localStorage.setItem('edgeAnimation', settings.edgeAnimation);
-  }, [setClickToFocusEnabled, setSnapToGrid, setSmartGuidesEnabled, setAutoSaveLayoutEnabled, setAutoSaveLayoutIntervalSeconds, setShowGrid, setGridSize, setGridStyle, setCanvasBackground, setEdgeStyling, setEdgeRouting, setEdgeAnimation]);
+  }, [setClickToFocusEnabled, setSnapToGrid, setSmartGuidesEnabled, setShowGrid, setGridSize, setGridStyle, setCanvasBackground, setEdgeStyling, setEdgeRouting, setEdgeAnimation]);
 
   // Sync local state with context
   React.useEffect(() => {
@@ -404,8 +394,6 @@ export default function StudioHeader({ onProjectTagsLoaded }: StudioHeaderProps)
               clickToFocusEnabled={clickToFocusEnabled}
               snapToGrid={snapToGrid}
               smartGuidesEnabled={smartGuidesEnabled}
-              autoSaveLayoutEnabled={autoSaveLayoutEnabled}
-              autoSaveLayoutIntervalSeconds={autoSaveLayoutIntervalSeconds}
               showGrid={showGrid}
               gridSize={gridSize}
               gridStyle={gridStyle}

--- a/objectified-ui/src/app/ade/studio/editor/page.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/page.tsx
@@ -187,6 +187,7 @@ import {
   type CanvasPresentationBookmark,
 } from './lib/canvas-presentation-bookmarks';
 import { CanvasPresentationPanel, PresentationExitHint } from './components/CanvasPresentationPanel';
+import { Switch } from '@/app/components/ui/Switch';
 
 // Import extracted components
 import { useExportFunctions } from './components';
@@ -300,6 +301,8 @@ const StudioContent = () => {
     setSmartGuidesEnabled,
     autoSaveLayoutEnabled,
     autoSaveLayoutIntervalSeconds,
+    setAutoSaveLayoutEnabled,
+    setAutoSaveLayoutIntervalSeconds,
     canvasBackground,
     groups,
     setGroups,
@@ -4633,6 +4636,7 @@ const StudioContent = () => {
   const autoSaveDefaultLayout = useCallback(async () => {
     if (
       !autoSaveLayoutEnabled ||
+      !hasExistingLayout ||
       !autoSavePendingRef.current ||
       isReadOnly ||
       !selectedVersionId ||
@@ -4668,6 +4672,7 @@ const StudioContent = () => {
     }
   }, [
     autoSaveLayoutEnabled,
+    hasExistingLayout,
     isReadOnly,
     selectedVersionId,
     currentUserId,
@@ -4675,14 +4680,14 @@ const StudioContent = () => {
   ]);
 
   useEffect(() => {
-    if (!autoSaveLayoutEnabled || autoSaveLayoutIntervalSeconds < 10) return;
+    if (!autoSaveLayoutEnabled || !hasExistingLayout || autoSaveLayoutIntervalSeconds < 10) return;
 
     const intervalId = window.setInterval(() => {
       void autoSaveDefaultLayout();
     }, autoSaveLayoutIntervalSeconds * 1000);
 
     return () => window.clearInterval(intervalId);
-  }, [autoSaveLayoutEnabled, autoSaveLayoutIntervalSeconds, autoSaveDefaultLayout]);
+  }, [autoSaveLayoutEnabled, hasExistingLayout, autoSaveLayoutIntervalSeconds, autoSaveDefaultLayout]);
 
   /**
    * Shared path for applying saved layout data (DB or JSON import) after groups are in the database.
@@ -8357,7 +8362,7 @@ const StudioContent = () => {
 
                 {/* Dropdown Menu */}
                 {layoutDropdownOpen && (
-                  <div className="absolute right-0 mt-2 w-64 bg-white dark:bg-gray-800 rounded-lg shadow-lg border border-gray-200 dark:border-gray-700 z-[1002]">
+                  <div className="absolute right-0 mt-2 w-80 bg-white dark:bg-gray-800 rounded-lg shadow-lg border border-gray-200 dark:border-gray-700 z-[1002]">
                     <div className="py-2">
                       {/* Save/Load Layout Buttons */}
                       <div className="px-4 py-3">
@@ -8439,6 +8444,53 @@ const StudioContent = () => {
                             <Upload className="w-4 h-4" />
                             <span>Load</span>
                           </button>
+                        </div>
+                        <div
+                          className={`mt-3 pt-3 border-t border-gray-200 dark:border-gray-700 space-y-2 ${
+                            !hasExistingLayout ? 'opacity-60' : ''
+                          }`}
+                        >
+                          <div className="flex items-center justify-between gap-2">
+                            <div className="min-w-0">
+                              <p className="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                                Auto-save default layout
+                              </p>
+                              <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                                {hasExistingLayout
+                                  ? 'Periodically saves the working canvas to your default slot. Interval applies while enabled.'
+                                  : 'Save a layout for this name first—then you can enable auto-save and choose an interval.'}
+                              </p>
+                            </div>
+                            <div className="flex items-center gap-2 shrink-0">
+                              <span className="text-xs tabular-nums px-2 py-0.5 rounded bg-indigo-100 dark:bg-indigo-900 text-indigo-700 dark:text-indigo-300 font-medium">
+                                {autoSaveLayoutIntervalSeconds}s
+                              </span>
+                              <Switch
+                                checked={autoSaveLayoutEnabled}
+                                disabled={!hasExistingLayout || isReadOnly}
+                                onCheckedChange={setAutoSaveLayoutEnabled}
+                                aria-label="Toggle layout auto-save"
+                              />
+                            </div>
+                          </div>
+                          <div className="p-2.5 bg-gray-50 dark:bg-gray-800/50 rounded-lg">
+                            <div className="flex items-center justify-between mb-2">
+                              <span className="text-xs text-gray-600 dark:text-gray-400">Interval</span>
+                              <span className="text-[10px] text-gray-500 dark:text-gray-500">
+                                10s–300s
+                              </span>
+                            </div>
+                            <input
+                              type="range"
+                              min={10}
+                              max={300}
+                              step={5}
+                              value={autoSaveLayoutIntervalSeconds}
+                              disabled={!hasExistingLayout || isReadOnly || !autoSaveLayoutEnabled}
+                              onChange={(e) => setAutoSaveLayoutIntervalSeconds(Number(e.target.value))}
+                              className="w-full h-2 bg-gray-200 dark:bg-gray-700 rounded-lg appearance-none cursor-pointer accent-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed"
+                            />
+                          </div>
                         </div>
                         <p className="text-xs text-gray-500 dark:text-gray-400 mt-2">
                           Type a custom name or pick a suggestion. Save and load multiple layouts per version.

--- a/objectified-ui/src/app/ade/studio/editor/page.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/page.tsx
@@ -8489,6 +8489,7 @@ const StudioContent = () => {
                               disabled={!hasExistingLayout || isReadOnly || !autoSaveLayoutEnabled}
                               onChange={(e) => setAutoSaveLayoutIntervalSeconds(Number(e.target.value))}
                               className="w-full h-2 bg-gray-200 dark:bg-gray-700 rounded-lg appearance-none cursor-pointer accent-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed"
+                              aria-label={`Auto-save interval: ${autoSaveLayoutIntervalSeconds} seconds`}
                             />
                           </div>
                         </div>


### PR DESCRIPTION
## Problem Statement

Users and teams need **canvas layout auto-save in layout menu (#831)** within the Objectified platform. Today this capability is missing or only partially implemented, which blocks dashboard workflows and creates inconsistency across tenants and projects.

## Solution / Scope

Implement **Canvas layout auto-save in layout menu (#831)** as part of **Dashboard**. KPIs, primitives browser, project overview, quick actions.

**Post-MVP** (prioritize after MVP slice) candidacy.

```mermaid
flowchart TB
  CP[Control Panel] --> KPIs[Stats cards]
  CP --> Primitives[Primitives list]
  CP --> Projects[Recent projects]
  CP --> Actions[Quick actions]
```

## Acceptance Criteria

- [ ] Feature behaves as described for: Canvas layout auto-save in layout menu (#831)
- [ ] Unit/integration tests cover happy path and primary error cases
- [ ] UI (if applicable) matches existing ADE patterns (Tailwind 4, Radix, Lucide)
- [ ] REST endpoints (if applicable) follow `/v1/{{feature}}/{{tenant_slug}}/...` conventions
- [ ] Documented in issue/PR; no regressions to existing schema/version flows

## Parallelism / Dependencies

- **Can run in parallel:** Yes
- **Blockers:** None identified; validate against current codebase before starting

## Technical Stack

- **Modules:** objectified-rest
- **Stack:** Next.js ADE dashboard, control panel components, REST stats APIs
- **Labels:** ``

---

**Epic:** [[Epic] Dashboard & Control Panel](https://github.com/objectified-project/objectified/issues/3493)
**Issue:** #865 · **Area:** Dashboard · **Roadmap batch:** legacy #64–#879 enrichment