### PR TITLE
Addresses #176 — Add named layout view/edit/delete permissions

### DIFF
--- a/PLANNED_FEATURE_ROADMAP_CANVAS.md
+++ b/PLANNED_FEATURE_ROADMAP_CANVAS.md
@@ -14,13 +14,12 @@
 #### Layout Sharing 📋 PARTIALLY IMPLEMENTED
 - ✅ Share layout configurations with team members (#174) — quick snapshot gallery: copy/download JSON envelope, import shared JSON for same API version
 - ✅ "Pin" layout as team default (#175) — tenant admins: Share → Pin as team default saves a shared named layout and sets tenant default for the version
-- 📋 [TODO] Layout permissions (view, edit, delete)
+- ✅ Layout permissions (view, edit, delete) (#176) — named layouts now expose view/edit/delete capability in the Layout panel; shared layouts are view-only for non-admins and only tenant admins can delete shared entries
 - 📋 [TODO] Layout comments and annotations
 - 📋 [TODO] Layout versioning with diff viewer
 
 | Ticket | Feature                                       |
 |--------|-----------------------------------------------|
-| #176   | Layout permissions (view, edit, delete)       |
 | #177   | Layout comments and annotations               |
 | #178   | Layout versioning with diff viewer            |
 

--- a/objectified-ui/lib/db/helper.ts
+++ b/objectified-ui/lib/db/helper.ts
@@ -4188,6 +4188,84 @@ export async function deleteCanvasLayout(layoutId: string) {
 }
 
 /**
+ * Delete a named layout visible to the current user.
+ * - Personal layout: owner can delete.
+ * - Shared layout (user_id null): tenant admins can delete when the version belongs to that tenant.
+ */
+export async function deleteNamedCanvasLayout(
+  versionId: string,
+  name: string,
+  tenantId?: string
+) {
+  const session = await getAuthSession();
+  const actingUserId = (session?.user as any)?.user_id;
+  if (!actingUserId) {
+    return errorResponse('Unauthorized');
+  }
+  const nameValue = name.trim();
+  if (!nameValue) {
+    return errorResponse('Layout name is required');
+  }
+  try {
+    const candidateResult = await connectionPool.query(
+      `SELECT id, user_id, name
+       FROM odb.canvas_layouts
+       WHERE version_id = $1
+         AND name = $2
+         AND (user_id = $3 OR user_id IS NULL)
+       ORDER BY (user_id = $3) DESC NULLS LAST, updated_at DESC
+       LIMIT 1`,
+      [versionId, nameValue, actingUserId]
+    );
+    if (candidateResult.rowCount === 0) {
+      return errorResponse('Layout not found');
+    }
+    const candidate = candidateResult.rows[0];
+    const ownerUserId = candidate.user_id as string | null;
+
+    if (ownerUserId === null) {
+      const trimmedTenantId = tenantId?.trim();
+      if (!trimmedTenantId) {
+        return errorResponse('Tenant id is required to delete shared layouts');
+      }
+      const tenantOwnsVersionResult = await connectionPool.query(
+        `SELECT 1
+         FROM odb.versions v
+         JOIN odb.projects p ON p.id = v.project_id
+         WHERE v.id = $1
+           AND p.tenant_id = $2`,
+        [versionId, trimmedTenantId]
+      );
+      if (tenantOwnsVersionResult.rowCount === 0) {
+        return errorResponse('Version does not belong to the provided tenant');
+      }
+      const adminResult = await connectionPool.query(
+        `SELECT 1 FROM odb.tenant_administrators WHERE tenant_id = $1 AND user_id = $2`,
+        [trimmedTenantId, actingUserId]
+      );
+      if (adminResult.rowCount === 0) {
+        return errorResponse('Only tenant administrators can delete shared layouts');
+      }
+    } else if (ownerUserId !== actingUserId) {
+      return errorResponse('You can only delete your own layouts');
+    }
+
+    const result = await connectionPool.query(
+      `DELETE FROM odb.canvas_layouts WHERE id = $1 RETURNING id`,
+      [candidate.id]
+    );
+
+    if (result.rowCount === 0) {
+      return errorResponse('Layout not found');
+    }
+    return successResponse({ deleted: true, name: nameValue });
+  } catch (error: any) {
+    console.error('Error deleting named canvas layout:', error);
+    return errorResponse(error.message);
+  }
+}
+
+/**
  * Save or update the default canvas layout for a version
  * This is a convenience function that creates or updates the default layout
  * Note: Groups are stored separately in the groups table, use syncGroupsForVersion

--- a/objectified-ui/lib/db/helper.ts
+++ b/objectified-ui/lib/db/helper.ts
@@ -3766,9 +3766,49 @@ export async function saveNamedCanvasLayout(
   nodes: any,
   edges?: any,
   groups?: any,
-  snapshotPngBase64?: string
+  snapshotPngBase64?: string,
+  tenantId?: string
 ) {
   try {
+    const session = await getAuthSession();
+    const actingUserId = (session?.user as any)?.user_id;
+    if (!actingUserId) {
+      return errorResponse('Unauthorized');
+    }
+
+    // Personal layout: ensure the caller cannot impersonate another user.
+    if (userId !== null && userId !== actingUserId) {
+      return errorResponse('You can only save layouts for your own account');
+    }
+
+    // Shared layout (userId === null): only tenant admins may create or overwrite them.
+    if (userId === null) {
+      const trimmedTenantId = tenantId?.trim();
+      if (!trimmedTenantId) {
+        return errorResponse('Tenant id is required to save shared layouts');
+      }
+      const tenantOwnsVersionResult = await connectionPool.query(
+        `SELECT 1
+         FROM odb.versions v
+         JOIN odb.projects p ON p.id = v.project_id
+         WHERE v.id = $1
+           AND p.tenant_id = $2
+           AND v.deleted_at IS NULL
+           AND p.deleted_at IS NULL`,
+        [versionId, trimmedTenantId]
+      );
+      if (tenantOwnsVersionResult.rowCount === 0) {
+        return errorResponse('Version does not belong to the provided tenant');
+      }
+      const adminResult = await connectionPool.query(
+        `SELECT 1 FROM odb.tenant_administrators WHERE tenant_id = $1 AND user_id = $2`,
+        [trimmedTenantId, actingUserId]
+      );
+      if (adminResult.rowCount === 0) {
+        return errorResponse('Only tenant administrators can save shared layouts');
+      }
+    }
+
     const nameValue = name.trim();
     if (!nameValue) {
       return errorResponse('Layout name is required');
@@ -4212,6 +4252,7 @@ export async function deleteNamedCanvasLayout(
        FROM odb.canvas_layouts
        WHERE version_id = $1
          AND name = $2
+         AND is_default = false
          AND (user_id = $3 OR user_id IS NULL)
        ORDER BY (user_id = $3) DESC NULLS LAST, updated_at DESC
        LIMIT 1`,
@@ -4233,7 +4274,9 @@ export async function deleteNamedCanvasLayout(
          FROM odb.versions v
          JOIN odb.projects p ON p.id = v.project_id
          WHERE v.id = $1
-           AND p.tenant_id = $2`,
+           AND p.tenant_id = $2
+           AND v.deleted_at IS NULL
+           AND p.deleted_at IS NULL`,
         [versionId, trimmedTenantId]
       );
       if (tenantOwnsVersionResult.rowCount === 0) {

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.8.85",
+  "version": "0.8.86",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -5,6 +5,7 @@ We continue to improve the platform based on your feedback with improvements and
 ---
 
 Improvements:
+- Canvas: layout permissions added for named layouts (#176) — Layout panel now shows view/edit/delete capability, enforces view-only behavior for shared layouts, and allows shared layout deletion only for tenant administrators
 - Canvas: tenant administrators can pin a quick snapshot as the team default from the gallery (Share → Pin as team default); saves a shared named layout for the API version (#175)
 - Canvas: share quick layout snapshots with teammates via JSON (copy or download from the gallery) and import shared files or pasted JSON for the same API version (#174)
 - Canvas: quick snapshots store timestamp, author (from your session), a required short summary, and optional description; capture opens a short form before saving (#173)

--- a/objectified-ui/src/app/ade/studio/editor/page.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/page.tsx
@@ -125,6 +125,7 @@ import {
   duplicateClassesInGroup,
   bulkApplyEditsToGroupClasses,
   pinTeamDefaultQuickSnapshot,
+  deleteNamedCanvasLayout,
 } from '../../../../../lib/db/helper';
 import { expandClassesForGroupExport, downloadTextFile } from '@/app/utils/group-schema-export';
 import { mapEdgesForLayoutSave, mapNodesForLayoutSave } from '../lib/canvasLayoutPayload';
@@ -616,6 +617,10 @@ const StudioContent = () => {
   const [availableLayoutNames, setAvailableLayoutNames] = useState<string[]>(BUILTIN_LAYOUT_NAMES);
   /** Data URLs for saved layout snapshots keyed by trimmed layout name */
   const [namedLayoutSnapshotDataUrls, setNamedLayoutSnapshotDataUrls] = useState<Record<string, string>>({});
+  /** Lightweight ownership/permission metadata per saved layout name. */
+  const [namedLayoutAccessByName, setNamedLayoutAccessByName] = useState<
+    Record<string, { isShared: boolean; canEdit: boolean; canDelete: boolean }>
+  >({});
   /** Local quick snapshots for this version (#168); restore UI follows in #170. */
   const [quickLayoutSnapshots, setQuickLayoutSnapshots] = useState<QuickLayoutSnapshot[]>([]);
   const [quickSnapshotSavedFlash, setQuickSnapshotSavedFlash] = useState(false);
@@ -4483,6 +4488,40 @@ const StudioContent = () => {
   // LAYOUT SAVE/LOAD HANDLERS
   // ============================================================================
 
+  const selectedLayoutNameTrimmed = selectedLayoutName.trim();
+  const selectedLayoutAccess = selectedLayoutNameTrimmed
+    ? namedLayoutAccessByName[selectedLayoutNameTrimmed]
+    : undefined;
+  const selectedLayoutIsShared = Boolean(selectedLayoutAccess?.isShared);
+  const selectedLayoutCanEdit =
+    !isReadOnly &&
+    Boolean(currentUserId) &&
+    (!selectedLayoutIsShared || Boolean(effectiveIsTenantAdmin && currentTenantId));
+  const selectedLayoutCanDelete =
+    !isReadOnly &&
+    Boolean(currentUserId) &&
+    Boolean(
+      selectedLayoutAccess &&
+        (selectedLayoutAccess.canDelete ||
+          (selectedLayoutAccess.isShared && effectiveIsTenantAdmin && currentTenantId))
+    );
+  const selectedLayoutSaveBlockedReason = isReadOnly
+    ? 'Cannot save in read-only mode'
+    : !currentUserId
+      ? 'Sign in to save layouts'
+      : selectedLayoutIsShared && !(effectiveIsTenantAdmin && currentTenantId)
+        ? 'View-only: only tenant administrators can edit shared team layouts'
+        : 'Save current layout';
+  const selectedLayoutDeleteBlockedReason = isReadOnly
+    ? 'Cannot delete in read-only mode'
+    : !currentUserId
+      ? 'Sign in to delete layouts'
+      : !hasExistingLayout
+        ? 'No saved layout available'
+        : selectedLayoutIsShared && !(effectiveIsTenantAdmin && currentTenantId)
+          ? 'View-only: only tenant administrators can delete shared team layouts'
+          : 'Delete this saved layout';
+
   // Save current canvas layout
   const handleSaveLayout = useCallback(async () => {
     if (isReadOnly || !selectedVersionId || !currentUserId) return;
@@ -4491,6 +4530,16 @@ const StudioContent = () => {
     if (!layoutName) {
       await alertDialog({
         message: 'Please enter a layout name.',
+        variant: 'warning',
+      });
+      return;
+    }
+    const selectedAccess = namedLayoutAccessByName[layoutName];
+    const selectedIsShared = Boolean(selectedAccess?.isShared);
+    const canEditLayout = !selectedIsShared || Boolean(effectiveIsTenantAdmin && currentTenantId);
+    if (!canEditLayout) {
+      await alertDialog({
+        message: 'This shared layout is view-only for your account. Only tenant administrators can edit it.',
         variant: 'warning',
       });
       return;
@@ -4548,6 +4597,10 @@ const StudioContent = () => {
         // Show "Saved" state temporarily
         setLayoutSaved(true);
         setHasExistingLayout(true);
+        setNamedLayoutAccessByName((prev) => ({
+          ...prev,
+          [layoutName]: { isShared: false, canEdit: true, canDelete: true },
+        }));
         setAvailableLayoutNames(prev => {
           if (prev.includes(layoutName)) return prev;
           return [...prev, layoutName];
@@ -4571,7 +4624,90 @@ const StudioContent = () => {
       setIsLoadingCanvas(false);
       setLoadingMessage('');
     }
-  }, [isReadOnly, selectedVersionId, currentUserId, selectedLayoutName, nodes, edges, groups, getViewport, alertDialog, isDark]);
+  }, [
+    isReadOnly,
+    selectedVersionId,
+    currentUserId,
+    selectedLayoutName,
+    namedLayoutAccessByName,
+    effectiveIsTenantAdmin,
+    currentTenantId,
+    nodes,
+    edges,
+    groups,
+    getViewport,
+    alertDialog,
+    isDark,
+  ]);
+
+  const handleDeleteLayout = useCallback(async () => {
+    if (isReadOnly || !selectedVersionId || !currentUserId) return;
+    const layoutName = selectedLayoutName.trim();
+    if (!layoutName) {
+      await alertDialog({ message: 'Please enter a layout name.', variant: 'warning' });
+      return;
+    }
+    const selectedAccess = namedLayoutAccessByName[layoutName];
+    const selectedIsShared = Boolean(selectedAccess?.isShared);
+    const canDelete =
+      Boolean(selectedAccess) && (!selectedIsShared || Boolean(effectiveIsTenantAdmin && currentTenantId));
+    if (!canDelete) {
+      await alertDialog({
+        message: selectedIsShared
+          ? 'This shared layout is view-only for your account. Only tenant administrators can delete it.'
+          : 'No saved layout exists for this name.',
+        variant: 'warning',
+      });
+      return;
+    }
+    const ok = await confirmDialog({
+      title: 'Delete layout',
+      message: `Delete saved layout "${layoutName}"? This cannot be undone.`,
+    });
+    if (!ok) return;
+    try {
+      const result = await deleteNamedCanvasLayout(
+        selectedVersionId,
+        layoutName,
+        currentTenantId || undefined
+      );
+      const parsed = JSON.parse(result);
+      if (!parsed.success) {
+        await alertDialog({ message: parsed.error || 'Could not delete layout', variant: 'error' });
+        return;
+      }
+      setAvailableLayoutNames((prev) =>
+        BUILTIN_LAYOUT_NAMES.includes(layoutName) ? prev : prev.filter((n) => n !== layoutName)
+      );
+      setNamedLayoutSnapshotDataUrls((prev) => {
+        const next = { ...prev };
+        delete next[layoutName];
+        return next;
+      });
+      setNamedLayoutAccessByName((prev) => {
+        const next = { ...prev };
+        delete next[layoutName];
+        return next;
+      });
+      setHasExistingLayout(false);
+      setSelectedLayoutName('Development Layout');
+      await alertDialog({ message: `Deleted layout "${layoutName}".`, variant: 'success' });
+    } catch (error) {
+      console.error('Error deleting named layout:', error);
+      await alertDialog({ message: 'Could not delete layout.', variant: 'error' });
+    }
+  }, [
+    isReadOnly,
+    selectedVersionId,
+    currentUserId,
+    selectedLayoutName,
+    namedLayoutAccessByName,
+    effectiveIsTenantAdmin,
+    currentTenantId,
+    confirmDialog,
+    alertDialog,
+    BUILTIN_LAYOUT_NAMES,
+  ]);
 
   const openQuickSnapshotCaptureDialog = useCallback(async () => {
     if (!selectedVersionId) {
@@ -6531,6 +6667,7 @@ const StudioContent = () => {
         setHasExistingLayout(false);
         setAvailableLayoutNames(BUILTIN_LAYOUT_NAMES);
         setNamedLayoutSnapshotDataUrls({});
+        setNamedLayoutAccessByName({});
         return;
       }
 
@@ -6548,13 +6685,23 @@ const StudioContent = () => {
         );
 
         const snapMap: Record<string, string> = {};
+        const accessByName: Record<string, { isShared: boolean; canEdit: boolean; canDelete: boolean }> = {};
         for (const layout of allLayoutsResponse.layouts || []) {
           const n = typeof layout.name === 'string' ? layout.name.trim() : '';
+          if (!n) continue;
+          const isShared = layout.user_id === null;
+          const canMutate = !isShared || Boolean(effectiveIsTenantAdmin && currentTenantId);
+          accessByName[n] = {
+            isShared,
+            canEdit: canMutate,
+            canDelete: canMutate,
+          };
           if (n && layout.snapshotImageBase64) {
             snapMap[n] = `data:image/png;base64,${layout.snapshotImageBase64}`;
           }
         }
         setNamedLayoutSnapshotDataUrls(snapMap);
+        setNamedLayoutAccessByName(accessByName);
 
         const trimmedSelection = selectedLayoutName.trim();
         const hasExistingLayoutForSelection =
@@ -6568,11 +6715,19 @@ const StudioContent = () => {
         setHasExistingLayout(false);
         setAvailableLayoutNames(BUILTIN_LAYOUT_NAMES);
         setNamedLayoutSnapshotDataUrls({});
+        setNamedLayoutAccessByName({});
       }
     };
 
     checkLayoutExists();
-  }, [selectedVersionId, currentUserId, selectedLayoutName, BUILTIN_LAYOUT_NAMES]);
+  }, [
+    selectedVersionId,
+    currentUserId,
+    selectedLayoutName,
+    BUILTIN_LAYOUT_NAMES,
+    effectiveIsTenantAdmin,
+    currentTenantId,
+  ]);
 
   // Regenerate edges when edge styling or routing preferences change
   useEffect(() => {
@@ -8789,21 +8944,39 @@ const StudioContent = () => {
                               </span>
                             </div>
                           ) : null}
+                          {hasExistingLayout && selectedLayoutNameTrimmed ? (
+                            <div className="mt-2 flex items-center gap-1.5">
+                              <span
+                                className={`rounded px-1.5 py-0.5 text-[10px] font-medium ${
+                                  selectedLayoutIsShared
+                                    ? 'bg-indigo-100 text-indigo-700 dark:bg-indigo-900/40 dark:text-indigo-300'
+                                    : 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300'
+                                }`}
+                              >
+                                {selectedLayoutIsShared ? 'Shared' : 'Personal'}
+                              </span>
+                              <span className="text-[10px] text-gray-500 dark:text-gray-400">
+                                Permissions: view
+                                {selectedLayoutCanEdit ? ', edit' : ''}
+                                {selectedLayoutCanDelete ? ', delete' : ''}
+                              </span>
+                            </div>
+                          ) : null}
                         </div>
-                        <div className="grid grid-cols-2 gap-2">
+                        <div className="grid grid-cols-3 gap-2">
                           <button
                             onClick={handleSaveLayout}
-                            disabled={isReadOnly || layoutSaved}
+                            disabled={!selectedLayoutCanEdit || layoutSaved}
                             className={`
                               px-3 py-2 text-sm font-medium rounded-lg transition-all duration-200 flex items-center justify-center gap-2
                               ${layoutSaved
                                 ? 'bg-green-50 dark:bg-green-900/30 text-green-700 dark:text-green-300 border border-green-200 dark:border-green-700'
-                                : !isReadOnly
+                                : selectedLayoutCanEdit
                                 ? 'bg-indigo-50 dark:bg-indigo-900/30 text-indigo-700 dark:text-indigo-300 hover:bg-indigo-100 dark:hover:bg-indigo-900/50 border border-indigo-200 dark:border-indigo-700'
                                 : 'bg-gray-100 dark:bg-gray-700 text-gray-400 dark:text-gray-500 cursor-not-allowed border border-gray-200 dark:border-gray-600'
                               }
                             `}
-                            title={layoutSaved ? 'Layout saved!' : isReadOnly ? 'Cannot save in read-only mode' : 'Save current layout'}
+                            title={layoutSaved ? 'Layout saved!' : selectedLayoutSaveBlockedReason}
                           >
                             {layoutSaved ? (
                               <>
@@ -8819,9 +8992,9 @@ const StudioContent = () => {
                           </button>
                           <button
                             onClick={handleLoadLayout}
-                            disabled={!hasExistingLayout}
+                            disabled={!hasExistingLayout || !selectedLayoutNameTrimmed}
                             className={`px-3 py-2 text-sm font-medium rounded-lg transition-all duration-200 flex items-center justify-center gap-2 ${
-                              hasExistingLayout
+                              hasExistingLayout && selectedLayoutNameTrimmed
                                 ? 'bg-purple-50 dark:bg-purple-900/30 text-purple-700 dark:text-purple-300 hover:bg-purple-100 dark:hover:bg-purple-900/50 border border-purple-200 dark:border-purple-700'
                                 : 'bg-gray-100 dark:bg-gray-700 text-gray-400 dark:text-gray-500 cursor-not-allowed border border-gray-200 dark:border-gray-600'
                             }`}
@@ -8829,6 +9002,19 @@ const StudioContent = () => {
                           >
                             <Upload className="w-4 h-4" />
                             <span>Load</span>
+                          </button>
+                          <button
+                            onClick={() => void handleDeleteLayout()}
+                            disabled={!selectedLayoutCanDelete || !hasExistingLayout}
+                            className={`px-3 py-2 text-sm font-medium rounded-lg transition-all duration-200 flex items-center justify-center gap-2 ${
+                              selectedLayoutCanDelete && hasExistingLayout
+                                ? 'bg-rose-50 dark:bg-rose-900/30 text-rose-700 dark:text-rose-300 hover:bg-rose-100 dark:hover:bg-rose-900/50 border border-rose-200 dark:border-rose-700'
+                                : 'bg-gray-100 dark:bg-gray-700 text-gray-400 dark:text-gray-500 cursor-not-allowed border border-gray-200 dark:border-gray-600'
+                            }`}
+                            title={selectedLayoutDeleteBlockedReason}
+                          >
+                            <Trash2 className="w-4 h-4" />
+                            <span>Delete</span>
                           </button>
                         </div>
                         <div className="mt-3 pt-3 border-t border-gray-200 dark:border-gray-700 space-y-2">

--- a/objectified-ui/src/app/ade/studio/editor/page.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/page.tsx
@@ -4584,7 +4584,8 @@ const StudioContent = () => {
         nodeData,
         edgeData,
         groups,
-        snapshotBase64ForServer
+        snapshotBase64ForServer,
+        currentTenantId ?? undefined
       );
 
       const response = JSON.parse(result);

--- a/objectified-ui/tests/canvas-layout-named.test.ts
+++ b/objectified-ui/tests/canvas-layout-named.test.ts
@@ -547,6 +547,51 @@ describe('Database Helper - default named canvas layout preference', () => {
     );
   });
 
+  test('deleteNamedCanvasLayout deletes personal layout owned by current user', async () => {
+    const { deleteNamedCanvasLayout } = await import('../lib/db/helper');
+
+    mockQuery
+      .mockResolvedValueOnce({
+        rowCount: 1,
+        rows: [{ id: 'layout-1', user_id: 'user-1', name: 'My Layout' }],
+      })
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 'layout-1' }] });
+
+    const result = await deleteNamedCanvasLayout('version-1', 'My Layout', 'tenant-1');
+    const parsed = JSON.parse(result);
+
+    expect(parsed.success).toBe(true);
+    expect(parsed.deleted).toBe(true);
+    expect(mockQuery).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining('FROM odb.canvas_layouts'),
+      ['version-1', 'My Layout', 'user-1']
+    );
+    expect(mockQuery).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining('DELETE FROM odb.canvas_layouts'),
+      ['layout-1']
+    );
+  });
+
+  test('deleteNamedCanvasLayout rejects shared delete for non-admin', async () => {
+    const { deleteNamedCanvasLayout } = await import('../lib/db/helper');
+
+    mockQuery
+      .mockResolvedValueOnce({
+        rowCount: 1,
+        rows: [{ id: 'layout-shared-1', user_id: null, name: 'Shared Layout' }],
+      })
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ '?column?': 1 }] }) // version belongs to tenant
+      .mockResolvedValueOnce({ rowCount: 0, rows: [] }); // not admin
+
+    const result = await deleteNamedCanvasLayout('version-1', 'Shared Layout', 'tenant-1');
+    const parsed = JSON.parse(result);
+
+    expect(parsed.success).toBe(false);
+    expect(parsed.error).toContain('tenant administrators');
+  });
+
   test('getClassIdsForVersion returns ids for non-deleted classes in version', async () => {
     const { getClassIdsForVersion } = await import('../lib/db/helper');
 

--- a/objectified-ui/tests/canvas-layout-named.test.ts
+++ b/objectified-ui/tests/canvas-layout-named.test.ts
@@ -22,11 +22,19 @@ jest.mock('crypto', () => ({
 
 describe('Database Helper - Named Canvas Layouts', () => {
   let mockQuery: jest.Mock<any>;
+  let mockGetAuthSession: jest.Mock<any>;
 
   beforeEach(() => {
     const db = require('../lib/db/db');
     mockQuery = db.query as jest.Mock;
     mockQuery.mockReset();
+
+    const serverSession = require('../lib/auth/server-session');
+    mockGetAuthSession = serverSession.getAuthSession as jest.Mock<any>;
+    mockGetAuthSession.mockReset();
+    mockGetAuthSession.mockResolvedValue({
+      user: { user_id: 'user-1', current_tenant_id: 'tenant-1' },
+    });
   });
 
   test('getNamedCanvasLayoutsForVersion deduplicates names and prefers user layouts', async () => {
@@ -279,6 +287,8 @@ describe('Database Helper - Named Canvas Layouts', () => {
     const { saveNamedCanvasLayout } = await import('../lib/db/helper');
 
     mockQuery
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ '?column?': 1 }] }) // version belongs to tenant
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ '?column?': 1 }] }) // user is tenant admin
       .mockResolvedValueOnce({ rowCount: 0, rows: [] }) // existing lookup
       .mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 'layout-shared-1', name: 'Shared Layout' }] }); // create return
 
