### PR TITLE
Fix #242 - Add industry domain pattern categories

### DIFF
--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.9.26",
+  "version": "0.9.27",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -24,6 +24,7 @@ We continue to improve the platform based on your feedback with improvements and
 
 ## Projects:
 - **Domain categories (#243):** Optional **domain category** per project (IoT, social, gaming, travel & hospitality, media & entertainment) — stored in project metadata, editable on create/edit, shown as a chip on the projects list
+- **Industry domain patterns (#242):** Seven additional categories — e-commerce, healthcare, finance, SaaS, education, real estate, and logistics — each with representative entity names in the label (e.g. Product, Cart, Order, Payment, Shipping)
 - **Quality score history (#246):** After a successful **Import specification** run, the OpenAPI **overall quality score** is saved in this browser per project; the projects table shows a **sparkline** and latest score, with a **trend chart** and history table in a detail dialog
 - Added ability to start a new project from a template
 

--- a/objectified-ui/src/app/utils/project-domain-categories.ts
+++ b/objectified-ui/src/app/utils/project-domain-categories.ts
@@ -1,5 +1,5 @@
 /**
- * Optional domain labels for projects (#243). Stored in project metadata as `domainCategory` (id string).
+ * Optional domain labels for projects (#243, #242). Stored in project metadata as `domainCategory` (id string).
  */
 
 export const PROJECT_DOMAIN_CATEGORY_NONE = 'none';
@@ -36,6 +36,41 @@ export const PROJECT_DOMAIN_CATEGORIES: readonly ProjectDomainCategory[] = [
     id: 'media',
     label: 'Media & entertainment',
     hint: 'Content catalogs, rights, playback, and editorial metadata.',
+  },
+  {
+    id: 'ecommerce',
+    label: 'E-commerce (Product, Cart, Order, Payment, Shipping)',
+    hint: 'Catalogs, carts, checkout, payments, and fulfillment models.',
+  },
+  {
+    id: 'healthcare',
+    label: 'Healthcare (Patient, Appointment, Medication, Insurance)',
+    hint: 'Clinical and administrative records, scheduling, prescriptions, and coverage.',
+  },
+  {
+    id: 'finance',
+    label: 'Finance (Account, Transaction, Investment, Loan)',
+    hint: 'Accounts, money movement, portfolios, and lending products.',
+  },
+  {
+    id: 'saas',
+    label: 'SaaS (Tenant, User, Subscription, Usage)',
+    hint: 'Multi-tenant identity, billing, metering, and subscription lifecycle.',
+  },
+  {
+    id: 'education',
+    label: 'Education (Course, Student, Assignment, Grade)',
+    hint: 'Curriculum, enrollment, coursework, and outcomes.',
+  },
+  {
+    id: 'realestate',
+    label: 'Real Estate (Property, Listing, Agent, Transaction)',
+    hint: 'Listings, brokerage, offers, and deal flow.',
+  },
+  {
+    id: 'logistics',
+    label: 'Logistics (Shipment, Route, Warehouse, Delivery)',
+    hint: 'Movements, routing, facilities, and last-mile delivery.',
   },
 ];
 

--- a/objectified-ui/tests/project-domain-categories.test.ts
+++ b/objectified-ui/tests/project-domain-categories.test.ts
@@ -22,6 +22,8 @@ describe('project-domain-categories', () => {
   test('getProjectDomainCategory resolves known ids', () => {
     expect(getProjectDomainCategory('iot')?.label).toBe('IoT device schemas');
     expect(getProjectDomainCategory('gaming')?.label).toContain('Gaming');
+    expect(getProjectDomainCategory('ecommerce')?.label).toContain('E-commerce');
+    expect(getProjectDomainCategory('logistics')?.label).toContain('Logistics');
   });
 
   test('getProjectDomainCategory returns undefined for unknown or empty', () => {


### PR DESCRIPTION
## What was done and why

Adds seven optional **project domain categories** aligned with common industry data-model patterns (#242): e-commerce, healthcare, finance, SaaS, education, real estate, and logistics. Each category uses the issue’s entity lists in the **label** (e.g. Product, Cart, Order, Payment, Shipping) and a short **hint** for the picker.

Implementation: extends `PROJECT_DOMAIN_CATEGORIES` in `objectified-ui/src/app/utils/project-domain-categories.ts` (same metadata field as #243). Patch version bump for `objectified-ui`; `public/WHATS_NEW.md` updated.

## How to test it

1. Open **Projects** → create or edit a project.
2. Open the **Domain category** dropdown — confirm the seven new options appear with full labels.
3. Select one, save, and confirm the chip on the projects list shows the label.

## Risk/notes

Low risk: additive metadata IDs (`ecommerce`, `healthcare`, etc.); existing projects unchanged.

Closes #242

Made with [Cursor](https://cursor.com)