### PR TITLE
Fix stale `oauth_link_intent` cookie not cleared on expired or malformed intent

### DIFF
--- a/objectified-ui/lib/auth/credentials.ts
+++ b/objectified-ui/lib/auth/credentials.ts
@@ -11,8 +11,6 @@ export interface ICredentials {
  */
 export const linkGithubAccount = async (userId: string, account: any, profile: any) => {
   try {
-    console.log('[linkGithubAccount] Linking GitHub account for user:', userId);
-
     const result = await helper.linkExternalAccount(
       userId,
       'github',
@@ -42,8 +40,6 @@ export const linkGithubAccount = async (userId: string, account: any, profile: a
  */
 export const linkGitlabAccount = async (userId: string, account: any, profile: any) => {
   try {
-    console.log('[linkGitlabAccount] Linking GitLab account for user:', userId);
-
     const result = await helper.linkExternalAccount(
       userId,
       'gitlab',
@@ -88,12 +84,12 @@ export const checkLinkingIntent = async () => {
           cookieStore.delete('oauth_link_intent');
           return intent;
         }
-      } catch (parseError) {
-        console.log('[checkLinkingIntent] Error parsing intent:', parseError);
+      } catch {
+        // Malformed or stale intent cookie; treat as no intent
       }
     }
-  } catch (error) {
-    console.log('[checkLinkingIntent] Could not check linking intent:', error);
+  } catch {
+    // Cookie store unavailable; treat as no intent
   }
 
   return null;
@@ -107,9 +103,6 @@ export const checkLinkingIntent = async () => {
  * 4. Failure returns a null, which the next-auth `authorize()` handler will interpret as an invalid account.
  */
 export const credentialsAuthorize = async (credentials: ICredentials) => {
-  console.log('[credentialsAuthorize] credentials login for user', credentials);
-
-  const emailAddress = credentials.email;
   const password = credentials.password;
   const results = await helper.getUserByEmail(credentials.email);
 
@@ -124,15 +117,11 @@ export const credentialsAuthorize = async (credentials: ICredentials) => {
         return userResult;
       }
 
-      console.log(`[credentialsAuthorize] credentials login for user ${emailAddress} failed: password mismatch`);
       return null;
     } else {
-      console.log(`[credentialsAuthorize] credentials login for user ${emailAddress} failed: no password is set`);
       return null;
     }
   }
-
-  console.log(`[credentialsAuthorize] credentials login for user ${emailAddress} not found`);
 
   return null;
 }
@@ -153,8 +142,6 @@ export const credentialsAuthorize = async (credentials: ICredentials) => {
 export const credentialsSignIn = async (payload: any) => {
   const user = payload.user;
 
-  console.log('[credentialsSignIn] Handling credentials provider');
-
   if (!user.enabled) {
     return '/login?error=Your account is currently disabled';
   }
@@ -162,8 +149,6 @@ export const credentialsSignIn = async (payload: any) => {
   if (!user.verified) {
     return '/login?error=You have not yet verified your account e-mail address';
   }
-
-  console.log('[credentialsSignIn] Login successful', user.email);
 
   if (user.id) {
     void helper.updateUserLastLoginAt(user.id).catch((error: any) => {
@@ -190,19 +175,13 @@ export const credentialsGithub = async (payload: any) => {
   const account = payload.account;
   const profile = payload.profile;
 
-  console.log('[credentialsGithub] Handling github provider', user, 'account:', account);
-
   // First, check if this GitHub account is already linked to an existing user
   if (account?.providerAccountId) {
-    console.log('[credentialsGithub] Checking for existing linked account with GitHub ID:', account.providerAccountId);
-
     // Check if this GitHub account is already linked
     const linkedAccountResult = await helper.getLinkedAccountByProvider('github', account.providerAccountId);
     const linkedAccount = JSON.parse(linkedAccountResult);
 
     if (linkedAccount.found && linkedAccount.account) {
-      console.log('[credentialsGithub] Found linked GitHub account for user:', linkedAccount.account.user_id);
-
       // Get the user by ID (not email, since email might not match)
       const userResults = await helper.getUserById(linkedAccount.account.user_id);
 
@@ -228,7 +207,6 @@ export const credentialsGithub = async (payload: any) => {
         payload.user.enabled = userResult.enabled;
         payload.user.verified = userResult.verified;
 
-        console.log('[credentialsGithub] Login successful via linked account, user_id:', userResult.id);
         void helper.updateUserLastLoginAt(userResult.id).catch((error: any) => {
           console.error('[credentialsGithub] Failed to update last login timestamp:', error);
         });
@@ -243,8 +221,6 @@ export const credentialsGithub = async (payload: any) => {
   if (results.rowCount > 0) {
     const userResult = results.rows[0];
 
-    console.log('[credentialsGithub] Retrieved user record from DB:', userResult);
-
     if (!userResult.enabled) {
       return '/login?error=Your account is currently disabled';
     }
@@ -255,7 +231,6 @@ export const credentialsGithub = async (payload: any) => {
 
     // Auto-link this GitHub account to the user on first successful login
     if (account?.providerAccountId) {
-      console.log('[credentialsGithub] Auto-linking GitHub account on first login');
       await linkGithubAccount(userResult.id, account, profile || user);
     }
 
@@ -267,15 +242,11 @@ export const credentialsGithub = async (payload: any) => {
     payload.user.enabled = userResult.enabled;
     payload.user.verified = userResult.verified;
 
-    console.log('[credentialsGithub] Login successful, user_id:', userResult.id);
-
     void helper.updateUserLastLoginAt(userResult.id).catch((error: any) => {
       console.error('[credentialsGithub] Failed to update last login timestamp:', error);
     });
     return true;
   }
-
-  console.log('[credentialsGithub] User account not found for e-mail address:', user.email);
 
   return false;
 }
@@ -296,19 +267,13 @@ export const credentialsGitlab = async (payload: any) => {
   const account = payload.account;
   const profile = payload.profile;
 
-  console.log('[credentialsGitlab] Handling gitlab provider', user, 'account:', account);
-
   // First, check if this GitLab account is already linked to an existing user
   if (account?.providerAccountId) {
-    console.log('[credentialsGitlab] Checking for existing linked account with GitLab ID:', account.providerAccountId);
-
     // Check if this GitLab account is already linked
     const linkedAccountResult = await helper.getLinkedAccountByProvider('gitlab', account.providerAccountId);
     const linkedAccount = JSON.parse(linkedAccountResult);
 
     if (linkedAccount.found && linkedAccount.account) {
-      console.log('[credentialsGitlab] Found linked GitLab account for user:', linkedAccount.account.user_id);
-
       // Get the user by ID (not email, since email might not match)
       const userResults = await helper.getUserById(linkedAccount.account.user_id);
 
@@ -334,7 +299,6 @@ export const credentialsGitlab = async (payload: any) => {
         payload.user.enabled = userResult.enabled;
         payload.user.verified = userResult.verified;
 
-        console.log('[credentialsGitlab] Login successful via linked account, user_id:', userResult.id);
         void helper.updateUserLastLoginAt(userResult.id).catch((error: any) => {
           console.error('[credentialsGitlab] Failed to update last login timestamp:', error);
         });
@@ -349,8 +313,6 @@ export const credentialsGitlab = async (payload: any) => {
   if (results.rowCount > 0) {
     const userResult = results.rows[0];
 
-    console.log('[credentialsGitlab] Retrieved user record from DB:', userResult);
-
     if (!userResult.enabled) {
       return '/login?error=Your account is currently disabled';
     }
@@ -361,7 +323,6 @@ export const credentialsGitlab = async (payload: any) => {
 
     // Auto-link this GitLab account to the user on first successful login
     if (account?.providerAccountId) {
-      console.log('[credentialsGitlab] Auto-linking GitLab account on first login');
       await linkGitlabAccount(userResult.id, account, profile || user);
     }
 
@@ -373,15 +334,11 @@ export const credentialsGitlab = async (payload: any) => {
     payload.user.enabled = userResult.enabled;
     payload.user.verified = userResult.verified;
 
-    console.log('[credentialsGitlab] Login successful, user_id:', userResult.id);
-
     void helper.updateUserLastLoginAt(userResult.id).catch((error: any) => {
       console.error('[credentialsGitlab] Failed to update last login timestamp:', error);
     });
     return true;
   }
-
-  console.log('[credentialsGitlab] User account not found for e-mail address:', user.email);
 
   return false;
 }

--- a/objectified-ui/lib/auth/credentials.ts
+++ b/objectified-ui/lib/auth/credentials.ts
@@ -84,8 +84,11 @@ export const checkLinkingIntent = async () => {
           cookieStore.delete('oauth_link_intent');
           return intent;
         }
+        // Expired intent cookie; clear it and treat as no intent
+        cookieStore.delete('oauth_link_intent');
       } catch {
-        // Malformed or stale intent cookie; treat as no intent
+        // Malformed intent cookie; clear it and treat as no intent
+        cookieStore.delete('oauth_link_intent');
       }
     }
   } catch {

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.9.13",
+  "version": "0.9.14",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -24,6 +24,7 @@ We continue to improve the platform based on your feedback with improvements and
 - Fixed group tag picker and chips so tag names and colors show correctly (project tags use `name`/`color` from the database)
 
 ## Account:
+- Removed verbose NextAuth debug logging from server and client auth flows (credentials, OAuth linking, JWT/session callbacks)
 - Profile shows your last successful login date and time (stored when you sign in with email/password or OAuth)
 
 View our YouTube channel [here](https://www.youtube.com/@objectifieddev) for detailed tutorials and walkthroughs!

--- a/objectified-ui/src/app/api/auth/[...nextauth]/route.ts
+++ b/objectified-ui/src/app/api/auth/[...nextauth]/route.ts
@@ -59,8 +59,6 @@ export const authOptions: NextAuthOptions = {
         const linkIntent = await checkLinkingIntent();
 
         if (linkIntent && linkIntent.provider === 'github') {
-          console.log('[signIn] Handling GitHub account linking for user:', linkIntent.userId);
-
           // Link the GitHub account to the current user
           const account = payload.account;
           const profile = payload.profile || user;
@@ -68,10 +66,8 @@ export const authOptions: NextAuthOptions = {
           const linked = await linkGithubAccount(linkIntent.userId, account, profile);
 
           if (linked) {
-            console.log('[signIn] Successfully linked GitHub account');
             return '/ade/dashboard/linked-accounts?linked=true';
           } else {
-            console.log('[signIn] Failed to link GitHub account');
             return '/ade/dashboard/linked-accounts?error=Failed to link account. It may already be linked to another user.';
           }
         }
@@ -85,8 +81,6 @@ export const authOptions: NextAuthOptions = {
         const linkIntent = await checkLinkingIntent();
 
         if (linkIntent && linkIntent.provider === 'gitlab') {
-          console.log('[signIn] Handling GitLab account linking for user:', linkIntent.userId);
-
           // Link the GitLab account to the current user
           const account = payload.account;
           const profile = payload.profile || user;
@@ -94,10 +88,8 @@ export const authOptions: NextAuthOptions = {
           const linked = await linkGitlabAccount(linkIntent.userId, account, profile);
 
           if (linked) {
-            console.log('[signIn] Successfully linked GitLab account');
             return '/ade/dashboard/linked-accounts?linked=true';
           } else {
-            console.log('[signIn] Failed to link GitLab account');
             return '/ade/dashboard/linked-accounts?error=Failed to link account. It may already be linked to another user.';
           }
         }
@@ -106,13 +98,9 @@ export const authOptions: NextAuthOptions = {
         return credentialsGitlab(payload);
       }
 
-      console.log('[signIn] unsupported provider:', loginProvider, 'user:', user, 'payload:', payload);
-
       return `/login?error=Your login attempt failed, provider "${loginProvider}" is not yet supported`;
     },
     // async redirect({ url, baseUrl }) {
-    //     console.log(`[next-auth::redirect]: url=${JSON.stringify(url)} baseUrl=${JSON.stringify(baseUrl)}`);
-    //
     //     // Override the login, redirecting to the login page if properly set.
     //     if (url === '/login') {
     //         return baseUrl + '/login';
@@ -143,27 +131,20 @@ export const authOptions: NextAuthOptions = {
     async jwt(payload: any) {
       const token = payload.token;
 
-      console.log('[JWT] JWT: trigger:', payload.trigger, 'payload:', payload);
-
       // If the trigger is "update", this indicates that the session payload has changed,
       // and the token should be updated accordingly.
       if (payload.trigger === 'update') {
-        console.log('[JWT] Updating session');
-
         if (payload.session?.user?.name) {
-          console.log('[JWT] Adjusting name (rename):', payload.session.user.name);
           token.name = payload.session.user.name;
         }
 
         if (payload.session?.current_tenant_id) {
-          console.log('[JWT] Adjusting session:', payload.session);
           token.current_tenant_id = payload.session.current_tenant_id;
         }
       }
 
       if (payload.user) {
         token.user_id = payload.user.id;
-        console.log('[JWT] Setting user_id from payload.user.id:', payload.user.id, 'email:', payload.user.email);
       }
 
       return token;

--- a/objectified-ui/src/app/api/auth/link/[provider]/route.ts
+++ b/objectified-ui/src/app/api/auth/link/[provider]/route.ts
@@ -22,8 +22,6 @@ export async function GET(
   const { provider } = await params;
   const userId = (session.user as any).user_id;
 
-  console.log(`[link/${provider}] User ${userId} initiating ${provider} account linking`);
-
   // Create response with success status
   const response = NextResponse.json({
     success: true,
@@ -43,8 +41,6 @@ export async function GET(
     path: '/',
     sameSite: 'lax' as const
   });
-
-  console.log(`[link/${provider}] Linking intent cookie set for user ${userId}`);
 
   return response;
 }

--- a/objectified-ui/src/app/components/auth/AuthenticatedLayout.tsx
+++ b/objectified-ui/src/app/components/auth/AuthenticatedLayout.tsx
@@ -25,10 +25,6 @@ export const AuthenticatedLayout: React.FC<AuthenticatedLayoutProps> = ({
   useEffect(() => {
     if (status === 'loading') return; // Wait for session to load
 
-    if (session) {
-      console.log('[AuthenticatedLayout] Session:', session, 'status:', status);
-    }
-
     if (session === null) {
       router.push(redirectTo);
     }


### PR DESCRIPTION
`checkLinkingIntent()` only deleted the `oauth_link_intent` cookie on a successful, valid read. Expired or malformed cookies were silently ignored but left in place, causing every subsequent sign-in to re-attempt parsing until the cookie naturally expired.

## Changes

- **`lib/auth/credentials.ts` — `checkLinkingIntent()`**
  - Delete cookie when intent timestamp has expired (falls through the validity check)
  - Delete cookie when `JSON.parse` throws (malformed/tampered value)

```ts
if (Date.now() - intent.timestamp < 600000) {
  cookieStore.delete('oauth_link_intent');
  return intent;
}
// Expired intent cookie; clear it and treat as no intent
cookieStore.delete('oauth_link_intent');
} catch {
  // Malformed intent cookie; clear it and treat as no intent
  cookieStore.delete('oauth_link_intent');
}
```

All three exit paths (valid, expired, malformed) now consistently clean up the cookie.