### PR TITLE
Fix #95 - Canvas group project tags

### DIFF
--- a/.cursor/skills/implement/SKILL.md
+++ b/.cursor/skills/implement/SKILL.md
@@ -87,6 +87,8 @@ Also run any package-specific tests the issue touches, per READMEs.
 
 1. Mark the ticket complete in **ROADMAP** and remove its entry from the issues list matching the issue number.
 2. Add a one-line summary of the work performed to **public/WHATS_NEW.md**.
+3. Bump the patch version of the application in the **objectified-ui/package.json** when a change is made in **objectified-ui**.
+4. Bump the patch version of pyproject.toml in **objectified-rest** when a change is made in that project.
 
 ## Phase 7 - Commit, Push, and PR
 

--- a/objectified-ui/lib/db/helper.ts
+++ b/objectified-ui/lib/db/helper.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { getAuthSession } from '../auth/server-session';
+import { buildGroupMetadataForSync } from '../utils/group-metadata';
 import { sortGroupsParentsBeforeChildren } from '../utils/group-sort';
 
 const connectionPool = require('./db');
@@ -4896,7 +4897,7 @@ export async function syncGroupsForVersion(versionId: string, groups: any[], nod
           group.zIndex || 0,
           group.opacity ?? 1.0,
           group.borderStyle || group.styleOptions?.borderStyle || 'dashed',
-          JSON.stringify(group.metadata || group.styleOptions || {}),
+          JSON.stringify(buildGroupMetadataForSync(group as Record<string, unknown>)),
           parentDbId,
           isCollapsed
         ]

--- a/objectified-ui/lib/utils/group-metadata.ts
+++ b/objectified-ui/lib/utils/group-metadata.ts
@@ -1,0 +1,29 @@
+/**
+ * Build `odb.groups.metadata` JSON from a client canvas group payload.
+ * Tags live on `group.tags`; legacy saves used `group.metadata` or the whole `styleOptions` object (#95).
+ */
+export function buildGroupMetadataForSync(group: Record<string, unknown>): Record<string, unknown> {
+  const rawMeta = group.metadata;
+  const hasMeta =
+    rawMeta &&
+    typeof rawMeta === 'object' &&
+    !Array.isArray(rawMeta);
+
+  if (hasMeta) {
+    const meta = { ...(rawMeta as Record<string, unknown>) };
+    if (group.tags !== undefined) {
+      meta.tags = group.tags;
+    }
+    return meta;
+  }
+
+  const meta: Record<string, unknown> = {};
+  const so = group.styleOptions;
+  if (so && typeof so === 'object' && !Array.isArray(so)) {
+    Object.assign(meta, so as Record<string, unknown>);
+  }
+  if (group.tags !== undefined) {
+    meta.tags = group.tags;
+  }
+  return meta;
+}

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.9.0",
+  "version": "0.9.3",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -6,6 +6,7 @@ We continue to improve the platform based on your feedback with improvements and
 
 ## Projects:
 - Added ability to start a new project from a template
+- Canvas groups can be assigned project tags from the group style settings (saved with the group for future search and filtering)
 
 ## Account:
 - Profile shows your last successful login date and time (stored when you sign in with email/password or OAuth)

--- a/objectified-ui/src/app/ade/studio/editor/page.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/page.tsx
@@ -4027,6 +4027,8 @@ const StudioContent = () => {
         ) => handleBulkEditGroupClassesRef.current?.(gid, cids, gn, opts),
         onColorChange: handleGroupColorChange,
         onStyleChange: handleGroupStyleChange,
+        tags: [],
+        onTagsChange: (gid: string, t: any[]) => handleGroupTagsChangeRef.current?.(gid, t),
         onDrillInto: () => handleDrillIntoNestedGroupRef.current(groupId),
         isReadOnly: isReadOnly
       }
@@ -4182,6 +4184,8 @@ const StudioContent = () => {
         ) => handleBulkEditGroupClassesRef.current?.(gid, cids, gn, opts),
         onColorChange: handleGroupColorChange,
         onStyleChange: handleGroupStyleChange,
