### PR TITLE
Fix #251 - Schema score comparison across versions

### DIFF
--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.9.16",
+  "version": "0.9.17",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -5,6 +5,7 @@ We continue to improve the platform based on your feedback with improvements and
 ---
 
 ## UI:
+- **Schema timeline:** **Compare schema scores** between any two versions (complexity, documentation, naming compliance, and size metrics with deltas)
 - **Schema metrics & timeline:** Export **score reports as PDF** from the Schema Metrics panel (full breakdown) or the Schema timeline panel (per-version metrics history)
 - **Property editor:** Optional **Owner** field (team or person responsible) stored as OpenAPI extension **`x-owner`** on the property schema; available in class property edit and project property library dialogs
 - **Import from URL:** Source tabs switch between File, URL, Clipboard, Git, and SwaggerHub; URL step matches the import spec (auth, URL options including cache, **Test URL** and **Next** in the dialog footer)

--- a/objectified-ui/src/app/ade/studio/components/SchemaTimelinePanel.tsx
+++ b/objectified-ui/src/app/ade/studio/components/SchemaTimelinePanel.tsx
@@ -1,12 +1,13 @@
 'use client';
 
 import * as React from 'react';
-import { History, ChevronDown, ChevronUp, X, Loader2, FileDown } from 'lucide-react';
+import { History, ChevronDown, ChevronUp, X, Loader2, FileDown, GitCompare } from 'lucide-react';
 import { cn } from '../../../../../lib/utils';
 import { getClassesWithPropertiesAndTagsWithSession } from '../../../../../lib/api/rest-client';
 import { computeSchemaMetricsFromClasses } from '@/app/utils/schema-metrics';
 import type { SchemaMetricsResult } from '@/app/utils/schema-metrics';
 import { downloadSchemaTimelineScoreReportPdf } from '@/app/utils/export-schema-score-report-pdf';
