### PR TITLE
Fix review feedback on ImportExecutionPanel (#296)

### DIFF
--- a/objectified-ui/lib/import-execution-live-rows.ts
+++ b/objectified-ui/lib/import-execution-live-rows.ts
@@ -1,0 +1,204 @@
+/**
+ * Derives per-schema checklist rows for the Import Execution panel (#296).
+ */
+
+import type { ImportEventLike } from './import-execution-error-indicators';
+
+export type LiveChecklistStatus = 'pending' | 'importing' | 'success' | 'warning' | 'error';
+
+export interface LiveChecklistRow {
+  id: string;
+  label: string;
+  status: LiveChecklistStatus;
+  detail?: string;
+}
+
+export interface ProgressLike {
+  phase?: string;
+  total?: number;
+  completed?: number;
+  currentItem?: string;
+}
+
+const CLASS_CREATED_RE = /^(?:Imported class:|Would import class:)\s*(.+)$/i;
+const CLASS_FAILED_RE = /^Failed to create class\s+([^:]+)/i;
+
+function extractCreatedClassName(message: string): string | null {
+  const m = message.match(CLASS_CREATED_RE);
+  return m ? m[1].trim() : null;
+}
+
+function extractFailedClassName(message: string): string | null {
+  const m = message.match(CLASS_FAILED_RE);
+  return m ? m[1].trim() : null;
+}
+
+function namesMatch(a: string, b: string): boolean {
+  if (a === b) return true;
+  return a.trim().toLowerCase() === b.trim().toLowerCase();
+}
+
+/** Preserve schema order from CLASS_CREATED / CLASS_FAILED sequence when Preview list is unavailable. */
+function inferOrderFromEvents(
+  events: ImportEventLike[],
+  created: Set<string>,
+  failed: Set<string>
+): string[] {
+  const seen = new Set<string>();
+  const order: string[] = [];
+  for (const ev of events) {
+    if (ev.code === 'CLASS_CREATED') {
+      const n = extractCreatedClassName(ev.message);
+      if (n && !seen.has(n)) {
+        seen.add(n);
+        order.push(n);
+      }
+    }
+    if (ev.code === 'CLASS_FAILED') {
+      const n = extractFailedClassName(ev.message);
+      if (n && !seen.has(n)) {
+        seen.add(n);
+        order.push(n);
+      }
+    }
+  }
+  for (const name of failed) {
+    if (!seen.has(name)) order.push(name);
+  }
+  for (const name of created) {
+    if (!seen.has(name)) order.push(name);
+  }
+  return order;
+}
+
+/** Warning lines associated with a class from import events. */
+function warningDetailForClass(events: ImportEventLike[], className: string): string | undefined {
+  const parts: string[] = [];
+  for (const ev of events) {
+    if (ev.level !== 'warn') continue;
+    const ctx = ev.context as { className?: string; propertyName?: string } | undefined;
+    if (ctx?.className && namesMatch(ctx.className, className)) {
+      parts.push(ev.message);
+      continue;
+    }
+    if (ev.message.includes(`class "${className}"`) || ev.message.includes(`class '${className}'`)) {
+      parts.push(ev.message);
+    }
+  }
+  if (parts.length === 0) return undefined;
+  return parts[0];
+}
+
+/**
+ * Builds one row per selected schema with pending / importing / success / warning / error.
+ * When `selectedSchemas` is empty, returns rows inferred from CLASS_CREATED / CLASS_FAILED events (order preserved by first appearance).
+ */
+export function buildImportLiveChecklist(
+  selectedSchemas: string[],
+  events: ImportEventLike[],
+  progress: ProgressLike | undefined,
+  jobState: string
+): LiveChecklistRow[] {
+  const created = new Set<string>();
+  const failed = new Set<string>();
+
+  for (const ev of events) {
+    if (ev.code === 'CLASS_CREATED') {
+      const n = extractCreatedClassName(ev.message);
+      if (n) created.add(n);
+    }
+    if (ev.code === 'CLASS_FAILED') {
+      const n = extractFailedClassName(ev.message);
+      if (n) failed.add(n);
+    }
+  }
+
+  const runningLike = ['queued', 'running', 'committing'].includes(jobState);
+
+  const order: string[] =
+    selectedSchemas.length > 0
+      ? [...selectedSchemas]
+      : inferOrderFromEvents(events, created, failed);
+
+  if (order.length === 0) {
+    return [];
+  }
+
+  const rows: LiveChecklistRow[] = order.map((label, i) => {
+    const id = `schema-${i}-${label}`;
+    const isFailed = [...failed].some((f) => namesMatch(f, label));
+    if (isFailed) {
+      return { id, label, status: 'error' as const };
+    }
+
+    const isCreated = [...created].some((c) => namesMatch(c, label));
+
+    if (isCreated) {
+      const warnDetail = warningDetailForClass(events, label);
+      if (warnDetail) {
+        return { id, label, status: 'warning' as const, detail: warnDetail };
+      }
+      return { id, label, status: 'success' as const };
+    }
+
+    const importing =
+      runningLike &&
+      progress?.phase === 'creating-classes' &&
+      progress.currentItem &&
+      namesMatch(progress.currentItem, label);
+
+    if (importing) {
+      return { id, label, status: 'importing' as const };
+    }
+
+    return { id, label, status: 'pending' as const };
+  });
+
+  return rows;
+}
+
+export function formatProgressPrimaryLine(
+  progress: ProgressLike | undefined,
+  jobState: string
+): string {
+  if (!progress) {
+    return jobState === 'queued' ? 'Waiting to start…' : 'Preparing…';
+  }
+
+  const { phase, total = 0, completed = 0, currentItem } = progress;
+
+  if (phase === 'creating-classes' && total >= 2) {
+    const n = total - 2;
+    if (n > 0) {
+      const idx = Math.min(Math.max(completed - 1, 1), n);
+      const name = currentItem && currentItem !== 'Verifying import...' ? currentItem : '';
+      return name
+        ? `Importing schema ${idx} of ${n}: ${name}`
+        : `Importing schema ${idx} of ${n}`;
+    }
+  }
+
+  const labels: Record<string, string> = {
+    initializing: 'Initializing import…',
+    'creating-project': currentItem ? `Creating project: ${currentItem}` : 'Creating project…',
+    'creating-version': currentItem ? `Creating version: ${currentItem}` : 'Creating version…',
+    'creating-properties': 'Creating shared properties in library…',
+    'creating-classes': currentItem ? `Working on: ${currentItem}` : 'Creating classes…',
+    verifying: 'Verifying imported data…',
+    finalizing: 'Finalizing…',
+  };
+
+  return labels[phase ?? ''] ?? (phase ? phase.replace(/-/g, ' ') : 'In progress…');
+}
+
+export function estimateSecondsRemaining(
+  percent: number,
+  elapsedMs: number
+): number | null {
+  if (percent <= 0 || percent >= 100) return null;
+  const p = Math.max(1, Math.min(99, percent));
+  const totalEstimated = (elapsedMs / p) * 100;
+  const remaining = totalEstimated - elapsedMs;
+  if (!Number.isFinite(remaining) || remaining < 0) return null;
+  return Math.max(1, Math.round(remaining / 1000));
+}

--- a/objectified-ui/lib/import-execution-live-rows.ts
+++ b/objectified-ui/lib/import-execution-live-rows.ts
@@ -124,14 +124,18 @@ export function buildImportLiveChecklist(
     return [];
   }
 
+  const createdLower = new Set<string>([...created].map((n) => n.trim().toLowerCase()));
+  const failedLower = new Set<string>([...failed].map((n) => n.trim().toLowerCase()));
+
   const rows: LiveChecklistRow[] = order.map((label, i) => {
     const id = `schema-${i}-${label}`;
-    const isFailed = [...failed].some((f) => namesMatch(f, label));
+    const labelLower = label.trim().toLowerCase();
+    const isFailed = failedLower.has(labelLower);
     if (isFailed) {
       return { id, label, status: 'error' as const };
     }
 
-    const isCreated = [...created].some((c) => namesMatch(c, label));
+    const isCreated = createdLower.has(labelLower);
 
     if (isCreated) {
       const warnDetail = warningDetailForClass(events, label);

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.9.10",
+  "version": "0.9.11",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -5,6 +5,7 @@ We continue to improve the platform based on your feedback with improvements and
 ---
 
 ## UI:
+- **OpenAPI import:** Import step shows the **Import Execution** layout — progress with schema index and ETA, per-schema live checklist (success / warning / in progress / pending), expandable import log, and technical summary in a collapsible section
 - **What's New** dialog is centered on the viewport again (overlay renders outside the header so it is not offset downward)
 - **Import classes:** duplicate-schema rows in the conflict report include **Schema diff** — side-by-side property diff (new / modified / removed), summary counts, and resolution choices (merge, replace, keep current, rename) before you apply
 - **OpenAPI import:** one shared rule for “direct” schema properties — specs that mix top-level `properties` with inline `allOf` fragments now pick up both (aligned with the unified class importer)

--- a/objectified-ui/src/app/components/ade/dashboard/ImportDialog.tsx
+++ b/objectified-ui/src/app/components/ade/dashboard/ImportDialog.tsx
@@ -1002,6 +1002,7 @@ const ImportDialog: React.FC<ImportDialogProps> = ({
               return (
                 <ImportExecutionPanel
                   jobId={jobId}
+                  selectedSchemas={importOptions?.selectedSchemas ?? []}
                   isReviewing={importComplete}
                   onComplete={(succeeded) => {
                     setImportComplete(true);

--- a/objectified-ui/src/app/components/ade/dashboard/ImportExecutionPanel.tsx
+++ b/objectified-ui/src/app/components/ade/dashboard/ImportExecutionPanel.tsx
@@ -1,15 +1,38 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import * as Progress from '@radix-ui/react-progress';
 import { Button } from '../../../components/ui/Button';
 import { Badge } from '../../../components/ui/Badge';
-import { AlertCircle, CheckCircle2, Info, XCircle, Pause, RotateCw, MinusCircle } from 'lucide-react';
+import {
+  AlertCircle,
+  AlertTriangle,
+  CheckCircle2,
+  Circle,
+  Info,
+  Loader2,
+  XCircle,
+  RotateCw,
+  MinusCircle,
+} from 'lucide-react';
 import { cancelImport, getImportStatus, commitImport, rollbackImport, retryImport } from '../../../../../lib/db/import-actions';
-import { getErrorEvents, formatEventContext, getLiveProgressRowClasses, getImportLogLineClasses, isSkippedEvent } from '../../../../../lib/import-execution-error-indicators';
+import {
+  getErrorEvents,
+  formatEventContext,
+  getLiveProgressRowClasses,
+  getImportLogLineClasses,
+  isSkippedEvent,
+} from '../../../../../lib/import-execution-error-indicators';
+import {
+  buildImportLiveChecklist,
+  formatProgressPrimaryLine,
+  estimateSecondsRemaining,
+} from '../../../../../lib/import-execution-live-rows';
 
 interface ImportExecutionPanelProps {
   jobId: string;
+  /** Schema names selected on the Preview step — drives the live checklist (#296). */
+  selectedSchemas?: string[];
   onComplete?: (succeeded: boolean) => void;
   /** When user retries a failed/canceled import, called with the new job ID so the dialog can switch to it. */
   onRetry?: (newJobId: string) => void;
@@ -24,11 +47,19 @@ interface ImportEvent {
   level: LogLevel;
   code: string;
   message: string;
-  context?: any;
+  context?: unknown;
 }
 
 interface ProgressInfo {
-  phase: 'initializing' | 'creating-project' | 'creating-version' | 'creating-properties' | 'creating-classes' | 'linking-properties' | 'verifying' | 'finalizing';
+  phase:
+    | 'initializing'
+    | 'creating-project'
+    | 'creating-version'
+    | 'creating-properties'
+    | 'creating-classes'
+    | 'linking-properties'
+    | 'verifying'
+    | 'finalizing';
   total: number;
   completed: number;
   currentItem?: string;
@@ -36,53 +67,85 @@ interface ProgressInfo {
 
 type JobState = 'queued' | 'running' | 'pending-approval' | 'committing' | 'completed' | 'failed' | 'canceled' | 'rolled-back';
 
-export default function ImportExecutionPanel({ jobId, onComplete, onRetry, isReviewing }: ImportExecutionPanelProps) {
+const IMPORT_LOG_PREVIEW_COUNT = 8;
+
+function formatEtaLine(seconds: number | null): string | null {
+  if (seconds == null) return null;
+  if (seconds < 60) return `Estimated time remaining: about ${seconds} seconds`;
+  const m = Math.max(1, Math.round(seconds / 60));
+  return m === 1 ? 'Estimated time remaining: about 1 minute' : `Estimated time remaining: about ${m} minutes`;
+}
+
+export default function ImportExecutionPanel({
+  jobId,
+  selectedSchemas = [],
+  onComplete,
+  onRetry,
+  isReviewing,
+}: ImportExecutionPanelProps) {
   const [state, setState] = useState<JobState>('queued');
   const [percent, setPercent] = useState(0);
   const [progress, setProgress] = useState<ProgressInfo | undefined>(undefined);
   const [events, setEvents] = useState<ImportEvent[]>([]);
-  const [summary, setSummary] = useState<any>(null);
-  const [hasNotifiedComplete, setHasNotifiedComplete] = useState(false);
+  const [summary, setSummary] = useState<Record<string, unknown> | null>(null);
   const [isCommitting, setIsCommitting] = useState(false);
   const [isRollingBack, setIsRollingBack] = useState(false);
   const [isRetrying, setIsRetrying] = useState(false);
   const [transactionPending, setTransactionPending] = useState(false);
+  const [logExpanded, setLogExpanded] = useState(false);
+  const importStartedAtMs = useRef<number | null>(null);
+  const completionNotifiedRef = useRef(false);
 
-  // Reset completion notification when jobId changes (e.g. after retry)
+  const liveRows = useMemo(
+    () => buildImportLiveChecklist(selectedSchemas, events, progress, state),
+    [selectedSchemas, events, progress, state]
+  );
+
+  const primaryLine = formatProgressPrimaryLine(progress, state);
+  const etaSeconds = estimateSecondsRemaining(
+    percent,
+    importStartedAtMs.current != null ? Date.now() - importStartedAtMs.current : 0
+  );
+  const etaLine =
+    ['running', 'queued', 'committing'].includes(state) && percent > 0 && percent < 100
+      ? formatEtaLine(etaSeconds)
+      : null;
+
   useEffect(() => {
-    setHasNotifiedComplete(false);
+    completionNotifiedRef.current = false;
+    importStartedAtMs.current = null;
   }, [jobId]);
 
   useEffect(() => {
     let mounted = true;
-    let timer: any;
+    let timer: ReturnType<typeof setInterval> | undefined;
 
     const poll = async () => {
       try {
         const status = await getImportStatus(jobId);
         if (!mounted) return;
+        if (importStartedAtMs.current === null && ((status.percent ?? 0) > 0 || (status.events?.length ?? 0) > 0)) {
+          importStartedAtMs.current = Date.now();
+        }
         setState(status.state as JobState);
         setPercent(status.percent || 0);
-        setProgress(status.progress as any);
+        setProgress(status.progress as ProgressInfo | undefined);
         setEvents(status.events || []);
         setSummary(status.summary || null);
-        setTransactionPending((status as any).transactionPending || false);
+        setTransactionPending((status as { transactionPending?: boolean }).transactionPending || false);
 
-        // Stop polling when in a terminal state or pending-approval
         if (['completed', 'failed', 'canceled', 'rolled-back', 'pending-approval'].includes(status.state)) {
-          clearInterval(timer);
-          // Notify parent that import reached a decision point
-          if (!hasNotifiedComplete && onComplete) {
-            setHasNotifiedComplete(true);
+          if (timer) clearInterval(timer);
+          if (!completionNotifiedRef.current && onComplete) {
+            completionNotifiedRef.current = true;
             onComplete(status.state === 'completed');
           }
         }
-      } catch (e) {
+      } catch {
         // Ignore transient errors
       }
     };
 
-    // If reviewing (came back from done step), just poll once to get final state
     if (isReviewing) {
       poll();
     } else {
@@ -94,7 +157,7 @@ export default function ImportExecutionPanel({ jobId, onComplete, onRetry, isRev
       mounted = false;
       if (timer) clearInterval(timer);
     };
-  }, [jobId, onComplete, isReviewing, hasNotifiedComplete]);
+  }, [jobId, onComplete, isReviewing]);
 
   const onCancel = async () => {
     await cancelImport(jobId);
@@ -110,7 +173,6 @@ export default function ImportExecutionPanel({ jobId, onComplete, onRetry, isRev
           onComplete(true);
         }
       } else {
-        // Poll to get updated state
         const status = await getImportStatus(jobId);
         setState(status.state as JobState);
         setEvents(status.events || []);
@@ -158,132 +220,27 @@ export default function ImportExecutionPanel({ jobId, onComplete, onRetry, isRev
     return <Info className="h-4 w-4 text-indigo-600 dark:text-indigo-400" aria-hidden />;
   };
 
+  const checklistIcon = (status: (typeof liveRows)[0]['status']) => {
+    switch (status) {
+      case 'success':
+        return <CheckCircle2 className="h-4 w-4 shrink-0 text-emerald-600 dark:text-emerald-400" aria-hidden />;
+      case 'warning':
+        return <AlertTriangle className="h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" aria-hidden />;
+      case 'error':
+        return <XCircle className="h-4 w-4 shrink-0 text-red-600 dark:text-red-400" aria-hidden />;
+      case 'importing':
+        return <Loader2 className="h-4 w-4 shrink-0 animate-spin text-indigo-600 dark:text-indigo-400" aria-hidden />;
+      default:
+        return <Circle className="h-4 w-4 shrink-0 text-gray-300 dark:text-gray-600" aria-hidden />;
+    }
+  };
+
   const errorEvents = getErrorEvents(events);
+  const logShown = logExpanded ? events : events.slice(0, IMPORT_LOG_PREVIEW_COUNT);
+  const logOverflow = events.length > IMPORT_LOG_PREVIEW_COUNT;
 
   return (
-    <div className="space-y-6">
-      {/* Overall Progress */}
-      <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-6">
-        <div className="flex items-center justify-between mb-4">
-          <div>
-            <h3 className="text-lg font-semibold text-gray-900 dark:text-white">Import Progress</h3>
-            <div className="text-sm text-gray-600 dark:text-gray-400">
-              {progress?.phase?.replace(/-/g,' ') || 'starting'}{progress?.currentItem ? `: ${progress.currentItem}` : ''}
-            </div>
-          </div>
-          <div>
-            <Badge variant={
-              state === 'completed' ? 'success' :
-              state === 'failed' ? 'error' :
-              state === 'canceled' || state === 'rolled-back' ? 'secondary' :
-              state === 'pending-approval' ? 'warning' :
-              'default'
-            }>
-              {state === 'pending-approval' ? 'PENDING APPROVAL' : state.toUpperCase().replace('-', ' ')}
-            </Badge>
-          </div>
-        </div>
-        <Progress.Root className="relative h-3 w-full overflow-hidden rounded-full bg-gray-200 dark:bg-gray-700" value={percent}>
-          <Progress.Indicator
-            className="h-full bg-gradient-to-r from-indigo-500 to-purple-600 transition-transform duration-300"
-            style={{ transform: `translateX(-${100 - (percent || 0)}%)` }}
-          />
-        </Progress.Root>
-        <div className="flex items-center justify-between text-xs text-gray-500 dark:text-gray-400 mt-2">
-          <span>{percent}%</span>
-          {progress && <span>{progress.completed} of {progress.total}</span>}
-        </div>
-        <div className="mt-4 flex flex-wrap gap-2">
-          {state === 'pending-approval' ? (
-            <>
-              <Button
-                onClick={onAccept}
-                disabled={isCommitting || isRollingBack}
-                className="bg-green-600 hover:bg-green-700 text-white"
-              >
-                <CheckCircle2 className="h-4 w-4 mr-1"/>
-                {isCommitting ? 'Committing...' : 'Accept & Commit'}
-              </Button>
-              <Button
-                variant="outline"
-                onClick={onReject}
-                disabled={isCommitting || isRollingBack}
-                className="text-red-600 border-red-300 hover:bg-red-50 dark:text-red-400 dark:border-red-700 dark:hover:bg-red-900/20"
-              >
-                <XCircle className="h-4 w-4 mr-1"/>
-                {isRollingBack ? 'Rolling Back...' : 'Reject & Rollback'}
-              </Button>
-            </>
-          ) : state === 'failed' || state === 'canceled' ? (
-            <>
-              {onRetry && (
-                <Button
-                  onClick={onRetryClick}
-                  disabled={isRetrying}
-                  className="bg-indigo-600 hover:bg-indigo-700 text-white"
-                >
-                  <RotateCw className={`h-4 w-4 mr-1 ${isRetrying ? 'animate-spin' : ''}`}/>
-                  {isRetrying ? 'Starting retry...' : 'Retry Import'}
-                </Button>
-              )}
-              <Button variant="outline" onClick={onCancel} disabled={isRetrying}>
-                <Pause className="h-4 w-4 mr-1"/> Cancel Import
-              </Button>
-            </>
-          ) : (
-            <Button variant="outline" onClick={onCancel} disabled={['completed','failed','canceled','rolled-back','pending-approval'].includes(state)}>
-              <Pause className="h-4 w-4 mr-1"/> Cancel Import
-            </Button>
-          )}
-        </div>
-
-        {/* Dry run complete notice */}
-        {state === 'completed' && summary?.dryRun && (
-          <div className="mt-4 p-3 rounded-lg bg-sky-50 dark:bg-sky-900/20 border border-sky-200 dark:border-sky-800">
-            <div className="flex items-center gap-2 text-sky-800 dark:text-sky-200">
-              <Info className="h-4 w-4" />
-              <span className="text-sm font-medium">
-                Dry run complete. No changes were saved.
-              </span>
-            </div>
-            <p className="text-xs text-sky-700 dark:text-sky-300 mt-1 ml-6">
-              Review the summary above. Uncheck &quot;Dry run (preview only)&quot; and run again to import for real.
-            </p>
-          </div>
-        )}
-
-        {/* Incremental mode complete notice */}
-        {state === 'completed' && summary?.incrementalMode && !summary?.dryRun && (
-          <div className="mt-4 p-3 rounded-lg bg-emerald-50 dark:bg-emerald-900/20 border border-emerald-200 dark:border-emerald-800">
-            <div className="flex items-center gap-2 text-emerald-800 dark:text-emerald-200">
-              <CheckCircle2 className="h-4 w-4" />
-              <span className="text-sm font-medium">
-                Incremental import complete.
-              </span>
-            </div>
-            <p className="text-xs text-emerald-700 dark:text-emerald-300 mt-1 ml-6">
-              Successful classes were saved; failed classes were skipped. You can open the project in Canvas or close this dialog.
-            </p>
-          </div>
-        )}
-
-        {/* Transaction pending notice */}
-        {transactionPending && state === 'pending-approval' && (
-          <div className="mt-4 p-3 rounded-lg bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800">
-            <div className="flex items-center gap-2 text-amber-800 dark:text-amber-200">
-              <AlertCircle className="h-4 w-4" />
-              <span className="text-sm font-medium">
-                Transaction pending - changes will only be saved if you accept.
-              </span>
-            </div>
-            <p className="text-xs text-amber-700 dark:text-amber-300 mt-1 ml-6">
-              Closing this dialog or rejecting will rollback all changes.
-            </p>
-          </div>
-        )}
-      </div>
-
-      {/* Error indicators: red for failures with details (#731) */}
+    <div className="space-y-4">
       {errorEvents.length > 0 && (
         <div
           className="rounded-xl border-2 border-red-300 dark:border-red-700 bg-red-50 dark:bg-red-950/40 p-6"
@@ -296,7 +253,7 @@ export default function ImportExecutionPanel({ jobId, onComplete, onRetry, isRev
               Failures ({errorEvents.length})
             </h3>
           </div>
-          <ul className="space-y-3 max-h-[280px] overflow-y-auto">
+          <ul className="space-y-3 max-h-72 overflow-y-auto">
             {errorEvents.map((ev) => (
               <li
                 key={ev.id}
@@ -320,61 +277,235 @@ export default function ImportExecutionPanel({ jobId, onComplete, onRetry, isRev
         </div>
       )}
 
-      {/* Live Progress - per event log */}
-      <div className="grid grid-cols-2 gap-6">
-        <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-6">
-          <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">Live Progress</h3>
-          <div className="max-h-[320px] overflow-y-auto space-y-2">
-            {events.slice().reverse().map(ev => (
-              <div key={ev.id} className={getLiveProgressRowClasses(ev)}>
-                {isSkippedEvent(ev) ? (
-                  <MinusCircle className="h-4 w-4 text-gray-500 dark:text-gray-400 shrink-0" aria-label="Intentionally skipped" />
-                ) : (
-                  levelIcon(ev.level)
-                )}
-                <div className="flex-1 min-w-0">
-                  <div className={`text-xs ${isSkippedEvent(ev) ? 'text-gray-400 dark:text-gray-500' : 'text-gray-500 dark:text-gray-400'}`}>{new Date(ev.ts).toLocaleTimeString()} • {ev.code}</div>
-                  <div className={`text-sm ${ev.level === 'error' ? 'text-red-900 dark:text-red-100 font-medium' : isSkippedEvent(ev) ? 'text-gray-500 dark:text-gray-400' : 'text-gray-900 dark:text-gray-100'}`}>{ev.message}</div>
-                  {ev.context != null && (
-                    <pre className="mt-1 text-xs text-gray-600 dark:text-gray-300 bg-gray-100 dark:bg-gray-900 rounded p-2 overflow-auto max-h-24">
-                      {formatEventContext(ev.context)}
-                    </pre>
-                  )}
-                </div>
-              </div>
-            ))}
-          </div>
+      <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-5 shadow-sm">
+        <div className="flex items-start justify-between gap-3 mb-4">
+          <h3 className="text-base font-semibold text-gray-900 dark:text-white">Import Progress</h3>
+          <Badge
+            variant={
+              state === 'completed'
+                ? 'success'
+                : state === 'failed'
+                  ? 'error'
+                  : state === 'canceled' || state === 'rolled-back'
+                    ? 'secondary'
+                    : state === 'pending-approval'
+                      ? 'warning'
+                      : 'default'
+            }
+          >
+            {state === 'pending-approval' ? 'PENDING APPROVAL' : state.toUpperCase().replace(/-/g, ' ')}
+          </Badge>
         </div>
 
-        {/* Import Log */}
-        <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-6">
-          <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">Import Log</h3>
-          <div className="max-h-[320px] overflow-y-auto space-y-1">
-            {events.map(ev => (
-              <div key={ev.id} className={getImportLogLineClasses(ev)}>
-                <span className={`mr-2 px-1.5 py-0.5 rounded ${isSkippedEvent(ev) ? 'bg-gray-200 dark:bg-gray-700 text-gray-500 dark:text-gray-400' : 'bg-gray-100 dark:bg-gray-900 text-gray-700 dark:text-gray-300'}`}>{new Date(ev.ts).toLocaleTimeString()}</span>
-                <span className={`mr-2 font-semibold ${isSkippedEvent(ev) ? 'text-gray-500 dark:text-gray-400' : ev.level === 'error' ? 'text-red-600 dark:text-red-400' : ev.level === 'warn' ? 'text-yellow-600 dark:text-yellow-400' : 'text-indigo-600 dark:text-indigo-400'}`}>{isSkippedEvent(ev) ? '[SKIPPED]' : `[${ev.level.toUpperCase()}]`}</span>
-                <span className={isSkippedEvent(ev) ? 'text-gray-500 dark:text-gray-400' : ev.level === 'error' ? 'text-red-900 dark:text-red-100' : 'text-gray-800 dark:text-gray-200'}>{ev.message}</span>
-                {ev.level === 'error' && ev.context != null && (
-                  <pre className="mt-1.5 ml-0 text-xs text-gray-600 dark:text-gray-300 bg-gray-100 dark:bg-gray-900 rounded p-2 overflow-auto max-h-20 border border-red-200 dark:border-red-800">
-                    {formatEventContext(ev.context)}
-                  </pre>
-                )}
-              </div>
-            ))}
-          </div>
+        <div className="flex items-center gap-4 mb-3">
+          <Progress.Root className="relative h-3 flex-1 overflow-hidden rounded-full bg-gray-200 dark:bg-gray-700" value={percent}>
+            <Progress.Indicator
+              className="h-full bg-gradient-to-r from-indigo-500 to-purple-600 transition-transform duration-300 ease-out"
+              style={{ transform: `translateX(-${100 - (percent || 0)}%)` }}
+            />
+          </Progress.Root>
+          <span className="text-2xl font-semibold tabular-nums text-gray-900 dark:text-white shrink-0">{percent}%</span>
         </div>
+
+        <p className="text-sm text-gray-700 dark:text-gray-300">{primaryLine}</p>
+        {etaLine && <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">{etaLine}</p>}
+        {progress && progress.total > 0 && (
+          <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+            Step {progress.completed} of {progress.total}
+          </p>
+        )}
+
+        <div className="mt-4 flex flex-wrap gap-2">
+          {state === 'pending-approval' ? (
+            <>
+              <Button
+                onClick={onAccept}
+                disabled={isCommitting || isRollingBack}
+                className="bg-green-600 hover:bg-green-700 text-white"
+              >
+                <CheckCircle2 className="h-4 w-4 mr-1" />
+                {isCommitting ? 'Committing...' : 'Accept & Commit'}
+              </Button>
+              <Button
+                variant="outline"
+                onClick={onReject}
+                disabled={isCommitting || isRollingBack}
+                className="text-red-600 border-red-300 hover:bg-red-50 dark:text-red-400 dark:border-red-700 dark:hover:bg-red-900/20"
+              >
+                <XCircle className="h-4 w-4 mr-1" />
+                {isRollingBack ? 'Rolling Back...' : 'Reject & Rollback'}
+              </Button>
+            </>
+          ) : state === 'failed' || state === 'canceled' ? (
+            <>
+              {onRetry && (
+                <Button
+                  onClick={onRetryClick}
+                  disabled={isRetrying}
+                  className="bg-indigo-600 hover:bg-indigo-700 text-white"
+                >
+                  <RotateCw className={`h-4 w-4 mr-1 ${isRetrying ? 'animate-spin' : ''}`} />
+                  {isRetrying ? 'Starting retry...' : 'Retry Import'}
+                </Button>
+              )}
+              <Button variant="outline" onClick={onCancel} disabled={isRetrying}>
+                Cancel import
+              </Button>
+            </>
+          ) : null}
+        </div>
+
+        {state === 'completed' && summary?.['dryRun'] === true && (
+          <div className="mt-4 p-3 rounded-lg bg-sky-50 dark:bg-sky-900/20 border border-sky-200 dark:border-sky-800">
+            <div className="flex items-center gap-2 text-sky-800 dark:text-sky-200">
+              <Info className="h-4 w-4" />
+              <span className="text-sm font-medium">Dry run complete. No changes were saved.</span>
+            </div>
+            <p className="text-xs text-sky-700 dark:text-sky-300 mt-1 ml-6">
+              Review the summary below. Uncheck &quot;Dry run (preview only)&quot; and run again to import for real.
+            </p>
+          </div>
+        )}
+
+        {state === 'completed' && summary?.['incrementalMode'] === true && summary?.['dryRun'] !== true && (
+          <div className="mt-4 p-3 rounded-lg bg-emerald-50 dark:bg-emerald-900/20 border border-emerald-200 dark:border-emerald-800">
+            <div className="flex items-center gap-2 text-emerald-800 dark:text-emerald-200">
+              <CheckCircle2 className="h-4 w-4" />
+              <span className="text-sm font-medium">Incremental import complete.</span>
+            </div>
+            <p className="text-xs text-emerald-700 dark:text-emerald-300 mt-1 ml-6">
+              Successful classes were saved; failed classes were skipped. You can open the project in Canvas or close this dialog.
+            </p>
+          </div>
+        )}
+
+        {transactionPending && state === 'pending-approval' && (
+          <div className="mt-4 p-3 rounded-lg bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800">
+            <div className="flex items-center gap-2 text-amber-800 dark:text-amber-200">
+              <AlertCircle className="h-4 w-4" />
+              <span className="text-sm font-medium">Transaction pending — changes will only be saved if you accept.</span>
+            </div>
+            <p className="text-xs text-amber-700 dark:text-amber-300 mt-1 ml-6">
+              Closing this dialog or rejecting will rollback all changes.
+            </p>
+          </div>
+        )}
       </div>
 
-      {/* Summary */}
-      {summary && (
-        <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-6">
-          <div className="flex items-center gap-2 mb-2">
-            <CheckCircle2 className="h-5 w-5 text-green-600 dark:text-green-400"/>
-            <h3 className="text-lg font-semibold text-gray-900 dark:text-white">Import Summary</h3>
+      <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-5 shadow-sm">
+        <h3 className="text-base font-semibold text-gray-900 dark:text-white mb-3">Live Progress</h3>
+        {liveRows.length > 0 ? (
+          <ul className="max-h-80 overflow-y-auto space-y-2 pr-1" aria-label="Per-schema import status">
+            {liveRows.map((row) => (
+              <li key={row.id} className="flex items-start gap-2 text-sm">
+                {checklistIcon(row.status)}
+                <div className="min-w-0 flex-1">
+                  <div className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
+                    <span className="font-medium text-gray-900 dark:text-gray-100">{row.label}</span>
+                    <span className="text-gray-600 dark:text-gray-400">
+                      {row.status === 'success' && 'Imported successfully'}
+                      {row.status === 'warning' && 'Imported with warnings'}
+                      {row.status === 'error' && 'Failed'}
+                      {row.status === 'importing' && 'Importing…'}
+                      {row.status === 'pending' && 'Pending'}
+                    </span>
+                  </div>
+                  {row.detail && (
+                    <p className="mt-1 text-xs text-amber-800 dark:text-amber-200 border-l-2 border-amber-300 dark:border-amber-700 pl-2">
+                      {row.detail}
+                    </p>
+                  )}
+                </div>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <div className="max-h-80 overflow-y-auto space-y-2">
+            {events.length === 0 ? (
+              <p className="text-sm text-gray-500 dark:text-gray-400">Waiting for import events…</p>
+            ) : (
+              events
+                .slice()
+                .reverse()
+                .slice(0, 20)
+                .map((ev) => (
+                  <div key={ev.id} className={getLiveProgressRowClasses(ev)}>
+                    {isSkippedEvent(ev) ? (
+                      <MinusCircle className="h-4 w-4 text-gray-500 dark:text-gray-400 shrink-0" aria-label="Intentionally skipped" />
+                    ) : (
+                      levelIcon(ev.level)
+                    )}
+                    <div className="flex-1 min-w-0">
+                      <div
+                        className={`text-xs ${isSkippedEvent(ev) ? 'text-gray-400 dark:text-gray-500' : 'text-gray-500 dark:text-gray-400'}`}
+                      >
+                        {new Date(ev.ts).toLocaleTimeString()} • {ev.code}
+                      </div>
+                      <div
+                        className={`text-sm ${ev.level === 'error' ? 'text-red-900 dark:text-red-100 font-medium' : isSkippedEvent(ev) ? 'text-gray-500 dark:text-gray-400' : 'text-gray-900 dark:text-gray-100'}`}
+                      >
+                        {ev.message}
+                      </div>
+                    </div>
+                  </div>
+                ))
+            )}
           </div>
-          <pre className="text-xs text-gray-700 dark:text-gray-300 bg-gray-50 dark:bg-gray-900 rounded p-3 overflow-auto">{JSON.stringify(summary, null, 2)}</pre>
+        )}
+      </div>
+
+      <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-5 shadow-sm">
+        <h3 className="text-base font-semibold text-gray-900 dark:text-white mb-3">Import Log</h3>
+        <div className="max-h-72 overflow-y-auto space-y-1 font-mono text-xs">
+          {logShown.map((ev) => (
+            <div key={ev.id} className={getImportLogLineClasses(ev)}>
+              <span
+                className={`mr-2 font-semibold ${isSkippedEvent(ev) ? 'text-gray-500 dark:text-gray-400' : ev.level === 'error' ? 'text-red-600 dark:text-red-400' : ev.level === 'warn' ? 'text-yellow-600 dark:text-yellow-400' : 'text-indigo-600 dark:text-indigo-400'}`}
+              >
+                {isSkippedEvent(ev) ? '[SKIPPED]' : `[${ev.level.toUpperCase()}]`}
+              </span>
+              <span className="text-gray-500 dark:text-gray-500 mr-2">{new Date(ev.ts).toLocaleTimeString()}</span>
+              <span
+                className={
+                  isSkippedEvent(ev)
+                    ? 'text-gray-500 dark:text-gray-400'
+                    : ev.level === 'error'
+                      ? 'text-red-900 dark:text-red-100'
+                      : 'text-gray-800 dark:text-gray-200'
+                }
+              >
+                {ev.message}
+              </span>
+              {ev.level === 'error' && ev.context != null && (
+                <pre className="mt-1.5 text-xs text-gray-600 dark:text-gray-300 bg-gray-100 dark:bg-gray-900 rounded p-2 overflow-auto max-h-20 border border-red-200 dark:border-red-800">
+                  {formatEventContext(ev.context)}
+                </pre>
+              )}
+            </div>
+          ))}
         </div>
+        {logOverflow && (
+          <button
+            type="button"
+            onClick={() => setLogExpanded((e) => !e)}
+            className="mt-2 text-sm font-medium text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300"
+          >
+            {logExpanded ? 'Show less' : 'Show more…'}
+          </button>
+        )}
+      </div>
+
+      {summary && (
+        <details className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-5 shadow-sm group">
+          <summary className="cursor-pointer text-base font-semibold text-gray-900 dark:text-white list-none flex items-center gap-2">
+            <CheckCircle2 className="h-5 w-5 text-green-600 dark:text-green-400 shrink-0" />
+            Import Summary
+            <span className="text-sm font-normal text-gray-500 dark:text-gray-400">(technical details)</span>
+          </summary>
+          <pre className="mt-3 text-xs text-gray-700 dark:text-gray-300 bg-gray-50 dark:bg-gray-900 rounded p-3 overflow-auto max-h-64">
+            {JSON.stringify(summary, null, 2)}
+          </pre>
+        </details>
       )}
     </div>
   );

--- a/objectified-ui/src/app/components/ade/dashboard/ImportExecutionPanel.tsx
+++ b/objectified-ui/src/app/components/ade/dashboard/ImportExecutionPanel.tsx
@@ -71,7 +71,11 @@ const IMPORT_LOG_PREVIEW_COUNT = 8;
 
 function formatEtaLine(seconds: number | null): string | null {
   if (seconds == null) return null;
-  if (seconds < 60) return `Estimated time remaining: about ${seconds} seconds`;
+  if (seconds < 60) {
+    return seconds === 1
+      ? 'Estimated time remaining: about 1 second'
+      : `Estimated time remaining: about ${seconds} seconds`;
+  }
   const m = Math.max(1, Math.round(seconds / 60));
   return m === 1 ? 'Estimated time remaining: about 1 minute' : `Estimated time remaining: about ${m} minutes`;
 }
@@ -236,7 +240,7 @@ export default function ImportExecutionPanel({
   };
 
   const errorEvents = getErrorEvents(events);
-  const logShown = logExpanded ? events : events.slice(0, IMPORT_LOG_PREVIEW_COUNT);
+  const logShown = logExpanded ? events : events.slice(-IMPORT_LOG_PREVIEW_COUNT);
   const logOverflow = events.length > IMPORT_LOG_PREVIEW_COUNT;
 
   return (
@@ -352,6 +356,11 @@ export default function ImportExecutionPanel({
                 Cancel import
               </Button>
             </>
+          ) : (state === 'queued' || state === 'running' || state === 'committing') ? (
+            <Button variant="outline" onClick={onCancel}>
+              <MinusCircle className="h-4 w-4 mr-1" />
+              Cancel Import
+            </Button>
           ) : null}
         </div>
 

--- a/objectified-ui/tests/import-execution-live-rows.test.ts
+++ b/objectified-ui/tests/import-execution-live-rows.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Unit tests for Import Execution live checklist helpers (#296).
+ */
+
+import { describe, test, expect } from '@jest/globals';
+import {
+  buildImportLiveChecklist,
+  formatProgressPrimaryLine,
+  estimateSecondsRemaining,
+} from '../lib/import-execution-live-rows';
+import type { ImportEventLike } from '../lib/import-execution-error-indicators';
+
+describe('import-execution-live-rows (#296)', () => {
+  describe('buildImportLiveChecklist', () => {
+    test('marks current schema as importing during creating-classes', () => {
+      const selected = ['Pet', 'Order'];
+      const events: ImportEventLike[] = [
+        { id: '1', ts: 1, level: 'info', code: 'CLASS_CREATED', message: 'Imported class: Pet' },
+      ];
+      const progress = {
+        phase: 'creating-classes' as const,
+        total: 4,
+        completed: 2,
+        currentItem: 'Order',
+      };
+      const rows = buildImportLiveChecklist(selected, events, progress, 'running');
+      expect(rows).toHaveLength(2);
+      expect(rows[0].status).toBe('success');
+      expect(rows[1].status).toBe('importing');
+    });
+
+    test('shows warning with first warn tied to class context', () => {
+      const selected = ['Order'];
+      const events: ImportEventLike[] = [
+        {
+          id: 'w',
+          ts: 1,
+          level: 'warn',
+          code: 'SKIP_PROPERTY',
+          message: 'Skipping property "shipDate" in class "Order"',
+          context: { className: 'Order', propertyName: 'shipDate' },
+        },
+        { id: 'c', ts: 2, level: 'info', code: 'CLASS_CREATED', message: 'Imported class: Order' },
+      ];
+      const rows = buildImportLiveChecklist(selected, events, undefined, 'completed');
+      expect(rows[0].status).toBe('warning');
+      expect(rows[0].detail).toContain('shipDate');
+    });
+
+    test('infers order from events when selectedSchemas is empty', () => {
+      const events: ImportEventLike[] = [
+        { id: 'a', ts: 1, level: 'info', code: 'CLASS_CREATED', message: 'Imported class: Alpha' },
+        { id: 'b', ts: 2, level: 'info', code: 'CLASS_CREATED', message: 'Imported class: Beta' },
+      ];
+      const rows = buildImportLiveChecklist([], events, undefined, 'completed');
+      expect(rows.map((r) => r.label)).toEqual(['Alpha', 'Beta']);
+      expect(rows.every((r) => r.status === 'success')).toBe(true);
+    });
+  });
+
+  describe('formatProgressPrimaryLine', () => {
+    test('formats creating-classes with schema index and name', () => {
+      const line = formatProgressPrimaryLine(
+        { phase: 'creating-classes', total: 14, completed: 9, currentItem: 'Order' },
+        'running'
+      );
+      expect(line).toBe('Importing schema 8 of 12: Order');
+    });
+
+    test('falls back when no progress', () => {
+      expect(formatProgressPrimaryLine(undefined, 'queued')).toBe('Waiting to start…');
+    });
+  });
+
+  describe('estimateSecondsRemaining', () => {
+    test('returns null at 0% or 100%', () => {
+      expect(estimateSecondsRemaining(0, 1000)).toBeNull();
+      expect(estimateSecondsRemaining(100, 1000)).toBeNull();
+    });
+
+    test('estimates remaining seconds from elapsed and percent', () => {
+      const sec = estimateSecondsRemaining(50, 5000);
+      expect(sec).not.toBeNull();
+      expect(sec!).toBeGreaterThan(0);
+    });
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -2681,7 +2681,7 @@
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
       "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright": "1.59.1"
@@ -5553,6 +5553,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -5562,7 +5563,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -6697,7 +6698,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-react-compiler/-/babel-plugin-react-compiler-1.0.0.tgz",
       "integrity": "sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.26.0"
@@ -14568,7 +14569,7 @@
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
       "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.59.1"
@@ -14587,7 +14588,7 @@
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
       "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -14600,6 +14601,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -16310,6 +16312,7 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
       "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/tailwindcss-animate": {
@@ -17866,7 +17869,7 @@
       "version": "1.0.1"
     },
     "objectified-ui": {
-      "version": "0.9.8",
+      "version": "0.9.11",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -45,7 +45,7 @@
   resolved "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.5.tgz"
   integrity sha512-6uFXyCayocRbqhZOB+6XcuZbkMNimwfVGFji8CTZnCzOHVGvDqzvitu1re2AU5LROliz7eQPhB8CpAMvnx9EjA==
 
-"@babel/core@^7.0.0", "@babel/core@^7.0.0 || ^8.0.0-0", "@babel/core@^7.0.0-0", "@babel/core@^7.11.0 || ^8.0.0-0", "@babel/core@^7.11.0 || ^8.0.0-beta.1", "@babel/core@^7.23.9", "@babel/core@^7.24.4", "@babel/core@^7.27.4", "@babel/core@>=7.0.0-beta.0 <8":
+"@babel/core@^7.23.9", "@babel/core@^7.24.4", "@babel/core@^7.27.4":
   version "7.28.5"
   resolved "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz"
   integrity sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==
@@ -366,12 +366,12 @@
     "@csstools/color-helpers" "^5.1.0"
     "@csstools/css-calc" "^2.1.4"
 
-"@csstools/css-parser-algorithms@^3.0.4", "@csstools/css-parser-algorithms@^3.0.5":
+"@csstools/css-parser-algorithms@^3.0.4":
   version "3.0.5"
   resolved "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz"
   integrity sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==
 
-"@csstools/css-tokenizer@^3.0.3", "@csstools/css-tokenizer@^3.0.4":
+"@csstools/css-tokenizer@^3.0.3":
   version "3.0.4"
   resolved "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz"
   integrity sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==
@@ -383,7 +383,7 @@
   dependencies:
     tslib "^2.0.0"
 
-"@dnd-kit/core@^6.3.0", "@dnd-kit/core@^6.3.1":
+"@dnd-kit/core@^6.3.1":
   version "6.3.1"
   resolved "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz"
   integrity sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==
@@ -474,7 +474,7 @@
   resolved "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz"
   integrity sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==
 
-"@emotion/react@^11.0.0-rc.0", "@emotion/react@^11.14.0":
+"@emotion/react@^11.14.0":
   version "11.14.0"
   resolved "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz"
   integrity sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==
@@ -911,7 +911,7 @@
     jest-haste-map "30.3.0"
     slash "^3.0.0"
 
-"@jest/transform@^29.0.0 || ^30.0.0", "@jest/transform@30.3.0":
+"@jest/transform@30.3.0":
   version "30.3.0"
   resolved "https://registry.npmjs.org/@jest/transform/-/transform-30.3.0.tgz"
   integrity sha512-TLKY33fSLVd/lKB2YI1pH69ijyUblO/BQvCj566YvnwuzoTNr648iE0j22vRvVNk2HsPwByPxATg3MleS3gf5A==
@@ -931,7 +931,7 @@
     slash "^3.0.0"
     write-file-atomic "^5.0.1"
 
-"@jest/types@^29.0.0 || ^30.0.0", "@jest/types@30.3.0":
+"@jest/types@30.3.0":
   version "30.3.0"
   resolved "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz"
   integrity sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==
@@ -1075,7 +1075,7 @@
   resolved "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz"
   integrity sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==
 
-"@playwright/test@^1.51.1", "@playwright/test@^1.58.2":
+"@playwright/test@^1.58.2":
   version "1.59.1"
   resolved "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz"
   integrity sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==
@@ -1879,7 +1879,7 @@
     postcss "^8.5.6"
     tailwindcss "4.2.2"
 
-"@testing-library/dom@^10.0.0", "@testing-library/dom@^10.4.1", "@testing-library/dom@>=7.21.4":
+"@testing-library/dom@^10.4.1":
   version "10.4.1"
   resolved "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz"
   integrity sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==
@@ -2341,12 +2341,12 @@
   resolved "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz"
   integrity sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==
 
-"@types/react-dom@*", "@types/react-dom@^18.0.0 || ^19.0.0", "@types/react-dom@^19.2.3":
+"@types/react-dom@^19.2.3":
   version "19.2.3"
   resolved "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz"
   integrity sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==
 
-"@types/react@*", "@types/react@^18.0.0 || ^19.0.0", "@types/react@^19.2.0", "@types/react@^19.2.14", "@types/react@>=16.8", "@types/react@>=18":
+"@types/react@^19.2.14":
   version "19.2.14"
   resolved "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz"
   integrity sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==
@@ -2410,7 +2410,7 @@
     natural-compare "^1.4.0"
     ts-api-utils "^2.1.0"
 
-"@typescript-eslint/parser@^8.46.2", "@typescript-eslint/parser@8.46.2":
+"@typescript-eslint/parser@8.46.2":
   version "8.46.2"
   resolved "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.46.2.tgz"
   integrity sha512-BnOroVl1SgrPLywqxyqdJ4l3S2MsKVLDVxZvjI1Eoe8ev2r3kGDo+PcMihNmDE+6/KjkTubSJnmqGZZjQSBq/g==
@@ -2552,7 +2552,7 @@ acorn-walk@^8.1.1:
   dependencies:
     acorn "^8.11.0"
 
-"acorn@^6.0.0 || ^7.0.0 || ^8.0.0", acorn@^8.11.0, acorn@^8.15.0, acorn@^8.4.1:
+acorn@^8.11.0, acorn@^8.15.0, acorn@^8.4.1:
   version "8.15.0"
   resolved "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz"
   integrity sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==
@@ -2790,7 +2790,7 @@ axobject-query@^4.1.0:
   resolved "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz"
   integrity sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==
 
-"babel-jest@^29.0.0 || ^30.0.0", babel-jest@30.3.0:
+babel-jest@30.3.0:
   version "30.3.0"
   resolved "https://registry.npmjs.org/babel-jest/-/babel-jest-30.3.0.tgz"
   integrity sha512-gRpauEU2KRrCox5Z296aeVHR4jQ98BCnu0IO332D/xpHNOsIH/bgSRk9k6GbKIbBw8vFeN6ctuu6tV8WOyVfYQ==
@@ -2830,7 +2830,7 @@ babel-plugin-macros@^3.1.0:
     cosmiconfig "^7.0.0"
     resolve "^1.19.0"
 
-babel-plugin-react-compiler@*, babel-plugin-react-compiler@^1.0.0:
+babel-plugin-react-compiler@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/babel-plugin-react-compiler/-/babel-plugin-react-compiler-1.0.0.tgz"
   integrity sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==
@@ -2923,7 +2923,7 @@ braces@^3.0.3:
   dependencies:
     fill-range "^7.1.1"
 
-browserslist@^4.24.0, "browserslist@>= 4.21.0":
+browserslist@^4.24.0:
   version "4.27.0"
   resolved "https://registry.npmjs.org/browserslist/-/browserslist-4.27.0.tgz"
   integrity sha512-AXVQwdhot1eqLihwasPElhX2tAZiBjWdJ9i/Zcj2S6QYIjkx62OKSfnobkriB81C3l4w0rVy3Nt4jaTBltYEpw==
@@ -3068,7 +3068,7 @@ chevrotain-allstar@~0.3.1:
   dependencies:
     lodash-es "^4.17.21"
 
-chevrotain@^11.0.0, chevrotain@~11.1.1:
+chevrotain@~11.1.1:
   version "11.1.2"
   resolved "https://registry.npmjs.org/chevrotain/-/chevrotain-11.1.2.tgz"
   integrity sha512-opLQzEVriiH1uUQ4Kctsd49bRoFDXGGSC4GUqj7pGyxM3RehRhvTlZJc1FL/Flew2p5uwxa1tUDWKzI4wNM8pg==
@@ -3271,7 +3271,7 @@ cytoscape-fcose@^2.2.0:
   dependencies:
     cose-base "^2.2.0"
 
-cytoscape@^3.2.0, cytoscape@^3.33.1:
+cytoscape@^3.33.1:
   version "3.33.1"
   resolved "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz"
   integrity sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==
@@ -3984,7 +3984,7 @@ eslint-module-utils@^2.12.1:
   dependencies:
     debug "^3.2.7"
 
-eslint-plugin-import@*, eslint-plugin-import@^2.32.0:
+eslint-plugin-import@^2.32.0:
   version "2.32.0"
   resolved "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz"
   integrity sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==
@@ -4083,7 +4083,7 @@ eslint-visitor-keys@^4.2.1:
   resolved "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz"
   integrity sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==
 
-eslint@*, "eslint@^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9", "eslint@^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9", "eslint@^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7", "eslint@^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0", "eslint@^6.0.0 || ^7.0.0 || >=8.0.0", "eslint@^8.57.0 || ^9.0.0", eslint@^9.39.4, eslint@>=9.0.0:
+eslint@^9.39.4:
   version "9.39.4"
   resolved "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz"
   integrity sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==
@@ -5358,7 +5358,7 @@ jest-resolve-dependencies@30.3.0:
     jest-regex-util "30.0.1"
     jest-snapshot "30.3.0"
 
-jest-resolve@*, jest-resolve@30.3.0:
+jest-resolve@30.3.0:
   version "30.3.0"
   resolved "https://registry.npmjs.org/jest-resolve/-/jest-resolve-30.3.0.tgz"
   integrity sha512-NRtTAHQlpd15F9rUR36jqwelbrDV/dY4vzNte3S2kxCKUJRYNd5/6nTSbYiak1VX5g8IoFF23Uj5TURkUW8O5g==
@@ -5455,7 +5455,7 @@ jest-snapshot@30.3.0:
     semver "^7.7.2"
     synckit "^0.11.8"
 
-"jest-util@^29.0.0 || ^30.0.0", jest-util@30.3.0:
+jest-util@30.3.0:
   version "30.3.0"
   resolved "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz"
   integrity sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==
@@ -5504,7 +5504,7 @@ jest-worker@30.3.0:
     merge-stream "^2.0.0"
     supports-color "^8.1.1"
 
-"jest@^29.0.0 || ^30.0.0", jest@^30.3.0:
+jest@^30.3.0:
   version "30.3.0"
   resolved "https://registry.npmjs.org/jest/-/jest-30.3.0.tgz"
   integrity sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==
@@ -5514,7 +5514,7 @@ jest-worker@30.3.0:
     import-local "^3.2.0"
     jest-cli "30.3.0"
 
-jiti@*, jiti@^2.6.1:
+jiti@^2.6.1:
   version "2.6.1"
   resolved "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz"
   integrity sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==
@@ -5552,7 +5552,7 @@ js-yaml@^4.1.1:
   dependencies:
     argparse "^2.0.1"
 
-jsdom@*, jsdom@^26.1.0:
+jsdom@^26.1.0:
   version "26.1.0"
   resolved "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz"
   integrity sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==
@@ -5578,7 +5578,7 @@ jsdom@*, jsdom@^26.1.0:
     ws "^8.18.0"
     xml-name-validator "^5.0.0"
 
-jsep@^0.4.0||^1.0.0, jsep@^1.4.0:
+jsep@^1.4.0:
   version "1.4.0"
   resolved "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz"
   integrity sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==
@@ -6505,7 +6505,7 @@ mlly@^1.7.4, mlly@^1.8.0:
     pkg-types "^1.3.1"
     ufo "^1.6.1"
 
-monaco-editor@^0.55.1, "monaco-editor@>= 0.25.0 < 1":
+monaco-editor@^0.55.1:
   version "0.55.1"
   resolved "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz"
   integrity sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==
@@ -6558,7 +6558,7 @@ next-themes@^0.4.6:
   resolved "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz"
   integrity sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==
 
-"next@^12.2.5 || ^13 || ^14 || ^15 || ^16", next@^16.2.1:
+next@^16.2.1:
   version "16.2.2"
   resolved "https://registry.npmjs.org/next/-/next-16.2.2.tgz"
   integrity sha512-i6AJdyVa4oQjyvX/6GeER8dpY/xlIV+4NMv/svykcLtURJSy/WzDnnUk/TM4d0uewFHK7xSQz4TbIwPgjky+3A==
@@ -6694,7 +6694,7 @@ object.values@^1.1.6, object.values@^1.2.1:
     es-object-atoms "^1.0.0"
 
 "objectified-ui@file:/home/runner/work/objectified-commercial/objectified-commercial/objectified-ui":
-  version "0.9.5"
+  version "0.9.11"
   resolved "file:objectified-ui"
   dependencies:
     "@dnd-kit/core" "^6.3.1"
@@ -6974,7 +6974,7 @@ pg-types@^2.2.0, pg-types@2.2.0:
     postgres-date "~1.0.4"
     postgres-interval "^1.1.0"
 
-pg@^8.20.0, pg@>=8.0:
+pg@^8.20.0:
   version "8.20.0"
   resolved "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz"
   integrity sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==
@@ -7003,11 +7003,6 @@ picomatch@^2.0.4, picomatch@^2.3.1:
   version "2.3.1"
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
-
-"picomatch@^3 || ^4":
-  version "4.0.3"
-  resolved "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz"
-  integrity sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==
 
 picomatch@^4.0.3:
   version "4.0.4"
@@ -7114,7 +7109,7 @@ preact-render-to-string@^5.1.19:
   dependencies:
     pretty-format "^3.8.0"
 
-preact@^10.6.3, preact@>=10:
+preact@^10.6.3:
   version "10.27.2"
   resolved "https://registry.npmjs.org/preact/-/preact-10.27.2.tgz"
   integrity sha512-5SYSgFKSyhCbk6SrXyMpqjb5+MQBgfvEKE/OC+PujcY34sOpqtr+0AZQtPYx5IA6VxynQ7rUPCtKzyovpj9Bpg==
@@ -7258,7 +7253,7 @@ raf@^3.4.1:
   dependencies:
     performance-now "^2.1.0"
 
-"react-dom@^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc", "react-dom@^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom@^17.0.2 || ^18 || ^19", "react-dom@^18.0.0 || ^19.0.0", "react-dom@^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react-dom@^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", react-dom@^19.2.4, react-dom@>=16.8.0, react-dom@>=17, "react-dom@16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc":
+react-dom@^19.2.4:
   version "19.2.4"
   resolved "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz"
   integrity sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==
@@ -7329,7 +7324,7 @@ react-style-singleton@^2.2.2, react-style-singleton@^2.2.3:
     get-nonce "^1.0.0"
     tslib "^2.0.0"
 
-react@*, "react@^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react@^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc", "react@^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react@^16.x || ^17.x || ^18.x || ^19.0.0 || ^19.0.0-rc", "react@^17.0.2 || ^18 || ^19", "react@^18.0.0 || ^19.0.0", "react@^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react@^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", react@^19.2.4, "react@>= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0", react@>=16.8, react@>=16.8.0, react@>=17, react@>=18, "react@16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc":
+react@^19.2.4:
   version "19.2.4"
   resolved "https://registry.npmjs.org/react/-/react-19.2.4.tgz"
   integrity sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==
@@ -8061,7 +8056,7 @@ tailwindcss-animate@^1.0.7:
   resolved "https://registry.npmjs.org/tailwindcss-animate/-/tailwindcss-animate-1.0.7.tgz"
   integrity sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==
 
-tailwindcss@^4.2.2, "tailwindcss@>=3.0.0 || insiders", tailwindcss@4.2.2:
+tailwindcss@^4.2.2, tailwindcss@4.2.2:
   version "4.2.2"
   resolved "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz"
   integrity sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==
@@ -8173,7 +8168,7 @@ ts-jest@^29.4.9:
     type-fest "^4.41.0"
     yargs-parser "^21.1.1"
 
-ts-node@^10.9.2, ts-node@>=9.0.0:
+ts-node@^10.9.2:
   version "10.9.2"
   resolved "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz"
   integrity sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==
@@ -8284,7 +8279,7 @@ typescript-eslint@^8.46.0:
     "@typescript-eslint/typescript-estree" "8.46.2"
     "@typescript-eslint/utils" "8.46.2"
 
-typescript@^5.9.3, typescript@>=2.7, typescript@>=3.3.1, "typescript@>=4.3 <7", typescript@>=4.8.4, "typescript@>=4.8.4 <6.0.0":
+typescript@^5.9.3:
   version "5.9.3"
   resolved "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz"
   integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==


### PR DESCRIPTION
Four correctness and UX issues flagged in code review on the import execution panel.

## Changes

- **Singular ETA grammar** — `formatEtaLine` now returns `"about 1 second"` instead of `"about 1 seconds"` when `seconds === 1`
- **Recent-first collapsed log** — collapsed log view now shows the most recent 8 events (`slice(-N)`) instead of the oldest 8, so users see current activity by default
- **Cancel button regression** — restored `Cancel Import` for `queued | running | committing` states; previously these states rendered `null` for the action area, silently removing the ability to cancel an in-progress import
- **O(1) checklist membership** — `buildImportLiveChecklist` now precomputes `createdLower`/`failedLower` `Set<string>` once before the `map` loop, replacing per-row `[...set].some(namesMatch)` O(n) scans

```ts
// Before: O(n) per row
const isFailed = [...failed].some((f) => namesMatch(f, label));

// After: O(1) per row
const failedLower = new Set<string>([...failed].map((n) => n.trim().toLowerCase()));
const isFailed = failedLower.has(label.trim().toLowerCase());
```