### PR TITLE
Fix rAF animation re-renders and add @jest/globals imports to easing tests

### DIFF
--- a/objectified-ui/lib/animation-easing.ts
+++ b/objectified-ui/lib/animation-easing.ts
@@ -1,0 +1,5 @@
+/** Eased progress for smooth UI animations (0 → 1, ease-out cubic). */
+export function easeOutCubic(t: number): number {
+  const x = Math.min(1, Math.max(0, t));
+  return 1 - (1 - x) ** 3;
+}

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.9.18",
+  "version": "0.9.19",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -5,7 +5,7 @@ We continue to improve the platform based on your feedback with improvements and
 ---
 
 ## UI:
-- **Version scoring:** New **Version scoring** panel (gauge icon) — pick a project version to see **per-schema** documentation, naming, and complexity scores with **animated radial gauges**
+- **Version scoring:** New **Version scoring** panel (gauge icon) — pick a project version to see **per-schema** documentation, naming, and complexity scores with **animated radial gauges** (eased arc and value; respects reduced motion)
 - **Schema timeline:** **Compare schema scores** between any two versions (complexity, documentation, naming compliance, and size metrics with deltas)
 - **Schema metrics & timeline:** Export **score reports as PDF** from the Schema Metrics panel (full breakdown) or the Schema timeline panel (per-version metrics history)
 - **Property editor:** Optional **Owner** field (team or person responsible) stored as OpenAPI extension **`x-owner`** on the property schema; available in class property edit and project property library dialogs

