### PR TITLE
Fix #96 - Group canvas classes by shared tag name

### DIFF
--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -114,7 +114,7 @@
     "jest": "^30.3.0",
     "jest-environment-jsdom": "^30.3.0",
     "tailwindcss": "^4.2.2",
-    "ts-jest": "^29.4.6",
+    "ts-jest": "^29.4.9",
     "ts-node": "^10.9.2",
     "typescript": "^5.9.3"
   }

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -6,6 +6,7 @@ We continue to improve the platform based on your feedback with improvements and
 
 ## Projects:
 - Added ability to start a new project from a template
+- Layout panel: group classes that share the same project tag name into separate canvas frames (multi-tagged classes are placed in one group via a clear A–Z rule)
 - Canvas groups can be assigned project tags from the group style settings (saved with the group for future search and filtering)
 - Fixed group tag picker and chips so tag names and colors show correctly (project tags use `name`/`color` from the database)
 

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -6,6 +6,8 @@ We continue to improve the platform based on your feedback with improvements and
 
 ## Projects:
 - Added ability to start a new project from a template
+
+## Groups:
 - Layout panel: group classes that share the same project tag name into separate canvas frames (multi-tagged classes are placed in one group via a clear A–Z rule)
 - Canvas groups can be assigned project tags from the group style settings (saved with the group for future search and filtering)
 - Fixed group tag picker and chips so tag names and colors show correctly (project tags use `name`/`color` from the database)

