### PR TITLE
Addresses #175 — Pin quick snapshot as team default for tenant admins

### DIFF
--- a/PLANNED_FEATURE_ROADMAP_CANVAS.md
+++ b/PLANNED_FEATURE_ROADMAP_CANVAS.md
@@ -13,14 +13,13 @@
 
 #### Layout Sharing 📋 PARTIALLY IMPLEMENTED
 - ✅ Share layout configurations with team members (#174) — quick snapshot gallery: copy/download JSON envelope, import shared JSON for same API version
-- 📋 [TODO] "Pin" layout as team default
+- ✅ "Pin" layout as team default (#175) — tenant admins: Share → Pin as team default saves a shared named layout and sets tenant default for the version
 - 📋 [TODO] Layout permissions (view, edit, delete)
 - 📋 [TODO] Layout comments and annotations
 - 📋 [TODO] Layout versioning with diff viewer
 
 | Ticket | Feature                                       |
 |--------|-----------------------------------------------|
-| #175   | "Pin" layout as team default                  |
 | #176   | Layout permissions (view, edit, delete)       |
 | #177   | Layout comments and annotations               |
 | #178   | Layout versioning with diff viewer            |

--- a/objectified-ui/lib/db/helper.ts
+++ b/objectified-ui/lib/db/helper.ts
@@ -3578,7 +3578,7 @@ export async function pinTeamDefaultQuickSnapshot(
       `SELECT 1 FROM odb.tenant_administrators WHERE tenant_id = $1 AND user_id = $2`,
       [tenantId, actingUserId]
     );
-    if (!adminCheck.rowCount) {
+    if (!adminCheck.rows.length) {
       return errorResponse('Only tenant administrators can pin a team default layout');
     }
     const verCheck = await connectionPool.query(
@@ -3587,7 +3587,7 @@ export async function pinTeamDefaultQuickSnapshot(
        WHERE v.id = $1 AND p.tenant_id = $2 AND v.deleted_at IS NULL AND p.deleted_at IS NULL`,
       [versionId, tenantId]
     );
-    if (!verCheck.rowCount) {
+    if (!verCheck.rows.length) {
       return errorResponse('Version not found for this tenant');
     }
 

--- a/objectified-ui/lib/db/helper.ts
+++ b/objectified-ui/lib/db/helper.ts
@@ -20,6 +20,12 @@ const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0
 /** 4-byte ASCII chunk type for the required IHDR chunk (first chunk in every PNG). */
 const PNG_IHDR_TYPE = Buffer.from([0x49, 0x48, 0x44, 0x52]);
 
+/**
+ * Reserved named layout used when a tenant admin pins a quick snapshot as the team default (#175).
+ * Must match the client-side constant TEAM_QUICK_SNAPSHOT_PINNED_LAYOUT_NAME in quick-layout-snapshots.ts.
+ */
+const TEAM_QUICK_SNAPSHOT_PINNED_LAYOUT_NAME = 'Team default (quick snapshot)';
+
 function parseLayoutSnapshotBase64(
   snapshotPngBase64: string
 ): { ok: true; buffer: Buffer } | { ok: false; error: string } {
@@ -3549,6 +3555,116 @@ export async function clearTenantCanvasLayoutDefaultName(
 }
 
 /**
+ * Atomically pin a quick snapshot as the shared team-default named layout for a version (#175).
+ * Derives the acting user from the session — never from a client-supplied parameter.
+ * Only tenant administrators of the owning tenant may call this action.
+ * Groups are intentionally excluded to avoid overwriting live group positions for all members.
+ */
+export async function pinTeamDefaultQuickSnapshot(
+  versionId: string,
+  tenantId: string,
+  viewport: any,
+  nodes: any,
+  edges?: any,
+  snapshotPngBase64?: string
+) {
+  const session = await getAuthSession();
+  const actingUserId = (session?.user as any)?.user_id;
+  if (!actingUserId) {
+    return errorResponse('Unauthorized');
+  }
+  try {
+    const adminCheck = await connectionPool.query(
+      `SELECT 1 FROM odb.tenant_administrators WHERE tenant_id = $1 AND user_id = $2`,
+      [tenantId, actingUserId]
+    );
+    if (!adminCheck.rowCount) {
+      return errorResponse('Only tenant administrators can pin a team default layout');
+    }
+    const verCheck = await connectionPool.query(
+      `SELECT 1 FROM odb.versions v
+       INNER JOIN odb.projects p ON v.project_id = p.id
+       WHERE v.id = $1 AND p.tenant_id = $2 AND v.deleted_at IS NULL AND p.deleted_at IS NULL`,
+      [versionId, tenantId]
+    );
+    if (!verCheck.rowCount) {
+      return errorResponse('Version not found for this tenant');
+    }
+
+    let snapshotBuffer: Buffer | undefined;
+    if (snapshotPngBase64 !== undefined && snapshotPngBase64.trim() !== '') {
+      const parsed = parseLayoutSnapshotBase64(snapshotPngBase64);
+      if (!parsed.ok) {
+        return errorResponse(parsed.error);
+      }
+      snapshotBuffer = parsed.buffer;
+    }
+
+    const name = TEAM_QUICK_SNAPSHOT_PINNED_LAYOUT_NAME;
+
+    // Upsert the shared (user_id = null) layout without touching group positions.
+    const existingResult = await connectionPool.query(
+      `SELECT id FROM odb.canvas_layouts
+       WHERE version_id = $1 AND name = $2 AND user_id IS NULL
+       LIMIT 1`,
+      [versionId, name]
+    );
+
+    if (existingResult.rowCount > 0) {
+      const updates: { viewport: any; nodes: any; edges: any; snapshotImage?: Buffer } = {
+        viewport,
+        nodes,
+        edges: edges || [],
+      };
+      if (snapshotBuffer !== undefined) {
+        updates.snapshotImage = snapshotBuffer;
+      }
+      const updateResult = await updateCanvasLayout(
+        existingResult.rows[0].id,
+        updates,
+        { recordRevision: true, revisionUserId: actingUserId }
+      );
+      const updateParsed = JSON.parse(updateResult);
+      if (!updateParsed.success) {
+        return errorResponse(updateParsed.error || 'Failed to update shared layout');
+      }
+    } else {
+      const createResult = await createCanvasLayout(
+        versionId,
+        null,
+        name,
+        false,
+        viewport,
+        nodes,
+        edges || [],
+        null,
+        { enabled: true, size: 20, snapToGrid: true, showGrid: true },
+        { enabled: true, position: 'bottom-right', size: 'medium' },
+        {},
+        snapshotBuffer ?? null
+      );
+      const createParsed = JSON.parse(createResult);
+      if (!createParsed.success) {
+        return errorResponse(createParsed.error || 'Failed to create shared layout');
+      }
+    }
+
+    // Set tenant canvas layout default atomically.
+    await connectionPool.query(
+      `INSERT INTO odb.tenant_canvas_layout_defaults (tenant_id, version_id, layout_name)
+       VALUES ($1, $2, $3)
+       ON CONFLICT (tenant_id, version_id) DO UPDATE
+       SET layout_name = EXCLUDED.layout_name, updated_at = CURRENT_TIMESTAMP`,
+      [tenantId, versionId, name]
+    );
+    return successResponse({ layoutName: name });
+  } catch (error: any) {
+    console.error('Error pinning team default quick snapshot:', error);
+    return errorResponse(error.message);
+  }
+}
+
+/**
  * Get all named canvas layouts for a version, preferring user-specific layouts.
  * Returns at most one layout per name.
  */
@@ -3592,6 +3708,8 @@ export async function getNamedCanvasLayoutsForVersion(versionId: string, userId?
 
 /**
  * Get a named canvas layout for a version, preferring user-specific layout.
+ * For the reserved team-default name, always loads the shared (user_id = null) layout so that
+ * a personal layout saved with the same name cannot shadow the team default.
  */
 export async function getNamedCanvasLayout(versionId: string, userId: string | null, name: string) {
   try {
@@ -3599,6 +3717,10 @@ export async function getNamedCanvasLayout(versionId: string, userId: string | n
     if (!nameValue) {
       return successResponse({ layout: null });
     }
+
+    // The pinned team-default is always shared; never allow a personal row to shadow it.
+    const isReserved = nameValue === TEAM_QUICK_SNAPSHOT_PINNED_LAYOUT_NAME;
+    const effectiveUserId = isReserved ? null : userId;
 
     const result = await connectionPool.query(
       `SELECT id, version_id, user_id, name, is_default, viewport, nodes, edges,
@@ -3609,7 +3731,7 @@ export async function getNamedCanvasLayout(versionId: string, userId: string | n
          AND (user_id = $3 OR user_id IS NULL)
        ORDER BY (user_id = $3) DESC NULLS LAST, updated_at DESC
        LIMIT 1`,
-      [versionId, nameValue, userId]
+      [versionId, nameValue, effectiveUserId]
     );
 
     if (result.rowCount === 0) {
@@ -3650,6 +3772,11 @@ export async function saveNamedCanvasLayout(
     const nameValue = name.trim();
     if (!nameValue) {
       return errorResponse('Layout name is required');
+    }
+
+    // Prevent personal layouts from using the reserved team-default name so it cannot be shadowed.
+    if (userId !== null && nameValue === TEAM_QUICK_SNAPSHOT_PINNED_LAYOUT_NAME) {
+      return errorResponse(`"${TEAM_QUICK_SNAPSHOT_PINNED_LAYOUT_NAME}" is reserved for the shared team default and cannot be used as a personal layout name`);
     }
 
     let snapshotBuffer: Buffer | undefined;

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.8.84",
+  "version": "0.8.85",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -5,6 +5,7 @@ We continue to improve the platform based on your feedback with improvements and
 ---
 
 Improvements:
+- Canvas: tenant administrators can pin a quick snapshot as the team default from the gallery (Share → Pin as team default); saves a shared named layout for the API version (#175)
 - Canvas: share quick layout snapshots with teammates via JSON (copy or download from the gallery) and import shared files or pasted JSON for the same API version (#174)
 - Canvas: quick snapshots store timestamp, author (from your session), a required short summary, and optional description; capture opens a short form before saving (#173)
 - Canvas: quick snapshot gallery in the Layout panel—browse captures in a scrollable grid with search, preview filters (all / with image / no image), and newest-or-oldest sort (#172)

--- a/objectified-ui/src/app/ade/studio/editor/components/QuickSnapshotGalleryDialog.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/components/QuickSnapshotGalleryDialog.tsx
@@ -4,7 +4,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import * as Dialog from '@radix-ui/react-dialog';
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 import * as ToggleGroup from '@radix-ui/react-toggle-group';
-import { X, LayoutGrid, Search, Image as ImageIcon, Share2, Upload } from 'lucide-react';
+import { X, LayoutGrid, Search, Image as ImageIcon, Share2, Upload, Pin } from 'lucide-react';
 import {
   formatQuickSnapshotCaption,
   quickSnapshotAuthorDisplay,
@@ -36,6 +36,9 @@ export interface QuickSnapshotGalleryDialogProps {
   /** Persist a shared JSON envelope; return success or an error message for the user. */
   onImportSharedJson: (jsonText: string) => Promise<ImportSharedQuickSnapshotResult>;
   alertDialog: (opts: { message: string; variant: QuickSnapshotGalleryAlertVariant }) => Promise<void>;
+  /** Tenant admins can pin a snapshot as the team default for this API version (shared named layout + tenant preference). */
+  pinTeamDefaultEnabled?: boolean;
+  onPinTeamDefault?: (snapshot: QuickLayoutSnapshot) => void | Promise<void>;
 }
 
 export function QuickSnapshotGalleryDialog({
@@ -48,6 +51,8 @@ export function QuickSnapshotGalleryDialog({
   versionId,
   onImportSharedJson,
   alertDialog,
+  pinTeamDefaultEnabled = false,
+  onPinTeamDefault,
 }: QuickSnapshotGalleryDialogProps) {
   const [query, setQuery] = useState('');
   const [previewFilter, setPreviewFilter] = useState<QuickSnapshotPreviewFilter>('all');
@@ -172,7 +177,8 @@ export function QuickSnapshotGalleryDialog({
                 <Dialog.Description className="mt-1 text-xs leading-snug text-gray-500 dark:text-gray-400">
                   Search by summary, author, description, time, snapshot id, or layout counts. Filter by preview image.
                   Newest captures appear first by default. Use Share on a tile to copy or download JSON for teammates on this
-                  version; Import adds a shared file or pasted JSON to your local gallery.
+                  version; Import adds a shared file or pasted JSON to your local gallery. Tenant administrators can pin a
+                  snapshot as the team default from the Share menu (saves a shared named layout for this version).
                 </Dialog.Description>
               </div>
             </div>
@@ -335,6 +341,17 @@ export function QuickSnapshotGalleryDialog({
                                   >
                                     Download JSON
                                   </DropdownMenu.Item>
+                                  {pinTeamDefaultEnabled && onPinTeamDefault ? (
+                                    <DropdownMenu.Item
+                                      className="cursor-pointer rounded px-2 py-1.5 outline-none hover:bg-gray-100 focus:bg-gray-100 dark:hover:bg-gray-800 dark:focus:bg-gray-800"
+                                      onSelect={() => void onPinTeamDefault(s)}
+                                    >
+                                      <span className="flex items-center gap-2">
+                                        <Pin className="h-3.5 w-3.5 shrink-0" aria-hidden />
+                                        Pin as team default
+                                      </span>
+                                    </DropdownMenu.Item>
+                                  ) : null}
                                 </DropdownMenu.Content>
                               </DropdownMenu.Portal>
                             </DropdownMenu.Root>

--- a/objectified-ui/src/app/ade/studio/editor/lib/quick-layout-snapshots.ts
+++ b/objectified-ui/src/app/ade/studio/editor/lib/quick-layout-snapshots.ts
@@ -7,6 +7,12 @@ export const QUICK_LAYOUT_SNAPSHOTS_SCHEMA_VERSION = 1 as const;
 
 export const DEFAULT_MAX_QUICK_LAYOUT_SNAPSHOTS = 20;
 
+/**
+ * Reserved named layout on the server when a tenant admin pins a quick snapshot as the team default (#175).
+ * Stored as a shared layout (`user_id` null) so every member resolves the same geometry for this name.
+ */
+export const TEAM_QUICK_SNAPSHOT_PINNED_LAYOUT_NAME = 'Team default (quick snapshot)';
+
 export interface QuickLayoutSnapshotPayload {
   schemaVersion: typeof QUICK_LAYOUT_SNAPSHOTS_SCHEMA_VERSION;
   viewport: { x: number; y: number; zoom: number };

--- a/objectified-ui/src/app/ade/studio/editor/page.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/page.tsx
@@ -124,6 +124,7 @@ import {
   isTenantAdmin,
   duplicateClassesInGroup,
   bulkApplyEditsToGroupClasses,
+  pinTeamDefaultQuickSnapshot,
 } from '../../../../../lib/db/helper';
 import { expandClassesForGroupExport, downloadTextFile } from '@/app/utils/group-schema-export';
 import { mapEdgesForLayoutSave, mapNodesForLayoutSave } from '../lib/canvasLayoutPayload';
@@ -4852,41 +4853,24 @@ const StudioContent = () => {
       try {
         setLoadingMessage('Pinning team layout…');
         setIsLoadingCanvas(true);
-        const { viewport, nodes, edges, groups } = snapshot.payload;
+        const { viewport, nodes, edges } = snapshot.payload;
         let snapshotBase64: string | undefined;
         const thumb = snapshot.thumbnailDataUrl;
         if (thumb?.startsWith('data:image/png;base64,')) {
           snapshotBase64 = thumb.slice('data:image/png;base64,'.length);
         }
-        const saveResult = await saveNamedCanvasLayout(
+        const pinResult = await pinTeamDefaultQuickSnapshot(
           selectedVersionId,
-          null,
-          TEAM_QUICK_SNAPSHOT_PINNED_LAYOUT_NAME,
+          currentTenantId,
           viewport,
           nodes,
           edges,
-          groups,
           snapshotBase64
         );
-        const saveParsed = JSON.parse(saveResult);
-        if (!saveParsed.success) {
+        const pinParsed = JSON.parse(pinResult);
+        if (!pinParsed.success) {
           await alertDialog({
-            message: saveParsed.error || 'Could not save the shared layout.',
-            variant: 'error',
-          });
-          return;
-        }
-        const tenantResult = await setTenantCanvasLayoutDefaultName(
-          selectedVersionId,
-          currentTenantId,
-          TEAM_QUICK_SNAPSHOT_PINNED_LAYOUT_NAME
-        );
-        const tenantParsed = JSON.parse(tenantResult);
-        if (!tenantParsed.success) {
-          await alertDialog({
-            message:
-              tenantParsed.error ||
-              'Layout was saved, but the team default could not be updated.',
+            message: pinParsed.error || 'Could not pin this snapshot as the team default.',
             variant: 'error',
           });
           return;

--- a/objectified-ui/src/app/ade/studio/editor/page.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/page.tsx
@@ -134,6 +134,7 @@ import {
   makeQuickLayoutSnapshotId,
   parseQuickLayoutShareText,
   QUICK_LAYOUT_SNAPSHOTS_SCHEMA_VERSION,
+  TEAM_QUICK_SNAPSHOT_PINNED_LAYOUT_NAME,
   type QuickLayoutSnapshot,
 } from './lib/quick-layout-snapshots';
 import {
@@ -4831,6 +4832,92 @@ const StudioContent = () => {
     alertDialog,
   ]);
 
+  /** Save snapshot geometry as a shared named layout and point tenant default at it (#175). */
+  const handlePinQuickSnapshotAsTeamDefault = useCallback(
+    async (snapshot: QuickLayoutSnapshot) => {
+      if (
+        isReadOnly ||
+        !selectedVersionId ||
+        !currentUserId ||
+        !currentTenantId ||
+        !effectiveIsTenantAdmin
+      ) {
+        return;
+      }
+      const ok = await confirmDialog({
+        title: 'Pin as team default',
+        message: `Save this snapshot as the shared named layout "${TEAM_QUICK_SNAPSHOT_PINNED_LAYOUT_NAME}" and set it as the team default for this API version? Members who have not chosen a personal default will load this layout when they open the version.`,
+      });
+      if (!ok) return;
+      try {
+        setLoadingMessage('Pinning team layout…');
+        setIsLoadingCanvas(true);
+        const { viewport, nodes, edges, groups } = snapshot.payload;
+        let snapshotBase64: string | undefined;
+        const thumb = snapshot.thumbnailDataUrl;
+        if (thumb?.startsWith('data:image/png;base64,')) {
+          snapshotBase64 = thumb.slice('data:image/png;base64,'.length);
+        }
+        const saveResult = await saveNamedCanvasLayout(
+          selectedVersionId,
+          null,
+          TEAM_QUICK_SNAPSHOT_PINNED_LAYOUT_NAME,
+          viewport,
+          nodes,
+          edges,
+          groups,
+          snapshotBase64
+        );
+        const saveParsed = JSON.parse(saveResult);
+        if (!saveParsed.success) {
+          await alertDialog({
+            message: saveParsed.error || 'Could not save the shared layout.',
+            variant: 'error',
+          });
+          return;
+        }
+        const tenantResult = await setTenantCanvasLayoutDefaultName(
+          selectedVersionId,
+          currentTenantId,
+          TEAM_QUICK_SNAPSHOT_PINNED_LAYOUT_NAME
+        );
+        const tenantParsed = JSON.parse(tenantResult);
+        if (!tenantParsed.success) {
+          await alertDialog({
+            message:
+              tenantParsed.error ||
+              'Layout was saved, but the team default could not be updated.',
+            variant: 'error',
+          });
+          return;
+        }
+        setSelectedLayoutName(TEAM_QUICK_SNAPSHOT_PINNED_LAYOUT_NAME);
+        await alertDialog({
+          message: `Team default for this version is now "${TEAM_QUICK_SNAPSHOT_PINNED_LAYOUT_NAME}".`,
+          variant: 'success',
+        });
+      } catch (e) {
+        console.error('Pin quick snapshot as team default failed:', e);
+        await alertDialog({
+          message: 'Could not pin this snapshot as the team default.',
+          variant: 'error',
+        });
+      } finally {
+        setIsLoadingCanvas(false);
+        setLoadingMessage('');
+      }
+    },
+    [
+      isReadOnly,
+      selectedVersionId,
+      currentUserId,
+      currentTenantId,
+      effectiveIsTenantAdmin,
+      confirmDialog,
+      alertDialog,
+    ]
+  );
+
   const autoSaveDefaultLayout = useCallback(async () => {
     if (
       !autoSaveLayoutEnabled ||
@@ -9486,6 +9573,15 @@ const StudioContent = () => {
             versionId={selectedVersionId}
             onImportSharedJson={handleImportSharedQuickSnapshotJson}
             alertDialog={alertDialog}
+            pinTeamDefaultEnabled={Boolean(
+              selectedVersionId &&
+                currentUserId &&
+                currentTenantId &&
+                effectiveIsTenantAdmin &&
+                !isReadOnly &&
+                !isLoadingCanvas
+            )}
+            onPinTeamDefault={(s) => void handlePinQuickSnapshotAsTeamDefault(s)}
           />
           <ExportWizard
             open={exportWizardOpen}

--- a/objectified-ui/tests/QuickSnapshotGalleryDialog.test.tsx
+++ b/objectified-ui/tests/QuickSnapshotGalleryDialog.test.tsx
@@ -1,5 +1,5 @@
 /**
- * Tests for QuickSnapshotGalleryDialog (#172, #174)
+ * Tests for QuickSnapshotGalleryDialog (#172, #174, #175)
  */
 import React from 'react';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
@@ -170,6 +170,33 @@ describe('QuickSnapshotGalleryDialog', () => {
 
     await waitFor(() => expect(alertCalls.length).toBeGreaterThan(0));
     expect(alertCalls[0].variant).toBe('success');
+  });
+
+  test('Share → Pin as team default calls onPinTeamDefault when enabled', async () => {
+    const user = userEvent.setup();
+    const onPinTeamDefault = jest.fn();
+    const snapshot = makeSnapshot('pin-snap', '2026-03-01T10:00:00.000Z');
+
+    render(
+      <QuickSnapshotGalleryDialog
+        open
+        onOpenChange={() => {}}
+        snapshots={[snapshot]}
+        onRestore={() => {}}
+        restoreDisabled={false}
+        versionId="version-1"
+        onImportSharedJson={noopImport}
+        alertDialog={noopAlert}
+        pinTeamDefaultEnabled
+        onPinTeamDefault={onPinTeamDefault}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: /Share snapshot/i }));
+    const pinItem = await screen.findByText('Pin as team default');
+    await user.click(pinItem);
+    expect(onPinTeamDefault).toHaveBeenCalledTimes(1);
+    expect(onPinTeamDefault).toHaveBeenCalledWith(expect.objectContaining({ id: 'pin-snap' }));
   });
 
   test('Import flow: success — calls onImportSharedJson and closes modal', async () => {

--- a/objectified-ui/tests/quick-layout-snapshots.test.ts
+++ b/objectified-ui/tests/quick-layout-snapshots.test.ts
@@ -14,6 +14,7 @@ import {
   quickSnapshotOptionLabel,
   stringifyQuickLayoutShareEnvelope,
   QUICK_LAYOUT_SHARE_KIND,
+  TEAM_QUICK_SNAPSHOT_PINNED_LAYOUT_NAME,
   type QuickLayoutSnapshot,
 } from '@/app/ade/studio/editor/lib/quick-layout-snapshots';
 
@@ -35,6 +36,11 @@ function makeSnapshot(id: string, createdAt: string): QuickLayoutSnapshot {
 }
 
 describe('quick-layout-snapshots', () => {
+  it('TEAM_QUICK_SNAPSHOT_PINNED_LAYOUT_NAME is a stable reserved layout name', () => {
+    expect(TEAM_QUICK_SNAPSHOT_PINNED_LAYOUT_NAME).toMatch(/quick snapshot/i);
+    expect(TEAM_QUICK_SNAPSHOT_PINNED_LAYOUT_NAME.trim().length).toBeGreaterThan(0);
+  });
+
   const versionId = 'ver-quick-snap-1';
   const userId = 'user-42';
 

--- a/objectified-ui/tests/quick-layout-snapshots.test.ts
+++ b/objectified-ui/tests/quick-layout-snapshots.test.ts
@@ -37,8 +37,7 @@ function makeSnapshot(id: string, createdAt: string): QuickLayoutSnapshot {
 
 describe('quick-layout-snapshots', () => {
   it('TEAM_QUICK_SNAPSHOT_PINNED_LAYOUT_NAME is a stable reserved layout name', () => {
-    expect(TEAM_QUICK_SNAPSHOT_PINNED_LAYOUT_NAME).toMatch(/quick snapshot/i);
-    expect(TEAM_QUICK_SNAPSHOT_PINNED_LAYOUT_NAME.trim().length).toBeGreaterThan(0);
+    expect(TEAM_QUICK_SNAPSHOT_PINNED_LAYOUT_NAME).toBe('Team default (quick snapshot)');
   });
 
   const versionId = 'ver-quick-snap-1';


### PR DESCRIPTION
## Problem Statement

Users and teams need **addresses #175 — pin quick snapshot as team default for tenant admins** within the Objectified platform. Today this capability is missing or only partially implemented, which blocks dashboard workflows and creates inconsistency across tenants and projects.

**Original request:**

Tenant admins can use Share → Pin as team default in the quick snapshot gallery. Saves geometry as a shared named layout and sets tenant_canvas_layout_defaults.

- Bump objectified-ui to 0.8.85; note in WHATS_NEW; mark canvas roadmap #175 done

Made-with: Cursor

Closes #175

## Solution / Scope

Implement **Addresses #175 — Pin quick snapshot as team default for tenant admins** as part of **Dashboard**. KPIs, primitives browser, project overview, quick actions.

**Post-MVP** (prioritize after MVP slice) candidacy.

```mermaid
flowchart TB
  CP[Control Panel] --> KPIs[Stats cards]
  CP --> Primitives[Primitives list]
  CP --> Projects[Recent projects]
  CP --> Actions[Quick actions]
```

## Acceptance Criteria

- [ ] Feature behaves as described for: Addresses #175 — Pin quick snapshot as team default for tenant admins
- [ ] Unit/integration tests cover happy path and primary error cases
- [ ] UI (if applicable) matches existing ADE patterns (Tailwind 4, Radix, Lucide)
- [ ] REST endpoints (if applicable) follow `/v1/{{feature}}/{{tenant_slug}}/...` conventions
- [ ] Documented in issue/PR; no regressions to existing schema/version flows

## Parallelism / Dependencies

- **Can run in parallel:** Yes
- **Blockers:** None identified; validate against current codebase before starting

## Technical Stack

- **Modules:** objectified-rest
- **Stack:** Next.js ADE dashboard, control panel components, REST stats APIs
- **Labels:** ``

---

**Epic:** [[Epic] Dashboard & Control Panel](https://github.com/objectified-project/objectified/issues/3493)
**Issue:** #875 · **Area:** Dashboard · **Roadmap batch:** legacy #64–#879 enrichment