### PR TITLE
Fix Owner field hidden in ClassPropertyEditDialog and PropertyDialog

### DIFF
--- a/docs/FEATURE_ROADMAP.md
+++ b/docs/FEATURE_ROADMAP.md
@@ -259,17 +259,13 @@
   - ✅ Deprecation notices with messages
 - **Metadata**: ✅ IMPLEMENTED
   - ✅ Tags
-  - 📋 Owner
+  - ✅ Owner (stored as `x-owner` on the property schema)
   - ✅ Created/modified timestamps
   - 📋 Version history per property
 - **Extension Properties**: ✅ IMPLEMENTED
   - ✅ Custom x- prefixed properties at class level
   - ✅ Custom x- prefixed properties at property level
   - ✅ JSON editor for extension values
-
-| Ticket | Feature Description                 |
-|--------|-------------------------------------|
-| #280   | Adds owner metadata to the property |
 
 **Summary**: Objectified implements **95%+ of OpenAPI 3.1 / JSON Schema 2020-12** features relevant to schema design. Missing features are primarily meta-schema features (`$id`, `$schema`, `$vocabulary`) and content encoding, which are rarely used in typical API development.
 

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.9.14",
+  "version": "0.9.15",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -5,6 +5,7 @@ We continue to improve the platform based on your feedback with improvements and
 ---
 
 ## UI:
+- **Property editor:** Optional **Owner** field (team or person responsible) stored as OpenAPI extension **`x-owner`** on the property schema; available in class property edit and project property library dialogs
 - **Import from URL:** Source tabs switch between File, URL, Clipboard, Git, and SwaggerHub; URL step matches the import spec (auth, URL options including cache, **Test URL** and **Next** in the dialog footer)
 - **Git import:** Load a GitHub repository by URL or `owner/repo`, pick a **branch** or **tag**, optionally type a **spec path** and open it, or browse the tree — directory listing uses the selected ref (same behavior when choosing a repo from the list)
 - **OpenAPI import:** Import step shows the **Import Execution** layout — progress with schema index and ETA, per-schema live checklist (success / warning / in progress / pending), expandable import log, and technical summary in a collapsible section

--- a/objectified-ui/src/app/components/ade/studio/ClassPropertyEditDialog.tsx
+++ b/objectified-ui/src/app/components/ade/studio/ClassPropertyEditDialog.tsx
@@ -1211,6 +1211,19 @@ export default function ClassPropertyEditDialog({ open, onClose, editingClassPro
                         />
                       )}
                     </div>
+
+                    {/* Owner */}
+                    <div className="mt-4 space-y-1">
+                      <Label htmlFor="owner" className="text-sm font-medium">Owner</Label>
+                      <Input
+                        id="owner"
+                        value={formData.owner || ''}
+                        onChange={(e) => setFormData(prev => ({ ...prev, owner: e.target.value }))}
+                        placeholder="e.g. platform-team or @handle"
+                        className="text-sm"
+                      />
+                      <p className="text-xs text-gray-500">Stored as <code>x-owner</code> on this property schema (team or person responsible).</p>
+                    </div>
                   </div>
                 );
               })()}

--- a/objectified-ui/src/app/components/ade/studio/ClassPropertyEditDialog.tsx
+++ b/objectified-ui/src/app/components/ade/studio/ClassPropertyEditDialog.tsx
@@ -196,10 +196,10 @@ export default function ClassPropertyEditDialog({ open, onClose, editingClassPro
       }
     }
 
