### PR TITLE
Fix #98 - Expand/collapse group entries in studio Groups tab

### DIFF
--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -8,6 +8,7 @@ We continue to improve the platform based on your feedback with improvements and
 - Added ability to start a new project from a template
 
 ## Groups:
+- Studio **Groups** tab: each group row can expand or collapse; collapsed rows show the group name and node count, expanded rows list the classes in that group (click a class to focus it on the canvas when click-to-focus is enabled)
 - Canvas group frames: set a custom container color with the palette popover (hex picker and `#RRGGBB` field); colors saved from the database display correctly
 - Layout panel: group classes that share the same project tag name into separate canvas frames (multi-tagged classes are placed in one group via a clear A–Z rule)
 - Canvas groups can be assigned project tags from the group style settings (saved with the group for future search and filtering)

--- a/objectified-ui/src/app/components/ade/studio/StudioSideNav.tsx
+++ b/objectified-ui/src/app/components/ade/studio/StudioSideNav.tsx
@@ -3,7 +3,7 @@
 
 import React, { useState } from 'react';
 import * as Tabs from '@radix-ui/react-tabs';
-import { Search, Plus, Pencil, Trash2, FileX, Upload, Library, ChevronDown, ChevronUp, Eye, EyeOff } from 'lucide-react';
+import { Search, Plus, Pencil, Trash2, FileX, Upload, Library, ChevronDown, ChevronUp, ChevronRight, Eye, EyeOff } from 'lucide-react';
 import { getPropertiesForClass } from '../../../../../lib/db/helper';
 import { useDarkMode } from '@/app/hooks/useDarkMode';
 
@@ -116,6 +116,7 @@ const StudioSideNav: React.FC<StudioSideNavProps> = ({
   const [selectedPropertyId, setSelectedPropertyId] = useState<string | null>(null);
   const [classWarnings, setClassWarnings] = useState<Record<string, boolean>>({});
   const [expandedPropertyIds, setExpandedPropertyIds] = useState<Set<string>>(new Set());
+  const [expandedGroupIds, setExpandedGroupIds] = useState<Set<string>>(new Set());
 
   // Helper to check if a property has inline properties (type: 'object' with properties, or array of objects)
   const hasInlineProperties = (prop: PropertyItem): boolean => {
@@ -161,6 +162,18 @@ const StudioSideNav: React.FC<StudioSideNavProps> = ({
     }
 
     return children;
+  };
+
+  const toggleGroupExpanded = (groupId: string) => {
+    setExpandedGroupIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(groupId)) {
+        next.delete(groupId);
+      } else {
+        next.add(groupId);
+      }
+      return next;
+    });
   };
 
   // Toggle expanded state for a property