@@ -288,7 +298,10 @@ describe('Database Helper - Named Canvas Layouts', () => {
       '  Shared Layout  ',
       { x: 0, y: 0, zoom: 1 },
       [{ id: 'node-1', type: 'classNode', position: { x: 1, y: 2 } }],
-      []
+      [],
+      undefined,
+      undefined,
+      'tenant-1'
     );
     const parsed = JSON.parse(result);
 
@@ -296,12 +309,12 @@ describe('Database Helper - Named Canvas Layouts', () => {
     expect(parsed.layout.id).toBe('layout-shared-1');
 
     expect(mockQuery).toHaveBeenNthCalledWith(
-      1,
+      3,
       expect.stringContaining('user_id IS NOT DISTINCT FROM $3'),
       ['version-1', 'Shared Layout', null]
     );
     expect(mockQuery).toHaveBeenNthCalledWith(
-      2,
+      4,
       expect.stringContaining('INSERT INTO odb.canvas_layouts'),
       expect.arrayContaining(['version-1', null, 'Shared Layout'])
     );
@@ -311,6 +324,8 @@ describe('Database Helper - Named Canvas Layouts', () => {
     const { saveNamedCanvasLayout } = await import('../lib/db/helper');
 
     mockQuery
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ '?column?': 1 }] }) // version belongs to tenant
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ '?column?': 1 }] }) // user is tenant admin
       .mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 'layout-shared-1' }] }) // existing lookup (pool)
       .mockResolvedValueOnce({ rowCount: 0 }) // BEGIN
       .mockResolvedValueOnce({
@@ -339,14 +354,17 @@ describe('Database Helper - Named Canvas Layouts', () => {
       'Shared Layout',
       { x: 0, y: 0, zoom: 1 },
       [{ id: 'node-1', type: 'classNode', position: { x: 1, y: 2 } }],
-      []
+      [],
+      undefined,
+      undefined,
+      'tenant-1'
     );
     const parsed = JSON.parse(result);
 
     expect(parsed.success).toBe(true);
     expect(parsed.layout.id).toBe('layout-shared-1');
     expect(mockQuery).toHaveBeenNthCalledWith(
-      1,
+      3,
       expect.stringContaining('user_id IS NOT DISTINCT FROM $3'),
       ['version-1', 'Shared Layout', null]
     );
@@ -590,6 +608,42 @@ describe('Database Helper - default named canvas layout preference', () => {
 
     expect(parsed.success).toBe(false);
     expect(parsed.error).toContain('tenant administrators');
+  });
+
+  test('deleteNamedCanvasLayout deletes shared layout when called by tenant admin', async () => {
+    const { deleteNamedCanvasLayout } = await import('../lib/db/helper');
+
+    mockQuery
+      .mockResolvedValueOnce({
+        rowCount: 1,
+        rows: [{ id: 'layout-shared-1', user_id: null, name: 'Shared Layout' }],
+      }) // shared layout
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ '?column?': 1 }] }) // version belongs to tenant
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ '?column?': 1 }] }) // user is tenant admin
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 'layout-shared-1' }] }); // delete
+
+    const result = await deleteNamedCanvasLayout('version-1', 'Shared Layout', 'tenant-1');
+    const parsed = JSON.parse(result);
+
+    expect(parsed.success).toBe(true);
+    expect(parsed.deleted).toBe(true);
+    expect(mockQuery).toHaveBeenCalledTimes(4);
+  });
+
+  test('deleteNamedCanvasLayout errors when deleting shared layout without tenantId', async () => {
+    const { deleteNamedCanvasLayout } = await import('../lib/db/helper');
+
+    mockQuery.mockResolvedValueOnce({
+      rowCount: 1,
+      rows: [{ id: 'layout-shared-1', user_id: null, name: 'Shared Layout' }],
+    });
+
+    const result = await deleteNamedCanvasLayout('version-1', 'Shared Layout', undefined as any);
+    const parsed = JSON.parse(result);
+
+    expect(parsed.success).toBe(false);
+    expect(parsed.error).toBeDefined();
+    expect(mockQuery).toHaveBeenCalledTimes(1);
   });
 
   test('getClassIdsForVersion returns ids for non-deleted classes in version', async () => {


### PR DESCRIPTION
## Problem Statement

Users and teams need **addresses #176 — add named layout view/edit/delete permissions** within the Objectified platform. Today this capability is missing or only partially implemented, which blocks dashboard workflows and creates inconsistency across tenants and projects.

**Original request:**

Expose layout permission state in the studio layout panel and enforce shared-layout delete/edit rules so non-admins remain view-only while tenant admins can manage shared entries.

Made-with: Cursor

Closes #176

## Solution / Scope

Implement **Addresses #176 — Add named layout view/edit/delete permissions** as part of **Dashboard**. KPIs, primitives browser, project overview, quick actions.

**Post-MVP** (prioritize after MVP slice) candidacy.

```mermaid
flowchart TB
  CP[Control Panel] --> KPIs[Stats cards]
  CP --> Primitives[Primitives list]
  CP --> Projects[Recent projects]
  CP --> Actions[Quick actions]
```

## Acceptance Criteria

- [ ] Feature behaves as described for: Addresses #176 — Add named layout view/edit/delete permissions
- [ ] Unit/integration tests cover happy path and primary error cases
- [ ] UI (if applicable) matches existing ADE patterns (Tailwind 4, Radix, Lucide)
- [ ] REST endpoints (if applicable) follow `/v1/{{feature}}/{{tenant_slug}}/...` conventions
- [ ] Documented in issue/PR; no regressions to existing schema/version flows

## Parallelism / Dependencies

- **Can run in parallel:** Yes
- **Blockers:** None identified; validate against current codebase before starting

## Technical Stack

- **Modules:** objectified-rest
- **Stack:** Next.js ADE dashboard, control panel components, REST stats APIs
- **Labels:** ``

---

**Epic:** [[Epic] Dashboard & Control Panel](https://github.com/objectified-project/objectified/issues/3493)
**Issue:** #876 · **Area:** Dashboard · **Roadmap batch:** legacy #64–#879 enrichment