-    // Extract extensions (x- prefixed properties) from the property data
+    // Extract extensions (x- prefixed properties) from the property data (x-owner uses dedicated Owner field)
     const extensions: Record<string, any> = {};
     Object.keys(propData).forEach(key => {
-      if (key.startsWith('x-')) {
+      if (key.startsWith('x-') && key !== 'x-owner') {
         extensions[key] = propData[key];
       }
     });
@@ -211,6 +211,7 @@ export default function ClassPropertyEditDialog({ open, onClose, editingClassPro
       nullable: isNullable,
       deprecated: !!propData.deprecated,
       deprecationMessage: propData.deprecationMessage || '',
+      owner: propData['x-owner'] != null && String(propData['x-owner']).trim() !== '' ? String(propData['x-owner']) : '',
       readOnly: !!propData.readOnly,
       writeOnly: !!propData.writeOnly,
       examples: propData.examples ? propData.examples.map((ex: any) => JSON.stringify(ex)) : [],
@@ -819,6 +820,12 @@ export default function ClassPropertyEditDialog({ open, onClose, editingClassPro
       // Then merge in the current extensions
       if (formData.extensions && Object.keys(formData.extensions).length > 0) {
         Object.assign(updatedData, formData.extensions);
+      }
+
+      if (formData.owner?.trim()) {
+        updatedData['x-owner'] = formData.owner.trim();
+      } else {
+        delete updatedData['x-owner'];
       }
 
       // Handle externalDocs

--- a/objectified-ui/src/app/components/ade/studio/PropertyDialog.tsx
+++ b/objectified-ui/src/app/components/ade/studio/PropertyDialog.tsx
@@ -1365,6 +1365,19 @@ export const PropertyDialog: React.FC<PropertyDialogProps> = ({
                       />
                     )}
                   </div>
+
+                  {/* Owner */}
+                  <div className="mt-4 space-y-1">
+                    <Label htmlFor="owner" className="text-sm font-medium">Owner</Label>
+                    <Input
+                      id="owner"
+                      value={formData.owner || ''}
+                      onChange={(e) => setFormData(prev => ({ ...prev, owner: e.target.value }))}
+                      placeholder="e.g. platform-team or @handle"
+                      className="text-sm"
+                    />
+                    <p className="text-xs text-gray-500">Stored as <code>x-owner</code> on this property schema (team or person responsible).</p>
+                  </div>
                 </div>
 
                 {/* SECTION 3: Default & Constant Values */}

--- a/objectified-ui/src/app/components/ade/studio/PropertyDialog.tsx
+++ b/objectified-ui/src/app/components/ade/studio/PropertyDialog.tsx
@@ -66,6 +66,8 @@ export interface PropertyItem {
   writeOnly?: boolean;
   deprecated?: boolean;
   deprecationMessage?: string;
+  /** OpenAPI extension; prefer editing via the Owner field in the form */
+  'x-owner'?: string;
   examples?: any[];
   additionalProperties?: boolean | any;
   minProperties?: number;
@@ -214,10 +216,10 @@ export const PropertyDialog: React.FC<PropertyDialogProps> = ({
         }
       }
 
-      // Extract extensions (x- prefixed properties)
+      // Extract extensions (x- prefixed properties); x-owner uses dedicated Owner field
       const extensions: Record<string, any> = {};
       Object.keys(property as any).forEach(key => {
-        if (key.startsWith('x-')) {
+        if (key.startsWith('x-') && key !== 'x-owner') {
           extensions[key] = (property as any)[key];
         }
       });
@@ -267,6 +269,9 @@ export const PropertyDialog: React.FC<PropertyDialogProps> = ({
         writeOnly: property.writeOnly || false,
         deprecated: property.deprecated || false,
         deprecationMessage: property.deprecationMessage || '',
+        owner: (property as any)['x-owner'] != null && String((property as any)['x-owner']).trim() !== ''
+          ? String((property as any)['x-owner'])
+          : '',
         examples: property.examples ? property.examples.map((ex: any) => JSON.stringify(ex)) : [],
         // Object constraints
         additionalProperties: additionalPropsValue,
@@ -577,6 +582,10 @@ export const PropertyDialog: React.FC<PropertyDialogProps> = ({
           schema.not = { type: formData.not };
         }
       }
+    }
+
+    if (formData.owner?.trim()) {
+      schema['x-owner'] = formData.owner.trim();
     }
 
     return schema;
@@ -1065,6 +1074,12 @@ export const PropertyDialog: React.FC<PropertyDialogProps> = ({
       // Then merge in the current extensions
       if (formData.extensions && Object.keys(formData.extensions).length > 0) {
         Object.assign(dataObject, formData.extensions);
+      }
+
+      if (formData.owner?.trim()) {
+        dataObject['x-owner'] = formData.owner.trim();
+      } else {
+        delete dataObject['x-owner'];
       }
 
       // Handle externalDocs

--- a/objectified-ui/src/app/components/ade/studio/PropertyFormFields.tsx
+++ b/objectified-ui/src/app/components/ade/studio/PropertyFormFields.tsx
@@ -267,6 +267,8 @@ export interface PropertyFormData {
   writeOnly?: boolean;
   deprecated?: boolean;
   deprecationMessage?: string;
+  /** Team or person responsible; persisted as OpenAPI extension `x-owner` on the property schema */
+  owner?: string;
   examples?: string[]; // Array of example values (JSON strings)
 
   // Object constraints
@@ -608,7 +610,8 @@ export const PropertyFormFields: React.FC<PropertyFormFieldsProps> = ({
     return {
       basicInfo: (d.description || '').trim() !== '' || (d.default || '').trim() !== ''
         || (d.examples && d.examples.length > 0) || (d.title || '').trim() !== '',
-      propertyFlags: d.required || d.nullable || d.readOnly || d.writeOnly || d.deprecated || (d.deprecationMessage || '').trim() !== '',
+      propertyFlags: d.required || d.nullable || d.readOnly || d.writeOnly || d.deprecated || (d.deprecationMessage || '').trim() !== ''
+        || (d.owner || '').trim() !== '',
       stringConstraints: (d.minLength || '').trim() !== '' || (d.maxLength || '').trim() !== '' || (d.pattern || '').trim() !== '' || (d.format || '').trim() !== '',
       numberConstraints: (d.minimum || '').trim() !== '' || (d.maximum || '').trim() !== '' || (d.multipleOf || '').trim() !== '' || d.minimumType || d.maximumType,
       arrayConstraints: (d.minItems || '').trim() !== '' || (d.maxItems || '').trim() !== '' || d.uniqueItems
@@ -1250,6 +1253,21 @@ export const PropertyFormFields: React.FC<PropertyFormFieldsProps> = ({
               }}
             />
           </Collapse>
+
+          <TextField
+            label="Owner"
+            size="small"
+            fullWidth
+            value={data.owner || ''}
+            onChange={(e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => onChange('owner', e.target.value)}
+            placeholder="e.g. platform-team or @handle"
+            helperText="Stored as x-owner on this property schema (team or person responsible)."
+            sx={{
+              mt: 1.5,
+              bgcolor: isDark ? '#0f172a' : 'white',
+              '& .MuiOutlinedInput-root': { borderRadius: 2 },
+            }}
+          />
         </Box>
       )}
 

--- a/objectified-ui/tests/unit/property-owner-metadata.test.ts
+++ b/objectified-ui/tests/unit/property-owner-metadata.test.ts
@@ -1,0 +1,31 @@
+jest.mock('../../src/app/utils/template-loader', () => ({
+  renderTemplate: jest.fn(),
+  loadTemplate: jest.fn(),
+}));
+
+import { buildClassSchema } from '../../src/app/utils/openapi';
+
+describe('property owner metadata (x-owner)', () => {
+  it('includes x-owner from class property data in generated class schema', () => {
+    const classData = {
+      name: 'Order',
+      schema: {},
+      properties: [
+        {
+          id: 'cp1',
+          name: 'status',
+          data: {
+            type: 'string',
+            'x-owner': 'fulfillment-team',
+          },
+        },
+      ],
+    };
+
+    const schema = buildClassSchema(classData as any);
+    expect(schema.properties?.status).toMatchObject({
+      type: 'string',
+      'x-owner': 'fulfillment-team',
+    });
+  });
+});


### PR DESCRIPTION
Both dialogs excluded `x-owner` from the generic extensions editor but never rendered a dedicated Owner input — making `x-owner` impossible to set or clear from the UI.

## Root cause
Both dialogs render their own "Property Flags" section and pass `showMetadata={false}` to `PropertyFormFields` to avoid duplicating the flag checkboxes. The Owner field lives inside the `showMetadata` block of `PropertyFormFields`, so it was silently hidden in both dialogs. The `formData.owner` ↔ `x-owner` round-trip logic was already correct; only the UI control was absent.

## Changes
- **`ClassPropertyEditDialog.tsx`** — added Owner `<Input>` directly to the dialog's "Property Flags" section, after the Deprecated block
- **`PropertyDialog.tsx`** — same: Owner `<Input>` added to the inline "Property Flags" section

Both inputs bind to `formData.owner` (already initialized from `propData['x-owner']` and persisted back on save).