### PR TITLE
Fix #292 review: cache correctness, auth-keyed cache keys, tabbar a11y, redundant state cleanup

### DIFF
--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.9.12",
+  "version": "0.9.13",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -5,6 +5,7 @@ We continue to improve the platform based on your feedback with improvements and
 ---
 
 ## UI:
+- **Import from URL:** Source tabs switch between File, URL, Clipboard, Git, and SwaggerHub; URL step matches the import spec (auth, URL options including cache, **Test URL** and **Next** in the dialog footer)
 - **Git import:** Load a GitHub repository by URL or `owner/repo`, pick a **branch** or **tag**, optionally type a **spec path** and open it, or browse the tree — directory listing uses the selected ref (same behavior when choosing a repo from the list)
 - **OpenAPI import:** Import step shows the **Import Execution** layout — progress with schema index and ETA, per-schema live checklist (success / warning / in progress / pending), expandable import log, and technical summary in a collapsible section
 - **What's New** dialog is centered on the viewport again (overlay renders outside the header so it is not offset downward)

--- a/objectified-ui/src/app/components/ade/dashboard/ImportDialog.tsx
+++ b/objectified-ui/src/app/components/ade/dashboard/ImportDialog.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { Upload, Link2, FileText, Github, Cloud, Package, X, FileCode, AlertTriangle, CheckCircle2, FileJson } from 'lucide-react';
 import {
   Dialog,
@@ -15,7 +15,8 @@ import { PreviewPanel, ImportOptions } from './PreviewPanel';
 import { analyzeSpecification, AnalysisResult, extractFileMetadata, FileMetadataPreview } from '../../../utils/openapi-analyzer';
 import ImportExecutionPanel from './ImportExecutionPanel';
 import ImportCompletePanel from './ImportCompletePanel';
-import UrlImportPanel from './UrlImportPanel';
+import UrlImportPanel, { type UrlImportPanelHandle, type UrlImportFooterState } from './UrlImportPanel';
+import { ImportSourceTabBar, type ImportSourceTabId } from './ImportSourceTabBar';
 import ClipboardImportPanel from './ClipboardImportPanel';
 import GitImportPanel from './GitImportPanel';
 import SwaggerHubImportPanel from './SwaggerHubImportPanel';
@@ -78,6 +79,16 @@ const ImportDialog: React.FC<ImportDialogProps> = ({
   const [postmanMetadata, setPostmanMetadata] = useState<FileMetadataPreview | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
+  const urlImportRef = useRef<UrlImportPanelHandle>(null);
+  const [urlImportFooter, setUrlImportFooter] = useState<UrlImportFooterState>({
+    canTestUrl: false,
+    isTesting: false,
+    urlTestedSuccessfully: false,
+  });
+  const handleUrlImportFooterState = useCallback((s: UrlImportFooterState) => {
+    setUrlImportFooter(s);
+  }, []);
+
   // When opened with spec from AI Design Chat (Projects dashboard), run analysis immediately
   useEffect(() => {
     if (!open || !initialLLMSpec) return;
@@ -99,7 +110,7 @@ const ImportDialog: React.FC<ImportDialogProps> = ({
       .finally(() => setIsAnalyzing(false));
   }, [open, initialLLMSpec, onConsumeInitialLLMSpec]);
 
-  const handleSourceClick = (source: string) => {
+  const handleSourceClick = (source: string | ImportSourceTabId) => {
     setErrorMessage(null);
     setSelectedSource(source);
     setCurrentStep('file-upload');
@@ -727,50 +738,8 @@ const ImportDialog: React.FC<ImportDialogProps> = ({
             <>
               {/* Step 1a: File Upload View */}
 
-              {/* Source Tabs */}
               <div className="mb-6">
-                <div className="flex gap-2 border-b border-gray-200 dark:border-gray-700">
-                  <button
-                    className="px-4 py-2 text-sm font-medium border-b-2 border-indigo-600 text-indigo-600 dark:text-indigo-400"
-                  >
-                    📁 File
-                  </button>
-                  <button
-                    disabled
-                    className="px-4 py-2 text-sm font-medium text-gray-400 dark:text-gray-600 cursor-not-allowed opacity-50"
-                    title="Coming soon"
-                  >
-                    🔗 URL
-                  </button>
-                  <button
-                    disabled
-                    className="px-4 py-2 text-sm font-medium text-gray-400 dark:text-gray-600 cursor-not-allowed opacity-50"
-                    title="Coming soon"
-                  >
-                    📋 Clipboard
-                  </button>
-                  <button
-                    disabled
-                    className="px-4 py-2 text-sm font-medium text-gray-400 dark:text-gray-600 cursor-not-allowed opacity-50"
-                    title="Coming soon"
-                  >
-                    🐙 Git
-                  </button>
-                  <button
-                    disabled
-                    className="px-4 py-2 text-sm font-medium text-gray-400 dark:text-gray-600 cursor-not-allowed opacity-50"
-                    title="Coming soon"
-                  >
-                    ☁️ SwaggerHub
-                  </button>
-                  <button
-                    disabled
-                    className="px-4 py-2 text-sm font-medium text-gray-400 dark:text-gray-600 cursor-not-allowed opacity-50"
-                    title="Coming soon"
-                  >
-                    📦 Registry
-                  </button>
-                </div>
+                <ImportSourceTabBar active="file" onSelect={(id) => handleSourceClick(id)} />
               </div>
 
               {/* Drop Zone */}
@@ -1022,7 +991,10 @@ const ImportDialog: React.FC<ImportDialogProps> = ({
               console.log('Rendering: URL import panel');
               return (
                 <UrlImportPanel
+                  ref={urlImportRef}
                   onSpecificationFetched={handleUrlSpecificationFetched}
+                  onSelectSource={(id) => handleSourceClick(id)}
+                  onFooterStateChange={handleUrlImportFooterState}
                 />
               );
             } else if (currentStep === 'file-upload' && selectedSource === 'clipboard') {
@@ -1126,6 +1098,24 @@ const ImportDialog: React.FC<ImportDialogProps> = ({
                 <Button variant="outline" onClick={handleClose}>
                   Cancel
                 </Button>
+                {currentStep === 'file-upload' && selectedSource === 'url' && (
+                  <Button
+                    variant="outline"
+                    onClick={() => void urlImportRef.current?.testUrl()}
+                    disabled={!urlImportFooter.canTestUrl || urlImportFooter.isTesting}
+                    className={
+                      urlImportFooter.urlTestedSuccessfully
+                        ? 'border-green-500 text-green-600 dark:border-green-500 dark:text-green-400'
+                        : undefined
+                    }
+                  >
+                    {urlImportFooter.isTesting
+                      ? 'Testing...'
+                      : urlImportFooter.urlTestedSuccessfully
+                        ? 'URL tested ✓'
+                        : 'Test URL'}
+                  </Button>
+                )}
                 {currentStep === 'file-upload' && selectedSource === 'file' && (
                   <Button
                     onClick={handleAnalyze}
@@ -1141,7 +1131,7 @@ const ImportDialog: React.FC<ImportDialogProps> = ({
                     disabled={!urlContent || isAnalyzing || (urlMetadata !== null && !urlMetadata.formatSupported)}
                     className="bg-gradient-to-r from-indigo-500 to-purple-600 hover:from-indigo-600 hover:to-purple-700"
                   >
-                    {isAnalyzing ? 'Analyzing...' : 'Analyze →'}
+                    {isAnalyzing ? 'Analyzing...' : 'Next →'}
                   </Button>
                 )}
                 {currentStep === 'file-upload' && selectedSource === 'clipboard' && (

--- a/objectified-ui/src/app/components/ade/dashboard/ImportSourceTabBar.tsx
+++ b/objectified-ui/src/app/components/ade/dashboard/ImportSourceTabBar.tsx
@@ -36,7 +36,11 @@ export interface ImportSourceTabBarProps {
 
 export function ImportSourceTabBar({ active, onSelect, className = '', disabledIds }: ImportSourceTabBarProps) {
   return (
-    <div className={`flex flex-wrap gap-1 border-b border-gray-200 dark:border-gray-700 ${className}`}>
+    <div
+      role="tablist"
+      aria-label="Import source"
+      className={`flex flex-wrap gap-1 border-b border-gray-200 dark:border-gray-700 ${className}`}
+    >
       {TABS.map(({ id, label, disabled }) => {
         const isDisabled = Boolean(disabled) || Boolean(disabledIds?.includes(id));
         const isActive = active === id;
@@ -45,6 +49,9 @@ export function ImportSourceTabBar({ active, onSelect, className = '', disabledI
           <button
             key={id}
             type="button"
+            role="tab"
+            aria-selected={isActive}
+            aria-disabled={isDisabled || undefined}
             disabled={isDisabled}
             onClick={() => !isDisabled && onSelect(id)}
             title={isDisabled ? 'Coming soon' : undefined}
@@ -56,7 +63,7 @@ export function ImportSourceTabBar({ active, onSelect, className = '', disabledI
                   : 'border-transparent text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200 hover:border-gray-300 dark:hover:border-gray-600'
             }`}
           >
-            {icon} {label}
+            <span aria-hidden="true">{icon}</span>{' '}{label}
           </button>
         );
       })}

--- a/objectified-ui/src/app/components/ade/dashboard/ImportSourceTabBar.tsx
+++ b/objectified-ui/src/app/components/ade/dashboard/ImportSourceTabBar.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+export type ImportSourceTabId =
+  | 'file'
+  | 'url'
+  | 'clipboard'
+  | 'git'
+  | 'swaggerhub'
+  | 'registry';
+
+const TABS: { id: ImportSourceTabId; label: string; disabled?: boolean }[] = [
+  { id: 'file', label: 'File' },
+  { id: 'url', label: 'URL' },
+  { id: 'clipboard', label: 'Clipboard' },
+  { id: 'git', label: 'Git' },
+  { id: 'swaggerhub', label: 'SwaggerHub' },
+  { id: 'registry', label: 'Registry', disabled: true },
+];
+
+const TAB_ICONS: Record<ImportSourceTabId, string> = {
+  file: '📁',
+  url: '🔗',
+  clipboard: '📋',
+  git: '🐙',
+  swaggerhub: '☁️',
+  registry: '📦',
+};
+
+export interface ImportSourceTabBarProps {
+  active: ImportSourceTabId;
+  onSelect: (id: ImportSourceTabId) => void;
+  className?: string;
+  /** Additional tab ids to disable (e.g. SwaggerHub when this flow does not support it). */
+  disabledIds?: ImportSourceTabId[];
+}
+
+export function ImportSourceTabBar({ active, onSelect, className = '', disabledIds }: ImportSourceTabBarProps) {
+  return (
+    <div className={`flex flex-wrap gap-1 border-b border-gray-200 dark:border-gray-700 ${className}`}>
+      {TABS.map(({ id, label, disabled }) => {
+        const isDisabled = Boolean(disabled) || Boolean(disabledIds?.includes(id));
+        const isActive = active === id;
+        const icon = TAB_ICONS[id];
+        return (
+          <button
+            key={id}
+            type="button"
+            disabled={isDisabled}
+            onClick={() => !isDisabled && onSelect(id)}
+            title={isDisabled ? 'Coming soon' : undefined}
+            className={`px-3 py-2 text-sm font-medium transition-colors rounded-t-md border-b-2 -mb-px ${
+              isDisabled
+                ? 'text-gray-400 dark:text-gray-600 cursor-not-allowed opacity-50 border-transparent'
+                : isActive
+                  ? 'border-indigo-600 text-indigo-600 dark:text-indigo-400'
+                  : 'border-transparent text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200 hover:border-gray-300 dark:hover:border-gray-600'
+            }`}
+          >
+            {icon} {label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/objectified-ui/src/app/components/ade/dashboard/UrlImportPanel.tsx
+++ b/objectified-ui/src/app/components/ade/dashboard/UrlImportPanel.tsx
@@ -1,20 +1,36 @@
 'use client';
 
-import { useState, useEffect } from 'react';
-import { Link2, Eye, EyeOff, CheckCircle2, AlertTriangle, Loader2, FileCode, Globe } from 'lucide-react';
-import { Button } from '../../../components/ui/Button';
+import { useState, useEffect, useCallback, useImperativeHandle, forwardRef } from 'react';
+import { Link2, Eye, EyeOff, CheckCircle2, AlertTriangle, FileCode, Globe } from 'lucide-react';
 import { fetchSpecificationFromUrl, validateImportUrl, UrlImportOptions, UrlImportResult } from '../../../utils/url-import';
 import { extractFileMetadata, FileMetadataPreview } from '../../../utils/openapi-analyzer';
+import { ImportSourceTabBar, type ImportSourceTabId } from './ImportSourceTabBar';
+
+export interface UrlImportFooterState {
+  canTestUrl: boolean;
+  isTesting: boolean;
+  urlTestedSuccessfully: boolean;
+}
+
+export interface UrlImportPanelHandle {
+  testUrl: () => Promise<void>;
+}
 
 interface UrlImportPanelProps {
   onSpecificationFetched: (content: string, filename: string, metadata?: FileMetadataPreview) => void;
+  /** Switch import source (same step, different panel). */
+  onSelectSource?: (source: ImportSourceTabId) => void;
+  onFooterStateChange?: (state: UrlImportFooterState) => void;
+  /** Extra tabs to disable (e.g. SwaggerHub in class import). */
+  tabDisabledIds?: ImportSourceTabId[];
 }
 
 type AuthType = 'none' | 'bearer' | 'apiKey' | 'basic';
 
-export const UrlImportPanel: React.FC<UrlImportPanelProps> = ({
-  onSpecificationFetched
-}) => {
+const UrlImportPanel = forwardRef<UrlImportPanelHandle, UrlImportPanelProps>(function UrlImportPanel(
+  { onSpecificationFetched, onSelectSource, onFooterStateChange, tabDisabledIds },
+  ref
+) {
   // Form state
   const [url, setUrl] = useState('');
   const [authType, setAuthType] = useState<AuthType>('none');
@@ -25,6 +41,7 @@ export const UrlImportPanel: React.FC<UrlImportPanelProps> = ({
   const [showPassword, setShowPassword] = useState(false);
   const [followRedirects, setFollowRedirects] = useState(true);
   const [resolveExternalRefs, setResolveExternalRefs] = useState(true);
+  const [cacheFetched, setCacheFetched] = useState(false);
   const [saveCredentials, setSaveCredentials] = useState(false);
 
   // UI state
@@ -51,21 +68,22 @@ export const UrlImportPanel: React.FC<UrlImportPanelProps> = ({
     }
   }, [url]);
 
-  // Build import options
-  const buildOptions = (): UrlImportOptions => ({
-    url: url.trim(),
-    authType,
-    authToken: authType === 'bearer' || authType === 'apiKey' ? token : undefined,
-    apiKeyHeader: authType === 'apiKey' ? apiKeyHeader : undefined,
-    username: authType === 'basic' ? username : undefined,
-    password: authType === 'basic' ? password : undefined,
-    followRedirects,
-    timeout: 30000
-  });
-
   // Test URL - fetches and validates but doesn't proceed to analysis
-  const handleTestUrl = async () => {
+  const handleTestUrl = useCallback(async () => {
     if (!url.trim() || urlError) return;
+
+    const options: UrlImportOptions = {
+      url: url.trim(),
+      authType,
+      authToken: authType === 'bearer' || authType === 'apiKey' ? token : undefined,
+      apiKeyHeader: authType === 'apiKey' ? apiKeyHeader : undefined,
+      username: authType === 'basic' ? username : undefined,
+      password: authType === 'basic' ? password : undefined,
+      followRedirects,
+      resolveExternalRefs,
+      useCache: cacheFetched,
+      timeout: 30000
+    };
 
     setIsFetching(true);
     setFetchResult(null);
@@ -75,21 +93,17 @@ export const UrlImportPanel: React.FC<UrlImportPanelProps> = ({
     setUrlTested(false);
 
     try {
-      const result = await fetchSpecificationFromUrl(buildOptions());
+      const result = await fetchSpecificationFromUrl(options);
       setFetchResult(result);
 
       if (result.success && result.content) {
-        // Extract metadata for preview
         const metadata = extractFileMetadata(result.content);
         setFileMetadata(metadata);
 
-        // Store content for later use when user clicks Analyze
         setFetchedContent(result.content);
         setFetchedFilename(result.filename || 'openapi-spec.yaml');
         setUrlTested(true);
 
-        // Notify parent that content is ready (for enabling Analyze button)
-        // Pass metadata so parent can check format support
         onSpecificationFetched(result.content, result.filename || 'openapi-spec.yaml', metadata);
       }
     } catch (error) {
@@ -100,7 +114,31 @@ export const UrlImportPanel: React.FC<UrlImportPanelProps> = ({
     } finally {
       setIsFetching(false);
     }
-  };
+  }, [
+    url,
+    urlError,
+    authType,
+    token,
+    apiKeyHeader,
+    username,
+    password,
+    followRedirects,
+    resolveExternalRefs,
+    cacheFetched,
+    onSpecificationFetched
+  ]);
+
+  useImperativeHandle(ref, () => ({
+    testUrl: () => handleTestUrl(),
+  }), [handleTestUrl]);
+
+  useEffect(() => {
+    onFooterStateChange?.({
+      canTestUrl: Boolean(url.trim()) && !urlError,
+      isTesting: isFetching,
+      urlTestedSuccessfully: Boolean(urlTested && fetchResult?.success),
+    });
+  }, [url, urlError, isFetching, urlTested, fetchResult?.success, onFooterStateChange]);
 
   // Reset tested state when URL or auth changes
   useEffect(() => {
@@ -113,48 +151,11 @@ export const UrlImportPanel: React.FC<UrlImportPanelProps> = ({
 
   return (
     <div className="space-y-6">
-      {/* Source Tabs */}
-      <div className="flex gap-2 border-b border-gray-200 dark:border-gray-700">
-        <button
-          disabled
-          className="px-4 py-2 text-sm font-medium text-gray-400 dark:text-gray-600 cursor-not-allowed opacity-50"
-        >
-          📁 File
-        </button>
-        <button
-          className="px-4 py-2 text-sm font-medium border-b-2 border-indigo-600 text-indigo-600 dark:text-indigo-400"
-        >
-          🔗 URL
-        </button>
-        <button
-          disabled
-          className="px-4 py-2 text-sm font-medium text-gray-400 dark:text-gray-600 cursor-not-allowed opacity-50"
-          title="Coming soon"
-        >
-          📋 Clipboard
-        </button>
-        <button
-          disabled
-          className="px-4 py-2 text-sm font-medium text-gray-400 dark:text-gray-600 cursor-not-allowed opacity-50"
-          title="Coming soon"
-        >
-          🐙 Git
-        </button>
-        <button
-          disabled
-          className="px-4 py-2 text-sm font-medium text-gray-400 dark:text-gray-600 cursor-not-allowed opacity-50"
-          title="Coming soon"
-        >
-          ☁️ SwaggerHub
-        </button>
-        <button
-          disabled
-          className="px-4 py-2 text-sm font-medium text-gray-400 dark:text-gray-600 cursor-not-allowed opacity-50"
-          title="Coming soon"
-        >
-          📦 Registry
-        </button>
-      </div>
+      <ImportSourceTabBar
+        active="url"
+        onSelect={(id) => onSelectSource?.(id)}
+        disabledIds={tabDisabledIds}
+      />
 
       {/* URL Input */}
       <div className="space-y-2">
@@ -371,6 +372,18 @@ export const UrlImportPanel: React.FC<UrlImportPanelProps> = ({
               Resolve external $ref URLs
             </span>
           </label>
+
+          <label className="flex items-center gap-2 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={cacheFetched}
+              onChange={(e) => setCacheFetched(e.target.checked)}
+              className="rounded text-indigo-600 focus:ring-indigo-500"
+            />
+            <span className="text-sm text-gray-600 dark:text-gray-400">
+              Cache fetched content
+            </span>
+          </label>
         </div>
       </div>
 
@@ -483,33 +496,6 @@ export const UrlImportPanel: React.FC<UrlImportPanelProps> = ({
         </div>
       )}
 
-      {/* Action Buttons */}
-      <div className="flex justify-end gap-3 pt-4 border-t border-gray-200 dark:border-gray-700">
-        <Button
-          onClick={handleTestUrl}
-          disabled={!url.trim() || !!urlError || isFetching}
-          variant={urlTested && fetchResult?.success ? 'outline' : 'default'}
-          className={urlTested && fetchResult?.success
-            ? 'border-green-500 text-green-600 hover:bg-green-50 dark:border-green-500 dark:text-green-400 dark:hover:bg-green-900/20'
-            : 'bg-indigo-600 hover:bg-indigo-700 text-white'
-          }
-        >
-          {isFetching ? (
-            <>
-              <Loader2 className="h-4 w-4 animate-spin mr-2" />
-              Testing...
-            </>
-          ) : urlTested && fetchResult?.success ? (
-            <>
-              <CheckCircle2 className="h-4 w-4 mr-2" />
-              URL Tested Successfully
-            </>
-          ) : (
-            'Test URL'
-          )}
-        </Button>
-      </div>
-
       {/* Help text for next steps */}
       {urlTested && fetchResult?.success && fileMetadata?.formatSupported && (
         <div className="p-4 rounded-lg bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800">
@@ -520,7 +506,7 @@ export const UrlImportPanel: React.FC<UrlImportPanelProps> = ({
                 URL verified successfully
               </div>
               <div className="text-sm text-green-700 dark:text-green-300 mt-1">
-                Click &quot;Analyze →&quot; below to proceed with the import.
+                Use &quot;Next →&quot; in the dialog footer to continue to analysis.
               </div>
             </div>
           </div>
@@ -528,7 +514,7 @@ export const UrlImportPanel: React.FC<UrlImportPanelProps> = ({
       )}
     </div>
   );
-};
+});
 
 export default UrlImportPanel;
 

--- a/objectified-ui/src/app/components/ade/dashboard/UrlImportPanel.tsx
+++ b/objectified-ui/src/app/components/ade/dashboard/UrlImportPanel.tsx
@@ -49,8 +49,6 @@ const UrlImportPanel = forwardRef<UrlImportPanelHandle, UrlImportPanelProps>(fun
   const [isFetching, setIsFetching] = useState(false);
   const [fetchResult, setFetchResult] = useState<UrlImportResult | null>(null);
   const [fileMetadata, setFileMetadata] = useState<FileMetadataPreview | null>(null);
-  const [fetchedContent, setFetchedContent] = useState<string | null>(null);
-  const [fetchedFilename, setFetchedFilename] = useState<string | null>(null);
   const [urlTested, setUrlTested] = useState(false);
 
   // Validate URL on change
@@ -88,8 +86,6 @@ const UrlImportPanel = forwardRef<UrlImportPanelHandle, UrlImportPanelProps>(fun
     setIsFetching(true);
     setFetchResult(null);
     setFileMetadata(null);
-    setFetchedContent(null);
-    setFetchedFilename(null);
     setUrlTested(false);
 
     try {
@@ -100,8 +96,6 @@ const UrlImportPanel = forwardRef<UrlImportPanelHandle, UrlImportPanelProps>(fun
         const metadata = extractFileMetadata(result.content);
         setFileMetadata(metadata);
 
-        setFetchedContent(result.content);
-        setFetchedFilename(result.filename || 'openapi-spec.yaml');
         setUrlTested(true);
 
         onSpecificationFetched(result.content, result.filename || 'openapi-spec.yaml', metadata);
@@ -145,8 +139,6 @@ const UrlImportPanel = forwardRef<UrlImportPanelHandle, UrlImportPanelProps>(fun
     setUrlTested(false);
     setFetchResult(null);
     setFileMetadata(null);
-    setFetchedContent(null);
-    setFetchedFilename(null);
   }, [url, authType, token, apiKeyHeader, username, password]);
 
   return (
@@ -506,7 +498,7 @@ const UrlImportPanel = forwardRef<UrlImportPanelHandle, UrlImportPanelProps>(fun
                 URL verified successfully
               </div>
               <div className="text-sm text-green-700 dark:text-green-300 mt-1">
-                Use &quot;Next →&quot; in the dialog footer to continue to analysis.
+                Use the button in the dialog footer to continue to analysis.
               </div>
             </div>
           </div>

--- a/objectified-ui/src/app/components/ade/studio/ClassImportDialog.tsx
+++ b/objectified-ui/src/app/components/ade/studio/ClassImportDialog.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useRef, useCallback } from 'react';
 import { Upload, X, FileCode, AlertTriangle, CheckCircle2, Package, Search, Check, ChevronRight, ArrowUpAZ, ArrowDownAZ, Link2, FileText, Github, ChevronDown } from 'lucide-react';
 import * as Checkbox from '@radix-ui/react-checkbox';
 import {
@@ -15,7 +15,8 @@ import { Button } from '../../ui/Button';
 import { analyzeSpecification, AnalysisResult, extractFileMetadata, FileMetadataPreview } from '../../../utils/openapi-analyzer';
 import { importClassesToVersion, ImportClassesResult } from '../../../../../lib/db/class-import-actions';
 import { getVersionById, createVersion, bumpPrereleaseVersion } from '../../../../../lib/db/helper';
-import UrlImportPanel from '../dashboard/UrlImportPanel';
+import UrlImportPanel, { type UrlImportPanelHandle, type UrlImportFooterState } from '../dashboard/UrlImportPanel';
+import { ImportSourceTabBar, type ImportSourceTabId } from '../dashboard/ImportSourceTabBar';
 import ClipboardImportPanel from '../dashboard/ClipboardImportPanel';
 import GitImportPanel from '../dashboard/GitImportPanel';
 import { ConflictReport, type ImportConflict } from '../dashboard/ConflictReport';
@@ -164,6 +165,16 @@ const ClassImportDialog: React.FC<ClassImportDialogProps> = ({
   const [importResult, setImportResult] = useState<ImportClassesResult | null>(null);
   const [urlContent, setUrlContent] = useState<string | null>(null);
   const [urlFilename, setUrlFilename] = useState<string | null>(null);
+  const [urlMetadata, setUrlMetadata] = useState<FileMetadataPreview | null>(null);
+  const urlImportRef = useRef<UrlImportPanelHandle>(null);
+  const [urlImportFooter, setUrlImportFooter] = useState<UrlImportFooterState>({
+    canTestUrl: false,
+    isTesting: false,
+    urlTestedSuccessfully: false,
+  });
+  const handleUrlImportFooterState = useCallback((s: UrlImportFooterState) => {
+    setUrlImportFooter(s);
+  }, []);
   const [clipboardContent, setClipboardContent] = useState<string | null>(null);
   const [clipboardFilename, setClipboardFilename] = useState<string | null>(null);
   const [gitContent, setGitContent] = useState<string | null>(null);
@@ -221,6 +232,7 @@ const ClassImportDialog: React.FC<ClassImportDialogProps> = ({
       setFileMetadata(null);
       setUrlContent(null);
       setUrlFilename(null);
+      setUrlMetadata(null);
       setClipboardContent(null);
       setClipboardFilename(null);
     }
@@ -244,6 +256,7 @@ const ClassImportDialog: React.FC<ClassImportDialogProps> = ({
     setImportResult(null);
     setUrlContent(null);
     setUrlFilename(null);
+    setUrlMetadata(null);
     setClipboardContent(null);
     setClipboardFilename(null);
     setGitContent(null);
@@ -299,37 +312,10 @@ const ClassImportDialog: React.FC<ClassImportDialogProps> = ({
     }
   };
 
-  const handleUrlSpecificationFetched = async (content: string, filename: string) => {
+  const handleUrlSpecificationFetched = (content: string, filename: string, metadata?: FileMetadataPreview) => {
     setUrlContent(content);
     setUrlFilename(filename);
-
-    // Auto-analyze when URL content is fetched
-    setIsAnalyzing(true);
-    try {
-      const result = await analyzeSpecification(content, filename);
-      setAnalysisResult(result);
-
-      // Initialize schemas list with conflict detection (#580, #582: duplicate = same name + different definition)
-      const schemaObj = result.document?.components?.schemas || result.document?.definitions || {};
-      const schemaList: SchemaInfo[] = Object.keys(schemaObj).map(name => {
-        const raw = schemaObj[name];
-        const exists = isDuplicateSchema(name, raw, existingClassNames, existingClassSchemas);
-        return {
-          name,
-          properties: countSchemaProperties(raw),
-          selected: !exists,
-          exists,
-          schemaType: getSchemaType(raw),
-          tags: getSchemaTags(raw),
-        };
-      });
-      setSchemas(schemaList);
-      setCurrentStep('select');
-    } catch (error) {
-      console.error('URL content analysis error:', error);
-    } finally {
-      setIsAnalyzing(false);
-    }
+    setUrlMetadata(metadata ?? null);
   };
 
   const handleClipboardSpecificationReady = (content: string, filename: string) => {
@@ -850,7 +836,14 @@ const ClassImportDialog: React.FC<ClassImportDialogProps> = ({
 
           {currentStep === 'file-upload' && selectedSource === 'url' && (
             <UrlImportPanel
+              ref={urlImportRef}
               onSpecificationFetched={handleUrlSpecificationFetched}
+              onSelectSource={(id: ImportSourceTabId) => {
+                if (id === 'registry' || id === 'swaggerhub') return;
+                handleSourceClick(id);
+              }}
+              onFooterStateChange={handleUrlImportFooterState}
+              tabDisabledIds={['swaggerhub']}
             />
           )}
 
@@ -869,6 +862,16 @@ const ClassImportDialog: React.FC<ClassImportDialogProps> = ({
 
           {currentStep === 'file-upload' && selectedSource === 'file' && (
             <>
+              <div className="mb-6">
+                <ImportSourceTabBar
+                  active="file"
+                  onSelect={(id) => {
+                    if (id === 'registry' || id === 'swaggerhub') return;
+                    handleSourceClick(id);
+                  }}
+                  disabledIds={['swaggerhub']}
+                />
+              </div>
               {/* Drop Zone */}
               <div className="mb-6">
                 <div
@@ -1821,10 +1824,37 @@ const ClassImportDialog: React.FC<ClassImportDialogProps> = ({
                 <Button variant="outline" onClick={handleClose}>
                   Cancel
                 </Button>
+                {currentStep === 'file-upload' && selectedSource === 'url' && (
+                  <Button
+                    variant="outline"
+                    onClick={() => void urlImportRef.current?.testUrl()}
+                    disabled={!urlImportFooter.canTestUrl || urlImportFooter.isTesting}
+                    className={
+                      urlImportFooter.urlTestedSuccessfully
+                        ? 'border-green-500 text-green-600 dark:border-green-500 dark:text-green-400'
+                        : undefined
+                    }
+                  >
+                    {urlImportFooter.isTesting
+                      ? 'Testing...'
+                      : urlImportFooter.urlTestedSuccessfully
+                        ? 'URL tested ✓'
+                        : 'Test URL'}
+                  </Button>
+                )}
                 {currentStep === 'file-upload' && selectedSource === 'file' && (
                   <Button
                     onClick={handleAnalyze}
                     disabled={!selectedFile || isAnalyzing || (fileMetadata !== null && !fileMetadata.formatSupported)}
+                    className="bg-gradient-to-r from-indigo-500 to-purple-600 hover:from-indigo-600 hover:to-purple-700"
+                  >
+                    {isAnalyzing ? 'Analyzing...' : 'Continue →'}
+                  </Button>
+                )}
+                {currentStep === 'file-upload' && selectedSource === 'url' && (
+                  <Button
+                    onClick={handleAnalyze}
+                    disabled={!urlContent || isAnalyzing || (urlMetadata !== null && !urlMetadata.formatSupported)}
                     className="bg-gradient-to-r from-indigo-500 to-purple-600 hover:from-indigo-600 hover:to-purple-700"
                   >
                     {isAnalyzing ? 'Analyzing...' : 'Continue →'}

--- a/objectified-ui/src/app/utils/url-import.ts
+++ b/objectified-ui/src/app/utils/url-import.ts
@@ -10,6 +10,58 @@ import { isProtobuf } from './protobuf-converter';
 import { isAvroSchemaObject } from './avro-converter';
 import { isThrift } from './thrift-converter';
 
+const URL_IMPORT_CACHE_STORAGE_KEY = 'objectified:url-import-cache:v1';
+const URL_IMPORT_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+
+type UrlImportCacheEntry = {
+  content: string;
+  filename: string;
+  storedAt: number;
+};
+
+type UrlImportCacheStore = Record<string, UrlImportCacheEntry>;
+
+function normalizeUrlKey(url: string): string {
+  try {
+    return new URL(url.trim()).href;
+  } catch {
+    return url.trim();
+  }
+}
+
+function readUrlImportCache(url: string): UrlImportCacheEntry | null {
+  if (typeof sessionStorage === 'undefined') return null;
+  try {
+    const raw = sessionStorage.getItem(URL_IMPORT_CACHE_STORAGE_KEY);
+    if (!raw) return null;
+    const store = JSON.parse(raw) as UrlImportCacheStore;
+    const key = normalizeUrlKey(url);
+    const entry = store[key];
+    if (!entry?.content) return null;
+    if (Date.now() - entry.storedAt > URL_IMPORT_CACHE_TTL_MS) {
+      delete store[key];
+      sessionStorage.setItem(URL_IMPORT_CACHE_STORAGE_KEY, JSON.stringify(store));
+      return null;
+    }
+    return entry;
+  } catch {
+    return null;
+  }
+}
+
+function writeUrlImportCache(url: string, content: string, filename: string): void {
+  if (typeof sessionStorage === 'undefined') return;
+  try {
+    const raw = sessionStorage.getItem(URL_IMPORT_CACHE_STORAGE_KEY);
+    const store = (raw ? JSON.parse(raw) : {}) as UrlImportCacheStore;
+    const key = normalizeUrlKey(url);
+    store[key] = { content, filename, storedAt: Date.now() };
+    sessionStorage.setItem(URL_IMPORT_CACHE_STORAGE_KEY, JSON.stringify(store));
+  } catch {
+    // ignore quota / private mode
+  }
+}
+
 export interface UrlImportOptions {
   /** The URL to fetch the specification from */
   url: string;
@@ -25,6 +77,13 @@ export interface UrlImportOptions {
   password?: string;
   /** Whether to follow redirects */
   followRedirects?: boolean;
+  /** When true, reuse a recent successful fetch from session cache (same normalized URL). */
+  useCache?: boolean;
+  /**
+   * Reserved for analysis/import: whether to attempt resolving external $ref URLs.
+   * The initial GET does not bundle refs; this flag is stored for downstream steps.
+   */
+  resolveExternalRefs?: boolean;
   /** Request timeout in milliseconds */
   timeout?: number;
 }
@@ -227,6 +286,20 @@ export async function fetchSpecificationFromUrl(options: UrlImportOptions): Prom
     };
   }
 
+  if (options.useCache) {
+    const cached = readUrlImportCache(options.url);
+    if (cached) {
+      const contentType = cached.content.trim().startsWith('{') ? 'application/json' : 'application/yaml';
+      return {
+        success: true,
+        content: cached.content,
+        contentType,
+        filename: cached.filename,
+        statusCode: 200,
+      };
+    }
+  }
+
   try {
     // Build request headers
     const headers: Record<string, string> = {
@@ -302,6 +375,10 @@ export async function fetchSpecificationFromUrl(options: UrlImportOptions): Prom
       response.headers.forEach((value, key) => {
         responseHeaders[key] = value;
       });
+
+      if (options.useCache) {
+        writeUrlImportCache(options.url, content, filename);
+      }
 
       return {
         success: true,

--- a/objectified-ui/src/app/utils/url-import.ts
+++ b/objectified-ui/src/app/utils/url-import.ts
@@ -17,6 +17,8 @@ type UrlImportCacheEntry = {
   content: string;
   filename: string;
   storedAt: number;
+  contentType?: string;
+  fileType?: string;
 };
 
 type UrlImportCacheStore = Record<string, UrlImportCacheEntry>;
@@ -29,17 +31,49 @@ function normalizeUrlKey(url: string): string {
   }
 }
 
-function readUrlImportCache(url: string): UrlImportCacheEntry | null {
+/**
+ * FNV-1a 32-bit hash – fast, non-reversible, no secrets stored in the key.
+ */
+function fnv1a32(str: string): string {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < str.length; i++) {
+    h ^= str.charCodeAt(i);
+    h = Math.imul(h, 0x01000193) >>> 0;
+  }
+  return h.toString(16);
+}
+
+/**
+ * Builds a stable cache key that is scoped to the URL *and* the auth inputs so
+ * that changing credentials always results in a fresh fetch.  Auth secrets are
+ * hashed (FNV-1a) so they are never stored verbatim in the key.
+ */
+function buildCacheKey(options: UrlImportOptions): string {
+  const urlPart = normalizeUrlKey(options.url);
+  const authParts: string[] = [options.authType ?? 'none'];
+  if (options.authType === 'bearer' && options.authToken) {
+    authParts.push(fnv1a32(options.authToken));
+  } else if (options.authType === 'apiKey') {
+    authParts.push(options.apiKeyHeader ?? 'X-API-Key');
+    if (options.authToken) authParts.push(fnv1a32(options.authToken));
+  } else if (options.authType === 'basic') {
+    if (options.username) authParts.push(fnv1a32(options.username));
+    if (options.password) authParts.push(fnv1a32(options.password));
+  }
+  return `${urlPart}::${authParts.join(':')}`;
+}
+
+function readUrlImportCache(cacheKey: string): UrlImportCacheEntry | null {
   if (typeof sessionStorage === 'undefined') return null;
   try {
     const raw = sessionStorage.getItem(URL_IMPORT_CACHE_STORAGE_KEY);
     if (!raw) return null;
     const store = JSON.parse(raw) as UrlImportCacheStore;
-    const key = normalizeUrlKey(url);
-    const entry = store[key];
-    if (!entry?.content) return null;
-    if (Date.now() - entry.storedAt > URL_IMPORT_CACHE_TTL_MS) {
-      delete store[key];
+    const entry = store[cacheKey];
+    if (!entry?.content || typeof entry.filename !== 'string') return null;
+    const storedAt = entry.storedAt;
+    if (typeof storedAt !== 'number' || !isFinite(storedAt) || Date.now() - storedAt > URL_IMPORT_CACHE_TTL_MS) {
+      delete store[cacheKey];
       sessionStorage.setItem(URL_IMPORT_CACHE_STORAGE_KEY, JSON.stringify(store));
       return null;
     }
@@ -49,13 +83,12 @@ function readUrlImportCache(url: string): UrlImportCacheEntry | null {
   }
 }
 
-function writeUrlImportCache(url: string, content: string, filename: string): void {
+function writeUrlImportCache(cacheKey: string, content: string, filename: string, contentType?: string, fileType?: string): void {
   if (typeof sessionStorage === 'undefined') return;
   try {
     const raw = sessionStorage.getItem(URL_IMPORT_CACHE_STORAGE_KEY);
     const store = (raw ? JSON.parse(raw) : {}) as UrlImportCacheStore;
-    const key = normalizeUrlKey(url);
-    store[key] = { content, filename, storedAt: Date.now() };
+    store[cacheKey] = { content, filename, storedAt: Date.now(), contentType, fileType };
     sessionStorage.setItem(URL_IMPORT_CACHE_STORAGE_KEY, JSON.stringify(store));
   } catch {
     // ignore quota / private mode
@@ -287,13 +320,13 @@ export async function fetchSpecificationFromUrl(options: UrlImportOptions): Prom
   }
 
   if (options.useCache) {
-    const cached = readUrlImportCache(options.url);
+    const cacheKey = buildCacheKey(options);
+    const cached = readUrlImportCache(cacheKey);
     if (cached) {
-      const contentType = cached.content.trim().startsWith('{') ? 'application/json' : 'application/yaml';
       return {
         success: true,
         content: cached.content,
-        contentType,
+        contentType: cached.contentType,
         filename: cached.filename,
         statusCode: 200,
       };
@@ -377,7 +410,8 @@ export async function fetchSpecificationFromUrl(options: UrlImportOptions): Prom
       });
 
       if (options.useCache) {
-        writeUrlImportCache(options.url, content, filename);
+        const cacheKey = buildCacheKey(options);
+        writeUrlImportCache(cacheKey, content, filename, contentType || undefined, fileType);
       }
 
       return {

--- a/objectified-ui/tests/url-import.test.js
+++ b/objectified-ui/tests/url-import.test.js
@@ -554,7 +554,9 @@ describe('URL Import - cache behavior', () => {
     // Expire the cache entry by back-dating storedAt
     const raw = storageMock.getItem(CACHE_KEY);
     const store = JSON.parse(raw);
-    const [key] = Object.keys(store);
+    const keys = Object.keys(store);
+    expect(keys.length).toBeGreaterThan(0);
+    const [key] = keys;
     store[key].storedAt = Date.now() - 25 * 60 * 60 * 1000; // 25 hours ago
     storageMock.setItem(CACHE_KEY, JSON.stringify(store));
 
@@ -573,7 +575,9 @@ describe('URL Import - cache behavior', () => {
     // Corrupt the storedAt field
     const raw = storageMock.getItem(CACHE_KEY);
     const store = JSON.parse(raw);
-    const [key] = Object.keys(store);
+    const keys = Object.keys(store);
+    expect(keys.length).toBeGreaterThan(0);
+    const [key] = keys;
     store[key].storedAt = 'not-a-number';
     storageMock.setItem(CACHE_KEY, JSON.stringify(store));
 

--- a/objectified-ui/tests/url-import.test.js
+++ b/objectified-ui/tests/url-import.test.js
@@ -471,3 +471,150 @@ describe('URL Import - testUrlAccessibility', () => {
 
 console.log('✅ URL Import tests defined - comprehensive coverage!');
 
+describe('URL Import - cache behavior', () => {
+  let storageMock;
+
+  beforeEach(() => {
+    mockFetch.mockClear();
+    // Fresh in-memory sessionStorage mock for each test
+    const store = {};
+    storageMock = {
+      getItem: jest.fn((key) => store[key] ?? null),
+      setItem: jest.fn((key, value) => { store[key] = String(value); }),
+      removeItem: jest.fn((key) => { delete store[key]; }),
+    };
+    Object.defineProperty(global, 'sessionStorage', { value: storageMock, writable: true });
+  });
+
+  const CACHE_KEY = 'objectified:url-import-cache:v1';
+
+  const mockYamlHeaders = () => {
+    const h = new Headers();
+    h.set('content-type', 'application/yaml');
+    return h;
+  };
+
+  const mockYamlFetch = (content = 'openapi: "3.1.0"') => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      text: () => Promise.resolve(content),
+      headers: mockYamlHeaders(),
+    });
+  };
+
+  test('cache miss: fetch is called when cache is empty', async () => {
+    mockYamlFetch();
+    const result = await fetchSpecificationFromUrl({
+      url: 'https://api.example.com/openapi.yaml',
+      useCache: true,
+    });
+    expect(result.success).toBe(true);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  test('cache hit: fetch is skipped on second call with same URL and auth', async () => {
+    mockYamlFetch();
+    const opts = { url: 'https://api.example.com/openapi.yaml', useCache: true };
+
+    await fetchSpecificationFromUrl(opts);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    mockFetch.mockClear();
+    const result = await fetchSpecificationFromUrl(opts);
+    expect(result.success).toBe(true);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  test('cache returns stored contentType on hit', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      text: () => Promise.resolve('{"openapi":"3.1.0"}'),
+      headers: (() => { const h = new Headers(); h.set('content-type', 'application/json'); return h; })(),
+    });
+    const opts = { url: 'https://api.example.com/openapi.json', useCache: true };
+    await fetchSpecificationFromUrl(opts);
+
+    mockFetch.mockClear();
+    const result = await fetchSpecificationFromUrl(opts);
+    expect(result.success).toBe(true);
+    expect(result.contentType).toBe('application/json');
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  test('cache miss after TTL expiry: fetch is called again', async () => {
+    mockYamlFetch();
+    const opts = { url: 'https://api.example.com/openapi.yaml', useCache: true };
+    await fetchSpecificationFromUrl(opts);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    // Expire the cache entry by back-dating storedAt
+    const raw = storageMock.getItem(CACHE_KEY);
+    const store = JSON.parse(raw);
+    const [key] = Object.keys(store);
+    store[key].storedAt = Date.now() - 25 * 60 * 60 * 1000; // 25 hours ago
+    storageMock.setItem(CACHE_KEY, JSON.stringify(store));
+
+    mockYamlFetch();
+    mockFetch.mockClear();
+    const result = await fetchSpecificationFromUrl(opts);
+    expect(result.success).toBe(true);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  test('invalid storedAt is treated as expired', async () => {
+    mockYamlFetch();
+    const opts = { url: 'https://api.example.com/openapi.yaml', useCache: true };
+    await fetchSpecificationFromUrl(opts);
+
+    // Corrupt the storedAt field
+    const raw = storageMock.getItem(CACHE_KEY);
+    const store = JSON.parse(raw);
+    const [key] = Object.keys(store);
+    store[key].storedAt = 'not-a-number';
+    storageMock.setItem(CACHE_KEY, JSON.stringify(store));
+
+    mockYamlFetch();
+    mockFetch.mockClear();
+    const result = await fetchSpecificationFromUrl(opts);
+    expect(result.success).toBe(true);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  test('different auth settings produce separate cache entries', async () => {
+    const url = 'https://api.example.com/openapi.yaml';
+
+    mockYamlFetch();
+    await fetchSpecificationFromUrl({ url, useCache: true, authType: 'bearer', authToken: 'token-a' });
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    // Different token — should NOT hit cache for token-a
+    mockYamlFetch();
+    mockFetch.mockClear();
+    await fetchSpecificationFromUrl({ url, useCache: true, authType: 'bearer', authToken: 'token-b' });
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    // Same token-a again — should hit cache
+    mockFetch.mockClear();
+    const result = await fetchSpecificationFromUrl({ url, useCache: true, authType: 'bearer', authToken: 'token-a' });
+    expect(result.success).toBe(true);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  test('no-auth and bearer-auth use separate cache entries for the same URL', async () => {
+    const url = 'https://api.example.com/openapi.yaml';
+
+    mockYamlFetch();
+    await fetchSpecificationFromUrl({ url, useCache: true });
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    mockYamlFetch();
+    mockFetch.mockClear();
+    await fetchSpecificationFromUrl({ url, useCache: true, authType: 'bearer', authToken: 'tok' });
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+});
+

--- a/objectified-ui/tests/url-import.test.ts
+++ b/objectified-ui/tests/url-import.test.ts
@@ -18,7 +18,6 @@ function buildSessionStorageMock() {
     getItem: jest.fn((key: string) => store[key] ?? null),
     setItem: jest.fn((key: string, value: string) => { store[key] = String(value); }),
     removeItem: jest.fn((key: string) => { delete store[key]; }),
-    _store: store,
   };
 }
 
@@ -94,7 +93,9 @@ describe('URL Import - cache behavior', () => {
     // Expire the cache by back-dating storedAt
     const raw = storageMock.getItem(CACHE_KEY);
     const cacheStore = JSON.parse(raw as string);
-    const key = Object.keys(cacheStore)[0];
+    const keys = Object.keys(cacheStore);
+    expect(keys.length).toBeGreaterThan(0);
+    const key = keys[0];
     cacheStore[key].storedAt = Date.now() - 25 * 60 * 60 * 1000; // 25 hours ago
     storageMock.setItem(CACHE_KEY, JSON.stringify(cacheStore));
 
@@ -113,7 +114,9 @@ describe('URL Import - cache behavior', () => {
     // Corrupt storedAt
     const raw = storageMock.getItem(CACHE_KEY);
     const cacheStore = JSON.parse(raw as string);
-    const key = Object.keys(cacheStore)[0];
+    const keys = Object.keys(cacheStore);
+    expect(keys.length).toBeGreaterThan(0);
+    const key = keys[0];
     (cacheStore[key] as Record<string, unknown>).storedAt = 'not-a-number';
     storageMock.setItem(CACHE_KEY, JSON.stringify(cacheStore));
 

--- a/objectified-ui/tests/url-import.test.ts
+++ b/objectified-ui/tests/url-import.test.ts
@@ -1,13 +1,160 @@
 /**
- * URL Import Tests
+ * URL Import Cache Tests (TypeScript)
  *
- * Tests have been moved to url-import.test.js to avoid TypeScript/Jest mock typing issues.
- * Please run url-import.test.js for URL import tests.
+ * Covers cache hit/miss, TTL expiry, invalid storedAt, and auth-keyed isolation.
+ * The broader functional tests live in url-import.test.js.
  */
 
-// Placeholder to prevent "no tests" error
-describe('URL Import Tests', () => {
-  test('placeholder - tests are in url-import.test.js', () => {
-    expect(true).toBe(true);
+import { fetchSpecificationFromUrl } from '../src/app/utils/url-import';
+
+const mockFetch = jest.fn();
+(global as unknown as Record<string, unknown>).fetch = mockFetch;
+
+const CACHE_KEY = 'objectified:url-import-cache:v1';
+
+function buildSessionStorageMock() {
+  const store: Record<string, string> = {};
+  return {
+    getItem: jest.fn((key: string) => store[key] ?? null),
+    setItem: jest.fn((key: string, value: string) => { store[key] = String(value); }),
+    removeItem: jest.fn((key: string) => { delete store[key]; }),
+    _store: store,
+  };
+}
+
+function mockYamlFetch(content = 'openapi: "3.1.0"') {
+  const h = new Headers();
+  h.set('content-type', 'application/yaml');
+  mockFetch.mockResolvedValueOnce({
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    text: () => Promise.resolve(content),
+    headers: h,
+  });
+}
+
+describe('URL Import - cache behavior', () => {
+  let storageMock: ReturnType<typeof buildSessionStorageMock>;
+
+  beforeEach(() => {
+    mockFetch.mockClear();
+    storageMock = buildSessionStorageMock();
+    Object.defineProperty(global, 'sessionStorage', { value: storageMock, writable: true, configurable: true });
+  });
+
+  test('cache miss: fetch is called when cache is empty', async () => {
+    mockYamlFetch();
+    const result = await fetchSpecificationFromUrl({
+      url: 'https://api.example.com/openapi.yaml',
+      useCache: true,
+    });
+    expect(result.success).toBe(true);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  test('cache hit: fetch is skipped on second call with same URL and auth', async () => {
+    mockYamlFetch();
+    const opts = { url: 'https://api.example.com/openapi.yaml', useCache: true };
+    await fetchSpecificationFromUrl(opts);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    mockFetch.mockClear();
+    const result = await fetchSpecificationFromUrl(opts);
+    expect(result.success).toBe(true);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  test('cache returns stored contentType on hit', async () => {
+    const jsonHeaders = new Headers();
+    jsonHeaders.set('content-type', 'application/json');
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      text: () => Promise.resolve('{"openapi":"3.1.0"}'),
+      headers: jsonHeaders,
+    });
+    const opts = { url: 'https://api.example.com/openapi.json', useCache: true };
+    await fetchSpecificationFromUrl(opts);
+
+    mockFetch.mockClear();
+    const result = await fetchSpecificationFromUrl(opts);
+    expect(result.success).toBe(true);
+    expect(result.contentType).toBe('application/json');
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  test('cache miss after TTL expiry: fetch is called again', async () => {
+    mockYamlFetch();
+    const opts = { url: 'https://api.example.com/openapi.yaml', useCache: true };
+    await fetchSpecificationFromUrl(opts);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    // Expire the cache by back-dating storedAt
+    const raw = storageMock.getItem(CACHE_KEY);
+    const cacheStore = JSON.parse(raw as string);
+    const key = Object.keys(cacheStore)[0];
+    cacheStore[key].storedAt = Date.now() - 25 * 60 * 60 * 1000; // 25 hours ago
+    storageMock.setItem(CACHE_KEY, JSON.stringify(cacheStore));
+
+    mockYamlFetch();
+    mockFetch.mockClear();
+    const result = await fetchSpecificationFromUrl(opts);
+    expect(result.success).toBe(true);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  test('invalid storedAt is treated as expired', async () => {
+    mockYamlFetch();
+    const opts = { url: 'https://api.example.com/openapi.yaml', useCache: true };
+    await fetchSpecificationFromUrl(opts);
+
+    // Corrupt storedAt
+    const raw = storageMock.getItem(CACHE_KEY);
+    const cacheStore = JSON.parse(raw as string);
+    const key = Object.keys(cacheStore)[0];
+    (cacheStore[key] as Record<string, unknown>).storedAt = 'not-a-number';
+    storageMock.setItem(CACHE_KEY, JSON.stringify(cacheStore));
+
+    mockYamlFetch();
+    mockFetch.mockClear();
+    const result = await fetchSpecificationFromUrl(opts);
+    expect(result.success).toBe(true);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  test('different auth tokens produce separate cache entries', async () => {
+    const url = 'https://api.example.com/openapi.yaml';
+
+    mockYamlFetch();
+    await fetchSpecificationFromUrl({ url, useCache: true, authType: 'bearer', authToken: 'token-a' });
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    // Different token — should NOT hit cache
+    mockYamlFetch();
+    mockFetch.mockClear();
+    await fetchSpecificationFromUrl({ url, useCache: true, authType: 'bearer', authToken: 'token-b' });
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    // Same token-a again — should hit cache
+    mockFetch.mockClear();
+    const result = await fetchSpecificationFromUrl({ url, useCache: true, authType: 'bearer', authToken: 'token-a' });
+    expect(result.success).toBe(true);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  test('no-auth and bearer-auth use separate cache entries for the same URL', async () => {
+    const url = 'https://api.example.com/openapi.yaml';
+
+    mockYamlFetch();
+    await fetchSpecificationFromUrl({ url, useCache: true });
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    mockYamlFetch();
+    mockFetch.mockClear();
+    await fetchSpecificationFromUrl({ url, useCache: true, authType: 'bearer', authToken: 'tok' });
+    expect(mockFetch).toHaveBeenCalledTimes(1);
   });
 });
+


### PR DESCRIPTION
Addresses all reviewer feedback on the URL import cache and UI changes from the previous PR.

## Cache fixes (`url-import.ts`)

- **Content type accuracy**: `UrlImportCacheEntry` now stores `contentType` and `fileType` alongside content; cache hits return the original server-derived values instead of guessing from a `{`-only heuristic.
- **Auth-keyed cache keys**: Added `buildCacheKey()` using FNV-1a hashing of auth credentials so that changing bearer token, API key, or basic auth credentials always produces a cache miss for the same URL — previously any cached response would be reused regardless of auth.
- **TTL robustness**: `readUrlImportCache` validates `storedAt` is a finite number before computing TTL; corrupted/schema-mismatched entries are evicted rather than silently never expiring.

```ts
// cache key is now scoped to URL + auth (secrets hashed, never stored verbatim)
function buildCacheKey(options: UrlImportOptions): string {
  const urlPart = normalizeUrlKey(options.url);
  const authParts = [options.authType ?? 'none'];
  if (options.authType === 'bearer' && options.authToken)
    authParts.push(fnv1a32(options.authToken));
  // ... apiKey / basic handled similarly
  return `${urlPart}::${authParts.join(':')}`;
}
```

## Cache tests (`url-import.test.ts`)

Replaced placeholder with 7 TypeScript tests: cache hit/miss, TTL expiry triggers re-fetch, corrupted `storedAt` treated as expired, and auth-token isolation (distinct tokens → distinct entries; same token → cache hit).

## `UrlImportPanel` cleanup

- Removed `fetchedContent` / `fetchedFilename` state — content already flows via `onSpecificationFetched`; these were write-only.
- Success help text no longer hardcodes `"Next →"` (inaccurate in class-import flow); now reads `"Use the button in the dialog footer to continue to analysis."`.

## `ImportSourceTabBar` accessibility

Added `role="tablist"` + `aria-label` on the container; `role="tab"` / `aria-selected` / `aria-disabled` on each button; emoji icons wrapped in `<span aria-hidden="true">`.