+        tags: [],
+        onTagsChange: (gid: string, t: any[]) => handleGroupTagsChangeRef.current?.(gid, t),
         onDrillInto: () => handleDrillIntoNestedGroupRef.current(groupId),
         isReadOnly: isReadOnly
       }
@@ -5244,7 +5248,7 @@ const StudioContent = () => {
                 color: group.color,
                 nodeIds: group.nodeIds || [],
                 parentId: group.parentId ?? null,
-                tags: group.metadata?.tags || [],
+                tags: group.tags ?? group.metadata?.tags ?? [],
                 styleOptions: group.styleOptions,
                 availableTags,
                 onRename: (groupId: string, name: string) => handleGroupRenameRef.current?.(groupId, name),
@@ -6593,12 +6597,12 @@ const StudioContent = () => {
                   color: group.color,
                   nodeIds: group.nodeIds || [],
                   parentId: group.parentId ?? null,
-                  tags: group.metadata?.tags || [],
-                  styleOptions: {
-                    borderStyle: group.borderStyle || 'dashed',
+                  tags: group.tags ?? group.metadata?.tags ?? [],
+                  styleOptions: group.styleOptions ?? {
+                    borderStyle: 'dashed',
                     opacity: group.opacity ?? 1,
-                    shadow: group.metadata?.shadow || 'none',
-                    icon: group.metadata?.icon || 'folder'
+                    shadow: 'none',
+                    icon: 'folder',
                   },
                   availableTags,
                   onRename: (groupId: string, name: string) => handleGroupRenameRef.current?.(groupId, name),

--- a/objectified-ui/src/app/components/ade/studio/ClassNode.tsx
+++ b/objectified-ui/src/app/components/ade/studio/ClassNode.tsx
@@ -171,6 +171,7 @@ import {
 import { useDialog } from '../../providers/DialogProvider';
 import * as Popover from '@radix-ui/react-popover';
 import { cn } from '../../../../../lib/utils';
+import { tagInlineColors } from '@/app/utils/tag-color-tokens';
 
 // Icon options for class nodes - curated list organized by category
 const NODE_ICON_OPTIONS: Array<{ name: string; icon: LucideIcon; category: string }> = [
@@ -1684,16 +1685,7 @@ function ClassNode({ id, data, selected }: NodeProps) {
                 transition: 'opacity 0.2s ease'
               }}>
                 {typedData.tags.map((tag) => {
-                  const colorMap: Record<string, { bg: string; border: string }> = {
-                    default: { bg: 'rgba(255, 255, 255, 0.15)', border: 'rgba(255, 255, 255, 0.25)' },
-                    primary: { bg: 'rgba(99, 102, 241, 0.3)', border: 'rgba(99, 102, 241, 0.5)' },
-                    secondary: { bg: 'rgba(168, 85, 247, 0.3)', border: 'rgba(168, 85, 247, 0.5)' },
-                    error: { bg: 'rgba(239, 68, 68, 0.3)', border: 'rgba(239, 68, 68, 0.5)' },
-                    warning: { bg: 'rgba(245, 158, 11, 0.3)', border: 'rgba(245, 158, 11, 0.5)' },
-                    info: { bg: 'rgba(59, 130, 246, 0.3)', border: 'rgba(59, 130, 246, 0.5)' },
-                    success: { bg: 'rgba(16, 185, 129, 0.3)', border: 'rgba(16, 185, 129, 0.5)' },
-                  };
-                  const colors = colorMap[tag.tag_color] || colorMap.default;
+                  const colors = tagInlineColors(tag.tag_color);
                   return (
                     <span
                       key={tag.id}

--- a/objectified-ui/src/app/components/ade/studio/GroupNode.tsx
+++ b/objectified-ui/src/app/components/ade/studio/GroupNode.tsx
@@ -12,6 +12,12 @@ import {
 import * as Popover from '@radix-ui/react-popover';
 import { COLLAPSED_GROUP_FRAME_WIDTH, COLLAPSED_GROUP_FRAME_HEIGHT } from '@/app/utils/canvas-group-collapse';
 import GroupBulkEditDialog, { type GroupBulkEditTagOption } from './GroupBulkEditDialog';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+} from '@/app/components/ui/Select';
 
 // Available group icons
 export const GROUP_ICONS = [
@@ -58,6 +64,33 @@ export const SHADOW_OPTIONS = [
   { name: 'md', label: 'Medium', class: 'shadow-md' },
   { name: 'lg', label: 'Large', class: 'shadow-lg' },
 ];
+
+/** Tailwind classes for project tag chips (matches class-node tag colors). */
+function tagChipClass(color: string): string {
+  const m: Record<string, string> = {
+    default: 'bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-100 border-gray-200 dark:border-gray-600',
+    primary: 'bg-indigo-100 dark:bg-indigo-900/40 text-indigo-800 dark:text-indigo-200 border-indigo-200 dark:border-indigo-700',
+    secondary: 'bg-purple-100 dark:bg-purple-900/40 text-purple-800 dark:text-purple-200 border-purple-200 dark:border-purple-700',
+    error: 'bg-red-100 dark:bg-red-900/40 text-red-800 dark:text-red-200 border-red-200 dark:border-red-700',
+    warning: 'bg-amber-100 dark:bg-amber-900/40 text-amber-900 dark:text-amber-200 border-amber-200 dark:border-amber-700',
+    info: 'bg-blue-100 dark:bg-blue-900/40 text-blue-800 dark:text-blue-200 border-blue-200 dark:border-blue-700',
+    success: 'bg-emerald-100 dark:bg-emerald-900/40 text-emerald-800 dark:text-emerald-200 border-emerald-200 dark:border-emerald-700',
+  };
+  return m[color] || m.default;
+}
+
+function tagDotClass(color: string): string {
+  const m: Record<string, string> = {
+    default: 'text-gray-500',
+    primary: 'text-indigo-500',
+    secondary: 'text-purple-500',
+    error: 'text-red-500',
+    warning: 'text-amber-500',
+    info: 'text-blue-500',
+    success: 'text-emerald-500',
+  };
+  return m[color] || m.default;
+}
 
 // Predefined group colors with name, bg, border, and text colors
 export const GROUP_COLORS = [
@@ -127,6 +160,9 @@ export interface GroupNodeData {
   ) => void | Promise<void>;
   /** Project tags for bulk assign */
   availableTags?: GroupBulkEditTagOption[];
+  /** Tags assigned to this group frame (project tags); persisted on group metadata (#95). */
+  tags?: Array<{ id: string; name: string; color: string }>;
+  onTagsChange?: (groupId: string, tags: Array<{ id: string; name: string; color: string }>) => void;
   onColorChange?: (groupId: string, newColor: string) => void;
   onStyleChange?: (groupId: string, styleOptions: GroupStyleOptions) => void;
   isReadOnly?: boolean;
@@ -139,7 +175,8 @@ export interface GroupNodeData {
   onDrillInto?: (groupId: string) => void;
 }
 
-const GroupNode = memo(({ id, data, selected }: NodeProps) => {
+const GroupNode = memo((props: NodeProps) => {
+  const { data, selected } = props;
   const groupData = data as unknown as GroupNodeData;
   const [isEditing, setIsEditing] = useState(false);
   const [editName, setEditName] = useState(groupData.name);
@@ -173,7 +210,10 @@ const GroupNode = memo(({ id, data, selected }: NodeProps) => {
   const colorConfig = GROUP_COLORS.find(c => c.name === groupData.color) || GROUP_COLORS[0];
 
   // Get style options with defaults
-  const styleOptions = { ...DEFAULT_STYLE_OPTIONS, ...groupData.styleOptions };
+  const styleOptions = useMemo(
+    () => ({ ...DEFAULT_STYLE_OPTIONS, ...groupData.styleOptions }),
+    [groupData.styleOptions]
+  );
 
   // Determine if we should use light text based on background darkness
   const useLightText = true;
@@ -189,6 +229,15 @@ const GroupNode = memo(({ id, data, selected }: NodeProps) => {
   const shadowClass = SHADOW_OPTIONS.find(s => s.name === styleOptions.shadow)?.class || '';
 
   const nodeCount = groupData.nodeIds?.length || 0;
+
+  const assignedTags = useMemo(() => groupData.tags ?? [], [groupData.tags]);
+  const addableTags = useMemo(
+    () =>
+      (groupData.availableTags ?? []).filter(
+        (t) => !assignedTags.some((a) => a.id === t.id)
+      ),
+    [groupData.availableTags, assignedTags]
+  );
 
   const handleStartEdit = useCallback((e: React.MouseEvent) => {
     e.stopPropagation();
@@ -280,11 +329,36 @@ const GroupNode = memo(({ id, data, selected }: NodeProps) => {
   }, [groupData]);
 
   // Handle style option changes
-  const handleStyleChange = useCallback((key: keyof GroupStyleOptions, value: any) => {
-    if (groupData.isReadOnly) return;
-    const newOptions = { ...styleOptions, [key]: value };
-    groupData.onStyleChange?.(groupData.id, newOptions);
-  }, [groupData, styleOptions]);
+  const handleStyleChange = useCallback(
+    (key: keyof GroupStyleOptions, value: GroupStyleOptions[keyof GroupStyleOptions]) => {
+      if (groupData.isReadOnly) return;
+      const newOptions = { ...styleOptions, [key]: value };
+      groupData.onStyleChange?.(groupData.id, newOptions);
+    },
+    [groupData, styleOptions]
+  );
+
+  const handleAddGroupTag = useCallback(
+    (tagId: string) => {
+      if (groupData.isReadOnly || !tagId) return;
+      const opt = groupData.availableTags?.find((t) => t.id === tagId);
+      if (!opt) return;
+      const color = opt.color && opt.color.length > 0 ? opt.color : 'default';
+      groupData.onTagsChange?.(groupData.id, [...assignedTags, { id: opt.id, name: opt.name, color }]);
+    },
+    [groupData, assignedTags]
+  );
+
+  const handleRemoveGroupTag = useCallback(
+    (tagId: string) => {
+      if (groupData.isReadOnly) return;
+      groupData.onTagsChange?.(
+        groupData.id,
+        assignedTags.filter((t) => t.id !== tagId)
+      );
+    },
+    [groupData, assignedTags]
+  );
 
   const isCollapsed = Boolean(groupData.collapsed);
 
@@ -399,6 +473,22 @@ const GroupNode = memo(({ id, data, selected }: NodeProps) => {
           )}
         </div>
 
+        {!isCollapsed && assignedTags.length > 0 && (
+          <div
+            className="absolute top-7 left-4 right-4 z-10 flex flex-wrap gap-1 pointer-events-none"
+            aria-label="Group tags"
+          >
+            {assignedTags.map((tag) => (
+              <span
+                key={tag.id}
+                className={`text-[10px] font-medium px-1.5 py-0.5 rounded border ${tagChipClass(tag.color)}`}
+              >
+                {tag.name}
+              </span>
+            ))}
+          </div>
+        )}
+
         {/* Floating toolbar: outside the title pill, top -24px / right -2px (#859) */}
         {showFloatingToolbar && (
           <div
@@ -441,6 +531,63 @@ const GroupNode = memo(({ id, data, selected }: NodeProps) => {
                     onClick={(e) => e.stopPropagation()}
                   >
                     <h4 className="text-sm font-semibold text-gray-900 dark:text-white mb-3">Group Styling</h4>
+
+                    {(assignedTags.length > 0 ||
+                      (!groupData.isReadOnly && (groupData.availableTags?.length ?? 0) > 0)) && (
+                      <div className="mb-4">
+                        <label className="text-xs font-medium text-gray-600 dark:text-gray-400 mb-2 block">
+                          Tags
+                        </label>
+                        {assignedTags.length > 0 && (
+                          <div className="flex flex-wrap gap-1.5 mb-2">
+                            {assignedTags.map((tag) => (
+                              <span
+                                key={tag.id}
+                                className={`inline-flex items-center gap-1 text-xs pl-2 pr-1 py-0.5 rounded-md border ${tagChipClass(tag.color)}`}
+                              >
+                                {tag.name}
+                                {!groupData.isReadOnly && (
+                                  <button
+                                    type="button"
+                                    onClick={() => handleRemoveGroupTag(tag.id)}
+                                    className="rounded p-0.5 hover:bg-black/10 dark:hover:bg-white/10"
+                                    aria-label={`Remove tag ${tag.name}`}
+                                  >
+                                    <X className="h-3 w-3" />
+                                  </button>
+                                )}
+                              </span>
+                            ))}
+                          </div>
+                        )}
+                        {!groupData.isReadOnly && addableTags.length > 0 && (
+                          <Select
+                            key={assignedTags.map((t) => t.id).join(',')}
+                            value=""
+                            onValueChange={(id) => {
+                              if (id) handleAddGroupTag(id);
+                            }}
+                          >
+                            <SelectTrigger className="h-8 text-xs border-dashed w-full">
+                              <Tag className="h-3 w-3 mr-1 shrink-0" />
+                              Add tag
+                            </SelectTrigger>
+                            <SelectContent>
+                              {addableTags.map((t) => (
+                                <SelectItem key={t.id} value={t.id}>
+                                  <span className="flex items-center gap-2">
+                                    <span className={`text-lg leading-none ${tagDotClass(t.color || 'default')}`}>
+                                      ●
+                                    </span>
+                                    {t.name}
+                                  </span>
+                                </SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
+                        )}
+                      </div>
+                    )}
 
                     {/* Icon Selection */}
                     <div className="mb-4">

--- a/objectified-ui/src/app/components/ade/studio/GroupNode.tsx
+++ b/objectified-ui/src/app/components/ade/studio/GroupNode.tsx
@@ -11,6 +11,7 @@ import {
 } from 'lucide-react';
 import * as Popover from '@radix-ui/react-popover';
 import { COLLAPSED_GROUP_FRAME_WIDTH, COLLAPSED_GROUP_FRAME_HEIGHT } from '@/app/utils/canvas-group-collapse';
+import { tagChipClass, tagDotClass } from '@/app/utils/tag-color-tokens';
 import GroupBulkEditDialog, { type GroupBulkEditTagOption } from './GroupBulkEditDialog';
 import {
   Select,
@@ -64,33 +65,6 @@ export const SHADOW_OPTIONS = [
   { name: 'md', label: 'Medium', class: 'shadow-md' },
   { name: 'lg', label: 'Large', class: 'shadow-lg' },
 ];
-
-/** Tailwind classes for project tag chips (matches class-node tag colors). */
-function tagChipClass(color: string): string {
-  const m: Record<string, string> = {
-    default: 'bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-100 border-gray-200 dark:border-gray-600',
-    primary: 'bg-indigo-100 dark:bg-indigo-900/40 text-indigo-800 dark:text-indigo-200 border-indigo-200 dark:border-indigo-700',
-    secondary: 'bg-purple-100 dark:bg-purple-900/40 text-purple-800 dark:text-purple-200 border-purple-200 dark:border-purple-700',
-    error: 'bg-red-100 dark:bg-red-900/40 text-red-800 dark:text-red-200 border-red-200 dark:border-red-700',
-    warning: 'bg-amber-100 dark:bg-amber-900/40 text-amber-900 dark:text-amber-200 border-amber-200 dark:border-amber-700',
-    info: 'bg-blue-100 dark:bg-blue-900/40 text-blue-800 dark:text-blue-200 border-blue-200 dark:border-blue-700',
-    success: 'bg-emerald-100 dark:bg-emerald-900/40 text-emerald-800 dark:text-emerald-200 border-emerald-200 dark:border-emerald-700',
-  };
-  return m[color] || m.default;
-}
-
-function tagDotClass(color: string): string {
-  const m: Record<string, string> = {
-    default: 'text-gray-500',
-    primary: 'text-indigo-500',
-    secondary: 'text-purple-500',
-    error: 'text-red-500',
-    warning: 'text-amber-500',
-    info: 'text-blue-500',
-    success: 'text-emerald-500',
-  };
-  return m[color] || m.default;
-}
 
 // Predefined group colors with name, bg, border, and text colors
 export const GROUP_COLORS = [

--- a/objectified-ui/src/app/utils/tag-color-tokens.ts
+++ b/objectified-ui/src/app/utils/tag-color-tokens.ts
@@ -1,0 +1,53 @@
+/**
+ * Shared tag color tokens for project-tag chips across canvas nodes (#95).
+ * Used by both GroupNode (Tailwind-class approach) and ClassNode (inline-style approach).
+ */
+
+/** Maps a project-tag color name to Tailwind classes for a chip (bg + text + border). */
+export function tagChipClass(color: string): string {
+  const m: Record<string, string> = {
+    default:
+      'bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-100 border-gray-200 dark:border-gray-600',
+    primary:
+      'bg-indigo-100 dark:bg-indigo-900/40 text-indigo-800 dark:text-indigo-200 border-indigo-200 dark:border-indigo-700',
+    secondary:
+      'bg-purple-100 dark:bg-purple-900/40 text-purple-800 dark:text-purple-200 border-purple-200 dark:border-purple-700',
+    error:
+      'bg-red-100 dark:bg-red-900/40 text-red-800 dark:text-red-200 border-red-200 dark:border-red-700',
+    warning:
+      'bg-amber-100 dark:bg-amber-900/40 text-amber-900 dark:text-amber-200 border-amber-200 dark:border-amber-700',
+    info:
+      'bg-blue-100 dark:bg-blue-900/40 text-blue-800 dark:text-blue-200 border-blue-200 dark:border-blue-700',
+    success:
+      'bg-emerald-100 dark:bg-emerald-900/40 text-emerald-800 dark:text-emerald-200 border-emerald-200 dark:border-emerald-700',
+  };
+  return m[color] ?? m.default;
+}
+
+/** Maps a project-tag color name to a Tailwind text-color class for a color dot. */
+export function tagDotClass(color: string): string {
+  const m: Record<string, string> = {
+    default: 'text-gray-500',
+    primary: 'text-indigo-500',
+    secondary: 'text-purple-500',
+    error: 'text-red-500',
+    warning: 'text-amber-500',
+    info: 'text-blue-500',
+    success: 'text-emerald-500',
+  };
+  return m[color] ?? m.default;
+}
+
+/** Maps a project-tag color name to inline rgba bg/border values (used by canvas nodes with inline styles). */
+export function tagInlineColors(color: string): { bg: string; border: string } {
+  const m: Record<string, { bg: string; border: string }> = {
+    default: { bg: 'rgba(255, 255, 255, 0.15)', border: 'rgba(255, 255, 255, 0.25)' },
+    primary: { bg: 'rgba(99, 102, 241, 0.3)', border: 'rgba(99, 102, 241, 0.5)' },
+    secondary: { bg: 'rgba(168, 85, 247, 0.3)', border: 'rgba(168, 85, 247, 0.5)' },
+    error: { bg: 'rgba(239, 68, 68, 0.3)', border: 'rgba(239, 68, 68, 0.5)' },
+    warning: { bg: 'rgba(245, 158, 11, 0.3)', border: 'rgba(245, 158, 11, 0.5)' },
+    info: { bg: 'rgba(59, 130, 246, 0.3)', border: 'rgba(59, 130, 246, 0.5)' },
+    success: { bg: 'rgba(16, 185, 129, 0.3)', border: 'rgba(16, 185, 129, 0.5)' },
+  };
+  return m[color] ?? m.default;
+}

--- a/objectified-ui/src/app/utils/tag-color-tokens.ts
+++ b/objectified-ui/src/app/utils/tag-color-tokens.ts
@@ -21,7 +21,7 @@ export function tagChipClass(color: string): string {
     success:
       'bg-emerald-100 dark:bg-emerald-900/40 text-emerald-800 dark:text-emerald-200 border-emerald-200 dark:border-emerald-700',
   };
-  return m[color] ?? m.default;
+  return m[color] || m.default;
 }
 
 /** Maps a project-tag color name to a Tailwind text-color class for a color dot. */
@@ -35,7 +35,7 @@ export function tagDotClass(color: string): string {
     info: 'text-blue-500',
     success: 'text-emerald-500',
   };
-  return m[color] ?? m.default;
+  return m[color] || m.default;
 }
 
 /** Maps a project-tag color name to inline rgba bg/border values (used by canvas nodes with inline styles). */
@@ -49,5 +49,5 @@ export function tagInlineColors(color: string): { bg: string; border: string } {
     info: { bg: 'rgba(59, 130, 246, 0.3)', border: 'rgba(59, 130, 246, 0.5)' },
     success: { bg: 'rgba(16, 185, 129, 0.3)', border: 'rgba(16, 185, 129, 0.5)' },
   };
-  return m[color] ?? m.default;
+  return m[color] || m.default;
 }

--- a/objectified-ui/tests/db/helper-group-metadata-sync.test.ts
+++ b/objectified-ui/tests/db/helper-group-metadata-sync.test.ts
@@ -44,4 +44,16 @@ describe('buildGroupMetadataForSync', () => {
     expect(meta.tags).toEqual([]);
     expect(meta.shadow).toBe('none');
   });
+
+  test('preserves existing metadata tags when tags are omitted', () => {
+    const meta = buildGroupMetadataForSync({
+      metadata: {
+        tags: [{ id: 'existing', name: 'Existing', color: 'default' }],
+        shadow: 'md',
+      },
+      styleOptions: { shadow: 'sm', icon: 'folder' },
+    });
+    expect(meta.tags).toEqual([{ id: 'existing', name: 'Existing', color: 'default' }]);
+    expect(meta.shadow).toBe('md');
+  });
 });

--- a/objectified-ui/tests/db/helper-group-metadata-sync.test.ts
+++ b/objectified-ui/tests/db/helper-group-metadata-sync.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Unit tests for buildGroupMetadataForSync (#95) — group tags persisted in odb.groups.metadata.
+ */
+
+import { describe, test, expect } from '@jest/globals';
+
+import { buildGroupMetadataForSync } from '../../lib/utils/group-metadata';
+
+describe('buildGroupMetadataForSync', () => {
+
+  test('merges tags into existing metadata object', () => {
+    const meta = buildGroupMetadataForSync({
+      metadata: { shadow: 'md', icon: 'box' },
+      tags: [{ id: 't1', name: 'API', color: 'primary' }],
+      styleOptions: { shadow: 'sm', icon: 'folder' },
+    });
+    expect(meta.shadow).toBe('md');
+    expect(meta.icon).toBe('box');
+    expect(meta.tags).toEqual([{ id: 't1', name: 'API', color: 'primary' }]);
+  });
+
+  test('uses styleOptions as metadata base when metadata is absent', () => {
+    const meta = buildGroupMetadataForSync({
+      styleOptions: {
+        borderStyle: 'solid',
+        opacity: 0.5,
+        shadow: 'lg',
+        icon: 'database',
+      },
+      tags: [{ id: 't2', name: 'Core', color: 'default' }],
+    });
+    expect(meta.borderStyle).toBe('solid');
+    expect(meta.opacity).toBe(0.5);
+    expect(meta.shadow).toBe('lg');
+    expect(meta.icon).toBe('database');
+    expect(meta.tags).toEqual([{ id: 't2', name: 'Core', color: 'default' }]);
+  });
+
+  test('clears tags when empty array provided with metadata', () => {
+    const meta = buildGroupMetadataForSync({
+      metadata: { tags: [{ id: 'old' }], shadow: 'none' },
+      tags: [],
+    });
+    expect(meta.tags).toEqual([]);
+    expect(meta.shadow).toBe('none');
+  });
+});


### PR DESCRIPTION
## What
- **Persist tags on sync:** `syncGroupsForVersion` now writes project tags into `odb.groups.metadata.tags` via `buildGroupMetadataForSync` (client groups use top-level `tags`, not only `metadata`).
- **Studio load:** Group nodes receive `tags` from the normalized canvas group shape (`group.tags`) instead of only `group.metadata?.tags`; initial load path uses `group.styleOptions` consistently.
- **UI:** Group **Style settings** includes a Tags section (add/remove project tags), plus compact tag chips on the group frame when tags are set.
- **New groups:** `handleCreateGroup` / `handleCreateGroupAtPosition` pass `tags` + `onTagsChange`.

## How to test
1. Open the studio editor with a version that has project tags.
2. Create or select a canvas group → **Style settings** (gear) → **Tags** → add tags, remove with ×.
3. Reload the page or re-open the version; tags should still appear on the group.
4. Run `yarn build` and `yarn workspace objectified-ui test`.

## Risk / notes
- Tags are stored in existing JSONB `metadata`; no schema migration.
- Search/filter by group tags is follow-up work (issue wording).

Closes #95

Made with [Cursor](https://cursor.com)