@@ -681,48 +694,114 @@ const StudioSideNav: React.FC<StudioSideNavProps> = ({
                   </div>
                 ) : (
                   <ul className="py-1 space-y-1 list-none p-0 m-0">
-                    {filteredGroups.map((group) => (
-                      <li key={group.id} className="mb-1 flex items-stretch rounded-lg group">
-                        <button
-                          type="button"
-                          onClick={() => callbacks.onGroupSelect?.(group.id)}
-                          className="flex-1 flex items-center gap-3 text-left rounded-lg px-3 py-2 transition-all hover:bg-violet-500/5 min-w-0"
-                        >
-                          <span
-                            className="w-3 h-3 rounded flex-shrink-0"
-                            style={{ backgroundColor: group.color || '#8b5cf6' }}
-                          />
-                          <div className="flex-1 min-w-0">
-                            <span className="block text-sm font-medium truncate">{group.name}</span>
-                            <span className="block text-xs text-slate-500 dark:text-slate-400 truncate">
-                              {group.nodeIds?.length || 0} classes
-                            </span>
-                          </div>
-                        </button>
-                        {!isReadOnly && (
-                          <div className="flex items-center opacity-60 group-hover:opacity-100">
-                            {(group.nodeIds?.length ?? 0) > 0 && (
+                    {filteredGroups.map((group) => {
+                      const nodeCount = group.nodeIds?.length ?? 0;
+                      const isGroupExpanded = expandedGroupIds.has(group.id);
+                      return (
+                        <li key={group.id} className="mb-1 rounded-lg group">
+                          <div className="flex flex-col rounded-lg">
+                            <div className="flex items-stretch">
                               <button
                                 type="button"
-                                onClick={(e) => { e.stopPropagation(); callbacks.onGroupDeleteAllClasses?.(group.id); }}
-                                title="Delete all classes in group"
-                                className="p-1.5 rounded hover:bg-amber-500/10 hover:text-amber-500"
+                                data-testid={`group-expand-${group.id}`}
+                                aria-expanded={isGroupExpanded}
+                                aria-label={isGroupExpanded ? 'Collapse group' : 'Expand group'}
+                                title={isGroupExpanded ? 'Collapse group' : 'Expand group'}
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  toggleGroupExpanded(group.id);
+                                }}
+                                className="shrink-0 flex w-8 items-center justify-center rounded-l-lg text-slate-500 hover:bg-violet-500/10 hover:text-violet-600 dark:hover:text-violet-400"
                               >
-                                <FileX className="w-4 h-4" />
+                                {isGroupExpanded ? (
+                                  <ChevronDown className="h-4 w-4" aria-hidden />
+                                ) : (
+                                  <ChevronRight className="h-4 w-4" aria-hidden />
+                                )}
                               </button>
+                              <button
+                                type="button"
+                                onClick={() => callbacks.onGroupSelect?.(group.id)}
+                                className="flex min-w-0 flex-1 items-center gap-3 rounded-r-lg py-2 pl-1 pr-3 text-left transition-all hover:bg-violet-500/5"
+                              >
+                                <span
+                                  className="h-3 w-3 shrink-0 rounded"
+                                  style={{ backgroundColor: group.color || '#8b5cf6' }}
+                                />
+                                <div className="flex min-w-0 flex-1 items-baseline justify-between gap-2">
+                                  <span className="truncate text-sm font-medium text-slate-900 dark:text-slate-100">
+                                    {group.name}
+                                  </span>
+                                  <span className="shrink-0 text-xs text-slate-500 tabular-nums dark:text-slate-400">
+                                    ({nodeCount})
+                                  </span>
+                                </div>
+                              </button>
+                              {!isReadOnly && (
+                                <div className="flex items-center opacity-60 group-hover:opacity-100">
+                                  {nodeCount > 0 && (
+                                    <button
+                                      type="button"
+                                      onClick={(e) => {
+                                        e.stopPropagation();
+                                        callbacks.onGroupDeleteAllClasses?.(group.id);
+                                      }}
+                                      title="Delete all classes in group"
+                                      className="rounded p-1.5 hover:bg-amber-500/10 hover:text-amber-500"
+                                    >
+                                      <FileX className="h-4 w-4" />
+                                    </button>
+                                  )}
+                                  <button
+                                    type="button"
+                                    onClick={(e) => {
+                                      e.stopPropagation();
+                                      callbacks.onGroupDelete?.(group.id);
+                                    }}
+                                    title="Delete group"
+                                    className="rounded p-1.5 hover:bg-red-500/10 hover:text-red-500"
+                                  >
+                                    <Trash2 className="h-4 w-4" />
+                                  </button>
+                                </div>
+                              )}
+                            </div>
+                            {isGroupExpanded && (
+                              <ul className="ml-8 mr-2 mb-2 mt-0.5 list-none space-y-0.5 border-l border-slate-200 py-0.5 pl-2 dark:border-slate-600">
+                                {nodeCount === 0 ? (
+                                  <li className="px-1 py-0.5 text-xs italic text-slate-500 dark:text-slate-400">
+                                    No classes in this group
+                                  </li>
+                                ) : (
+                                  group.nodeIds.map((nodeId) => {
+                                    const classItem = classes.find((c) => c.id === nodeId);
+                                    const label = classItem?.name ?? nodeId;
+                                    return (
+                                      <li key={nodeId}>
+                                        <button
+                                          type="button"
+                                          data-testid={`group-class-${group.id}-${nodeId}`}
+                                          onClick={() => {
+                                            if (classItem) {
+                                              handleClassSelect(classItem);
+                                            }
+                                          }}
+                                          disabled={!classItem}
+                                          title={classItem ? `Focus ${classItem.name}` : 'Unknown class'}
+                                          className="w-full truncate rounded px-1 py-0.5 text-left text-xs text-slate-600 hover:bg-violet-500/10 disabled:cursor-default disabled:opacity-60 dark:text-slate-300"
+                                        >
+                                          {label}
+                                        </button>
+                                      </li>
+                                    );
+                                  })
+                                )}
+                              </ul>
                             )}
-                            <button
-                              type="button"
-                              onClick={(e) => { e.stopPropagation(); callbacks.onGroupDelete?.(group.id); }}
-                              title="Delete group"
-                              className="p-1.5 rounded hover:bg-red-500/10 hover:text-red-500"
-                            >
-                              <Trash2 className="w-4 h-4" />
-                            </button>
                           </div>
-                        )}
-                      </li>
-                    ))}
+                        </li>
+                      );
+                    })}
                   </ul>
                 )}
               </div>