+import { buildSchemaScoreCompareRows } from '@/app/utils/schema-version-score-compare';
 
 export interface SchemaTimelineVersion {
   id: string;
@@ -34,6 +35,8 @@ type TimelinePoint = {
   metrics: SchemaMetricsResult | null;
   loadError?: string;
 };
+
+type TimelinePointWithMetrics = TimelinePoint & { metrics: SchemaMetricsResult };
 
 const CHART_W = 320;
 const CHART_H = 120;
@@ -68,6 +71,8 @@ export default function SchemaTimelinePanel({
   const [loading, setLoading] = React.useState(false);
   const [points, setPoints] = React.useState<TimelinePoint[]>([]);
   const [globalError, setGlobalError] = React.useState<string | null>(null);
+  const [compareVersionA, setCompareVersionA] = React.useState<string | null>(null);
+  const [compareVersionB, setCompareVersionB] = React.useState<string | null>(null);
 
   const sortedVersions = React.useMemo(() => {
     const copy = [...versions];
@@ -147,6 +152,33 @@ export default function SchemaTimelinePanel({
       controller.abort();
     };
   }, [sortedVersions]);
+
+  const pointsWithMetrics = React.useMemo(
+    () =>
+      points.filter((p): p is TimelinePointWithMetrics => p.metrics != null && p.loadError == null),
+    [points]
+  );
+
+  React.useEffect(() => {
+    const ok = pointsWithMetrics;
+    if (ok.length < 2) {
+      setCompareVersionA(null);
+      setCompareVersionB(null);
+      return;
+    }
+    setCompareVersionA((prev) => (prev && ok.some((p) => p.versionId === prev) ? prev : ok[0].versionId));
+    setCompareVersionB((prev) =>
+      prev && ok.some((p) => p.versionId === prev) ? prev : ok[ok.length - 1].versionId
+    );
+  }, [pointsWithMetrics]);
+
+  const compareRows = React.useMemo(() => {
+    if (!compareVersionA || !compareVersionB || compareVersionA === compareVersionB) return null;
+    const ma = pointsWithMetrics.find((p) => p.versionId === compareVersionA)?.metrics;
+    const mb = pointsWithMetrics.find((p) => p.versionId === compareVersionB)?.metrics;
+    if (!ma || !mb) return null;
+    return buildSchemaScoreCompareRows(ma, mb);
+  }, [compareVersionA, compareVersionB, pointsWithMetrics]);
 
   const chartData = React.useMemo(() => {
     const ok = points.filter((p) => p.metrics);
@@ -302,6 +334,92 @@ export default function SchemaTimelinePanel({
               </span>
             </div>
           </div>
+        )}
+
+        {!loading && pointsWithMetrics.length >= 2 && (
+          <details className="rounded-lg border border-gray-200/80 dark:border-gray-700/80 bg-gray-50/80 dark:bg-gray-900/40 px-2 py-2">
+            <summary className="cursor-pointer flex items-center gap-1.5 text-xs font-medium text-gray-800 dark:text-gray-200 select-none">
+              <GitCompare className="w-3.5 h-3.5 text-indigo-500 shrink-0" />
+              Compare schema scores
+            </summary>
+            <div className="mt-2 space-y-2 pt-1 border-t border-gray-200/80 dark:border-gray-700/80">
+              <p className="text-[10px] text-gray-500 dark:text-gray-400">
+                Pick two versions. Δ is the change from the first selection to the second (second minus first).
+              </p>
+              <div className="grid grid-cols-1 gap-2">
+                <label className="block text-[10px] font-medium text-gray-600 dark:text-gray-300">
+                  First version
+                  <select
+                    className="mt-0.5 w-full rounded-md border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 text-xs px-2 py-1"
+                    value={compareVersionA ?? ''}
+                    onChange={(e) => setCompareVersionA(e.target.value || null)}
+                  >
+                    {pointsWithMetrics.map((p) => (
+                      <option key={p.versionId} value={p.versionId}>
+                        v{p.label}
+                        {p.createdAt && Number.isFinite(Date.parse(p.createdAt))
+                          ? ` · ${new Date(p.createdAt).toLocaleDateString()}`
+                          : ''}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <label className="block text-[10px] font-medium text-gray-600 dark:text-gray-300">
+                  Second version
+                  <select
+                    className="mt-0.5 w-full rounded-md border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 text-xs px-2 py-1"
+                    value={compareVersionB ?? ''}
+                    onChange={(e) => setCompareVersionB(e.target.value || null)}
+                  >
+                    {pointsWithMetrics.map((p) => (
+                      <option key={`b-${p.versionId}`} value={p.versionId}>
+                        v{p.label}
+                        {p.createdAt && Number.isFinite(Date.parse(p.createdAt))
+                          ? ` · ${new Date(p.createdAt).toLocaleDateString()}`
+                          : ''}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              </div>
+              {compareVersionA && compareVersionB && compareVersionA === compareVersionB && (
+                <p className="text-[10px] text-amber-700 dark:text-amber-300">Choose two different versions to compare.</p>
+              )}
+              {compareRows && (
+                <div className="overflow-x-auto">
+                  <table className="w-full text-[10px] text-left border-collapse">
+                    <thead>
+                      <tr className="text-gray-500 dark:text-gray-400 border-b border-gray-200/80 dark:border-gray-700/80">
+                        <th className="py-1 pr-2 font-medium">Metric</th>
+                        <th className="py-1 pr-2 font-medium tabular-nums">First</th>
+                        <th className="py-1 pr-2 font-medium tabular-nums">Second</th>
+                        <th className="py-1 font-medium tabular-nums">Δ</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {compareRows.map((row) => (
+                        <tr key={row.label} className="border-b border-gray-100/80 dark:border-gray-800/80">
+                          <td className="py-1 pr-2 text-gray-700 dark:text-gray-200">{row.label}</td>
+                          <td className="py-1 pr-2 tabular-nums text-gray-600 dark:text-gray-300">{row.valueA}</td>
+                          <td className="py-1 pr-2 tabular-nums text-gray-600 dark:text-gray-300">{row.valueB}</td>
+                          <td
+                            className={cn(
+                              'py-1 tabular-nums',
+                              row.deltaTone === 'positive' && 'text-emerald-600 dark:text-emerald-400',
+                              row.deltaTone === 'negative' && 'text-rose-600 dark:text-rose-400',
+                              row.deltaTone === 'neutral' && 'text-gray-600 dark:text-gray-400'
+                            )}
+                          >
+                            {row.delta}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </div>
+          </details>
         )}
 
         <ul className="space-y-1.5 text-xs">

--- a/objectified-ui/src/app/utils/schema-version-score-compare.ts
+++ b/objectified-ui/src/app/utils/schema-version-score-compare.ts
@@ -1,0 +1,86 @@
+/**
+ * Side-by-side schema score comparison between two versions (#251).
+ */
+
+import type { SchemaMetricsResult } from './schema-metrics';
+
+export type ScoreCompareDeltaTone = 'positive' | 'negative' | 'neutral';
+
+export interface SchemaScoreCompareRow {
+  label: string;
+  valueA: string;
+  valueB: string;
+  delta: string;
+  deltaTone: ScoreCompareDeltaTone;
+}
+
+function fmtInt(n: number): string {
+  return String(Math.round(n));
+}
+
+function fmtPct(n: number): string {
+  return `${Math.round(n)}%`;
+}
+
+export function formatScoreDelta(value: number, decimals: 0 | 1 = 0): string {
+  if (value === 0) return '0';
+  const rounded = decimals === 0 ? Math.round(value) : Number(value.toFixed(1));
+  const sign = rounded > 0 ? '+' : '';
+  return `${sign}${rounded}`;
+}
+
+function toneLowerIsBetter(delta: number): ScoreCompareDeltaTone {
+  if (delta === 0) return 'neutral';
+  return delta < 0 ? 'positive' : 'negative';
+}
+
+function toneHigherIsBetter(delta: number): ScoreCompareDeltaTone {
+  if (delta === 0) return 'neutral';
+  return delta > 0 ? 'positive' : 'negative';
+}
+
+export function buildSchemaScoreCompareRows(
+  a: SchemaMetricsResult,
+  b: SchemaMetricsResult
+): SchemaScoreCompareRow[] {
+  const rows: SchemaScoreCompareRow[] = [];
+
+  const push = (
+    label: string,
+    valA: number,
+    valB: number,
+    format: (n: number) => string,
+    toneFn: (delta: number) => ScoreCompareDeltaTone,
+    decimals: 0 | 1 = 0
+  ) => {
+    const delta = valB - valA;
+    rows.push({
+      label,
+      valueA: format(valA),
+      valueB: format(valB),
+      delta: formatScoreDelta(delta, decimals),
+      deltaTone: toneFn(delta),
+    });
+  };
+
+  push('Complexity score', a.complexityScore, b.complexityScore, fmtInt, toneLowerIsBetter);
+  push(
+    'Documentation',
+    a.documentationCompletionPercentage,
+    b.documentationCompletionPercentage,
+    fmtPct,
+    toneHigherIsBetter
+  );
+  push(
+    'Naming compliance',
+    a.namingCompliance.compliancePercentage,
+    b.namingCompliance.compliancePercentage,
+    fmtPct,
+    toneHigherIsBetter
+  );
+  push('Classes', a.classCount, b.classCount, fmtInt, () => 'neutral');
+  push('Relationships', a.relationshipCount, b.relationshipCount, fmtInt, () => 'neutral');
+  push('Properties', a.totalProperties, b.totalProperties, fmtInt, () => 'neutral');
+
+  return rows;
+}

--- a/objectified-ui/tests/unit/schema-version-score-compare.test.ts
+++ b/objectified-ui/tests/unit/schema-version-score-compare.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from '@jest/globals';
+import type { SchemaMetricsResult } from '@/app/utils/schema-metrics';
+import {
+  formatScoreDelta,
+  buildSchemaScoreCompareRows,
+} from '@/app/utils/schema-version-score-compare';
+
+function makeMinimalMetrics(overrides: Partial<SchemaMetricsResult> = {}): SchemaMetricsResult {
+  return {
+    classCount: 3,
+    totalProperties: 9,
+    averagePropertiesPerClass: 3,
+    relationshipCount: 2,
+    hubClassIds: [],
+    hubNames: [],
+    isolatedClassIds: [],
+    isolatedNames: [],
+    deepestChainLength: 2,
+    circularDependencyCount: 0,
+    circularSampleNames: [],
+    circularDependencyNodeIds: [],
+    complexityScore: 30,
+    complexityLabel: 'Low',
+    complexityBreakdown: [{ label: 'Class count', value: 3, weight: 10, contribution: 3 }],
+    documentationCompletionPercentage: 80,
+    classesMissingDocumentation: [],
+    propertiesMissingDocumentation: [],
+    namingCompliance: {
+      classes: { pascal: 3, camel: 0, snake: 0, other: 0, total: 3 },
+      properties: { pascal: 0, camel: 9, snake: 0, other: 0, total: 9 },
+      compliancePercentage: 90,
+      classesNonPascal: [],
+      propertiesNonCamel: [],
+    },
+    dependencyMetricsPerClass: [],
+    ...overrides,
+  };
+}
+
+describe('formatScoreDelta', () => {
+  it('formats zero without sign', () => {
+    expect(formatScoreDelta(0)).toBe('0');
+  });
+
+  it('formats positive integers with plus', () => {
+    expect(formatScoreDelta(5)).toBe('+5');
+  });
+
+  it('formats negative integers', () => {
+    expect(formatScoreDelta(-3)).toBe('-3');
+  });
+});
+
+describe('buildSchemaScoreCompareRows', () => {
+  it('labels complexity decrease as positive tone (simpler)', () => {
+    const older = makeMinimalMetrics({ complexityScore: 60 });
+    const newer = makeMinimalMetrics({ complexityScore: 40 });
+    const rows = buildSchemaScoreCompareRows(older, newer);
+    const row = rows.find((r) => r.label === 'Complexity score');
+    expect(row?.delta).toBe('-20');
+    expect(row?.deltaTone).toBe('positive');
+  });
+
+  it('labels documentation increase as positive tone', () => {
+    const older = makeMinimalMetrics({ documentationCompletionPercentage: 50 });
+    const newer = makeMinimalMetrics({ documentationCompletionPercentage: 75 });
+    const rows = buildSchemaScoreCompareRows(older, newer);
+    const row = rows.find((r) => r.label === 'Documentation');
+    expect(row?.delta).toBe('+25');
+    expect(row?.deltaTone).toBe('positive');
+  });
+
+  it('uses neutral tone for class count deltas', () => {
+    const older = makeMinimalMetrics({ classCount: 2 });
+    const newer = makeMinimalMetrics({ classCount: 5 });
+    const rows = buildSchemaScoreCompareRows(older, newer);
+    const row = rows.find((r) => r.label === 'Classes');
+    expect(row?.delta).toBe('+3');
+    expect(row?.deltaTone).toBe('neutral');
+  });
+
+  it('includes naming compliance row with percent values', () => {
+    const a = makeMinimalMetrics({ namingCompliance: { ...makeMinimalMetrics().namingCompliance, compliancePercentage: 70 } });
+    const b = makeMinimalMetrics({ namingCompliance: { ...makeMinimalMetrics().namingCompliance, compliancePercentage: 85 } });
+    const rows = buildSchemaScoreCompareRows(a, b);
+    const row = rows.find((r) => r.label === 'Naming compliance');
+    expect(row?.valueA).toBe('70%');
+    expect(row?.valueB).toBe('85%');
+    expect(row?.delta).toBe('+15');
+  });
+});


### PR DESCRIPTION
## What
Adds a **Compare schema scores** section to the Schema timeline panel so users can pick any two versions (with loaded metrics) and see side-by-side values plus deltas for complexity, documentation %, naming compliance %, and structural counts.

## How to test
1. Open Studio with a project that has **at least two versions**.
2. Open **Schema timeline** from the editor.
3. Expand **Compare schema scores**, choose two versions in the dropdowns.
4. Confirm the table matches expectations when moving from an older to a newer snapshot (Δ = second − first).

## Risk / notes
- Deltas are computed client-side from the same metrics as the timeline chart; **lower complexity score** is treated as improvement (green when Δ is negative).
- Neutral deltas for class/relationship/property counts (no good/bad coloring).

Closes #251

Made with [Cursor](https://cursor.com)