### PR TITLE
Fix #170 — Restore quick layout snapshots in one click

### DIFF
--- a/FEATURE_ROADMAP.md
+++ b/FEATURE_ROADMAP.md
@@ -112,7 +112,7 @@
 **Layout Snapshots**
 - Take quick snapshots of current layout
 - Thumbnail preview of each snapshot
-- Restore any snapshot with one click
+- ✅ Restore any snapshot with one click (#170)
 - Compare two snapshots side-by-side
 - Snapshot gallery view with search/filter
 - Auto-snapshots before major changes

--- a/PLANNED_FEATURE_ROADMAP_CANVAS.md
+++ b/PLANNED_FEATURE_ROADMAP_CANVAS.md
@@ -15,7 +15,7 @@
 - ✅ PNG snapshot stored with each named layout save; thumbnail preview when picking a layout name (#314)
 - ✅ Take quick snapshots of current layout (#168) — local browser capture from Layout panel
 - ✅ Thumbnail preview of each snapshot (#169)
-- 📋 [TODO] Restore any snapshot with one click
+- ✅ Restore any snapshot with one click (#170)
 - 📋 [TODO] Compare two snapshots side-by-side
 - 📋 [TODO] Snapshot gallery view with search/filter
 - 📋 [TODO] Auto-snapshots before major changes
@@ -23,7 +23,6 @@
 
 | Ticket | Feature                                           |
 |--------|---------------------------------------------------|
-| #170   | Restore any snapshot with one click               |
 | #171   | Compare two snapshots side-by-side                |
 | #172   | Snapshot gallery view with search/filter          |
 | #173   | Snapshot metadata: timestamp, author, description |

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.8.79",
+  "version": "0.8.80",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -19,8 +19,9 @@ Improvements:
 - Canvas: layout auto-save uses a steady timer while edits are pending so saves occur every 30 seconds (or your chosen interval) without resetting on each move (#315)
 - Canvas: schema timeline panel shows class count, relationships, and complexity across project versions (#323)
 - Canvas: named layout saves store a PNG snapshot for thumbnail preview in the layout menu
-- Canvas: Layout panel quick snapshots capture viewport, nodes, edges, groups, and a local PNG preview in the browser without naming or server save; restore UI is planned (#168)
+- Canvas: Layout panel quick snapshots capture viewport, nodes, edges, groups, and a local PNG preview in the browser without naming or server save (#168)
 - Canvas: quick snapshot list shows a thumbnail card per capture (scrollable grid; placeholder when preview was not stored) (#169)
+- Canvas: click a quick snapshot thumbnail to restore that layout (confirm + sign-in; groups sync like layout import) (#170)
 - Canvas: export and import canvas layouts as versioned JSON (share across versions and projects)
 - Canvas: layout import and named layout load restore edge handle routing when saved edge IDs match the canvas (#316)
 

--- a/objectified-ui/src/app/ade/studio/editor/page.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/page.tsx
@@ -180,6 +180,7 @@ import {
   buildCanvasLayoutJsonDocument,
   CANVAS_LAYOUT_JSON_FORMAT_VERSION,
   type CanvasLayoutJsonDocument,
+  type FilteredCanvasLayoutForImport,
   parseCanvasLayoutJson,
   filterCanvasLayoutForTargetClasses,
   mergeSavedEdgeHandles,
@@ -5015,6 +5016,54 @@ const StudioContent = () => {
     ]
   );
 
+  /**
+   * Shared helper: sync groups for the current version, warn about dropped classes, then apply the
+   * filtered layout. Returns `true` on success, `false` if sync failed (caller should abort).
+   */
+  const syncGroupsAndApplyFilteredLayout = useCallback(
+    async (
+      filtered: FilteredCanvasLayoutForImport,
+      options?: { layoutNameToSet?: string; droppedFromLabel?: string }
+    ): Promise<boolean> => {
+      const syncRes = await syncGroupsForVersion(
+        selectedVersionId,
+        filtered.groups,
+        filtered.nodePositions
+      );
+      const syncParsed = JSON.parse(syncRes);
+      if (!syncParsed.success) {
+        await alertDialog({
+          message: syncParsed.error || 'Failed to sync groups for this layout.',
+          variant: 'error',
+        });
+        setIsLoadingCanvas(false);
+        setLoadingMessage('');
+        return false;
+      }
+
+      if (filtered.droppedClassCount > 0) {
+        const from = options?.droppedFromLabel ?? 'the layout';
+        await alertDialog({
+          message: `${filtered.droppedClassCount} class(es) from ${from} are not in this version and were skipped.`,
+          variant: 'warning',
+        });
+      }
+
+      await applyCanvasLayoutPayload({
+        layout: {
+          viewport: filtered.viewport,
+          nodes: filtered.nodes,
+          edges: filtered.edges,
+        },
+        layoutNameToSet: options?.layoutNameToSet,
+        clearGroupsWhenEmpty: true,
+      });
+
+      return true;
+    },
+    [selectedVersionId, alertDialog, applyCanvasLayoutPayload]
+  );
+
   /** Restore a local quick snapshot: sync groups to DB then apply viewport, node positions, and edges. */
   const handleRestoreQuickLayoutSnapshot = useCallback(
     async (snapshot: QuickLayoutSnapshot) => {
@@ -5070,37 +5119,10 @@ const StudioContent = () => {
         };
         const filtered = filterCanvasLayoutForTargetClasses(doc, validIds);
 
-        const syncRes = await syncGroupsForVersion(
-          selectedVersionId,
-          filtered.groups,
-          filtered.nodePositions
-        );
-        const syncParsed = JSON.parse(syncRes);
-        if (!syncParsed.success) {
-          await alertDialog({
-            message: syncParsed.error || 'Failed to sync groups for this snapshot.',
-            variant: 'error',
-          });
-          setIsLoadingCanvas(false);
-          setLoadingMessage('');
-          return;
-        }
-
-        if (filtered.droppedClassCount > 0) {
-          await alertDialog({
-            message: `${filtered.droppedClassCount} class(es) from the snapshot are not in this version and were skipped.`,
-            variant: 'warning',
-          });
-        }
-
-        await applyCanvasLayoutPayload({
-          layout: {
-            viewport: filtered.viewport,
-            nodes: filtered.nodes,
-            edges: filtered.edges,
-          },
-          clearGroupsWhenEmpty: true,
+        const applied = await syncGroupsAndApplyFilteredLayout(filtered, {
+          droppedFromLabel: 'the snapshot',
         });
+        if (!applied) return;
       } catch (error) {
         console.error('Error restoring quick layout snapshot:', error);
         await alertDialog({
@@ -5118,10 +5140,9 @@ const StudioContent = () => {
       isReadOnly,
       alertDialog,
       confirmDialog,
-      applyCanvasLayoutPayload,
+      syncGroupsAndApplyFilteredLayout,
     ]
   );
-
   // Load saved canvas layout
   const handleLoadLayout = useCallback(async () => {
     if (!selectedVersionId || !currentUserId) return;
@@ -5273,40 +5294,11 @@ const StudioContent = () => {
         const validIds = new Set<string>(idsParsed.classIds);
         const filtered = filterCanvasLayoutForTargetClasses(parsed.doc, validIds);
 
-        const syncRes = await syncGroupsForVersion(
-          selectedVersionId,
-          filtered.groups,
-          filtered.nodePositions
-        );
-        const syncParsed = JSON.parse(syncRes);
-        if (!syncParsed.success) {
-          await alertDialog({
-            message: syncParsed.error || 'Failed to sync groups for this layout.',
-            variant: 'error',
-          });
-          setIsLoadingCanvas(false);
-          setLoadingMessage('');
-          return;
-        }
-
-        if (filtered.droppedClassCount > 0) {
-          await alertDialog({
-            message: `${filtered.droppedClassCount} class(es) from the file are not in this version and were skipped.`,
-            variant: 'warning',
-          });
-        }
-
-        const layoutPayload = {
-          viewport: filtered.viewport,
-          nodes: filtered.nodes,
-          edges: filtered.edges,
-        };
-
-        await applyCanvasLayoutPayload({
-          layout: layoutPayload,
+        const applied = await syncGroupsAndApplyFilteredLayout(filtered, {
           layoutNameToSet: parsed.doc.layoutName?.trim() || selectedLayoutName,
-          clearGroupsWhenEmpty: true,
+          droppedFromLabel: 'the file',
         });
+        if (!applied) return;
       } catch (err) {
         console.error('Error importing layout JSON:', err);
         await alertDialog({
@@ -5324,11 +5316,10 @@ const StudioContent = () => {
       isReadOnly,
       alertDialog,
       confirmDialog,
-      applyCanvasLayoutPayload,
+      syncGroupsAndApplyFilteredLayout,
       selectedLayoutName,
     ]
   );
-
   const handleRestoreLayoutRevision = useCallback(
     async (revisionId: string) => {
       if (!selectedVersionId || !currentUserId || isReadOnly) return;
@@ -8748,6 +8739,7 @@ const StudioContent = () => {
                                         type="button"
                                         disabled={restoreDisabled}
                                         onClick={() => void handleRestoreQuickLayoutSnapshot(s)}
+                                        aria-label={`Restore quick snapshot from ${caption}`}
                                         className={`w-full overflow-hidden rounded-md border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-800/70 shadow-sm text-left transition-opacity ${
                                           restoreDisabled
                                             ? 'opacity-50 cursor-not-allowed'
@@ -8760,9 +8752,9 @@ const StudioContent = () => {
                                               : !currentUserId
                                                 ? 'Sign in to restore snapshots'
                                                 : 'Please wait…'
-                                            : `Restore canvas from ${s.createdAt}`
+                                            : `Restore canvas from ${caption}`
                                         }
-                                      >
+                                       >
                                         <div className="relative aspect-[5/3] w-full bg-gray-100 dark:bg-gray-900 pointer-events-none">
                                           {s.thumbnailDataUrl ? (
                                             <img

--- a/objectified-ui/src/app/ade/studio/editor/page.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/page.tsx
@@ -178,6 +178,8 @@ import {
 import { computeLayoutQuality } from '@/app/utils/layout-quality';
 import {
   buildCanvasLayoutJsonDocument,
+  CANVAS_LAYOUT_JSON_FORMAT_VERSION,
+  type CanvasLayoutJsonDocument,
   parseCanvasLayoutJson,
   filterCanvasLayoutForTargetClasses,
   mergeSavedEdgeHandles,
@@ -5013,6 +5015,113 @@ const StudioContent = () => {
     ]
   );
 
+  /** Restore a local quick snapshot: sync groups to DB then apply viewport, node positions, and edges. */
+  const handleRestoreQuickLayoutSnapshot = useCallback(
+    async (snapshot: QuickLayoutSnapshot) => {
+      if (!selectedVersionId) {
+        await alertDialog({
+          message: 'Open a version before restoring a snapshot.',
+          variant: 'warning',
+        });
+        return;
+      }
+      if (!currentUserId) {
+        await alertDialog({
+          message: 'Sign in to restore a snapshot. Group frames are synced to your workspace.',
+          variant: 'warning',
+        });
+        return;
+      }
+      if (isReadOnly) {
+        await alertDialog({ message: 'Cannot restore a snapshot in read-only mode.', variant: 'warning' });
+        return;
+      }
+      const ok = await confirmDialog({
+        title: 'Restore quick snapshot',
+        message:
+          'Replace the current canvas with this snapshot? Classes removed since the capture are skipped; group membership matches the snapshot after sync.',
+      });
+      if (!ok) return;
+
+      try {
+        setLoadingMessage('Restoring snapshot...');
+        setIsLoadingCanvas(true);
+
+        const idsRes = await getClassIdsForVersion(selectedVersionId);
+        const idsParsed = JSON.parse(idsRes);
+        if (!idsParsed.success || !Array.isArray(idsParsed.classIds)) {
+          await alertDialog({
+            message: idsParsed.error || 'Could not load classes for this version.',
+            variant: 'error',
+          });
+          setIsLoadingCanvas(false);
+          setLoadingMessage('');
+          return;
+        }
+
+        const validIds = new Set<string>(idsParsed.classIds);
+        const doc: CanvasLayoutJsonDocument = {
+          formatVersion: CANVAS_LAYOUT_JSON_FORMAT_VERSION,
+          exportedAt: snapshot.createdAt,
+          viewport: snapshot.payload.viewport,
+          nodes: snapshot.payload.nodes as unknown[],
+          edges: snapshot.payload.edges as unknown[],
+          groups: snapshot.payload.groups as unknown[],
+        };
+        const filtered = filterCanvasLayoutForTargetClasses(doc, validIds);
+
+        const syncRes = await syncGroupsForVersion(
+          selectedVersionId,
+          filtered.groups,
+          filtered.nodePositions
+        );
+        const syncParsed = JSON.parse(syncRes);
+        if (!syncParsed.success) {
+          await alertDialog({
+            message: syncParsed.error || 'Failed to sync groups for this snapshot.',
+            variant: 'error',
+          });
+          setIsLoadingCanvas(false);
+          setLoadingMessage('');
+          return;
+        }
+
+        if (filtered.droppedClassCount > 0) {
+          await alertDialog({
+            message: `${filtered.droppedClassCount} class(es) from the snapshot are not in this version and were skipped.`,
+            variant: 'warning',
+          });
+        }
+
+        await applyCanvasLayoutPayload({
+          layout: {
+            viewport: filtered.viewport,
+            nodes: filtered.nodes,
+            edges: filtered.edges,
+          },
+          clearGroupsWhenEmpty: true,
+        });
+      } catch (error) {
+        console.error('Error restoring quick layout snapshot:', error);
+        await alertDialog({
+          message: 'Could not restore this snapshot. Try again.',
+          variant: 'error',
+        });
+        setIsLoadingCanvas(false);
+        setLoadingMessage('');
+        setLayoutDropdownOpen(false);
+      }
+    },
+    [
+      selectedVersionId,
+      currentUserId,
+      isReadOnly,
+      alertDialog,
+      confirmDialog,
+      applyCanvasLayoutPayload,
+    ]
+  );
+
   // Load saved canvas layout
   const handleLoadLayout = useCallback(async () => {
     if (!selectedVersionId || !currentUserId) return;
@@ -8586,7 +8695,7 @@ const StudioContent = () => {
                             Quick snapshots
                           </p>
                           <p className="text-xs text-gray-500 dark:text-gray-400 leading-snug">
-                            Save the current canvas to this browser only—no layout name or server save. Each capture keeps a thumbnail preview below; restore is planned next (#170).
+                            Save the current canvas to this browser only—no layout name or server save. Click a thumbnail to restore that capture (sign-in required; confirms before replacing the canvas).
                           </p>
                           <button
                             type="button"
@@ -8632,35 +8741,52 @@ const StudioContent = () => {
                                     hour: '2-digit',
                                     minute: '2-digit',
                                   });
+                                  const restoreDisabled = isReadOnly || !currentUserId || isLoadingCanvas;
                                   return (
-                                    <li
-                                      key={s.id}
-                                      className="overflow-hidden rounded-md border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-800/70 shadow-sm"
-                                      title={`Quick snapshot — ${s.createdAt}`}
-                                    >
-                                      <div className="relative aspect-[5/3] w-full bg-gray-100 dark:bg-gray-900">
-                                        {s.thumbnailDataUrl ? (
-                                          <img
-                                            src={s.thumbnailDataUrl}
-                                            alt=""
-                                            className="absolute inset-0 h-full w-full object-cover"
-                                            loading="lazy"
-                                            decoding="async"
-                                          />
-                                        ) : (
-                                          <div
-                                            className="absolute inset-0 flex flex-col items-center justify-center gap-1 px-1 text-center text-gray-400 dark:text-gray-500"
-                                            role="img"
-                                            aria-label="No preview image for this snapshot"
-                                          >
-                                            <Image className="h-5 w-5 shrink-0 opacity-60" aria-hidden />
-                                            <span className="text-[9px] leading-tight">No preview</span>
-                                          </div>
-                                        )}
-                                      </div>
-                                      <p className="border-t border-gray-100 dark:border-gray-700/80 px-1.5 py-1 text-[10px] tabular-nums text-gray-600 dark:text-gray-300 truncate">
-                                        {caption}
-                                      </p>
+                                    <li key={s.id} className="list-none">
+                                      <button
+                                        type="button"
+                                        disabled={restoreDisabled}
+                                        onClick={() => void handleRestoreQuickLayoutSnapshot(s)}
+                                        className={`w-full overflow-hidden rounded-md border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-800/70 shadow-sm text-left transition-opacity ${
+                                          restoreDisabled
+                                            ? 'opacity-50 cursor-not-allowed'
+                                            : 'hover:ring-2 hover:ring-indigo-400 dark:hover:ring-indigo-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500'
+                                        }`}
+                                        title={
+                                          restoreDisabled
+                                            ? isReadOnly
+                                              ? 'Read-only: cannot restore'
+                                              : !currentUserId
+                                                ? 'Sign in to restore snapshots'
+                                                : 'Please wait…'
+                                            : `Restore canvas from ${s.createdAt}`
+                                        }
+                                      >
+                                        <div className="relative aspect-[5/3] w-full bg-gray-100 dark:bg-gray-900 pointer-events-none">
+                                          {s.thumbnailDataUrl ? (
+                                            <img
+                                              src={s.thumbnailDataUrl}
+                                              alt=""
+                                              className="absolute inset-0 h-full w-full object-cover"
+                                              loading="lazy"
+                                              decoding="async"
+                                            />
+                                          ) : (
+                                            <div
+                                              className="absolute inset-0 flex flex-col items-center justify-center gap-1 px-1 text-center text-gray-400 dark:text-gray-500"
+                                              role="img"
+                                              aria-label="No preview image for this snapshot"
+                                            >
+                                              <Image className="h-5 w-5 shrink-0 opacity-60" aria-hidden />
+                                              <span className="text-[9px] leading-tight">No preview</span>
+                                            </div>
+                                          )}
+                                        </div>
+                                        <p className="border-t border-gray-100 dark:border-gray-700/80 px-1.5 py-1 text-[10px] tabular-nums text-gray-600 dark:text-gray-300 truncate pointer-events-none">
+                                          {caption}
+                                        </p>
+                                      </button>
                                     </li>
                                   );
                                 })}

--- a/objectified-ui/tests/canvas-layout-json.test.ts
+++ b/objectified-ui/tests/canvas-layout-json.test.ts
@@ -116,6 +116,28 @@ describe('canvas-layout-json', () => {
     expect((filtered.groups[0] as { nodeIds: string[] }).nodeIds).toEqual(['keep']);
   });
 
+  test('filterCanvasLayoutForTargetClasses accepts quick snapshot style nodes from mapNodesForLayoutSave', () => {
+    const doc = buildCanvasLayoutJsonDocument({
+      viewport: { x: 2, y: -3, zoom: 0.75 },
+      nodes: [
+        {
+          id: 'c1',
+          type: 'classNode',
+          position: { x: 11, y: 22 },
+          dimensions: { width: 180, height: 90 },
+        },
+      ],
+      edges: [{ id: 'e1', source: 'c1', target: 'c1', sourceHandle: 'h1', targetHandle: 'h2' }],
+      groups: [{ id: 'g1', name: 'G', nodeIds: ['c1'], position: { x: 0, y: 0 }, dimensions: { width: 50, height: 50 } }],
+    });
+    const filtered = filterCanvasLayoutForTargetClasses(doc, new Set(['c1']));
+    expect(filtered.viewport).toEqual({ x: 2, y: -3, zoom: 0.75 });
+    expect(filtered.nodes).toHaveLength(1);
+    expect(filtered.nodes[0]).toEqual({ id: 'c1', position: { x: 11, y: 22 } });
+    expect(filtered.edges).toHaveLength(1);
+    expect((filtered.groups[0] as { id: string }).id).toBe('g1');
+  });
+
   test('filterCanvasLayoutForTargetClasses drops nodes with invalid positions', () => {
     const doc = buildCanvasLayoutJsonDocument({
       viewport: { x: 0, y: 0, zoom: 1 },


### PR DESCRIPTION
## Problem Statement

Users and teams need **fix #170 — restore quick layout snapshots in one click** within the Objectified platform. Today this capability is missing or only partially implemented, which blocks dashboard workflows and creates inconsistency across tenants and projects.

## Solution / Scope

Implement **Fix #170 — Restore quick layout snapshots in one click** as part of **Dashboard**. KPIs, primitives browser, project overview, quick actions.

**Post-MVP** (prioritize after MVP slice) candidacy.

```mermaid
flowchart TB
  CP[Control Panel] --> KPIs[Stats cards]
  CP --> Primitives[Primitives list]
  CP --> Projects[Recent projects]
  CP --> Actions[Quick actions]
```

## Acceptance Criteria

- [ ] Feature behaves as described for: Fix #170 — Restore quick layout snapshots in one click
- [ ] Unit/integration tests cover happy path and primary error cases
- [ ] UI (if applicable) matches existing ADE patterns (Tailwind 4, Radix, Lucide)
- [ ] REST endpoints (if applicable) follow `/v1/{{feature}}/{{tenant_slug}}/...` conventions
- [ ] Documented in issue/PR; no regressions to existing schema/version flows

## Parallelism / Dependencies

- **Can run in parallel:** Yes
- **Blockers:** None identified; validate against current codebase before starting

## Technical Stack

- **Modules:** objectified-rest
- **Stack:** Next.js ADE dashboard, control panel components, REST stats APIs
- **Labels:** ``

---

**Epic:** [[Epic] Dashboard & Control Panel](https://github.com/objectified-project/objectified/issues/3493)
**Issue:** #870 · **Area:** Dashboard · **Roadmap batch:** legacy #64–#879 enrichment