### PR TITLE
Fix: align setSchemaQualityScore type with StudioContext setter convention

### DIFF
--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.9.22",
+  "version": "0.9.23",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -5,6 +5,7 @@ We continue to improve the platform based on your feedback with improvements and
 ---
 
 ## UI:
+- **Studio schema quality (#245):** **Overall score (0–100)** in the Studio header — weighted blend of documentation, naming, structural load (inverted complexity), and canvas layout quality; updates live on the Canvas
 - **Import quality score (#247):** **Weighted breakdown by category** — Design Quality (30 pts), Documentation (20), API Best Practices (25), Security (15), Performance (10); overall total out of 100 points with per-category progress and issues
 - **Score bands (#248):** Shared **green / yellow / orange / red** tiers for 0–100 scores (90+ excellent down to 0–49 poor) on import **Quality Score** (overall + per-metric bars and guide), **Schema Metrics** docs/naming bars, and **Version scoring** radial gauges (documentation & naming; complexity still uses its own low/medium/high scale)
 - **Version scoring:** New **Version scoring** panel (gauge icon) — pick a project version to see **per-schema** documentation, naming, and complexity scores with **animated radial gauges** (eased arc and value; respects reduced motion)

--- a/objectified-ui/src/app/ade/studio/StudioContext.tsx
+++ b/objectified-ui/src/app/ade/studio/StudioContext.tsx
@@ -163,6 +163,9 @@ interface StudioContextType {
   /** When true, studio chrome (sidebar, studio header) is hidden for canvas presentation mode (#517). */
   canvasPresentationMode: boolean;
   setCanvasPresentationMode: (value: boolean) => void;
+  /** Live overall schema quality 0–100 from Canvas (#245); null when not on editor or no classes yet */
+  schemaQualityScore: number | null;
+  setSchemaQualityScore: Dispatch<SetStateAction<number | null>>;
 }
 
 const StudioContext = createContext<StudioContextType | undefined>(undefined);
@@ -362,6 +365,7 @@ export function StudioProvider({ children }: { children: ReactNode }) {
   const [clearSearchHistoryFn, setClearSearchHistoryFn] = useState<(() => void) | null>(null);
 
   const [canvasPresentationMode, setCanvasPresentationMode] = useState(false);
+  const [schemaQualityScore, setSchemaQualityScore] = useState<number | null>(null);
 
   // Persist grid settings to localStorage
   useEffect(() => {
@@ -537,7 +541,9 @@ export function StudioProvider({ children }: { children: ReactNode }) {
       clearSearchHistoryFn,
       setClearSearchHistoryFn,
       canvasPresentationMode,
-      setCanvasPresentationMode
+      setCanvasPresentationMode,
+      schemaQualityScore,
+      setSchemaQualityScore
     }}>
       {children}
     </StudioContext.Provider>

--- a/objectified-ui/src/app/ade/studio/StudioContext.tsx
+++ b/objectified-ui/src/app/ade/studio/StudioContext.tsx
@@ -165,7 +165,7 @@ interface StudioContextType {
   setCanvasPresentationMode: (value: boolean) => void;
   /** Live overall schema quality 0–100 from Canvas (#245); null when not on editor or no classes yet */
   schemaQualityScore: number | null;
-  setSchemaQualityScore: Dispatch<SetStateAction<number | null>>;
+  setSchemaQualityScore: (value: number | null) => void;
 }
 
 const StudioContext = createContext<StudioContextType | undefined>(undefined);

--- a/objectified-ui/src/app/ade/studio/components/StudioHeader.tsx
+++ b/objectified-ui/src/app/ade/studio/components/StudioHeader.tsx
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import { useSession } from 'next-auth/react';
 import { useRouter, usePathname } from 'next/navigation';
-import { Check, Settings } from 'lucide-react';
+import { Check, Gauge, Settings } from 'lucide-react';
 import * as Select from '@radix-ui/react-select';
 import * as ToggleGroup from '@radix-ui/react-toggle-group';
 import { useStudio } from '../StudioContext';
@@ -12,6 +12,8 @@ import {
   getTagsForProject
 } from '../../../../../lib/db/helper';
 import CanvasSettingsDialog from './CanvasSettingsDialog';
+import { cn } from '../../../../../lib/utils';
+import { getNumericScoreTier } from '@/app/utils/numeric-score-tier';
 
 interface Project {
   id: string;
@@ -66,7 +68,8 @@ export default function StudioHeader({ onProjectTagsLoaded }: StudioHeaderProps)
     edgeAnimation,
     setEdgeAnimation,
     searchHistoryCount,
-    clearSearchHistoryFn
+    clearSearchHistoryFn,
+    schemaQualityScore
   } = useStudio();
 
   const [projects, setProjects] = React.useState<Project[]>([]);
@@ -356,6 +359,35 @@ export default function StudioHeader({ onProjectTagsLoaded }: StudioHeaderProps)
             </Select.Portal>
           </Select.Root>
         </div>
+
+        {/* Overall schema quality (#245) — live from Canvas; null on Code view or before metrics load */}
+        {localProjectId && localVersionId && (
+          <div
+            className="flex items-center gap-2 rounded-xl border border-gray-200 dark:border-gray-600 bg-white/90 dark:bg-gray-700/40 px-3 py-1 shadow-sm shrink-0"
+            title={
+              schemaQualityScore != null
+                ? 'Overall schema quality (0–100): documentation, naming, structural load, and canvas layout. Updates live on the Canvas.'
+                : 'Open the Canvas view to compute a live schema quality score.'
+            }
+          >
+            <Gauge className="w-5 h-5 text-indigo-500 shrink-0" aria-hidden />
+            <div className="flex flex-col min-w-0">
+              <span className="text-[10px] uppercase tracking-wide text-gray-500 dark:text-gray-400 leading-none">
+                Schema quality
+              </span>
+              <span
+                className={cn(
+                  'text-2xl font-bold tabular-nums leading-none',
+                  schemaQualityScore != null
+                    ? getNumericScoreTier(schemaQualityScore).textClass
+                    : 'text-gray-400 dark:text-gray-500'
+                )}
+              >
+                {schemaQualityScore != null ? schemaQualityScore : '—'}
+              </span>
+            </div>
+          </div>
+        )}
 
         {/* View Switcher and Settings - only show when project and version selected */}
         {localProjectId && localVersionId && (

--- a/objectified-ui/src/app/ade/studio/editor/page.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/page.tsx
@@ -188,6 +188,7 @@ import {
   ghostNodeClassName,
 } from '@/app/utils/canvas-ghost-mode';
 import { computeLayoutQuality } from '@/app/utils/layout-quality';
+import { computeOverallSchemaQualityScore } from '@/app/utils/overall-schema-quality';
 import {
   buildCanvasLayoutJsonDocument,
   CANVAS_LAYOUT_JSON_FORMAT_VERSION,
@@ -346,6 +347,7 @@ const StudioContent = () => {
     setSearchHistoryCount,
     setClearSearchHistoryFn,
     setCanvasPresentationMode,
+    setSchemaQualityScore,
   } = useStudio();
 
   // Toggle click-to-focus mode (defined after useStudio to access setContextClickToFocusEnabled)
@@ -868,6 +870,25 @@ const StudioContent = () => {
     if (classNodes.length === 0) return null;
     return computeLayoutQuality(nodes, edges);
   }, [nodes, edges]);
+
+  const overallSchemaQualityScore = useMemo(() => {
+    if (!schemaMetrics || !layoutQuality) return null;
+    return computeOverallSchemaQualityScore(schemaMetrics, layoutQuality);
+  }, [schemaMetrics, layoutQuality]);
+
+  useEffect(() => {
+    if (!contextProjectId || !contextVersionId) {
+      setSchemaQualityScore(null);
+      return;
+    }
+    setSchemaQualityScore(overallSchemaQualityScore);
+  }, [contextProjectId, contextVersionId, overallSchemaQualityScore, setSchemaQualityScore]);
+
+  useEffect(() => {
+    return () => {
+      setSchemaQualityScore(null);
+    };
+  }, [setSchemaQualityScore]);
 
   // Canvas improvement suggestions (#474)
   const groupMemberIds = useMemo(() => {

--- a/objectified-ui/src/app/utils/overall-schema-quality.ts
+++ b/objectified-ui/src/app/utils/overall-schema-quality.ts
@@ -1,0 +1,36 @@
+/**
+ * Single 0–100 overall schema quality score for Studio (#245).
+ * Combines documentation, naming, inverted complexity (lower structural load is better),
+ * and canvas layout quality using fixed weights that sum to 100%.
+ */
+
+import type { LayoutQualityResult } from '@/app/utils/layout-quality';
+import type { SchemaMetricsResult } from '@/app/utils/schema-metrics';
+
+const W_DOC = 0.3;
+const W_NAMING = 0.3;
+const W_SIMPLICITY = 0.25;
+const W_LAYOUT = 0.15;
+
+/**
+ * Weighted composite of schema metrics and optional layout quality.
+ * When `layoutQuality` is omitted, layout is excluded and weights are renormalized across the other three factors.
+ */
+export function computeOverallSchemaQualityScore(
+  metrics: SchemaMetricsResult,
+  layoutQuality: LayoutQualityResult | null | undefined
+): number {
+  const doc = metrics.documentationCompletionPercentage;
+  const naming = metrics.namingCompliance.compliancePercentage;
+  const simplicity = 100 - metrics.complexityScore;
+
+  if (layoutQuality == null) {
+    const sumW = W_DOC + W_NAMING + W_SIMPLICITY;
+    const raw = ((W_DOC / sumW) * doc + (W_NAMING / sumW) * naming + (W_SIMPLICITY / sumW) * simplicity);
+    return Math.min(100, Math.max(0, Math.round(raw)));
+  }
+
+  const raw =
+    W_DOC * doc + W_NAMING * naming + W_SIMPLICITY * simplicity + W_LAYOUT * layoutQuality.overallScore;
+  return Math.min(100, Math.max(0, Math.round(raw)));
+}

--- a/objectified-ui/tests/unit/overall-schema-quality.test.ts
+++ b/objectified-ui/tests/unit/overall-schema-quality.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from '@jest/globals';
+import type { SchemaMetricsResult } from '@/app/utils/schema-metrics';
+import { computeOverallSchemaQualityScore } from '@/app/utils/overall-schema-quality';
+
+function makeMinimalMetrics(overrides: Partial<SchemaMetricsResult> = {}): SchemaMetricsResult {
+  return {
+    classCount: 3,
+    totalProperties: 9,
+    averagePropertiesPerClass: 3,
+    relationshipCount: 2,
+    hubClassIds: [],
+    hubNames: [],
+    isolatedClassIds: [],
+    isolatedNames: [],
+    deepestChainLength: 2,
+    circularDependencyCount: 0,
+    circularSampleNames: [],
+    circularDependencyNodeIds: [],
+    complexityScore: 30,
+    complexityLabel: 'Low',
+    complexityBreakdown: [{ label: 'Classes', value: 3, weight: 1.5, contribution: 4.5 }],
+    documentationCompletionPercentage: 80,
+    classesMissingDocumentation: [],
+    propertiesMissingDocumentation: [],
+    namingCompliance: {
+      classes: { pascal: 3, camel: 0, snake: 0, other: 0, total: 3 },
+      properties: { pascal: 0, camel: 9, snake: 0, other: 0, total: 9 },
+      compliancePercentage: 90,
+      classesNonPascal: [],
+      propertiesNonCamel: [],
+    },
+    dependencyMetricsPerClass: [],
+    ...overrides,
+  };
+}
+
+describe('computeOverallSchemaQualityScore (#245)', () => {
+  it('returns 0–100 integer', () => {
+    const m = makeMinimalMetrics();
+    const s = computeOverallSchemaQualityScore(m, { overallScore: 80, edgeCrossingCount: 0, nodeSpacingUniformityScore: 80, layoutSymmetryScore: 80, visualBalanceScore: 80 });
+    expect(s).toBeGreaterThanOrEqual(0);
+    expect(s).toBeLessThanOrEqual(100);
+    expect(Number.isInteger(s)).toBe(true);
+  });
+
+  it('is 100 when all inputs are ideal and complexity is minimal', () => {
+    const m = makeMinimalMetrics({
+      complexityScore: 0,
+      documentationCompletionPercentage: 100,
+      namingCompliance: {
+        classes: { pascal: 1, camel: 0, snake: 0, other: 0, total: 1 },
+        properties: { pascal: 0, camel: 0, snake: 0, other: 0, total: 0 },
+        compliancePercentage: 100,
+        classesNonPascal: [],
+        propertiesNonCamel: [],
+      },
+    });
+    const s = computeOverallSchemaQualityScore(m, {
+      overallScore: 100,
+      edgeCrossingCount: 0,
+      nodeSpacingUniformityScore: 100,
+      layoutSymmetryScore: 100,
+      visualBalanceScore: 100,
+    });
+    expect(s).toBe(100);
+  });
+
+  it('omitting layout renormalizes weights across docs, naming, and inverted complexity', () => {
+    const m = makeMinimalMetrics({
+      complexityScore: 0,
+      documentationCompletionPercentage: 100,
+      namingCompliance: {
+        classes: { pascal: 1, camel: 0, snake: 0, other: 0, total: 1 },
+        properties: { pascal: 0, camel: 0, snake: 0, other: 0, total: 0 },
+        compliancePercentage: 100,
+        classesNonPascal: [],
+        propertiesNonCamel: [],
+      },
+    });
+    expect(computeOverallSchemaQualityScore(m, null)).toBe(100);
+  });
+});


### PR DESCRIPTION
`setSchemaQualityScore` was typed as `Dispatch<SetStateAction<number | null>>`, inconsistent with every other scalar setter in `StudioContextType` (e.g. `setCanvasPresentationMode: (value: boolean) => void`). Functional-updater semantics aren't needed here, and the `Dispatch` type leaks React internals into the context API surface.

## Change

```ts
// Before
setSchemaQualityScore: Dispatch<SetStateAction<number | null>>;

// After
setSchemaQualityScore: (value: number | null) => void;
```