### PR TITLE
Addresses #168 — quick local canvas layout snapshots

### DIFF
--- a/PLANNED_FEATURE_ROADMAP_CANVAS.md
+++ b/PLANNED_FEATURE_ROADMAP_CANVAS.md
@@ -13,7 +13,7 @@
 
 #### Layout Snapshots ✅ BASIC (named layouts)
 - ✅ PNG snapshot stored with each named layout save; thumbnail preview when picking a layout name (#314)
-- 📋 [TODO] Take quick snapshots of current layout
+- ✅ Take quick snapshots of current layout (#168) — local browser capture from Layout panel
 - 📋 [TODO] Thumbnail preview of each snapshot
 - 📋 [TODO] Restore any snapshot with one click
 - 📋 [TODO] Compare two snapshots side-by-side
@@ -23,7 +23,6 @@
 
 | Ticket | Feature                                           |
 |--------|---------------------------------------------------|
-| #168   | Take quick snapshots of current layout            |
 | #169   | Thumbnail preview of each snapshot                |
 | #170   | Restore any snapshot with one click               |
 | #171   | Compare two snapshots side-by-side                |

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.8.77",
+  "version": "0.8.78",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -19,6 +19,7 @@ Improvements:
 - Canvas: layout auto-save uses a steady timer while edits are pending so saves occur every 30 seconds (or your chosen interval) without resetting on each move (#315)
 - Canvas: schema timeline panel shows class count, relationships, and complexity across project versions (#323)
 - Canvas: named layout saves store a PNG snapshot for thumbnail preview in the layout menu
+- Canvas: Layout panel quick snapshots capture viewport, nodes, edges, groups, and a local PNG preview in the browser without naming or server save; restore UI is planned (#168)
 - Canvas: export and import canvas layouts as versioned JSON (share across versions and projects)
 - Canvas: layout import and named layout load restore edge handle routing when saved edge IDs match the canvas (#316)
 

--- a/objectified-ui/src/app/ade/studio/editor/lib/quick-layout-snapshots.ts
+++ b/objectified-ui/src/app/ade/studio/editor/lib/quick-layout-snapshots.ts
@@ -1,0 +1,111 @@
+/**
+ * Browser-local quick canvas layout snapshots per version (#168).
+ * Stored in localStorage for fast capture without naming or server round-trips.
+ */
+
+export const QUICK_LAYOUT_SNAPSHOTS_SCHEMA_VERSION = 1 as const;
+
+export const DEFAULT_MAX_QUICK_LAYOUT_SNAPSHOTS = 20;
+
+export interface QuickLayoutSnapshotPayload {
+  schemaVersion: typeof QUICK_LAYOUT_SNAPSHOTS_SCHEMA_VERSION;
+  viewport: { x: number; y: number; zoom: number };
+  nodes: unknown[];
+  edges: unknown[];
+  groups: unknown[];
+}
+
+export interface QuickLayoutSnapshot {
+  id: string;
+  createdAt: string;
+  /** PNG data URL for preview; omitted if capture failed or was too large. */
+  thumbnailDataUrl?: string;
+  payload: QuickLayoutSnapshotPayload;
+}
+
+export function quickLayoutSnapshotsStorageKey(versionId: string, userId: string | null): string {
+  const uid = userId && userId.trim() ? userId.trim() : 'anonymous';
+  return `objectified.quickCanvasSnapshots.v1:${versionId}:${uid}`;
+}
+
+function isViewport(v: unknown): v is { x: number; y: number; zoom: number } {
+  if (!v || typeof v !== 'object') return false;
+  const o = v as Record<string, unknown>;
+  return (
+    typeof o.x === 'number' &&
+    Number.isFinite(o.x) &&
+    typeof o.y === 'number' &&
+    Number.isFinite(o.y) &&
+    typeof o.zoom === 'number' &&
+    Number.isFinite(o.zoom)
+  );
+}
+
+export function isQuickLayoutSnapshot(raw: unknown): raw is QuickLayoutSnapshot {
+  if (!raw || typeof raw !== 'object') return false;
+  const o = raw as Record<string, unknown>;
+  if (typeof o.id !== 'string' || !o.id.trim()) return false;
+  if (typeof o.createdAt !== 'string' || !o.createdAt.trim()) return false;
+  const payload = o.payload;
+  if (!payload || typeof payload !== 'object') return false;
+  const p = payload as Record<string, unknown>;
+  if (p.schemaVersion !== QUICK_LAYOUT_SNAPSHOTS_SCHEMA_VERSION) return false;
+  if (!isViewport(p.viewport)) return false;
+  if (!Array.isArray(p.nodes) || !Array.isArray(p.edges) || !Array.isArray(p.groups)) return false;
+  if (o.thumbnailDataUrl !== undefined) {
+    if (typeof o.thumbnailDataUrl !== 'string') return false;
+    if (!o.thumbnailDataUrl.startsWith('data:image/png;base64,')) return false;
+  }
+  return true;
+}
+
+export function loadQuickLayoutSnapshots(versionId: string, userId: string | null): QuickLayoutSnapshot[] {
+  if (typeof window === 'undefined') return [];
+  if (!versionId || !versionId.trim()) return [];
+  try {
+    const raw = window.localStorage.getItem(quickLayoutSnapshotsStorageKey(versionId, userId));
+    if (!raw || !raw.trim()) return [];
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(isQuickLayoutSnapshot);
+  } catch {
+    return [];
+  }
+}
+
+function persistQuickLayoutSnapshots(
+  versionId: string,
+  userId: string | null,
+  list: QuickLayoutSnapshot[]
+): void {
+  if (typeof window === 'undefined') return;
+  if (!versionId || !versionId.trim()) return;
+  try {
+    window.localStorage.setItem(quickLayoutSnapshotsStorageKey(versionId, userId), JSON.stringify(list));
+  } catch (e) {
+    console.warn('quick layout snapshots: failed to persist', e);
+  }
+}
+
+/**
+ * Prepend a snapshot and cap list length. Returns the stored list after write.
+ */
+export function appendQuickLayoutSnapshot(
+  versionId: string,
+  userId: string | null,
+  snapshot: QuickLayoutSnapshot,
+  options?: { maxSnapshots?: number }
+): QuickLayoutSnapshot[] {
+  const max = options?.maxSnapshots ?? DEFAULT_MAX_QUICK_LAYOUT_SNAPSHOTS;
+  const existing = loadQuickLayoutSnapshots(versionId, userId);
+  const next = [snapshot, ...existing].slice(0, max);
+  persistQuickLayoutSnapshots(versionId, userId, next);
+  return next;
+}
+
+export function makeQuickLayoutSnapshotId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `qs-${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
+}

--- a/objectified-ui/src/app/ade/studio/editor/lib/quick-layout-snapshots.ts
+++ b/objectified-ui/src/app/ade/studio/editor/lib/quick-layout-snapshots.ts
@@ -25,7 +25,7 @@ export interface QuickLayoutSnapshot {
 
 export function quickLayoutSnapshotsStorageKey(versionId: string, userId: string | null): string {
   const uid = userId && userId.trim() ? userId.trim() : 'anonymous';
-  return `objectified.quickCanvasSnapshots.v1:${versionId}:${uid}`;
+  return `objectified.quickCanvasSnapshots.v${QUICK_LAYOUT_SNAPSHOTS_SCHEMA_VERSION}:${versionId}:${uid}`;
 }
 
 function isViewport(v: unknown): v is { x: number; y: number; zoom: number } {
@@ -77,30 +77,43 @@ function persistQuickLayoutSnapshots(
   versionId: string,
   userId: string | null,
   list: QuickLayoutSnapshot[]
-): void {
-  if (typeof window === 'undefined') return;
-  if (!versionId || !versionId.trim()) return;
+): boolean {
+  if (typeof window === 'undefined') return false;
+  if (!versionId || !versionId.trim()) return false;
+  const key = quickLayoutSnapshotsStorageKey(versionId, userId);
   try {
-    window.localStorage.setItem(quickLayoutSnapshotsStorageKey(versionId, userId), JSON.stringify(list));
-  } catch (e) {
-    console.warn('quick layout snapshots: failed to persist', e);
+    window.localStorage.setItem(key, JSON.stringify(list));
+    return true;
+  } catch {
+    // Quota likely exceeded; retry with thumbnails stripped to reduce payload size.
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const stripped = list.map(({ thumbnailDataUrl: _t, ...rest }) => rest);
+      window.localStorage.setItem(key, JSON.stringify(stripped));
+      return true;
+    } catch (e) {
+      console.warn('quick layout snapshots: failed to persist', e);
+      return false;
+    }
   }
 }
 
 /**
- * Prepend a snapshot and cap list length. Returns the stored list after write.
+ * Prepend a snapshot and cap list length.
+ * Returns the in-memory list together with a `persisted` flag indicating
+ * whether the write to localStorage succeeded.
  */
 export function appendQuickLayoutSnapshot(
   versionId: string,
   userId: string | null,
   snapshot: QuickLayoutSnapshot,
   options?: { maxSnapshots?: number }
-): QuickLayoutSnapshot[] {
+): { snapshots: QuickLayoutSnapshot[]; persisted: boolean } {
   const max = options?.maxSnapshots ?? DEFAULT_MAX_QUICK_LAYOUT_SNAPSHOTS;
   const existing = loadQuickLayoutSnapshots(versionId, userId);
   const next = [snapshot, ...existing].slice(0, max);
-  persistQuickLayoutSnapshots(versionId, userId, next);
-  return next;
+  const persisted = persistQuickLayoutSnapshots(versionId, userId, next);
+  return { snapshots: next, persisted };
 }
 
 export function makeQuickLayoutSnapshotId(): string {

--- a/objectified-ui/src/app/ade/studio/editor/page.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/page.tsx
@@ -4613,10 +4613,17 @@ const StudioContent = () => {
           groups: groupsPlain,
         },
       };
-      const next = appendQuickLayoutSnapshot(selectedVersionId, currentUserId, snapshot);
+      const { snapshots: next, persisted } = appendQuickLayoutSnapshot(selectedVersionId, currentUserId, snapshot);
       setQuickLayoutSnapshots(next);
-      setQuickSnapshotSavedFlash(true);
-      window.setTimeout(() => setQuickSnapshotSavedFlash(false), 2000);
+      if (persisted) {
+        setQuickSnapshotSavedFlash(true);
+        window.setTimeout(() => setQuickSnapshotSavedFlash(false), 2000);
+      } else {
+        await alertDialog({
+          message: 'Quick snapshot could not be saved (storage quota may be full). Try clearing old snapshots.',
+          variant: 'warning',
+        });
+      }
     } catch (error) {
       console.error('Error capturing quick layout snapshot:', error);
       await alertDialog({

--- a/objectified-ui/src/app/ade/studio/editor/page.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/page.tsx
@@ -64,6 +64,7 @@ import {
   TrendingUp,
   Presentation,
   PanelLeft,
+  Camera,
 } from 'lucide-react';
 import * as Select from '@radix-ui/react-select';
 import * as ToggleGroup from '@radix-ui/react-toggle-group';
@@ -124,6 +125,13 @@ import {
 } from '../../../../../lib/db/helper';
 import { expandClassesForGroupExport, downloadTextFile } from '@/app/utils/group-schema-export';
 import { mapEdgesForLayoutSave, mapNodesForLayoutSave } from '../lib/canvasLayoutPayload';
+import {
+  appendQuickLayoutSnapshot,
+  loadQuickLayoutSnapshots,
+  makeQuickLayoutSnapshotId,
+  QUICK_LAYOUT_SNAPSHOTS_SCHEMA_VERSION,
+  type QuickLayoutSnapshot,
+} from './lib/quick-layout-snapshots';
 import {
   deleteClassWithSession,
   updateClassCanvasMetadataWithSession,
@@ -588,6 +596,9 @@ const StudioContent = () => {
   const [availableLayoutNames, setAvailableLayoutNames] = useState<string[]>(BUILTIN_LAYOUT_NAMES);
   /** Data URLs for saved layout snapshots keyed by trimmed layout name */
   const [namedLayoutSnapshotDataUrls, setNamedLayoutSnapshotDataUrls] = useState<Record<string, string>>({});
+  /** Local quick snapshots for this version (#168); restore UI follows in #170. */
+  const [quickLayoutSnapshots, setQuickLayoutSnapshots] = useState<QuickLayoutSnapshot[]>([]);
+  const [quickSnapshotSavedFlash, setQuickSnapshotSavedFlash] = useState(false);
   const canvasCaptureAreaRef = useRef<HTMLDivElement>(null);
   const presentationShellRef = useRef<HTMLDivElement>(null);
   const selectedLayoutNameRef = useRef(selectedLayoutName);
@@ -600,6 +611,14 @@ const StudioContent = () => {
   useEffect(() => {
     selectedLayoutNameRef.current = selectedLayoutName;
   }, [selectedLayoutName]);
+
+  useEffect(() => {
+    if (!selectedVersionId) {
+      setQuickLayoutSnapshots([]);
+      return;
+    }
+    setQuickLayoutSnapshots(loadQuickLayoutSnapshots(selectedVersionId, currentUserId));
+  }, [selectedVersionId, currentUserId]);
 
   useEffect(() => {
     setAutoSavePending(false);
@@ -4529,6 +4548,95 @@ const StudioContent = () => {
       setLoadingMessage('');
     }
   }, [isReadOnly, selectedVersionId, currentUserId, selectedLayoutName, nodes, edges, groups, getViewport, alertDialog, isDark]);
+
+  /** Capture a local quick snapshot (viewport, nodes, edges, groups, optional PNG thumb) without naming. */
+  const handleQuickLayoutSnapshot = useCallback(async () => {
+    if (!selectedVersionId) {
+      await alertDialog({
+        message: 'Open a version to capture a layout snapshot.',
+        variant: 'warning',
+      });
+      return;
+    }
+    try {
+      setLoadingMessage('Capturing quick snapshot...');
+      setIsLoadingCanvas(true);
+      let thumbnailDataUrl: string | undefined;
+      const captureEl = canvasCaptureAreaRef.current;
+      if (captureEl) {
+        try {
+          const dataUrl = await toPng(captureEl, {
+            pixelRatio: 0.4,
+            cacheBust: true,
+            backgroundColor: isDark ? '#111827' : '#f8fafc',
+          });
+          const comma = dataUrl.indexOf(',');
+          if (comma !== -1 && dataUrl.slice(0, comma).includes('image/png')) {
+            const base64Part = dataUrl.slice(comma + 1);
+            if (base64Part.length <= 240_000) {
+              thumbnailDataUrl = dataUrl;
+            }
+          }
+        } catch (snapErr) {
+          console.warn('Quick snapshot thumbnail failed:', snapErr);
+        }
+      }
+      const viewportRaw = getViewport();
+      const viewport = {
+        x: typeof viewportRaw.x === 'number' && Number.isFinite(viewportRaw.x) ? viewportRaw.x : 0,
+        y: typeof viewportRaw.y === 'number' && Number.isFinite(viewportRaw.y) ? viewportRaw.y : 0,
+        zoom: typeof viewportRaw.zoom === 'number' && Number.isFinite(viewportRaw.zoom) ? viewportRaw.zoom : 1,
+      };
+      const nodeData = mapNodesForLayoutSave(nodes);
+      const edgeData = mapEdgesForLayoutSave(edges);
+      const groupsPlain = groups.map((g) => ({
+        id: g.id,
+        name: g.name,
+        description: g.description,
+        color: g.color,
+        nodeIds: [...g.nodeIds],
+        parentId: g.parentId ?? null,
+        tags: g.tags ? g.tags.map((t) => ({ ...t })) : undefined,
+        position: { ...g.position },
+        dimensions: { ...g.dimensions },
+        styleOptions: g.styleOptions ? { ...g.styleOptions } : undefined,
+      }));
+      const snapshot: QuickLayoutSnapshot = {
+        id: makeQuickLayoutSnapshotId(),
+        createdAt: new Date().toISOString(),
+        ...(thumbnailDataUrl ? { thumbnailDataUrl } : {}),
+        payload: {
+          schemaVersion: QUICK_LAYOUT_SNAPSHOTS_SCHEMA_VERSION,
+          viewport,
+          nodes: nodeData,
+          edges: edgeData,
+          groups: groupsPlain,
+        },
+      };
+      const next = appendQuickLayoutSnapshot(selectedVersionId, currentUserId, snapshot);
+      setQuickLayoutSnapshots(next);
+      setQuickSnapshotSavedFlash(true);
+      window.setTimeout(() => setQuickSnapshotSavedFlash(false), 2000);
+    } catch (error) {
+      console.error('Error capturing quick layout snapshot:', error);
+      await alertDialog({
+        message: 'Could not save quick snapshot. Please try again.',
+        variant: 'error',
+      });
+    } finally {
+      setIsLoadingCanvas(false);
+      setLoadingMessage('');
+    }
+  }, [
+    selectedVersionId,
+    currentUserId,
+    nodes,
+    edges,
+    groups,
+    getViewport,
+    isDark,
+    alertDialog,
+  ]);
 
   const handleSetMyDefaultLayoutName = useCallback(async () => {
     if (isReadOnly || !selectedVersionId || !currentUserId) return;
@@ -8465,6 +8573,75 @@ const StudioContent = () => {
                             <Upload className="w-4 h-4" />
                             <span>Load</span>
                           </button>
+                        </div>
+                        <div className="mt-3 pt-3 border-t border-gray-200 dark:border-gray-700 space-y-2">
+                          <p className="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                            Quick snapshots
+                          </p>
+                          <p className="text-xs text-gray-500 dark:text-gray-400 leading-snug">
+                            Save the current canvas to this browser only—no layout name or server save. Use for ad-hoc checkpoints; restore and gallery are planned next.
+                          </p>
+                          <button
+                            type="button"
+                            onClick={() => void handleQuickLayoutSnapshot()}
+                            disabled={!selectedVersionId}
+                            className={`w-full px-3 py-2 text-sm font-medium rounded-lg transition-all duration-200 flex items-center justify-center gap-2 border ${
+                              quickSnapshotSavedFlash
+                                ? 'bg-emerald-50 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-300 border-emerald-200 dark:border-emerald-700'
+                                : selectedVersionId
+                                  ? 'bg-white dark:bg-gray-700/50 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600 border-gray-200 dark:border-gray-600'
+                                  : 'bg-gray-100 dark:bg-gray-700 text-gray-400 cursor-not-allowed border-gray-200 dark:border-gray-600'
+                            }`}
+                            title={
+                              !selectedVersionId
+                                ? 'Open a version first'
+                                : quickSnapshotSavedFlash
+                                  ? 'Snapshot captured'
+                                  : 'Capture a local snapshot of this layout'
+                            }
+                          >
+                            {quickSnapshotSavedFlash ? (
+                              <>
+                                <Check className="w-4 h-4" />
+                                <span>Captured</span>
+                              </>
+                            ) : (
+                              <>
+                                <Camera className="w-4 h-4" />
+                                <span>Capture snapshot</span>
+                              </>
+                            )}
+                          </button>
+                          {quickLayoutSnapshots.length > 0 ? (
+                            <div className="rounded-lg border border-gray-200 dark:border-gray-600 bg-gray-50 dark:bg-gray-800/40 px-2.5 py-2 max-h-32 overflow-y-auto overscroll-contain">
+                              <p className="text-[10px] font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-1.5">
+                                Recent ({quickLayoutSnapshots.length})
+                              </p>
+                              <ul className="space-y-1.5">
+                                {quickLayoutSnapshots.slice(0, 6).map((s) => (
+                                  <li key={s.id} className="flex items-center gap-2 text-xs text-gray-600 dark:text-gray-300">
+                                    {s.thumbnailDataUrl ? (
+                                      <img
+                                        src={s.thumbnailDataUrl}
+                                        alt=""
+                                        className="h-9 w-14 shrink-0 rounded object-cover border border-gray-200 dark:border-gray-600 bg-gray-100 dark:bg-gray-800"
+                                      />
+                                    ) : (
+                                      <span className="h-9 w-14 shrink-0 rounded border border-dashed border-gray-300 dark:border-gray-600 bg-gray-100/50 dark:bg-gray-800/50" />
+                                    )}
+                                    <span className="tabular-nums truncate" title={s.createdAt}>
+                                      {new Date(s.createdAt).toLocaleString(undefined, {
+                                        month: 'short',
+                                        day: 'numeric',
+                                        hour: '2-digit',
+                                        minute: '2-digit',
+                                      })}
+                                    </span>
+                                  </li>
+                                ))}
+                              </ul>
+                            </div>
+                          ) : null}
                         </div>
                         <div
                           className={`mt-3 pt-3 border-t border-gray-200 dark:border-gray-700 space-y-2 ${

--- a/objectified-ui/tests/quick-layout-snapshots.test.ts
+++ b/objectified-ui/tests/quick-layout-snapshots.test.ts
@@ -44,11 +44,55 @@ describe('quick-layout-snapshots', () => {
 
   it('round-trips snapshots through localStorage', () => {
     const s = makeSnapshot('a', new Date().toISOString());
-    appendQuickLayoutSnapshot(versionId, userId, s);
+    const { snapshots, persisted } = appendQuickLayoutSnapshot(versionId, userId, s);
+    expect(persisted).toBe(true);
+    expect(snapshots).toHaveLength(1);
     const loaded = loadQuickLayoutSnapshots(versionId, userId);
     expect(loaded).toHaveLength(1);
     expect(loaded[0].id).toBe('a');
     expect(loaded[0].payload.viewport.zoom).toBe(1);
+  });
+
+  it('returns persisted:false and retries without thumbnails when setItem throws', () => {
+    const s = makeSnapshot('quota-test', new Date().toISOString());
+    let callCount = 0;
+    const original = Storage.prototype.setItem;
+    Storage.prototype.setItem = (key: string, value: string) => {
+      callCount += 1;
+      // First call fails (simulates quota exceeded), second call succeeds.
+      if (callCount === 1) throw new DOMException('QuotaExceededError');
+      original.call(localStorage, key, value);
+    };
+    try {
+      const { persisted } = appendQuickLayoutSnapshot(versionId, userId, s);
+      // Second attempt (stripped thumbnails) should succeed.
+      expect(persisted).toBe(true);
+      expect(callCount).toBe(2);
+      // Thumbnail should be stripped in the persisted data.
+      const loaded = loadQuickLayoutSnapshots(versionId, userId);
+      expect(loaded).toHaveLength(1);
+      expect(loaded[0].thumbnailDataUrl).toBeUndefined();
+    } finally {
+      Storage.prototype.setItem = original;
+    }
+  });
+
+  it('returns persisted:false when both setItem attempts throw', () => {
+    const s = makeSnapshot('always-fails', new Date().toISOString());
+    const original = Storage.prototype.setItem;
+    Storage.prototype.setItem = () => {
+      throw new DOMException('QuotaExceededError');
+    };
+    try {
+      const { snapshots, persisted } = appendQuickLayoutSnapshot(versionId, userId, s);
+      expect(persisted).toBe(false);
+      // In-memory list is still returned.
+      expect(snapshots).toHaveLength(1);
+      // Nothing written to storage.
+      expect(loadQuickLayoutSnapshots(versionId, userId)).toHaveLength(0);
+    } finally {
+      Storage.prototype.setItem = original;
+    }
   });
 
   it('prepends newest snapshots', () => {

--- a/objectified-ui/tests/quick-layout-snapshots.test.ts
+++ b/objectified-ui/tests/quick-layout-snapshots.test.ts
@@ -1,0 +1,108 @@
+import {
+  appendQuickLayoutSnapshot,
+  loadQuickLayoutSnapshots,
+  quickLayoutSnapshotsStorageKey,
+  isQuickLayoutSnapshot,
+  DEFAULT_MAX_QUICK_LAYOUT_SNAPSHOTS,
+  type QuickLayoutSnapshot,
+} from '@/app/ade/studio/editor/lib/quick-layout-snapshots';
+
+const samplePayload = {
+  schemaVersion: 1 as const,
+  viewport: { x: 0, y: 0, zoom: 1 },
+  nodes: [],
+  edges: [],
+  groups: [],
+};
+
+function makeSnapshot(id: string, createdAt: string): QuickLayoutSnapshot {
+  return {
+    id,
+    createdAt,
+    thumbnailDataUrl: 'data:image/png;base64,AA==',
+    payload: { ...samplePayload },
+  };
+}
+
+describe('quick-layout-snapshots', () => {
+  const versionId = 'ver-quick-snap-1';
+  const userId = 'user-42';
+
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('builds a stable storage key including version and user', () => {
+    expect(quickLayoutSnapshotsStorageKey(versionId, userId)).toBe(
+      `objectified.quickCanvasSnapshots.v1:${versionId}:${userId}`
+    );
+  });
+
+  it('uses anonymous bucket when userId is null', () => {
+    expect(quickLayoutSnapshotsStorageKey(versionId, null)).toContain('anonymous');
+  });
+
+  it('round-trips snapshots through localStorage', () => {
+    const s = makeSnapshot('a', new Date().toISOString());
+    appendQuickLayoutSnapshot(versionId, userId, s);
+    const loaded = loadQuickLayoutSnapshots(versionId, userId);
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0].id).toBe('a');
+    expect(loaded[0].payload.viewport.zoom).toBe(1);
+  });
+
+  it('prepends newest snapshots', () => {
+    const first = makeSnapshot('first', '2026-01-01T00:00:00.000Z');
+    const second = makeSnapshot('second', '2026-01-02T00:00:00.000Z');
+    appendQuickLayoutSnapshot(versionId, userId, first);
+    appendQuickLayoutSnapshot(versionId, userId, second);
+    const loaded = loadQuickLayoutSnapshots(versionId, userId);
+    expect(loaded.map((x) => x.id)).toEqual(['second', 'first']);
+  });
+
+  it('caps snapshot count', () => {
+    const max = DEFAULT_MAX_QUICK_LAYOUT_SNAPSHOTS;
+    for (let i = 0; i < max + 5; i += 1) {
+      appendQuickLayoutSnapshot(versionId, userId, makeSnapshot(`id-${i}`, `2026-01-01T00:00:0${i}.000Z`), {
+        maxSnapshots: max,
+      });
+    }
+    expect(loadQuickLayoutSnapshots(versionId, userId)).toHaveLength(max);
+    expect(loadQuickLayoutSnapshots(versionId, userId)[0].id).toBe(`id-${max + 4}`);
+  });
+
+  it('returns empty array for invalid JSON in storage', () => {
+    localStorage.setItem(quickLayoutSnapshotsStorageKey(versionId, userId), 'not-json');
+    expect(loadQuickLayoutSnapshots(versionId, userId)).toEqual([]);
+  });
+
+  it('filters out invalid snapshot entries', () => {
+    const ok = makeSnapshot('ok', '2026-01-01T00:00:00.000Z');
+    localStorage.setItem(
+      quickLayoutSnapshotsStorageKey(versionId, userId),
+      JSON.stringify([ok, { id: '', createdAt: 'x', payload: {} }])
+    );
+    expect(loadQuickLayoutSnapshots(versionId, userId)).toHaveLength(1);
+    expect(loadQuickLayoutSnapshots(versionId, userId)[0].id).toBe('ok');
+  });
+
+  it('isQuickLayoutSnapshot rejects wrong schema version', () => {
+    expect(
+      isQuickLayoutSnapshot({
+        id: '1',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        payload: { schemaVersion: 0, viewport: { x: 0, y: 0, zoom: 1 }, nodes: [], edges: [], groups: [] },
+      })
+    ).toBe(false);
+  });
+
+  it('isQuickLayoutSnapshot accepts snapshot without thumbnail', () => {
+    expect(
+      isQuickLayoutSnapshot({
+        id: '1',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        payload: samplePayload,
+      })
+    ).toBe(true);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -14,6 +14,6 @@
   ],
   "packageManager": "yarn@4.12.0",
   "devDependencies": {
-    "turbo": "^2.9.1"
+    "turbo": "^2.9.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3549,44 +3549,44 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@turbo/darwin-64@npm:2.9.1":
-  version: 2.9.1
-  resolution: "@turbo/darwin-64@npm:2.9.1"
+"@turbo/darwin-64@npm:2.9.3":
+  version: 2.9.3
+  resolution: "@turbo/darwin-64@npm:2.9.3"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@turbo/darwin-arm64@npm:2.9.1":
-  version: 2.9.1
-  resolution: "@turbo/darwin-arm64@npm:2.9.1"
+"@turbo/darwin-arm64@npm:2.9.3":
+  version: 2.9.3
+  resolution: "@turbo/darwin-arm64@npm:2.9.3"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@turbo/linux-64@npm:2.9.1":
-  version: 2.9.1
-  resolution: "@turbo/linux-64@npm:2.9.1"
+"@turbo/linux-64@npm:2.9.3":
+  version: 2.9.3
+  resolution: "@turbo/linux-64@npm:2.9.3"
   conditions: os=linux & cpu=x64
   languageName: node
   linkType: hard
 
-"@turbo/linux-arm64@npm:2.9.1":
-  version: 2.9.1
-  resolution: "@turbo/linux-arm64@npm:2.9.1"
+"@turbo/linux-arm64@npm:2.9.3":
+  version: 2.9.3
+  resolution: "@turbo/linux-arm64@npm:2.9.3"
   conditions: os=linux & cpu=arm64
   languageName: node
   linkType: hard
 
-"@turbo/windows-64@npm:2.9.1":
-  version: 2.9.1
-  resolution: "@turbo/windows-64@npm:2.9.1"
+"@turbo/windows-64@npm:2.9.3":
+  version: 2.9.3
+  resolution: "@turbo/windows-64@npm:2.9.3"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
-"@turbo/windows-arm64@npm:2.9.1":
-  version: 2.9.1
-  resolution: "@turbo/windows-arm64@npm:2.9.1"
+"@turbo/windows-arm64@npm:2.9.3":
+  version: 2.9.3
+  resolution: "@turbo/windows-arm64@npm:2.9.3"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
@@ -10488,7 +10488,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "objectified@workspace:."
   dependencies:
-    turbo: "npm:^2.9.1"
+    turbo: "npm:^2.9.3"
   languageName: unknown
   linkType: soft
 
@@ -12527,16 +12527,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"turbo@npm:^2.9.1":
-  version: 2.9.1
-  resolution: "turbo@npm:2.9.1"
+"turbo@npm:^2.9.3":
+  version: 2.9.3
+  resolution: "turbo@npm:2.9.3"
   dependencies:
-    "@turbo/darwin-64": "npm:2.9.1"
-    "@turbo/darwin-arm64": "npm:2.9.1"
-    "@turbo/linux-64": "npm:2.9.1"
-    "@turbo/linux-arm64": "npm:2.9.1"
-    "@turbo/windows-64": "npm:2.9.1"
-    "@turbo/windows-arm64": "npm:2.9.1"
+    "@turbo/darwin-64": "npm:2.9.3"
+    "@turbo/darwin-arm64": "npm:2.9.3"
+    "@turbo/linux-64": "npm:2.9.3"
+    "@turbo/linux-arm64": "npm:2.9.3"
+    "@turbo/windows-64": "npm:2.9.3"
+    "@turbo/windows-arm64": "npm:2.9.3"
   dependenciesMeta:
     "@turbo/darwin-64":
       optional: true
@@ -12552,7 +12552,7 @@ __metadata:
       optional: true
   bin:
     turbo: bin/turbo
-  checksum: 10c0/c474a2dbdc60534a66ce7e0dafa49cd21269334e8420cbae5026e4d99af5d5bcb5b1cfdb243deac61d41ff80b9fc0c42efc2b048241ae7753df961cb12c4c3d0
+  checksum: 10c0/902ce6cccd5a3a947b3cf55d60efd9ab15aae4fb5c3745589a64db918691b7660cd529c4bf21d2e0b2e769ddb230a989bede3d6113f9b8c2de28794924c00d76
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Problem Statement

Users and teams need **addresses #168 — quick local canvas layout snapshots** within the Objectified platform. Today this capability is missing or only partially implemented, which blocks dashboard workflows and creates inconsistency across tenants and projects.

## Solution / Scope

Implement **Addresses #168 — quick local canvas layout snapshots** as part of **Dashboard**. KPIs, primitives browser, project overview, quick actions.

**Post-MVP** (prioritize after MVP slice) candidacy.

```mermaid
flowchart TB
  CP[Control Panel] --> KPIs[Stats cards]
  CP --> Primitives[Primitives list]
  CP --> Projects[Recent projects]
  CP --> Actions[Quick actions]
```

## Acceptance Criteria

- [ ] Feature behaves as described for: Addresses #168 — quick local canvas layout snapshots
- [ ] Unit/integration tests cover happy path and primary error cases
- [ ] UI (if applicable) matches existing ADE patterns (Tailwind 4, Radix, Lucide)
- [ ] REST endpoints (if applicable) follow `/v1/{{feature}}/{{tenant_slug}}/...` conventions
- [ ] Documented in issue/PR; no regressions to existing schema/version flows

## Parallelism / Dependencies

- **Can run in parallel:** Yes
- **Blockers:** None identified; validate against current codebase before starting

## Technical Stack

- **Modules:** objectified-rest
- **Stack:** Next.js ADE dashboard, control panel components, REST stats APIs
- **Labels:** ``

---

**Epic:** [[Epic] Dashboard & Control Panel](https://github.com/objectified-project/objectified/issues/3493)
**Issue:** #868 · **Area:** Dashboard · **Roadmap batch:** legacy #64–#879 enrichment