--- a/objectified-ui/src/app/ade/studio/editor/page.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/page.tsx
@@ -4,7 +4,7 @@ import { useCallback, useState, useEffect, useRef, useMemo, type ChangeEvent, ty
 import { useSession } from 'next-auth/react';
 import { useSearchParams } from 'next/navigation';
 import dynamic from 'next/dynamic';
-import { useStudio } from '../StudioContext';
+import { useStudio, type CanvasGroup } from '../StudioContext';
 import {
   Copy,
   Download,
@@ -154,6 +154,7 @@ import SmartEdge from '../../../components/ade/studio/SmartEdge';
 import { applyAutoLayout } from '@/app/utils/canvas-auto-layout';
 import { getCanvasBackgroundStyle } from '@/app/utils/canvas-background-style';
 import { mapProjectTagToGroupOption, normalizeStoredGroupTags } from '@/app/utils/tag-color-tokens';
+import { computeTagGroupPlan } from '@/app/utils/group-classes-by-tag-name';
 import { applyEdgeStyling } from '@/app/utils/edge-styling';
 import { computeCanvasSuggestions } from '@/app/utils/canvas-suggestions';
 import { getVisibleNodeIdsForIsolateSelection } from '@/app/utils/canvas-node-visibility';
@@ -5898,6 +5899,245 @@ const StudioContent = () => {
     [handlePreviewLayout]
   );
 
+  /** #96: Create one canvas group per tag name (≥2 classes), greedy assignment by tag name A–Z. */
+  const handleGroupCanvasByTagName = useCallback(async () => {
+    if (isReadOnly) {
+      await alertDialog({
+        message: 'Switch to an editable version to group classes by tag.',
+        variant: 'warning',
+      });
+      return;
+    }
+
+    const confirmed = await confirmDialog({
+      title: 'Group classes by tag',
+      message:
+        'Create one canvas group per tag name that has at least two classes. Classes with multiple tags are placed in only one group (first tag name in A–Z order among tags that still need members). Classes are removed from their current groups. Continue?',
+    });
+    if (!confirmed) return;
+
+    setLayoutDropdownOpen(false);
+
+    const classNodes = getNodes().filter((n) => n.type === 'classNode');
+    const plan = computeTagGroupPlan(
+      classNodes.map((n) => ({
+        id: n.id,
+        tags: (n.data as { tags?: Array<{ id: string; tag_name?: string; name?: string }> }).tags,
+      })),
+      projectTags
+    );
+
+    if (plan.length === 0) {
+      await alertDialog({
+        message:
+          'No tag has two or more classes on the canvas. Add shared project tags to classes first.',
+        variant: 'info',
+      });
+      return;
+    }
+
+    const assignedIds = new Set(plan.flatMap((p) => p.classIds));
+
+    const strippedGroups = groups.map((g) => ({
+      ...g,
+      nodeIds: g.nodeIds.filter((id) => !assignedIds.has(id)),
+    }));
+
+    const tagCatalog = new Map(projectTags.map((t) => [t.id, mapProjectTagToGroupOption(t)]));
+
+    const PAD = 40;
+    const CELL_W = 280;
+    const CELL_H = 180;
+    const COLS = 2;
+    const GAP_X = 520;
+    const GAP_Y = 420;
+    const ORIGIN_X = 100;
+    const ORIGIN_Y = 100;
+
+    const newCanvasGroups: CanvasGroup[] = [];
+
+    plan.forEach((entry, index) => {
+      const col = index % 3;
+      const row = Math.floor(index / 3);
+      const gx = ORIGIN_X + col * GAP_X;
+      const gy = ORIGIN_Y + row * GAP_Y;
+      const n = entry.classIds.length;
+      const rows = Math.ceil(n / COLS);
+      const width = Math.max(400, PAD * 2 + COLS * CELL_W);
+      const height = Math.max(260, PAD * 2 + rows * CELL_H);
+
+      const groupId = generateGroupId();
+      const groupTags = normalizeStoredGroupTags([{ id: entry.tagId }], tagCatalog);
+      const colorName = GROUP_COLORS[(strippedGroups.length + index) % GROUP_COLORS.length]!.name;
+
+      newCanvasGroups.push({
+        id: groupId,
+        name: entry.tagName,
+        color: colorName,
+        nodeIds: [...entry.classIds],
+        parentId: null,
+        position: { x: gx, y: gy },
+        dimensions: { width, height },
+        styleOptions: {
+          borderStyle: 'dashed',
+          opacity: 1,
+          shadow: 'none',
+          icon: 'tag',
+        },
+        tags: groupTags,
+      });
+    });
+
+    const nextGroups = [...strippedGroups, ...newCanvasGroups];
+    setGroups(nextGroups);
+
+    const classPositionUpdates = new Map<string, { x: number; y: number }>();
+    plan.forEach((entry, index) => {
+      const col = index % 3;
+      const row = Math.floor(index / 3);
+      const gx = ORIGIN_X + col * GAP_X;
+      const gy = ORIGIN_Y + row * GAP_Y;
+      entry.classIds.forEach((classId, i) => {
+        classPositionUpdates.set(classId, {
+          x: gx + PAD + (i % COLS) * CELL_W,
+          y: gy + PAD + Math.floor(i / COLS) * CELL_H,
+        });
+      });
+    });
+
+    const availableTags = projectTags.map(mapProjectTagToGroupOption);
+
+    const newFlowNodes: Node[] = newCanvasGroups.map((newGroup) => {
+      const groupId = newGroup.id;
+      groupPositionsRef.current.set(groupId, { ...newGroup.position });
+      return {
+        id: groupId,
+        type: 'groupNode',
+        position: newGroup.position,
+        width: newGroup.dimensions.width,
+        height: newGroup.dimensions.height,
+        style: {
+          width: newGroup.dimensions.width,
+          height: newGroup.dimensions.height,
+          zIndex: -1,
+        },
+        data: {
+          id: groupId,
+          name: newGroup.name,
+          color: newGroup.color,
+          nodeIds: newGroup.nodeIds,
+          styleOptions: newGroup.styleOptions,
+          parentId: null,
+          availableTags,
+          tags: newGroup.tags ?? [],
+          onRename: (gid: string, name: string) => handleGroupRenameRef.current?.(gid, name),
+          onDelete: (gid: string) => handleGroupDeleteRef.current?.(gid),
+          onDeleteAllClassesInGroup: (gid: string, cids?: string[], gn?: string) =>
+            handleDeleteAllClassesInGroupRef.current?.(gid, cids, gn),
+          onExportGroupSchema: (gid: string, cids: string[], gn: string, fmt: 'json' | 'yaml') =>
+            handleExportGroupSchemaRef.current?.(gid, cids, gn, fmt),
+          onDuplicateGroup: (gid: string, cids: string[], gn: string) =>
+            handleDuplicateGroupRef.current?.(gid, cids, gn),
+          onBulkEditGroupClasses: (
+            gid: string,
+            cids: string[],
+            gn: string,
+            opts: {
+              descriptionPrefix?: string;
+              descriptionSuffix?: string;
+              tagId?: string;
+              topLevelPropertyReadOnly?: boolean;
+            }
+          ) => handleBulkEditGroupClassesRef.current?.(gid, cids, gn, opts),
+          onColorChange: (gid: string, color: string) => handleGroupColorChangeRef.current?.(gid, color),
+          onStyleChange: (gid: string, style: unknown) => handleGroupStyleChangeRef.current?.(gid, style),
+          onTagsChange: (gid: string, t: unknown[]) => handleGroupTagsChangeRef.current?.(gid, t),
+          onDrillInto: () => handleDrillIntoNestedGroupRef.current(groupId),
+          isReadOnly,
+        },
+      };
+    });
+
+    const prevFlow = getNodes();
+    const mergedNodes: Node[] = [
+      ...newFlowNodes,
+      ...prevFlow.map((node) => {
+        if (node.type === 'classNode' && classPositionUpdates.has(node.id)) {
+          return {
+            ...node,
+            position: classPositionUpdates.get(node.id)!,
+          };
+        }
+        if (node.type === 'groupNode') {
+          const g = nextGroups.find((ng) => ng.id === node.id);
+          if (g) {
+            return {
+              ...node,
+              position: g.position,
+              width: g.dimensions.width,
+              height: g.dimensions.height,
+              style: {
+                ...node.style,
+                width: g.dimensions.width,
+                height: g.dimensions.height,
+              },
+              data: {
+                ...node.data,
+                nodeIds: g.nodeIds,
+                name: g.name,
+                tags: g.tags ?? (node.data as { tags?: unknown }).tags,
+              },
+            };
+          }
+        }
+        return node;
+      }),
+    ];
+
+    setNodes(mergedNodes);
+
+    if (selectedVersionId && currentUserId) {
+      try {
+        const viewport = getViewport();
+        await saveDefaultCanvasLayout(
+          selectedVersionId,
+          currentUserId,
+          viewport,
+          mapNodesForLayoutSave(mergedNodes),
+          mapEdgesForLayoutSave(getEdges()),
+          nextGroups
+        );
+      } catch (e) {
+        console.error('Failed to save canvas after group-by-tag:', e);
+      }
+    }
+
+    setTimeout(() => fitView({ padding: 0.15, duration: 300 }), 120);
+    triggerSidebarRefresh();
+
+    await alertDialog({
+      message: `Created ${plan.length} group(s) from shared tag names.`,
+      variant: 'success',
+    });
+  }, [
+    isReadOnly,
+    alertDialog,
+    confirmDialog,
+    getNodes,
+    getEdges,
+    projectTags,
+    groups,
+    generateGroupId,
+    setGroups,
+    setNodes,
+    saveDefaultCanvasLayout,
+    selectedVersionId,
+    currentUserId,
+    getViewport,
+    fitView,
+    triggerSidebarRefresh,
+  ]);
+
   // ============================================================================
   // END LAYOUT SAVE/LOAD HANDLERS
   // ============================================================================
@@ -9612,6 +9852,31 @@ const StudioContent = () => {
                         </div>
                         <p className="text-xs text-gray-500 dark:text-gray-400 mt-2">
                           Automatically arrange classes hierarchically based on relationships
+                        </p>
+                      </section>
+
+                      {/* #96 Group classes that share a project tag name */}
+                      <section aria-labelledby="layout-popover-group-by-tag-heading" className="pt-4 border-t border-gray-200 dark:border-gray-700">
+                        <h4 id="layout-popover-group-by-tag-heading" className="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider mb-3">
+                          Group by tag
+                        </h4>
+                        <button
+                          type="button"
+                          onClick={() => void handleGroupCanvasByTagName()}
+                          disabled={
+                            isReadOnly ||
+                            nodes.filter((n) => n.type === 'classNode').length === 0 ||
+                            projectTags.length === 0
+                          }
+                          className="w-full px-3 py-2 text-sm font-medium rounded-lg transition-all duration-200 flex items-center justify-center gap-2 bg-amber-50 dark:bg-amber-900/30 text-amber-900 dark:text-amber-200 hover:bg-amber-100 dark:hover:bg-amber-900/50 border border-amber-200 dark:border-amber-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                          title="Create one group per tag name that has at least two classes"
+                        >
+                          <Tag className="w-4 h-4 shrink-0" aria-hidden />
+                          <span>Group classes with the same tag</span>
+                        </button>
+                        <p className="text-xs text-gray-500 dark:text-gray-400 mt-2 leading-snug">
+                          Puts classes that share a tag name into separate frames. Multi-tagged classes go to one group
+                          only (see confirmation text). Existing group membership is updated.
                         </p>
                       </section>
 

--- a/objectified-ui/src/app/ade/studio/editor/page.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/page.tsx
@@ -5970,11 +5970,21 @@ const StudioContent = () => {
       rowMaxHeights[row] = Math.max(rowMaxHeights[row] ?? 0, height);
     });
 
+    // Track the widest frame in each group-column to avoid horizontal overlap.
+    const colMaxWidths: number[] = [];
+    planDims.forEach(({ width }, index) => {
+      const col = index % GROUP_COLS;
+      colMaxWidths[col] = Math.max(colMaxWidths[col] ?? 0, width);
+    });
+
     // Derive group-frame origins from actual dimensions + padding.
-    const planPositions = planDims.map(({ width }, index) => {
+    const planPositions = planDims.map((_, index) => {
       const col = index % GROUP_COLS;
       const row = Math.floor(index / GROUP_COLS);
-      const gx = ORIGIN_X + col * (width + INTER_PAD);
+      let gx = ORIGIN_X;
+      for (let c = 0; c < col; c++) {
+        gx += (colMaxWidths[c] ?? 0) + INTER_PAD;
+      }
       let gy = ORIGIN_Y;
       for (let r = 0; r < row; r++) {
         gy += (rowMaxHeights[r] ?? 0) + INTER_PAD;

--- a/objectified-ui/src/app/ade/studio/editor/page.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/page.tsx
@@ -5949,22 +5949,44 @@ const StudioContent = () => {
     const CELL_W = 280;
     const CELL_H = 180;
     const COLS = 2;
-    const GAP_X = 520;
-    const GAP_Y = 420;
+    const INTER_PAD = 40;
+    const GROUP_COLS = 3;
     const ORIGIN_X = 100;
     const ORIGIN_Y = 100;
+
+    // Pre-compute dimensions for each group frame (height varies by class count).
+    const planDims = plan.map((entry) => {
+      const n = entry.classIds.length;
+      const innerRows = Math.ceil(n / COLS);
+      const width = Math.max(400, PAD * 2 + COLS * CELL_W);
+      const height = Math.max(260, PAD * 2 + innerRows * CELL_H);
+      return { width, height };
+    });
+
+    // Track the tallest frame in each group-row to avoid vertical overlap.
+    const rowMaxHeights: number[] = [];
+    planDims.forEach(({ height }, index) => {
+      const row = Math.floor(index / GROUP_COLS);
+      rowMaxHeights[row] = Math.max(rowMaxHeights[row] ?? 0, height);
+    });
+
+    // Derive group-frame origins from actual dimensions + padding.
+    const planPositions = planDims.map(({ width }, index) => {
+      const col = index % GROUP_COLS;
+      const row = Math.floor(index / GROUP_COLS);
+      const gx = ORIGIN_X + col * (width + INTER_PAD);
+      let gy = ORIGIN_Y;
+      for (let r = 0; r < row; r++) {
+        gy += (rowMaxHeights[r] ?? 0) + INTER_PAD;
+      }
+      return { gx, gy };
+    });
 
     const newCanvasGroups: CanvasGroup[] = [];
 
     plan.forEach((entry, index) => {
-      const col = index % 3;
-      const row = Math.floor(index / 3);
-      const gx = ORIGIN_X + col * GAP_X;
-      const gy = ORIGIN_Y + row * GAP_Y;
-      const n = entry.classIds.length;
-      const rows = Math.ceil(n / COLS);
-      const width = Math.max(400, PAD * 2 + COLS * CELL_W);
-      const height = Math.max(260, PAD * 2 + rows * CELL_H);
+      const { gx, gy } = planPositions[index]!;
+      const { width, height } = planDims[index]!;
 
       const groupId = generateGroupId();
       const groupTags = normalizeStoredGroupTags([{ id: entry.tagId }], tagCatalog);
@@ -5993,10 +6015,7 @@ const StudioContent = () => {
 
     const classPositionUpdates = new Map<string, { x: number; y: number }>();
     plan.forEach((entry, index) => {
-      const col = index % 3;
-      const row = Math.floor(index / 3);
-      const gx = ORIGIN_X + col * GAP_X;
-      const gy = ORIGIN_Y + row * GAP_Y;
+      const { gx, gy } = planPositions[index]!;
       entry.classIds.forEach((classId, i) => {
         classPositionUpdates.set(classId, {
           x: gx + PAD + (i % COLS) * CELL_W,

--- a/objectified-ui/src/app/utils/group-classes-by-tag-name.ts
+++ b/objectified-ui/src/app/utils/group-classes-by-tag-name.ts
@@ -1,0 +1,65 @@
+import { mapProjectTagToGroupOption } from '@/app/utils/tag-color-tokens';
+
+export interface TagGroupPlanEntry {
+  /** Display name used for the group title (from project tag catalog when available). */
+  tagName: string;
+  /** Representative project tag id for styling / group tag chips. */
+  tagId: string;
+  classIds: string[];
+}
+
+/**
+ * Plans canvas groups so each tag name (shared by at least two classes) gets its own group.
+ * Classes with multiple tags are assigned to at most one group: the first tag name in
+ * Unicode sort order among tag names that still need members (greedy assignment).
+ */
+export function computeTagGroupPlan(
+  classes: Array<{ id: string; tags?: Array<{ id: string; tag_name?: string; name?: string }> }>,
+  projectTags: Array<{
+    id: string;
+    name?: string;
+    tag_name?: string;
+    color?: string;
+    tag_color?: string;
+  }>
+): TagGroupPlanEntry[] {
+  const catalog = new Map(projectTags.map((t) => [t.id, mapProjectTagToGroupOption(t)]));
+
+  const byTagName = new Map<string, { tagIds: string[]; classIds: Set<string> }>();
+
+  for (const cls of classes) {
+    for (const t of cls.tags || []) {
+      const opt = catalog.get(t.id);
+      const name = (opt?.name ?? t.tag_name ?? t.name ?? '').trim();
+      if (!name) continue;
+
+      let bucket = byTagName.get(name);
+      if (!bucket) {
+        bucket = { tagIds: [], classIds: new Set<string>() };
+        byTagName.set(name, bucket);
+      }
+      if (!bucket.tagIds.includes(t.id)) {
+        bucket.tagIds.push(t.id);
+      }
+      bucket.classIds.add(cls.id);
+    }
+  }
+
+  const sortedNames = [...byTagName.keys()].sort((a, b) => a.localeCompare(b));
+  const assigned = new Set<string>();
+  const result: TagGroupPlanEntry[] = [];
+
+  for (const name of sortedNames) {
+    const bucket = byTagName.get(name)!;
+    const members = [...bucket.classIds].filter((id) => !assigned.has(id));
+    if (members.length < 2) continue;
+
+    const tagId = [...bucket.tagIds].sort()[0]!;
+    for (const id of members) {
+      assigned.add(id);
+    }
+    result.push({ tagName: name, tagId, classIds: members });
+  }
+
+  return result;
+}

--- a/objectified-ui/src/app/utils/group-classes-by-tag-name.ts
+++ b/objectified-ui/src/app/utils/group-classes-by-tag-name.ts
@@ -11,7 +11,9 @@ export interface TagGroupPlanEntry {
 /**
  * Plans canvas groups so each tag name (shared by at least two classes) gets its own group.
  * Classes with multiple tags are assigned to at most one group: the first tag name in
- * Unicode sort order among tag names that still need members (greedy assignment).
+ * Unicode code-point order among tag names that still need members (greedy assignment).
+ * Code-point ordering is used (not localeCompare) to guarantee identical results across
+ * all runtime locales.
  */
 export function computeTagGroupPlan(
   classes: Array<{ id: string; tags?: Array<{ id: string; tag_name?: string; name?: string }> }>,
@@ -45,7 +47,7 @@ export function computeTagGroupPlan(
     }
   }
 
-  const sortedNames = [...byTagName.keys()].sort((a, b) => a.localeCompare(b));
+  const sortedNames = [...byTagName.keys()].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
   const assigned = new Set<string>();
   const result: TagGroupPlanEntry[] = [];
 

--- a/objectified-ui/tests/group-classes-by-tag-name.test.ts
+++ b/objectified-ui/tests/group-classes-by-tag-name.test.ts
@@ -1,0 +1,76 @@
+import { computeTagGroupPlan } from '@/app/utils/group-classes-by-tag-name';
+
+describe('computeTagGroupPlan', () => {
+  const projectTags = [
+    { id: 't1', name: 'Alpha', color: 'primary' },
+    { id: 't2', name: 'Beta', color: 'success' },
+    { id: 't3', name: 'Gamma', color: 'warning' },
+  ];
+
+  it('returns empty when no tag has two or more classes', () => {
+    expect(
+      computeTagGroupPlan(
+        [
+          { id: 'c1', tags: [{ id: 't1', tag_name: 'Alpha' }] },
+          { id: 'c2', tags: [{ id: 't2', tag_name: 'Beta' }] },
+        ],
+        projectTags
+      )
+    ).toEqual([]);
+  });
+
+  it('groups two classes sharing one tag', () => {
+    const plan = computeTagGroupPlan(
+      [
+        { id: 'c1', tags: [{ id: 't1', tag_name: 'Alpha' }] },
+        { id: 'c2', tags: [{ id: 't1', tag_name: 'Alpha' }] },
+      ],
+      projectTags
+    );
+    expect(plan).toHaveLength(1);
+    expect(plan[0]!.tagName).toBe('Alpha');
+    expect(plan[0]!.tagId).toBe('t1');
+    expect(new Set(plan[0]!.classIds)).toEqual(new Set(['c1', 'c2']));
+  });
+
+  it('assigns a multi-tagged class to the first tag name in A–Z order that still forms a multi-class group', () => {
+    const tags = [
+      { id: 'tA', name: 'Alpha', color: 'primary' },
+      { id: 'tZ', name: 'Zeta', color: 'secondary' },
+    ];
+    const plan = computeTagGroupPlan(
+      [
+        {
+          id: 'c1',
+          tags: [
+            { id: 'tZ', tag_name: 'Zeta' },
+            { id: 'tA', tag_name: 'Alpha' },
+          ],
+        },
+        { id: 'c2', tags: [{ id: 'tA', tag_name: 'Alpha' }] },
+        { id: 'c3', tags: [{ id: 'tZ', tag_name: 'Zeta' }] },
+        { id: 'c4', tags: [{ id: 'tZ', tag_name: 'Zeta' }] },
+      ],
+      tags
+    );
+    const alpha = plan.find((p) => p.tagName === 'Alpha');
+    const zeta = plan.find((p) => p.tagName === 'Zeta');
+    expect(alpha?.classIds.sort()).toEqual(['c1', 'c2']);
+    expect(zeta?.classIds.sort()).toEqual(['c3', 'c4']);
+  });
+
+  it('merges classes that share the same display name via different tag ids', () => {
+    const plan = computeTagGroupPlan(
+      [
+        { id: 'c1', tags: [{ id: 't1', tag_name: 'Shared' }] },
+        { id: 'c2', tags: [{ id: 't1a', tag_name: 'Shared' }] },
+      ],
+      [
+        { id: 't1', name: 'Shared', color: 'primary' },
+        { id: 't1a', name: 'Shared', color: 'secondary' },
+      ]
+    );
+    expect(plan).toHaveLength(1);
+    expect(new Set(plan[0]!.classIds)).toEqual(new Set(['c1', 'c2']));
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -2681,7 +2681,7 @@
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
       "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright": "1.59.1"
@@ -5553,7 +5553,6 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -5563,7 +5562,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -6698,7 +6697,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-react-compiler/-/babel-plugin-react-compiler-1.0.0.tgz",
       "integrity": "sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.26.0"
@@ -14569,7 +14568,7 @@
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
       "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.59.1"
@@ -14588,7 +14587,7 @@
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
       "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -14601,7 +14600,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -16312,7 +16310,6 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
       "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/tailwindcss-animate": {
@@ -17869,7 +17866,7 @@
       "version": "1.0.1"
     },
     "objectified-ui": {
-      "version": "0.9.4",
+      "version": "0.9.5",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
@@ -17947,7 +17944,7 @@
         "jest": "^30.3.0",
         "jest-environment-jsdom": "^30.3.0",
         "tailwindcss": "^4.2.2",
-        "ts-jest": "^29.4.6",
+        "ts-jest": "^29.4.9",
         "ts-node": "^10.9.2",
         "typescript": "^5.9.3"
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -45,7 +45,7 @@
   resolved "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.5.tgz"
   integrity sha512-6uFXyCayocRbqhZOB+6XcuZbkMNimwfVGFji8CTZnCzOHVGvDqzvitu1re2AU5LROliz7eQPhB8CpAMvnx9EjA==
 
-"@babel/core@^7.23.9", "@babel/core@^7.24.4", "@babel/core@^7.27.4":
+"@babel/core@^7.0.0", "@babel/core@^7.0.0 || ^8.0.0-0", "@babel/core@^7.0.0-0", "@babel/core@^7.11.0 || ^8.0.0-0", "@babel/core@^7.11.0 || ^8.0.0-beta.1", "@babel/core@^7.23.9", "@babel/core@^7.24.4", "@babel/core@^7.27.4", "@babel/core@>=7.0.0-beta.0 <8":
   version "7.28.5"
   resolved "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz"
   integrity sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==
@@ -366,12 +366,12 @@
     "@csstools/color-helpers" "^5.1.0"
     "@csstools/css-calc" "^2.1.4"
 
-"@csstools/css-parser-algorithms@^3.0.4":
+"@csstools/css-parser-algorithms@^3.0.4", "@csstools/css-parser-algorithms@^3.0.5":
   version "3.0.5"
   resolved "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz"
   integrity sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==
 
-"@csstools/css-tokenizer@^3.0.3":
+"@csstools/css-tokenizer@^3.0.3", "@csstools/css-tokenizer@^3.0.4":
   version "3.0.4"
   resolved "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz"
   integrity sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==
@@ -383,7 +383,7 @@
   dependencies:
     tslib "^2.0.0"
 
-"@dnd-kit/core@^6.3.1":
+"@dnd-kit/core@^6.3.0", "@dnd-kit/core@^6.3.1":
   version "6.3.1"
   resolved "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz"
   integrity sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==
@@ -474,7 +474,7 @@
   resolved "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz"
   integrity sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==
 
-"@emotion/react@^11.14.0":
+"@emotion/react@^11.0.0-rc.0", "@emotion/react@^11.14.0":
   version "11.14.0"
   resolved "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz"
   integrity sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==
@@ -911,7 +911,7 @@
     jest-haste-map "30.3.0"
     slash "^3.0.0"
 
-"@jest/transform@30.3.0":
+"@jest/transform@^29.0.0 || ^30.0.0", "@jest/transform@30.3.0":
   version "30.3.0"
   resolved "https://registry.npmjs.org/@jest/transform/-/transform-30.3.0.tgz"
   integrity sha512-TLKY33fSLVd/lKB2YI1pH69ijyUblO/BQvCj566YvnwuzoTNr648iE0j22vRvVNk2HsPwByPxATg3MleS3gf5A==
@@ -931,7 +931,7 @@
     slash "^3.0.0"
     write-file-atomic "^5.0.1"
 
-"@jest/types@30.3.0":
+"@jest/types@^29.0.0 || ^30.0.0", "@jest/types@30.3.0":
   version "30.3.0"
   resolved "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz"
   integrity sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==
@@ -1075,7 +1075,7 @@
   resolved "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz"
   integrity sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==
 
-"@playwright/test@^1.58.2":
+"@playwright/test@^1.51.1", "@playwright/test@^1.58.2":
   version "1.59.1"
   resolved "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz"
   integrity sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==
@@ -1879,7 +1879,7 @@
     postcss "^8.5.6"
     tailwindcss "4.2.2"
 
-"@testing-library/dom@^10.4.1":
+"@testing-library/dom@^10.0.0", "@testing-library/dom@^10.4.1", "@testing-library/dom@>=7.21.4":
   version "10.4.1"
   resolved "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz"
   integrity sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==
@@ -2341,12 +2341,12 @@
   resolved "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz"
   integrity sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==
 
-"@types/react-dom@^19.2.3":
+"@types/react-dom@*", "@types/react-dom@^18.0.0 || ^19.0.0", "@types/react-dom@^19.2.3":
   version "19.2.3"
   resolved "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz"
   integrity sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==
 
-"@types/react@^19.2.14":
+"@types/react@*", "@types/react@^18.0.0 || ^19.0.0", "@types/react@^19.2.0", "@types/react@^19.2.14", "@types/react@>=16.8", "@types/react@>=18":
   version "19.2.14"
   resolved "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz"
   integrity sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==
@@ -2410,7 +2410,7 @@
     natural-compare "^1.4.0"
     ts-api-utils "^2.1.0"
 
-"@typescript-eslint/parser@8.46.2":
+"@typescript-eslint/parser@^8.46.2", "@typescript-eslint/parser@8.46.2":
   version "8.46.2"
   resolved "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.46.2.tgz"
   integrity sha512-BnOroVl1SgrPLywqxyqdJ4l3S2MsKVLDVxZvjI1Eoe8ev2r3kGDo+PcMihNmDE+6/KjkTubSJnmqGZZjQSBq/g==
@@ -2552,7 +2552,7 @@ acorn-walk@^8.1.1:
   dependencies:
     acorn "^8.11.0"
 
-acorn@^8.11.0, acorn@^8.15.0, acorn@^8.4.1:
+"acorn@^6.0.0 || ^7.0.0 || ^8.0.0", acorn@^8.11.0, acorn@^8.15.0, acorn@^8.4.1:
   version "8.15.0"
   resolved "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz"
   integrity sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==
@@ -2790,7 +2790,7 @@ axobject-query@^4.1.0:
   resolved "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz"
   integrity sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==
 
-babel-jest@30.3.0:
+"babel-jest@^29.0.0 || ^30.0.0", babel-jest@30.3.0:
   version "30.3.0"
   resolved "https://registry.npmjs.org/babel-jest/-/babel-jest-30.3.0.tgz"
   integrity sha512-gRpauEU2KRrCox5Z296aeVHR4jQ98BCnu0IO332D/xpHNOsIH/bgSRk9k6GbKIbBw8vFeN6ctuu6tV8WOyVfYQ==
@@ -2830,7 +2830,7 @@ babel-plugin-macros@^3.1.0:
     cosmiconfig "^7.0.0"
     resolve "^1.19.0"
 
-babel-plugin-react-compiler@^1.0.0:
+babel-plugin-react-compiler@*, babel-plugin-react-compiler@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/babel-plugin-react-compiler/-/babel-plugin-react-compiler-1.0.0.tgz"
   integrity sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==
@@ -2923,7 +2923,7 @@ braces@^3.0.3:
   dependencies:
     fill-range "^7.1.1"
 
-browserslist@^4.24.0:
+browserslist@^4.24.0, "browserslist@>= 4.21.0":
   version "4.27.0"
   resolved "https://registry.npmjs.org/browserslist/-/browserslist-4.27.0.tgz"
   integrity sha512-AXVQwdhot1eqLihwasPElhX2tAZiBjWdJ9i/Zcj2S6QYIjkx62OKSfnobkriB81C3l4w0rVy3Nt4jaTBltYEpw==
@@ -3068,7 +3068,7 @@ chevrotain-allstar@~0.3.1:
   dependencies:
     lodash-es "^4.17.21"
 
-chevrotain@~11.1.1:
+chevrotain@^11.0.0, chevrotain@~11.1.1:
   version "11.1.2"
   resolved "https://registry.npmjs.org/chevrotain/-/chevrotain-11.1.2.tgz"
   integrity sha512-opLQzEVriiH1uUQ4Kctsd49bRoFDXGGSC4GUqj7pGyxM3RehRhvTlZJc1FL/Flew2p5uwxa1tUDWKzI4wNM8pg==
@@ -3271,7 +3271,7 @@ cytoscape-fcose@^2.2.0:
   dependencies:
     cose-base "^2.2.0"
 
-cytoscape@^3.33.1:
+cytoscape@^3.2.0, cytoscape@^3.33.1:
   version "3.33.1"
   resolved "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz"
   integrity sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==
@@ -3984,7 +3984,7 @@ eslint-module-utils@^2.12.1:
   dependencies:
     debug "^3.2.7"
 
-eslint-plugin-import@^2.32.0:
+eslint-plugin-import@*, eslint-plugin-import@^2.32.0:
   version "2.32.0"
   resolved "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz"
   integrity sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==
@@ -4083,7 +4083,7 @@ eslint-visitor-keys@^4.2.1:
   resolved "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz"
   integrity sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==
 
-eslint@^9.39.4:
+eslint@*, "eslint@^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9", "eslint@^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9", "eslint@^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7", "eslint@^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0", "eslint@^6.0.0 || ^7.0.0 || >=8.0.0", "eslint@^8.57.0 || ^9.0.0", eslint@^9.39.4, eslint@>=9.0.0:
   version "9.39.4"
   resolved "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz"
   integrity sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==
@@ -5358,7 +5358,7 @@ jest-resolve-dependencies@30.3.0:
     jest-regex-util "30.0.1"
     jest-snapshot "30.3.0"
 
-jest-resolve@30.3.0:
+jest-resolve@*, jest-resolve@30.3.0:
   version "30.3.0"
   resolved "https://registry.npmjs.org/jest-resolve/-/jest-resolve-30.3.0.tgz"
   integrity sha512-NRtTAHQlpd15F9rUR36jqwelbrDV/dY4vzNte3S2kxCKUJRYNd5/6nTSbYiak1VX5g8IoFF23Uj5TURkUW8O5g==
@@ -5455,7 +5455,7 @@ jest-snapshot@30.3.0:
     semver "^7.7.2"
     synckit "^0.11.8"
 
-jest-util@30.3.0:
+"jest-util@^29.0.0 || ^30.0.0", jest-util@30.3.0:
   version "30.3.0"
   resolved "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz"
   integrity sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==
@@ -5504,7 +5504,7 @@ jest-worker@30.3.0:
     merge-stream "^2.0.0"
     supports-color "^8.1.1"
 
-jest@^30.3.0:
+"jest@^29.0.0 || ^30.0.0", jest@^30.3.0:
   version "30.3.0"
   resolved "https://registry.npmjs.org/jest/-/jest-30.3.0.tgz"
   integrity sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==
@@ -5514,7 +5514,7 @@ jest@^30.3.0:
     import-local "^3.2.0"
     jest-cli "30.3.0"
 
-jiti@^2.6.1:
+jiti@*, jiti@^2.6.1:
   version "2.6.1"
   resolved "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz"
   integrity sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==
@@ -5552,7 +5552,7 @@ js-yaml@^4.1.1:
   dependencies:
     argparse "^2.0.1"
 
-jsdom@^26.1.0:
+jsdom@*, jsdom@^26.1.0:
   version "26.1.0"
   resolved "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz"
   integrity sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==
@@ -5578,7 +5578,7 @@ jsdom@^26.1.0:
     ws "^8.18.0"
     xml-name-validator "^5.0.0"
 
-jsep@^1.4.0:
+jsep@^0.4.0||^1.0.0, jsep@^1.4.0:
   version "1.4.0"
   resolved "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz"
   integrity sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==
@@ -6505,7 +6505,7 @@ mlly@^1.7.4, mlly@^1.8.0:
     pkg-types "^1.3.1"
     ufo "^1.6.1"
 
-monaco-editor@^0.55.1:
+monaco-editor@^0.55.1, "monaco-editor@>= 0.25.0 < 1":
   version "0.55.1"
   resolved "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz"
   integrity sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==
@@ -6558,7 +6558,7 @@ next-themes@^0.4.6:
   resolved "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz"
   integrity sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==
 
-next@^16.2.1:
+"next@^12.2.5 || ^13 || ^14 || ^15 || ^16", next@^16.2.1:
   version "16.2.2"
   resolved "https://registry.npmjs.org/next/-/next-16.2.2.tgz"
   integrity sha512-i6AJdyVa4oQjyvX/6GeER8dpY/xlIV+4NMv/svykcLtURJSy/WzDnnUk/TM4d0uewFHK7xSQz4TbIwPgjky+3A==
@@ -6694,7 +6694,7 @@ object.values@^1.1.6, object.values@^1.2.1:
     es-object-atoms "^1.0.0"
 
 "objectified-ui@file:/home/runner/work/objectified-commercial/objectified-commercial/objectified-ui":
-  version "0.9.4"
+  version "0.9.5"
   resolved "file:objectified-ui"
   dependencies:
     "@dnd-kit/core" "^6.3.1"
@@ -6974,7 +6974,7 @@ pg-types@^2.2.0, pg-types@2.2.0:
     postgres-date "~1.0.4"
     postgres-interval "^1.1.0"
 
-pg@^8.20.0:
+pg@^8.20.0, pg@>=8.0:
   version "8.20.0"
   resolved "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz"
   integrity sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==
@@ -7003,6 +7003,11 @@ picomatch@^2.0.4, picomatch@^2.3.1:
   version "2.3.1"
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
+
+"picomatch@^3 || ^4":
+  version "4.0.3"
+  resolved "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz"
+  integrity sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==
 
 picomatch@^4.0.3:
   version "4.0.4"
@@ -7109,7 +7114,7 @@ preact-render-to-string@^5.1.19:
   dependencies:
     pretty-format "^3.8.0"
 
-preact@^10.6.3:
+preact@^10.6.3, preact@>=10:
   version "10.27.2"
   resolved "https://registry.npmjs.org/preact/-/preact-10.27.2.tgz"
   integrity sha512-5SYSgFKSyhCbk6SrXyMpqjb5+MQBgfvEKE/OC+PujcY34sOpqtr+0AZQtPYx5IA6VxynQ7rUPCtKzyovpj9Bpg==
@@ -7253,7 +7258,7 @@ raf@^3.4.1:
   dependencies:
     performance-now "^2.1.0"
 
-react-dom@^19.2.4:
+"react-dom@^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc", "react-dom@^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom@^17.0.2 || ^18 || ^19", "react-dom@^18.0.0 || ^19.0.0", "react-dom@^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react-dom@^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", react-dom@^19.2.4, react-dom@>=16.8.0, react-dom@>=17, "react-dom@16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc":
   version "19.2.4"
   resolved "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz"
   integrity sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==
@@ -7324,7 +7329,7 @@ react-style-singleton@^2.2.2, react-style-singleton@^2.2.3:
     get-nonce "^1.0.0"
     tslib "^2.0.0"
 
-react@^19.2.4:
+react@*, "react@^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react@^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc", "react@^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react@^16.x || ^17.x || ^18.x || ^19.0.0 || ^19.0.0-rc", "react@^17.0.2 || ^18 || ^19", "react@^18.0.0 || ^19.0.0", "react@^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react@^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", react@^19.2.4, "react@>= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0", react@>=16.8, react@>=16.8.0, react@>=17, react@>=18, "react@16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc":
   version "19.2.4"
   resolved "https://registry.npmjs.org/react/-/react-19.2.4.tgz"
   integrity sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==
@@ -8056,7 +8061,7 @@ tailwindcss-animate@^1.0.7:
   resolved "https://registry.npmjs.org/tailwindcss-animate/-/tailwindcss-animate-1.0.7.tgz"
   integrity sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==
 
-tailwindcss@^4.2.2, tailwindcss@4.2.2:
+tailwindcss@^4.2.2, "tailwindcss@>=3.0.0 || insiders", tailwindcss@4.2.2:
   version "4.2.2"
   resolved "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz"
   integrity sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==
@@ -8153,7 +8158,7 @@ ts-dedent@^2.2.0:
   resolved "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz"
   integrity sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==
 
-ts-jest@^29.4.6:
+ts-jest@^29.4.9:
   version "29.4.9"
   resolved "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.9.tgz"
   integrity sha512-LTb9496gYPMCqjeDLdPrKuXtncudeV1yRZnF4Wo5l3SFi0RYEnYRNgMrFIdg+FHvfzjCyQk1cLncWVqiSX+EvQ==
@@ -8168,7 +8173,7 @@ ts-jest@^29.4.6:
     type-fest "^4.41.0"
     yargs-parser "^21.1.1"
 
-ts-node@^10.9.2:
+ts-node@^10.9.2, ts-node@>=9.0.0:
   version "10.9.2"
   resolved "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz"
   integrity sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==
@@ -8279,7 +8284,7 @@ typescript-eslint@^8.46.0:
     "@typescript-eslint/typescript-estree" "8.46.2"
     "@typescript-eslint/utils" "8.46.2"
 
-typescript@^5.9.3:
+typescript@^5.9.3, typescript@>=2.7, typescript@>=3.3.1, "typescript@>=4.3 <7", typescript@>=4.8.4, "typescript@>=4.8.4 <6.0.0":
   version "5.9.3"
   resolved "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz"
   integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==


### PR DESCRIPTION
## What
Adds **Layout → Group by tag**: one new canvas group per project tag **name** that has at least two classes on the canvas. Classes are removed from their current groups and positioned in a simple grid inside each new frame. Multi-tagged classes are assigned to exactly one group using a deterministic rule (tag names processed A–Z; each class is taken by the first tag bucket that still needs members).

## How to test
1. Open ADE Studio editor with a version that has project tags and several classes sharing a tag name.
2. Open the **Layout** panel (top-right) → **Group classes with the same tag** under **Group by tag**.
3. Confirm the dialog; verify new group frames appear, class positions update, and layout saves when signed in.

## Risk / notes
- Reorganizes group membership for classes that participate in tag groups; confirms before running.
- Uses existing `saveDefaultCanvasLayout` / group sync (same as other group operations).

Closes #96

Made with [Cursor](https://cursor.com)