--- a/objectified-ui/tests/StudioSideNav-groups-expand.test.tsx
+++ b/objectified-ui/tests/StudioSideNav-groups-expand.test.tsx
@@ -1,0 +1,100 @@
+/**
+ * Studio sidebar Groups tab: expand/collapse group entries (#98).
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+
+import StudioSideNav from '../src/app/components/ade/studio/StudioSideNav';
+
+jest.mock('../lib/db/helper', () => ({
+  getPropertiesForClass: jest.fn().mockResolvedValue('[]'),
+}));
+
+describe('StudioSideNav Groups expand/collapse', () => {
+  const groups = [
+    {
+      id: 'g1',
+      name: 'Orders',
+      color: '#8b5cf6',
+      nodeIds: ['c1', 'c2'],
+    },
+  ];
+
+  const classes = [
+    { id: 'c1', name: 'Order' },
+    { id: 'c2', name: 'LineItem' },
+  ];
+
+  it('shows group title and node count when collapsed; lists classes when expanded', async () => {
+    const user = userEvent.setup();
+    render(
+      <StudioSideNav
+        classes={classes}
+        groups={groups}
+        selectedProjectId="p1"
+        selectedVersionId={null}
+        callbacks={{}}
+      />
+    );
+
+    await user.click(screen.getByRole('tab', { name: 'Groups' }));
+
+    expect(screen.getByText('Orders')).toBeInTheDocument();
+    expect(screen.getByText('(2)')).toBeInTheDocument();
+    expect(screen.queryByText('Order')).not.toBeInTheDocument();
+    expect(screen.queryByText('LineItem')).not.toBeInTheDocument();
+
+    await user.click(screen.getByTestId('group-expand-g1'));
+
+    expect(screen.getByText('Order')).toBeInTheDocument();
+    expect(screen.getByText('LineItem')).toBeInTheDocument();
+  });
+
+  it('toggles aria-expanded on the expand control', async () => {
+    const user = userEvent.setup();
+    render(
+      <StudioSideNav
+        classes={classes}
+        groups={groups}
+        selectedProjectId="p1"
+        selectedVersionId={null}
+        callbacks={{}}
+      />
+    );
+
+    await user.click(screen.getByRole('tab', { name: 'Groups' }));
+
+    const expandBtn = screen.getByRole('button', { name: 'Expand group' });
+    expect(expandBtn).toHaveAttribute('aria-expanded', 'false');
+
+    await user.click(expandBtn);
+    expect(screen.getByRole('button', { name: 'Collapse group' })).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('calls onClassSelect when clicking a class under an expanded group', async () => {
+    const onClassSelect = jest.fn();
+    const user = userEvent.setup();
+
+    render(
+      <StudioSideNav
+        classes={classes}
+        groups={groups}
+        selectedProjectId="p1"
+        selectedVersionId={null}
+        callbacks={{ onClassSelect }}
+      />
+    );
+
+    await user.click(screen.getByRole('tab', { name: 'Groups' }));
+    await user.click(screen.getByTestId('group-expand-g1'));
+    await user.click(screen.getByTestId('group-class-g1-c1'));
+
+    expect(onClassSelect).toHaveBeenCalledTimes(1);
+    expect(onClassSelect).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'c1', name: 'Order' })
+    );
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -17866,7 +17866,7 @@
       "version": "1.0.1"
     },
     "objectified-ui": {
-      "version": "0.9.5",
+      "version": "0.9.7",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",


### PR DESCRIPTION
## What
Adds per-group expand/collapse on the ADE studio **Groups** sidebar tab. Each row always shows the group name and node count `(n)`. Expanding lists each class in the group; clicking a class runs the existing `onClassSelect` handler (same as the Classes tab, including zoom when click-to-focus is on).

## How to test
1. Open a version with canvas groups that contain classes.
2. Open the sidebar **Groups** tab.
3. Use the chevron to expand/collapse a group; confirm collapsed state shows name + count only (no class list), expanded state lists class names.
4. Click a class name under an expanded group and confirm canvas focus/zoom behavior matches the Classes tab.

## Risk / notes
- UI-only change in `StudioSideNav`; group frame behavior on the canvas is unchanged.
- Unknown node IDs (missing from `classes`) still appear with their id and are not clickable.

Closes #98

Made with [Cursor](https://cursor.com)