--- a/objectified-ui/src/app/ade/studio/components/SchemaVersionScoringPanel.tsx
+++ b/objectified-ui/src/app/ade/studio/components/SchemaVersionScoringPanel.tsx
@@ -39,18 +39,43 @@ function AnimatedScoreGauge({
   /** Bump to re-run mount animation */
   animationKey: string;
 }) {
-  const [display, setDisplay] = React.useState(0);
+  const arcRef = React.useRef<SVGCircleElement>(null);
+  const textRef = React.useRef<HTMLSpanElement>(null);
+
+  const target = Math.min(100, Math.max(0, value));
+
+  // Compute stroke color class from the final target value so it never
+  // changes during the animation (avoids class-swap thrash on every tick).
+  const strokeClass =
+    variant === 'complexity'
+      ? target <= 33
+        ? 'text-emerald-500'
+        : target <= 66
+          ? 'text-amber-500'
+          : 'text-rose-500'
+      : target >= 80
+        ? 'text-emerald-500'
+        : target >= 50
+          ? 'text-amber-500'
+          : 'text-rose-500';
 
   React.useEffect(() => {
-    const target = Math.min(100, Math.max(0, value));
+    const arc = arcRef.current;
+    const text = textRef.current;
+    if (!arc || !text) return;
+
     let cancelled = false;
 
     if (typeof window !== 'undefined' && window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
-      setDisplay(target);
+      arc.style.strokeDashoffset = String(GAUGE_C * (1 - target / 100));
+      text.textContent = String(Math.round(target));
       return;
     }
 
-    setDisplay(0);
+    // Reset to 0 imperatively – no React state, no re-render.
+    arc.style.strokeDashoffset = String(GAUGE_C);
+    text.textContent = '0';
+
     let start: number | null = null;
     let raf = 0;
 
@@ -60,7 +85,9 @@ function AnimatedScoreGauge({
       const elapsed = now - start;
       const t = Math.min(1, elapsed / GAUGE_ANIMATION_MS);
       const eased = easeOutCubic(t);
-      setDisplay(eased * target);
+      const displayValue = eased * target;
+      arc.style.strokeDashoffset = String(GAUGE_C * (1 - displayValue / 100));
+      text.textContent = String(Math.round(displayValue));
       if (t < 1) {
         raf = window.requestAnimationFrame(step);
       }
@@ -72,21 +99,7 @@ function AnimatedScoreGauge({
       cancelled = true;
       window.cancelAnimationFrame(raf);
     };
-  }, [value, animationKey]);
-
-  const offset = GAUGE_C * (1 - display / 100);
-  const strokeClass =
-    variant === 'complexity'
-      ? display <= 33
-        ? 'text-emerald-500'
-        : display <= 66
-          ? 'text-amber-500'
-          : 'text-rose-500'
-      : display >= 80
-        ? 'text-emerald-500'
-        : display >= 50
-          ? 'text-amber-500'
-          : 'text-rose-500';
+  }, [target, animationKey]);
 
   return (
     <div className="flex flex-col items-center gap-0.5 min-w-0">
@@ -101,6 +114,7 @@ function AnimatedScoreGauge({
             strokeWidth="4"
           />
           <circle
+            ref={arcRef}
             cx="20"
             cy="20"
             r={GAUGE_R}
@@ -109,11 +123,14 @@ function AnimatedScoreGauge({
             strokeWidth="4"
             strokeLinecap="round"
             strokeDasharray={GAUGE_C}
-            strokeDashoffset={offset}
+            strokeDashoffset={GAUGE_C}
           />
         </svg>
-        <span className="absolute inset-0 z-10 flex items-center justify-center text-[9px] font-semibold text-gray-800 dark:text-gray-100 tabular-nums pointer-events-none">
-          {Math.round(display)}
+        <span
+          ref={textRef}
+          className="absolute inset-0 z-10 flex items-center justify-center text-[9px] font-semibold text-gray-800 dark:text-gray-100 tabular-nums pointer-events-none"
+        >
+          0
         </span>
       </div>
       <span className="text-[9px] text-center text-gray-500 dark:text-gray-400 leading-tight max-w-[4.5rem] truncate" title={label}>

--- a/objectified-ui/src/app/ade/studio/components/SchemaVersionScoringPanel.tsx
+++ b/objectified-ui/src/app/ade/studio/components/SchemaVersionScoringPanel.tsx
@@ -3,6 +3,7 @@
 import * as React from 'react';
 import { Gauge, Loader2, X, ChevronDown, ChevronUp } from 'lucide-react';
 import { cn } from '../../../../../lib/utils';
+import { easeOutCubic } from '../../../../../lib/animation-easing';
 import { getClassesWithPropertiesAndTagsWithSession } from '../../../../../lib/api/rest-client';
 import { computePerSchemaScoresFromClasses } from '@/app/utils/schema-metrics';
 import type { PerSchemaScoreRow } from '@/app/utils/schema-metrics';
@@ -24,6 +25,7 @@ export interface SchemaVersionScoringPanelProps {
 
 const GAUGE_R = 16;
 const GAUGE_C = 2 * Math.PI * GAUGE_R;
+const GAUGE_ANIMATION_MS = 750;
 
 function AnimatedScoreGauge({
   value,
@@ -40,11 +42,36 @@ function AnimatedScoreGauge({
   const [display, setDisplay] = React.useState(0);
 
   React.useEffect(() => {
+    const target = Math.min(100, Math.max(0, value));
+    let cancelled = false;
+
+    if (typeof window !== 'undefined' && window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      setDisplay(target);
+      return;
+    }
+
     setDisplay(0);
-    const id = window.requestAnimationFrame(() => {
-      setDisplay(Math.min(100, Math.max(0, value)));
-    });
-    return () => window.cancelAnimationFrame(id);
+    let start: number | null = null;
+    let raf = 0;
+
+    const step = (now: number) => {
+      if (cancelled) return;
+      if (start === null) start = now;
+      const elapsed = now - start;
+      const t = Math.min(1, elapsed / GAUGE_ANIMATION_MS);
+      const eased = easeOutCubic(t);
+      setDisplay(eased * target);
+      if (t < 1) {
+        raf = window.requestAnimationFrame(step);
+      }
+    };
+
+    raf = window.requestAnimationFrame(step);
+
+    return () => {
+      cancelled = true;
+      window.cancelAnimationFrame(raf);
+    };
   }, [value, animationKey]);
 
   const offset = GAUGE_C * (1 - display / 100);
@@ -78,7 +105,7 @@ function AnimatedScoreGauge({
             cy="20"
             r={GAUGE_R}
             fill="none"
-            className={cn('stroke-current transition-[stroke-dashoffset] duration-700 ease-out', strokeClass)}
+            className={cn('stroke-current', strokeClass)}
             strokeWidth="4"
             strokeLinecap="round"
             strokeDasharray={GAUGE_C}

--- a/objectified-ui/tests/unit/animation-easing.test.ts
+++ b/objectified-ui/tests/unit/animation-easing.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect } from '@jest/globals';
 import { easeOutCubic } from '../../lib/animation-easing';
 
 describe('easeOutCubic', () => {

--- a/objectified-ui/tests/unit/animation-easing.test.ts
+++ b/objectified-ui/tests/unit/animation-easing.test.ts
@@ -1,0 +1,23 @@
+import { easeOutCubic } from '../../lib/animation-easing';
+
+describe('easeOutCubic', () => {
+  it('maps endpoints to 0 and 1', () => {
+    expect(easeOutCubic(0)).toBe(0);
+    expect(easeOutCubic(1)).toBe(1);
+  });
+
+  it('clamps input to [0, 1]', () => {
+    expect(easeOutCubic(-1)).toBe(0);
+    expect(easeOutCubic(2)).toBe(1);
+  });
+
+  it('is monotonic non-decreasing on [0, 1]', () => {
+    let prev = easeOutCubic(0);
+    for (let i = 1; i <= 100; i += 1) {
+      const x = i / 100;
+      const next = easeOutCubic(x);
+      expect(next).toBeGreaterThanOrEqual(prev);
+      prev = next;
+    }
+  });
+});


### PR DESCRIPTION
`AnimatedScoreGauge` called `setDisplay()` on every rAF tick, causing `3 × rows × ~45` React re-renders per 750 ms animation at 60 fps — visibly impacting responsiveness with many class rows.

## Changes

- **`SchemaVersionScoringPanel.tsx`** — remove `useState(display)`; replace with `useRef<SVGCircleElement>` + `useRef<HTMLSpanElement>`. The rAF `step` callback now mutates `arc.style.strokeDashoffset` and `text.textContent` directly — zero React re-renders during animation. Stroke color class is derived from the stable final `target` once at render time instead of per tick.

```ts
// before: triggers a React re-render every frame
setDisplay(eased * target);

// after: direct DOM mutation, no re-render
arc.style.strokeDashoffset = String(GAUGE_C * (1 - displayValue / 100));
text.textContent = String(Math.round(displayValue));
```

- **`animation-easing.test.ts`** — add `import { describe, it, expect } from '@jest/globals'` to match the convention used across `tests/unit/`.