### PR TITLE
Fix aria accessibility in Schema quality dialog

### DIFF
--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.9.23",
+  "version": "0.9.24",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -5,6 +5,7 @@ We continue to improve the platform based on your feedback with improvements and
 ---
 
 ## UI:
+- **Schema quality details (#2548):** **Studio header** Schema quality is **clickable** — opens a dialog with **letter grade (A–F)**, weighted **factor table**, and the same **score band guide** as import quality. **Schema Metrics** shows the same **overall schema quality** block (numeric score + letter + guide) above the per-metric controls
 - **Studio schema quality (#245):** **Overall score (0–100)** in the Studio header — weighted blend of documentation, naming, structural load (inverted complexity), and canvas layout quality; updates live on the Canvas
 - **Import quality score (#247):** **Weighted breakdown by category** — Design Quality (30 pts), Documentation (20), API Best Practices (25), Security (15), Performance (10); overall total out of 100 points with per-category progress and issues
 - **Score bands (#248):** Shared **green / yellow / orange / red** tiers for 0–100 scores (90+ excellent down to 0–49 poor) on import **Quality Score** (overall + per-metric bars and guide), **Schema Metrics** docs/naming bars, and **Version scoring** radial gauges (documentation & naming; complexity still uses its own low/medium/high scale)

--- a/objectified-ui/src/app/ade/studio/StudioContext.tsx
+++ b/objectified-ui/src/app/ade/studio/StudioContext.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { createContext, useContext, useState, useEffect, useCallback, ReactNode, Dispatch, SetStateAction } from 'react';
+import type { OverallSchemaQualityDetail } from '@/app/utils/overall-schema-quality';
 
 // Group style options
 export interface GroupStyleOptions {
@@ -166,6 +167,9 @@ interface StudioContextType {
   /** Live overall schema quality 0–100 from Canvas (#245); null when not on editor or no classes yet */
   schemaQualityScore: number | null;
   setSchemaQualityScore: (value: number | null) => void;
+  /** Weighted breakdown for header dialog / metrics card (#2548); null when score is unavailable */
+  schemaQualityDetail: OverallSchemaQualityDetail | null;
+  setSchemaQualityDetail: (value: OverallSchemaQualityDetail | null) => void;
 }
 
 const StudioContext = createContext<StudioContextType | undefined>(undefined);
@@ -366,6 +370,7 @@ export function StudioProvider({ children }: { children: ReactNode }) {
 
   const [canvasPresentationMode, setCanvasPresentationMode] = useState(false);
   const [schemaQualityScore, setSchemaQualityScore] = useState<number | null>(null);
+  const [schemaQualityDetail, setSchemaQualityDetail] = useState<OverallSchemaQualityDetail | null>(null);
 
   // Persist grid settings to localStorage
   useEffect(() => {
@@ -543,7 +548,9 @@ export function StudioProvider({ children }: { children: ReactNode }) {
       canvasPresentationMode,
       setCanvasPresentationMode,
       schemaQualityScore,
-      setSchemaQualityScore
+      setSchemaQualityScore,
+      schemaQualityDetail,
+      setSchemaQualityDetail
     }}>
       {children}
     </StudioContext.Provider>

--- a/objectified-ui/src/app/ade/studio/components/SchemaMetricsPanel.tsx
+++ b/objectified-ui/src/app/ade/studio/components/SchemaMetricsPanel.tsx
@@ -9,11 +9,14 @@ import type { LayoutQualityResult } from '@/app/utils/layout-quality';
 import type { SchemaMetricsResult } from '@/app/utils/schema-metrics';
 import type { CanvasSuggestion } from '@/app/utils/canvas-suggestions';
 import { downloadSchemaScoreReportPdf } from '@/app/utils/export-schema-score-report-pdf';
-import { getNumericScoreTier } from '@/app/utils/numeric-score-tier';
+import { getNumericScoreTier, NUMERIC_SCORE_TIER_LEGEND } from '@/app/utils/numeric-score-tier';
+import { OVERALL_SCHEMA_QUALITY_WEIGHTS, type OverallSchemaQualityDetail } from '@/app/utils/overall-schema-quality';
 
 interface SchemaMetricsPanelProps {
   metrics: SchemaMetricsResult | null;
   layoutQuality?: LayoutQualityResult | null;
+  /** Weighted overall + letter grade; same formula as Studio header (#2548) */
+  overallSchemaQualityDetail?: OverallSchemaQualityDetail | null;
   /** Canvas improvement suggestions (#474) */
   suggestions?: CanvasSuggestion[];
   /** Shown on exported PDF cover (#252) */
@@ -29,6 +32,7 @@ interface SchemaMetricsPanelProps {
 export default function SchemaMetricsPanel({
   metrics,
   layoutQuality,
+  overallSchemaQualityDetail = null,
   suggestions = [],
   projectName,
   versionLabel,
@@ -176,6 +180,56 @@ export default function SchemaMetricsPanel({
               </div>
             </div>
           </div>
+          {/* Overall schema quality — matches import Quality Score presentation (#2548) */}
+          {overallSchemaQualityDetail && (
+            <div className="mt-2 rounded-lg border border-gray-200 dark:border-gray-700 bg-gradient-to-br from-gray-50 to-gray-100 dark:from-gray-900/50 dark:to-gray-800/50 px-3 py-2.5">
+              <div className="flex items-center justify-between gap-2">
+                <div className="flex items-center gap-2 min-w-0">
+                  <div
+                    className={`text-3xl font-bold tabular-nums leading-none shrink-0 ${overallSchemaQualityDetail.tier.textClass}`}
+                    title={`${overallSchemaQualityDetail.tier.shortLabel} (${overallSchemaQualityDetail.tier.rangeLabel})`}
+                  >
+                    {overallSchemaQualityDetail.letterGrade}
+                  </div>
+                  <div className="min-w-0">
+                    <div className="text-[10px] uppercase tracking-wide text-gray-500 dark:text-gray-400 leading-none">
+                      Schema quality
+                    </div>
+                    <div className={`text-xs font-semibold mt-0.5 leading-tight ${overallSchemaQualityDetail.tier.textClass}`}>
+                      {overallSchemaQualityDetail.tier.shortLabel} — {overallSchemaQualityDetail.tier.detailLabel}
+                    </div>
+                  </div>
+                </div>
+                <div className="text-right shrink-0">
+                  <div className={`text-2xl font-bold tabular-nums leading-none ${overallSchemaQualityDetail.tier.textClass}`}>
+                    {overallSchemaQualityDetail.overall}
+                  </div>
+                  <div className="text-[10px] text-gray-500 dark:text-gray-400 tabular-nums">/ 100</div>
+                </div>
+              </div>
+              <p className="text-[10px] text-gray-500 dark:text-gray-400 mt-2 leading-snug">
+                Weighted blend — documentation {OVERALL_SCHEMA_QUALITY_WEIGHTS.documentation}, naming {OVERALL_SCHEMA_QUALITY_WEIGHTS.naming}, structural load {OVERALL_SCHEMA_QUALITY_WEIGHTS.structuralLoad}
+                {overallSchemaQualityDetail.layoutIncluded
+                  ? `, canvas layout ${OVERALL_SCHEMA_QUALITY_WEIGHTS.layout}.`
+                  : '.'}
+              </p>
+              <div className="mt-2 pt-2 border-t border-gray-200/80 dark:border-gray-600/80">
+                <div className="text-[9px] font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400 mb-1.5">
+                  Score guide
+                </div>
+                <ul className="space-y-1 text-[10px] text-gray-600 dark:text-gray-300">
+                  {NUMERIC_SCORE_TIER_LEGEND.map((row) => (
+                    <li key={row.band} className="flex items-start gap-1.5">
+                      <span className={`mt-1 h-1.5 w-1.5 shrink-0 rounded-full ${row.barSolidClass}`} aria-hidden />
+                      <span>
+                        <span className="font-medium tabular-nums">{row.rangeLabel}:</span> {row.shortLabel}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+          )}
           {/* Realtime schema complexity score (#556); click to see why */}
           <Popover.Root>
             <Popover.Trigger asChild>

--- a/objectified-ui/src/app/ade/studio/components/StudioHeader.tsx
+++ b/objectified-ui/src/app/ade/studio/components/StudioHeader.tsx
@@ -3,8 +3,9 @@
 import * as React from 'react';
 import { useSession } from 'next-auth/react';
 import { useRouter, usePathname } from 'next/navigation';
-import { Check, Gauge, Settings } from 'lucide-react';
+import { Check, Gauge, Settings, X } from 'lucide-react';
 import * as Select from '@radix-ui/react-select';
+import * as Dialog from '@radix-ui/react-dialog';
 import * as ToggleGroup from '@radix-ui/react-toggle-group';
 import { useStudio } from '../StudioContext';
 import { Spinner } from '../../../components/ui/Spinner';
@@ -13,7 +14,8 @@ import {
 } from '../../../../../lib/db/helper';
 import CanvasSettingsDialog from './CanvasSettingsDialog';
 import { cn } from '../../../../../lib/utils';
-import { getNumericScoreTier } from '@/app/utils/numeric-score-tier';
+import { getNumericScoreTier, NUMERIC_SCORE_TIER_LEGEND } from '@/app/utils/numeric-score-tier';
+import { OVERALL_SCHEMA_QUALITY_WEIGHTS } from '@/app/utils/overall-schema-quality';
 
 interface Project {
   id: string;
@@ -69,8 +71,11 @@ export default function StudioHeader({ onProjectTagsLoaded }: StudioHeaderProps)
     setEdgeAnimation,
     searchHistoryCount,
     clearSearchHistoryFn,
-    schemaQualityScore
+    schemaQualityScore,
+    schemaQualityDetail
   } = useStudio();
+
+  const [schemaQualityDialogOpen, setSchemaQualityDialogOpen] = React.useState(false);
 
   const [projects, setProjects] = React.useState<Project[]>([]);
   const [versions, setVersions] = React.useState<Version[]>([]);
@@ -360,33 +365,177 @@ export default function StudioHeader({ onProjectTagsLoaded }: StudioHeaderProps)
           </Select.Root>
         </div>
 
-        {/* Overall schema quality (#245) — live from Canvas; null on Code view or before metrics load */}
+        {/* Overall schema quality (#245) — live from Canvas; click for breakdown (#2548) */}
         {localProjectId && localVersionId && (
-          <div
-            className="flex items-center gap-2 rounded-xl border border-gray-200 dark:border-gray-600 bg-white/90 dark:bg-gray-700/40 px-3 py-1 shadow-sm shrink-0"
-            title={
-              schemaQualityScore != null
-                ? 'Overall schema quality (0–100): documentation, naming, structural load, and canvas layout. Updates live on the Canvas.'
-                : 'Open the Canvas view to compute a live schema quality score.'
-            }
-          >
-            <Gauge className="w-5 h-5 text-indigo-500 shrink-0" aria-hidden />
-            <div className="flex flex-col min-w-0">
-              <span className="text-[10px] uppercase tracking-wide text-gray-500 dark:text-gray-400 leading-none">
-                Schema quality
-              </span>
-              <span
-                className={cn(
-                  'text-2xl font-bold tabular-nums leading-none',
-                  schemaQualityScore != null
-                    ? getNumericScoreTier(schemaQualityScore).textClass
-                    : 'text-gray-400 dark:text-gray-500'
-                )}
+          <>
+            {schemaQualityScore != null ? (
+              <button
+                type="button"
+                onClick={() => setSchemaQualityDialogOpen(true)}
+                className="flex items-center gap-2 rounded-xl border border-gray-200 dark:border-gray-600 bg-white/90 dark:bg-gray-700/40 px-3 py-1 shadow-sm shrink-0 text-left hover:bg-gray-50 dark:hover:bg-gray-600/50 hover:border-indigo-300 dark:hover:border-indigo-500/40 focus:outline-none focus:ring-2 focus:ring-indigo-400 focus:ring-offset-2 focus:ring-offset-white dark:focus:ring-offset-gray-900 transition-colors"
+                title="Overall schema quality (0–100). Click for weighted breakdown and letter grade."
+                aria-label="Schema quality details"
               >
-                {schemaQualityScore != null ? schemaQualityScore : '—'}
-              </span>
-            </div>
-          </div>
+                <Gauge className="w-5 h-5 text-indigo-500 shrink-0" aria-hidden />
+                <div className="flex flex-col min-w-0">
+                  <span className="text-[10px] uppercase tracking-wide text-gray-500 dark:text-gray-400 leading-none">
+                    Schema quality
+                  </span>
+                  <span className="flex items-baseline gap-1.5">
+                    <span
+                      className={cn(
+                        'text-2xl font-bold tabular-nums leading-none',
+                        getNumericScoreTier(schemaQualityScore).textClass
+                      )}
+                    >
+                      {schemaQualityScore}
+                    </span>
+                    {schemaQualityDetail && (
+                      <span
+                        className={cn(
+                          'text-lg font-bold tabular-nums leading-none',
+                          schemaQualityDetail.tier.textClass
+                        )}
+                        title={`Letter grade (${schemaQualityDetail.tier.rangeLabel})`}
+                      >
+                        {schemaQualityDetail.letterGrade}
+                      </span>
+                    )}
+                  </span>
+                </div>
+              </button>
+            ) : (
+              <div
+                className="flex items-center gap-2 rounded-xl border border-gray-200 dark:border-gray-600 bg-white/90 dark:bg-gray-700/40 px-3 py-1 shadow-sm shrink-0"
+                title="Open the Canvas view with classes on the canvas to compute a live schema quality score."
+              >
+                <Gauge className="w-5 h-5 text-indigo-500 shrink-0" aria-hidden />
+                <div className="flex flex-col min-w-0">
+                  <span className="text-[10px] uppercase tracking-wide text-gray-500 dark:text-gray-400 leading-none">
+                    Schema quality
+                  </span>
+                  <span className="text-2xl font-bold tabular-nums leading-none text-gray-400 dark:text-gray-500">
+                    —
+                  </span>
+                </div>
+              </div>
+            )}
+
+            <Dialog.Root open={schemaQualityDialogOpen} onOpenChange={setSchemaQualityDialogOpen}>
+              <Dialog.Portal>
+                <Dialog.Overlay className="fixed inset-0 bg-black/50 z-[10000]" />
+                <Dialog.Content
+                  aria-describedby={undefined}
+                  className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 bg-white dark:bg-gray-800 rounded-xl shadow-2xl z-[10001] w-full max-w-md max-h-[85vh] overflow-y-auto p-6 border border-gray-200 dark:border-gray-700"
+                >
+                  <div className="flex items-start justify-between gap-3 mb-4">
+                    <div>
+                      <Dialog.Title className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+                        Schema quality
+                      </Dialog.Title>
+                      <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+                        Weighted blend of documentation, naming, inverted structural complexity, and canvas layout. Updates live on the Canvas.
+                      </p>
+                    </div>
+                    <Dialog.Close asChild>
+                      <button
+                        type="button"
+                        className="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 text-gray-500"
+                        aria-label="Close"
+                      >
+                        <X className="w-5 h-5" />
+                      </button>
+                    </Dialog.Close>
+                  </div>
+
+                  {schemaQualityDetail ? (
+                    <>
+                      <div className="flex items-center justify-between gap-4 p-4 rounded-lg border border-gray-200 dark:border-gray-700 bg-gradient-to-br from-gray-50 to-gray-100 dark:from-gray-900/50 dark:to-gray-800/50 mb-4">
+                        <div className="flex items-center gap-3">
+                          <span
+                            className={cn('text-5xl font-bold tabular-nums', schemaQualityDetail.tier.textClass)}
+                            title={`${schemaQualityDetail.tier.shortLabel} (${schemaQualityDetail.tier.rangeLabel})`}
+                          >
+                            {schemaQualityDetail.letterGrade}
+                          </span>
+                          <div>
+                            <div className={cn('text-base font-semibold', schemaQualityDetail.tier.textClass)}>
+                              {schemaQualityDetail.tier.shortLabel} — {schemaQualityDetail.tier.detailLabel}
+                            </div>
+                            <div className="text-xs text-gray-500 dark:text-gray-400">
+                              Letter grade · {schemaQualityDetail.tier.rangeLabel}
+                            </div>
+                          </div>
+                        </div>
+                        <div className="text-right">
+                          <div className={cn('text-3xl font-bold tabular-nums', schemaQualityDetail.tier.textClass)}>
+                            {schemaQualityDetail.overall}
+                          </div>
+                          <div className="text-xs text-gray-500 dark:text-gray-400">/ 100</div>
+                        </div>
+                      </div>
+
+                      <p className="text-xs text-gray-500 dark:text-gray-400 mb-3">
+                        Default weights: documentation {OVERALL_SCHEMA_QUALITY_WEIGHTS.documentation}, naming {OVERALL_SCHEMA_QUALITY_WEIGHTS.naming}, structural load {OVERALL_SCHEMA_QUALITY_WEIGHTS.structuralLoad}
+                        {schemaQualityDetail.layoutIncluded
+                          ? `, canvas layout ${OVERALL_SCHEMA_QUALITY_WEIGHTS.layout}.`
+                          : ' (canvas layout is included when the graph is laid out on the Canvas).'}
+                      </p>
+
+                      <div className="text-xs font-semibold text-gray-700 dark:text-gray-200 mb-2">Contributions</div>
+                      <table className="w-full text-xs text-left border-collapse mb-4">
+                        <thead>
+                          <tr className="border-b border-gray-200 dark:border-gray-600 text-gray-500 dark:text-gray-400">
+                            <th className="py-1.5 pr-2 font-medium">Factor</th>
+                            <th className="py-1.5 pr-2 font-medium text-right tabular-nums">Value</th>
+                            <th className="py-1.5 pr-2 font-medium text-right">Weight</th>
+                            <th className="py-1.5 font-medium text-right tabular-nums">Pts</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {schemaQualityDetail.rows.map((row) => (
+                            <tr key={row.id} className="border-b border-gray-100 dark:border-gray-700/80">
+                              <td className="py-1.5 pr-2 text-gray-800 dark:text-gray-200">{row.label}</td>
+                              <td className="py-1.5 pr-2 text-right tabular-nums text-gray-700 dark:text-gray-300">{Math.round(row.value)}</td>
+                              <td className="py-1.5 pr-2 text-right tabular-nums text-gray-500 dark:text-gray-400">
+                                {(row.effectiveWeight * 100).toFixed(0)}%
+                              </td>
+                              <td className="py-1.5 text-right tabular-nums font-medium text-gray-800 dark:text-gray-100">
+                                {row.contribution.toFixed(1)}
+                              </td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                      <p className="text-xs text-gray-500 dark:text-gray-400 mb-4">
+                        Final score is the sum of contributions, rounded to a whole number 0–100 (same rule as the OpenAPI import quality score bands).
+                      </p>
+
+                      <div className="rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50/80 dark:bg-gray-900/40 px-3 py-2">
+                        <div className="text-[10px] font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400 mb-2">
+                          Score guide
+                        </div>
+                        <ul className="space-y-1.5 text-xs text-gray-700 dark:text-gray-300">
+                          {NUMERIC_SCORE_TIER_LEGEND.map((row) => (
+                            <li key={row.band} className="flex items-start gap-2">
+                              <span className={`mt-1.5 h-2 w-2 shrink-0 rounded-full ${row.barSolidClass}`} aria-hidden />
+                              <span>
+                                <span className="font-medium tabular-nums">{row.rangeLabel}:</span> {row.shortLabel} — {row.detailLabel}
+                              </span>
+                            </li>
+                          ))}
+                        </ul>
+                      </div>
+                    </>
+                  ) : (
+                    <p className="text-sm text-gray-600 dark:text-gray-400">
+                      Detailed breakdown is unavailable. Open the Canvas with at least one class and a computed layout to see documentation, naming, structural load, and layout weights.
+                    </p>
+                  )}
+                </Dialog.Content>
+              </Dialog.Portal>
+            </Dialog.Root>
+          </>
         )}
 
         {/* View Switcher and Settings - only show when project and version selected */}

--- a/objectified-ui/src/app/ade/studio/components/StudioHeader.tsx
+++ b/objectified-ui/src/app/ade/studio/components/StudioHeader.tsx
@@ -425,7 +425,6 @@ export default function StudioHeader({ onProjectTagsLoaded }: StudioHeaderProps)
               <Dialog.Portal>
                 <Dialog.Overlay className="fixed inset-0 bg-black/50 z-[10000]" />
                 <Dialog.Content
-                  aria-describedby={undefined}
                   className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 bg-white dark:bg-gray-800 rounded-xl shadow-2xl z-[10001] w-full max-w-md max-h-[85vh] overflow-y-auto p-6 border border-gray-200 dark:border-gray-700"
                 >
                   <div className="flex items-start justify-between gap-3 mb-4">
@@ -433,9 +432,9 @@ export default function StudioHeader({ onProjectTagsLoaded }: StudioHeaderProps)
                       <Dialog.Title className="text-lg font-semibold text-gray-900 dark:text-gray-100">
                         Schema quality
                       </Dialog.Title>
-                      <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+                      <Dialog.Description className="text-sm text-gray-500 dark:text-gray-400 mt-1">
                         Weighted blend of documentation, naming, inverted structural complexity, and canvas layout. Updates live on the Canvas.
-                      </p>
+                      </Dialog.Description>
                     </div>
                     <Dialog.Close asChild>
                       <button

--- a/objectified-ui/src/app/ade/studio/editor/page.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/page.tsx
@@ -188,7 +188,7 @@ import {
   ghostNodeClassName,
 } from '@/app/utils/canvas-ghost-mode';
 import { computeLayoutQuality } from '@/app/utils/layout-quality';
-import { computeOverallSchemaQualityScore } from '@/app/utils/overall-schema-quality';
+import { computeOverallSchemaQualityScore, computeOverallSchemaQualityDetail } from '@/app/utils/overall-schema-quality';
 import {
   buildCanvasLayoutJsonDocument,
   CANVAS_LAYOUT_JSON_FORMAT_VERSION,
@@ -348,6 +348,7 @@ const StudioContent = () => {
     setClearSearchHistoryFn,
     setCanvasPresentationMode,
     setSchemaQualityScore,
+    setSchemaQualityDetail,
   } = useStudio();
 
   // Toggle click-to-focus mode (defined after useStudio to access setContextClickToFocusEnabled)
@@ -876,19 +877,27 @@ const StudioContent = () => {
     return computeOverallSchemaQualityScore(schemaMetrics, layoutQuality);
   }, [schemaMetrics, layoutQuality]);
 
+  const overallSchemaQualityDetail = useMemo(() => {
+    if (!schemaMetrics || !layoutQuality) return null;
+    return computeOverallSchemaQualityDetail(schemaMetrics, layoutQuality);
+  }, [schemaMetrics, layoutQuality]);
+
   useEffect(() => {
     if (!contextProjectId || !contextVersionId) {
       setSchemaQualityScore(null);
+      setSchemaQualityDetail(null);
       return;
     }
     setSchemaQualityScore(overallSchemaQualityScore);
-  }, [contextProjectId, contextVersionId, overallSchemaQualityScore, setSchemaQualityScore]);
+    setSchemaQualityDetail(overallSchemaQualityDetail);
+  }, [contextProjectId, contextVersionId, overallSchemaQualityScore, overallSchemaQualityDetail, setSchemaQualityScore, setSchemaQualityDetail]);
 
   useEffect(() => {
     return () => {
       setSchemaQualityScore(null);
+      setSchemaQualityDetail(null);
     };
-  }, [setSchemaQualityScore]);
+  }, [setSchemaQualityScore, setSchemaQualityDetail]);
 
   // Canvas improvement suggestions (#474)
   const groupMemberIds = useMemo(() => {
@@ -10152,6 +10161,7 @@ const StudioContent = () => {
                 <SchemaMetricsPanel
                   metrics={schemaMetrics}
                   layoutQuality={layoutQuality}
+                  overallSchemaQualityDetail={overallSchemaQualityDetail}
                   suggestions={canvasSuggestions}
                   projectName={selectedProject?.name}
                   versionLabel={selectedVersion?.version_id}

--- a/objectified-ui/src/app/utils/overall-schema-quality.ts
+++ b/objectified-ui/src/app/utils/overall-schema-quality.ts
@@ -6,11 +6,117 @@
 
 import type { LayoutQualityResult } from '@/app/utils/layout-quality';
 import type { SchemaMetricsResult } from '@/app/utils/schema-metrics';
+import { getNumericScoreTier, letterGradeFromOverallPercent } from '@/app/utils/numeric-score-tier';
 
 const W_DOC = 0.3;
 const W_NAMING = 0.3;
 const W_SIMPLICITY = 0.25;
 const W_LAYOUT = 0.15;
+
+/** Human-readable weight labels for UI (must match {@link computeOverallSchemaQualityScore}). */
+export const OVERALL_SCHEMA_QUALITY_WEIGHTS = {
+  documentation: '30%',
+  naming: '30%',
+  structuralLoad: '25%',
+  layout: '15%',
+} as const;
+
+export interface OverallSchemaQualityBreakdownRow {
+  id: 'documentation' | 'naming' | 'structuralLoad' | 'layout';
+  label: string;
+  /** Raw 0–100 input to the weighted blend (structural load uses inverted complexity). */
+  value: number;
+  /** Effective weight as a fraction of 1 (after renormalization when layout is omitted). */
+  effectiveWeight: number;
+  /** contribution = effectiveWeight * value (before final rounding). */
+  contribution: number;
+}
+
+export interface OverallSchemaQualityDetail {
+  overall: number;
+  letterGrade: ReturnType<typeof letterGradeFromOverallPercent>;
+  tier: ReturnType<typeof getNumericScoreTier>;
+  layoutIncluded: boolean;
+  rows: OverallSchemaQualityBreakdownRow[];
+}
+
+/**
+ * Explains how the overall score is built from metrics; matches {@link computeOverallSchemaQualityScore}.
+ */
+export function computeOverallSchemaQualityDetail(
+  metrics: SchemaMetricsResult,
+  layoutQuality: LayoutQualityResult | null | undefined
+): OverallSchemaQualityDetail {
+  const doc = metrics.documentationCompletionPercentage;
+  const naming = metrics.namingCompliance.compliancePercentage;
+  const simplicity = 100 - metrics.complexityScore;
+  const overall = computeOverallSchemaQualityScore(metrics, layoutQuality);
+  const tier = getNumericScoreTier(overall);
+  const letterGrade = letterGradeFromOverallPercent(overall);
+
+  if (layoutQuality == null) {
+    const sumW = W_DOC + W_NAMING + W_SIMPLICITY;
+    const wDoc = W_DOC / sumW;
+    const wNam = W_NAMING / sumW;
+    const wSim = W_SIMPLICITY / sumW;
+    const rows: OverallSchemaQualityBreakdownRow[] = [
+      {
+        id: 'documentation',
+        label: 'Documentation coverage',
+        value: doc,
+        effectiveWeight: wDoc,
+        contribution: wDoc * doc,
+      },
+      {
+        id: 'naming',
+        label: 'Naming conventions',
+        value: naming,
+        effectiveWeight: wNam,
+        contribution: wNam * naming,
+      },
+      {
+        id: 'structuralLoad',
+        label: 'Structural load (100 − complexity)',
+        value: simplicity,
+        effectiveWeight: wSim,
+        contribution: wSim * simplicity,
+      },
+    ];
+    return { overall, letterGrade, tier, layoutIncluded: false, rows };
+  }
+
+  const rows: OverallSchemaQualityBreakdownRow[] = [
+    {
+      id: 'documentation',
+      label: 'Documentation coverage',
+      value: doc,
+      effectiveWeight: W_DOC,
+      contribution: W_DOC * doc,
+    },
+    {
+      id: 'naming',
+      label: 'Naming conventions',
+      value: naming,
+      effectiveWeight: W_NAMING,
+      contribution: W_NAMING * naming,
+    },
+    {
+      id: 'structuralLoad',
+      label: 'Structural load (100 − complexity)',
+      value: simplicity,
+      effectiveWeight: W_SIMPLICITY,
+      contribution: W_SIMPLICITY * simplicity,
+    },
+    {
+      id: 'layout',
+      label: 'Canvas layout quality',
+      value: layoutQuality.overallScore,
+      effectiveWeight: W_LAYOUT,
+      contribution: W_LAYOUT * layoutQuality.overallScore,
+    },
+  ];
+  return { overall, letterGrade, tier, layoutIncluded: true, rows };
+}
 
 /**
  * Weighted composite of schema metrics and optional layout quality.

--- a/objectified-ui/tests/unit/overall-schema-quality.test.ts
+++ b/objectified-ui/tests/unit/overall-schema-quality.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from '@jest/globals';
 import type { SchemaMetricsResult } from '@/app/utils/schema-metrics';
-import { computeOverallSchemaQualityScore } from '@/app/utils/overall-schema-quality';
+import { computeOverallSchemaQualityScore, computeOverallSchemaQualityDetail } from '@/app/utils/overall-schema-quality';
 
 function makeMinimalMetrics(overrides: Partial<SchemaMetricsResult> = {}): SchemaMetricsResult {
   return {
@@ -78,5 +78,44 @@ describe('computeOverallSchemaQualityScore (#245)', () => {
       },
     });
     expect(computeOverallSchemaQualityScore(m, null)).toBe(100);
+  });
+});
+
+describe('computeOverallSchemaQualityDetail (#2548)', () => {
+  it('matches overall score and includes letter grade', () => {
+    const m = makeMinimalMetrics();
+    const layout = {
+      overallScore: 80,
+      edgeCrossingCount: 0,
+      nodeSpacingUniformityScore: 80,
+      layoutSymmetryScore: 80,
+      visualBalanceScore: 80,
+    };
+    const overall = computeOverallSchemaQualityScore(m, layout);
+    const detail = computeOverallSchemaQualityDetail(m, layout);
+    expect(detail.overall).toBe(overall);
+    expect(detail.letterGrade).toMatch(/^[A-F]$/);
+    expect(detail.layoutIncluded).toBe(true);
+    expect(detail.rows).toHaveLength(4);
+    expect(detail.rows.map((r) => r.id)).toEqual(['documentation', 'naming', 'structuralLoad', 'layout']);
+  });
+
+  it('omits layout row when layout is null and still matches overall', () => {
+    const m = makeMinimalMetrics({
+      complexityScore: 0,
+      documentationCompletionPercentage: 100,
+      namingCompliance: {
+        classes: { pascal: 1, camel: 0, snake: 0, other: 0, total: 1 },
+        properties: { pascal: 0, camel: 0, snake: 0, other: 0, total: 0 },
+        compliancePercentage: 100,
+        classesNonPascal: [],
+        propertiesNonCamel: [],
+      },
+    });
+    const overall = computeOverallSchemaQualityScore(m, null);
+    const detail = computeOverallSchemaQualityDetail(m, null);
+    expect(detail.overall).toBe(overall);
+    expect(detail.layoutIncluded).toBe(false);
+    expect(detail.rows).toHaveLength(3);
   });
 });


### PR DESCRIPTION
`Dialog.Content` was suppressing Radix UI's automatic `aria-describedby` wiring via `aria-describedby={undefined}`, and the description was a plain `<p>` element invisible to the accessibility tree as a dialog description.

## Changes

- **`StudioHeader.tsx`**: Remove `aria-describedby={undefined}` override from `Dialog.Content`; replace `<p>` description with `<Dialog.Description>` so Radix auto-generates the `id` and wires `aria-describedby` on the dialog root