### PR TITLE
Apply PR review feedback to quality score history feature

### DIFF
--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.9.21",
+  "version": "0.9.22",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -20,6 +20,7 @@ We continue to improve the platform based on your feedback with improvements and
 
 
 ## Projects:
+- **Quality score history (#246):** After a successful **Import specification** run, the OpenAPI **overall quality score** is saved in this browser per project; the projects table shows a **sparkline** and latest score, with a **trend chart** and history table in a detail dialog
 - Added ability to start a new project from a template
 
 ## Groups:

--- a/objectified-ui/src/app/ade/dashboard/projects/page.tsx
+++ b/objectified-ui/src/app/ade/dashboard/projects/page.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { useSession } from 'next-auth/react';
-import { useEffect, useState, useRef } from 'react';
-import { Plus, Edit2, Trash2, FolderOpen, Lock, Upload, AlertTriangle, MoreVertical, ExternalLink, Bot, FileEdit, Layers } from 'lucide-react';
+import { useEffect, useState, useRef, useMemo } from 'react';
+import { Plus, Edit2, Trash2, FolderOpen, Lock, Upload, AlertTriangle, MoreVertical, ExternalLink, Bot, FileEdit, Layers, TrendingUp } from 'lucide-react';
 import {
   Dialog,
   DialogContent,
@@ -33,6 +33,10 @@ import {
   getProjectStartTemplate,
   type ProjectOpenApiMetadata,
 } from '../../../utils/project-templates';
+import { getProjectQualityHistory } from '../../../utils/project-quality-score-history';
+import { getNumericScoreTier } from '../../../utils/numeric-score-tier';
+import { ProjectQualityTrendSparkline } from '../../../components/ade/dashboard/ProjectQualityTrendSparkline';
+import { ProjectQualityHistoryDialog } from '../../../components/ade/dashboard/ProjectQualityHistoryDialog';
 
 type ProjectMetadata = ProjectOpenApiMetadata;
 
@@ -84,6 +88,9 @@ const Projects = () => {
   const [metadataLicenseIdentifier, setMetadataLicenseIdentifier] = useState('');
   const [metadataLicenseUrl, setMetadataLicenseUrl] = useState('');
   const [selectedStartTemplateId, setSelectedStartTemplateId] = useState('blank');
+  const [qualityHistoryEpoch, setQualityHistoryEpoch] = useState(0);
+  const [qualityTrendProject, setQualityTrendProject] = useState<Project | null>(null);
+  const prevImportOpen = useRef(false);
 
   const currentTenantId = (session?.user as any)?.current_tenant_id;
   const currentUserId = (session?.user as any)?.user_id;
@@ -96,6 +103,21 @@ const Projects = () => {
   useEffect(() => {
     if (currentTenantId) loadProjects();
   }, [currentTenantId]);
+
+  useEffect(() => {
+    if (prevImportOpen.current && !showNewImportDialog) {
+      setQualityHistoryEpoch((e) => e + 1);
+    }
+    prevImportOpen.current = showNewImportDialog;
+  }, [showNewImportDialog]);
+
+  const projectQualityHistoryMap = useMemo(() => {
+    const m: Record<string, ReturnType<typeof getProjectQualityHistory>> = {};
+    for (const p of projects) {
+      m[p.id] = getProjectQualityHistory(p.id);
+    }
+    return m;
+  }, [projects, qualityHistoryEpoch]);
 
   const loadProjects = async () => {
     if (!currentTenantId) return;
@@ -150,7 +172,10 @@ const Projects = () => {
   };
 
   const handleImportClick = () => setShowImportDialog(true);
-  const handleImportSuccess = async () => await loadProjects();
+  const handleImportSuccess = async () => {
+    await loadProjects();
+    setQualityHistoryEpoch((e) => e + 1);
+  };
 
   const handleCreateSubmit = async () => {
     if (!projectName.trim()) { setErrorMessage('Project name is required'); return; }
@@ -394,6 +419,12 @@ const Projects = () => {
                   <th scope="col" className="px-6 py-4 text-left text-xs font-bold text-gray-500 dark:text-gray-400 uppercase tracking-wider">
                     Description
                   </th>
+                  <th scope="col" className="px-6 py-4 text-left text-xs font-bold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-52">
+                    <span className="inline-flex items-center gap-1.5">
+                      <TrendingUp className="h-3.5 w-3.5 opacity-70" aria-hidden />
+                      Quality trend
+                    </span>
+                  </th>
                   <th scope="col" className="px-6 py-4 text-left text-xs font-bold text-gray-500 dark:text-gray-400 uppercase tracking-wider w-48">
                     Status
                   </th>
@@ -433,6 +464,33 @@ const Projects = () => {
                           {project.metadata.summary}
                         </div>
                       )}
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap align-middle">
+                      {(() => {
+                        const qh = projectQualityHistoryMap[project.id] ?? [];
+                        const latest = qh.length > 0 ? qh[qh.length - 1] : null;
+                        const tier = latest ? getNumericScoreTier(latest.overall) : null;
+                        if (!latest) {
+                          return (
+                            <span className="text-xs text-gray-400 dark:text-gray-600" title="No import scores recorded yet in this browser">
+                              —
+                            </span>
+                          );
+                        }
+                        return (
+                          <button
+                            type="button"
+                            onClick={() => setQualityTrendProject(project)}
+                            className="flex items-center gap-2 text-left rounded-lg border border-transparent hover:border-indigo-200 dark:hover:border-indigo-800 hover:bg-indigo-50/60 dark:hover:bg-indigo-950/40 px-2 py-1 -mx-2 -my-1 transition-colors w-full min-w-0"
+                            title="Open quality score history"
+                          >
+                            <div className="h-8 w-24 shrink-0 overflow-hidden rounded-md bg-gray-100 dark:bg-gray-900/80 border border-gray-200/80 dark:border-gray-700">
+                              <ProjectQualityTrendSparkline history={qh} className="h-full w-full" />
+                            </div>
+                            <span className={`text-sm font-semibold tabular-nums shrink-0 ${tier?.textClass ?? ''}`}>{latest.overall}</span>
+                          </button>
+                        );
+                      })()}
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap">
                       <div className="flex flex-col gap-2">
@@ -783,6 +841,15 @@ const Projects = () => {
           </Tabs>
         </DialogContent>
       </Dialog>
+
+      <ProjectQualityHistoryDialog
+        open={qualityTrendProject !== null}
+        onOpenChange={(open) => {
+          if (!open) setQualityTrendProject(null);
+        }}
+        projectName={qualityTrendProject?.name ?? ''}
+        history={qualityTrendProject ? projectQualityHistoryMap[qualityTrendProject.id] ?? [] : []}
+      />
 
       {/* New Import Dialog (Step 1 - Source Selection) */}
       {currentTenantId && currentUserId && (

--- a/objectified-ui/src/app/ade/dashboard/projects/page.tsx
+++ b/objectified-ui/src/app/ade/dashboard/projects/page.tsx
@@ -111,10 +111,23 @@ const Projects = () => {
     prevImportOpen.current = showNewImportDialog;
   }, [showNewImportDialog]);
 
+  const projectQualityHistoryCacheRef = useRef<Record<string, ReturnType<typeof getProjectQualityHistory>>>({});
+  const projectQualityHistoryCacheEpochRef = useRef(qualityHistoryEpoch);
+
   const projectQualityHistoryMap = useMemo(() => {
+    if (projectQualityHistoryCacheEpochRef.current !== qualityHistoryEpoch) {
+      projectQualityHistoryCacheRef.current = {};
+      projectQualityHistoryCacheEpochRef.current = qualityHistoryEpoch;
+    }
+
+    const cache = projectQualityHistoryCacheRef.current;
     const m: Record<string, ReturnType<typeof getProjectQualityHistory>> = {};
+
     for (const p of projects) {
-      m[p.id] = getProjectQualityHistory(p.id);
+      if (!(p.id in cache)) {
+        cache[p.id] = getProjectQualityHistory(p.id);
+      }
+      m[p.id] = cache[p.id];
     }
     return m;
   }, [projects, qualityHistoryEpoch]);

--- a/objectified-ui/src/app/components/ade/dashboard/ImportDialog.tsx
+++ b/objectified-ui/src/app/components/ade/dashboard/ImportDialog.tsx
@@ -23,6 +23,7 @@ import SwaggerHubImportPanel from './SwaggerHubImportPanel';
 import PostmanImportPanel from './PostmanImportPanel';
 import { startImport, getImportStatus, rollbackImport } from '../../../../../lib/db/import-actions';
 import { generateSlug } from '../../../utils/slug';
+import { appendProjectQualitySnapshot } from '../../../utils/project-quality-score-history';
 
 interface ImportDialogProps {
   open: boolean;
@@ -80,6 +81,7 @@ const ImportDialog: React.FC<ImportDialogProps> = ({
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   const urlImportRef = useRef<UrlImportPanelHandle>(null);
+  const dryRunRef = useRef(false);
   const [urlImportFooter, setUrlImportFooter] = useState<UrlImportFooterState>({
     canTestUrl: false,
     isTesting: false,
@@ -88,6 +90,31 @@ const ImportDialog: React.FC<ImportDialogProps> = ({
   const handleUrlImportFooterState = useCallback((s: UrlImportFooterState) => {
     setUrlImportFooter(s);
   }, []);
+
+  useEffect(() => {
+    if (!importComplete || !importSucceeded || !jobId || !analysisResult?.qualityScore) return;
+    if (dryRunRef.current) return;
+
+    let cancelled = false;
+    void (async () => {
+      try {
+        const status = await getImportStatus(jobId);
+        if (cancelled) return;
+        const projectId = (status as { result?: { projectId?: string } }).result?.projectId;
+        if (!projectId) return;
+        appendProjectQualitySnapshot(projectId, {
+          overall: analysisResult.qualityScore.overall,
+          grade: analysisResult.qualityScore.grade,
+          importJobId: jobId,
+        });
+      } catch {
+        // ignore
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [importComplete, importSucceeded, jobId, analysisResult]);
 
   // When opened with spec from AI Design Chat (Projects dashboard), run analysis immediately
   useEffect(() => {
@@ -194,6 +221,7 @@ const ImportDialog: React.FC<ImportDialogProps> = ({
     setPostmanFilename(null);
     setPostmanMetadata(null);
     setErrorMessage(null);
+    dryRunRef.current = false;
   };
 
   const handleClose = async () => {
@@ -364,6 +392,8 @@ const ImportDialog: React.FC<ImportDialogProps> = ({
 
   const beginImport = async () => {
     if (!analysisResult || !importOptions) return;
+
+    dryRunRef.current = Boolean(importOptions.dryRun);
 
     // Validate that we have required IDs
     if (!tenantId) {

--- a/objectified-ui/src/app/components/ade/dashboard/ProjectQualityHistoryDialog.tsx
+++ b/objectified-ui/src/app/components/ade/dashboard/ProjectQualityHistoryDialog.tsx
@@ -1,0 +1,175 @@
+'use client';
+
+import { useId } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '../../../components/ui/Dialog';
+import { buildQualityTrendPoints, type ProjectQualitySnapshot } from '../../../utils/project-quality-score-history';
+import { getNumericScoreTier } from '../../../utils/numeric-score-tier';
+
+interface ProjectQualityHistoryDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  projectName: string;
+  history: ProjectQualitySnapshot[];
+}
+
+function formatShortDate(iso: string): string {
+  try {
+    const d = new Date(iso);
+    if (Number.isNaN(d.getTime())) return iso;
+    return d.toLocaleString(undefined, {
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  } catch {
+    return iso;
+  }
+}
+
+export function ProjectQualityHistoryDialog({
+  open,
+  onOpenChange,
+  projectName,
+  history,
+}: ProjectQualityHistoryDialogProps) {
+  const gradId = `pqhist-${useId().replace(/\W/g, '')}`;
+  const overalls = history.map((h) => h.overall);
+  const pts = buildQualityTrendPoints(overalls);
+  const w = 400;
+  const h = 160;
+  const pad = 36;
+  const innerW = w - pad * 2;
+  const innerH = h - pad * 2;
+
+  const lineD =
+    pts.length === 0
+      ? ''
+      : pts
+          .map((p, i) => {
+            const x = pad + (p.x / 100) * innerW;
+            const y = pad + (p.y / 100) * innerH;
+            return `${i === 0 ? 'M' : 'L'} ${x.toFixed(1)} ${y.toFixed(1)}`;
+          })
+          .join(' ');
+
+  const areaD =
+    lineD && pts.length > 0
+      ? `${lineD} L ${pad + innerW} ${pad + innerH} L ${pad} ${pad + innerH} Z`
+      : '';
+
+  const first = history[0];
+  const last = history[history.length - 1];
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto" aria-describedby={undefined}>
+        <DialogHeader>
+          <DialogTitle>Quality score trend — {projectName}</DialogTitle>
+        </DialogHeader>
+        <p className="text-sm text-gray-600 dark:text-gray-400">
+          OpenAPI quality scores (0–100) recorded in this browser when an import finishes successfully. History is stored locally and is not synced across devices.
+        </p>
+
+        {history.length === 0 ? (
+          <p className="text-sm text-gray-500 dark:text-gray-500 py-8 text-center">No snapshots yet. Import a specification to record the first score.</p>
+        ) : (
+          <>
+            <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900/40 p-4">
+              <svg
+                viewBox={`0 0 ${w} ${h}`}
+                className="w-full h-40 text-indigo-500 dark:text-indigo-400"
+                role="img"
+                aria-label={`Quality trend from ${first ? formatShortDate(first.recordedAt) : ''} to ${last ? formatShortDate(last.recordedAt) : ''}`}
+              >
+                <title>
+                  Overall quality {overalls.join(', ')}
+                </title>
+                {/* grid */}
+                {[0, 25, 50, 75, 100].map((tick) => {
+                  const y = pad + ((100 - tick) / 100) * innerH;
+                  return (
+                    <g key={tick}>
+                      <line
+                        x1={pad}
+                        y1={y}
+                        x2={pad + innerW}
+                        y2={y}
+                        className="stroke-gray-200 dark:stroke-gray-700"
+                        strokeWidth={1}
+                      />
+                      <text x={4} y={y + 4} className="fill-gray-500 text-[10px] font-medium">
+                        {tick}
+                      </text>
+                    </g>
+                  );
+                })}
+                <defs>
+                  <linearGradient id={gradId} x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="0%" stopColor="currentColor" stopOpacity={0.2} />
+                    <stop offset="100%" stopColor="currentColor" stopOpacity={0} />
+                  </linearGradient>
+                </defs>
+                {areaD ? <path d={areaD} fill={`url(#${gradId})`} /> : null}
+                {lineD ? (
+                  <path d={lineD} fill="none" stroke="currentColor" strokeWidth={2.5} vectorEffect="non-scaling-stroke" />
+                ) : null}
+                {pts.map((p, i) => {
+                  const cx = pad + (p.x / 100) * innerW;
+                  const cy = pad + (p.y / 100) * innerH;
+                  return (
+                    <circle
+                      key={`${p.x}-${p.y}-${i}`}
+                      cx={cx}
+                      cy={cy}
+                      r={4}
+                      className="fill-white dark:fill-gray-900 stroke-current"
+                      strokeWidth={2}
+                    />
+                  );
+                })}
+              </svg>
+              <div className="flex justify-between text-xs text-gray-500 dark:text-gray-400 mt-2 px-1">
+                <span>{first ? formatShortDate(first.recordedAt) : ''}</span>
+                <span>{last ? formatShortDate(last.recordedAt) : ''}</span>
+              </div>
+            </div>
+
+            <div className="overflow-x-auto rounded-lg border border-gray-200 dark:border-gray-700">
+              <table className="min-w-full text-sm">
+                <thead className="bg-gray-50 dark:bg-gray-900/50 text-left text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                  <tr>
+                    <th className="px-3 py-2 font-semibold">Recorded</th>
+                    <th className="px-3 py-2 font-semibold">Overall</th>
+                    <th className="px-3 py-2 font-semibold">Grade</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-gray-100 dark:divide-gray-800">
+                  {[...history].reverse().map((row, idx) => {
+                    const tier = getNumericScoreTier(row.overall);
+                    return (
+                      <tr key={`${row.recordedAt}-${row.overall}-${idx}`}>
+                        <td className="px-3 py-2 text-gray-700 dark:text-gray-300 whitespace-nowrap">
+                          {formatShortDate(row.recordedAt)}
+                        </td>
+                        <td className="px-3 py-2">
+                          <span className={`font-semibold tabular-nums ${tier.textClass}`}>{row.overall}</span>
+                        </td>
+                        <td className="px-3 py-2 text-gray-800 dark:text-gray-200">{row.grade}</td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/objectified-ui/src/app/components/ade/dashboard/ProjectQualityTrendSparkline.tsx
+++ b/objectified-ui/src/app/components/ade/dashboard/ProjectQualityTrendSparkline.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { useId } from 'react';
+import { buildQualityTrendPoints, type ProjectQualitySnapshot } from '../../../utils/project-quality-score-history';
+
+interface ProjectQualityTrendSparklineProps {
+  history: ProjectQualitySnapshot[];
+  className?: string;
+}
+
+/** Inline SVG trend (0–100 quality over time). */
+export function ProjectQualityTrendSparkline({ history, className }: ProjectQualityTrendSparklineProps) {
+  const gradId = `pqspark-${useId().replace(/\W/g, '')}`;
+  const overalls = history.map((h) => h.overall);
+  const points = buildQualityTrendPoints(overalls);
+  if (points.length === 0) return null;
+
+  const d = points.map((p, i) => `${i === 0 ? 'M' : 'L'} ${p.x.toFixed(2)} ${p.y.toFixed(2)}`).join(' ');
+  const last = overalls[overalls.length - 1];
+  const summary = `${overalls.length} snapshot${overalls.length === 1 ? '' : 's'}, latest ${last}`;
+
+  return (
+    <svg
+      viewBox="0 0 100 100"
+      preserveAspectRatio="none"
+      className={`text-indigo-500 dark:text-indigo-400 ${className ?? ''}`}
+      aria-hidden
+      focusable="false"
+    >
+      <title>{summary}</title>
+      <defs>
+        <linearGradient id={gradId} x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor="currentColor" stopOpacity={0.22} />
+          <stop offset="100%" stopColor="currentColor" stopOpacity={0} />
+        </linearGradient>
+      </defs>
+      <path
+        d={`${d} L 100 100 L 0 100 Z`}
+        fill={`url(#${gradId})`}
+      />
+      <path d={d} fill="none" stroke="currentColor" strokeWidth={3} vectorEffect="non-scaling-stroke" />
+    </svg>
+  );
+}

--- a/objectified-ui/src/app/utils/project-quality-score-history.ts
+++ b/objectified-ui/src/app/utils/project-quality-score-history.ts
@@ -20,8 +20,35 @@ interface StoreShape {
 const STORAGE_KEY = 'objectified:project-quality-history:v1';
 const MAX_ENTRIES_PER_PROJECT = 120;
 
-/** Prevents duplicate snapshots when import completion runs twice (e.g. React Strict Mode). */
-const appendedImportJobIds = new Set<string>();
+const MAX_APPENDED_IMPORT_JOB_IDS = 500;
+
+/**
+ * Prevents duplicate snapshots when import completion runs twice
+ * (e.g. React Strict Mode), while avoiding unbounded growth for long-lived tabs.
+ */
+const appendedImportJobIds = (() => {
+  const ids = new Set<string>();
+  const order: string[] = [];
+
+  return {
+    has(id: string): boolean {
+      return ids.has(id);
+    },
+    add(id: string): void {
+      if (ids.has(id)) return;
+
+      ids.add(id);
+      order.push(id);
+
+      if (order.length > MAX_APPENDED_IMPORT_JOB_IDS) {
+        const oldestId = order.shift();
+        if (oldestId) {
+          ids.delete(oldestId);
+        }
+      }
+    },
+  };
+})();
 
 function loadStore(): StoreShape {
   if (typeof window === 'undefined') return { byProject: {} };
@@ -48,7 +75,8 @@ function saveStore(store: StoreShape): void {
 }
 
 function clampOverall(n: number): number {
-  return Math.max(0, Math.min(100, Math.round(n)));
+  const safeValue = Number.isFinite(n) ? n : 0;
+  return Math.max(0, Math.min(100, Math.round(safeValue)));
 }
 
 /**

--- a/objectified-ui/src/app/utils/project-quality-score-history.ts
+++ b/objectified-ui/src/app/utils/project-quality-score-history.ts
@@ -1,0 +1,138 @@
+/**
+ * Browser-local history of OpenAPI quality scores per project (#246).
+ * Snapshots are appended when an import completes successfully (Import dialog).
+ */
+
+export type QualityLetterGrade = 'A' | 'B' | 'C' | 'D' | 'F';
+
+export interface ProjectQualitySnapshot {
+  recordedAt: string;
+  overall: number;
+  grade: QualityLetterGrade;
+  /** Dedupes Strict Mode / duplicate effect runs for the same import job */
+  importJobId?: string;
+}
+
+interface StoreShape {
+  byProject: Record<string, ProjectQualitySnapshot[]>;
+}
+
+const STORAGE_KEY = 'objectified:project-quality-history:v1';
+const MAX_ENTRIES_PER_PROJECT = 120;
+
+/** Prevents duplicate snapshots when import completion runs twice (e.g. React Strict Mode). */
+const appendedImportJobIds = new Set<string>();
+
+function loadStore(): StoreShape {
+  if (typeof window === 'undefined') return { byProject: {} };
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return { byProject: {} };
+    const parsed = JSON.parse(raw) as StoreShape;
+    if (!parsed || typeof parsed !== 'object' || !parsed.byProject || typeof parsed.byProject !== 'object') {
+      return { byProject: {} };
+    }
+    return parsed;
+  } catch {
+    return { byProject: {} };
+  }
+}
+
+function saveStore(store: StoreShape): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(store));
+  } catch {
+    // quota or private mode
+  }
+}
+
+function clampOverall(n: number): number {
+  return Math.max(0, Math.min(100, Math.round(n)));
+}
+
+/**
+ * Append a snapshot for a project. Keeps entries ordered by `recordedAt` ascending.
+ * Skips if the last entry for this project has the same `importJobId`.
+ */
+export function appendProjectQualitySnapshot(
+  projectId: string,
+  payload: {
+    overall: number;
+    grade: QualityLetterGrade;
+    importJobId?: string;
+    recordedAt?: string;
+  }
+): void {
+  if (!projectId) return;
+
+  if (payload.importJobId && appendedImportJobIds.has(payload.importJobId)) return;
+
+  const store = loadStore();
+  const prev = [...(store.byProject[projectId] ?? [])].sort(
+    (a, b) => new Date(a.recordedAt).getTime() - new Date(b.recordedAt).getTime()
+  );
+
+  if (payload.importJobId) {
+    const last = prev[prev.length - 1];
+    if (last?.importJobId === payload.importJobId) return;
+  }
+
+  if (payload.importJobId) appendedImportJobIds.add(payload.importJobId);
+
+  const snap: ProjectQualitySnapshot = {
+    recordedAt: payload.recordedAt ?? new Date().toISOString(),
+    overall: clampOverall(payload.overall),
+    grade: payload.grade,
+    ...(payload.importJobId ? { importJobId: payload.importJobId } : {}),
+  };
+
+  const next = [...prev, snap];
+  if (next.length > MAX_ENTRIES_PER_PROJECT) {
+    next.splice(0, next.length - MAX_ENTRIES_PER_PROJECT);
+  }
+
+  store.byProject[projectId] = next;
+  saveStore(store);
+}
+
+export function getProjectQualityHistory(projectId: string): ProjectQualitySnapshot[] {
+  if (!projectId) return [];
+  const store = loadStore();
+  const list = store.byProject[projectId] ?? [];
+  return [...list].sort((a, b) => new Date(a.recordedAt).getTime() - new Date(b.recordedAt).getTime());
+}
+
+/** Latest overall score if any history exists */
+export function getLatestProjectQualityOverall(projectId: string): number | null {
+  const h = getProjectQualityHistory(projectId);
+  if (h.length === 0) return null;
+  return h[h.length - 1].overall;
+}
+
+export interface SparklinePoint {
+  x: number;
+  y: number;
+  overall: number;
+}
+
+/**
+ * Normalized SVG coordinates (0–100 viewBox) for a polyline / area under the curve.
+ */
+export function buildQualityTrendPoints(overallValues: number[]): SparklinePoint[] {
+  const vals = overallValues.map((v) => clampOverall(v));
+  if (vals.length === 0) return [];
+  if (vals.length === 1) {
+    const y = 100 - vals[0];
+    return [
+      { x: 0, y, overall: vals[0] },
+      { x: 100, y, overall: vals[0] },
+    ];
+  }
+  const n = vals.length;
+  return vals.map((overall, i) => ({
+    x: (i / (n - 1)) * 100,
+    y: 100 - overall,
+    overall,
+  }));
+}

--- a/objectified-ui/tests/unit/project-quality-score-history.test.ts
+++ b/objectified-ui/tests/unit/project-quality-score-history.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
 import { buildQualityTrendPoints } from '@/app/utils/project-quality-score-history';
 
 describe('project-quality-score-history', () => {

--- a/objectified-ui/tests/unit/project-quality-score-history.test.ts
+++ b/objectified-ui/tests/unit/project-quality-score-history.test.ts
@@ -1,0 +1,47 @@
+import { buildQualityTrendPoints } from '@/app/utils/project-quality-score-history';
+
+describe('project-quality-score-history', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    jest.resetModules();
+  });
+
+  describe('buildQualityTrendPoints', () => {
+    it('maps a single value to a flat line across the viewBox', () => {
+      const pts = buildQualityTrendPoints([72]);
+      expect(pts).toHaveLength(2);
+      expect(pts[0].overall).toBe(72);
+      expect(pts[1].overall).toBe(72);
+      expect(pts[0].y).toBe(100 - 72);
+    });
+
+    it('maps multiple values across x', () => {
+      const pts = buildQualityTrendPoints([0, 50, 100]);
+      expect(pts).toHaveLength(3);
+      expect(pts[0].x).toBe(0);
+      expect(pts[2].x).toBe(100);
+      expect(pts[2].y).toBe(0);
+    });
+  });
+
+  describe('appendProjectQualitySnapshot', () => {
+    it('stores and reads snapshots per project', async () => {
+      const { appendProjectQualitySnapshot, getProjectQualityHistory } = await import(
+        '@/app/utils/project-quality-score-history'
+      );
+      appendProjectQualitySnapshot('p1', { overall: 80, grade: 'B', importJobId: 'job-a' });
+      expect(getProjectQualityHistory('p1')).toHaveLength(1);
+      expect(getProjectQualityHistory('p1')[0].overall).toBe(80);
+      expect(getProjectQualityHistory('p1')[0].grade).toBe('B');
+    });
+
+    it('dedupes the same import job id', async () => {
+      const { appendProjectQualitySnapshot, getProjectQualityHistory } = await import(
+        '@/app/utils/project-quality-score-history'
+      );
+      appendProjectQualitySnapshot('p1', { overall: 80, grade: 'B', importJobId: 'job-x' });
+      appendProjectQualitySnapshot('p1', { overall: 81, grade: 'B', importJobId: 'job-x' });
+      expect(getProjectQualityHistory('p1')).toHaveLength(1);
+    });
+  });
+});


### PR DESCRIPTION
Four issues flagged in review on the per-project OpenAPI quality score history implementation.

## Changes

- **Test imports** — explicitly import `describe`, `it`, `expect`, `beforeEach`, `jest` from `@jest/globals` in the test file, consistent with the rest of the unit test suite.

- **`clampOverall()` NaN guard** — guard against non-finite inputs (corrupted localStorage, unexpected analyzer output) before rounding/clamping:
  ```ts
  const safeValue = Number.isFinite(n) ? n : 0;
  return Math.max(0, Math.min(100, Math.round(safeValue)));
  ```

- **Bounded `appendedImportJobIds`** — replace unbounded `Set<string>` with a capped IIFE (max 500 entries, oldest evicted), preventing memory growth in long-lived tabs.

- **`projectQualityHistoryMap` cache** — add a `useRef` cache invalidated by `qualityHistoryEpoch`, so `getProjectQualityHistory()` / localStorage parsing runs once per epoch rather than once per project per render.