### PR TITLE
Addresses #177 — layout comments and annotations

### DIFF
--- a/PLANNED_FEATURE_ROADMAP_CANVAS.md
+++ b/PLANNED_FEATURE_ROADMAP_CANVAS.md
@@ -15,12 +15,11 @@
 - ✅ Share layout configurations with team members (#174) — quick snapshot gallery: copy/download JSON envelope, import shared JSON for same API version
 - ✅ "Pin" layout as team default (#175) — tenant admins: Share → Pin as team default saves a shared named layout and sets tenant default for the version
 - ✅ Layout permissions (view, edit, delete) (#176) — named layouts now expose view/edit/delete capability in the Layout panel; shared layouts are view-only for non-admins and only tenant admins can delete shared entries
-- 📋 [TODO] Layout comments and annotations
+- ✅ Layout comments and annotations (#177) — named layouts now support a short comment and longer annotations in the Layout panel; both are saved per layout and restored when the name is selected
 - 📋 [TODO] Layout versioning with diff viewer
 
 | Ticket | Feature                                       |
 |--------|-----------------------------------------------|
-| #177   | Layout comments and annotations               |
 | #178   | Layout versioning with diff viewer            |
 
 ---

--- a/objectified-ui/lib/db/helper.ts
+++ b/objectified-ui/lib/db/helper.ts
@@ -19,6 +19,8 @@ const MAX_CANVAS_LAYOUT_SNAPSHOT_BASE64_CHARS = Math.ceil(MAX_CANVAS_LAYOUT_SNAP
 const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
 /** 4-byte ASCII chunk type for the required IHDR chunk (first chunk in every PNG). */
 const PNG_IHDR_TYPE = Buffer.from([0x49, 0x48, 0x44, 0x52]);
+const MAX_LAYOUT_COMMENT_LENGTH = 240;
+const MAX_LAYOUT_ANNOTATIONS_LENGTH = 4000;
 
 /**
  * Reserved named layout used when a tenant admin pins a quick snapshot as the team default (#175).
@@ -66,6 +68,22 @@ function layoutRowWithoutBinarySnapshot(row: any) {
   if (!row) return row;
   const { snapshot_image: _s, ...rest } = row;
   return rest;
+}
+
+type NamedLayoutAnnotationsInput =
+  | {
+      comment?: unknown;
+      annotations?: unknown;
+    }
+  | null
+  | undefined;
+
+function sanitizeNamedLayoutAnnotations(input: NamedLayoutAnnotationsInput) {
+  const rawComment = typeof input?.comment === 'string' ? input.comment.trim() : '';
+  const rawAnnotations = typeof input?.annotations === 'string' ? input.annotations.trim() : '';
+  const comment = rawComment ? rawComment.slice(0, MAX_LAYOUT_COMMENT_LENGTH) : undefined;
+  const annotations = rawAnnotations ? rawAnnotations.slice(0, MAX_LAYOUT_ANNOTATIONS_LENGTH) : undefined;
+  return { comment, annotations };
 }
 
 export const getUserByEmail = async (emailAddress: string) =>
@@ -3671,7 +3689,7 @@ export async function pinTeamDefaultQuickSnapshot(
 export async function getNamedCanvasLayoutsForVersion(versionId: string, userId?: string) {
   try {
     const result = await connectionPool.query(
-      `SELECT id, version_id, user_id, name, is_default, snapshot_image, created_at, updated_at
+      `SELECT id, version_id, user_id, name, is_default, metadata, snapshot_image, created_at, updated_at
        FROM odb.canvas_layouts
        WHERE version_id = $1
          AND name IS NOT NULL
@@ -3767,7 +3785,8 @@ export async function saveNamedCanvasLayout(
   edges?: any,
   groups?: any,
   snapshotPngBase64?: string,
-  tenantId?: string
+  tenantId?: string,
+  annotationsInput?: NamedLayoutAnnotationsInput
 ) {
   try {
     const session = await getAuthSession();
@@ -3829,13 +3848,14 @@ export async function saveNamedCanvasLayout(
     }
 
     const existingResult = await connectionPool.query(
-      `SELECT id FROM odb.canvas_layouts
+      `SELECT id, metadata FROM odb.canvas_layouts
        WHERE version_id = $1
          AND name = $2
          AND user_id IS NOT DISTINCT FROM $3
        LIMIT 1`,
       [versionId, nameValue, userId]
     );
+    const normalizedAnnotations = sanitizeNamedLayoutAnnotations(annotationsInput);
 
     // Keep group storage behavior aligned with default layout saves.
     if (groups && Array.isArray(groups)) {
@@ -3859,12 +3879,30 @@ export async function saveNamedCanvasLayout(
         viewport: any;
         nodes: any;
         edges: any;
+        metadata?: any;
         snapshotImage?: Buffer;
       } = {
         viewport,
         nodes,
         edges: edges || []
       };
+      const existingMetadata =
+        existingResult.rows[0]?.metadata && typeof existingResult.rows[0].metadata === 'object'
+          ? existingResult.rows[0].metadata
+          : {};
+      const mergedMetadata = {
+        ...existingMetadata,
+        ...(normalizedAnnotations.comment !== undefined ? { comment: normalizedAnnotations.comment } : {}),
+        ...(normalizedAnnotations.annotations !== undefined ? { annotations: normalizedAnnotations.annotations } : {}),
+      };
+      // If user cleared a field, remove it rather than keeping stale text.
+      if (normalizedAnnotations.comment === undefined) {
+        delete mergedMetadata.comment;
+      }
+      if (normalizedAnnotations.annotations === undefined) {
+        delete mergedMetadata.annotations;
+      }
+      updates.metadata = mergedMetadata;
       if (snapshotBuffer !== undefined) {
         updates.snapshotImage = snapshotBuffer;
       }
@@ -3886,7 +3924,10 @@ export async function saveNamedCanvasLayout(
       null,
       { enabled: true, size: 20, snapToGrid: true, showGrid: true },
       { enabled: true, position: 'bottom-right', size: 'medium' },
-      {},
+      {
+        ...(normalizedAnnotations.comment !== undefined ? { comment: normalizedAnnotations.comment } : {}),
+        ...(normalizedAnnotations.annotations !== undefined ? { annotations: normalizedAnnotations.annotations } : {}),
+      },
       snapshotBuffer ?? null
     );
   } catch (error: any) {

--- a/objectified-ui/lib/db/helper.ts
+++ b/objectified-ui/lib/db/helper.ts
@@ -3890,17 +3890,26 @@ export async function saveNamedCanvasLayout(
         existingResult.rows[0]?.metadata && typeof existingResult.rows[0].metadata === 'object'
           ? existingResult.rows[0].metadata
           : {};
-      const mergedMetadata = {
+      const mergedMetadata: Record<string, unknown> = {
         ...existingMetadata,
-        ...(normalizedAnnotations.comment !== undefined ? { comment: normalizedAnnotations.comment } : {}),
-        ...(normalizedAnnotations.annotations !== undefined ? { annotations: normalizedAnnotations.annotations } : {}),
       };
-      // If user cleared a field, remove it rather than keeping stale text.
-      if (normalizedAnnotations.comment === undefined) {
-        delete mergedMetadata.comment;
-      }
-      if (normalizedAnnotations.annotations === undefined) {
-        delete mergedMetadata.annotations;
+      // Apply metadata changes only when explicitly provided.
+      // Treat empty strings as an explicit request to clear the field.
+      if (annotationsInput != null) {
+        if (Object.prototype.hasOwnProperty.call(annotationsInput, 'comment')) {
+          if (normalizedAnnotations.comment) {
+            mergedMetadata.comment = normalizedAnnotations.comment;
+          } else {
+            delete mergedMetadata.comment;
+          }
+        }
+        if (Object.prototype.hasOwnProperty.call(annotationsInput, 'annotations')) {
+          if (normalizedAnnotations.annotations) {
+            mergedMetadata.annotations = normalizedAnnotations.annotations;
+          } else {
+            delete mergedMetadata.annotations;
+          }
+        }
       }
       updates.metadata = mergedMetadata;
       if (snapshotBuffer !== undefined) {

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.8.86",
+  "version": "0.8.87",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -5,6 +5,7 @@ We continue to improve the platform based on your feedback with improvements and
 ---
 
 Improvements:
+- Canvas: named layouts now support a short comment and longer annotations in the Layout panel, saved per layout name and restored when selected (#177)
 - Canvas: layout permissions added for named layouts (#176) — Layout panel now shows view/edit/delete capability, enforces view-only behavior for shared layouts, and allows shared layout deletion only for tenant administrators
 - Canvas: tenant administrators can pin a quick snapshot as the team default from the gallery (Share → Pin as team default); saves a shared named layout for the API version (#175)
 - Canvas: share quick layout snapshots with teammates via JSON (copy or download from the gallery) and import shared files or pasted JSON for the same API version (#174)

--- a/objectified-ui/src/app/ade/studio/editor/page.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/page.tsx
@@ -227,6 +227,9 @@ const Editor = dynamic(() => import('@monaco-editor/react'), {
   ),
 });
 
+const LAYOUT_COMMENT_MAX_LENGTH = 240;
+const LAYOUT_ANNOTATIONS_MAX_LENGTH = 4000;
+
 const StudioContent = () => {
   const BUILTIN_LAYOUT_NAMES = useMemo(
     () => ['Development Layout', 'Presentation Layout', 'Logical Layout', 'Dependency Layout'],
@@ -621,6 +624,11 @@ const StudioContent = () => {
   const [namedLayoutAccessByName, setNamedLayoutAccessByName] = useState<
     Record<string, { isShared: boolean; canEdit: boolean; canDelete: boolean }>
   >({});
+  const [namedLayoutAnnotationsByName, setNamedLayoutAnnotationsByName] = useState<
+    Record<string, { comment?: string; annotations?: string }>
+  >({});
+  const [layoutCommentDraft, setLayoutCommentDraft] = useState('');
+  const [layoutAnnotationsDraft, setLayoutAnnotationsDraft] = useState('');
   /** Local quick snapshots for this version (#168); restore UI follows in #170. */
   const [quickLayoutSnapshots, setQuickLayoutSnapshots] = useState<QuickLayoutSnapshot[]>([]);
   const [quickSnapshotSavedFlash, setQuickSnapshotSavedFlash] = useState(false);
@@ -640,6 +648,18 @@ const StudioContent = () => {
   useEffect(() => {
     selectedLayoutNameRef.current = selectedLayoutName;
   }, [selectedLayoutName]);
+
+  useEffect(() => {
+    const key = selectedLayoutName.trim();
+    if (!key) {
+      setLayoutCommentDraft('');
+      setLayoutAnnotationsDraft('');
+      return;
+    }
+    const existing = namedLayoutAnnotationsByName[key];
+    setLayoutCommentDraft(existing?.comment ?? '');
+    setLayoutAnnotationsDraft(existing?.annotations ?? '');
+  }, [selectedLayoutName, namedLayoutAnnotationsByName]);
 
   useEffect(() => {
     if (!selectedVersionId) {
@@ -4574,6 +4594,8 @@ const StudioContent = () => {
 
       const nodeData = mapNodesForLayoutSave(nodes);
       const edgeData = mapEdgesForLayoutSave(edges);
+      const comment = layoutCommentDraft.trim().slice(0, LAYOUT_COMMENT_MAX_LENGTH);
+      const annotations = layoutAnnotationsDraft.trim().slice(0, LAYOUT_ANNOTATIONS_MAX_LENGTH);
 
       // Save selected named layout to database
       const result = await saveNamedCanvasLayout(
@@ -4585,7 +4607,11 @@ const StudioContent = () => {
         edgeData,
         groups,
         snapshotBase64ForServer,
-        currentTenantId ?? undefined
+        currentTenantId ?? undefined,
+        {
+          comment,
+          annotations,
+        }
       );
 
       const response = JSON.parse(result);
@@ -4602,6 +4628,18 @@ const StudioContent = () => {
           ...prev,
           [layoutName]: { isShared: false, canEdit: true, canDelete: true },
         }));
+        setNamedLayoutAnnotationsByName((prev) => {
+          const next = { ...prev };
+          if (comment || annotations) {
+            next[layoutName] = {
+              ...(comment ? { comment } : {}),
+              ...(annotations ? { annotations } : {}),
+            };
+          } else {
+            delete next[layoutName];
+          }
+          return next;
+        });
         setAvailableLayoutNames(prev => {
           if (prev.includes(layoutName)) return prev;
           return [...prev, layoutName];
@@ -4639,6 +4677,8 @@ const StudioContent = () => {
     getViewport,
     alertDialog,
     isDark,
+    layoutCommentDraft,
+    layoutAnnotationsDraft,
   ]);
 
   const handleDeleteLayout = useCallback(async () => {
@@ -4686,6 +4726,11 @@ const StudioContent = () => {
         return next;
       });
       setNamedLayoutAccessByName((prev) => {
+        const next = { ...prev };
+        delete next[layoutName];
+        return next;
+      });
+      setNamedLayoutAnnotationsByName((prev) => {
         const next = { ...prev };
         delete next[layoutName];
         return next;
@@ -6669,6 +6714,7 @@ const StudioContent = () => {
         setAvailableLayoutNames(BUILTIN_LAYOUT_NAMES);
         setNamedLayoutSnapshotDataUrls({});
         setNamedLayoutAccessByName({});
+        setNamedLayoutAnnotationsByName({});
         return;
       }
 
@@ -6687,6 +6733,7 @@ const StudioContent = () => {
 
         const snapMap: Record<string, string> = {};
         const accessByName: Record<string, { isShared: boolean; canEdit: boolean; canDelete: boolean }> = {};
+        const annotationsByName: Record<string, { comment?: string; annotations?: string }> = {};
         for (const layout of allLayoutsResponse.layouts || []) {
           const n = typeof layout.name === 'string' ? layout.name.trim() : '';
           if (!n) continue;
@@ -6700,9 +6747,24 @@ const StudioContent = () => {
           if (n && layout.snapshotImageBase64) {
             snapMap[n] = `data:image/png;base64,${layout.snapshotImageBase64}`;
           }
+          const rawComment =
+            layout?.metadata && typeof layout.metadata === 'object' && typeof layout.metadata.comment === 'string'
+              ? layout.metadata.comment.trim()
+              : '';
+          const rawAnnotations =
+            layout?.metadata && typeof layout.metadata === 'object' && typeof layout.metadata.annotations === 'string'
+              ? layout.metadata.annotations.trim()
+              : '';
+          if (rawComment || rawAnnotations) {
+            annotationsByName[n] = {
+              ...(rawComment ? { comment: rawComment } : {}),
+              ...(rawAnnotations ? { annotations: rawAnnotations } : {}),
+            };
+          }
         }
         setNamedLayoutSnapshotDataUrls(snapMap);
         setNamedLayoutAccessByName(accessByName);
+        setNamedLayoutAnnotationsByName(annotationsByName);
 
         const trimmedSelection = selectedLayoutName.trim();
         const hasExistingLayoutForSelection =
@@ -6717,6 +6779,7 @@ const StudioContent = () => {
         setAvailableLayoutNames(BUILTIN_LAYOUT_NAMES);
         setNamedLayoutSnapshotDataUrls({});
         setNamedLayoutAccessByName({});
+        setNamedLayoutAnnotationsByName({});
       }
     };
 
@@ -8963,6 +9026,48 @@ const StudioContent = () => {
                               </span>
                             </div>
                           ) : null}
+                          <div className="mt-3 space-y-2">
+                            <div>
+                              <label
+                                htmlFor="layout-comment-input"
+                                className="block text-xs text-gray-500 dark:text-gray-400 mb-1"
+                              >
+                                Comment
+                              </label>
+                              <input
+                                id="layout-comment-input"
+                                type="text"
+                                value={layoutCommentDraft}
+                                onChange={(e) => setLayoutCommentDraft(e.target.value.slice(0, LAYOUT_COMMENT_MAX_LENGTH))}
+                                placeholder="Short context for this layout"
+                                className="w-full px-2.5 py-2 text-sm rounded-lg border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-700/50 text-gray-700 dark:text-gray-200 placeholder:text-gray-400 dark:placeholder:text-gray-500 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                              />
+                              <p className="mt-1 text-right text-[10px] text-gray-400 dark:text-gray-500">
+                                {layoutCommentDraft.length}/{LAYOUT_COMMENT_MAX_LENGTH}
+                              </p>
+                            </div>
+                            <div>
+                              <label
+                                htmlFor="layout-annotations-input"
+                                className="block text-xs text-gray-500 dark:text-gray-400 mb-1"
+                              >
+                                Annotations
+                              </label>
+                              <textarea
+                                id="layout-annotations-input"
+                                value={layoutAnnotationsDraft}
+                                onChange={(e) =>
+                                  setLayoutAnnotationsDraft(e.target.value.slice(0, LAYOUT_ANNOTATIONS_MAX_LENGTH))
+                                }
+                                rows={3}
+                                placeholder="Longer notes, reminders, or review context"
+                                className="w-full px-2.5 py-2 text-sm rounded-lg border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-700/50 text-gray-700 dark:text-gray-200 placeholder:text-gray-400 dark:placeholder:text-gray-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 resize-y"
+                              />
+                              <p className="mt-1 text-right text-[10px] text-gray-400 dark:text-gray-500">
+                                {layoutAnnotationsDraft.length}/{LAYOUT_ANNOTATIONS_MAX_LENGTH}
+                              </p>
+                            </div>
+                          </div>
                         </div>
                         <div className="grid grid-cols-3 gap-2">
                           <button

--- a/objectified-ui/tests/canvas-layout-named.test.ts
+++ b/objectified-ui/tests/canvas-layout-named.test.ts
@@ -81,6 +81,31 @@ describe('Database Helper - Named Canvas Layouts', () => {
     expect(parsed.layouts[0].name).toBe('Development Layout');
   });
 
+  test('getNamedCanvasLayoutsForVersion includes stored layout annotations metadata', async () => {
+    const { getNamedCanvasLayoutsForVersion } = await import('../lib/db/helper');
+
+    mockQuery.mockResolvedValue({
+      rows: [
+        {
+          id: 'u1',
+          name: 'Development Layout',
+          user_id: 'user-1',
+          metadata: { comment: 'Review', annotations: 'Keep service nodes grouped.' },
+        },
+      ],
+    });
+
+    const result = await getNamedCanvasLayoutsForVersion('version-1', 'user-1');
+    const parsed = JSON.parse(result);
+
+    expect(parsed.success).toBe(true);
+    expect(parsed.layouts).toHaveLength(1);
+    expect(parsed.layouts[0].metadata).toEqual({
+      comment: 'Review',
+      annotations: 'Keep service nodes grouped.',
+    });
+  });
+
   test('getNamedCanvasLayout returns null when no named layout exists', async () => {
     const { getNamedCanvasLayout } = await import('../lib/db/helper');
 
@@ -182,6 +207,49 @@ describe('Database Helper - Named Canvas Layouts', () => {
 
     expect(parsed.success).toBe(true);
     expect(parsed.layout.name).toBe('Presentation Layout');
+  });
+
+  test('saveNamedCanvasLayout stores comment and annotations in metadata on create', async () => {
+    const { saveNamedCanvasLayout } = await import('../lib/db/helper');
+
+    mockQuery
+      .mockResolvedValueOnce({ rowCount: 0, rows: [] }) // existing lookup
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 'layout-3', name: 'Annotated Layout' }] }); // create return
+
+    const result = await saveNamedCanvasLayout(
+      'version-1',
+      'user-1',
+      'Annotated Layout',
+      { x: 0, y: 0, zoom: 1 },
+      [{ id: 'node-1', type: 'classNode', position: { x: 1, y: 2 } }],
+      [],
+      undefined,
+      undefined,
+      undefined,
+      {
+        comment: 'Team review',
+        annotations: 'Use this before migration.',
+      }
+    );
+    const parsed = JSON.parse(result);
+
+    expect(parsed.success).toBe(true);
+    expect(mockQuery).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining('INSERT INTO odb.canvas_layouts'),
+      expect.arrayContaining([
+        'version-1',
+        'user-1',
+        'Annotated Layout',
+        expect.anything(),
+        expect.any(String),
+        expect.any(String),
+        expect.any(String),
+        expect.any(String),
+        expect.any(String),
+        JSON.stringify({ comment: 'Team review', annotations: 'Use this before migration.' }),
+      ])
+    );
   });
 
   test('saveNamedCanvasLayout rejects blank layout name after trim', async () => {

--- a/objectified-ui/tests/canvas-layout-named.test.ts
+++ b/objectified-ui/tests/canvas-layout-named.test.ts
@@ -252,6 +252,131 @@ describe('Database Helper - Named Canvas Layouts', () => {
     );
   });
 
+  test('saveNamedCanvasLayout merges metadata on update and preserves unrelated keys', async () => {
+    const { saveNamedCanvasLayout } = await import('../lib/db/helper');
+
+    mockQuery
+      .mockResolvedValueOnce({
+        rowCount: 1,
+        rows: [{ id: 'layout-4', name: 'Annotated Layout', metadata: { comment: 'Old comment', annotations: 'Existing note', extra: 'keep-me' } }],
+      }) // existing layout lookup
+      .mockResolvedValueOnce({ rowCount: 0 }) // BEGIN
+      .mockResolvedValueOnce({
+        rowCount: 1,
+        rows: [{ version_id: 'version-1', user_id: 'user-1', viewport: { x: 0, y: 0, zoom: 1 }, nodes: [], edges: [], grid_settings: {}, minimap_settings: {} }],
+      }) // SELECT FOR UPDATE
+      .mockResolvedValueOnce({ rows: [{ n: 0 }] }) // max revision
+      .mockResolvedValueOnce({ rowCount: 1 }) // insert revision
+      .mockResolvedValueOnce({ rowCount: 0 }) // prune old revisions
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 'layout-4', name: 'Annotated Layout' }] }) // UPDATE RETURNING
+      .mockResolvedValueOnce({ rowCount: 0 }); // COMMIT
+
+    const result = await saveNamedCanvasLayout(
+      'version-1',
+      'user-1',
+      'Annotated Layout',
+      { x: 0, y: 0, zoom: 1 },
+      [{ id: 'node-1', type: 'classNode', position: { x: 1, y: 2 } }],
+      [],
+      undefined,
+      undefined,
+      undefined,
+      { comment: 'Updated comment' }
+    );
+    const parsed = JSON.parse(result);
+
+    expect(parsed.success).toBe(true);
+    expect(mockQuery).toHaveBeenNthCalledWith(
+      7,
+      expect.stringContaining('UPDATE odb.canvas_layouts'),
+      expect.arrayContaining([
+        JSON.stringify({ comment: 'Updated comment', annotations: 'Existing note', extra: 'keep-me' }),
+      ])
+    );
+  });
+
+  test('saveNamedCanvasLayout clears comment on update when empty string is provided but preserves other metadata', async () => {
+    const { saveNamedCanvasLayout } = await import('../lib/db/helper');
+
+    mockQuery
+      .mockResolvedValueOnce({
+        rowCount: 1,
+        rows: [{ id: 'layout-5', name: 'Annotated Layout', metadata: { comment: 'Old comment', annotations: 'Existing note', extra: 'keep-me' } }],
+      }) // existing layout lookup
+      .mockResolvedValueOnce({ rowCount: 0 }) // BEGIN
+      .mockResolvedValueOnce({
+        rowCount: 1,
+        rows: [{ version_id: 'version-1', user_id: 'user-1', viewport: { x: 0, y: 0, zoom: 1 }, nodes: [], edges: [], grid_settings: {}, minimap_settings: {} }],
+      }) // SELECT FOR UPDATE
+      .mockResolvedValueOnce({ rows: [{ n: 0 }] }) // max revision
+      .mockResolvedValueOnce({ rowCount: 1 }) // insert revision
+      .mockResolvedValueOnce({ rowCount: 0 }) // prune old revisions
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 'layout-5', name: 'Annotated Layout' }] }) // UPDATE RETURNING
+      .mockResolvedValueOnce({ rowCount: 0 }); // COMMIT
+
+    const result = await saveNamedCanvasLayout(
+      'version-1',
+      'user-1',
+      'Annotated Layout',
+      { x: 0, y: 0, zoom: 1 },
+      [{ id: 'node-1', type: 'classNode', position: { x: 1, y: 2 } }],
+      [],
+      undefined,
+      undefined,
+      undefined,
+      { comment: '' }
+    );
+    const parsed = JSON.parse(result);
+
+    expect(parsed.success).toBe(true);
+    expect(mockQuery).toHaveBeenNthCalledWith(
+      7,
+      expect.stringContaining('UPDATE odb.canvas_layouts'),
+      expect.arrayContaining([
+        JSON.stringify({ annotations: 'Existing note', extra: 'keep-me' }),
+      ])
+    );
+  });
+
+  test('saveNamedCanvasLayout preserves existing metadata on update when annotationsInput is omitted', async () => {
+    const { saveNamedCanvasLayout } = await import('../lib/db/helper');
+
+    mockQuery
+      .mockResolvedValueOnce({
+        rowCount: 1,
+        rows: [{ id: 'layout-6', name: 'Annotated Layout', metadata: { comment: 'Old comment', annotations: 'Existing note', extra: 'keep-me' } }],
+      }) // existing layout lookup
+      .mockResolvedValueOnce({ rowCount: 0 }) // BEGIN
+      .mockResolvedValueOnce({
+        rowCount: 1,
+        rows: [{ version_id: 'version-1', user_id: 'user-1', viewport: { x: 0, y: 0, zoom: 1 }, nodes: [], edges: [], grid_settings: {}, minimap_settings: {} }],
+      }) // SELECT FOR UPDATE
+      .mockResolvedValueOnce({ rows: [{ n: 0 }] }) // max revision
+      .mockResolvedValueOnce({ rowCount: 1 }) // insert revision
+      .mockResolvedValueOnce({ rowCount: 0 }) // prune old revisions
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 'layout-6', name: 'Annotated Layout' }] }) // UPDATE RETURNING
+      .mockResolvedValueOnce({ rowCount: 0 }); // COMMIT
+
+    const result = await saveNamedCanvasLayout(
+      'version-1',
+      'user-1',
+      'Annotated Layout',
+      { x: 0, y: 0, zoom: 1 },
+      [{ id: 'node-1', type: 'classNode', position: { x: 1, y: 2 } }],
+      [] // no annotationsInput -> should not alter existing metadata
+    );
+    const parsed = JSON.parse(result);
+
+    expect(parsed.success).toBe(true);
+    expect(mockQuery).toHaveBeenNthCalledWith(
+      7,
+      expect.stringContaining('UPDATE odb.canvas_layouts'),
+      expect.arrayContaining([
+        JSON.stringify({ comment: 'Old comment', annotations: 'Existing note', extra: 'keep-me' }),
+      ])
+    );
+  });
+
   test('saveNamedCanvasLayout rejects blank layout name after trim', async () => {
     const { saveNamedCanvasLayout } = await import('../lib/db/helper');
 


### PR DESCRIPTION
## Problem Statement

Users and teams need **addresses #177 — layout comments and annotations** within the Objectified platform. Today this capability is missing or only partially implemented, which blocks dashboard workflows and creates inconsistency across tenants and projects.

## Solution / Scope

Implement **Addresses #177 — layout comments and annotations** as part of **Dashboard**. KPIs, primitives browser, project overview, quick actions.

**Post-MVP** (prioritize after MVP slice) candidacy.

```mermaid
flowchart TB
  CP[Control Panel] --> KPIs[Stats cards]
  CP --> Primitives[Primitives list]
  CP --> Projects[Recent projects]
  CP --> Actions[Quick actions]
```

## Acceptance Criteria

- [ ] Feature behaves as described for: Addresses #177 — layout comments and annotations
- [ ] Unit/integration tests cover happy path and primary error cases
- [ ] UI (if applicable) matches existing ADE patterns (Tailwind 4, Radix, Lucide)
- [ ] REST endpoints (if applicable) follow `/v1/{{feature}}/{{tenant_slug}}/...` conventions
- [ ] Documented in issue/PR; no regressions to existing schema/version flows

## Parallelism / Dependencies

- **Can run in parallel:** Yes
- **Blockers:** None identified; validate against current codebase before starting

## Technical Stack

- **Modules:** objectified-rest
- **Stack:** Next.js ADE dashboard, control panel components, REST stats APIs
- **Labels:** ``

---

**Epic:** [[Epic] Dashboard & Control Panel](https://github.com/objectified-project/objectified/issues/3493)
**Issue:** #877 · **Area:** Dashboard · **Roadmap batch:** legacy #64–#879 enrichment