### PR TITLE
Fix #97 - Custom visual container colors for canvas groups

### DIFF
--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -8,6 +8,7 @@ We continue to improve the platform based on your feedback with improvements and
 - Added ability to start a new project from a template
 
 ## Groups:
+- Canvas group frames: set a custom container color with the palette popover (hex picker and `#RRGGBB` field); colors saved from the database display correctly
 - Layout panel: group classes that share the same project tag name into separate canvas frames (multi-tagged classes are placed in one group via a clear A–Z rule)
 - Canvas groups can be assigned project tags from the group style settings (saved with the group for future search and filtering)
 - Fixed group tag picker and chips so tag names and colors show correctly (project tags use `name`/`color` from the database)

--- a/objectified-ui/src/app/ade/studio/layout.tsx
+++ b/objectified-ui/src/app/ade/studio/layout.tsx
@@ -9,6 +9,7 @@ import { StudioProvider, useStudio } from './StudioContext';
 import { useDialog } from '../../components/providers/DialogProvider';
 import StudioHeader from './components/StudioHeader';
 import { GROUP_COLORS } from '@/app/components/ade/studio/GroupNode';
+import { resolveGroupFrameHex } from '@/app/utils/group-frame-colors';
 
 import StudioSideNav, { ClassItem, PropertyItem, StudioSideNavCallbacks } from '@/app/components/ade/studio/StudioSideNav';
 import PropertyDialog from '@/app/components/ade/studio/PropertyDialog';
