### PR TITLE
Addresses #174 — Share quick layout snapshots as JSON with teammates

### DIFF
--- a/PLANNED_FEATURE_ROADMAP_CANVAS.md
+++ b/PLANNED_FEATURE_ROADMAP_CANVAS.md
@@ -11,7 +11,7 @@
 
 ### 1. Canvas Layout & Organization
 
-#### Layout Sharing 📋 PLANNED
+#### Layout Sharing 📋 PARTIALLY IMPLEMENTED
 - ✅ Share layout configurations with team members (#174) — quick snapshot gallery: copy/download JSON envelope, import shared JSON for same API version
 - 📋 [TODO] "Pin" layout as team default
 - 📋 [TODO] Layout permissions (view, edit, delete)

--- a/PLANNED_FEATURE_ROADMAP_CANVAS.md
+++ b/PLANNED_FEATURE_ROADMAP_CANVAS.md
@@ -12,7 +12,7 @@
 ### 1. Canvas Layout & Organization
 
 #### Layout Sharing 📋 PLANNED
-- 📋 [TODO] Share layout configurations with team members
+- ✅ Share layout configurations with team members (#174) — quick snapshot gallery: copy/download JSON envelope, import shared JSON for same API version
 - 📋 [TODO] "Pin" layout as team default
 - 📋 [TODO] Layout permissions (view, edit, delete)
 - 📋 [TODO] Layout comments and annotations
@@ -20,7 +20,6 @@
 
 | Ticket | Feature                                       |
 |--------|-----------------------------------------------|
-| #174   | Share layout configurations with team members |
 | #175   | "Pin" layout as team default                  |
 | #176   | Layout permissions (view, edit, delete)       |
 | #177   | Layout comments and annotations               |

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.8.83",
+  "version": "0.8.84",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -5,6 +5,7 @@ We continue to improve the platform based on your feedback with improvements and
 ---
 
 Improvements:
+- Canvas: share quick layout snapshots with teammates via JSON (copy or download from the gallery) and import shared files or pasted JSON for the same API version (#174)
 - Canvas: quick snapshots store timestamp, author (from your session), a required short summary, and optional description; capture opens a short form before saving (#173)
 - Canvas: quick snapshot gallery in the Layout panel—browse captures in a scrollable grid with search, preview filters (all / with image / no image), and newest-or-oldest sort (#172)
 - Canvas: project and version dropdowns show a loading spinner and label while projects or versions are being fetched (#866)

--- a/objectified-ui/src/app/ade/studio/editor/components/QuickSnapshotGalleryDialog.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/components/QuickSnapshotGalleryDialog.tsx
@@ -1,19 +1,27 @@
 'use client';
 
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import * as Dialog from '@radix-ui/react-dialog';
+import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 import * as ToggleGroup from '@radix-ui/react-toggle-group';
-import { X, LayoutGrid, Search, Image as ImageIcon } from 'lucide-react';
+import { X, LayoutGrid, Search, Image as ImageIcon, Share2, Upload } from 'lucide-react';
 import {
   formatQuickSnapshotCaption,
   quickSnapshotAuthorDisplay,
   quickSnapshotCountsSummary,
   quickSnapshotMatchesSearch,
+  stringifyQuickLayoutShareEnvelope,
   type QuickLayoutSnapshot,
 } from '../lib/quick-layout-snapshots';
 
 export type QuickSnapshotPreviewFilter = 'all' | 'with' | 'without';
 export type QuickSnapshotSortOrder = 'newest' | 'oldest';
+
+export type QuickSnapshotGalleryAlertVariant = 'success' | 'error' | 'warning' | 'info';
+
+export type ImportSharedQuickSnapshotResult =
+  | { success: true }
+  | { success: false; message: string };
 
 export interface QuickSnapshotGalleryDialogProps {
   open: boolean;
@@ -23,6 +31,11 @@ export interface QuickSnapshotGalleryDialogProps {
   restoreDisabled: boolean;
   /** Shown as title/tooltip when restore is disabled (e.g. read-only). */
   restoreDisabledReason?: string;
+  /** Current API version id — required to build share JSON and validate imports. */
+  versionId: string | null;
+  /** Persist a shared JSON envelope; return success or an error message for the user. */
+  onImportSharedJson: (jsonText: string) => Promise<ImportSharedQuickSnapshotResult>;
+  alertDialog: (opts: { message: string; variant: QuickSnapshotGalleryAlertVariant }) => Promise<void>;
 }
 
 export function QuickSnapshotGalleryDialog({
@@ -32,16 +45,96 @@ export function QuickSnapshotGalleryDialog({
   onRestore,
   restoreDisabled,
   restoreDisabledReason,
+  versionId,
+  onImportSharedJson,
+  alertDialog,
 }: QuickSnapshotGalleryDialogProps) {
   const [query, setQuery] = useState('');
   const [previewFilter, setPreviewFilter] = useState<QuickSnapshotPreviewFilter>('all');
   const [sortOrder, setSortOrder] = useState<QuickSnapshotSortOrder>('newest');
+  const [importOpen, setImportOpen] = useState(false);
+  const [importText, setImportText] = useState('');
+  const [importBusy, setImportBusy] = useState(false);
+  const importFileRef = useRef<HTMLInputElement>(null);
+
+  const shareEnabled = Boolean(versionId?.trim());
+
+  const copyShareJson = useCallback(
+    async (snapshot: QuickLayoutSnapshot) => {
+      if (!shareEnabled || !versionId) {
+        await alertDialog({ message: 'Open a version to share snapshots.', variant: 'warning' });
+        return;
+      }
+      try {
+        const text = stringifyQuickLayoutShareEnvelope(versionId, snapshot);
+        await navigator.clipboard.writeText(text);
+        await alertDialog({
+          message:
+            'Snapshot JSON copied. Paste it into chat or a file for teammates; they can import it from this gallery for this API version.',
+          variant: 'success',
+        });
+      } catch (e) {
+        console.error('Quick snapshot share copy failed:', e);
+        await alertDialog({ message: 'Could not copy to the clipboard.', variant: 'error' });
+      }
+    },
+    [alertDialog, shareEnabled, versionId]
+  );
+
+  const downloadShareJson = useCallback(
+    async (snapshot: QuickLayoutSnapshot) => {
+      if (!shareEnabled || !versionId) {
+        await alertDialog({ message: 'Open a version to share snapshots.', variant: 'warning' });
+        return;
+      }
+      try {
+        const text = stringifyQuickLayoutShareEnvelope(versionId, snapshot);
+        const safeId = snapshot.id.replace(/[^a-zA-Z0-9_-]/g, '').slice(0, 12) || 'snapshot';
+        const blob = new Blob([text], { type: 'application/json;charset=utf-8' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = `objectified-quick-snapshot-${safeId}.json`;
+        a.rel = 'noopener';
+        document.body.appendChild(a);
+        a.click();
+        a.remove();
+        window.setTimeout(() => URL.revokeObjectURL(url), 2_000);
+      } catch (e) {
+        console.error('Quick snapshot share download failed:', e);
+        await alertDialog({ message: 'Could not start the download.', variant: 'error' });
+      }
+    },
+    [alertDialog, shareEnabled, versionId]
+  );
+
+  const runImport = useCallback(async () => {
+    setImportBusy(true);
+    try {
+      const result = await onImportSharedJson(importText);
+      if (result.success) {
+        await alertDialog({ message: 'Shared snapshot added to your gallery.', variant: 'success' });
+        setImportOpen(false);
+        setImportText('');
+      } else {
+        await alertDialog({ message: result.message, variant: 'error' });
+      }
+    } catch (e) {
+      console.error('Import shared quick snapshot failed:', e);
+      await alertDialog({ message: 'Could not import the snapshot.', variant: 'error' });
+    } finally {
+      setImportBusy(false);
+    }
+  }, [alertDialog, importText, onImportSharedJson]);
 
   useEffect(() => {
     if (!open) {
       setQuery('');
       setPreviewFilter('all');
       setSortOrder('newest');
+      setImportOpen(false);
+      setImportText('');
+      setImportBusy(false);
     }
   }, [open]);
 
@@ -78,7 +171,8 @@ export function QuickSnapshotGalleryDialog({
                 </Dialog.Title>
                 <Dialog.Description className="mt-1 text-xs leading-snug text-gray-500 dark:text-gray-400">
                   Search by summary, author, description, time, snapshot id, or layout counts. Filter by preview image.
-                  Newest captures appear first by default.
+                  Newest captures appear first by default. Use Share on a tile to copy or download JSON for teammates on this
+                  version; Import adds a shared file or pasted JSON to your local gallery.
                 </Dialog.Description>
               </div>
             </div>
@@ -158,6 +252,22 @@ export function QuickSnapshotGalleryDialog({
             <p className="text-[11px] text-gray-500 dark:text-gray-400">
               Showing {filteredSorted.length} of {snapshots.length}
             </p>
+            <div className="flex flex-wrap items-center gap-2">
+              <button
+                type="button"
+                disabled={!shareEnabled}
+                onClick={() => setImportOpen(true)}
+                className={`inline-flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-xs font-medium transition-colors ${
+                  shareEnabled
+                    ? 'border-indigo-200 bg-indigo-50 text-indigo-800 hover:bg-indigo-100 dark:border-indigo-800 dark:bg-indigo-950/40 dark:text-indigo-200 dark:hover:bg-indigo-900/50'
+                    : 'cursor-not-allowed border-gray-200 bg-gray-100 text-gray-400 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-500'
+                }`}
+                title={shareEnabled ? 'Add a snapshot shared by a teammate (same API version)' : 'Open a version first'}
+              >
+                <Upload className="h-3.5 w-3.5 shrink-0" aria-hidden />
+                Import shared snapshot
+              </button>
+            </div>
           </div>
 
           <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-4 py-3">
@@ -188,55 +298,98 @@ export function QuickSnapshotGalleryDialog({
                     .join('\n\n');
                   return (
                     <li key={s.id} className="list-none">
-                      <button
-                        type="button"
-                        disabled={restoreDisabled}
-                        onClick={() => onRestore(s)}
-                        aria-label={`Restore quick snapshot: ${summaryLine}, ${caption}`}
-                        className={`w-full overflow-hidden rounded-lg border border-gray-200 bg-white text-left shadow-sm transition-opacity dark:border-gray-600 dark:bg-gray-800/70 ${
-                          restoreDisabled
-                            ? 'cursor-not-allowed opacity-50'
-                            : 'hover:ring-2 hover:ring-indigo-400 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 dark:hover:ring-indigo-500'
+                      <div
+                        className={`relative overflow-hidden rounded-lg border border-gray-200 bg-white text-left shadow-sm dark:border-gray-600 dark:bg-gray-800/70 ${
+                          restoreDisabled ? 'opacity-50' : ''
                         }`}
-                        title={titleParts}
                       >
-                        <div className="relative aspect-[5/3] w-full bg-gray-100 dark:bg-gray-900 pointer-events-none">
-                          {s.thumbnailDataUrl ? (
-                            <img
-                              src={s.thumbnailDataUrl}
-                              alt=""
-                              className="absolute inset-0 h-full w-full object-cover"
-                              loading="lazy"
-                              decoding="async"
-                            />
-                          ) : (
-                            <div
-                              className="absolute inset-0 flex flex-col items-center justify-center gap-1 px-1 text-center text-gray-400 dark:text-gray-500"
-                              role="img"
-                              aria-label="No preview image for this snapshot"
-                            >
-                              <ImageIcon className="h-5 w-5 shrink-0 opacity-60" aria-hidden />
-                              <span className="text-[9px] leading-tight">No preview</span>
+                        <div className="relative">
+                          {shareEnabled ? (
+                            <DropdownMenu.Root>
+                              <DropdownMenu.Trigger asChild>
+                                <button
+                                  type="button"
+                                  className="absolute right-1 top-1 z-10 flex h-7 w-7 items-center justify-center rounded-md border border-gray-200/90 bg-white/95 text-gray-700 shadow-sm hover:bg-white focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 dark:border-gray-600 dark:bg-gray-900/95 dark:text-gray-200 dark:hover:bg-gray-800"
+                                  aria-label={`Share snapshot: ${summaryLine}`}
+                                  title="Copy or download JSON for teammates"
+                                  onPointerDown={(e) => e.stopPropagation()}
+                                >
+                                  <Share2 className="h-3.5 w-3.5" aria-hidden />
+                                </button>
+                              </DropdownMenu.Trigger>
+                              <DropdownMenu.Portal>
+                                <DropdownMenu.Content
+                                  className="z-[1400] min-w-[10rem] overflow-hidden rounded-md border border-gray-200 bg-white p-1 text-sm shadow-lg dark:border-gray-600 dark:bg-gray-900"
+                                  sideOffset={4}
+                                  align="end"
+                                >
+                                  <DropdownMenu.Item
+                                    className="cursor-pointer rounded px-2 py-1.5 outline-none hover:bg-gray-100 focus:bg-gray-100 dark:hover:bg-gray-800 dark:focus:bg-gray-800"
+                                    onSelect={() => void copyShareJson(s)}
+                                  >
+                                    Copy JSON
+                                  </DropdownMenu.Item>
+                                  <DropdownMenu.Item
+                                    className="cursor-pointer rounded px-2 py-1.5 outline-none hover:bg-gray-100 focus:bg-gray-100 dark:hover:bg-gray-800 dark:focus:bg-gray-800"
+                                    onSelect={() => void downloadShareJson(s)}
+                                  >
+                                    Download JSON
+                                  </DropdownMenu.Item>
+                                </DropdownMenu.Content>
+                              </DropdownMenu.Portal>
+                            </DropdownMenu.Root>
+                          ) : null}
+                          <button
+                            type="button"
+                            disabled={restoreDisabled}
+                            onClick={() => onRestore(s)}
+                            aria-label={`Restore quick snapshot: ${summaryLine}, ${caption}`}
+                            className={`w-full overflow-hidden text-left ${
+                              restoreDisabled
+                                ? 'cursor-not-allowed'
+                                : 'hover:ring-2 hover:ring-indigo-400 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 dark:hover:ring-indigo-500'
+                            }`}
+                            title={titleParts}
+                          >
+                            <div className="relative aspect-[5/3] w-full bg-gray-100 dark:bg-gray-900 pointer-events-none">
+                              {s.thumbnailDataUrl ? (
+                                <img
+                                  src={s.thumbnailDataUrl}
+                                  alt=""
+                                  className="absolute inset-0 h-full w-full object-cover"
+                                  loading="lazy"
+                                  decoding="async"
+                                />
+                              ) : (
+                                <div
+                                  className="absolute inset-0 flex flex-col items-center justify-center gap-1 px-1 text-center text-gray-400 dark:text-gray-500"
+                                  role="img"
+                                  aria-label="No preview image for this snapshot"
+                                >
+                                  <ImageIcon className="h-5 w-5 shrink-0 opacity-60" aria-hidden />
+                                  <span className="text-[9px] leading-tight">No preview</span>
+                                </div>
+                              )}
                             </div>
-                          )}
+                            <div className="pointer-events-none border-t border-gray-100 px-2 py-1.5 dark:border-gray-700/80">
+                              <p className="truncate text-[10px] font-medium tabular-nums text-gray-700 dark:text-gray-200">
+                                {caption}
+                              </p>
+                              {author ? (
+                                <p className="truncate text-[9px] text-gray-500 dark:text-gray-400">{author}</p>
+                              ) : null}
+                              <p className="truncate text-[9px] font-medium text-gray-700 dark:text-gray-200">{summaryLine}</p>
+                              {userSummary ? (
+                                <p className="truncate text-[9px] text-gray-500 dark:text-gray-400">{countsLine}</p>
+                              ) : null}
+                              {desc ? (
+                                <p className="line-clamp-2 text-[9px] leading-tight text-gray-500 dark:text-gray-400">{desc}</p>
+                              ) : null}
+                              <p className="mt-0.5 truncate font-mono text-[9px] text-gray-400 dark:text-gray-500">{s.id}</p>
+                            </div>
+                          </button>
                         </div>
-                        <div className="pointer-events-none border-t border-gray-100 px-2 py-1.5 dark:border-gray-700/80">
-                          <p className="truncate text-[10px] font-medium tabular-nums text-gray-700 dark:text-gray-200">
-                            {caption}
-                          </p>
-                          {author ? (
-                            <p className="truncate text-[9px] text-gray-500 dark:text-gray-400">{author}</p>
-                          ) : null}
-                          <p className="truncate text-[9px] font-medium text-gray-700 dark:text-gray-200">{summaryLine}</p>
-                          {userSummary ? (
-                            <p className="truncate text-[9px] text-gray-500 dark:text-gray-400">{countsLine}</p>
-                          ) : null}
-                          {desc ? (
-                            <p className="line-clamp-2 text-[9px] leading-tight text-gray-500 dark:text-gray-400">{desc}</p>
-                          ) : null}
-                          <p className="mt-0.5 truncate font-mono text-[9px] text-gray-400 dark:text-gray-500">{s.id}</p>
-                        </div>
-                      </button>
+                      </div>
                     </li>
                   );
                 })}
@@ -244,6 +397,83 @@ export function QuickSnapshotGalleryDialog({
             )}
           </div>
         </Dialog.Content>
+
+        <Dialog.Root open={importOpen} onOpenChange={setImportOpen}>
+          <Dialog.Portal>
+            <Dialog.Overlay className="fixed inset-0 z-[1302] bg-black/60 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
+            <Dialog.Content
+              className="fixed left-1/2 top-1/2 z-[1303] w-[min(96vw,24rem)] -translate-x-1/2 -translate-y-1/2 rounded-xl border border-gray-200 bg-white p-4 shadow-xl outline-none dark:border-gray-700 dark:bg-gray-900"
+              onPointerDownOutside={(e) => {
+                if (importBusy) e.preventDefault();
+              }}
+            >
+              <Dialog.Title className="text-sm font-semibold text-gray-900 dark:text-white">
+                Import shared snapshot
+              </Dialog.Title>
+              <Dialog.Description className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                Paste JSON from a teammate (same API version) or choose a{' '}
+                <code className="rounded bg-gray-100 px-0.5 text-[10px] dark:bg-gray-800">.json</code> file.
+              </Dialog.Description>
+              <textarea
+                value={importText}
+                onChange={(e) => setImportText(e.target.value)}
+                rows={8}
+                className="mt-3 w-full rounded-lg border border-gray-200 bg-white px-2 py-1.5 font-mono text-[11px] text-gray-900 shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+                placeholder='{ "kind": "objectified.quickLayoutSnapshotShare", ... }'
+                disabled={importBusy}
+                aria-label="Shared snapshot JSON"
+              />
+              <input
+                ref={importFileRef}
+                type="file"
+                accept="application/json,.json"
+                className="sr-only"
+                aria-hidden
+                tabIndex={-1}
+                onChange={(e) => {
+                  const file = e.target.files?.[0];
+                  e.target.value = '';
+                  if (!file) return;
+                  const reader = new FileReader();
+                  reader.onload = () => {
+                    const text = typeof reader.result === 'string' ? reader.result : '';
+                    setImportText(text);
+                  };
+                  reader.readAsText(file);
+                }}
+              />
+              <div className="mt-3 flex flex-wrap items-center justify-end gap-2">
+                <button
+                  type="button"
+                  disabled={importBusy}
+                  onClick={() => importFileRef.current?.click()}
+                  className="mr-auto rounded-lg border border-gray-200 bg-white px-2.5 py-1.5 text-xs font-medium text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
+                >
+                  Choose file…
+                </button>
+                <button
+                  type="button"
+                  disabled={importBusy}
+                  onClick={() => {
+                    setImportOpen(false);
+                    setImportText('');
+                  }}
+                  className="rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-xs font-medium text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  disabled={importBusy || !importText.trim()}
+                  onClick={() => void runImport()}
+                  className="rounded-lg bg-indigo-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-indigo-700 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  {importBusy ? 'Importing…' : 'Import'}
+                </button>
+              </div>
+            </Dialog.Content>
+          </Dialog.Portal>
+        </Dialog.Root>
       </Dialog.Portal>
     </Dialog.Root>
   );

--- a/objectified-ui/src/app/ade/studio/editor/components/QuickSnapshotGalleryDialog.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/components/QuickSnapshotGalleryDialog.tsx
@@ -406,6 +406,9 @@ export function QuickSnapshotGalleryDialog({
               onPointerDownOutside={(e) => {
                 if (importBusy) e.preventDefault();
               }}
+              onEscapeKeyDown={(e) => {
+                if (importBusy) e.preventDefault();
+              }}
             >
               <Dialog.Title className="text-sm font-semibold text-gray-900 dark:text-white">
                 Import shared snapshot

--- a/objectified-ui/src/app/ade/studio/editor/lib/quick-layout-snapshots.ts
+++ b/objectified-ui/src/app/ade/studio/editor/lib/quick-layout-snapshots.ts
@@ -196,3 +196,86 @@ export function makeQuickLayoutSnapshotId(): string {
   }
   return `qs-${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
 }
+
+// --- Team share envelope (#174): JSON teammates can pass via file or chat for the same API version ---
+
+export const QUICK_LAYOUT_SHARE_KIND = 'objectified.quickLayoutSnapshotShare' as const;
+export const QUICK_LAYOUT_SHARE_SCHEMA_VERSION = 1 as const;
+
+export interface QuickLayoutShareEnvelope {
+  kind: typeof QUICK_LAYOUT_SHARE_KIND;
+  schemaVersion: typeof QUICK_LAYOUT_SHARE_SCHEMA_VERSION;
+  /** API version this snapshot was captured for; import requires an exact match. */
+  versionId: string;
+  snapshot: QuickLayoutSnapshot;
+}
+
+export function buildQuickLayoutShareEnvelope(
+  versionId: string,
+  snapshot: QuickLayoutSnapshot
+): QuickLayoutShareEnvelope {
+  const vid = versionId.trim();
+  if (!vid) {
+    throw new Error('versionId is required to share a quick layout snapshot');
+  }
+  return {
+    kind: QUICK_LAYOUT_SHARE_KIND,
+    schemaVersion: QUICK_LAYOUT_SHARE_SCHEMA_VERSION,
+    versionId: vid,
+    snapshot,
+  };
+}
+
+export function stringifyQuickLayoutShareEnvelope(versionId: string, snapshot: QuickLayoutSnapshot): string {
+  return JSON.stringify(buildQuickLayoutShareEnvelope(versionId, snapshot), null, 2);
+}
+
+export type ParseQuickLayoutShareResult =
+  | { ok: true; versionId: string; snapshot: QuickLayoutSnapshot }
+  | { ok: false; error: string };
+
+/**
+ * Validates a JSON string produced for team sharing. Rejects truncated or wrong-kind payloads.
+ */
+export function parseQuickLayoutShareText(text: string): ParseQuickLayoutShareResult {
+  const raw = text.trim();
+  if (!raw) {
+    return { ok: false, error: 'No JSON to import.' };
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw) as unknown;
+  } catch {
+    return { ok: false, error: 'Invalid JSON.' };
+  }
+  if (!parsed || typeof parsed !== 'object') {
+    return { ok: false, error: 'Shared snapshot must be a JSON object.' };
+  }
+  const o = parsed as Record<string, unknown>;
+  if (o.kind !== QUICK_LAYOUT_SHARE_KIND) {
+    return {
+      ok: false,
+      error: 'Not a shared quick snapshot file (missing or wrong kind). Use Copy JSON or Download from the gallery.',
+    };
+  }
+  if (o.schemaVersion !== QUICK_LAYOUT_SHARE_SCHEMA_VERSION) {
+    return { ok: false, error: `Unsupported share format version: ${String(o.schemaVersion)}.` };
+  }
+  if (typeof o.versionId !== 'string' || !o.versionId.trim()) {
+    return { ok: false, error: 'Shared snapshot is missing versionId.' };
+  }
+  if (!isQuickLayoutSnapshot(o.snapshot)) {
+    return { ok: false, error: 'Shared snapshot data is invalid or corrupt.' };
+  }
+  return { ok: true, versionId: o.versionId.trim(), snapshot: o.snapshot };
+}
+
+/**
+ * Clone a teammate's snapshot with a new id so it can live alongside local captures without collision.
+ */
+export function cloneQuickLayoutSnapshotForImport(snapshot: QuickLayoutSnapshot): QuickLayoutSnapshot {
+  return {
+    ...snapshot,
+    id: makeQuickLayoutSnapshotId(),
+  };
+}

--- a/objectified-ui/src/app/ade/studio/editor/page.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/page.tsx
@@ -4692,7 +4692,8 @@ const StudioContent = () => {
   /** Import a teammate's shared quick snapshot JSON (same API version) into local storage (#174). */
   const handleImportSharedQuickSnapshotJson = useCallback(
     async (jsonText: string): Promise<{ success: true } | { success: false; message: string }> => {
-      if (!selectedVersionId?.trim()) {
+      const vid = selectedVersionId?.trim();
+      if (!vid) {
         return { success: false, message: 'Open a version before importing a shared snapshot.' };
       }
       if (!currentUserId) {
@@ -4702,15 +4703,15 @@ const StudioContent = () => {
       if (!parsed.ok) {
         return { success: false, message: parsed.error };
       }
-      if (parsed.versionId !== selectedVersionId.trim()) {
+      if (parsed.versionId !== vid) {
         return {
           success: false,
-          message: `This snapshot is for API version "${parsed.versionId}" but the open version is "${selectedVersionId.trim()}". Open the matching version or ask your teammate to export again.`,
+          message: `This snapshot is for API version "${parsed.versionId}" but the open version is "${vid}". Open the matching version or ask your teammate to export again.`,
         };
       }
       const incoming = cloneQuickLayoutSnapshotForImport(parsed.snapshot);
       const { snapshots: next, persisted } = appendQuickLayoutSnapshot(
-        selectedVersionId,
+        vid,
         currentUserId,
         incoming
       );

--- a/objectified-ui/src/app/ade/studio/editor/page.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/page.tsx
@@ -129,8 +129,10 @@ import { expandClassesForGroupExport, downloadTextFile } from '@/app/utils/group
 import { mapEdgesForLayoutSave, mapNodesForLayoutSave } from '../lib/canvasLayoutPayload';
 import {
   appendQuickLayoutSnapshot,
+  cloneQuickLayoutSnapshotForImport,
   loadQuickLayoutSnapshots,
   makeQuickLayoutSnapshotId,
+  parseQuickLayoutShareText,
   QUICK_LAYOUT_SNAPSHOTS_SCHEMA_VERSION,
   type QuickLayoutSnapshot,
 } from './lib/quick-layout-snapshots';
@@ -4687,6 +4689,43 @@ const StudioContent = () => {
     ]
   );
 
+  /** Import a teammate's shared quick snapshot JSON (same API version) into local storage (#174). */
+  const handleImportSharedQuickSnapshotJson = useCallback(
+    async (jsonText: string): Promise<{ success: true } | { success: false; message: string }> => {
+      if (!selectedVersionId?.trim()) {
+        return { success: false, message: 'Open a version before importing a shared snapshot.' };
+      }
+      if (!currentUserId) {
+        return { success: false, message: 'Sign in to import snapshots into your gallery.' };
+      }
+      const parsed = parseQuickLayoutShareText(jsonText);
+      if (!parsed.ok) {
+        return { success: false, message: parsed.error };
+      }
+      if (parsed.versionId !== selectedVersionId.trim()) {
+        return {
+          success: false,
+          message: `This snapshot is for API version "${parsed.versionId}" but the open version is "${selectedVersionId.trim()}". Open the matching version or ask your teammate to export again.`,
+        };
+      }
+      const incoming = cloneQuickLayoutSnapshotForImport(parsed.snapshot);
+      const { snapshots: next, persisted } = appendQuickLayoutSnapshot(
+        selectedVersionId,
+        currentUserId,
+        incoming
+      );
+      if (!persisted) {
+        return {
+          success: false,
+          message: 'Could not save the imported snapshot (storage quota may be full). Try removing old snapshots.',
+        };
+      }
+      setQuickLayoutSnapshots(next);
+      return { success: true };
+    },
+    [selectedVersionId, currentUserId]
+  );
+
   const handleSetMyDefaultLayoutName = useCallback(async () => {
     if (isReadOnly || !selectedVersionId || !currentUserId) return;
     const layoutName = selectedLayoutName.trim();
@@ -8726,8 +8765,9 @@ const StudioContent = () => {
                           </p>
                           <p className="text-xs text-gray-500 dark:text-gray-400 leading-snug">
                             Save the current canvas to this browser only—no layout name or server save. Capture asks for a
-                            short summary and optional description; author and timestamp are stored automatically. Open the
-                            gallery to restore (sign-in required; confirms before replacing the canvas).
+                            short summary and optional description; author and timestamp are stored automatically. Share a
+                            snapshot as JSON from the gallery or import a teammate&apos;s file for this API version. Open
+                            the gallery to restore (sign-in required; confirms before replacing the canvas).
                           </p>
                           <div className="grid grid-cols-2 gap-2">
                             <button
@@ -8783,16 +8823,16 @@ const StudioContent = () => {
                           <button
                             type="button"
                             onClick={() => setQuickSnapshotGalleryOpen(true)}
-                            disabled={quickLayoutSnapshots.length === 0}
+                            disabled={!selectedVersionId}
                             className={`mt-2 w-full px-3 py-2 text-sm font-medium rounded-lg transition-all duration-200 flex items-center justify-center gap-2 border ${
-                              quickLayoutSnapshots.length > 0
+                              selectedVersionId
                                 ? 'bg-white dark:bg-gray-700/50 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600 border-gray-200 dark:border-gray-600'
                                 : 'bg-gray-100 dark:bg-gray-700 text-gray-400 cursor-not-allowed border-gray-200 dark:border-gray-600'
                             }`}
                             title={
-                              quickLayoutSnapshots.length === 0
-                                ? 'Capture at least one snapshot to open the gallery'
-                                : 'Browse all quick snapshots with search and filters'
+                              !selectedVersionId
+                                ? 'Open a version first'
+                                : 'Browse snapshots, search, import shared JSON, or copy JSON for teammates'
                             }
                           >
                             <LayoutGrid className="w-4 h-4" />
@@ -9442,6 +9482,9 @@ const StudioContent = () => {
                     ? 'Please wait…'
                     : undefined
             }
+            versionId={selectedVersionId}
+            onImportSharedJson={handleImportSharedQuickSnapshotJson}
+            alertDialog={alertDialog}
           />
           <ExportWizard
             open={exportWizardOpen}

--- a/objectified-ui/tests/QuickSnapshotGalleryDialog.test.tsx
+++ b/objectified-ui/tests/QuickSnapshotGalleryDialog.test.tsx
@@ -9,6 +9,9 @@ import { QuickSnapshotGalleryDialog } from '../src/app/ade/studio/editor/compone
 import type { QuickLayoutSnapshot } from '../src/app/ade/studio/editor/lib/quick-layout-snapshots';
 import { QUICK_LAYOUT_SNAPSHOTS_SCHEMA_VERSION } from '../src/app/ade/studio/editor/lib/quick-layout-snapshots';
 
+const noopAlert = async () => {};
+const noopImport = async () => ({ success: true as const });
+
 function makeSnapshot(
   id: string,
   createdAt: string,
@@ -41,6 +44,9 @@ describe('QuickSnapshotGalleryDialog', () => {
         snapshots={[]}
         onRestore={() => {}}
         restoreDisabled={false}
+        versionId="version-1"
+        onImportSharedJson={noopImport}
+        alertDialog={noopAlert}
       />
     );
     expect(screen.getByText(/No quick snapshots yet/i)).toBeInTheDocument();
@@ -59,6 +65,9 @@ describe('QuickSnapshotGalleryDialog', () => {
         snapshots={[b, a]}
         onRestore={() => {}}
         restoreDisabled={false}
+        versionId="version-1"
+        onImportSharedJson={noopImport}
+        alertDialog={noopAlert}
       />
     );
 
@@ -82,6 +91,9 @@ describe('QuickSnapshotGalleryDialog', () => {
         snapshots={[withThumb, noThumb]}
         onRestore={onRestore}
         restoreDisabled={false}
+        versionId="version-1"
+        onImportSharedJson={noopImport}
+        alertDialog={noopAlert}
       />
     );
 
@@ -102,6 +114,9 @@ describe('QuickSnapshotGalleryDialog', () => {
         onRestore={() => {}}
         restoreDisabled
         restoreDisabledReason="Read-only"
+        versionId="version-1"
+        onImportSharedJson={noopImport}
+        alertDialog={noopAlert}
       />
     );
     expect(screen.getByRole('button', { name: /Restore quick snapshot/i })).toBeDisabled();

--- a/objectified-ui/tests/QuickSnapshotGalleryDialog.test.tsx
+++ b/objectified-ui/tests/QuickSnapshotGalleryDialog.test.tsx
@@ -1,13 +1,17 @@
 /**
- * Tests for QuickSnapshotGalleryDialog (#172)
+ * Tests for QuickSnapshotGalleryDialog (#172, #174)
  */
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import { QuickSnapshotGalleryDialog } from '../src/app/ade/studio/editor/components/QuickSnapshotGalleryDialog';
 import type { QuickLayoutSnapshot } from '../src/app/ade/studio/editor/lib/quick-layout-snapshots';
-import { QUICK_LAYOUT_SNAPSHOTS_SCHEMA_VERSION } from '../src/app/ade/studio/editor/lib/quick-layout-snapshots';
+import {
+  QUICK_LAYOUT_SNAPSHOTS_SCHEMA_VERSION,
+  QUICK_LAYOUT_SHARE_KIND,
+  QUICK_LAYOUT_SHARE_SCHEMA_VERSION,
+} from '../src/app/ade/studio/editor/lib/quick-layout-snapshots';
 
 const noopAlert = async () => {};
 const noopImport = async () => ({ success: true as const });
@@ -120,5 +124,127 @@ describe('QuickSnapshotGalleryDialog', () => {
       />
     );
     expect(screen.getByRole('button', { name: /Restore quick snapshot/i })).toBeDisabled();
+  });
+
+  test('Share → Copy JSON calls clipboard.writeText with a JSON envelope and shows success alert', async () => {
+    const user = userEvent.setup();
+    const writeText = jest.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      writable: true,
+      configurable: true,
+    });
+
+    const alertCalls: Array<{ message: string; variant: string }> = [];
+    const alertDialog = jest.fn(async (opts: { message: string; variant: string }) => {
+      alertCalls.push(opts);
+    });
+
+    const snapshot = makeSnapshot('share-snap', '2026-03-01T10:00:00.000Z');
+
+    render(
+      <QuickSnapshotGalleryDialog
+        open
+        onOpenChange={() => {}}
+        snapshots={[snapshot]}
+        onRestore={() => {}}
+        restoreDisabled={false}
+        versionId="version-1"
+        onImportSharedJson={noopImport}
+        alertDialog={alertDialog}
+      />
+    );
+
+    const shareBtn = screen.getByRole('button', { name: /Share snapshot/i });
+    await user.click(shareBtn);
+
+    const copyItem = await screen.findByText('Copy JSON');
+    await user.click(copyItem);
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1));
+    const written = writeText.mock.calls[0][0] as string;
+    const envelope = JSON.parse(written) as Record<string, unknown>;
+    expect(envelope.kind).toBe(QUICK_LAYOUT_SHARE_KIND);
+    expect(envelope.schemaVersion).toBe(QUICK_LAYOUT_SHARE_SCHEMA_VERSION);
+    expect(envelope.versionId).toBe('version-1');
+
+    await waitFor(() => expect(alertCalls.length).toBeGreaterThan(0));
+    expect(alertCalls[0].variant).toBe('success');
+  });
+
+  test('Import flow: success — calls onImportSharedJson and closes modal', async () => {
+    const user = userEvent.setup();
+    const onImportSharedJson = jest.fn().mockResolvedValue({ success: true as const });
+    const alertCalls: Array<{ message: string; variant: string }> = [];
+    const alertDialog = jest.fn(async (opts: { message: string; variant: string }) => {
+      alertCalls.push(opts);
+    });
+
+    const snapshot = makeSnapshot('imp-snap', '2026-03-01T00:00:00.000Z');
+    const validJson = JSON.stringify({
+      kind: QUICK_LAYOUT_SHARE_KIND,
+      schemaVersion: QUICK_LAYOUT_SHARE_SCHEMA_VERSION,
+      versionId: 'version-1',
+      snapshot,
+    });
+
+    render(
+      <QuickSnapshotGalleryDialog
+        open
+        onOpenChange={() => {}}
+        snapshots={[snapshot]}
+        onRestore={() => {}}
+        restoreDisabled={false}
+        versionId="version-1"
+        onImportSharedJson={onImportSharedJson}
+        alertDialog={alertDialog}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: /Import shared snapshot/i }));
+
+    const textarea = await screen.findByRole('textbox', { name: /Shared snapshot JSON/i });
+    fireEvent.change(textarea, { target: { value: validJson } });
+
+    await user.click(screen.getByRole('button', { name: /^Import$/i }));
+
+    await waitFor(() => expect(onImportSharedJson).toHaveBeenCalledWith(validJson));
+    await waitFor(() => expect(alertCalls.some((c) => c.variant === 'success')).toBe(true));
+    await waitFor(() => expect(screen.queryByRole('dialog', { name: /Import shared snapshot/i })).not.toBeInTheDocument());
+  });
+
+  test('Import flow: error — shows error alert when onImportSharedJson returns failure', async () => {
+    const user = userEvent.setup();
+    const errorMsg = 'Version mismatch';
+    const onImportSharedJson = jest.fn().mockResolvedValue({ success: false as const, message: errorMsg });
+    const alertCalls: Array<{ message: string; variant: string }> = [];
+    const alertDialog = jest.fn(async (opts: { message: string; variant: string }) => {
+      alertCalls.push(opts);
+    });
+
+    const snapshot = makeSnapshot('err-snap', '2026-03-01T00:00:00.000Z');
+
+    render(
+      <QuickSnapshotGalleryDialog
+        open
+        onOpenChange={() => {}}
+        snapshots={[snapshot]}
+        onRestore={() => {}}
+        restoreDisabled={false}
+        versionId="version-1"
+        onImportSharedJson={onImportSharedJson}
+        alertDialog={alertDialog}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: /Import shared snapshot/i }));
+
+    const textarea = await screen.findByRole('textbox', { name: /Shared snapshot JSON/i });
+    fireEvent.change(textarea, { target: { value: '{ "some": "json" }' } });
+
+    await user.click(screen.getByRole('button', { name: /^Import$/i }));
+
+    await waitFor(() => expect(onImportSharedJson).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(alertCalls.some((c) => c.variant === 'error' && c.message === errorMsg)).toBe(true));
   });
 });

--- a/objectified-ui/tests/quick-layout-snapshots.test.ts
+++ b/objectified-ui/tests/quick-layout-snapshots.test.ts
@@ -1,6 +1,9 @@
 import {
   appendQuickLayoutSnapshot,
+  buildQuickLayoutShareEnvelope,
+  cloneQuickLayoutSnapshotForImport,
   loadQuickLayoutSnapshots,
+  parseQuickLayoutShareText,
   quickLayoutSnapshotsStorageKey,
   isQuickLayoutSnapshot,
   DEFAULT_MAX_QUICK_LAYOUT_SNAPSHOTS,
@@ -9,6 +12,8 @@ import {
   quickSnapshotListLabel,
   quickSnapshotMatchesSearch,
   quickSnapshotOptionLabel,
+  stringifyQuickLayoutShareEnvelope,
+  QUICK_LAYOUT_SHARE_KIND,
   type QuickLayoutSnapshot,
 } from '@/app/ade/studio/editor/lib/quick-layout-snapshots';
 
@@ -237,5 +242,36 @@ describe('quick-layout-snapshots', () => {
     expect(quickSnapshotOptionLabel(snap)).toBe(`Beta · ${cap}`);
     delete snap.summary;
     expect(quickSnapshotOptionLabel(snap)).toBe(cap);
+  });
+
+  it('buildQuickLayoutShareEnvelope includes kind and version', () => {
+    const snap = makeSnapshot('snap-1', '2026-01-01T00:00:00.000Z');
+    const env = buildQuickLayoutShareEnvelope('ver-a', snap);
+    expect(env.kind).toBe(QUICK_LAYOUT_SHARE_KIND);
+    expect(env.versionId).toBe('ver-a');
+    expect(env.snapshot.id).toBe('snap-1');
+  });
+
+  it('stringifyQuickLayoutShareEnvelope round-trips with parseQuickLayoutShareText', () => {
+    const snap = makeSnapshot('snap-1', '2026-01-01T00:00:00.000Z');
+    const text = stringifyQuickLayoutShareEnvelope('ver-a', snap);
+    const parsed = parseQuickLayoutShareText(text);
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) throw new Error('expected ok');
+    expect(parsed.versionId).toBe('ver-a');
+    expect(parsed.snapshot.id).toBe('snap-1');
+  });
+
+  it('parseQuickLayoutShareText rejects empty or wrong kind', () => {
+    expect(parseQuickLayoutShareText('').ok).toBe(false);
+    expect(parseQuickLayoutShareText('{}').ok).toBe(false);
+    expect(parseQuickLayoutShareText('{"kind":"other"}').ok).toBe(false);
+  });
+
+  it('cloneQuickLayoutSnapshotForImport assigns a new id', () => {
+    const snap = makeSnapshot('old-id', '2026-01-01T00:00:00.000Z');
+    const c = cloneQuickLayoutSnapshotForImport(snap);
+    expect(c.id).not.toBe('old-id');
+    expect(c.createdAt).toBe(snap.createdAt);
   });
 });


### PR DESCRIPTION
## Problem Statement

Users and teams need **addresses #174 — share quick layout snapshots as json with teammates** within the Objectified platform. Today this capability is missing or only partially implemented, which blocks dashboard workflows and creates inconsistency across tenants and projects.

**Original request:**

Add version-scoped share envelope, gallery Copy/Download, and import (paste or file) into local storage for the same API version.

Made-with: Cursor

## Summary
- Adds a version-scoped JSON envelope for quick layout snapshots so teammates can share via chat or files.
- Gallery: Copy/Download JSON per snapshot; Import (paste or `.json` file) with strict `versionId` match.
- 
## How to test
1. Open a version, capture a quick snapshot, open **Gallery**.
2. Use **Share → Copy JSON**, paste into a text file or another browser profile with the **same version** → **Import shared snapshot** → confirm it appears in the gallery.
3. Try importing JSON for a **different** `versionId` → expect a clear error.

Closes #174

## Solution / Scope

Implement **Addresses #174 — Share quick layout snapshots as JSON with teammates** as part of **Dashboard**. KPIs, primitives browser, project overview, quick actions.

**Post-MVP** (prioritize after MVP slice) candidacy.

```mermaid
flowchart TB
  CP[Control Panel] --> KPIs[Stats cards]
  CP --> Primitives[Primitives list]
  CP --> Projects[Recent projects]
  CP --> Actions[Quick actions]
```

## Acceptance Criteria

- [ ] Feature behaves as described for: Addresses #174 — Share quick layout snapshots as JSON with teammates
- [ ] Unit/integration tests cover happy path and primary error cases
- [ ] UI (if applicable) matches existing ADE patterns (Tailwind 4, Radix, Lucide)
- [ ] REST endpoints (if applicable) follow `/v1/{{feature}}/{{tenant_slug}}/...` conventions
- [ ] Documented in issue/PR; no regressions to existing schema/version flows

## Parallelism / Dependencies

- **Can run in parallel:** Yes
- **Blockers:** None identified; validate against current codebase before starting

## Technical Stack

- **Modules:** objectified-rest
- **Stack:** Next.js ADE dashboard, control panel components, REST stats APIs
- **Labels:** ``

---

**Epic:** [[Epic] Dashboard & Control Panel](https://github.com/objectified-project/objectified/issues/3493)
**Issue:** #874 · **Area:** Dashboard · **Roadmap batch:** legacy #64–#879 enrichment