### PR TITLE
Quick snapshot gallery with search and filters (#172)

### DIFF
--- a/FEATURE_ROADMAP.md
+++ b/FEATURE_ROADMAP.md
@@ -114,7 +114,7 @@
 - Thumbnail preview of each snapshot
 - ✅ Restore any snapshot with one click (#170)
 - Compare two snapshots side-by-side
-- Snapshot gallery view with search/filter
+- ✅ Snapshot gallery view with search/filter (#172)
 - Auto-snapshots before major changes
 - Snapshot metadata: timestamp, author, description
 

--- a/PLANNED_FEATURE_ROADMAP_CANVAS.md
+++ b/PLANNED_FEATURE_ROADMAP_CANVAS.md
@@ -17,13 +17,12 @@
 - ✅ Thumbnail preview of each snapshot (#169)
 - ✅ Restore any snapshot with one click (#170)
 - ✅ Compare two snapshots side-by-side (#171)
-- 📋 [TODO] Snapshot gallery view with search/filter
+- ✅ Snapshot gallery view with search/filter (#172)
 - 📋 [TODO] Auto-snapshots before major changes
 - 📋 [TODO] Snapshot metadata: timestamp, author, description
 
 | Ticket | Feature                                           |
 |--------|---------------------------------------------------|
-| #172   | Snapshot gallery view with search/filter          |
 | #173   | Snapshot metadata: timestamp, author, description |
 
 #### Layout Sharing 📋 PLANNED

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.8.81",
+  "version": "0.8.82",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -5,6 +5,7 @@ We continue to improve the platform based on your feedback with improvements and
 ---
 
 Improvements:
+- Canvas: quick snapshot gallery in the Layout panel—browse captures in a scrollable grid with search, preview filters (all / with image / no image), and newest-or-oldest sort (#172)
 - Canvas: project and version dropdowns show a loading spinner and label while projects or versions are being fetched (#866)
 - Canvas: layout auto-save interval and on/off switch moved into the layout menu; auto-save stays off by default and is only available after you have saved a layout for the current name (#831)
 - Canvas: Expand, Collapse, Search, View Mode, and Tags live in a left slide-out drawer opened from the **Tools** control in the upper-left (#842)

--- a/objectified-ui/src/app/ade/studio/editor/components/QuickSnapshotCompareDialog.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/components/QuickSnapshotCompareDialog.tsx
@@ -3,31 +3,16 @@
 import React, { useEffect, useLayoutEffect, useMemo, useState } from 'react';
 import * as Dialog from '@radix-ui/react-dialog';
 import { X, Columns2, ArrowLeftRight, Image as ImageIcon } from 'lucide-react';
-import type { QuickLayoutSnapshot } from '../lib/quick-layout-snapshots';
+import {
+  formatQuickSnapshotCaption,
+  quickSnapshotCountsSummary,
+  type QuickLayoutSnapshot,
+} from '../lib/quick-layout-snapshots';
 
 export interface QuickSnapshotCompareDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   snapshots: QuickLayoutSnapshot[];
-}
-
-function formatSnapshotCaption(createdAt: string): string {
-  const d = new Date(createdAt);
-  if (!Number.isFinite(d.getTime())) return 'Unknown time';
-  return d.toLocaleString(undefined, {
-    month: 'short',
-    day: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
-  });
-}
-
-function snapshotSummary(s: QuickLayoutSnapshot): string {
-  const { nodes, edges, groups } = s.payload;
-  const n = Array.isArray(nodes) ? nodes.length : 0;
-  const e = Array.isArray(edges) ? edges.length : 0;
-  const g = Array.isArray(groups) ? groups.length : 0;
-  return `${n} nodes · ${e} edges · ${g} groups`;
 }
 
 export function QuickSnapshotCompareDialog({
@@ -130,7 +115,7 @@ export function QuickSnapshotCompareDialog({
                       >
                         {snapshots.map((s) => (
                           <option key={s.id} value={s.id}>
-                            {formatSnapshotCaption(s.createdAt)}
+                            {formatQuickSnapshotCaption(s.createdAt)}
                           </option>
                         ))}
                       </select>
@@ -156,8 +141,8 @@ export function QuickSnapshotCompareDialog({
                         <div className="border-t border-gray-200 px-2 py-1.5 text-[10px] leading-snug text-gray-600 dark:text-gray-300 dark:border-gray-700">
                           {snap ? (
                             <>
-                              <p className="font-medium tabular-nums">{formatSnapshotCaption(snap.createdAt)}</p>
-                              <p className="text-gray-500 dark:text-gray-400">{snapshotSummary(snap)}</p>
+                              <p className="font-medium tabular-nums">{formatQuickSnapshotCaption(snap.createdAt)}</p>
+                              <p className="text-gray-500 dark:text-gray-400">{quickSnapshotCountsSummary(snap)}</p>
                             </>
                           ) : (
                             <p className="text-gray-500">Select a snapshot</p>

--- a/objectified-ui/src/app/ade/studio/editor/components/QuickSnapshotGalleryDialog.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/components/QuickSnapshotGalleryDialog.tsx
@@ -1,0 +1,228 @@
+'use client';
+
+import React, { useEffect, useMemo, useState } from 'react';
+import * as Dialog from '@radix-ui/react-dialog';
+import * as ToggleGroup from '@radix-ui/react-toggle-group';
+import { X, LayoutGrid, Search, Image as ImageIcon } from 'lucide-react';
+import {
+  formatQuickSnapshotCaption,
+  quickSnapshotCountsSummary,
+  quickSnapshotMatchesSearch,
+  type QuickLayoutSnapshot,
+} from '../lib/quick-layout-snapshots';
+
+export type QuickSnapshotPreviewFilter = 'all' | 'with' | 'without';
+export type QuickSnapshotSortOrder = 'newest' | 'oldest';
+
+export interface QuickSnapshotGalleryDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  snapshots: QuickLayoutSnapshot[];
+  onRestore: (snapshot: QuickLayoutSnapshot) => void;
+  restoreDisabled: boolean;
+  /** Shown as title/tooltip when restore is disabled (e.g. read-only). */
+  restoreDisabledReason?: string;
+}
+
+export function QuickSnapshotGalleryDialog({
+  open,
+  onOpenChange,
+  snapshots,
+  onRestore,
+  restoreDisabled,
+  restoreDisabledReason,
+}: QuickSnapshotGalleryDialogProps) {
+  const [query, setQuery] = useState('');
+  const [previewFilter, setPreviewFilter] = useState<QuickSnapshotPreviewFilter>('all');
+  const [sortOrder, setSortOrder] = useState<QuickSnapshotSortOrder>('newest');
+
+  useEffect(() => {
+    if (!open) {
+      setQuery('');
+      setPreviewFilter('all');
+      setSortOrder('newest');
+    }
+  }, [open]);
+
+  const filteredSorted = useMemo(() => {
+    let list = snapshots.filter((s) => quickSnapshotMatchesSearch(s, query));
+    if (previewFilter === 'with') {
+      list = list.filter((s) => Boolean(s.thumbnailDataUrl));
+    } else if (previewFilter === 'without') {
+      list = list.filter((s) => !s.thumbnailDataUrl);
+    }
+    const mult = sortOrder === 'newest' ? -1 : 1;
+    return [...list].sort((a, b) => mult * (new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()));
+  }, [snapshots, query, previewFilter, sortOrder]);
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-[1300] bg-black/50 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
+        <Dialog.Content
+          className="fixed left-1/2 top-1/2 z-[1301] flex max-h-[min(92vh,48rem)] w-[min(96vw,42rem)] min-h-0 -translate-x-1/2 -translate-y-1/2 flex-col overflow-hidden rounded-xl border border-gray-200 bg-white shadow-xl outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 dark:border-gray-700 dark:bg-gray-900"
+        >
+          <div className="flex shrink-0 items-start justify-between gap-3 border-b border-gray-200 px-4 py-3 dark:border-gray-700">
+            <div className="flex min-w-0 items-start gap-2">
+              <LayoutGrid className="mt-0.5 h-5 w-5 shrink-0 text-indigo-600 dark:text-indigo-400" aria-hidden />
+              <div className="min-w-0">
+                <Dialog.Title className="text-sm font-semibold text-gray-900 dark:text-white">
+                  Quick snapshot gallery
+                </Dialog.Title>
+                <Dialog.Description className="mt-1 text-xs leading-snug text-gray-500 dark:text-gray-400">
+                  Search by time, snapshot id, or layout counts. Filter by preview image. Newest captures appear first by
+                  default.
+                </Dialog.Description>
+              </div>
+            </div>
+            <Dialog.Close
+              type="button"
+              className="rounded-lg p-1.5 text-gray-500 hover:bg-gray-100 hover:text-gray-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+              aria-label="Close"
+            >
+              <X className="h-4 w-4" />
+            </Dialog.Close>
+          </div>
+
+          <div className="shrink-0 space-y-3 border-b border-gray-200 px-4 py-3 dark:border-gray-700">
+            <div className="relative">
+              <Search
+                className="pointer-events-none absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400 dark:text-gray-500"
+                aria-hidden
+              />
+              <input
+                type="search"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                placeholder="Search snapshots…"
+                className="w-full rounded-lg border border-gray-200 bg-white py-2 pl-9 pr-3 text-sm text-gray-900 shadow-sm placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 dark:placeholder:text-gray-500"
+                aria-label="Search quick snapshots"
+              />
+            </div>
+            <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center sm:gap-4">
+              <div className="flex min-w-0 flex-col gap-1.5 sm:flex-row sm:items-center">
+                <span className="shrink-0 text-[10px] font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                  Preview
+                </span>
+                <ToggleGroup.Root
+                  type="single"
+                  value={previewFilter}
+                  onValueChange={(v) => v && setPreviewFilter(v as QuickSnapshotPreviewFilter)}
+                  className="inline-flex flex-wrap gap-1 rounded-md border border-gray-200 bg-gray-50 p-1 dark:border-gray-600 dark:bg-gray-800"
+                  aria-label="Filter by preview image"
+                >
+                  {(['all', 'with', 'without'] as const).map((v) => (
+                    <ToggleGroup.Item
+                      key={v}
+                      value={v}
+                      className="rounded px-2.5 py-1.5 text-xs font-medium text-gray-700 hover:bg-gray-100 data-[state=on]:bg-indigo-100 data-[state=on]:text-indigo-800 dark:text-gray-300 dark:hover:bg-gray-700 dark:data-[state=on]:bg-indigo-900/50 dark:data-[state=on]:text-indigo-200"
+                    >
+                      {v === 'all' ? 'All' : v === 'with' ? 'With image' : 'No image'}
+                    </ToggleGroup.Item>
+                  ))}
+                </ToggleGroup.Root>
+              </div>
+              <div className="flex min-w-0 flex-col gap-1.5 sm:flex-row sm:items-center">
+                <span className="shrink-0 text-[10px] font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                  Sort
+                </span>
+                <ToggleGroup.Root
+                  type="single"
+                  value={sortOrder}
+                  onValueChange={(v) => v && setSortOrder(v as QuickSnapshotSortOrder)}
+                  className="inline-flex gap-1 rounded-md border border-gray-200 bg-gray-50 p-1 dark:border-gray-600 dark:bg-gray-800"
+                  aria-label="Sort order"
+                >
+                  <ToggleGroup.Item
+                    value="newest"
+                    className="rounded px-2.5 py-1.5 text-xs font-medium text-gray-700 hover:bg-gray-100 data-[state=on]:bg-indigo-100 data-[state=on]:text-indigo-800 dark:text-gray-300 dark:hover:bg-gray-700 dark:data-[state=on]:bg-indigo-900/50 dark:data-[state=on]:text-indigo-200"
+                  >
+                    Newest
+                  </ToggleGroup.Item>
+                  <ToggleGroup.Item
+                    value="oldest"
+                    className="rounded px-2.5 py-1.5 text-xs font-medium text-gray-700 hover:bg-gray-100 data-[state=on]:bg-indigo-100 data-[state=on]:text-indigo-800 dark:text-gray-300 dark:hover:bg-gray-700 dark:data-[state=on]:bg-indigo-900/50 dark:data-[state=on]:text-indigo-200"
+                  >
+                    Oldest
+                  </ToggleGroup.Item>
+                </ToggleGroup.Root>
+              </div>
+            </div>
+            <p className="text-[11px] text-gray-500 dark:text-gray-400">
+              Showing {filteredSorted.length} of {snapshots.length}
+            </p>
+          </div>
+
+          <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-4 py-3">
+            {snapshots.length === 0 ? (
+              <p className="text-sm text-gray-600 dark:text-gray-400">
+                No quick snapshots yet. Use{' '}
+                <span className="font-semibold text-gray-800 dark:text-gray-200">Capture</span> in the Layout panel.
+              </p>
+            ) : filteredSorted.length === 0 ? (
+              <p className="text-sm text-gray-600 dark:text-gray-400">
+                No snapshots match your search or filters. Try clearing the search box or setting the preview filter to{' '}
+                <span className="font-semibold text-gray-800 dark:text-gray-200">All</span>.
+              </p>
+            ) : (
+              <ul className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+                {filteredSorted.map((s) => {
+                  const caption = formatQuickSnapshotCaption(s.createdAt);
+                  const summary = quickSnapshotCountsSummary(s);
+                  return (
+                    <li key={s.id} className="list-none">
+                      <button
+                        type="button"
+                        disabled={restoreDisabled}
+                        onClick={() => onRestore(s)}
+                        aria-label={`Restore quick snapshot from ${caption}`}
+                        className={`w-full overflow-hidden rounded-lg border border-gray-200 bg-white text-left shadow-sm transition-opacity dark:border-gray-600 dark:bg-gray-800/70 ${
+                          restoreDisabled
+                            ? 'cursor-not-allowed opacity-50'
+                            : 'hover:ring-2 hover:ring-indigo-400 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 dark:hover:ring-indigo-500'
+                        }`}
+                        title={
+                          restoreDisabled
+                            ? restoreDisabledReason ?? 'Cannot restore'
+                            : `Restore canvas from ${caption}`
+                        }
+                      >
+                        <div className="relative aspect-[5/3] w-full bg-gray-100 dark:bg-gray-900 pointer-events-none">
+                          {s.thumbnailDataUrl ? (
+                            <img
+                              src={s.thumbnailDataUrl}
+                              alt=""
+                              className="absolute inset-0 h-full w-full object-cover"
+                              loading="lazy"
+                              decoding="async"
+                            />
+                          ) : (
+                            <div
+                              className="absolute inset-0 flex flex-col items-center justify-center gap-1 px-1 text-center text-gray-400 dark:text-gray-500"
+                              role="img"
+                              aria-label="No preview image for this snapshot"
+                            >
+                              <ImageIcon className="h-5 w-5 shrink-0 opacity-60" aria-hidden />
+                              <span className="text-[9px] leading-tight">No preview</span>
+                            </div>
+                          )}
+                        </div>
+                        <div className="pointer-events-none border-t border-gray-100 px-2 py-1.5 dark:border-gray-700/80">
+                          <p className="truncate text-[10px] font-medium tabular-nums text-gray-700 dark:text-gray-200">
+                            {caption}
+                          </p>
+                          <p className="truncate text-[9px] text-gray-500 dark:text-gray-400">{summary}</p>
+                          <p className="mt-0.5 truncate font-mono text-[9px] text-gray-400 dark:text-gray-500">{s.id}</p>
+                        </div>
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/objectified-ui/src/app/ade/studio/editor/components/QuickSnapshotGalleryDialog.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/components/QuickSnapshotGalleryDialog.tsx
@@ -52,7 +52,13 @@ export function QuickSnapshotGalleryDialog({
       list = list.filter((s) => !s.thumbnailDataUrl);
     }
     const mult = sortOrder === 'newest' ? -1 : 1;
-    return [...list].sort((a, b) => mult * (new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()));
+    return [...list].sort((a, b) => {
+      const taRaw = Date.parse(a.createdAt as unknown as string);
+      const tbRaw = Date.parse(b.createdAt as unknown as string);
+      const ta = Number.isFinite(taRaw) ? taRaw : 0;
+      const tb = Number.isFinite(tbRaw) ? tbRaw : 0;
+      return mult * (ta - tb);
+    });
   }, [snapshots, query, previewFilter, sortOrder]);
 
   return (

--- a/objectified-ui/src/app/ade/studio/editor/lib/quick-layout-snapshots.ts
+++ b/objectified-ui/src/app/ade/studio/editor/lib/quick-layout-snapshots.ts
@@ -23,6 +23,45 @@ export interface QuickLayoutSnapshot {
   payload: QuickLayoutSnapshotPayload;
 }
 
+/** Locale-aware caption for UI lists and search (same formatting across gallery and compare). */
+export function formatQuickSnapshotCaption(createdAt: string): string {
+  const d = new Date(createdAt);
+  if (!Number.isFinite(d.getTime())) return 'Unknown time';
+  return d.toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+export function quickSnapshotCountsSummary(s: QuickLayoutSnapshot): string {
+  const { nodes, edges, groups } = s.payload;
+  const n = Array.isArray(nodes) ? nodes.length : 0;
+  const e = Array.isArray(edges) ? edges.length : 0;
+  const g = Array.isArray(groups) ? groups.length : 0;
+  return `${n} nodes · ${e} edges · ${g} groups`;
+}
+
+/**
+ * Case-insensitive match: every whitespace-separated token must appear in id, ISO time,
+ * formatted caption, or counts summary.
+ */
+export function quickSnapshotMatchesSearch(snapshot: QuickLayoutSnapshot, query: string): boolean {
+  const raw = query.trim().toLowerCase();
+  if (!raw) return true;
+  const haystack = [
+    snapshot.id,
+    snapshot.createdAt,
+    formatQuickSnapshotCaption(snapshot.createdAt),
+    quickSnapshotCountsSummary(snapshot),
+  ]
+    .join('\n')
+    .toLowerCase();
+  const tokens = raw.split(/\s+/).filter(Boolean);
+  return tokens.every((t) => haystack.includes(t));
+}
+
 export function quickLayoutSnapshotsStorageKey(versionId: string, userId: string | null): string {
   const uid = userId && userId.trim() ? userId.trim() : 'anonymous';
   return `objectified.quickCanvasSnapshots.v${QUICK_LAYOUT_SNAPSHOTS_SCHEMA_VERSION}:${versionId}:${uid}`;

--- a/objectified-ui/src/app/ade/studio/editor/page.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/page.tsx
@@ -66,6 +66,7 @@ import {
   PanelLeft,
   Camera,
   Columns2,
+  LayoutGrid,
 } from 'lucide-react';
 import * as Select from '@radix-ui/react-select';
 import * as ToggleGroup from '@radix-ui/react-toggle-group';
@@ -189,6 +190,7 @@ import {
 import { computeSchemaMetrics, getCircularDependencyEdgeIds, getDependencyDepthMap, getAffectedClassIds, getUpstreamClassIds, getDependencyChainNodeAndEdgeIds } from '@/app/utils/schema-metrics';
 import { toPng } from 'html-to-image';
 import { QuickSnapshotCompareDialog } from './components/QuickSnapshotCompareDialog';
+import { QuickSnapshotGalleryDialog } from './components/QuickSnapshotGalleryDialog';
 import DraggablePanel from '../components/DraggablePanel';
 import MemoryProfiler from '../components/MemoryProfiler';
 import SchemaMetricsPanel from '../components/SchemaMetricsPanel';
@@ -605,6 +607,7 @@ const StudioContent = () => {
   const [quickLayoutSnapshots, setQuickLayoutSnapshots] = useState<QuickLayoutSnapshot[]>([]);
   const [quickSnapshotSavedFlash, setQuickSnapshotSavedFlash] = useState(false);
   const [quickSnapshotCompareOpen, setQuickSnapshotCompareOpen] = useState(false);
+  const [quickSnapshotGalleryOpen, setQuickSnapshotGalleryOpen] = useState(false);
   const canvasCaptureAreaRef = useRef<HTMLDivElement>(null);
   const presentationShellRef = useRef<HTMLDivElement>(null);
   const selectedLayoutNameRef = useRef(selectedLayoutName);
@@ -8742,6 +8745,24 @@ const StudioContent = () => {
                               <span>Compare</span>
                             </button>
                           </div>
+                          <button
+                            type="button"
+                            onClick={() => setQuickSnapshotGalleryOpen(true)}
+                            disabled={quickLayoutSnapshots.length === 0}
+                            className={`mt-2 w-full px-3 py-2 text-sm font-medium rounded-lg transition-all duration-200 flex items-center justify-center gap-2 border ${
+                              quickLayoutSnapshots.length > 0
+                                ? 'bg-white dark:bg-gray-700/50 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600 border-gray-200 dark:border-gray-600'
+                                : 'bg-gray-100 dark:bg-gray-700 text-gray-400 cursor-not-allowed border-gray-200 dark:border-gray-600'
+                            }`}
+                            title={
+                              quickLayoutSnapshots.length === 0
+                                ? 'Capture at least one snapshot to open the gallery'
+                                : 'Browse all quick snapshots with search and filters'
+                            }
+                          >
+                            <LayoutGrid className="w-4 h-4" />
+                            <span>Gallery</span>
+                          </button>
                           {quickLayoutSnapshots.length > 0 ? (
                             <div className="rounded-lg border border-gray-200 dark:border-gray-600 bg-gray-50 dark:bg-gray-800/40 px-2.5 py-2 max-h-60 overflow-y-auto overscroll-contain">
                               <p className="text-[10px] font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-2">
@@ -9360,6 +9381,22 @@ const StudioContent = () => {
             open={quickSnapshotCompareOpen}
             onOpenChange={setQuickSnapshotCompareOpen}
             snapshots={quickLayoutSnapshots}
+          />
+          <QuickSnapshotGalleryDialog
+            open={quickSnapshotGalleryOpen}
+            onOpenChange={setQuickSnapshotGalleryOpen}
+            snapshots={quickLayoutSnapshots}
+            onRestore={(s) => void handleRestoreQuickLayoutSnapshot(s)}
+            restoreDisabled={isReadOnly || !currentUserId || isLoadingCanvas}
+            restoreDisabledReason={
+              isReadOnly
+                ? 'Read-only: cannot restore'
+                : !currentUserId
+                  ? 'Sign in to restore snapshots'
+                  : isLoadingCanvas
+                    ? 'Please wait…'
+                    : undefined
+            }
           />
           <ExportWizard
             open={exportWizardOpen}

--- a/objectified-ui/tests/QuickSnapshotGalleryDialog.test.tsx
+++ b/objectified-ui/tests/QuickSnapshotGalleryDialog.test.tsx
@@ -1,0 +1,108 @@
+/**
+ * Tests for QuickSnapshotGalleryDialog (#172)
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import { QuickSnapshotGalleryDialog } from '../src/app/ade/studio/editor/components/QuickSnapshotGalleryDialog';
+import type { QuickLayoutSnapshot } from '../src/app/ade/studio/editor/lib/quick-layout-snapshots';
+import { QUICK_LAYOUT_SNAPSHOTS_SCHEMA_VERSION } from '../src/app/ade/studio/editor/lib/quick-layout-snapshots';
+
+function makeSnapshot(
+  id: string,
+  createdAt: string,
+  opts?: { withThumb?: boolean; nodeCount?: number }
+): QuickLayoutSnapshot {
+  const n = opts?.nodeCount ?? 1;
+  const out: QuickLayoutSnapshot = {
+    id,
+    createdAt,
+    payload: {
+      schemaVersion: QUICK_LAYOUT_SNAPSHOTS_SCHEMA_VERSION,
+      viewport: { x: 0, y: 0, zoom: 1 },
+      nodes: Array.from({ length: n }, (_, i) => ({ id: `n${i}` })),
+      edges: [],
+      groups: [],
+    },
+  };
+  if (opts?.withThumb) {
+    out.thumbnailDataUrl = 'data:image/png;base64,iVBORw0KGgo=';
+  }
+  return out;
+}
+
+describe('QuickSnapshotGalleryDialog', () => {
+  test('shows empty state when there are no snapshots', () => {
+    render(
+      <QuickSnapshotGalleryDialog
+        open
+        onOpenChange={() => {}}
+        snapshots={[]}
+        onRestore={() => {}}
+        restoreDisabled={false}
+      />
+    );
+    expect(screen.getByText(/No quick snapshots yet/i)).toBeInTheDocument();
+  });
+
+  test('filters by search query', async () => {
+    const user = userEvent.setup();
+    const a = makeSnapshot('alpha-snap', '2026-03-01T10:00:00.000Z', { nodeCount: 2 });
+    const b = makeSnapshot('beta-snap', '2026-03-02T10:00:00.000Z', { nodeCount: 5 });
+
+    render(
+      <QuickSnapshotGalleryDialog
+        open
+        onOpenChange={() => {}}
+        snapshots={[b, a]}
+        onRestore={() => {}}
+        restoreDisabled={false}
+      />
+    );
+
+    expect(screen.getByText(/Showing 2 of 2/i)).toBeInTheDocument();
+    const search = screen.getByRole('searchbox', { name: /Search quick snapshots/i });
+    await user.type(search, 'beta');
+    expect(screen.getByText(/Showing 1 of 2/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Restore quick snapshot/i)).toBeInTheDocument();
+  });
+
+  test('filters by preview toggle and calls onRestore', async () => {
+    const user = userEvent.setup();
+    const withThumb = makeSnapshot('has-thumb', '2026-01-01T00:00:00.000Z', { withThumb: true });
+    const noThumb = makeSnapshot('no-thumb', '2026-01-02T00:00:00.000Z');
+    const onRestore = jest.fn();
+
+    render(
+      <QuickSnapshotGalleryDialog
+        open
+        onOpenChange={() => {}}
+        snapshots={[withThumb, noThumb]}
+        onRestore={onRestore}
+        restoreDisabled={false}
+      />
+    );
+
+    await user.click(screen.getByRole('radio', { name: /No image/i }));
+    expect(screen.getByText(/Showing 1 of 2/i)).toBeInTheDocument();
+    const restoreBtn = screen.getByLabelText(/Restore quick snapshot/i);
+    await user.click(restoreBtn);
+    expect(onRestore).toHaveBeenCalledWith(expect.objectContaining({ id: 'no-thumb' }));
+  });
+
+  test('restore buttons disabled when restoreDisabled', () => {
+    const s = makeSnapshot('s1', '2026-01-01T00:00:00.000Z');
+    render(
+      <QuickSnapshotGalleryDialog
+        open
+        onOpenChange={() => {}}
+        snapshots={[s]}
+        onRestore={() => {}}
+        restoreDisabled
+        restoreDisabledReason="Read-only"
+      />
+    );
+    expect(screen.getByRole('button', { name: /Restore quick snapshot/i })).toBeDisabled();
+  });
+});

--- a/objectified-ui/tests/quick-layout-snapshots.test.ts
+++ b/objectified-ui/tests/quick-layout-snapshots.test.ts
@@ -4,6 +4,9 @@ import {
   quickLayoutSnapshotsStorageKey,
   isQuickLayoutSnapshot,
   DEFAULT_MAX_QUICK_LAYOUT_SNAPSHOTS,
+  formatQuickSnapshotCaption,
+  quickSnapshotCountsSummary,
+  quickSnapshotMatchesSearch,
   type QuickLayoutSnapshot,
 } from '@/app/ade/studio/editor/lib/quick-layout-snapshots';
 
@@ -148,5 +151,38 @@ describe('quick-layout-snapshots', () => {
         payload: samplePayload,
       })
     ).toBe(true);
+  });
+
+  it('formatQuickSnapshotCaption handles invalid dates', () => {
+    expect(formatQuickSnapshotCaption('not-a-date')).toBe('Unknown time');
+  });
+
+  it('quickSnapshotCountsSummary reflects payload arrays', () => {
+    const snap: QuickLayoutSnapshot = {
+      id: 'x',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      payload: {
+        schemaVersion: 1,
+        viewport: { x: 0, y: 0, zoom: 1 },
+        nodes: [{ id: 'a' }, { id: 'b' }],
+        edges: [{ id: 'e1' }],
+        groups: [{ id: 'g1' }, { id: 'g2' }, { id: 'g3' }],
+      },
+    };
+    expect(quickSnapshotCountsSummary(snap)).toBe('2 nodes · 1 edges · 3 groups');
+  });
+
+  it('quickSnapshotMatchesSearch matches id, iso time, and count tokens', () => {
+    const snap = makeSnapshot('abc-unique-id', '2026-06-15T12:30:00.000Z');
+    snap.payload = {
+      ...samplePayload,
+      nodes: [{ id: 'n1' }, { id: 'n2' }, { id: 'n3' }],
+    };
+    expect(quickSnapshotMatchesSearch(snap, '')).toBe(true);
+    expect(quickSnapshotMatchesSearch(snap, 'unique')).toBe(true);
+    expect(quickSnapshotMatchesSearch(snap, '2026-06-15')).toBe(true);
+    expect(quickSnapshotMatchesSearch(snap, '3 nodes')).toBe(true);
+    expect(quickSnapshotMatchesSearch(snap, '2026-06-15 3 nodes')).toBe(true);
+    expect(quickSnapshotMatchesSearch(snap, 'nomatch-xyz-123')).toBe(false);
   });
 });


### PR DESCRIPTION
## Problem Statement

Users and teams need **quick snapshot gallery with search and filters (#172)** within the Objectified platform. Today this capability is missing or only partially implemented, which blocks dashboard workflows and creates inconsistency across tenants and projects.

## Solution / Scope

Implement **Quick snapshot gallery with search and filters (#172)** as part of **Dashboard**. KPIs, primitives browser, project overview, quick actions.

**Post-MVP** (prioritize after MVP slice) candidacy.

```mermaid
flowchart TB
  CP[Control Panel] --> KPIs[Stats cards]
  CP --> Primitives[Primitives list]
  CP --> Projects[Recent projects]
  CP --> Actions[Quick actions]
```

## Acceptance Criteria

- [ ] Feature behaves as described for: Quick snapshot gallery with search and filters (#172)
- [ ] Unit/integration tests cover happy path and primary error cases
- [ ] UI (if applicable) matches existing ADE patterns (Tailwind 4, Radix, Lucide)
- [ ] REST endpoints (if applicable) follow `/v1/{{feature}}/{{tenant_slug}}/...` conventions
- [ ] Documented in issue/PR; no regressions to existing schema/version flows

## Parallelism / Dependencies

- **Can run in parallel:** Yes
- **Blockers:** None identified; validate against current codebase before starting

## Technical Stack

- **Modules:** objectified-rest
- **Stack:** Next.js ADE dashboard, control panel components, REST stats APIs
- **Labels:** ``

---

**Epic:** [[Epic] Dashboard & Control Panel](https://github.com/objectified-project/objectified/issues/3493)
**Issue:** #872 · **Area:** Dashboard · **Roadmap batch:** legacy #64–#879 enrichment