@@ -395,11 +396,11 @@ function StudioLayoutContent({ children }: Readonly<{ children: React.ReactNode 
   // Transform groups for sidebar display
   const sidebarGroups = React.useMemo(() => {
     return groups.map(group => {
-      const colorConfig = GROUP_COLORS.find(c => c.name === group.color) || GROUP_COLORS[0];
+      const { hex: colorHex } = resolveGroupFrameHex(group.color, GROUP_COLORS);
       return {
         id: group.id,
         name: group.name,
-        color: colorConfig.hex,
+        color: colorHex,
         nodeIds: group.nodeIds,
       };
     });

--- a/objectified-ui/src/app/components/ade/studio/GroupNode.tsx
+++ b/objectified-ui/src/app/components/ade/studio/GroupNode.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { memo, useState, useCallback, useMemo } from 'react';
+import React, { memo, useState, useCallback, useMemo, useEffect } from 'react';
 import { NodeProps, NodeResizer } from '@xyflow/react';
 import {
   Folder, Edit2, Trash2, X, Check, Palette, Settings,
@@ -11,6 +11,7 @@ import {
 } from 'lucide-react';
 import * as Popover from '@radix-ui/react-popover';
 import { COLLAPSED_GROUP_FRAME_WIDTH, COLLAPSED_GROUP_FRAME_HEIGHT } from '@/app/utils/canvas-group-collapse';
+import { parseCssHexColor, resolveGroupFrameHex } from '@/app/utils/group-frame-colors';
 import { tagChipClass, tagDotClass } from '@/app/utils/tag-color-tokens';
 import GroupBulkEditDialog, { type GroupBulkEditTagOption } from './GroupBulkEditDialog';
 import {
@@ -104,7 +105,8 @@ export interface GroupNodeData {
   id: string;
   name: string;
   description?: string;
-  color: string; // Color name from GROUP_COLORS
+  /** Preset name from GROUP_COLORS or custom `#RRGGBB` / `#RGB` (#97). */
+  color: string;
   nodeIds: string[]; // IDs of nodes contained in this group
   styleOptions?: GroupStyleOptions; // Visual styling options
   isHighlighted?: boolean; // Visual highlight when node is dragged over
@@ -159,6 +161,7 @@ const GroupNode = memo((props: NodeProps) => {
   const [exportPopoverOpen, setExportPopoverOpen] = useState(false);
   const [bulkDialogOpen, setBulkDialogOpen] = useState(false);
   const [isFrameHovered, setIsFrameHovered] = useState(false);
+  const [customHexDraft, setCustomHexDraft] = useState('');
 
   const showFloatingToolbar = useMemo(
     () =>
@@ -180,8 +183,19 @@ const GroupNode = memo((props: NodeProps) => {
     ]
   );
 
-  // Get color configuration
-  const colorConfig = GROUP_COLORS.find(c => c.name === groupData.color) || GROUP_COLORS[0];
+  const { hex: frameHex, preset: matchedPreset } = useMemo(
+    () => resolveGroupFrameHex(groupData.color, GROUP_COLORS),
+    [groupData.color]
+  );
+
+  const presetBorderClass = matchedPreset ? matchedPreset.border : '';
+  const useCustomFrameBorder = !matchedPreset && parseCssHexColor(groupData.color) !== null;
+
+  useEffect(() => {
+    if (!colorPickerOpen) return;
+    const { hex: h, preset: p } = resolveGroupFrameHex(groupData.color, GROUP_COLORS);
+    setCustomHexDraft(p ? '' : h);
+  }, [colorPickerOpen, groupData.color]);
 
   // Get style options with defaults
   const styleOptions = useMemo(
@@ -191,7 +205,7 @@ const GroupNode = memo((props: NodeProps) => {
 
   // Determine if we should use light text based on background darkness
   const useLightText = true;
-  const textColorClass = useLightText ? 'text-white' : colorConfig.text;
+  const textColorClass = useLightText ? 'text-white' : (matchedPreset?.text ?? GROUP_COLORS[0].text);
 
   // Get the icon component
   const IconComponent = GROUP_ICONS.find(i => i.name === styleOptions.icon)?.icon || Folder;
@@ -296,11 +310,14 @@ const GroupNode = memo((props: NodeProps) => {
     [groupData]
   );
 
-  const handleColorChange = useCallback((colorName: string) => {
-    if (groupData.isReadOnly) return;
-    groupData.onColorChange?.(groupData.id, colorName);
-    setColorPickerOpen(false);
-  }, [groupData]);
+  const handleColorChange = useCallback(
+    (colorValue: string) => {
+      if (groupData.isReadOnly) return;
+      groupData.onColorChange?.(groupData.id, colorValue);
+      setColorPickerOpen(false);
+    },
+    [groupData]
+  );
 
   // Handle style option changes
   const handleStyleChange = useCallback(
@@ -351,14 +368,15 @@ const GroupNode = memo((props: NodeProps) => {
         data-testid="group-node-surface"
         className={`
           relative w-full h-full rounded-2xl border-2 transition-all duration-200
-          ${borderStyleClass} ${colorConfig.border} ${shadowClass}
+          ${borderStyleClass} ${presetBorderClass} ${shadowClass}
           ${selected ? 'ring-2 ring-indigo-500 ring-offset-2 dark:ring-offset-gray-900' : ''}
           ${groupData.isHighlighted ? 'ring-4 ring-green-500 ring-offset-4 dark:ring-offset-gray-900 scale-[1.02] border-green-500 dark:border-green-400' : ''}
         `}
         style={{
           minWidth: isCollapsed ? COLLAPSED_GROUP_FRAME_WIDTH : 200,
           minHeight: isCollapsed ? COLLAPSED_GROUP_FRAME_HEIGHT : 150,
-          backgroundColor: `${colorConfig.hex}${Math.round(styleOptions.opacity * 25.5).toString(16).padStart(2, '0')}`
+          backgroundColor: `${frameHex}${Math.round(styleOptions.opacity * 25.5).toString(16).padStart(2, '0')}`,
+          ...(useCustomFrameBorder ? { borderColor: `${frameHex}99` } : {})
         }}
         onMouseEnter={() => setIsFrameHovered(true)}
         onMouseLeave={() => setIsFrameHovered(false)}
@@ -367,11 +385,12 @@ const GroupNode = memo((props: NodeProps) => {
         <div
           className={`
             absolute -top-3 left-4 px-3 py-1 rounded-lg border ${shadowClass || 'shadow-sm'}
-            ${colorConfig.border} ${textColorClass}
+            ${presetBorderClass} ${textColorClass}
             flex items-center gap-2 cursor-move
           `}
           style={{
-            backgroundColor: `${colorConfig.hex}${Math.round(Math.min(styleOptions.opacity + 0.3, 1) * 255).toString(16).padStart(2, '0')}`
+            backgroundColor: `${frameHex}${Math.round(Math.min(styleOptions.opacity + 0.3, 1) * 255).toString(16).padStart(2, '0')}`,
+            ...(useCustomFrameBorder ? { borderColor: `${frameHex}cc` } : {})
           }}
         >
           <button
@@ -471,10 +490,11 @@ const GroupNode = memo((props: NodeProps) => {
             className={`
               absolute -top-6 right-[-2px] z-20 flex max-w-[min(100%,calc(100vw-2rem))] flex-wrap items-center gap-1 rounded-lg border px-1.5 py-1
               ${shadowClass || 'shadow-md'}
-              ${colorConfig.border} ${textColorClass}
+              ${presetBorderClass} ${textColorClass}
             `}
             style={{
-              backgroundColor: `${colorConfig.hex}${Math.round(Math.min(styleOptions.opacity + 0.3, 1) * 255).toString(16).padStart(2, '0')}`
+              backgroundColor: `${frameHex}${Math.round(Math.min(styleOptions.opacity + 0.3, 1) * 255).toString(16).padStart(2, '0')}`,
+              ...(useCustomFrameBorder ? { borderColor: `${frameHex}cc` } : {})
             }}
             onMouseDown={(e) => e.stopPropagation()}
             onPointerDown={(e) => e.stopPropagation()}
@@ -686,15 +706,56 @@ const GroupNode = memo((props: NodeProps) => {
                       {GROUP_COLORS.map((color) => (
                         <button
                           key={color.name}
+                          type="button"
+                          disabled={groupData.isReadOnly}
                           onClick={() => handleColorChange(color.name)}
                           className={`
                             w-6 h-6 rounded-full border-2 transition-transform hover:scale-110
-                            ${color.name === groupData.color ? 'ring-2 ring-offset-2 ring-indigo-500' : ''}
+                            ${color.name === groupData.color ? 'ring-2 ring-offset-2 ring-indigo-500 dark:ring-offset-gray-800' : ''}
                           `}
                           style={{ backgroundColor: color.hex }}
                           title={color.name}
                         />
                       ))}
+                    </div>
+                    <div className="border-t border-gray-200 dark:border-gray-600 pt-3 mt-3 space-y-2">
+                      <div className="text-xs font-medium text-gray-600 dark:text-gray-400">Custom color</div>
+                      <div className="flex items-center gap-2">
+                        <input
+                          type="color"
+                          value={frameHex}
+                          onChange={(e) => {
+                            const v = parseCssHexColor(e.target.value);
+                            if (v) handleColorChange(v);
+                          }}
+                          className="h-8 w-10 shrink-0 cursor-pointer rounded border border-gray-300 dark:border-gray-600 bg-transparent p-0"
+                          title="Pick a custom container color"
+                          aria-label="Custom color picker"
+                          disabled={groupData.isReadOnly}
+                        />
+                        <input
+                          type="text"
+                          value={customHexDraft}
+                          onChange={(e) => setCustomHexDraft(e.target.value)}
+                          onKeyDown={(e) => {
+                            if (e.key === 'Enter') {
+                              const v = parseCssHexColor(customHexDraft);
+                              if (v) handleColorChange(v);
+                            }
+                          }}
+                          onBlur={() => {
+                            const v = parseCssHexColor(customHexDraft);
+                            if (v) handleColorChange(v);
+                          }}
+                          placeholder="#6366f1"
+                          disabled={groupData.isReadOnly}
+                          className="min-w-0 flex-1 rounded-md border border-gray-200 bg-white px-2 py-1 font-mono text-xs text-gray-900 dark:border-gray-600 dark:bg-gray-900 dark:text-gray-100"
+                          aria-label="Custom color hex value"
+                        />
+                      </div>
+                      {useCustomFrameBorder ? (
+                        <p className="text-[10px] text-gray-500 dark:text-gray-400">Custom container color (saved with the layout)</p>
+                      ) : null}
                     </div>
                     <Popover.Arrow className="fill-white dark:fill-gray-800" />
                   </Popover.Content>

--- a/objectified-ui/src/app/components/ade/studio/GroupNode.tsx
+++ b/objectified-ui/src/app/components/ade/studio/GroupNode.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { memo, useState, useCallback, useMemo, useEffect } from 'react';
+import React, { memo, useState, useCallback, useMemo, useEffect, useRef } from 'react';
 import { NodeProps, NodeResizer } from '@xyflow/react';
 import {
   Folder, Edit2, Trash2, X, Check, Palette, Settings,
@@ -157,6 +157,7 @@ const GroupNode = memo((props: NodeProps) => {
   const [isEditing, setIsEditing] = useState(false);
   const [editName, setEditName] = useState(groupData.name);
   const [colorPickerOpen, setColorPickerOpen] = useState(false);
+  const colorPopoverContentRef = useRef<HTMLDivElement>(null);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [exportPopoverOpen, setExportPopoverOpen] = useState(false);
   const [bulkDialogOpen, setBulkDialogOpen] = useState(false);
@@ -697,6 +698,7 @@ const GroupNode = memo((props: NodeProps) => {
                 </Popover.Trigger>
                 <Popover.Portal>
                   <Popover.Content
+                    ref={colorPopoverContentRef}
                     className="z-[9999] bg-white dark:bg-gray-800 rounded-xl shadow-xl border border-gray-200 dark:border-gray-700 p-3"
                     sideOffset={5}
                     onOpenAutoFocus={(e) => e.preventDefault()}
@@ -743,7 +745,13 @@ const GroupNode = memo((props: NodeProps) => {
                               if (v) handleColorChange(v);
                             }
                           }}
-                          onBlur={() => {
+                          onBlur={(e) => {
+                            if (
+                              e.relatedTarget instanceof Element &&
+                              colorPopoverContentRef.current?.contains(e.relatedTarget)
+                            ) {
+                              return;
+                            }
                             const v = parseCssHexColor(customHexDraft);
                             if (v) handleColorChange(v);
                           }}

--- a/objectified-ui/src/app/utils/group-frame-colors.ts
+++ b/objectified-ui/src/app/utils/group-frame-colors.ts
@@ -1,0 +1,46 @@
+/**
+ * Resolve canvas group frame colors: presets use theme names; DB and custom picks use #RGB / #RRGGBB (#97).
+ */
+
+export type GroupColorPreset = {
+  name: string;
+  hex: string;
+  bg: string;
+  border: string;
+  text: string;
+};
+
+/** Parse and normalize a CSS hex color, or null if invalid. */
+export function parseCssHexColor(input: string | undefined | null): string | null {
+  if (input == null || typeof input !== 'string') return null;
+  const s = input.trim();
+  const m = /^#([0-9a-f]{3}|[0-9a-f]{6})$/i.exec(s);
+  if (!m) return null;
+  const cap = m[1];
+  if (cap.length === 3) {
+    const [r, g, b] = cap.split('').map((c) => c + c);
+    return `#${r}${g}${b}`.toLowerCase();
+  }
+  return `#${cap.toLowerCase()}`;
+}
+
+export function resolveGroupFrameHex(
+  color: string | undefined,
+  presets: readonly GroupColorPreset[]
+): { hex: string; preset: GroupColorPreset | null } {
+  if (!presets.length) {
+    return { hex: '#6366f1', preset: null };
+  }
+  if (!color) {
+    return { hex: presets[0].hex, preset: presets[0] };
+  }
+  const byName = presets.find((p) => p.name === color);
+  if (byName) {
+    return { hex: byName.hex, preset: byName };
+  }
+  const hex = parseCssHexColor(color);
+  if (hex) {
+    return { hex, preset: null };
+  }
+  return { hex: presets[0].hex, preset: presets[0] };
+}

--- a/objectified-ui/tests/unit/group-frame-colors.test.ts
+++ b/objectified-ui/tests/unit/group-frame-colors.test.ts
@@ -1,0 +1,48 @@
+import {
+  parseCssHexColor,
+  resolveGroupFrameHex,
+} from '@/app/utils/group-frame-colors';
+
+const PRESETS = [
+  { name: 'indigo', hex: '#6366f1', bg: '', border: '', text: '' },
+  { name: 'blue', hex: '#3b82f6', bg: '', border: '', text: '' },
+] as const;
+
+describe('group-frame-colors', () => {
+  describe('parseCssHexColor', () => {
+    it('normalizes 6-digit hex', () => {
+      expect(parseCssHexColor('#Aa00Ff')).toBe('#aa00ff');
+    });
+
+    it('expands 3-digit hex', () => {
+      expect(parseCssHexColor('#abc')).toBe('#aabbcc');
+    });
+
+    it('returns null for invalid input', () => {
+      expect(parseCssHexColor('')).toBeNull();
+      expect(parseCssHexColor('indigo')).toBeNull();
+      expect(parseCssHexColor('#gg0000')).toBeNull();
+      expect(parseCssHexColor('#12345')).toBeNull();
+    });
+  });
+
+  describe('resolveGroupFrameHex', () => {
+    it('resolves preset by name', () => {
+      const r = resolveGroupFrameHex('blue', PRESETS);
+      expect(r.hex).toBe('#3b82f6');
+      expect(r.preset?.name).toBe('blue');
+    });
+
+    it('resolves custom hex from DB', () => {
+      const r = resolveGroupFrameHex('#EF4444', PRESETS);
+      expect(r.hex).toBe('#ef4444');
+      expect(r.preset).toBeNull();
+    });
+
+    it('falls back to first preset for unknown strings', () => {
+      const r = resolveGroupFrameHex('not-a-color', PRESETS);
+      expect(r.hex).toBe('#6366f1');
+      expect(r.preset).toBe(PRESETS[0]);
+    });
+  });
+});


### PR DESCRIPTION
## What / why
Canvas group frames already stored `color` as a hex string in the database, but the UI only treated values as preset names. That made DB-backed hex colors render as the wrong swatch. This adds explicit hex resolution and a **Custom color** section (native picker + `#RRGGBB` field) in the group palette popover so teams can define **custom visual containers** for grouped classes.

## How to test
1. Open the studio canvas, add or select a group frame.
2. Open the palette popover on the group toolbar → **Custom color**: pick a color or enter e.g. `#ef4444`.
3. Save layout / reload: the frame should keep the chosen color.
4. Run `npm test -- tests/unit/group-frame-colors.test.ts` in `objectified-ui`.

## Risk / notes
- Custom colors persist as `#RRGGBB` in `group.color` (same column as before). Preset names still work.
- Project ESLint reports many pre-existing issues; `next build` and the new unit tests pass.

Closes #97

Made with [Cursor](https://cursor.com)