### PR TITLE
Addresses #173 — Quick snapshot metadata (author, summary, description)

### DIFF
--- a/PLANNED_FEATURE_ROADMAP_CANVAS.md
+++ b/PLANNED_FEATURE_ROADMAP_CANVAS.md
@@ -19,11 +19,7 @@
 - ✅ Compare two snapshots side-by-side (#171)
 - ✅ Snapshot gallery view with search/filter (#172)
 - 📋 [TODO] Auto-snapshots before major changes
-- 📋 [TODO] Snapshot metadata: timestamp, author, description
-
-| Ticket | Feature                                           |
-|--------|---------------------------------------------------|
-| #173   | Snapshot metadata: timestamp, author, description |
+- ✅ Snapshot metadata: timestamp, author, summary, and description on capture (#173)
 
 #### Layout Sharing 📋 PLANNED
 - 📋 [TODO] Share layout configurations with team members

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.8.82",
+  "version": "0.8.83",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -5,6 +5,7 @@ We continue to improve the platform based on your feedback with improvements and
 ---
 
 Improvements:
+- Canvas: quick snapshots store timestamp, author (from your session), a required short summary, and optional description; capture opens a short form before saving (#173)
 - Canvas: quick snapshot gallery in the Layout panel—browse captures in a scrollable grid with search, preview filters (all / with image / no image), and newest-or-oldest sort (#172)
 - Canvas: project and version dropdowns show a loading spinner and label while projects or versions are being fetched (#866)
 - Canvas: layout auto-save interval and on/off switch moved into the layout menu; auto-save stays off by default and is only available after you have saved a layout for the current name (#831)

--- a/objectified-ui/src/app/ade/studio/editor/components/QuickSnapshotCaptureDialog.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/components/QuickSnapshotCaptureDialog.tsx
@@ -1,0 +1,166 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import * as Dialog from '@radix-ui/react-dialog';
+import { Camera, X } from 'lucide-react';
+import {
+  QUICK_SNAPSHOT_DESCRIPTION_MAX_LEN,
+  QUICK_SNAPSHOT_SUMMARY_MAX_LEN,
+} from '../lib/quick-layout-snapshots';
+
+export interface QuickSnapshotCaptureDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Shown read-only; stored on the snapshot as author. */
+  authorLabel: string;
+  isSaving: boolean;
+  onConfirm: (meta: { summary: string; description: string }) => void;
+}
+
+export function QuickSnapshotCaptureDialog({
+  open,
+  onOpenChange,
+  authorLabel,
+  isSaving,
+  onConfirm,
+}: QuickSnapshotCaptureDialogProps) {
+  const [summary, setSummary] = useState('');
+  const [description, setDescription] = useState('');
+  const [summaryError, setSummaryError] = useState<string | undefined>();
+
+  useEffect(() => {
+    if (!open) {
+      setSummary('');
+      setDescription('');
+      setSummaryError(undefined);
+    }
+  }, [open]);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const trimmed = summary.trim();
+    if (!trimmed) {
+      setSummaryError('Enter a short summary for this snapshot.');
+      return;
+    }
+    setSummaryError(undefined);
+    onConfirm({
+      summary: trimmed.slice(0, QUICK_SNAPSHOT_SUMMARY_MAX_LEN),
+      description: description.trim().slice(0, QUICK_SNAPSHOT_DESCRIPTION_MAX_LEN),
+    });
+  };
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-[1300] bg-black/50 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
+        <Dialog.Content
+          className="fixed left-1/2 top-1/2 z-[1301] w-[min(96vw,26rem)] max-h-[min(92vh,32rem)] -translate-x-1/2 -translate-y-1/2 overflow-y-auto rounded-xl border border-gray-200 bg-white p-0 shadow-xl outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 dark:border-gray-700 dark:bg-gray-900"
+        >
+          <div className="flex items-start justify-between gap-3 border-b border-gray-200 px-4 py-3 dark:border-gray-700">
+            <div className="flex min-w-0 items-start gap-2">
+              <Camera className="mt-0.5 h-5 w-5 shrink-0 text-indigo-600 dark:text-indigo-400" aria-hidden />
+              <div className="min-w-0">
+                <Dialog.Title className="text-sm font-semibold text-gray-900 dark:text-white">
+                  Capture quick snapshot
+                </Dialog.Title>
+                <Dialog.Description className="mt-1 text-xs leading-snug text-gray-500 dark:text-gray-400">
+                  Add a summary and optional description. Timestamp and canvas capture run when you save.
+                </Dialog.Description>
+              </div>
+            </div>
+            <Dialog.Close
+              type="button"
+              disabled={isSaving}
+              className="rounded-lg p-1.5 text-gray-500 hover:bg-gray-100 hover:text-gray-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 disabled:opacity-50 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+              aria-label="Close"
+            >
+              <X className="h-4 w-4" />
+            </Dialog.Close>
+          </div>
+
+          <form onSubmit={handleSubmit} className="space-y-3 px-4 py-3">
+            <div>
+              <p className="text-[11px] font-medium text-gray-600 dark:text-gray-300">
+                Author{' '}
+                <span className="font-normal text-gray-500 dark:text-gray-400">(stored with this capture)</span>
+              </p>
+              <p className="mt-0.5 truncate text-sm text-gray-900 dark:text-gray-100">{authorLabel}</p>
+            </div>
+
+            <div>
+              <label htmlFor="quick-snapshot-summary" className="text-[11px] font-medium text-gray-600 dark:text-gray-300">
+                Summary <span className="text-red-600 dark:text-red-400">*</span>
+              </label>
+              <input
+                id="quick-snapshot-summary"
+                type="text"
+                value={summary}
+                onChange={(e) => {
+                  setSummary(e.target.value.slice(0, QUICK_SNAPSHOT_SUMMARY_MAX_LEN));
+                  if (summaryError) setSummaryError(undefined);
+                }}
+                disabled={isSaving}
+                maxLength={QUICK_SNAPSHOT_SUMMARY_MAX_LEN}
+                placeholder="e.g. Before refactoring auth flow"
+                className="mt-1 w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:opacity-60 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 dark:placeholder:text-gray-500"
+                aria-invalid={Boolean(summaryError)}
+                aria-describedby={summaryError ? 'quick-snapshot-summary-error' : undefined}
+                autoComplete="off"
+              />
+              <div className="mt-0.5 flex justify-between gap-2 text-[10px] text-gray-400 dark:text-gray-500">
+                {summaryError ? (
+                  <span id="quick-snapshot-summary-error" className="text-red-600 dark:text-red-400">
+                    {summaryError}
+                  </span>
+                ) : (
+                  <span />
+                )}
+                <span>
+                  {summary.length}/{QUICK_SNAPSHOT_SUMMARY_MAX_LEN}
+                </span>
+              </div>
+            </div>
+
+            <div>
+              <label htmlFor="quick-snapshot-description" className="text-[11px] font-medium text-gray-600 dark:text-gray-300">
+                Description <span className="font-normal text-gray-500">(optional)</span>
+              </label>
+              <textarea
+                id="quick-snapshot-description"
+                value={description}
+                onChange={(e) => setDescription(e.target.value.slice(0, QUICK_SNAPSHOT_DESCRIPTION_MAX_LEN))}
+                disabled={isSaving}
+                rows={3}
+                placeholder="Context or notes for your future self…"
+                className="mt-1 w-full resize-y rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:opacity-60 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 dark:placeholder:text-gray-500"
+              />
+              <p className="mt-0.5 text-right text-[10px] text-gray-400 dark:text-gray-500">
+                {description.length}/{QUICK_SNAPSHOT_DESCRIPTION_MAX_LEN}
+              </p>
+            </div>
+
+            <div className="flex justify-end gap-2 pt-1">
+              <Dialog.Close asChild>
+                <button
+                  type="button"
+                  disabled={isSaving}
+                  className="rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
+                >
+                  Cancel
+                </button>
+              </Dialog.Close>
+              <button
+                type="submit"
+                disabled={isSaving}
+                className="rounded-lg bg-indigo-600 px-3 py-2 text-sm font-medium text-white hover:bg-indigo-500 disabled:opacity-50 dark:bg-indigo-500 dark:hover:bg-indigo-400"
+              >
+                {isSaving ? 'Capturing…' : 'Save snapshot'}
+              </button>
+            </div>
+          </form>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/objectified-ui/src/app/ade/studio/editor/components/QuickSnapshotCompareDialog.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/components/QuickSnapshotCompareDialog.tsx
@@ -5,7 +5,9 @@ import * as Dialog from '@radix-ui/react-dialog';
 import { X, Columns2, ArrowLeftRight, Image as ImageIcon } from 'lucide-react';
 import {
   formatQuickSnapshotCaption,
+  quickSnapshotAuthorDisplay,
   quickSnapshotCountsSummary,
+  quickSnapshotOptionLabel,
   type QuickLayoutSnapshot,
 } from '../lib/quick-layout-snapshots';
 
@@ -99,7 +101,9 @@ export function QuickSnapshotCompareDialog({
                       { label: 'Left', id: leftId, setId: setLeftId, snap: left },
                       { label: 'Right', id: rightId, setId: setRightId, snap: right },
                     ] as const
-                  ).map(({ label, id, setId, snap }) => (
+                  ).map(({ label, id, setId, snap }) => {
+                    const snapAuthor = snap ? quickSnapshotAuthorDisplay(snap) : undefined;
+                    return (
                     <div key={label} className="flex min-w-0 flex-col gap-2">
                       <label
                         htmlFor={`snapshot-select-${label.toLowerCase()}`}
@@ -115,7 +119,7 @@ export function QuickSnapshotCompareDialog({
                       >
                         {snapshots.map((s) => (
                           <option key={s.id} value={s.id}>
-                            {formatQuickSnapshotCaption(s.createdAt)}
+                            {quickSnapshotOptionLabel(s)}
                           </option>
                         ))}
                       </select>
@@ -142,7 +146,14 @@ export function QuickSnapshotCompareDialog({
                           {snap ? (
                             <>
                               <p className="font-medium tabular-nums">{formatQuickSnapshotCaption(snap.createdAt)}</p>
+                              {snapAuthor ? <p className="text-gray-600 dark:text-gray-300">{snapAuthor}</p> : null}
+                              {snap.summary?.trim() ? (
+                                <p className="font-medium text-gray-800 dark:text-gray-100">{snap.summary.trim()}</p>
+                              ) : null}
                               <p className="text-gray-500 dark:text-gray-400">{quickSnapshotCountsSummary(snap)}</p>
+                              {snap.description?.trim() ? (
+                                <p className="line-clamp-3 text-gray-500 dark:text-gray-400">{snap.description.trim()}</p>
+                              ) : null}
                             </>
                           ) : (
                             <p className="text-gray-500">Select a snapshot</p>
@@ -150,7 +161,8 @@ export function QuickSnapshotCompareDialog({
                         </div>
                       </div>
                     </div>
-                  ))}
+                    );
+                  })}
                 </div>
               </div>
             )}

--- a/objectified-ui/src/app/ade/studio/editor/components/QuickSnapshotGalleryDialog.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/components/QuickSnapshotGalleryDialog.tsx
@@ -6,6 +6,7 @@ import * as ToggleGroup from '@radix-ui/react-toggle-group';
 import { X, LayoutGrid, Search, Image as ImageIcon } from 'lucide-react';
 import {
   formatQuickSnapshotCaption,
+  quickSnapshotAuthorDisplay,
   quickSnapshotCountsSummary,
   quickSnapshotMatchesSearch,
   type QuickLayoutSnapshot,
@@ -76,8 +77,8 @@ export function QuickSnapshotGalleryDialog({
                   Quick snapshot gallery
                 </Dialog.Title>
                 <Dialog.Description className="mt-1 text-xs leading-snug text-gray-500 dark:text-gray-400">
-                  Search by time, snapshot id, or layout counts. Filter by preview image. Newest captures appear first by
-                  default.
+                  Search by summary, author, description, time, snapshot id, or layout counts. Filter by preview image.
+                  Newest captures appear first by default.
                 </Dialog.Description>
               </div>
             </div>
@@ -174,24 +175,30 @@ export function QuickSnapshotGalleryDialog({
               <ul className="grid grid-cols-2 gap-3 sm:grid-cols-3">
                 {filteredSorted.map((s) => {
                   const caption = formatQuickSnapshotCaption(s.createdAt);
-                  const summary = quickSnapshotCountsSummary(s);
+                  const countsLine = quickSnapshotCountsSummary(s);
+                  const userSummary = s.summary?.trim();
+                  const summaryLine = userSummary || countsLine;
+                  const author = quickSnapshotAuthorDisplay(s);
+                  const desc = s.description?.trim();
+                  const titleParts = [
+                    desc || undefined,
+                    !restoreDisabled ? `Restore canvas from ${caption}` : restoreDisabledReason ?? 'Cannot restore',
+                  ]
+                    .filter(Boolean)
+                    .join('\n\n');
                   return (
                     <li key={s.id} className="list-none">
                       <button
                         type="button"
                         disabled={restoreDisabled}
                         onClick={() => onRestore(s)}
-                        aria-label={`Restore quick snapshot from ${caption}`}
+                        aria-label={`Restore quick snapshot: ${summaryLine}, ${caption}`}
                         className={`w-full overflow-hidden rounded-lg border border-gray-200 bg-white text-left shadow-sm transition-opacity dark:border-gray-600 dark:bg-gray-800/70 ${
                           restoreDisabled
                             ? 'cursor-not-allowed opacity-50'
                             : 'hover:ring-2 hover:ring-indigo-400 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 dark:hover:ring-indigo-500'
                         }`}
-                        title={
-                          restoreDisabled
-                            ? restoreDisabledReason ?? 'Cannot restore'
-                            : `Restore canvas from ${caption}`
-                        }
+                        title={titleParts}
                       >
                         <div className="relative aspect-[5/3] w-full bg-gray-100 dark:bg-gray-900 pointer-events-none">
                           {s.thumbnailDataUrl ? (
@@ -217,7 +224,16 @@ export function QuickSnapshotGalleryDialog({
                           <p className="truncate text-[10px] font-medium tabular-nums text-gray-700 dark:text-gray-200">
                             {caption}
                           </p>
-                          <p className="truncate text-[9px] text-gray-500 dark:text-gray-400">{summary}</p>
+                          {author ? (
+                            <p className="truncate text-[9px] text-gray-500 dark:text-gray-400">{author}</p>
+                          ) : null}
+                          <p className="truncate text-[9px] font-medium text-gray-700 dark:text-gray-200">{summaryLine}</p>
+                          {userSummary ? (
+                            <p className="truncate text-[9px] text-gray-500 dark:text-gray-400">{countsLine}</p>
+                          ) : null}
+                          {desc ? (
+                            <p className="line-clamp-2 text-[9px] leading-tight text-gray-500 dark:text-gray-400">{desc}</p>
+                          ) : null}
                           <p className="mt-0.5 truncate font-mono text-[9px] text-gray-400 dark:text-gray-500">{s.id}</p>
                         </div>
                       </button>

--- a/objectified-ui/src/app/ade/studio/editor/lib/quick-layout-snapshots.ts
+++ b/objectified-ui/src/app/ade/studio/editor/lib/quick-layout-snapshots.ts
@@ -18,10 +18,19 @@ export interface QuickLayoutSnapshotPayload {
 export interface QuickLayoutSnapshot {
   id: string;
   createdAt: string;
+  /** Display name or email captured at save time (#173). */
+  author?: string;
+  /** Short label entered when capturing (#173). */
+  summary?: string;
+  /** Optional longer notes (#173). */
+  description?: string;
   /** PNG data URL for preview; omitted if capture failed or was too large. */
   thumbnailDataUrl?: string;
   payload: QuickLayoutSnapshotPayload;
 }
+
+export const QUICK_SNAPSHOT_SUMMARY_MAX_LEN = 120;
+export const QUICK_SNAPSHOT_DESCRIPTION_MAX_LEN = 2000;
 
 /** Locale-aware caption for UI lists and search (same formatting across gallery and compare). */
 export function formatQuickSnapshotCaption(createdAt: string): string {
@@ -43,6 +52,26 @@ export function quickSnapshotCountsSummary(s: QuickLayoutSnapshot): string {
   return `${n} nodes · ${e} edges · ${g} groups`;
 }
 
+/** One-line label for selects and compact lists: summary, else formatted time. */
+export function quickSnapshotListLabel(snapshot: QuickLayoutSnapshot): string {
+  const sum = snapshot.summary?.trim();
+  if (sum) return sum;
+  return formatQuickSnapshotCaption(snapshot.createdAt);
+}
+
+/** Dropdown / compare selector: "Summary · Mar 3, 10:00" or caption only when no summary. */
+export function quickSnapshotOptionLabel(snapshot: QuickLayoutSnapshot): string {
+  const cap = formatQuickSnapshotCaption(snapshot.createdAt);
+  const sum = snapshot.summary?.trim();
+  if (sum) return `${sum} · ${cap}`;
+  return cap;
+}
+
+export function quickSnapshotAuthorDisplay(snapshot: QuickLayoutSnapshot): string | undefined {
+  const a = snapshot.author?.trim();
+  return a || undefined;
+}
+
 /**
  * Case-insensitive match: every whitespace-separated token must appear in id, ISO time,
  * formatted caption, or counts summary.
@@ -55,6 +84,9 @@ export function quickSnapshotMatchesSearch(snapshot: QuickLayoutSnapshot, query:
     snapshot.createdAt,
     formatQuickSnapshotCaption(snapshot.createdAt),
     quickSnapshotCountsSummary(snapshot),
+    snapshot.author ?? '',
+    snapshot.summary ?? '',
+    snapshot.description ?? '',
   ]
     .join('\n')
     .toLowerCase();
@@ -91,6 +123,9 @@ export function isQuickLayoutSnapshot(raw: unknown): raw is QuickLayoutSnapshot 
   if (p.schemaVersion !== QUICK_LAYOUT_SNAPSHOTS_SCHEMA_VERSION) return false;
   if (!isViewport(p.viewport)) return false;
   if (!Array.isArray(p.nodes) || !Array.isArray(p.edges) || !Array.isArray(p.groups)) return false;
+  if (o.author !== undefined && typeof o.author !== 'string') return false;
+  if (o.summary !== undefined && typeof o.summary !== 'string') return false;
+  if (o.description !== undefined && typeof o.description !== 'string') return false;
   if (o.thumbnailDataUrl !== undefined) {
     if (typeof o.thumbnailDataUrl !== 'string') return false;
     if (!o.thumbnailDataUrl.startsWith('data:image/png;base64,')) return false;

--- a/objectified-ui/src/app/ade/studio/editor/lib/quick-layout-snapshots.ts
+++ b/objectified-ui/src/app/ade/studio/editor/lib/quick-layout-snapshots.ts
@@ -74,7 +74,7 @@ export function quickSnapshotAuthorDisplay(snapshot: QuickLayoutSnapshot): strin
 
 /**
  * Case-insensitive match: every whitespace-separated token must appear in id, ISO time,
- * formatted caption, or counts summary.
+ * formatted caption, counts summary, author, summary, or description.
  */
 export function quickSnapshotMatchesSearch(snapshot: QuickLayoutSnapshot, query: string): boolean {
   const raw = query.trim().toLowerCase();

--- a/objectified-ui/src/app/ade/studio/editor/page.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/page.tsx
@@ -4583,7 +4583,14 @@ const StudioContent = () => {
   /** Capture a local quick snapshot (viewport, nodes, edges, groups, optional PNG thumb) with metadata (#173). */
   const performQuickLayoutSnapshotCapture = useCallback(
     async (meta: { summary: string; description: string }) => {
-      if (!selectedVersionId) return;
+      if (!selectedVersionId) {
+        setQuickSnapshotCaptureOpen(false);
+        await alertDialog({
+          message: 'No version is currently open. Please open a version before capturing a snapshot.',
+          variant: 'warning',
+        });
+        return;
+      }
       try {
         setQuickSnapshotCaptureSaving(true);
         setLoadingMessage('Capturing quick snapshot...');

--- a/objectified-ui/src/app/ade/studio/editor/page.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/page.tsx
@@ -189,6 +189,7 @@ import {
 } from '@/app/utils/canvas-layout-json';
 import { computeSchemaMetrics, getCircularDependencyEdgeIds, getDependencyDepthMap, getAffectedClassIds, getUpstreamClassIds, getDependencyChainNodeAndEdgeIds } from '@/app/utils/schema-metrics';
 import { toPng } from 'html-to-image';
+import { QuickSnapshotCaptureDialog } from './components/QuickSnapshotCaptureDialog';
 import { QuickSnapshotCompareDialog } from './components/QuickSnapshotCompareDialog';
 import { QuickSnapshotGalleryDialog } from './components/QuickSnapshotGalleryDialog';
 import DraggablePanel from '../components/DraggablePanel';
@@ -365,6 +366,14 @@ const StudioContent = () => {
   const currentTenantId = (session?.user as any)?.current_tenant_id;
   const currentUserId = (session?.user as any)?.user_id;
   const sessionIsTenantAdmin = Boolean((session?.user as any)?.is_tenant_admin);
+  const quickSnapshotAuthorLabel = useMemo(() => {
+    const u = session?.user as { name?: string | null; email?: string | null } | undefined;
+    const name = u?.name?.trim();
+    if (name) return name;
+    const email = u?.email?.trim();
+    if (email) return email;
+    return 'Anonymous';
+  }, [session]);
   const [effectiveIsTenantAdmin, setEffectiveIsTenantAdmin] = useState(false);
 
   useEffect(() => {
@@ -606,6 +615,8 @@ const StudioContent = () => {
   /** Local quick snapshots for this version (#168); restore UI follows in #170. */
   const [quickLayoutSnapshots, setQuickLayoutSnapshots] = useState<QuickLayoutSnapshot[]>([]);
   const [quickSnapshotSavedFlash, setQuickSnapshotSavedFlash] = useState(false);
+  const [quickSnapshotCaptureOpen, setQuickSnapshotCaptureOpen] = useState(false);
+  const [quickSnapshotCaptureSaving, setQuickSnapshotCaptureSaving] = useState(false);
   const [quickSnapshotCompareOpen, setQuickSnapshotCompareOpen] = useState(false);
   const [quickSnapshotGalleryOpen, setQuickSnapshotGalleryOpen] = useState(false);
   const canvasCaptureAreaRef = useRef<HTMLDivElement>(null);
@@ -4558,8 +4569,7 @@ const StudioContent = () => {
     }
   }, [isReadOnly, selectedVersionId, currentUserId, selectedLayoutName, nodes, edges, groups, getViewport, alertDialog, isDark]);
 
-  /** Capture a local quick snapshot (viewport, nodes, edges, groups, optional PNG thumb) without naming. */
-  const handleQuickLayoutSnapshot = useCallback(async () => {
+  const openQuickSnapshotCaptureDialog = useCallback(async () => {
     if (!selectedVersionId) {
       await alertDialog({
         message: 'Open a version to capture a layout snapshot.',
@@ -4567,92 +4577,108 @@ const StudioContent = () => {
       });
       return;
     }
-    try {
-      setLoadingMessage('Capturing quick snapshot...');
-      setIsLoadingCanvas(true);
-      let thumbnailDataUrl: string | undefined;
-      const captureEl = canvasCaptureAreaRef.current;
-      if (captureEl) {
-        try {
-          const dataUrl = await toPng(captureEl, {
-            pixelRatio: 0.4,
-            cacheBust: true,
-            backgroundColor: isDark ? '#111827' : '#f8fafc',
-          });
-          const comma = dataUrl.indexOf(',');
-          if (comma !== -1 && dataUrl.slice(0, comma).includes('image/png')) {
-            const base64Part = dataUrl.slice(comma + 1);
-            if (base64Part.length <= 240_000) {
-              thumbnailDataUrl = dataUrl;
+    setQuickSnapshotCaptureOpen(true);
+  }, [selectedVersionId, alertDialog]);
+
+  /** Capture a local quick snapshot (viewport, nodes, edges, groups, optional PNG thumb) with metadata (#173). */
+  const performQuickLayoutSnapshotCapture = useCallback(
+    async (meta: { summary: string; description: string }) => {
+      if (!selectedVersionId) return;
+      try {
+        setQuickSnapshotCaptureSaving(true);
+        setLoadingMessage('Capturing quick snapshot...');
+        setIsLoadingCanvas(true);
+        let thumbnailDataUrl: string | undefined;
+        const captureEl = canvasCaptureAreaRef.current;
+        if (captureEl) {
+          try {
+            const dataUrl = await toPng(captureEl, {
+              pixelRatio: 0.4,
+              cacheBust: true,
+              backgroundColor: isDark ? '#111827' : '#f8fafc',
+            });
+            const comma = dataUrl.indexOf(',');
+            if (comma !== -1 && dataUrl.slice(0, comma).includes('image/png')) {
+              const base64Part = dataUrl.slice(comma + 1);
+              if (base64Part.length <= 240_000) {
+                thumbnailDataUrl = dataUrl;
+              }
             }
+          } catch (snapErr) {
+            console.warn('Quick snapshot thumbnail failed:', snapErr);
           }
-        } catch (snapErr) {
-          console.warn('Quick snapshot thumbnail failed:', snapErr);
         }
-      }
-      const viewportRaw = getViewport();
-      const viewport = {
-        x: typeof viewportRaw.x === 'number' && Number.isFinite(viewportRaw.x) ? viewportRaw.x : 0,
-        y: typeof viewportRaw.y === 'number' && Number.isFinite(viewportRaw.y) ? viewportRaw.y : 0,
-        zoom: typeof viewportRaw.zoom === 'number' && Number.isFinite(viewportRaw.zoom) ? viewportRaw.zoom : 1,
-      };
-      const nodeData = mapNodesForLayoutSave(nodes);
-      const edgeData = mapEdgesForLayoutSave(edges);
-      const groupsPlain = groups.map((g) => ({
-        id: g.id,
-        name: g.name,
-        description: g.description,
-        color: g.color,
-        nodeIds: [...g.nodeIds],
-        parentId: g.parentId ?? null,
-        tags: g.tags ? g.tags.map((t) => ({ ...t })) : undefined,
-        position: { ...g.position },
-        dimensions: { ...g.dimensions },
-        styleOptions: g.styleOptions ? { ...g.styleOptions } : undefined,
-      }));
-      const snapshot: QuickLayoutSnapshot = {
-        id: makeQuickLayoutSnapshotId(),
-        createdAt: new Date().toISOString(),
-        ...(thumbnailDataUrl ? { thumbnailDataUrl } : {}),
-        payload: {
-          schemaVersion: QUICK_LAYOUT_SNAPSHOTS_SCHEMA_VERSION,
-          viewport,
-          nodes: nodeData,
-          edges: edgeData,
-          groups: groupsPlain,
-        },
-      };
-      const { snapshots: next, persisted } = appendQuickLayoutSnapshot(selectedVersionId, currentUserId, snapshot);
-      setQuickLayoutSnapshots(next);
-      if (persisted) {
-        setQuickSnapshotSavedFlash(true);
-        window.setTimeout(() => setQuickSnapshotSavedFlash(false), 2000);
-      } else {
+        const viewportRaw = getViewport();
+        const viewport = {
+          x: typeof viewportRaw.x === 'number' && Number.isFinite(viewportRaw.x) ? viewportRaw.x : 0,
+          y: typeof viewportRaw.y === 'number' && Number.isFinite(viewportRaw.y) ? viewportRaw.y : 0,
+          zoom: typeof viewportRaw.zoom === 'number' && Number.isFinite(viewportRaw.zoom) ? viewportRaw.zoom : 1,
+        };
+        const nodeData = mapNodesForLayoutSave(nodes);
+        const edgeData = mapEdgesForLayoutSave(edges);
+        const groupsPlain = groups.map((g) => ({
+          id: g.id,
+          name: g.name,
+          description: g.description,
+          color: g.color,
+          nodeIds: [...g.nodeIds],
+          parentId: g.parentId ?? null,
+          tags: g.tags ? g.tags.map((t) => ({ ...t })) : undefined,
+          position: { ...g.position },
+          dimensions: { ...g.dimensions },
+          styleOptions: g.styleOptions ? { ...g.styleOptions } : undefined,
+        }));
+        const snapshot: QuickLayoutSnapshot = {
+          id: makeQuickLayoutSnapshotId(),
+          createdAt: new Date().toISOString(),
+          author: quickSnapshotAuthorLabel,
+          summary: meta.summary,
+          description: meta.description,
+          ...(thumbnailDataUrl ? { thumbnailDataUrl } : {}),
+          payload: {
+            schemaVersion: QUICK_LAYOUT_SNAPSHOTS_SCHEMA_VERSION,
+            viewport,
+            nodes: nodeData,
+            edges: edgeData,
+            groups: groupsPlain,
+          },
+        };
+        const { snapshots: next, persisted } = appendQuickLayoutSnapshot(selectedVersionId, currentUserId, snapshot);
+        setQuickLayoutSnapshots(next);
+        if (persisted) {
+          setQuickSnapshotSavedFlash(true);
+          window.setTimeout(() => setQuickSnapshotSavedFlash(false), 2000);
+          setQuickSnapshotCaptureOpen(false);
+        } else {
+          await alertDialog({
+            message: 'Quick snapshot could not be saved (storage quota may be full). Try clearing old snapshots.',
+            variant: 'warning',
+          });
+        }
+      } catch (error) {
+        console.error('Error capturing quick layout snapshot:', error);
         await alertDialog({
-          message: 'Quick snapshot could not be saved (storage quota may be full). Try clearing old snapshots.',
-          variant: 'warning',
+          message: 'Could not save quick snapshot. Please try again.',
+          variant: 'error',
         });
+      } finally {
+        setQuickSnapshotCaptureSaving(false);
+        setIsLoadingCanvas(false);
+        setLoadingMessage('');
       }
-    } catch (error) {
-      console.error('Error capturing quick layout snapshot:', error);
-      await alertDialog({
-        message: 'Could not save quick snapshot. Please try again.',
-        variant: 'error',
-      });
-    } finally {
-      setIsLoadingCanvas(false);
-      setLoadingMessage('');
-    }
-  }, [
-    selectedVersionId,
-    currentUserId,
-    nodes,
-    edges,
-    groups,
-    getViewport,
-    isDark,
-    alertDialog,
-  ]);
+    },
+    [
+      selectedVersionId,
+      currentUserId,
+      nodes,
+      edges,
+      groups,
+      getViewport,
+      isDark,
+      alertDialog,
+      quickSnapshotAuthorLabel,
+    ]
+  );
 
   const handleSetMyDefaultLayoutName = useCallback(async () => {
     if (isReadOnly || !selectedVersionId || !currentUserId) return;
@@ -8692,12 +8718,14 @@ const StudioContent = () => {
                             Quick snapshots
                           </p>
                           <p className="text-xs text-gray-500 dark:text-gray-400 leading-snug">
-                            Save the current canvas to this browser only—no layout name or server save. Click a thumbnail to restore that capture (sign-in required; confirms before replacing the canvas).
+                            Save the current canvas to this browser only—no layout name or server save. Capture asks for a
+                            short summary and optional description; author and timestamp are stored automatically. Open the
+                            gallery to restore (sign-in required; confirms before replacing the canvas).
                           </p>
                           <div className="grid grid-cols-2 gap-2">
                             <button
                               type="button"
-                              onClick={() => void handleQuickLayoutSnapshot()}
+                              onClick={() => void openQuickSnapshotCaptureDialog()}
                               disabled={!selectedVersionId}
                               className={`w-full px-3 py-2 text-sm font-medium rounded-lg transition-all duration-200 flex items-center justify-center gap-2 border ${
                                 quickSnapshotSavedFlash
@@ -9377,6 +9405,16 @@ const StudioContent = () => {
           )}
 
           {/* Compare Snapshots & Export Wizard Dialogs */}
+          <QuickSnapshotCaptureDialog
+            open={quickSnapshotCaptureOpen}
+            onOpenChange={(open) => {
+              if (!open && quickSnapshotCaptureSaving) return;
+              setQuickSnapshotCaptureOpen(open);
+            }}
+            authorLabel={quickSnapshotAuthorLabel}
+            isSaving={quickSnapshotCaptureSaving}
+            onConfirm={(meta) => void performQuickLayoutSnapshotCapture(meta)}
+          />
           <QuickSnapshotCompareDialog
             open={quickSnapshotCompareOpen}
             onOpenChange={setQuickSnapshotCompareOpen}

--- a/objectified-ui/tests/QuickSnapshotCaptureDialog.test.tsx
+++ b/objectified-ui/tests/QuickSnapshotCaptureDialog.test.tsx
@@ -1,0 +1,58 @@
+/**
+ * Tests for QuickSnapshotCaptureDialog (#173)
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import { QuickSnapshotCaptureDialog } from '../src/app/ade/studio/editor/components/QuickSnapshotCaptureDialog';
+
+describe('QuickSnapshotCaptureDialog', () => {
+  test('shows author label and requires summary before confirm', async () => {
+    const user = userEvent.setup();
+    const onConfirm = jest.fn();
+
+    render(
+      <QuickSnapshotCaptureDialog
+        open
+        onOpenChange={() => {}}
+        authorLabel="Alex Example"
+        isSaving={false}
+        onConfirm={onConfirm}
+      />
+    );
+
+    expect(screen.getByText('Alex Example')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /save snapshot/i }));
+    expect(onConfirm).not.toHaveBeenCalled();
+    expect(screen.getByText(/enter a short summary/i)).toBeInTheDocument();
+
+    await user.type(screen.getByRole('textbox', { name: /summary/i }), 'Morning layout');
+    await user.click(screen.getByRole('button', { name: /save snapshot/i }));
+    expect(onConfirm).toHaveBeenCalledWith({
+      summary: 'Morning layout',
+      description: '',
+    });
+  });
+
+  test('passes trimmed description', async () => {
+    const user = userEvent.setup();
+    const onConfirm = jest.fn();
+
+    render(
+      <QuickSnapshotCaptureDialog
+        open
+        onOpenChange={() => {}}
+        authorLabel="A"
+        isSaving={false}
+        onConfirm={onConfirm}
+      />
+    );
+
+    await user.type(screen.getByRole('textbox', { name: /summary/i }), 'S');
+    await user.type(screen.getByRole('textbox', { name: /description/i }), '  note  ');
+    await user.click(screen.getByRole('button', { name: /save snapshot/i }));
+    expect(onConfirm).toHaveBeenCalledWith({ summary: 'S', description: 'note' });
+  });
+});

--- a/objectified-ui/tests/QuickSnapshotGalleryDialog.test.tsx
+++ b/objectified-ui/tests/QuickSnapshotGalleryDialog.test.tsx
@@ -46,9 +46,10 @@ describe('QuickSnapshotGalleryDialog', () => {
     expect(screen.getByText(/No quick snapshots yet/i)).toBeInTheDocument();
   });
 
-  test('filters by search query', async () => {
+  test('filters by search query on summary text', async () => {
     const user = userEvent.setup();
     const a = makeSnapshot('alpha-snap', '2026-03-01T10:00:00.000Z', { nodeCount: 2 });
+    a.summary = 'Payment flow draft';
     const b = makeSnapshot('beta-snap', '2026-03-02T10:00:00.000Z', { nodeCount: 5 });
 
     render(
@@ -63,7 +64,7 @@ describe('QuickSnapshotGalleryDialog', () => {
 
     expect(screen.getByText(/Showing 2 of 2/i)).toBeInTheDocument();
     const search = screen.getByRole('searchbox', { name: /Search quick snapshots/i });
-    await user.type(search, 'beta');
+    await user.type(search, 'payment');
     expect(screen.getByText(/Showing 1 of 2/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/Restore quick snapshot/i)).toBeInTheDocument();
   });

--- a/objectified-ui/tests/quick-layout-snapshots.test.ts
+++ b/objectified-ui/tests/quick-layout-snapshots.test.ts
@@ -6,7 +6,9 @@ import {
   DEFAULT_MAX_QUICK_LAYOUT_SNAPSHOTS,
   formatQuickSnapshotCaption,
   quickSnapshotCountsSummary,
+  quickSnapshotListLabel,
   quickSnapshotMatchesSearch,
+  quickSnapshotOptionLabel,
   type QuickLayoutSnapshot,
 } from '@/app/ade/studio/editor/lib/quick-layout-snapshots';
 
@@ -153,6 +155,30 @@ describe('quick-layout-snapshots', () => {
     ).toBe(true);
   });
 
+  it('isQuickLayoutSnapshot accepts snapshot with metadata strings', () => {
+    expect(
+      isQuickLayoutSnapshot({
+        id: '1',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        author: 'Ada',
+        summary: 'Baseline',
+        description: 'Before edits',
+        payload: samplePayload,
+      })
+    ).toBe(true);
+  });
+
+  it('isQuickLayoutSnapshot rejects non-string metadata fields', () => {
+    expect(
+      isQuickLayoutSnapshot({
+        id: '1',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        author: 1,
+        payload: samplePayload,
+      })
+    ).toBe(false);
+  });
+
   it('formatQuickSnapshotCaption handles invalid dates', () => {
     expect(formatQuickSnapshotCaption('not-a-date')).toBe('Unknown time');
   });
@@ -184,5 +210,32 @@ describe('quick-layout-snapshots', () => {
     expect(quickSnapshotMatchesSearch(snap, '3 nodes')).toBe(true);
     expect(quickSnapshotMatchesSearch(snap, '2026-06-15 3 nodes')).toBe(true);
     expect(quickSnapshotMatchesSearch(snap, 'nomatch-xyz-123')).toBe(false);
+  });
+
+  it('quickSnapshotMatchesSearch matches author, summary, and description', () => {
+    const snap = makeSnapshot('x', '2026-01-01T00:00:00.000Z');
+    snap.author = 'River Tam';
+    snap.summary = 'Auth refactor';
+    snap.description = 'Moved guards to middleware';
+    expect(quickSnapshotMatchesSearch(snap, 'river')).toBe(true);
+    expect(quickSnapshotMatchesSearch(snap, 'refactor')).toBe(true);
+    expect(quickSnapshotMatchesSearch(snap, 'middleware')).toBe(true);
+  });
+
+  it('quickSnapshotListLabel prefers trimmed summary over formatted time', () => {
+    const snap = makeSnapshot('x', '2026-06-15T12:30:00.000Z');
+    snap.summary = '  My label  ';
+    expect(quickSnapshotListLabel(snap)).toBe('My label');
+    delete snap.summary;
+    expect(quickSnapshotListLabel(snap)).toBe(formatQuickSnapshotCaption(snap.createdAt));
+  });
+
+  it('quickSnapshotOptionLabel joins summary and caption', () => {
+    const snap = makeSnapshot('x', '2026-06-15T12:30:00.000Z');
+    const cap = formatQuickSnapshotCaption(snap.createdAt);
+    snap.summary = 'Beta';
+    expect(quickSnapshotOptionLabel(snap)).toBe(`Beta · ${cap}`);
+    delete snap.summary;
+    expect(quickSnapshotOptionLabel(snap)).toBe(cap);
   });
 });


### PR DESCRIPTION
## Problem Statement

Users and teams need **addresses #173 — quick snapshot metadata (author, summary, description)** within the Objectified platform. Today this capability is missing or only partially implemented, which blocks dashboard workflows and creates inconsistency across tenants and projects.

## Solution / Scope

Implement **Addresses #173 — Quick snapshot metadata (author, summary, description)** as part of **Dashboard**. KPIs, primitives browser, project overview, quick actions.

**Post-MVP** (prioritize after MVP slice) candidacy.

```mermaid
flowchart TB
  CP[Control Panel] --> KPIs[Stats cards]
  CP --> Primitives[Primitives list]
  CP --> Projects[Recent projects]
  CP --> Actions[Quick actions]
```

## Acceptance Criteria

- [ ] Feature behaves as described for: Addresses #173 — Quick snapshot metadata (author, summary, description)
- [ ] Unit/integration tests cover happy path and primary error cases
- [ ] UI (if applicable) matches existing ADE patterns (Tailwind 4, Radix, Lucide)
- [ ] REST endpoints (if applicable) follow `/v1/{{feature}}/{{tenant_slug}}/...` conventions
- [ ] Documented in issue/PR; no regressions to existing schema/version flows

## Parallelism / Dependencies

- **Can run in parallel:** Yes
- **Blockers:** None identified; validate against current codebase before starting

## Technical Stack

- **Modules:** objectified-rest
- **Stack:** Next.js ADE dashboard, control panel components, REST stats APIs
- **Labels:** ``

---

**Epic:** [[Epic] Dashboard & Control Panel](https://github.com/objectified-project/objectified/issues/3493)
**Issue:** #873 · **Area:** Dashboard · **Roadmap batch:** legacy #64–#879 enrichment