### PR TITLE
test: split boundary and rounding tests in numeric-score-tier

### DIFF
--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.9.19",
+  "version": "0.9.20",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -5,6 +5,7 @@ We continue to improve the platform based on your feedback with improvements and
 ---
 
 ## UI:
+- **Score bands (#248):** Shared **green / yellow / orange / red** tiers for 0–100 scores (90+ excellent down to 0–49 poor) on import **Quality Score** (overall + per-metric bars and guide), **Schema Metrics** docs/naming bars, and **Version scoring** radial gauges (documentation & naming; complexity still uses its own low/medium/high scale)
 - **Version scoring:** New **Version scoring** panel (gauge icon) — pick a project version to see **per-schema** documentation, naming, and complexity scores with **animated radial gauges** (eased arc and value; respects reduced motion)
 - **Schema timeline:** **Compare schema scores** between any two versions (complexity, documentation, naming compliance, and size metrics with deltas)
 - **Schema metrics & timeline:** Export **score reports as PDF** from the Schema Metrics panel (full breakdown) or the Schema timeline panel (per-version metrics history)

--- a/objectified-ui/src/app/ade/studio/components/SchemaMetricsPanel.tsx
+++ b/objectified-ui/src/app/ade/studio/components/SchemaMetricsPanel.tsx
@@ -9,6 +9,7 @@ import type { LayoutQualityResult } from '@/app/utils/layout-quality';
 import type { SchemaMetricsResult } from '@/app/utils/schema-metrics';
 import type { CanvasSuggestion } from '@/app/utils/canvas-suggestions';
 import { downloadSchemaScoreReportPdf } from '@/app/utils/export-schema-score-report-pdf';
+import { getNumericScoreTier } from '@/app/utils/numeric-score-tier';
 
 interface SchemaMetricsPanelProps {
   metrics: SchemaMetricsResult | null;
@@ -74,6 +75,9 @@ export default function SchemaMetricsPanel({
     namingCompliance,
     dependencyMetricsPerClass = [],
   } = metrics;
+
+  const docsScoreTier = getNumericScoreTier(documentationCompletionPercentage);
+  const namingScoreTier = getNumericScoreTier(namingCompliance.compliancePercentage);
 
   const hasHubs = hubNames.length > 0;
   const hasIsolated = isolatedNames.length > 0;
@@ -239,12 +243,7 @@ export default function SchemaMetricsPanel({
                   </div>
                   <div className="mt-1.5 h-1.5 rounded-full bg-gray-200 dark:bg-gray-600 overflow-hidden">
                     <div
-                      className={cn(
-                        'h-full rounded-full transition-all duration-300',
-                        documentationCompletionPercentage >= 80 && 'bg-emerald-500',
-                        documentationCompletionPercentage >= 50 && documentationCompletionPercentage < 80 && 'bg-amber-500',
-                        documentationCompletionPercentage < 50 && 'bg-rose-500'
-                      )}
+                      className={cn('h-full rounded-full transition-all duration-300', docsScoreTier.barSolidClass)}
                       style={{ width: `${documentationCompletionPercentage}%` }}
                     />
                   </div>
@@ -330,12 +329,7 @@ export default function SchemaMetricsPanel({
                   </div>
                   <div className="mt-1.5 h-1.5 rounded-full bg-gray-200 dark:bg-gray-600 overflow-hidden">
                     <div
-                      className={cn(
-                        'h-full rounded-full transition-all duration-300',
-                        namingCompliance.compliancePercentage >= 80 && 'bg-emerald-500',
-                        namingCompliance.compliancePercentage >= 50 && namingCompliance.compliancePercentage < 80 && 'bg-amber-500',
-                        namingCompliance.compliancePercentage < 50 && 'bg-rose-500'
-                      )}
+                      className={cn('h-full rounded-full transition-all duration-300', namingScoreTier.barSolidClass)}
                       style={{ width: `${namingCompliance.compliancePercentage}%` }}
                     />
                   </div>

--- a/objectified-ui/src/app/ade/studio/components/SchemaVersionScoringPanel.tsx
+++ b/objectified-ui/src/app/ade/studio/components/SchemaVersionScoringPanel.tsx
@@ -6,6 +6,7 @@ import { cn } from '../../../../../lib/utils';
 import { easeOutCubic } from '../../../../../lib/animation-easing';
 import { getClassesWithPropertiesAndTagsWithSession } from '../../../../../lib/api/rest-client';
 import { computePerSchemaScoresFromClasses } from '@/app/utils/schema-metrics';
+import { getNumericScoreTier } from '@/app/utils/numeric-score-tier';
 import type { PerSchemaScoreRow } from '@/app/utils/schema-metrics';
 import type { Version } from '../editor/components/types';
 
@@ -53,11 +54,7 @@ function AnimatedScoreGauge({
         : target <= 66
           ? 'text-amber-500'
           : 'text-rose-500'
-      : target >= 80
-        ? 'text-emerald-500'
-        : target >= 50
-          ? 'text-amber-500'
-          : 'text-rose-500';
+      : getNumericScoreTier(target).gaugeStrokeClass;
 
   React.useEffect(() => {
     const arc = arcRef.current;

--- a/objectified-ui/src/app/components/ade/dashboard/AnalysisPanel.tsx
+++ b/objectified-ui/src/app/components/ade/dashboard/AnalysisPanel.tsx
@@ -5,6 +5,7 @@ import { CheckCircle2, AlertCircle, XCircle, FileCode, AlertTriangle, X, Chevron
 import * as Progress from '@radix-ui/react-progress';
 import * as Dialog from '@radix-ui/react-dialog';
 import { AnalysisResult, QualityIssue, UnsupportedFeature } from '../../../utils/openapi-analyzer';
+import { getNumericScoreTier, NUMERIC_SCORE_TIER_LEGEND } from '../../../utils/numeric-score-tier';
 
 interface AnalysisPanelProps {
   fileName: string;
@@ -34,27 +35,7 @@ const categoryDescriptions: Record<string, { title: string; description: string 
 export function AnalysisPanel({ fileName, analysis }: AnalysisPanelProps) {
   const [selectedCategory, setSelectedCategory] = useState<'completeness' | 'consistency' | 'bestPractices' | 'security' | null>(null);
 
-  const getGradeColor = (grade: string) => {
-    switch (grade) {
-      case 'A': return 'text-green-600 dark:text-green-400';
-      case 'B': return 'text-blue-600 dark:text-blue-400';
-      case 'C': return 'text-yellow-600 dark:text-yellow-400';
-      case 'D': return 'text-orange-600 dark:text-orange-400';
-      case 'F': return 'text-red-600 dark:text-red-400';
-      default: return 'text-gray-600 dark:text-gray-400';
-    }
-  };
-
-  const getGradeLabel = (grade: string) => {
-    switch (grade) {
-      case 'A': return 'Excellent Quality';
-      case 'B': return 'Good Quality';
-      case 'C': return 'Fair Quality';
-      case 'D': return 'Poor Quality';
-      case 'F': return 'Needs Improvement';
-      default: return 'Unknown';
-    }
-  };
+  const overallTier = getNumericScoreTier(analysis.qualityScore.overall);
 
   // Get issues for a specific category
   const getIssuesForCategory = (category: 'completeness' | 'consistency' | 'bestPractices' | 'security'): QualityIssue[] => {
@@ -498,26 +479,42 @@ export function AnalysisPanel({ fileName, analysis }: AnalysisPanelProps) {
           Quality Score
         </h3>
 
-        {/* Overall Grade */}
-        <div className="flex items-center justify-between mb-6 p-6 bg-gradient-to-br from-gray-50 to-gray-100 dark:from-gray-900/50 dark:to-gray-800/50 rounded-lg border border-gray-200 dark:border-gray-700">
+        {/* Overall score + letter grade (colors follow numeric bands #248) */}
+        <div className="flex items-center justify-between mb-4 p-6 bg-gradient-to-br from-gray-50 to-gray-100 dark:from-gray-900/50 dark:to-gray-800/50 rounded-lg border border-gray-200 dark:border-gray-700">
           <div className="flex items-center gap-4">
-            <div className={`text-6xl font-bold ${getGradeColor(analysis.qualityScore.grade)}`}>
+            <div className={`text-6xl font-bold ${overallTier.textClass}`} title={`${overallTier.shortLabel} (${overallTier.rangeLabel})`}>
               {analysis.qualityScore.grade}
             </div>
             <div>
-              <div className="text-lg font-semibold text-gray-900 dark:text-white">
-                {getGradeLabel(analysis.qualityScore.grade)}
+              <div className={`text-lg font-semibold ${overallTier.textClass}`}>
+                {overallTier.shortLabel} — {overallTier.detailLabel}
               </div>
               <div className="text-sm text-gray-600 dark:text-gray-400">
-                Based on specification analysis
+                Based on specification analysis · {overallTier.rangeLabel}
               </div>
             </div>
           </div>
           <div className="text-right">
-            <div className="text-3xl font-bold text-gray-900 dark:text-white">
+            <div className={`text-3xl font-bold ${overallTier.textClass} tabular-nums`}>
               {analysis.qualityScore.overall}%
             </div>
           </div>
+        </div>
+        <div className="mb-6 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50/80 dark:bg-gray-900/40 px-3 py-2">
+          <div className="text-[10px] font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400 mb-2">
+            Score guide
+          </div>
+          <ul className="grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-1.5 text-xs text-gray-700 dark:text-gray-300">
+            {NUMERIC_SCORE_TIER_LEGEND.map((row) => (
+              <li key={row.band} className="flex items-start gap-2">
+                <span className={`mt-1.5 h-2 w-2 shrink-0 rounded-full ${row.barSolidClass}`} aria-hidden />
+                <span>
+                  <span className="font-medium tabular-nums">{row.rangeLabel}:</span>{' '}
+                  {row.shortLabel} — {row.detailLabel}
+                </span>
+              </li>
+            ))}
+          </ul>
         </div>
 
         {/* Quality Metrics - Clickable Cards */}
@@ -531,7 +528,7 @@ export function AnalysisPanel({ fileName, analysis }: AnalysisPanelProps) {
                 <span className="text-xs font-medium text-gray-600 dark:text-gray-400 uppercase tracking-wider">
                   Completeness
                 </span>
-                <span className="text-sm font-bold text-gray-900 dark:text-white">
+                <span className={`text-sm font-bold tabular-nums ${getNumericScoreTier(analysis.qualityScore.completeness).textClass}`}>
                   {analysis.qualityScore.completeness}%
                 </span>
               </div>
@@ -540,7 +537,7 @@ export function AnalysisPanel({ fileName, analysis }: AnalysisPanelProps) {
                 value={analysis.qualityScore.completeness}
               >
                 <Progress.Indicator
-                  className="h-full bg-gradient-to-r from-indigo-500 to-indigo-600 transition-transform duration-300"
+                  className={`h-full bg-gradient-to-r ${getNumericScoreTier(analysis.qualityScore.completeness).progressGradientClass} transition-transform duration-300`}
                   style={{ transform: `translateX(-${100 - analysis.qualityScore.completeness}%)` }}
                 />
               </Progress.Root>
@@ -563,7 +560,7 @@ export function AnalysisPanel({ fileName, analysis }: AnalysisPanelProps) {
                 <span className="text-xs font-medium text-gray-600 dark:text-gray-400 uppercase tracking-wider">
                   Consistency
                 </span>
-                <span className="text-sm font-bold text-gray-900 dark:text-white">
+                <span className={`text-sm font-bold tabular-nums ${getNumericScoreTier(analysis.qualityScore.consistency).textClass}`}>
                   {analysis.qualityScore.consistency}%
                 </span>
               </div>
@@ -572,7 +569,7 @@ export function AnalysisPanel({ fileName, analysis }: AnalysisPanelProps) {
                 value={analysis.qualityScore.consistency}
               >
                 <Progress.Indicator
-                  className="h-full bg-gradient-to-r from-purple-500 to-purple-600 transition-transform duration-300"
+                  className={`h-full bg-gradient-to-r ${getNumericScoreTier(analysis.qualityScore.consistency).progressGradientClass} transition-transform duration-300`}
                   style={{ transform: `translateX(-${100 - analysis.qualityScore.consistency}%)` }}
                 />
               </Progress.Root>
@@ -595,7 +592,7 @@ export function AnalysisPanel({ fileName, analysis }: AnalysisPanelProps) {
                 <span className="text-xs font-medium text-gray-600 dark:text-gray-400 uppercase tracking-wider">
                   Best Practices
                 </span>
-                <span className="text-sm font-bold text-gray-900 dark:text-white">
+                <span className={`text-sm font-bold tabular-nums ${getNumericScoreTier(analysis.qualityScore.bestPractices).textClass}`}>
                   {analysis.qualityScore.bestPractices}%
                 </span>
               </div>
@@ -604,7 +601,7 @@ export function AnalysisPanel({ fileName, analysis }: AnalysisPanelProps) {
                 value={analysis.qualityScore.bestPractices}
               >
                 <Progress.Indicator
-                  className="h-full bg-gradient-to-r from-blue-500 to-blue-600 transition-transform duration-300"
+                  className={`h-full bg-gradient-to-r ${getNumericScoreTier(analysis.qualityScore.bestPractices).progressGradientClass} transition-transform duration-300`}
                   style={{ transform: `translateX(-${100 - analysis.qualityScore.bestPractices}%)` }}
                 />
               </Progress.Root>
@@ -627,7 +624,7 @@ export function AnalysisPanel({ fileName, analysis }: AnalysisPanelProps) {
                 <span className="text-xs font-medium text-gray-600 dark:text-gray-400 uppercase tracking-wider">
                   Security
                 </span>
-                <span className="text-sm font-bold text-gray-900 dark:text-white">
+                <span className={`text-sm font-bold tabular-nums ${getNumericScoreTier(analysis.qualityScore.security).textClass}`}>
                   {analysis.qualityScore.security}%
                 </span>
               </div>
@@ -636,7 +633,7 @@ export function AnalysisPanel({ fileName, analysis }: AnalysisPanelProps) {
                 value={analysis.qualityScore.security}
               >
                 <Progress.Indicator
-                  className="h-full bg-gradient-to-r from-green-500 to-green-600 transition-transform duration-300"
+                  className={`h-full bg-gradient-to-r ${getNumericScoreTier(analysis.qualityScore.security).progressGradientClass} transition-transform duration-300`}
                   style={{ transform: `translateX(-${100 - analysis.qualityScore.security}%)` }}
                 />
               </Progress.Root>

--- a/objectified-ui/src/app/utils/numeric-score-tier.ts
+++ b/objectified-ui/src/app/utils/numeric-score-tier.ts
@@ -1,0 +1,120 @@
+/**
+ * Shared 0–100 score bands where higher is better (#248).
+ *
+ * - 90–100: Excellent — Production ready (green)
+ * - 70–89: Good — Minor improvements needed (yellow)
+ * - 50–69: Fair — Significant improvements recommended (orange)
+ * - 0–49: Poor — Major issues must be addressed (red)
+ */
+
+export type NumericScoreBand = 'excellent' | 'good' | 'fair' | 'poor';
+
+export interface NumericScoreTierStyle {
+  band: NumericScoreBand;
+  rangeLabel: string;
+  shortLabel: string;
+  detailLabel: string;
+  textClass: string;
+  /** For SVG gauges using `stroke-current` */
+  gaugeStrokeClass: string;
+  progressGradientClass: string;
+  barSolidClass: string;
+}
+
+function tier(
+  band: NumericScoreBand,
+  rangeLabel: string,
+  shortLabel: string,
+  detailLabel: string,
+  textClass: string,
+  gaugeStrokeClass: string,
+  progressGradientClass: string,
+  barSolidClass: string
+): NumericScoreTierStyle {
+  return {
+    band,
+    rangeLabel,
+    shortLabel,
+    detailLabel,
+    textClass,
+    gaugeStrokeClass,
+    progressGradientClass,
+    barSolidClass,
+  };
+}
+
+const EXCELLENT = tier(
+  'excellent',
+  '90–100',
+  'Excellent',
+  'Production ready',
+  'text-green-600 dark:text-green-400',
+  'text-green-500 dark:text-green-400',
+  'from-green-500 to-green-600',
+  'bg-green-500'
+);
+
+const GOOD = tier(
+  'good',
+  '70–89',
+  'Good',
+  'Minor improvements needed',
+  'text-yellow-600 dark:text-yellow-400',
+  'text-yellow-500 dark:text-yellow-400',
+  'from-yellow-500 to-amber-500',
+  'bg-yellow-500'
+);
+
+const FAIR = tier(
+  'fair',
+  '50–69',
+  'Fair',
+  'Significant improvements recommended',
+  'text-orange-600 dark:text-orange-400',
+  'text-orange-500 dark:text-orange-400',
+  'from-orange-500 to-orange-600',
+  'bg-orange-500'
+);
+
+const POOR = tier(
+  'poor',
+  '0–49',
+  'Poor',
+  'Major issues must be addressed',
+  'text-red-600 dark:text-red-400',
+  'text-red-500 dark:text-red-400',
+  'from-red-500 to-red-600',
+  'bg-red-500'
+);
+
+/** Static legend rows for tooltips and help copy */
+export const NUMERIC_SCORE_TIER_LEGEND: readonly NumericScoreTierStyle[] = [
+  EXCELLENT,
+  GOOD,
+  FAIR,
+  POOR,
+] as const;
+
+/**
+ * @param percent Raw 0–100 score (fractional values rounded to nearest integer)
+ */
+export function getNumericScoreTier(percent: number): NumericScoreTierStyle {
+  const n = Math.min(100, Math.max(0, Math.round(Number(percent))));
+  if (n >= 90) return EXCELLENT;
+  if (n >= 70) return GOOD;
+  if (n >= 50) return FAIR;
+  return POOR;
+}
+
+/**
+ * Letter grade aligned to the same numeric bands as {@link getNumericScoreTier},
+ * with D/F split in the poor band so the union stays A–F for legacy fields.
+ */
+export function letterGradeFromOverallPercent(percent: number): 'A' | 'B' | 'C' | 'D' | 'F' {
+  const n = Math.min(100, Math.max(0, Math.round(Number(percent))));
+  if (n >= 90) return 'A';
+  if (n >= 70) return 'B';
+  if (n >= 50) return 'C';
+  if (n >= 40) return 'D';
+  return 'F';
+}

--- a/objectified-ui/src/app/utils/openapi-analyzer.ts
+++ b/objectified-ui/src/app/utils/openapi-analyzer.ts
@@ -14,6 +14,7 @@ import { convertProtobufToOpenAPI, isProtobuf } from './protobuf-converter';
 import { convertAvroToOpenAPI, isAvroSchemaObject } from './avro-converter';
 import { convertThriftToOpenAPI, isThrift } from './thrift-converter';
 import { inferArazzoSchemasFromWorkflows } from '../../../lib/importers/arazzo';
+import { letterGradeFromOverallPercent } from './numeric-score-tier';
 
 export interface AnalysisResult {
   isValid: boolean;
@@ -770,12 +771,7 @@ function calculateQualityScore(doc: any): {
     ...securityResult.issues
   ];
 
-  let grade: 'A' | 'B' | 'C' | 'D' | 'F';
-  if (overall >= 90) grade = 'A';
-  else if (overall >= 80) grade = 'B';
-  else if (overall >= 70) grade = 'C';
-  else if (overall >= 60) grade = 'D';
-  else grade = 'F';
+  const grade = letterGradeFromOverallPercent(overall);
 
   return {
     overall,

--- a/objectified-ui/tests/unit/numeric-score-tier.test.ts
+++ b/objectified-ui/tests/unit/numeric-score-tier.test.ts
@@ -9,12 +9,15 @@ describe('numeric-score-tier', () => {
     it('maps 90–100 to excellent (green)', () => {
       expect(getNumericScoreTier(90).band).toBe('excellent');
       expect(getNumericScoreTier(100).band).toBe('excellent');
-      expect(getNumericScoreTier(89.6).band).toBe('excellent');
     });
 
     it('maps 70–89 to good (yellow)', () => {
       expect(getNumericScoreTier(70).band).toBe('good');
       expect(getNumericScoreTier(89).band).toBe('good');
+    });
+
+    it('rounds near thresholds before mapping bands', () => {
+      expect(getNumericScoreTier(89.6).band).toBe('excellent');
       expect(getNumericScoreTier(69.5).band).toBe('good');
     });
 

--- a/objectified-ui/tests/unit/numeric-score-tier.test.ts
+++ b/objectified-ui/tests/unit/numeric-score-tier.test.ts
@@ -1,0 +1,63 @@
+import {
+  getNumericScoreTier,
+  letterGradeFromOverallPercent,
+  NUMERIC_SCORE_TIER_LEGEND,
+} from '@/app/utils/numeric-score-tier';
+
+describe('numeric-score-tier', () => {
+  describe('getNumericScoreTier', () => {
+    it('maps 90–100 to excellent (green)', () => {
+      expect(getNumericScoreTier(90).band).toBe('excellent');
+      expect(getNumericScoreTier(100).band).toBe('excellent');
+      expect(getNumericScoreTier(89.6).band).toBe('excellent');
+    });
+
+    it('maps 70–89 to good (yellow)', () => {
+      expect(getNumericScoreTier(70).band).toBe('good');
+      expect(getNumericScoreTier(89).band).toBe('good');
+      expect(getNumericScoreTier(69.5).band).toBe('good');
+    });
+
+    it('maps 50–69 to fair (orange)', () => {
+      expect(getNumericScoreTier(50).band).toBe('fair');
+      expect(getNumericScoreTier(69).band).toBe('fair');
+    });
+
+    it('maps 0–49 to poor (red)', () => {
+      expect(getNumericScoreTier(0).band).toBe('poor');
+      expect(getNumericScoreTier(49).band).toBe('poor');
+    });
+
+    it('clamps out-of-range inputs', () => {
+      expect(getNumericScoreTier(-5).band).toBe('poor');
+      expect(getNumericScoreTier(150).band).toBe('excellent');
+    });
+
+    it('includes expected labels on excellent tier', () => {
+      const t = getNumericScoreTier(95);
+      expect(t.shortLabel).toBe('Excellent');
+      expect(t.detailLabel).toBe('Production ready');
+      expect(t.progressGradientClass).toContain('green');
+    });
+  });
+
+  describe('letterGradeFromOverallPercent', () => {
+    it('aligns A/B/C with tier bands', () => {
+      expect(letterGradeFromOverallPercent(90)).toBe('A');
+      expect(letterGradeFromOverallPercent(70)).toBe('B');
+      expect(letterGradeFromOverallPercent(50)).toBe('C');
+    });
+
+    it('splits poor band into D and F', () => {
+      expect(letterGradeFromOverallPercent(45)).toBe('D');
+      expect(letterGradeFromOverallPercent(39)).toBe('F');
+    });
+  });
+
+  it('legend lists four bands', () => {
+    expect(NUMERIC_SCORE_TIER_LEGEND).toHaveLength(4);
+    expect(NUMERIC_SCORE_TIER_LEGEND.map((x) => x.band).sort()).toEqual(
+      ['excellent', 'fair', 'good', 'poor'].sort()
+    );
+  });
+});


### PR DESCRIPTION
Band-mapping tests were mixing clean boundary checks with rounding-behavior cases (e.g. `89.6` asserted inside the `'maps 70–89'` group), making test intent ambiguous.

## Changes
- **`numeric-score-tier.test.ts`**: Removed `89.6` / `69.5` from the in-range boundary tests so each `'maps X–Y'` block uses only integer values clearly within that band.
- Added a dedicated `'rounds near thresholds before mapping bands'` test to explicitly document that `Math.round` promotes `89.6 → 90 → excellent` and `69.5 → 70 → good`.

```ts
it('maps 70–89 to good (yellow)', () => {
  expect(getNumericScoreTier(70).band).toBe('good');
  expect(getNumericScoreTier(89).band).toBe('good');
});

it('rounds near thresholds before mapping bands', () => {
  expect(getNumericScoreTier(89.6).band).toBe('excellent');
  expect(getNumericScoreTier(69.5).band).toBe('good');
});
```