### PR TITLE
Fixes #178 — Add layout versioning diff viewer

### DIFF
--- a/PLANNED_FEATURE_ROADMAP_CANVAS.md
+++ b/PLANNED_FEATURE_ROADMAP_CANVAS.md
@@ -16,11 +16,7 @@
 - ✅ "Pin" layout as team default (#175) — tenant admins: Share → Pin as team default saves a shared named layout and sets tenant default for the version
 - ✅ Layout permissions (view, edit, delete) (#176) — named layouts now expose view/edit/delete capability in the Layout panel; shared layouts are view-only for non-admins and only tenant admins can delete shared entries
 - ✅ Layout comments and annotations (#177) — named layouts now support a short comment and longer annotations in the Layout panel; both are saved per layout and restored when the name is selected
-- 📋 [TODO] Layout versioning with diff viewer
-
-| Ticket | Feature                                       |
-|--------|-----------------------------------------------|
-| #178   | Layout versioning with diff viewer            |
+- ✅ Layout versioning with diff viewer (#178) — compare any two layout revisions (or the current state) in a structured diff dialog showing nodes added/removed/moved, edges changed, viewport and settings differences
 
 ---
 

--- a/objectified-ui/lib/db/helper.ts
+++ b/objectified-ui/lib/db/helper.ts
@@ -4263,10 +4263,15 @@ export async function restoreCanvasLayoutFromRevision(
 export async function getCanvasLayoutRevisionData(
   revisionId: string,
   layoutId: string,
-  versionId: string,
-  userId: string | null
+  versionId: string
 ) {
   try {
+    const session = await getAuthSession();
+    const actingUserId = (session?.user as any)?.user_id;
+    if (!actingUserId) {
+      return errorResponse('Unauthorized');
+    }
+
     const result = await connectionPool.query(
       `SELECT r.id, r.revision, r.viewport, r.nodes, r.edges,
               r.grid_settings, r.minimap_settings, r.created_at, r.created_by
@@ -4276,7 +4281,7 @@ export async function getCanvasLayoutRevisionData(
          AND r.canvas_layout_id = $2
          AND cl.version_id = $3
          AND (cl.user_id = $4 OR cl.user_id IS NULL)`,
-      [revisionId, layoutId, versionId, userId]
+      [revisionId, layoutId, versionId, actingUserId]
     );
 
     if (result.rowCount === 0) {

--- a/objectified-ui/lib/db/helper.ts
+++ b/objectified-ui/lib/db/helper.ts
@@ -4257,6 +4257,39 @@ export async function restoreCanvasLayoutFromRevision(
 }
 
 /**
+ * Fetch full revision data (viewport, nodes, edges, settings) for diff comparison.
+ * Access is restricted to layouts belonging to `versionId` owned by `userId` or shared.
+ */
+export async function getCanvasLayoutRevisionData(
+  revisionId: string,
+  layoutId: string,
+  versionId: string,
+  userId: string | null
+) {
+  try {
+    const result = await connectionPool.query(
+      `SELECT r.id, r.revision, r.viewport, r.nodes, r.edges,
+              r.grid_settings, r.minimap_settings, r.created_at, r.created_by
+       FROM odb.canvas_layout_revisions r
+       JOIN odb.canvas_layouts cl ON cl.id = r.canvas_layout_id
+       WHERE r.id = $1
+         AND r.canvas_layout_id = $2
+         AND cl.version_id = $3
+         AND (cl.user_id = $4 OR cl.user_id IS NULL)`,
+      [revisionId, layoutId, versionId, userId]
+    );
+
+    if (result.rowCount === 0) {
+      return errorResponse('Revision not found');
+    }
+    return successResponse({ revision: result.rows[0] });
+  } catch (error: any) {
+    console.error('Error fetching canvas layout revision data:', error);
+    return errorResponse(error.message);
+  }
+}
+
+/**
  * Delete a canvas layout
  */
 export async function deleteCanvasLayout(layoutId: string) {

--- a/objectified-ui/lib/layout-diff.ts
+++ b/objectified-ui/lib/layout-diff.ts
@@ -1,0 +1,353 @@
+/**
+ * Layout diff utility for comparing canvas layout states.
+ * Detects additions, removals, and modifications in nodes, edges,
+ * viewport, and settings between two layout snapshots.
+ */
+
+export type LayoutDiffChangeType = 'added' | 'removed' | 'modified' | 'unchanged';
+export type LayoutDiffCategory = 'node' | 'edge' | 'viewport' | 'grid' | 'minimap';
+
+export interface LayoutDiffEntry {
+  type: LayoutDiffChangeType;
+  category: LayoutDiffCategory;
+  id: string;
+  label: string;
+  changes?: string[];
+  oldValue?: unknown;
+  newValue?: unknown;
+}
+
+export interface LayoutDiffSummary {
+  nodes: {
+    added: LayoutDiffEntry[];
+    removed: LayoutDiffEntry[];
+    modified: LayoutDiffEntry[];
+    unchanged: number;
+  };
+  edges: {
+    added: LayoutDiffEntry[];
+    removed: LayoutDiffEntry[];
+    modified: LayoutDiffEntry[];
+    unchanged: number;
+  };
+  viewport: LayoutDiffEntry | null;
+  gridSettings: LayoutDiffEntry | null;
+  minimapSettings: LayoutDiffEntry | null;
+  totalChanges: number;
+}
+
+interface LayoutNode {
+  id: string;
+  type?: string;
+  position?: { x: number; y: number };
+  dimensions?: { width?: string | number; height?: string | number };
+  data?: Record<string, unknown>;
+}
+
+interface LayoutEdge {
+  id: string;
+  source: string;
+  target: string;
+  sourceHandle?: string | null;
+  targetHandle?: string | null;
+}
+
+interface LayoutViewport {
+  x?: number;
+  y?: number;
+  zoom?: number;
+}
+
+export interface LayoutState {
+  viewport?: LayoutViewport | null;
+  nodes?: LayoutNode[] | null;
+  edges?: LayoutEdge[] | null;
+  grid_settings?: Record<string, unknown> | null;
+  minimap_settings?: Record<string, unknown> | null;
+}
+
+const POSITION_THRESHOLD = 0.5;
+
+function safeArray<T>(arr: T[] | null | undefined): T[] {
+  return Array.isArray(arr) ? arr : [];
+}
+
+function nodeLabel(node: LayoutNode): string {
+  const name = typeof node.data?.name === 'string' ? node.data.name : undefined;
+  return name || node.id;
+}
+
+function positionChanged(a: LayoutNode['position'], b: LayoutNode['position']): boolean {
+  if (!a && !b) return false;
+  if (!a || !b) return true;
+  return (
+    Math.abs((a.x ?? 0) - (b.x ?? 0)) > POSITION_THRESHOLD ||
+    Math.abs((a.y ?? 0) - (b.y ?? 0)) > POSITION_THRESHOLD
+  );
+}
+
+function toDimensionNum(v: string | number | undefined): number {
+  if (v === undefined || v === null) return 0;
+  const n = typeof v === 'string' ? parseFloat(v) : v;
+  return Number.isFinite(n) ? n : 0;
+}
+
+function dimensionsChanged(a: LayoutNode['dimensions'], b: LayoutNode['dimensions']): boolean {
+  if (!a && !b) return false;
+  if (!a || !b) return true;
+  return (
+    toDimensionNum(a.width) !== toDimensionNum(b.width) ||
+    toDimensionNum(a.height) !== toDimensionNum(b.height)
+  );
+}
+
+function compareNodes(leftNodes: LayoutNode[], rightNodes: LayoutNode[]) {
+  const leftMap = new Map(leftNodes.map((n) => [n.id, n]));
+  const rightMap = new Map(rightNodes.map((n) => [n.id, n]));
+
+  const added: LayoutDiffEntry[] = [];
+  const removed: LayoutDiffEntry[] = [];
+  const modified: LayoutDiffEntry[] = [];
+  let unchanged = 0;
+
+  for (const [id, node] of rightMap) {
+    if (!leftMap.has(id)) {
+      added.push({
+        type: 'added',
+        category: 'node',
+        id,
+        label: nodeLabel(node),
+        newValue: node,
+      });
+    }
+  }
+
+  for (const [id, node] of leftMap) {
+    if (!rightMap.has(id)) {
+      removed.push({
+        type: 'removed',
+        category: 'node',
+        id,
+        label: nodeLabel(node),
+        oldValue: node,
+      });
+    }
+  }
+
+  for (const [id, leftNode] of leftMap) {
+    const rightNode = rightMap.get(id);
+    if (!rightNode) continue;
+
+    const changes: string[] = [];
+
+    if (leftNode.type !== rightNode.type) {
+      changes.push('type');
+    }
+    if (positionChanged(leftNode.position, rightNode.position)) {
+      changes.push('position');
+    }
+    if (dimensionsChanged(leftNode.dimensions, rightNode.dimensions)) {
+      changes.push('dimensions');
+    }
+    if (
+      leftNode.data &&
+      rightNode.data &&
+      JSON.stringify(leftNode.data) !== JSON.stringify(rightNode.data)
+    ) {
+      changes.push('data');
+    }
+
+    if (changes.length > 0) {
+      modified.push({
+        type: 'modified',
+        category: 'node',
+        id,
+        label: nodeLabel(leftNode),
+        changes,
+        oldValue: leftNode,
+        newValue: rightNode,
+      });
+    } else {
+      unchanged++;
+    }
+  }
+
+  return { added, removed, modified, unchanged };
+}
+
+function edgeLabel(edge: LayoutEdge): string {
+  return `${edge.source} → ${edge.target}`;
+}
+
+function compareEdges(leftEdges: LayoutEdge[], rightEdges: LayoutEdge[]) {
+  const leftMap = new Map(leftEdges.map((e) => [e.id, e]));
+  const rightMap = new Map(rightEdges.map((e) => [e.id, e]));
+
+  const added: LayoutDiffEntry[] = [];
+  const removed: LayoutDiffEntry[] = [];
+  const modified: LayoutDiffEntry[] = [];
+  let unchanged = 0;
+
+  for (const [id, edge] of rightMap) {
+    if (!leftMap.has(id)) {
+      added.push({
+        type: 'added',
+        category: 'edge',
+        id,
+        label: edgeLabel(edge),
+        newValue: edge,
+      });
+    }
+  }
+
+  for (const [id, edge] of leftMap) {
+    if (!rightMap.has(id)) {
+      removed.push({
+        type: 'removed',
+        category: 'edge',
+        id,
+        label: edgeLabel(edge),
+        oldValue: edge,
+      });
+    }
+  }
+
+  for (const [id, leftEdge] of leftMap) {
+    const rightEdge = rightMap.get(id);
+    if (!rightEdge) continue;
+
+    const changes: string[] = [];
+
+    if (leftEdge.source !== rightEdge.source) changes.push('source');
+    if (leftEdge.target !== rightEdge.target) changes.push('target');
+    if ((leftEdge.sourceHandle ?? null) !== (rightEdge.sourceHandle ?? null))
+      changes.push('sourceHandle');
+    if ((leftEdge.targetHandle ?? null) !== (rightEdge.targetHandle ?? null))
+      changes.push('targetHandle');
+
+    if (changes.length > 0) {
+      modified.push({
+        type: 'modified',
+        category: 'edge',
+        id,
+        label: edgeLabel(leftEdge),
+        changes,
+        oldValue: leftEdge,
+        newValue: rightEdge,
+      });
+    } else {
+      unchanged++;
+    }
+  }
+
+  return { added, removed, modified, unchanged };
+}
+
+function compareViewport(
+  left: LayoutViewport | null | undefined,
+  right: LayoutViewport | null | undefined
+): LayoutDiffEntry | null {
+  const l = left ?? {};
+  const r = right ?? {};
+
+  const changes: string[] = [];
+  if (Math.abs((l.x ?? 0) - (r.x ?? 0)) > POSITION_THRESHOLD) changes.push('x');
+  if (Math.abs((l.y ?? 0) - (r.y ?? 0)) > POSITION_THRESHOLD) changes.push('y');
+  if ((l.zoom ?? 1) !== (r.zoom ?? 1)) changes.push('zoom');
+
+  if (changes.length === 0) return null;
+
+  return {
+    type: 'modified',
+    category: 'viewport',
+    id: 'viewport',
+    label: 'Viewport',
+    changes,
+    oldValue: l,
+    newValue: r,
+  };
+}
+
+function compareSettings(
+  left: Record<string, unknown> | null | undefined,
+  right: Record<string, unknown> | null | undefined,
+  category: 'grid' | 'minimap'
+): LayoutDiffEntry | null {
+  const lStr = JSON.stringify(left ?? {});
+  const rStr = JSON.stringify(right ?? {});
+  if (lStr === rStr) return null;
+
+  const l = left ?? {};
+  const r = right ?? {};
+  const allKeys = new Set([...Object.keys(l), ...Object.keys(r)]);
+  const changes: string[] = [];
+
+  for (const key of allKeys) {
+    if (JSON.stringify(l[key]) !== JSON.stringify(r[key])) {
+      changes.push(key);
+    }
+  }
+
+  if (changes.length === 0) return null;
+
+  const label = category === 'grid' ? 'Grid settings' : 'Minimap settings';
+  return {
+    type: 'modified',
+    category,
+    id: category,
+    label,
+    changes,
+    oldValue: l,
+    newValue: r,
+  };
+}
+
+/**
+ * Compare two canvas layout states and return a structured diff summary.
+ */
+export function compareLayouts(left: LayoutState, right: LayoutState): LayoutDiffSummary {
+  const nodes = compareNodes(safeArray(left.nodes), safeArray(right.nodes));
+  const edges = compareEdges(safeArray(left.edges), safeArray(right.edges));
+  const viewport = compareViewport(left.viewport, right.viewport);
+  const gridSettings = compareSettings(left.grid_settings, right.grid_settings, 'grid');
+  const minimapSettings = compareSettings(left.minimap_settings, right.minimap_settings, 'minimap');
+
+  const totalChanges =
+    nodes.added.length +
+    nodes.removed.length +
+    nodes.modified.length +
+    edges.added.length +
+    edges.removed.length +
+    edges.modified.length +
+    (viewport ? 1 : 0) +
+    (gridSettings ? 1 : 0) +
+    (minimapSettings ? 1 : 0);
+
+  return {
+    nodes,
+    edges,
+    viewport,
+    gridSettings,
+    minimapSettings,
+    totalChanges,
+  };
+}
+
+/**
+ * Collect all diff entries from a summary into a flat list,
+ * ordered by category (nodes, edges, viewport, settings).
+ */
+export function flattenDiffEntries(summary: LayoutDiffSummary): LayoutDiffEntry[] {
+  const entries: LayoutDiffEntry[] = [
+    ...summary.nodes.added,
+    ...summary.nodes.removed,
+    ...summary.nodes.modified,
+    ...summary.edges.added,
+    ...summary.edges.removed,
+    ...summary.edges.modified,
+  ];
+  if (summary.viewport) entries.push(summary.viewport);
+  if (summary.gridSettings) entries.push(summary.gridSettings);
+  if (summary.minimapSettings) entries.push(summary.minimapSettings);
+  return entries;
+}

--- a/objectified-ui/lib/layout-diff.ts
+++ b/objectified-ui/lib/layout-diff.ts
@@ -150,9 +150,8 @@ function compareNodes(leftNodes: LayoutNode[], rightNodes: LayoutNode[]) {
       changes.push('dimensions');
     }
     if (
-      leftNode.data &&
-      rightNode.data &&
-      JSON.stringify(leftNode.data) !== JSON.stringify(rightNode.data)
+      JSON.stringify(leftNode.data ?? null) !==
+      JSON.stringify(rightNode.data ?? null)
     ) {
       changes.push('data');
     }

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.8.87",
+  "version": "0.8.88",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -5,6 +5,7 @@ We continue to improve the platform based on your feedback with improvements and
 ---
 
 Improvements:
+- Canvas: compare any two layout revisions (or the current layout) in a structured diff viewer showing nodes added/removed/moved, edges changed, viewport and settings differences (#178)
 - Canvas: named layouts now support a short comment and longer annotations in the Layout panel, saved per layout name and restored when selected (#177)
 - Canvas: layout permissions added for named layouts (#176) — Layout panel now shows view/edit/delete capability, enforces view-only behavior for shared layouts, and allows shared layout deletion only for tenant administrators
 - Canvas: tenant administrators can pin a quick snapshot as the team default from the gallery (Share → Pin as team default); saves a shared named layout for the API version (#175)

--- a/objectified-ui/src/app/ade/studio/editor/components/LayoutRevisionDiffDialog.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/components/LayoutRevisionDiffDialog.tsx
@@ -158,7 +158,8 @@ export function LayoutRevisionDiffDialog({
   useEffect(() => {
     if (!open) return;
     if (revisions.length >= 1) {
-      setLeftId(revisions[0].id);
+      const oldestRevision = revisions[revisions.length - 1];
+      setLeftId(oldestRevision.id);
       setRightId('current');
     }
   }, [open, revisions]);

--- a/objectified-ui/src/app/ade/studio/editor/components/LayoutRevisionDiffDialog.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/components/LayoutRevisionDiffDialog.tsx
@@ -1,0 +1,428 @@
+'use client';
+
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import * as Dialog from '@radix-ui/react-dialog';
+import {
+  X,
+  GitCompareArrows,
+  ArrowLeftRight,
+  Plus,
+  Minus,
+  Pencil,
+  Move,
+  Maximize2,
+  Link2,
+  Settings2,
+  Map,
+  Loader2,
+} from 'lucide-react';
+import {
+  compareLayouts,
+  type LayoutDiffSummary,
+  type LayoutDiffEntry,
+  type LayoutState,
+} from '../../../../../../lib/layout-diff';
+
+export interface RevisionOption {
+  id: string;
+  revision: number;
+  created_at: string;
+}
+
+export interface LayoutRevisionDiffDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  revisions: RevisionOption[];
+  currentLayout: LayoutState | null;
+  onFetchRevisionData: (revisionId: string) => Promise<LayoutState | null>;
+}
+
+type DiffSide = { id: string; label: string; state: LayoutState } | null;
+
+const CATEGORY_ICONS: Record<string, React.ReactNode> = {
+  node: <Move className="h-3.5 w-3.5 shrink-0" aria-hidden />,
+  edge: <Link2 className="h-3.5 w-3.5 shrink-0" aria-hidden />,
+  viewport: <Maximize2 className="h-3.5 w-3.5 shrink-0" aria-hidden />,
+  grid: <Settings2 className="h-3.5 w-3.5 shrink-0" aria-hidden />,
+  minimap: <Map className="h-3.5 w-3.5 shrink-0" aria-hidden />,
+};
+
+const TYPE_CONFIG = {
+  added: {
+    icon: <Plus className="h-3 w-3" aria-hidden />,
+    badgeClass: 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-300',
+    textClass: 'text-emerald-700 dark:text-emerald-300',
+  },
+  removed: {
+    icon: <Minus className="h-3 w-3" aria-hidden />,
+    badgeClass: 'bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-300',
+    textClass: 'text-red-700 dark:text-red-300',
+  },
+  modified: {
+    icon: <Pencil className="h-3 w-3" aria-hidden />,
+    badgeClass: 'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300',
+    textClass: 'text-amber-700 dark:text-amber-300',
+  },
+  unchanged: {
+    icon: null,
+    badgeClass: 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400',
+    textClass: 'text-gray-500 dark:text-gray-400',
+  },
+} as const;
+
+function formatRevisionLabel(rev: RevisionOption): string {
+  const date = new Date(rev.created_at);
+  return `Rev ${rev.revision} · ${date.toLocaleString()}`;
+}
+
+function DiffStatBadge({ count, type }: { count: number; type: 'added' | 'removed' | 'modified' }) {
+  if (count === 0) return null;
+  const config = TYPE_CONFIG[type];
+  return (
+    <span
+      className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-semibold ${config.badgeClass}`}
+    >
+      {config.icon}
+      {count} {type}
+    </span>
+  );
+}
+
+function DiffEntryRow({ entry }: { entry: LayoutDiffEntry }) {
+  const config = TYPE_CONFIG[entry.type];
+  const icon = CATEGORY_ICONS[entry.category];
+
+  return (
+    <div className="flex items-start gap-2 rounded-md px-2 py-1.5 text-xs hover:bg-gray-50 dark:hover:bg-gray-800/50">
+      <span className={`mt-0.5 shrink-0 ${config.textClass}`}>{config.icon}</span>
+      <span className="mt-0.5 shrink-0 text-gray-400 dark:text-gray-500">{icon}</span>
+      <div className="min-w-0 flex-1">
+        <span className={`font-medium ${config.textClass}`}>{entry.label}</span>
+        {entry.changes && entry.changes.length > 0 && (
+          <span className="ml-1.5 text-gray-500 dark:text-gray-400">
+            ({entry.changes.join(', ')})
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function DiffCategorySection({
+  title,
+  entries,
+  unchangedCount,
+}: {
+  title: string;
+  entries: LayoutDiffEntry[];
+  unchangedCount?: number;
+}) {
+  if (entries.length === 0 && (unchangedCount ?? 0) === 0) return null;
+
+  return (
+    <div>
+      <h4 className="mb-1 text-[10px] font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
+        {title}
+      </h4>
+      {entries.length === 0 ? (
+        <p className="px-2 py-1 text-xs text-gray-400 dark:text-gray-500">No changes</p>
+      ) : (
+        <div className="space-y-0.5">
+          {entries.map((entry) => (
+            <DiffEntryRow key={`${entry.category}-${entry.id}-${entry.type}`} entry={entry} />
+          ))}
+        </div>
+      )}
+      {(unchangedCount ?? 0) > 0 && (
+        <p className="mt-1 px-2 text-[10px] text-gray-400 dark:text-gray-500">
+          {unchangedCount} unchanged
+        </p>
+      )}
+    </div>
+  );
+}
+
+export function LayoutRevisionDiffDialog({
+  open,
+  onOpenChange,
+  revisions,
+  currentLayout,
+  onFetchRevisionData,
+}: LayoutRevisionDiffDialogProps) {
+  const [leftId, setLeftId] = useState<string>('');
+  const [rightId, setRightId] = useState<string>('current');
+  const [leftData, setLeftData] = useState<DiffSide>(null);
+  const [rightData, setRightData] = useState<DiffSide>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    if (revisions.length >= 1) {
+      setLeftId(revisions[0].id);
+      setRightId('current');
+    }
+  }, [open, revisions]);
+
+  const fetchSide = useCallback(
+    async (sideId: string): Promise<DiffSide> => {
+      if (sideId === 'current') {
+        return currentLayout
+          ? { id: 'current', label: 'Current layout', state: currentLayout }
+          : null;
+      }
+      const rev = revisions.find((r) => r.id === sideId);
+      if (!rev) return null;
+      const data = await onFetchRevisionData(sideId);
+      if (!data) return null;
+      return { id: sideId, label: formatRevisionLabel(rev), state: data };
+    },
+    [currentLayout, onFetchRevisionData, revisions]
+  );
+
+  useEffect(() => {
+    if (!open || (!leftId && !rightId)) return;
+    let cancelled = false;
+
+    (async () => {
+      setLoading(true);
+      try {
+        const [l, r] = await Promise.all([
+          leftId ? fetchSide(leftId) : Promise.resolve(null),
+          rightId ? fetchSide(rightId) : Promise.resolve(null),
+        ]);
+        if (!cancelled) {
+          setLeftData(l);
+          setRightData(r);
+        }
+      } catch (err) {
+        console.error('Error fetching revision data for diff:', err);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [open, leftId, rightId, fetchSide]);
+
+  const diff = useMemo<LayoutDiffSummary | null>(() => {
+    if (!leftData || !rightData) return null;
+    return compareLayouts(leftData.state, rightData.state);
+  }, [leftData, rightData]);
+
+  const swapSides = () => {
+    setLeftId(rightId);
+    setRightId(leftId);
+  };
+
+  const selectOptions = useMemo(() => {
+    const opts: { value: string; label: string }[] = [
+      { value: 'current', label: 'Current layout' },
+      ...revisions.map((r) => ({
+        value: r.id,
+        label: formatRevisionLabel(r),
+      })),
+    ];
+    return opts;
+  }, [revisions]);
+
+  const canCompare = revisions.length >= 1;
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-[1300] bg-black/50 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
+        <Dialog.Content className="fixed left-1/2 top-1/2 z-[1301] w-[min(96vw,52rem)] max-h-[min(92vh,44rem)] -translate-x-1/2 -translate-y-1/2 rounded-xl border border-gray-200 bg-white shadow-xl dark:border-gray-700 dark:bg-gray-900 flex flex-col min-h-0 outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95">
+          {/* Header */}
+          <div className="flex shrink-0 items-start justify-between gap-3 border-b border-gray-200 px-4 py-3 dark:border-gray-700">
+            <div className="flex items-start gap-2 min-w-0">
+              <GitCompareArrows
+                className="mt-0.5 h-5 w-5 shrink-0 text-indigo-600 dark:text-indigo-400"
+                aria-hidden
+              />
+              <div className="min-w-0">
+                <Dialog.Title className="text-sm font-semibold text-gray-900 dark:text-white">
+                  Compare layout revisions
+                </Dialog.Title>
+                <Dialog.Description className="mt-1 text-xs text-gray-500 dark:text-gray-400 leading-snug">
+                  Select two revisions (or the current layout) to see what changed — nodes
+                  added/removed/moved, edges, viewport, and settings.
+                </Dialog.Description>
+              </div>
+            </div>
+            <Dialog.Close
+              type="button"
+              className="rounded-lg p-1.5 text-gray-500 hover:bg-gray-100 hover:text-gray-800 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
+              aria-label="Close"
+            >
+              <X className="h-4 w-4" />
+            </Dialog.Close>
+          </div>
+
+          {/* Body */}
+          <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-4 py-3">
+            {!canCompare ? (
+              <p className="text-sm text-gray-600 dark:text-gray-400">
+                Save at least one layout revision to compare. Each named save stores the previous
+                state (up to 50).
+              </p>
+            ) : (
+              <div className="space-y-4">
+                {/* Selectors */}
+                <div className="flex flex-wrap items-end gap-3">
+                  <SideSelector
+                    label="Left (older)"
+                    htmlId="diff-select-left"
+                    value={leftId}
+                    onChange={setLeftId}
+                    options={selectOptions}
+                  />
+                  <button
+                    type="button"
+                    onClick={swapSides}
+                    className="mb-0.5 inline-flex items-center gap-1.5 self-end rounded-lg border border-gray-200 bg-white px-2.5 py-1.5 text-xs font-medium text-gray-700 shadow-sm hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
+                  >
+                    <ArrowLeftRight className="h-3.5 w-3.5" aria-hidden />
+                    Swap
+                  </button>
+                  <SideSelector
+                    label="Right (newer)"
+                    htmlId="diff-select-right"
+                    value={rightId}
+                    onChange={setRightId}
+                    options={selectOptions}
+                  />
+                </div>
+
+                {/* Loading */}
+                {loading && (
+                  <div className="flex items-center gap-2 py-4 text-sm text-gray-500 dark:text-gray-400">
+                    <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+                    Loading revision data…
+                  </div>
+                )}
+
+                {/* Diff results */}
+                {!loading && diff && (
+                  <div className="space-y-4">
+                    {/* Summary bar */}
+                    <div className="flex flex-wrap items-center gap-2 rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 dark:border-gray-700 dark:bg-gray-800/60">
+                      {diff.totalChanges === 0 ? (
+                        <span className="text-xs font-medium text-gray-500 dark:text-gray-400">
+                          No differences found
+                        </span>
+                      ) : (
+                        <>
+                          <span className="text-xs font-medium text-gray-700 dark:text-gray-300">
+                            {diff.totalChanges} change{diff.totalChanges !== 1 ? 's' : ''}
+                          </span>
+                          <DiffStatBadge
+                            count={diff.nodes.added.length + diff.edges.added.length}
+                            type="added"
+                          />
+                          <DiffStatBadge
+                            count={diff.nodes.removed.length + diff.edges.removed.length}
+                            type="removed"
+                          />
+                          <DiffStatBadge
+                            count={
+                              diff.nodes.modified.length +
+                              diff.edges.modified.length +
+                              (diff.viewport ? 1 : 0) +
+                              (diff.gridSettings ? 1 : 0) +
+                              (diff.minimapSettings ? 1 : 0)
+                            }
+                            type="modified"
+                          />
+                        </>
+                      )}
+                    </div>
+
+                    {/* Detail sections */}
+                    {diff.totalChanges > 0 && (
+                      <div className="space-y-3 divide-y divide-gray-100 dark:divide-gray-800">
+                        <DiffCategorySection
+                          title="Nodes"
+                          entries={[
+                            ...diff.nodes.added,
+                            ...diff.nodes.removed,
+                            ...diff.nodes.modified,
+                          ]}
+                          unchangedCount={diff.nodes.unchanged}
+                        />
+                        <DiffCategorySection
+                          title="Edges"
+                          entries={[
+                            ...diff.edges.added,
+                            ...diff.edges.removed,
+                            ...diff.edges.modified,
+                          ]}
+                          unchangedCount={diff.edges.unchanged}
+                        />
+                        {(diff.viewport || diff.gridSettings || diff.minimapSettings) && (
+                          <DiffCategorySection
+                            title="Settings"
+                            entries={[
+                              ...(diff.viewport ? [diff.viewport] : []),
+                              ...(diff.gridSettings ? [diff.gridSettings] : []),
+                              ...(diff.minimapSettings ? [diff.minimapSettings] : []),
+                            ]}
+                          />
+                        )}
+                      </div>
+                    )}
+                  </div>
+                )}
+
+                {/* No data state */}
+                {!loading && !diff && leftId && rightId && (
+                  <p className="text-xs text-gray-500 dark:text-gray-400">
+                    Could not load one or both revisions for comparison.
+                  </p>
+                )}
+              </div>
+            )}
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}
+
+function SideSelector({
+  label,
+  htmlId,
+  value,
+  onChange,
+  options,
+}: {
+  label: string;
+  htmlId: string;
+  value: string;
+  onChange: (v: string) => void;
+  options: { value: string; label: string }[];
+}) {
+  return (
+    <div className="flex min-w-0 flex-1 flex-col gap-1">
+      <label
+        htmlFor={htmlId}
+        className="text-[10px] font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400"
+      >
+        {label}
+      </label>
+      <select
+        id={htmlId}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="w-full rounded-lg border border-gray-200 bg-white px-2 py-2 text-xs text-gray-800 shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+      >
+        {options.map((opt) => (
+          <option key={opt.value} value={opt.value}>
+            {opt.label}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/objectified-ui/src/app/ade/studio/editor/page.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/page.tsx
@@ -686,6 +686,7 @@ const StudioContent = () => {
     Array<{ id: string; revision: number; created_at: string }>
   >([]);
   const [layoutHistoryLoading, setLayoutHistoryLoading] = useState(false);
+  const [layoutHistoryLayoutId, setLayoutHistoryLayoutId] = useState<string | null>(null);
   const [layoutDiffOpen, setLayoutDiffOpen] = useState(false);
 
   // #517: Canvas presentation — fullscreen slideshow of viewport bookmarks, speaker notes, timer
@@ -5737,6 +5738,7 @@ const StudioContent = () => {
         if (!name) {
           if (!cancelled) {
             setLayoutHistoryRevisions([]);
+            setLayoutHistoryLayoutId(null);
           }
           return;
         }
@@ -5745,6 +5747,7 @@ const StudioContent = () => {
         if (!parsed.success || !parsed.layout) {
           if (!cancelled) {
             setLayoutHistoryRevisions([]);
+            setLayoutHistoryLayoutId(null);
           }
           return;
         }
@@ -5752,11 +5755,13 @@ const StudioContent = () => {
         const revParsed = JSON.parse(revRes);
         if (!cancelled && revParsed.success) {
           setLayoutHistoryRevisions(revParsed.revisions || []);
+          setLayoutHistoryLayoutId(parsed.layout.id);
         }
       } catch (error) {
         console.error('Error loading layout history:', error);
         if (!cancelled) {
           setLayoutHistoryRevisions([]);
+          setLayoutHistoryLayoutId(null);
         }
       } finally {
         if (!cancelled) {
@@ -5788,19 +5793,12 @@ const StudioContent = () => {
 
   const handleFetchRevisionDataForDiff = useCallback(
     async (revisionId: string) => {
-      if (!selectedVersionId || !currentUserId) return null;
-      const name = selectedLayoutName.trim();
-      if (!name) return null;
+      if (!selectedVersionId || !layoutHistoryLayoutId) return null;
       try {
-        const layoutRes = await getNamedCanvasLayout(selectedVersionId, currentUserId, name);
-        const layoutParsed = JSON.parse(layoutRes);
-        if (!layoutParsed.success || !layoutParsed.layout) return null;
-
         const res = await getCanvasLayoutRevisionData(
           revisionId,
-          layoutParsed.layout.id,
-          selectedVersionId,
-          currentUserId
+          layoutHistoryLayoutId,
+          selectedVersionId
         );
         const parsed = JSON.parse(res);
         if (!parsed.success || !parsed.revision) return null;
@@ -5817,7 +5815,7 @@ const StudioContent = () => {
         return null;
       }
     },
-    [selectedVersionId, currentUserId, selectedLayoutName]
+    [selectedVersionId, layoutHistoryLayoutId]
   );
 
   // #471: Preview layout before applying — compute layout and show preview (do not commit)

--- a/objectified-ui/src/app/ade/studio/editor/page.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/page.tsx
@@ -67,6 +67,7 @@ import {
   Camera,
   Columns2,
   LayoutGrid,
+  GitCompareArrows,
 } from 'lucide-react';
 import * as Select from '@radix-ui/react-select';
 import * as ToggleGroup from '@radix-ui/react-toggle-group';
@@ -116,6 +117,7 @@ import {
   saveNamedCanvasLayout,
   listCanvasLayoutRevisions,
   restoreCanvasLayoutFromRevision,
+  getCanvasLayoutRevisionData,
   getGroupsForVersion,
   getClassIdsForVersion,
   syncGroupsForVersion,
@@ -197,6 +199,7 @@ import { toPng } from 'html-to-image';
 import { QuickSnapshotCaptureDialog } from './components/QuickSnapshotCaptureDialog';
 import { QuickSnapshotCompareDialog } from './components/QuickSnapshotCompareDialog';
 import { QuickSnapshotGalleryDialog } from './components/QuickSnapshotGalleryDialog';
+import { LayoutRevisionDiffDialog } from './components/LayoutRevisionDiffDialog';
 import DraggablePanel from '../components/DraggablePanel';
 import MemoryProfiler from '../components/MemoryProfiler';
 import SchemaMetricsPanel from '../components/SchemaMetricsPanel';
@@ -683,6 +686,7 @@ const StudioContent = () => {
     Array<{ id: string; revision: number; created_at: string }>
   >([]);
   const [layoutHistoryLoading, setLayoutHistoryLoading] = useState(false);
+  const [layoutDiffOpen, setLayoutDiffOpen] = useState(false);
 
   // #517: Canvas presentation — fullscreen slideshow of viewport bookmarks, speaker notes, timer
   const [canvasPresentationActive, setCanvasPresentationActive] = useState(false);
@@ -5771,6 +5775,51 @@ const StudioContent = () => {
     selectedLayoutName,
   ]);
 
+  const currentLayoutStateForDiff = useMemo(() => {
+    const viewport = getViewport();
+    return {
+      viewport,
+      nodes: mapNodesForLayoutSave(nodes),
+      edges: mapEdgesForLayoutSave(edges),
+      grid_settings: { size: gridSize, snapToGrid, showGrid, gridStyle },
+      minimap_settings: null,
+    };
+  }, [nodes, edges, getViewport, gridSize, snapToGrid, showGrid, gridStyle]);
+
+  const handleFetchRevisionDataForDiff = useCallback(
+    async (revisionId: string) => {
+      if (!selectedVersionId || !currentUserId) return null;
+      const name = selectedLayoutName.trim();
+      if (!name) return null;
+      try {
+        const layoutRes = await getNamedCanvasLayout(selectedVersionId, currentUserId, name);
+        const layoutParsed = JSON.parse(layoutRes);
+        if (!layoutParsed.success || !layoutParsed.layout) return null;
+
+        const res = await getCanvasLayoutRevisionData(
+          revisionId,
+          layoutParsed.layout.id,
+          selectedVersionId,
+          currentUserId
+        );
+        const parsed = JSON.parse(res);
+        if (!parsed.success || !parsed.revision) return null;
+
+        return {
+          viewport: parsed.revision.viewport,
+          nodes: parsed.revision.nodes,
+          edges: parsed.revision.edges,
+          grid_settings: parsed.revision.grid_settings,
+          minimap_settings: parsed.revision.minimap_settings,
+        };
+      } catch (err) {
+        console.error('Error fetching revision data for diff:', err);
+        return null;
+      }
+    },
+    [selectedVersionId, currentUserId, selectedLayoutName]
+  );
+
   // #471: Preview layout before applying — compute layout and show preview (do not commit)
   const handlePreviewLayout = useCallback((direction: 'TB' | 'LR') => {
     if (nodes.length === 0) return;
@@ -9469,6 +9518,16 @@ const StudioContent = () => {
                                     </button>
                                   </div>
                                 ))}
+                              {!layoutHistoryLoading && layoutHistoryRevisions.length >= 1 && (
+                                <button
+                                  type="button"
+                                  onClick={() => setLayoutDiffOpen(true)}
+                                  className="mt-2 flex w-full items-center justify-center gap-1.5 rounded-lg border border-indigo-200 bg-indigo-50 px-2.5 py-1.5 text-xs font-medium text-indigo-700 transition-colors hover:bg-indigo-100 dark:border-indigo-700 dark:bg-indigo-950/40 dark:text-indigo-300 dark:hover:bg-indigo-900/50"
+                                >
+                                  <GitCompareArrows className="h-3.5 w-3.5" aria-hidden />
+                                  Compare revisions
+                                </button>
+                              )}
                             </div>
                           )}
                         </div>
@@ -9830,6 +9889,13 @@ const StudioContent = () => {
             open={quickSnapshotCompareOpen}
             onOpenChange={setQuickSnapshotCompareOpen}
             snapshots={quickLayoutSnapshots}
+          />
+          <LayoutRevisionDiffDialog
+            open={layoutDiffOpen}
+            onOpenChange={setLayoutDiffOpen}
+            revisions={layoutHistoryRevisions}
+            currentLayout={currentLayoutStateForDiff}
+            onFetchRevisionData={handleFetchRevisionDataForDiff}
           />
           <QuickSnapshotGalleryDialog
             open={quickSnapshotGalleryOpen}

--- a/objectified-ui/tests/canvas-layout-revision-data.test.ts
+++ b/objectified-ui/tests/canvas-layout-revision-data.test.ts
@@ -22,11 +22,18 @@ jest.mock('crypto', () => ({
 
 describe('Database Helper - getCanvasLayoutRevisionData', () => {
   let mockQuery: jest.Mock<any>;
+  let mockGetAuthSession: jest.Mock<any>;
 
   beforeEach(() => {
     const db = require('../lib/db/db');
     mockQuery = db.query as jest.Mock;
     mockQuery.mockReset();
+
+    const serverSession = require('../lib/auth/server-session');
+    mockGetAuthSession = serverSession.getAuthSession as jest.Mock<any>;
+    mockGetAuthSession.mockResolvedValue({
+      user: { user_id: 'session-user-1' },
+    });
   });
 
   test('returns full revision data with viewport, nodes, edges, and settings', async () => {
@@ -49,12 +56,7 @@ describe('Database Helper - getCanvasLayoutRevisionData', () => {
 
     mockQuery.mockResolvedValue({ rowCount: 1, rows: [revisionData] });
 
-    const result = await getCanvasLayoutRevisionData(
-      'rev-1',
-      'layout-1',
-      'version-1',
-      'user-1'
-    );
+    const result = await getCanvasLayoutRevisionData('rev-1', 'layout-1', 'version-1');
     const parsed = JSON.parse(result);
 
     expect(parsed.success).toBe(true);
@@ -70,19 +72,14 @@ describe('Database Helper - getCanvasLayoutRevisionData', () => {
 
     mockQuery.mockResolvedValue({ rowCount: 0, rows: [] });
 
-    const result = await getCanvasLayoutRevisionData(
-      'nonexistent',
-      'layout-1',
-      'version-1',
-      'user-1'
-    );
+    const result = await getCanvasLayoutRevisionData('nonexistent', 'layout-1', 'version-1');
     const parsed = JSON.parse(result);
 
     expect(parsed.success).toBe(false);
     expect(parsed.error).toBe('Revision not found');
   });
 
-  test('queries with correct parameters including access control', async () => {
+  test('queries with correct parameters derived from session (access control)', async () => {
     const { getCanvasLayoutRevisionData } = await import('../lib/db/helper');
 
     mockQuery.mockResolvedValue({
@@ -90,11 +87,11 @@ describe('Database Helper - getCanvasLayoutRevisionData', () => {
       rows: [{ id: 'rev-1', revision: 1, viewport: null, nodes: [], edges: [] }],
     });
 
-    await getCanvasLayoutRevisionData('rev-id', 'layout-id', 'ver-id', 'usr-id');
+    await getCanvasLayoutRevisionData('rev-id', 'layout-id', 'ver-id');
 
     expect(mockQuery).toHaveBeenCalledWith(
       expect.stringContaining('canvas_layout_revisions'),
-      ['rev-id', 'layout-id', 'ver-id', 'usr-id']
+      ['rev-id', 'layout-id', 'ver-id', 'session-user-1']
     );
     expect(mockQuery).toHaveBeenCalledWith(
       expect.stringContaining('cl.user_id = $4 OR cl.user_id IS NULL'),
@@ -102,17 +99,25 @@ describe('Database Helper - getCanvasLayoutRevisionData', () => {
     );
   });
 
+  test('returns Unauthorized when no session', async () => {
+    mockGetAuthSession.mockResolvedValue(null);
+
+    const { getCanvasLayoutRevisionData } = await import('../lib/db/helper');
+
+    const result = await getCanvasLayoutRevisionData('rev-1', 'layout-1', 'version-1');
+    const parsed = JSON.parse(result);
+
+    expect(parsed.success).toBe(false);
+    expect(parsed.error).toBe('Unauthorized');
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
   test('handles database errors gracefully', async () => {
     const { getCanvasLayoutRevisionData } = await import('../lib/db/helper');
 
     mockQuery.mockRejectedValue(new Error('Connection failed'));
 
-    const result = await getCanvasLayoutRevisionData(
-      'rev-1',
-      'layout-1',
-      'version-1',
-      'user-1'
-    );
+    const result = await getCanvasLayoutRevisionData('rev-1', 'layout-1', 'version-1');
     const parsed = JSON.parse(result);
 
     expect(parsed.success).toBe(false);

--- a/objectified-ui/tests/canvas-layout-revision-data.test.ts
+++ b/objectified-ui/tests/canvas-layout-revision-data.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, jest, test } from '@jest/globals';
+
+jest.mock('../lib/db/db', () => {
+  const query = jest.fn();
+  return {
+    query,
+    connect: jest.fn(async () => ({
+      query,
+      release: jest.fn(),
+    })),
+  };
+});
+
+jest.mock('bcrypt', () => ({
+  compare: jest.fn(),
+  hash: jest.fn(),
+}));
+
+jest.mock('crypto', () => ({
+  randomBytes: jest.fn(() => Buffer.from('test-api-key-data')),
+}));
+
+describe('Database Helper - getCanvasLayoutRevisionData', () => {
+  let mockQuery: jest.Mock<any>;
+
+  beforeEach(() => {
+    const db = require('../lib/db/db');
+    mockQuery = db.query as jest.Mock;
+    mockQuery.mockReset();
+  });
+
+  test('returns full revision data with viewport, nodes, edges, and settings', async () => {
+    const { getCanvasLayoutRevisionData } = await import('../lib/db/helper');
+
+    const revisionData = {
+      id: 'rev-1',
+      revision: 3,
+      viewport: { x: 100, y: 200, zoom: 0.5 },
+      nodes: [
+        { id: 'n1', type: 'classNode', position: { x: 10, y: 20 } },
+        { id: 'n2', type: 'classNode', position: { x: 30, y: 40 } },
+      ],
+      edges: [{ id: 'e1', source: 'n1', target: 'n2' }],
+      grid_settings: { size: 20, snapToGrid: true },
+      minimap_settings: { visible: true },
+      created_at: '2026-03-30T10:00:00Z',
+      created_by: 'user-1',
+    };
+
+    mockQuery.mockResolvedValue({ rowCount: 1, rows: [revisionData] });
+
+    const result = await getCanvasLayoutRevisionData(
+      'rev-1',
+      'layout-1',
+      'version-1',
+      'user-1'
+    );
+    const parsed = JSON.parse(result);
+
+    expect(parsed.success).toBe(true);
+    expect(parsed.revision.id).toBe('rev-1');
+    expect(parsed.revision.viewport).toEqual({ x: 100, y: 200, zoom: 0.5 });
+    expect(parsed.revision.nodes).toHaveLength(2);
+    expect(parsed.revision.edges).toHaveLength(1);
+    expect(parsed.revision.grid_settings).toEqual({ size: 20, snapToGrid: true });
+  });
+
+  test('returns error when revision is not found', async () => {
+    const { getCanvasLayoutRevisionData } = await import('../lib/db/helper');
+
+    mockQuery.mockResolvedValue({ rowCount: 0, rows: [] });
+
+    const result = await getCanvasLayoutRevisionData(
+      'nonexistent',
+      'layout-1',
+      'version-1',
+      'user-1'
+    );
+    const parsed = JSON.parse(result);
+
+    expect(parsed.success).toBe(false);
+    expect(parsed.error).toBe('Revision not found');
+  });
+
+  test('queries with correct parameters including access control', async () => {
+    const { getCanvasLayoutRevisionData } = await import('../lib/db/helper');
+
+    mockQuery.mockResolvedValue({
+      rowCount: 1,
+      rows: [{ id: 'rev-1', revision: 1, viewport: null, nodes: [], edges: [] }],
+    });
+
+    await getCanvasLayoutRevisionData('rev-id', 'layout-id', 'ver-id', 'usr-id');
+
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining('canvas_layout_revisions'),
+      ['rev-id', 'layout-id', 'ver-id', 'usr-id']
+    );
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining('cl.user_id = $4 OR cl.user_id IS NULL'),
+      expect.any(Array)
+    );
+  });
+
+  test('handles database errors gracefully', async () => {
+    const { getCanvasLayoutRevisionData } = await import('../lib/db/helper');
+
+    mockQuery.mockRejectedValue(new Error('Connection failed'));
+
+    const result = await getCanvasLayoutRevisionData(
+      'rev-1',
+      'layout-1',
+      'version-1',
+      'user-1'
+    );
+    const parsed = JSON.parse(result);
+
+    expect(parsed.success).toBe(false);
+    expect(parsed.error).toBe('Connection failed');
+  });
+});

--- a/objectified-ui/tests/layout-diff.test.ts
+++ b/objectified-ui/tests/layout-diff.test.ts
@@ -1,0 +1,444 @@
+import { describe, expect, test } from '@jest/globals';
+import {
+  compareLayouts,
+  flattenDiffEntries,
+  type LayoutState,
+} from '../lib/layout-diff';
+
+describe('layout-diff', () => {
+  const emptyState: LayoutState = {
+    viewport: { x: 0, y: 0, zoom: 1 },
+    nodes: [],
+    edges: [],
+    grid_settings: null,
+    minimap_settings: null,
+  };
+
+  describe('compareLayouts — nodes', () => {
+    test('detects added nodes', () => {
+      const left: LayoutState = { ...emptyState, nodes: [] };
+      const right: LayoutState = {
+        ...emptyState,
+        nodes: [{ id: 'n1', type: 'classNode', position: { x: 10, y: 20 } }],
+      };
+      const diff = compareLayouts(left, right);
+
+      expect(diff.nodes.added).toHaveLength(1);
+      expect(diff.nodes.added[0].id).toBe('n1');
+      expect(diff.nodes.added[0].type).toBe('added');
+      expect(diff.nodes.removed).toHaveLength(0);
+      expect(diff.nodes.modified).toHaveLength(0);
+    });
+
+    test('detects removed nodes', () => {
+      const left: LayoutState = {
+        ...emptyState,
+        nodes: [{ id: 'n1', type: 'classNode', position: { x: 10, y: 20 } }],
+      };
+      const right: LayoutState = { ...emptyState, nodes: [] };
+      const diff = compareLayouts(left, right);
+
+      expect(diff.nodes.removed).toHaveLength(1);
+      expect(diff.nodes.removed[0].id).toBe('n1');
+      expect(diff.nodes.added).toHaveLength(0);
+    });
+
+    test('detects position changes', () => {
+      const left: LayoutState = {
+        ...emptyState,
+        nodes: [{ id: 'n1', type: 'classNode', position: { x: 10, y: 20 } }],
+      };
+      const right: LayoutState = {
+        ...emptyState,
+        nodes: [{ id: 'n1', type: 'classNode', position: { x: 100, y: 200 } }],
+      };
+      const diff = compareLayouts(left, right);
+
+      expect(diff.nodes.modified).toHaveLength(1);
+      expect(diff.nodes.modified[0].changes).toContain('position');
+    });
+
+    test('detects dimension changes', () => {
+      const left: LayoutState = {
+        ...emptyState,
+        nodes: [
+          {
+            id: 'n1',
+            type: 'classNode',
+            position: { x: 0, y: 0 },
+            dimensions: { width: 100, height: 50 },
+          },
+        ],
+      };
+      const right: LayoutState = {
+        ...emptyState,
+        nodes: [
+          {
+            id: 'n1',
+            type: 'classNode',
+            position: { x: 0, y: 0 },
+            dimensions: { width: 200, height: 50 },
+          },
+        ],
+      };
+      const diff = compareLayouts(left, right);
+
+      expect(diff.nodes.modified).toHaveLength(1);
+      expect(diff.nodes.modified[0].changes).toContain('dimensions');
+      expect(diff.nodes.modified[0].changes).not.toContain('position');
+    });
+
+    test('detects type changes', () => {
+      const left: LayoutState = {
+        ...emptyState,
+        nodes: [{ id: 'n1', type: 'classNode', position: { x: 0, y: 0 } }],
+      };
+      const right: LayoutState = {
+        ...emptyState,
+        nodes: [{ id: 'n1', type: 'groupNode', position: { x: 0, y: 0 } }],
+      };
+      const diff = compareLayouts(left, right);
+
+      expect(diff.nodes.modified).toHaveLength(1);
+      expect(diff.nodes.modified[0].changes).toContain('type');
+    });
+
+    test('detects data changes on group nodes', () => {
+      const left: LayoutState = {
+        ...emptyState,
+        nodes: [
+          {
+            id: 'g1',
+            type: 'groupNode',
+            position: { x: 0, y: 0 },
+            data: { name: 'Group A', color: 'blue', nodeIds: ['n1'] },
+          },
+        ],
+      };
+      const right: LayoutState = {
+        ...emptyState,
+        nodes: [
+          {
+            id: 'g1',
+            type: 'groupNode',
+            position: { x: 0, y: 0 },
+            data: { name: 'Group B', color: 'red', nodeIds: ['n1', 'n2'] },
+          },
+        ],
+      };
+      const diff = compareLayouts(left, right);
+
+      expect(diff.nodes.modified).toHaveLength(1);
+      expect(diff.nodes.modified[0].changes).toContain('data');
+    });
+
+    test('reports unchanged node count', () => {
+      const nodes = [
+        { id: 'n1', type: 'classNode', position: { x: 10, y: 20 } },
+        { id: 'n2', type: 'classNode', position: { x: 30, y: 40 } },
+      ];
+      const diff = compareLayouts(
+        { ...emptyState, nodes },
+        { ...emptyState, nodes }
+      );
+
+      expect(diff.nodes.unchanged).toBe(2);
+      expect(diff.nodes.added).toHaveLength(0);
+      expect(diff.nodes.removed).toHaveLength(0);
+      expect(diff.nodes.modified).toHaveLength(0);
+    });
+
+    test('ignores sub-threshold position changes', () => {
+      const left: LayoutState = {
+        ...emptyState,
+        nodes: [{ id: 'n1', type: 'classNode', position: { x: 10, y: 20 } }],
+      };
+      const right: LayoutState = {
+        ...emptyState,
+        nodes: [{ id: 'n1', type: 'classNode', position: { x: 10.3, y: 20.1 } }],
+      };
+      const diff = compareLayouts(left, right);
+
+      expect(diff.nodes.modified).toHaveLength(0);
+      expect(diff.nodes.unchanged).toBe(1);
+    });
+
+    test('uses node data name as label for group nodes', () => {
+      const left: LayoutState = { ...emptyState, nodes: [] };
+      const right: LayoutState = {
+        ...emptyState,
+        nodes: [
+          {
+            id: 'g1',
+            type: 'groupNode',
+            position: { x: 0, y: 0 },
+            data: { name: 'My Group' },
+          },
+        ],
+      };
+      const diff = compareLayouts(left, right);
+
+      expect(diff.nodes.added[0].label).toBe('My Group');
+    });
+  });
+
+  describe('compareLayouts — edges', () => {
+    test('detects added edges', () => {
+      const left: LayoutState = { ...emptyState, edges: [] };
+      const right: LayoutState = {
+        ...emptyState,
+        edges: [{ id: 'e1', source: 'a', target: 'b' }],
+      };
+      const diff = compareLayouts(left, right);
+
+      expect(diff.edges.added).toHaveLength(1);
+      expect(diff.edges.added[0].label).toBe('a → b');
+    });
+
+    test('detects removed edges', () => {
+      const left: LayoutState = {
+        ...emptyState,
+        edges: [{ id: 'e1', source: 'a', target: 'b' }],
+      };
+      const right: LayoutState = { ...emptyState, edges: [] };
+      const diff = compareLayouts(left, right);
+
+      expect(diff.edges.removed).toHaveLength(1);
+    });
+
+    test('detects reconnected edges (source change)', () => {
+      const left: LayoutState = {
+        ...emptyState,
+        edges: [{ id: 'e1', source: 'a', target: 'b' }],
+      };
+      const right: LayoutState = {
+        ...emptyState,
+        edges: [{ id: 'e1', source: 'c', target: 'b' }],
+      };
+      const diff = compareLayouts(left, right);
+
+      expect(diff.edges.modified).toHaveLength(1);
+      expect(diff.edges.modified[0].changes).toContain('source');
+    });
+
+    test('detects handle changes', () => {
+      const left: LayoutState = {
+        ...emptyState,
+        edges: [{ id: 'e1', source: 'a', target: 'b', sourceHandle: 'h1', targetHandle: 'h2' }],
+      };
+      const right: LayoutState = {
+        ...emptyState,
+        edges: [{ id: 'e1', source: 'a', target: 'b', sourceHandle: 'h3', targetHandle: 'h2' }],
+      };
+      const diff = compareLayouts(left, right);
+
+      expect(diff.edges.modified).toHaveLength(1);
+      expect(diff.edges.modified[0].changes).toContain('sourceHandle');
+      expect(diff.edges.modified[0].changes).not.toContain('targetHandle');
+    });
+
+    test('reports unchanged edge count', () => {
+      const edges = [{ id: 'e1', source: 'a', target: 'b' }];
+      const diff = compareLayouts(
+        { ...emptyState, edges },
+        { ...emptyState, edges }
+      );
+
+      expect(diff.edges.unchanged).toBe(1);
+    });
+  });
+
+  describe('compareLayouts — viewport', () => {
+    test('detects viewport pan changes', () => {
+      const left: LayoutState = { ...emptyState, viewport: { x: 0, y: 0, zoom: 1 } };
+      const right: LayoutState = { ...emptyState, viewport: { x: 100, y: 200, zoom: 1 } };
+      const diff = compareLayouts(left, right);
+
+      expect(diff.viewport).not.toBeNull();
+      expect(diff.viewport!.changes).toContain('x');
+      expect(diff.viewport!.changes).toContain('y');
+    });
+
+    test('detects viewport zoom changes', () => {
+      const left: LayoutState = { ...emptyState, viewport: { x: 0, y: 0, zoom: 1 } };
+      const right: LayoutState = { ...emptyState, viewport: { x: 0, y: 0, zoom: 0.5 } };
+      const diff = compareLayouts(left, right);
+
+      expect(diff.viewport).not.toBeNull();
+      expect(diff.viewport!.changes).toContain('zoom');
+    });
+
+    test('returns null for identical viewports', () => {
+      const diff = compareLayouts(
+        { ...emptyState, viewport: { x: 5, y: 10, zoom: 1.5 } },
+        { ...emptyState, viewport: { x: 5, y: 10, zoom: 1.5 } }
+      );
+
+      expect(diff.viewport).toBeNull();
+    });
+
+    test('handles null viewports gracefully', () => {
+      const diff = compareLayouts(
+        { ...emptyState, viewport: null },
+        { ...emptyState, viewport: null }
+      );
+
+      expect(diff.viewport).toBeNull();
+    });
+  });
+
+  describe('compareLayouts — settings', () => {
+    test('detects grid setting changes', () => {
+      const left: LayoutState = {
+        ...emptyState,
+        grid_settings: { size: 20, snapToGrid: true, showGrid: true },
+      };
+      const right: LayoutState = {
+        ...emptyState,
+        grid_settings: { size: 40, snapToGrid: false, showGrid: true },
+      };
+      const diff = compareLayouts(left, right);
+
+      expect(diff.gridSettings).not.toBeNull();
+      expect(diff.gridSettings!.changes).toContain('size');
+      expect(diff.gridSettings!.changes).toContain('snapToGrid');
+      expect(diff.gridSettings!.changes).not.toContain('showGrid');
+    });
+
+    test('detects minimap setting changes', () => {
+      const left: LayoutState = { ...emptyState, minimap_settings: { visible: true } };
+      const right: LayoutState = { ...emptyState, minimap_settings: { visible: false } };
+      const diff = compareLayouts(left, right);
+
+      expect(diff.minimapSettings).not.toBeNull();
+    });
+
+    test('returns null for identical settings', () => {
+      const settings = { size: 20, snapToGrid: true };
+      const diff = compareLayouts(
+        { ...emptyState, grid_settings: settings },
+        { ...emptyState, grid_settings: settings }
+      );
+
+      expect(diff.gridSettings).toBeNull();
+    });
+
+    test('handles null settings gracefully', () => {
+      const diff = compareLayouts(
+        { ...emptyState, grid_settings: null, minimap_settings: null },
+        { ...emptyState, grid_settings: null, minimap_settings: null }
+      );
+
+      expect(diff.gridSettings).toBeNull();
+      expect(diff.minimapSettings).toBeNull();
+    });
+  });
+
+  describe('compareLayouts — totalChanges', () => {
+    test('counts all change types', () => {
+      const left: LayoutState = {
+        viewport: { x: 0, y: 0, zoom: 1 },
+        nodes: [
+          { id: 'n1', type: 'classNode', position: { x: 0, y: 0 } },
+          { id: 'n2', type: 'classNode', position: { x: 10, y: 10 } },
+        ],
+        edges: [{ id: 'e1', source: 'n1', target: 'n2' }],
+        grid_settings: { size: 20 },
+        minimap_settings: null,
+      };
+      const right: LayoutState = {
+        viewport: { x: 500, y: 500, zoom: 2 },
+        nodes: [
+          { id: 'n1', type: 'classNode', position: { x: 100, y: 200 } },
+          { id: 'n3', type: 'classNode', position: { x: 50, y: 50 } },
+        ],
+        edges: [{ id: 'e2', source: 'n1', target: 'n3' }],
+        grid_settings: { size: 40 },
+        minimap_settings: null,
+      };
+      const diff = compareLayouts(left, right);
+
+      expect(diff.nodes.added).toHaveLength(1);
+      expect(diff.nodes.removed).toHaveLength(1);
+      expect(diff.nodes.modified).toHaveLength(1);
+      expect(diff.edges.added).toHaveLength(1);
+      expect(diff.edges.removed).toHaveLength(1);
+      expect(diff.viewport).not.toBeNull();
+      expect(diff.gridSettings).not.toBeNull();
+      expect(diff.totalChanges).toBe(7);
+    });
+
+    test('is zero for identical layouts', () => {
+      const state: LayoutState = {
+        viewport: { x: 5, y: 10, zoom: 1 },
+        nodes: [{ id: 'n1', position: { x: 0, y: 0 } }],
+        edges: [{ id: 'e1', source: 'n1', target: 'n1' }],
+        grid_settings: { size: 20 },
+        minimap_settings: { visible: true },
+      };
+      const diff = compareLayouts(state, state);
+
+      expect(diff.totalChanges).toBe(0);
+    });
+  });
+
+  describe('compareLayouts — null/undefined safety', () => {
+    test('handles null nodes and edges', () => {
+      const diff = compareLayouts(
+        { viewport: null, nodes: null, edges: null, grid_settings: null, minimap_settings: null },
+        { viewport: null, nodes: null, edges: null, grid_settings: null, minimap_settings: null }
+      );
+
+      expect(diff.totalChanges).toBe(0);
+    });
+
+    test('handles undefined nodes and edges', () => {
+      const diff = compareLayouts({}, {});
+
+      expect(diff.totalChanges).toBe(0);
+    });
+
+    test('compares null left nodes against populated right nodes', () => {
+      const diff = compareLayouts(
+        { nodes: null },
+        { nodes: [{ id: 'n1', position: { x: 0, y: 0 } }] }
+      );
+
+      expect(diff.nodes.added).toHaveLength(1);
+    });
+  });
+
+  describe('flattenDiffEntries', () => {
+    test('collects all entries from summary', () => {
+      const left: LayoutState = {
+        viewport: { x: 0, y: 0, zoom: 1 },
+        nodes: [{ id: 'n1', position: { x: 0, y: 0 } }],
+        edges: [],
+        grid_settings: { size: 20 },
+        minimap_settings: null,
+      };
+      const right: LayoutState = {
+        viewport: { x: 100, y: 0, zoom: 1 },
+        nodes: [{ id: 'n2', position: { x: 10, y: 10 } }],
+        edges: [{ id: 'e1', source: 'n2', target: 'n2' }],
+        grid_settings: { size: 40 },
+        minimap_settings: null,
+      };
+      const diff = compareLayouts(left, right);
+      const flat = flattenDiffEntries(diff);
+
+      expect(flat.length).toBeGreaterThanOrEqual(4);
+      expect(flat.some((e) => e.category === 'node')).toBe(true);
+      expect(flat.some((e) => e.category === 'edge')).toBe(true);
+      expect(flat.some((e) => e.category === 'viewport')).toBe(true);
+      expect(flat.some((e) => e.category === 'grid')).toBe(true);
+    });
+
+    test('returns empty array for identical layouts', () => {
+      const diff = compareLayouts(emptyState, emptyState);
+      const flat = flattenDiffEntries(diff);
+
+      expect(flat).toHaveLength(0);
+    });
+  });
+});

--- a/objectified-ui/tests/layout-diff.test.ts
+++ b/objectified-ui/tests/layout-diff.test.ts
@@ -132,6 +132,36 @@ describe('layout-diff', () => {
       expect(diff.nodes.modified[0].changes).toContain('data');
     });
 
+    test('detects data added when left has no data but right does', () => {
+      const left: LayoutState = {
+        ...emptyState,
+        nodes: [{ id: 'n1', type: 'classNode', position: { x: 0, y: 0 } }],
+      };
+      const right: LayoutState = {
+        ...emptyState,
+        nodes: [{ id: 'n1', type: 'classNode', position: { x: 0, y: 0 }, data: { label: 'new' } }],
+      };
+      const diff = compareLayouts(left, right);
+
+      expect(diff.nodes.modified).toHaveLength(1);
+      expect(diff.nodes.modified[0].changes).toContain('data');
+    });
+
+    test('detects data removed when left has data but right does not', () => {
+      const left: LayoutState = {
+        ...emptyState,
+        nodes: [{ id: 'n1', type: 'classNode', position: { x: 0, y: 0 }, data: { label: 'old' } }],
+      };
+      const right: LayoutState = {
+        ...emptyState,
+        nodes: [{ id: 'n1', type: 'classNode', position: { x: 0, y: 0 } }],
+      };
+      const diff = compareLayouts(left, right);
+
+      expect(diff.nodes.modified).toHaveLength(1);
+      expect(diff.nodes.modified[0].changes).toContain('data');
+    });
+
     test('reports unchanged node count', () => {
       const nodes = [
         { id: 'n1', type: 'classNode', position: { x: 10, y: 20 } },


### PR DESCRIPTION
## Problem Statement

Users and teams need **fixes #178 — add layout versioning diff viewer** within the Objectified platform. Today this capability is missing or only partially implemented, which blocks dashboard workflows and creates inconsistency across tenants and projects.

## Solution / Scope

Implement **Fixes #178 — Add layout versioning diff viewer** as part of **Dashboard**. KPIs, primitives browser, project overview, quick actions.

**Post-MVP** (prioritize after MVP slice) candidacy.

```mermaid
flowchart TB
  CP[Control Panel] --> KPIs[Stats cards]
  CP --> Primitives[Primitives list]
  CP --> Projects[Recent projects]
  CP --> Actions[Quick actions]
```

## Acceptance Criteria

- [ ] Feature behaves as described for: Fixes #178 — Add layout versioning diff viewer
- [ ] Unit/integration tests cover happy path and primary error cases
- [ ] UI (if applicable) matches existing ADE patterns (Tailwind 4, Radix, Lucide)
- [ ] REST endpoints (if applicable) follow `/v1/{{feature}}/{{tenant_slug}}/...` conventions
- [ ] Documented in issue/PR; no regressions to existing schema/version flows

## Parallelism / Dependencies

- **Can run in parallel:** Yes
- **Blockers:** None identified; validate against current codebase before starting

## Technical Stack

- **Modules:** objectified-rest
- **Stack:** Next.js ADE dashboard, control panel components, REST stats APIs
- **Labels:** ``

---

**Epic:** [[Epic] Dashboard & Control Panel](https://github.com/objectified-project/objectified/issues/3493)
**Issue:** #878 · **Area:** Dashboard · **Roadmap batch:** legacy #64–#879 enrichment