### PR TITLE
Canvas: thumbnail card for each quick layout snapshot (#169)

### DIFF
--- a/PLANNED_FEATURE_ROADMAP_CANVAS.md
+++ b/PLANNED_FEATURE_ROADMAP_CANVAS.md
@@ -14,7 +14,7 @@
 #### Layout Snapshots ✅ BASIC (named layouts)
 - ✅ PNG snapshot stored with each named layout save; thumbnail preview when picking a layout name (#314)
 - ✅ Take quick snapshots of current layout (#168) — local browser capture from Layout panel
-- 📋 [TODO] Thumbnail preview of each snapshot
+- ✅ Thumbnail preview of each snapshot (#169)
 - 📋 [TODO] Restore any snapshot with one click
 - 📋 [TODO] Compare two snapshots side-by-side
 - 📋 [TODO] Snapshot gallery view with search/filter
@@ -23,7 +23,6 @@
 
 | Ticket | Feature                                           |
 |--------|---------------------------------------------------|
-| #169   | Thumbnail preview of each snapshot                |
 | #170   | Restore any snapshot with one click               |
 | #171   | Compare two snapshots side-by-side                |
 | #172   | Snapshot gallery view with search/filter          |

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.8.78",
+  "version": "0.8.79",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -20,6 +20,7 @@ Improvements:
 - Canvas: schema timeline panel shows class count, relationships, and complexity across project versions (#323)
 - Canvas: named layout saves store a PNG snapshot for thumbnail preview in the layout menu
 - Canvas: Layout panel quick snapshots capture viewport, nodes, edges, groups, and a local PNG preview in the browser without naming or server save; restore UI is planned (#168)
+- Canvas: quick snapshot list shows a thumbnail card per capture (scrollable grid; placeholder when preview was not stored) (#169)
 - Canvas: export and import canvas layouts as versioned JSON (share across versions and projects)
 - Canvas: layout import and named layout load restore edge handle routing when saved edge IDs match the canvas (#316)
 

--- a/objectified-ui/src/app/ade/studio/editor/page.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/page.tsx
@@ -8586,7 +8586,7 @@ const StudioContent = () => {
                             Quick snapshots
                           </p>
                           <p className="text-xs text-gray-500 dark:text-gray-400 leading-snug">
-                            Save the current canvas to this browser only—no layout name or server save. Use for ad-hoc checkpoints; restore and gallery are planned next.
+                            Save the current canvas to this browser only—no layout name or server save. Each capture keeps a thumbnail preview below; restore is planned next (#170).
                           </p>
                           <button
                             type="button"
@@ -8620,32 +8620,47 @@ const StudioContent = () => {
                             )}
                           </button>
                           {quickLayoutSnapshots.length > 0 ? (
-                            <div className="rounded-lg border border-gray-200 dark:border-gray-600 bg-gray-50 dark:bg-gray-800/40 px-2.5 py-2 max-h-32 overflow-y-auto overscroll-contain">
-                              <p className="text-[10px] font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-1.5">
+                            <div className="rounded-lg border border-gray-200 dark:border-gray-600 bg-gray-50 dark:bg-gray-800/40 px-2.5 py-2 max-h-60 overflow-y-auto overscroll-contain">
+                              <p className="text-[10px] font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-2">
                                 Recent ({quickLayoutSnapshots.length})
                               </p>
-                              <ul className="space-y-1.5">
-                                {quickLayoutSnapshots.slice(0, 6).map((s) => (
-                                  <li key={s.id} className="flex items-center gap-2 text-xs text-gray-600 dark:text-gray-300">
-                                    {s.thumbnailDataUrl ? (
-                                      <img
-                                        src={s.thumbnailDataUrl}
-                                        alt=""
-                                        className="h-9 w-14 shrink-0 rounded object-cover border border-gray-200 dark:border-gray-600 bg-gray-100 dark:bg-gray-800"
-                                      />
-                                    ) : (
-                                      <span className="h-9 w-14 shrink-0 rounded border border-dashed border-gray-300 dark:border-gray-600 bg-gray-100/50 dark:bg-gray-800/50" />
-                                    )}
-                                    <span className="tabular-nums truncate" title={s.createdAt}>
-                                      {new Date(s.createdAt).toLocaleString(undefined, {
-                                        month: 'short',
-                                        day: 'numeric',
-                                        hour: '2-digit',
-                                        minute: '2-digit',
-                                      })}
-                                    </span>
-                                  </li>
-                                ))}
+                              <ul className="grid grid-cols-2 gap-2">
+                                {quickLayoutSnapshots.map((s) => {
+                                  const caption = new Date(s.createdAt).toLocaleString(undefined, {
+                                    month: 'short',
+                                    day: 'numeric',
+                                    hour: '2-digit',
+                                    minute: '2-digit',
+                                  });
+                                  return (
+                                    <li
+                                      key={s.id}
+                                      className="overflow-hidden rounded-md border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-800/70 shadow-sm"
+                                      title={`Quick snapshot — ${s.createdAt}`}
+                                    >
+                                      <div className="relative aspect-[5/3] w-full bg-gray-100 dark:bg-gray-900">
+                                        {s.thumbnailDataUrl ? (
+                                          <img
+                                            src={s.thumbnailDataUrl}
+                                            alt=""
+                                            className="absolute inset-0 h-full w-full object-cover"
+                                          />
+                                        ) : (
+                                          <div
+                                            className="absolute inset-0 flex flex-col items-center justify-center gap-1 px-1 text-center text-gray-400 dark:text-gray-500"
+                                            aria-label="No preview image for this snapshot"
+                                          >
+                                            <Image className="h-5 w-5 shrink-0 opacity-60" aria-hidden />
+                                            <span className="text-[9px] leading-tight">No preview</span>
+                                          </div>
+                                        )}
+                                      </div>
+                                      <p className="border-t border-gray-100 dark:border-gray-700/80 px-1.5 py-1 text-[10px] tabular-nums text-gray-600 dark:text-gray-300 truncate">
+                                        {caption}
+                                      </p>
+                                    </li>
+                                  );
+                                })}
                               </ul>
                             </div>
                           ) : null}

--- a/objectified-ui/src/app/ade/studio/editor/page.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/page.tsx
@@ -8644,10 +8644,13 @@ const StudioContent = () => {
                                             src={s.thumbnailDataUrl}
                                             alt=""
                                             className="absolute inset-0 h-full w-full object-cover"
+                                            loading="lazy"
+                                            decoding="async"
                                           />
                                         ) : (
                                           <div
                                             className="absolute inset-0 flex flex-col items-center justify-center gap-1 px-1 text-center text-gray-400 dark:text-gray-500"
+                                            role="img"
                                             aria-label="No preview image for this snapshot"
                                           >
                                             <Image className="h-5 w-5 shrink-0 opacity-60" aria-hidden />


### PR DESCRIPTION
## Problem Statement

Users and teams need **canvas: thumbnail card for each quick layout snapshot (#169)** within the Objectified platform. Today this capability is missing or only partially implemented, which blocks dashboard workflows and creates inconsistency across tenants and projects.

## Solution / Scope

Implement **Canvas: thumbnail card for each quick layout snapshot (#169)** as part of **Dashboard**. KPIs, primitives browser, project overview, quick actions.

**Post-MVP** (prioritize after MVP slice) candidacy.

```mermaid
flowchart TB
  CP[Control Panel] --> KPIs[Stats cards]
  CP --> Primitives[Primitives list]
  CP --> Projects[Recent projects]
  CP --> Actions[Quick actions]
```

## Acceptance Criteria

- [ ] Feature behaves as described for: Canvas: thumbnail card for each quick layout snapshot (#169)
- [ ] Unit/integration tests cover happy path and primary error cases
- [ ] UI (if applicable) matches existing ADE patterns (Tailwind 4, Radix, Lucide)
- [ ] REST endpoints (if applicable) follow `/v1/{{feature}}/{{tenant_slug}}/...` conventions
- [ ] Documented in issue/PR; no regressions to existing schema/version flows

## Parallelism / Dependencies

- **Can run in parallel:** Yes
- **Blockers:** None identified; validate against current codebase before starting

## Technical Stack

- **Modules:** objectified-rest
- **Stack:** Next.js ADE dashboard, control panel components, REST stats APIs
- **Labels:** ``

---

**Epic:** [[Epic] Dashboard & Control Panel](https://github.com/objectified-project/objectified/issues/3493)
**Issue:** #869 · **Area:** Dashboard · **Roadmap batch:** legacy #64–#879 enrichment