### PR TITLE
Fix #2531 - What's New dialog viewport centering

### DIFF
--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.9.7",
+  "version": "0.9.8",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -4,6 +4,9 @@ We continue to improve the platform based on your feedback with improvements and
 
 ---
 
+## UI:
+- **What's New** dialog is centered on the viewport again (overlay renders outside the header so it is not offset downward)
+
 ## Projects:
 - Added ability to start a new project from a template
 

--- a/objectified-ui/src/app/components/ade/WhatsNewDialog.tsx
+++ b/objectified-ui/src/app/components/ade/WhatsNewDialog.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import rehypeRaw from 'rehype-raw';
@@ -33,7 +34,7 @@ const WhatsNewDialog: React.FC<WhatsNewDialogProps> = ({ isOpen, onClose }) => {
 
   if (!isOpen) return null;
 
-  return (
+  return createPortal(
     <div
       className="fixed inset-0 z-[3000] flex items-center justify-center bg-black/50 backdrop-blur-sm"
       onClick={onClose}
@@ -206,7 +207,8 @@ const WhatsNewDialog: React.FC<WhatsNewDialogProps> = ({ isOpen, onClose }) => {
           )}
         </div>
       </div>
-    </div>
+    </div>,
+    document.body
   );
 };
 

--- a/objectified-ui/tests/WhatsNewDialog.test.tsx
+++ b/objectified-ui/tests/WhatsNewDialog.test.tsx
@@ -1,0 +1,49 @@
+/**
+ * What's New dialog: viewport-centered overlay (#2531).
+ */
+
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+jest.mock('rehype-raw', () => ({
+  __esModule: true,
+  default: () => () => {},
+}));
+
+import WhatsNewDialog from '../src/app/components/ade/WhatsNewDialog';
+
+describe('WhatsNewDialog', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn();
+    (global.fetch as jest.Mock).mockResolvedValue({
+      text: () => Promise.resolve('# Test\n\nHello.'),
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('renders the backdrop as a direct child of document.body (viewport-fixed centering)', async () => {
+    render(<WhatsNewDialog isOpen onClose={jest.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: /what's new/i })).toBeInTheDocument();
+    });
+
+    const backdrop = screen
+      .getByRole('heading', { name: /what's new/i })
+      .closest('.fixed.inset-0');
+
+    expect(backdrop).toBeTruthy();
+    expect(backdrop?.parentElement).toBe(document.body);
+  });
+
+  it('renders nothing when closed', () => {
+    const { container } = render(<WhatsNewDialog isOpen={false} onClose={jest.fn()} />);
+
+    expect(container.firstChild).toBeNull();
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -17866,7 +17866,7 @@
       "version": "1.0.1"
     },
     "objectified-ui": {
-      "version": "0.9.7",
+      "version": "0.9.8",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",


### PR DESCRIPTION
## What changed
The **What's New** overlay was rendered inside `TopHeader`, which uses `backdrop-blur-sm` (`backdrop-filter`). That establishes a containing block in supporting browsers, so `position: fixed` was resolved against the header instead of the viewport—making the modal look vertically offset (centered under the header bar).

The dialog is now rendered with `createPortal(..., document.body)` so the full-screen backdrop and flex centering apply to the real viewport.

## How to test
1. Open the ADE app with the top header visible.
2. Click the version / **What's New** control next to the logo.
3. Confirm the modal and dimmed backdrop are centered in the browser window (not shifted down as if tied to the header).

## Risk / notes
- Low risk: same markup and behavior; only the mount point changes.
- Monorepo `yarn build` via turbo failed locally due to workspace lockfile resolution (`yarn install` needed); `objectified-ui` `npm run build` and full `objectified-ui` Jest suite passed.

Closes #2531

Made with [Cursor](https://cursor.com)