### PR TITLE
Compare quick layout snapshots side-by-side (#171)

### DIFF
--- a/PLANNED_FEATURE_ROADMAP_CANVAS.md
+++ b/PLANNED_FEATURE_ROADMAP_CANVAS.md
@@ -16,14 +16,13 @@
 - ✅ Take quick snapshots of current layout (#168) — local browser capture from Layout panel
 - ✅ Thumbnail preview of each snapshot (#169)
 - ✅ Restore any snapshot with one click (#170)
-- 📋 [TODO] Compare two snapshots side-by-side
+- ✅ Compare two snapshots side-by-side (#171)
 - 📋 [TODO] Snapshot gallery view with search/filter
 - 📋 [TODO] Auto-snapshots before major changes
 - 📋 [TODO] Snapshot metadata: timestamp, author, description
 
 | Ticket | Feature                                           |
 |--------|---------------------------------------------------|
-| #171   | Compare two snapshots side-by-side                |
 | #172   | Snapshot gallery view with search/filter          |
 | #173   | Snapshot metadata: timestamp, author, description |
 

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.8.80",
+  "version": "0.8.81",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -22,6 +22,7 @@ Improvements:
 - Canvas: Layout panel quick snapshots capture viewport, nodes, edges, groups, and a local PNG preview in the browser without naming or server save (#168)
 - Canvas: quick snapshot list shows a thumbnail card per capture (scrollable grid; placeholder when preview was not stored) (#169)
 - Canvas: click a quick snapshot thumbnail to restore that layout (confirm + sign-in; groups sync like layout import) (#170)
+- Canvas: compare two quick snapshots side by side (previews, timestamps, node/edge/group counts) from the Layout panel (#171)
 - Canvas: export and import canvas layouts as versioned JSON (share across versions and projects)
 - Canvas: layout import and named layout load restore edge handle routing when saved edge IDs match the canvas (#316)
 

--- a/objectified-ui/src/app/ade/studio/editor/components/QuickSnapshotCompareDialog.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/components/QuickSnapshotCompareDialog.tsx
@@ -12,7 +12,9 @@ export interface QuickSnapshotCompareDialogProps {
 }
 
 function formatSnapshotCaption(createdAt: string): string {
-  return new Date(createdAt).toLocaleString(undefined, {
+  const d = new Date(createdAt);
+  if (!Number.isFinite(d.getTime())) return 'Unknown time';
+  return d.toLocaleString(undefined, {
     month: 'short',
     day: 'numeric',
     hour: '2-digit',
@@ -66,7 +68,6 @@ export function QuickSnapshotCompareDialog({
         <Dialog.Overlay className="fixed inset-0 z-[1300] bg-black/50 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
         <Dialog.Content
           className="fixed left-1/2 top-1/2 z-[1301] w-[min(96vw,56rem)] max-h-[min(92vh,44rem)] -translate-x-1/2 -translate-y-1/2 rounded-xl border border-gray-200 bg-white shadow-xl dark:border-gray-700 dark:bg-gray-900 flex flex-col min-h-0 outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95"
-          onOpenAutoFocus={(e) => e.preventDefault()}
         >
           <div className="flex shrink-0 items-start justify-between gap-3 border-b border-gray-200 px-4 py-3 dark:border-gray-700">
             <div className="flex items-start gap-2 min-w-0">
@@ -115,10 +116,14 @@ export function QuickSnapshotCompareDialog({
                     ] as const
                   ).map(({ label, id, setId, snap }) => (
                     <div key={label} className="flex min-w-0 flex-col gap-2">
-                      <label className="text-[10px] font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                      <label
+                        htmlFor={`snapshot-select-${label.toLowerCase()}`}
+                        className="text-[10px] font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400"
+                      >
                         {label}
                       </label>
                       <select
+                        id={`snapshot-select-${label.toLowerCase()}`}
                         value={id ?? ''}
                         onChange={(e) => setId(e.target.value || null)}
                         className="w-full rounded-lg border border-gray-200 bg-white px-2 py-2 text-xs text-gray-800 shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"

--- a/objectified-ui/src/app/ade/studio/editor/components/QuickSnapshotCompareDialog.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/components/QuickSnapshotCompareDialog.tsx
@@ -1,0 +1,172 @@
+'use client';
+
+import React, { useEffect, useLayoutEffect, useMemo, useState } from 'react';
+import * as Dialog from '@radix-ui/react-dialog';
+import { X, Columns2, ArrowLeftRight, Image as ImageIcon } from 'lucide-react';
+import type { QuickLayoutSnapshot } from '../lib/quick-layout-snapshots';
+
+export interface QuickSnapshotCompareDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  snapshots: QuickLayoutSnapshot[];
+}
+
+function formatSnapshotCaption(createdAt: string): string {
+  return new Date(createdAt).toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+function snapshotSummary(s: QuickLayoutSnapshot): string {
+  const { nodes, edges, groups } = s.payload;
+  const n = Array.isArray(nodes) ? nodes.length : 0;
+  const e = Array.isArray(edges) ? edges.length : 0;
+  const g = Array.isArray(groups) ? groups.length : 0;
+  return `${n} nodes · ${e} edges · ${g} groups`;
+}
+
+export function QuickSnapshotCompareDialog({
+  open,
+  onOpenChange,
+  snapshots,
+}: QuickSnapshotCompareDialogProps) {
+  const [leftId, setLeftId] = useState<string | null>(null);
+  const [rightId, setRightId] = useState<string | null>(null);
+
+  useLayoutEffect(() => {
+    if (!open || snapshots.length < 2) return;
+    const ids = new Set(snapshots.map((s) => s.id));
+    setLeftId((L) => (L && ids.has(L) ? L : snapshots[1].id));
+    setRightId((R) => (R && ids.has(R) ? R : snapshots[0].id));
+  }, [open, snapshots]);
+
+  const byId = useMemo(() => new Map(snapshots.map((s) => [s.id, s])), [snapshots]);
+  const left = leftId ? byId.get(leftId) : undefined;
+  const right = rightId ? byId.get(rightId) : undefined;
+
+  useEffect(() => {
+    if (!open || !leftId || !rightId || leftId !== rightId || snapshots.length < 2) return;
+    const alt = snapshots.find((s) => s.id !== leftId);
+    if (alt) setRightId(alt.id);
+  }, [open, leftId, rightId, snapshots]);
+
+  const swapSides = () => {
+    setLeftId(rightId);
+    setRightId(leftId);
+  };
+
+  const canCompare = snapshots.length >= 2;
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-[1300] bg-black/50 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
+        <Dialog.Content
+          className="fixed left-1/2 top-1/2 z-[1301] w-[min(96vw,56rem)] max-h-[min(92vh,44rem)] -translate-x-1/2 -translate-y-1/2 rounded-xl border border-gray-200 bg-white shadow-xl dark:border-gray-700 dark:bg-gray-900 flex flex-col min-h-0 outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95"
+          onOpenAutoFocus={(e) => e.preventDefault()}
+        >
+          <div className="flex shrink-0 items-start justify-between gap-3 border-b border-gray-200 px-4 py-3 dark:border-gray-700">
+            <div className="flex items-start gap-2 min-w-0">
+              <Columns2 className="mt-0.5 h-5 w-5 shrink-0 text-indigo-600 dark:text-indigo-400" aria-hidden />
+              <div className="min-w-0">
+                <Dialog.Title className="text-sm font-semibold text-gray-900 dark:text-white">
+                  Compare quick snapshots
+                </Dialog.Title>
+                <Dialog.Description className="mt-1 text-xs text-gray-500 dark:text-gray-400 leading-snug">
+                  Side-by-side preview and layout counts. List order is newest first; defaults put the older capture on
+                  the left and the newer on the right.
+                </Dialog.Description>
+              </div>
+            </div>
+            <Dialog.Close
+              type="button"
+              className="rounded-lg p-1.5 text-gray-500 hover:bg-gray-100 hover:text-gray-800 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
+              aria-label="Close"
+            >
+              <X className="h-4 w-4" />
+            </Dialog.Close>
+          </div>
+
+          <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-4 py-3">
+            {!canCompare ? (
+              <p className="text-sm text-gray-600 dark:text-gray-400">Capture at least two quick snapshots to compare.</p>
+            ) : (
+              <div className="space-y-3">
+                <div className="flex flex-wrap items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={swapSides}
+                    disabled={!left || !right}
+                    className="inline-flex items-center gap-1.5 rounded-lg border border-gray-200 bg-white px-2.5 py-1.5 text-xs font-medium text-gray-700 shadow-sm hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
+                  >
+                    <ArrowLeftRight className="h-3.5 w-3.5" aria-hidden />
+                    Swap sides
+                  </button>
+                </div>
+
+                <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                  {(
+                    [
+                      { label: 'Left', id: leftId, setId: setLeftId, snap: left },
+                      { label: 'Right', id: rightId, setId: setRightId, snap: right },
+                    ] as const
+                  ).map(({ label, id, setId, snap }) => (
+                    <div key={label} className="flex min-w-0 flex-col gap-2">
+                      <label className="text-[10px] font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                        {label}
+                      </label>
+                      <select
+                        value={id ?? ''}
+                        onChange={(e) => setId(e.target.value || null)}
+                        className="w-full rounded-lg border border-gray-200 bg-white px-2 py-2 text-xs text-gray-800 shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+                      >
+                        {snapshots.map((s) => (
+                          <option key={s.id} value={s.id}>
+                            {formatSnapshotCaption(s.createdAt)}
+                          </option>
+                        ))}
+                      </select>
+                      <div className="overflow-hidden rounded-lg border border-gray-200 bg-gray-50 dark:border-gray-600 dark:bg-gray-800/60">
+                        <div className="relative aspect-[5/3] w-full bg-gray-100 dark:bg-gray-900">
+                          {snap?.thumbnailDataUrl ? (
+                            <img
+                              src={snap.thumbnailDataUrl}
+                              alt=""
+                              className="absolute inset-0 h-full w-full object-cover"
+                            />
+                          ) : (
+                            <div
+                              className="absolute inset-0 flex flex-col items-center justify-center gap-1 px-2 text-center text-gray-400 dark:text-gray-500"
+                              role="img"
+                              aria-label="No preview"
+                            >
+                              <ImageIcon className="h-6 w-6 opacity-60" aria-hidden />
+                              <span className="text-[10px]">No preview</span>
+                            </div>
+                          )}
+                        </div>
+                        <div className="border-t border-gray-200 px-2 py-1.5 text-[10px] leading-snug text-gray-600 dark:text-gray-300 dark:border-gray-700">
+                          {snap ? (
+                            <>
+                              <p className="font-medium tabular-nums">{formatSnapshotCaption(snap.createdAt)}</p>
+                              <p className="text-gray-500 dark:text-gray-400">{snapshotSummary(snap)}</p>
+                            </>
+                          ) : (
+                            <p className="text-gray-500">Select a snapshot</p>
+                          )}
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/objectified-ui/src/app/ade/studio/editor/page.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/page.tsx
@@ -9355,7 +9355,7 @@ const StudioContent = () => {
             </DraggablePanel>
           )}
 
-          {/* Export Wizard Dialog */}
+          {/* Compare Snapshots & Export Wizard Dialogs */}
           <QuickSnapshotCompareDialog
             open={quickSnapshotCompareOpen}
             onOpenChange={setQuickSnapshotCompareOpen}

--- a/objectified-ui/src/app/ade/studio/editor/page.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/page.tsx
@@ -65,6 +65,7 @@ import {
   Presentation,
   PanelLeft,
   Camera,
+  Columns2,
 } from 'lucide-react';
 import * as Select from '@radix-ui/react-select';
 import * as ToggleGroup from '@radix-ui/react-toggle-group';
@@ -187,6 +188,7 @@ import {
 } from '@/app/utils/canvas-layout-json';
 import { computeSchemaMetrics, getCircularDependencyEdgeIds, getDependencyDepthMap, getAffectedClassIds, getUpstreamClassIds, getDependencyChainNodeAndEdgeIds } from '@/app/utils/schema-metrics';
 import { toPng } from 'html-to-image';
+import { QuickSnapshotCompareDialog } from './components/QuickSnapshotCompareDialog';
 import DraggablePanel from '../components/DraggablePanel';
 import MemoryProfiler from '../components/MemoryProfiler';
 import SchemaMetricsPanel from '../components/SchemaMetricsPanel';
@@ -602,6 +604,7 @@ const StudioContent = () => {
   /** Local quick snapshots for this version (#168); restore UI follows in #170. */
   const [quickLayoutSnapshots, setQuickLayoutSnapshots] = useState<QuickLayoutSnapshot[]>([]);
   const [quickSnapshotSavedFlash, setQuickSnapshotSavedFlash] = useState(false);
+  const [quickSnapshotCompareOpen, setQuickSnapshotCompareOpen] = useState(false);
   const canvasCaptureAreaRef = useRef<HTMLDivElement>(null);
   const presentationShellRef = useRef<HTMLDivElement>(null);
   const selectedLayoutNameRef = useRef(selectedLayoutName);
@@ -8688,37 +8691,57 @@ const StudioContent = () => {
                           <p className="text-xs text-gray-500 dark:text-gray-400 leading-snug">
                             Save the current canvas to this browser only—no layout name or server save. Click a thumbnail to restore that capture (sign-in required; confirms before replacing the canvas).
                           </p>
-                          <button
-                            type="button"
-                            onClick={() => void handleQuickLayoutSnapshot()}
-                            disabled={!selectedVersionId}
-                            className={`w-full px-3 py-2 text-sm font-medium rounded-lg transition-all duration-200 flex items-center justify-center gap-2 border ${
-                              quickSnapshotSavedFlash
-                                ? 'bg-emerald-50 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-300 border-emerald-200 dark:border-emerald-700'
-                                : selectedVersionId
+                          <div className="grid grid-cols-2 gap-2">
+                            <button
+                              type="button"
+                              onClick={() => void handleQuickLayoutSnapshot()}
+                              disabled={!selectedVersionId}
+                              className={`w-full px-3 py-2 text-sm font-medium rounded-lg transition-all duration-200 flex items-center justify-center gap-2 border ${
+                                quickSnapshotSavedFlash
+                                  ? 'bg-emerald-50 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-300 border-emerald-200 dark:border-emerald-700'
+                                  : selectedVersionId
+                                    ? 'bg-white dark:bg-gray-700/50 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600 border-gray-200 dark:border-gray-600'
+                                    : 'bg-gray-100 dark:bg-gray-700 text-gray-400 cursor-not-allowed border-gray-200 dark:border-gray-600'
+                              }`}
+                              title={
+                                !selectedVersionId
+                                  ? 'Open a version first'
+                                  : quickSnapshotSavedFlash
+                                    ? 'Snapshot captured'
+                                    : 'Capture a local snapshot of this layout'
+                              }
+                            >
+                              {quickSnapshotSavedFlash ? (
+                                <>
+                                  <Check className="w-4 h-4" />
+                                  <span>Captured</span>
+                                </>
+                              ) : (
+                                <>
+                                  <Camera className="w-4 h-4" />
+                                  <span>Capture</span>
+                                </>
+                              )}
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() => setQuickSnapshotCompareOpen(true)}
+                              disabled={quickLayoutSnapshots.length < 2}
+                              className={`w-full px-3 py-2 text-sm font-medium rounded-lg transition-all duration-200 flex items-center justify-center gap-2 border ${
+                                quickLayoutSnapshots.length >= 2
                                   ? 'bg-white dark:bg-gray-700/50 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600 border-gray-200 dark:border-gray-600'
                                   : 'bg-gray-100 dark:bg-gray-700 text-gray-400 cursor-not-allowed border-gray-200 dark:border-gray-600'
-                            }`}
-                            title={
-                              !selectedVersionId
-                                ? 'Open a version first'
-                                : quickSnapshotSavedFlash
-                                  ? 'Snapshot captured'
-                                  : 'Capture a local snapshot of this layout'
-                            }
-                          >
-                            {quickSnapshotSavedFlash ? (
-                              <>
-                                <Check className="w-4 h-4" />
-                                <span>Captured</span>
-                              </>
-                            ) : (
-                              <>
-                                <Camera className="w-4 h-4" />
-                                <span>Capture snapshot</span>
-                              </>
-                            )}
-                          </button>
+                              }`}
+                              title={
+                                quickLayoutSnapshots.length < 2
+                                  ? 'Capture at least two snapshots to compare'
+                                  : 'Compare two snapshots side by side'
+                              }
+                            >
+                              <Columns2 className="w-4 h-4" />
+                              <span>Compare</span>
+                            </button>
+                          </div>
                           {quickLayoutSnapshots.length > 0 ? (
                             <div className="rounded-lg border border-gray-200 dark:border-gray-600 bg-gray-50 dark:bg-gray-800/40 px-2.5 py-2 max-h-60 overflow-y-auto overscroll-contain">
                               <p className="text-[10px] font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-2">
@@ -9333,6 +9356,11 @@ const StudioContent = () => {
           )}
 
           {/* Export Wizard Dialog */}
+          <QuickSnapshotCompareDialog
+            open={quickSnapshotCompareOpen}
+            onOpenChange={setQuickSnapshotCompareOpen}
+            snapshots={quickLayoutSnapshots}
+          />
           <ExportWizard
             open={exportWizardOpen}
             onClose={() => setExportWizardOpen(false)}

--- a/objectified-ui/tests/QuickSnapshotCompareDialog.test.tsx
+++ b/objectified-ui/tests/QuickSnapshotCompareDialog.test.tsx
@@ -1,0 +1,72 @@
+/**
+ * Tests for QuickSnapshotCompareDialog (#171)
+ */
+import React from 'react';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import { QuickSnapshotCompareDialog } from '../src/app/ade/studio/editor/components/QuickSnapshotCompareDialog';
+import type { QuickLayoutSnapshot } from '../src/app/ade/studio/editor/lib/quick-layout-snapshots';
+import { QUICK_LAYOUT_SNAPSHOTS_SCHEMA_VERSION } from '../src/app/ade/studio/editor/lib/quick-layout-snapshots';
+
+function makeSnapshot(
+  id: string,
+  createdAt: string,
+  opts?: { thumb?: string; nodeCount?: number }
+): QuickLayoutSnapshot {
+  const n = opts?.nodeCount ?? 1;
+  return {
+    id,
+    createdAt,
+    ...(opts?.thumb ? { thumbnailDataUrl: opts.thumb } : {}),
+    payload: {
+      schemaVersion: QUICK_LAYOUT_SNAPSHOTS_SCHEMA_VERSION,
+      viewport: { x: 0, y: 0, zoom: 1 },
+      nodes: Array.from({ length: n }, (_, i) => ({ id: `n${i}` })),
+      edges: [],
+      groups: [],
+    },
+  };
+}
+
+describe('QuickSnapshotCompareDialog', () => {
+  test('shows hint when fewer than two snapshots', () => {
+    const one = makeSnapshot('a', '2026-03-01T10:00:00.000Z');
+    render(
+      <QuickSnapshotCompareDialog open onOpenChange={() => {}} snapshots={[one]} />
+    );
+    expect(screen.getByText(/Capture at least two quick snapshots/i)).toBeInTheDocument();
+  });
+
+  test('renders two panels and summary counts when comparing two snapshots', async () => {
+    const user = userEvent.setup();
+    const thumb = 'data:image/png;base64,iVBORw0KGgo=';
+    const older = makeSnapshot('older', '2026-03-01T10:00:00.000Z', { thumb, nodeCount: 2 });
+    const newer = makeSnapshot('newer', '2026-03-02T15:00:00.000Z', { nodeCount: 5 });
+
+    render(
+      <QuickSnapshotCompareDialog open onOpenChange={() => {}} snapshots={[newer, older]} />
+    );
+
+    expect(screen.getByText('Compare quick snapshots')).toBeInTheDocument();
+
+    expect(screen.getAllByText(/2 nodes/).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText(/5 nodes/).length).toBeGreaterThanOrEqual(1);
+
+    await user.click(screen.getByRole('button', { name: /swap sides/i }));
+    expect(screen.getByRole('button', { name: /swap sides/i })).toBeEnabled();
+  });
+
+  test('selectors list both snapshots', () => {
+    const a = makeSnapshot('snap-a', '2026-01-01T08:00:00.000Z');
+    const b = makeSnapshot('snap-b', '2026-01-02T08:00:00.000Z');
+    render(<QuickSnapshotCompareDialog open onOpenChange={() => {}} snapshots={[b, a]} />);
+
+    const combos = screen.getAllByRole('combobox');
+    expect(combos).toHaveLength(2);
+    for (const combo of combos) {
+      const options = within(combo as HTMLElement).getAllByRole('option');
+      expect(options).toHaveLength(2);
+    }
+  });
+});


### PR DESCRIPTION
## Problem Statement

Users and teams need **compare quick layout snapshots side-by-side (#171)** within the Objectified platform. Today this capability is missing or only partially implemented, which blocks dashboard workflows and creates inconsistency across tenants and projects.

## Solution / Scope

Implement **Compare quick layout snapshots side-by-side (#171)** as part of **Dashboard**. KPIs, primitives browser, project overview, quick actions.

**Post-MVP** (prioritize after MVP slice) candidacy.

```mermaid
flowchart TB
  CP[Control Panel] --> KPIs[Stats cards]
  CP --> Primitives[Primitives list]
  CP --> Projects[Recent projects]
  CP --> Actions[Quick actions]
```

## Acceptance Criteria

- [ ] Feature behaves as described for: Compare quick layout snapshots side-by-side (#171)
- [ ] Unit/integration tests cover happy path and primary error cases
- [ ] UI (if applicable) matches existing ADE patterns (Tailwind 4, Radix, Lucide)
- [ ] REST endpoints (if applicable) follow `/v1/{{feature}}/{{tenant_slug}}/...` conventions
- [ ] Documented in issue/PR; no regressions to existing schema/version flows

## Parallelism / Dependencies

- **Can run in parallel:** Yes
- **Blockers:** None identified; validate against current codebase before starting

## Technical Stack

- **Modules:** objectified-rest
- **Stack:** Next.js ADE dashboard, control panel components, REST stats APIs
- **Labels:** ``

---

**Epic:** [[Epic] Dashboard & Control Panel](https://github.com/objectified-project/objectified/issues/3493)
**Issue:** #871 · **Area:** Dashboard · **Roadmap batch:** legacy #64–#879 enrichment