### PR TITLE
Fix #147 - Studio GraphQL SDL from templates

### DIFF
--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.9.28",
+  "version": "0.9.29",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -5,6 +5,7 @@ We continue to improve the platform based on your feedback with improvements and
 ---
 
 ## UI:
+- **Studio Code / GraphQL (#147):** GraphQL SDL in the Code tab is generated from a **Handlebars template** (`templates/graphql/graphql-schema.hbs`) instead of inlined string building, aligned with OpenAPI and Arazzo; template loader init is synchronous so tooling can import it safely
 - **Schema quality details (#2548):** **Studio header** Schema quality is **clickable** — opens a dialog with **letter grade (A–F)**, weighted **factor table**, and the same **score band guide** as import quality. **Schema Metrics** shows the same **overall schema quality** block (numeric score + letter + guide) above the per-metric controls
 - **Studio schema quality (#245):** **Overall score (0–100)** in the Studio header — weighted blend of documentation, naming, structural load (inverted complexity), and canvas layout quality; updates live on the Canvas
 - **Import quality score (#247):** **Weighted breakdown by category** — Design Quality (30 pts), Documentation (20), API Best Practices (25), Security (15), Performance (10); overall total out of 100 points with per-category progress and issues

--- a/objectified-ui/src/app/ade/studio/code/page.tsx
+++ b/objectified-ui/src/app/ade/studio/code/page.tsx
@@ -297,7 +297,7 @@ export default function CodePage() {
         });
         setJsonSchemaSpec(jsonSchemaContent);
 
-        const graphqlContent = generateGraphQLSchema(classesWithProperties, {
+        const graphqlContent = await generateGraphQLSchema(classesWithProperties, {
           projectName: currentProject?.name || 'API',
           version: currentVersion?.version_id || '1.0.0',
           description: currentVersion?.description || ''

--- a/objectified-ui/src/app/utils/graphql.ts
+++ b/objectified-ui/src/app/utils/graphql.ts
@@ -1,7 +1,10 @@
 /**
  * GraphQL SDL Generator
- * Generates GraphQL Schema Definition Language from class definitions
+ * Generates GraphQL Schema Definition Language from class definitions.
+ * Output is rendered from Handlebars templates (see templates/graphql/).
  */
+
+import { renderTemplate } from './template-loader';
 
 interface ClassWithProperties {
   id: string;
@@ -50,114 +53,56 @@ function mapTypeToGraphQL(property: any): string {
   }
 }
 
+function buildGraphQLTemplateData(classes: ClassWithProperties[], options: GraphQLOptions) {
+  const projectName = options.projectName || 'Project';
+  const generatedAt = new Date().toISOString();
+
+  const mappedClasses = classes.map((cls) => {
+    const properties = Array.isArray(cls.properties) ? cls.properties : [];
+    const mappedProps = properties.map((prop: any) => {
+      const isRequired = prop.required || false;
+      const graphQLType = mapTypeToGraphQL(prop);
+      return {
+        name: prop.name,
+        description: prop.description || null,
+        graphQLType,
+        nullable: isRequired ? '!' : '',
+      };
+    });
+
+    const className = cls.name;
+    const camelName = className.charAt(0).toLowerCase() + className.slice(1);
+
+    return {
+      name: className,
+      description: cls.description || null,
+      camelName,
+      properties: mappedProps,
+      createInputProperties: mappedProps,
+      updateInputProperties: mappedProps.map((p) => ({
+        name: p.name,
+        graphQLType: p.graphQLType,
+      })),
+    };
+  });
+
+  return {
+    projectName,
+    version: options.version || null,
+    apiDescription: options.description || null,
+    generatedAt,
+    classes: mappedClasses,
+    hasClasses: mappedClasses.length > 0,
+  };
+}
+
 /**
  * Generate GraphQL SDL from classes
  */
-export function generateGraphQLSchema(
+export async function generateGraphQLSchema(
   classes: ClassWithProperties[],
   options: GraphQLOptions = {}
-): string {
-  let sdl = '# GraphQL Schema Definition Language (SDL)\n';
-  sdl += `# Generated from ${options.projectName || 'Project'}\n`;
-  if (options.version) {
-    sdl += `# Version: ${options.version}\n`;
-  }
-  if (options.description) {
-    sdl += `# ${options.description}\n`;
-  }
-  sdl += `# Generated at ${new Date().toISOString()}\n\n`;
-
-  // Process each class
-  for (const cls of classes) {
-    const className = cls.name;
-    const description = cls.description;
-    const properties = Array.isArray(cls.properties) ? cls.properties : [];
-
-    // Add description as comment if available
-    if (description) {
-      sdl += `"""\n${description}\n"""\n`;
-    }
-
-    sdl += `type ${className} {\n`;
-
-    // Add ID field by default
-    sdl += `  id: ID!\n`;
-
-    // Process properties
-    for (const prop of properties) {
-      const propName = prop.name;
-      const propDescription = prop.description;
-      const isRequired = prop.required || false;
-      const graphQLType = mapTypeToGraphQL(prop);
-      const nullable = isRequired ? '!' : '';
-
-      // Add property description as comment
-      if (propDescription) {
-        sdl += `  """\n  ${propDescription}\n  """\n`;
-      }
-
-      sdl += `  ${propName}: ${graphQLType}${nullable}\n`;
-    }
-
-    sdl += `}\n\n`;
-  }
-
-  // Add Query type
-  if (classes.length > 0) {
-    sdl += `type Query {\n`;
-    for (const cls of classes) {
-      const className = cls.name;
-      const lowerClassName = className.charAt(0).toLowerCase() + className.slice(1);
-
-      sdl += `  ${lowerClassName}(id: ID!): ${className}\n`;
-      sdl += `  ${lowerClassName}s: [${className}!]!\n`;
-    }
-    sdl += `}\n\n`;
-
-    // Add Mutation type
-    sdl += `type Mutation {\n`;
-    for (const cls of classes) {
-      const className = cls.name;
-      const lowerClassName = className.charAt(0).toLowerCase() + className.slice(1);
-
-      sdl += `  create${className}(input: Create${className}Input!): ${className}!\n`;
-      sdl += `  update${className}(id: ID!, input: Update${className}Input!): ${className}!\n`;
-      sdl += `  delete${className}(id: ID!): Boolean!\n`;
-    }
-    sdl += `}\n\n`;
-
-    // Add Input types for mutations
-    for (const cls of classes) {
-      const className = cls.name;
-      const properties = Array.isArray(cls.properties) ? cls.properties : [];
-
-      // Create Input
-      sdl += `input Create${className}Input {\n`;
-      for (const prop of properties) {
-        const propName = prop.name;
-        const isRequired = prop.required || false;
-        const graphQLType = mapTypeToGraphQL(prop);
-        const nullable = isRequired ? '!' : '';
-        sdl += `  ${propName}: ${graphQLType}${nullable}\n`;
-      }
-      sdl += `}\n\n`;
-
-      // Update Input (all fields optional)
-      sdl += `input Update${className}Input {\n`;
-      for (const prop of properties) {
-        const propName = prop.name;
-        const graphQLType = mapTypeToGraphQL(prop);
-        sdl += `  ${propName}: ${graphQLType}\n`;
-      }
-      sdl += `}\n\n`;
-    }
-  }
-
-  // Add scalar definitions for common types
-  sdl += `# Custom scalar types\n`;
-  sdl += `scalar DateTime\n`;
-  sdl += `scalar JSON\n`;
-
-  return sdl;
+): Promise<string> {
+  const templateData = buildGraphQLTemplateData(classes, options);
+  return renderTemplate('graphql/graphql-schema.hbs', templateData);
 }
-

--- a/objectified-ui/src/app/utils/template-loader.ts
+++ b/objectified-ui/src/app/utils/template-loader.ts
@@ -18,7 +18,7 @@ const templateCache = new Map<string, HandlebarsTemplateDelegate>();
 /**
  * Register custom Handlebars helpers
  */
-async function registerHelpers() {
+function registerHelpers(): void {
   // Helper to convert objects to JSON strings
   Handlebars.registerHelper('json', function(context) {
     return JSON.stringify(context, null, 2);
@@ -40,8 +40,7 @@ async function registerHelpers() {
   });
 }
 
-// Register helpers on module load
-await registerHelpers();
+registerHelpers();
 
 /**
  * Load and compile a Handlebars template

--- a/objectified-ui/src/app/utils/templates/graphql/graphql-schema.hbs
+++ b/objectified-ui/src/app/utils/templates/graphql/graphql-schema.hbs
@@ -1,0 +1,63 @@
+# GraphQL Schema Definition Language (SDL)
+# Generated from {{projectName}}
+{{#if version}}
+# Version: {{version}}
+{{/if}}
+{{#if apiDescription}}
+# {{apiDescription}}
+{{/if}}
+# Generated at {{generatedAt}}
+
+{{#each classes}}
+{{#if description}}
+"""
+{{{description}}}
+"""
+{{/if}}
+type {{name}} {
+  id: ID!
+{{#each properties}}
+{{#if description}}
+  """
+  {{{description}}}
+  """
+{{/if}}
+  {{name}}: {{graphQLType}}{{nullable}}
+{{/each}}
+}
+
+{{/each}}
+{{#if hasClasses}}
+type Query {
+{{#each classes}}
+  {{camelName}}(id: ID!): {{name}}
+  {{camelName}}s: [{{name}}!]!
+{{/each}}
+}
+
+type Mutation {
+{{#each classes}}
+  create{{name}}(input: Create{{name}}Input!): {{name}}!
+  update{{name}}(id: ID!, input: Update{{name}}Input!): {{name}}!
+  delete{{name}}(id: ID!): Boolean!
+{{/each}}
+}
+
+{{#each classes}}
+input Create{{name}}Input {
+{{#each createInputProperties}}
+  {{name}}: {{graphQLType}}{{nullable}}
+{{/each}}
+}
+
+input Update{{name}}Input {
+{{#each updateInputProperties}}
+  {{name}}: {{graphQLType}}
+{{/each}}
+}
+
+{{/each}}
+{{/if}}
+# Custom scalar types
+scalar DateTime
+scalar JSON

--- a/objectified-ui/tests/utils/graphql.test.ts
+++ b/objectified-ui/tests/utils/graphql.test.ts
@@ -2,7 +2,7 @@ import { generateGraphQLSchema } from '../../src/app/utils/graphql';
 
 describe('generateGraphQLSchema', () => {
   describe('Basic Type Generation', () => {
-    it('should generate a simple GraphQL type from a class', () => {
+    it('should generate a simple GraphQL type from a class', async () => {
       const classes = [
         {
           id: '1',
@@ -15,7 +15,7 @@ describe('generateGraphQLSchema', () => {
         },
       ];
 
-      const schema = generateGraphQLSchema(classes);
+      const schema = await generateGraphQLSchema(classes);
 
       expect(schema).toContain('type User {');
       expect(schema).toContain('id: ID!');
@@ -26,7 +26,7 @@ describe('generateGraphQLSchema', () => {
       expect(schema).toContain('The user name');
     });
 
-    it('should generate multiple types', () => {
+    it('should generate multiple types', async () => {
       const classes = [
         {
           id: '1',
@@ -40,13 +40,13 @@ describe('generateGraphQLSchema', () => {
         },
       ];
 
-      const schema = generateGraphQLSchema(classes);
+      const schema = await generateGraphQLSchema(classes);
 
       expect(schema).toContain('type User {');
       expect(schema).toContain('type Product {');
     });
 
-    it('should include project metadata in comments', () => {
+    it('should include project metadata in comments', async () => {
       const classes = [
         {
           id: '1',
@@ -55,7 +55,7 @@ describe('generateGraphQLSchema', () => {
         },
       ];
 
-      const schema = generateGraphQLSchema(classes, {
+      const schema = await generateGraphQLSchema(classes, {
         projectName: 'My API',
         version: '1.0.0',
         description: 'A test API',
@@ -68,7 +68,7 @@ describe('generateGraphQLSchema', () => {
   });
 
   describe('Type Mapping', () => {
-    it('should map string types correctly', () => {
+    it('should map string types correctly', async () => {
       const classes = [
         {
           id: '1',
@@ -82,7 +82,7 @@ describe('generateGraphQLSchema', () => {
         },
       ];
 
-      const schema = generateGraphQLSchema(classes);
+      const schema = await generateGraphQLSchema(classes);
 
       expect(schema).toContain('text: String!');
       expect(schema).toContain('email: String');
@@ -90,7 +90,7 @@ describe('generateGraphQLSchema', () => {
       expect(schema).toContain('date: String');
     });
 
-    it('should map numeric types correctly', () => {
+    it('should map numeric types correctly', async () => {
       const classes = [
         {
           id: '1',
@@ -103,14 +103,14 @@ describe('generateGraphQLSchema', () => {
         },
       ];
 
-      const schema = generateGraphQLSchema(classes);
+      const schema = await generateGraphQLSchema(classes);
 
       expect(schema).toContain('count: Int!');
       expect(schema).toContain('price: Float');
       expect(schema).toContain('quantity: Int');
     });
 
-    it('should map boolean types correctly', () => {
+    it('should map boolean types correctly', async () => {
       const classes = [
         {
           id: '1',
@@ -122,13 +122,13 @@ describe('generateGraphQLSchema', () => {
         },
       ];
 
-      const schema = generateGraphQLSchema(classes);
+      const schema = await generateGraphQLSchema(classes);
 
       expect(schema).toContain('active: Boolean!');
       expect(schema).toContain('verified: Boolean');
     });
 
-    it('should map array types correctly', () => {
+    it('should map array types correctly', async () => {
       const classes = [
         {
           id: '1',
@@ -140,13 +140,13 @@ describe('generateGraphQLSchema', () => {
         },
       ];
 
-      const schema = generateGraphQLSchema(classes);
+      const schema = await generateGraphQLSchema(classes);
 
       expect(schema).toContain('tags: [String!]!');
       expect(schema).toContain('counts: [Integer!]');
     });
 
-    it('should handle object types with JSON scalar', () => {
+    it('should handle object types with JSON scalar', async () => {
       const classes = [
         {
           id: '1',
@@ -157,12 +157,12 @@ describe('generateGraphQLSchema', () => {
         },
       ];
 
-      const schema = generateGraphQLSchema(classes);
+      const schema = await generateGraphQLSchema(classes);
 
       expect(schema).toContain('metadata: JSON');
     });
 
-    it('should handle unknown types as String', () => {
+    it('should handle unknown types as String', async () => {
       const classes = [
         {
           id: '1',
@@ -173,14 +173,14 @@ describe('generateGraphQLSchema', () => {
         },
       ];
 
-      const schema = generateGraphQLSchema(classes);
+      const schema = await generateGraphQLSchema(classes);
 
       expect(schema).toContain('unknown: String');
     });
   });
 
   describe('Query Type Generation', () => {
-    it('should generate Query type with single and list queries', () => {
+    it('should generate Query type with single and list queries', async () => {
       const classes = [
         {
           id: '1',
@@ -189,14 +189,14 @@ describe('generateGraphQLSchema', () => {
         },
       ];
 
-      const schema = generateGraphQLSchema(classes);
+      const schema = await generateGraphQLSchema(classes);
 
       expect(schema).toContain('type Query {');
       expect(schema).toContain('user(id: ID!): User');
       expect(schema).toContain('users: [User!]!');
     });
 
-    it('should generate queries for multiple types', () => {
+    it('should generate queries for multiple types', async () => {
       const classes = [
         {
           id: '1',
@@ -210,7 +210,7 @@ describe('generateGraphQLSchema', () => {
         },
       ];
 
-      const schema = generateGraphQLSchema(classes);
+      const schema = await generateGraphQLSchema(classes);
 
       expect(schema).toContain('user(id: ID!): User');
       expect(schema).toContain('users: [User!]!');
@@ -218,7 +218,7 @@ describe('generateGraphQLSchema', () => {
       expect(schema).toContain('products: [Product!]!');
     });
 
-    it('should handle PascalCase class names correctly', () => {
+    it('should handle PascalCase class names correctly', async () => {
       const classes = [
         {
           id: '1',
@@ -227,7 +227,7 @@ describe('generateGraphQLSchema', () => {
         },
       ];
 
-      const schema = generateGraphQLSchema(classes);
+      const schema = await generateGraphQLSchema(classes);
 
       expect(schema).toContain('userProfile(id: ID!): UserProfile');
       expect(schema).toContain('userProfiles: [UserProfile!]!');
@@ -235,7 +235,7 @@ describe('generateGraphQLSchema', () => {
   });
 
   describe('Mutation Type Generation', () => {
-    it('should generate Mutation type with CRUD operations', () => {
+    it('should generate Mutation type with CRUD operations', async () => {
       const classes = [
         {
           id: '1',
@@ -244,7 +244,7 @@ describe('generateGraphQLSchema', () => {
         },
       ];
 
-      const schema = generateGraphQLSchema(classes);
+      const schema = await generateGraphQLSchema(classes);
 
       expect(schema).toContain('type Mutation {');
       expect(schema).toContain('createUser(input: CreateUserInput!): User!');
@@ -252,7 +252,7 @@ describe('generateGraphQLSchema', () => {
       expect(schema).toContain('deleteUser(id: ID!): Boolean!');
     });
 
-    it('should generate mutations for multiple types', () => {
+    it('should generate mutations for multiple types', async () => {
       const classes = [
         {
           id: '1',
@@ -266,7 +266,7 @@ describe('generateGraphQLSchema', () => {
         },
       ];
 
-      const schema = generateGraphQLSchema(classes);
+      const schema = await generateGraphQLSchema(classes);
 
       expect(schema).toContain('createUser(input: CreateUserInput!): User!');
       expect(schema).toContain('createProduct(input: CreateProductInput!): Product!');
@@ -274,7 +274,7 @@ describe('generateGraphQLSchema', () => {
   });
 
   describe('Input Type Generation', () => {
-    it('should generate CreateInput types with required fields', () => {
+    it('should generate CreateInput types with required fields', async () => {
       const classes = [
         {
           id: '1',
@@ -286,14 +286,14 @@ describe('generateGraphQLSchema', () => {
         },
       ];
 
-      const schema = generateGraphQLSchema(classes);
+      const schema = await generateGraphQLSchema(classes);
 
       expect(schema).toContain('input CreateUserInput {');
       expect(schema).toContain('name: String!');
       expect(schema).toContain('email: String');
     });
 
-    it('should generate UpdateInput types with all fields optional', () => {
+    it('should generate UpdateInput types with all fields optional', async () => {
       const classes = [
         {
           id: '1',
@@ -305,14 +305,14 @@ describe('generateGraphQLSchema', () => {
         },
       ];
 
-      const schema = generateGraphQLSchema(classes);
+      const schema = await generateGraphQLSchema(classes);
 
       expect(schema).toContain('input UpdateUserInput {');
       expect(schema).toContain('name: String');
       expect(schema).toContain('email: String');
     });
 
-    it('should generate input types for all types', () => {
+    it('should generate input types for all types', async () => {
       const classes = [
         {
           id: '1',
@@ -326,7 +326,7 @@ describe('generateGraphQLSchema', () => {
         },
       ];
 
-      const schema = generateGraphQLSchema(classes);
+      const schema = await generateGraphQLSchema(classes);
 
       expect(schema).toContain('input CreateUserInput {');
       expect(schema).toContain('input UpdateUserInput {');
@@ -336,7 +336,7 @@ describe('generateGraphQLSchema', () => {
   });
 
   describe('Custom Scalars', () => {
-    it('should include DateTime and JSON scalar definitions', () => {
+    it('should include DateTime and JSON scalar definitions', async () => {
       const classes = [
         {
           id: '1',
@@ -345,7 +345,7 @@ describe('generateGraphQLSchema', () => {
         },
       ];
 
-      const schema = generateGraphQLSchema(classes);
+      const schema = await generateGraphQLSchema(classes);
 
       expect(schema).toContain('# Custom scalar types');
       expect(schema).toContain('scalar DateTime');
@@ -354,7 +354,7 @@ describe('generateGraphQLSchema', () => {
   });
 
   describe('Property Descriptions', () => {
-    it('should include property descriptions as comments', () => {
+    it('should include property descriptions as comments', async () => {
       const classes = [
         {
           id: '1',
@@ -366,13 +366,13 @@ describe('generateGraphQLSchema', () => {
         },
       ];
 
-      const schema = generateGraphQLSchema(classes);
+      const schema = await generateGraphQLSchema(classes);
 
       expect(schema).toContain('The full name of the user');
       expect(schema).toContain('User email address');
     });
 
-    it('should include class descriptions as comments', () => {
+    it('should include class descriptions as comments', async () => {
       const classes = [
         {
           id: '1',
@@ -382,15 +382,15 @@ describe('generateGraphQLSchema', () => {
         },
       ];
 
-      const schema = generateGraphQLSchema(classes);
+      const schema = await generateGraphQLSchema(classes);
 
       expect(schema).toContain('Represents a user account in the system');
     });
   });
 
   describe('Edge Cases', () => {
-    it('should handle empty class list', () => {
-      const schema = generateGraphQLSchema([]);
+    it('should handle empty class list', async () => {
+      const schema = await generateGraphQLSchema([]);
 
       expect(schema).toContain('# GraphQL Schema Definition Language (SDL)');
       expect(schema).toContain('scalar DateTime');
@@ -399,7 +399,7 @@ describe('generateGraphQLSchema', () => {
       expect(schema).not.toContain('type Mutation');
     });
 
-    it('should handle class with no properties', () => {
+    it('should handle class with no properties', async () => {
       const classes = [
         {
           id: '1',
@@ -408,14 +408,14 @@ describe('generateGraphQLSchema', () => {
         },
       ];
 
-      const schema = generateGraphQLSchema(classes);
+      const schema = await generateGraphQLSchema(classes);
 
       expect(schema).toContain('type User {');
       expect(schema).toContain('id: ID!');
       expect(schema).toContain('}');
     });
 
-    it('should handle properties with missing required field', () => {
+    it('should handle properties with missing required field', async () => {
       const classes = [
         {
           id: '1',
@@ -426,12 +426,12 @@ describe('generateGraphQLSchema', () => {
         },
       ];
 
-      const schema = generateGraphQLSchema(classes);
+      const schema = await generateGraphQLSchema(classes);
 
       expect(schema).toContain('name: String'); // defaults to optional
     });
 
-    it('should handle properties with undefined type', () => {
+    it('should handle properties with undefined type', async () => {
       const classes = [
         {
           id: '1',
@@ -442,12 +442,12 @@ describe('generateGraphQLSchema', () => {
         },
       ];
 
-      const schema = generateGraphQLSchema(classes);
+      const schema = await generateGraphQLSchema(classes);
 
       expect(schema).toContain('data: String'); // defaults to String
     });
 
-    it('should handle non-array properties field gracefully', () => {
+    it('should handle non-array properties field gracefully', async () => {
       const classes = [
         {
           id: '1',
@@ -456,7 +456,7 @@ describe('generateGraphQLSchema', () => {
         },
       ];
 
-      const schema = generateGraphQLSchema(classes);
+      const schema = await generateGraphQLSchema(classes);
 
       expect(schema).toContain('type User {');
       expect(schema).toContain('id: ID!');
@@ -464,7 +464,7 @@ describe('generateGraphQLSchema', () => {
   });
 
   describe('Complex Schema', () => {
-    it('should generate a complete schema with multiple related types', () => {
+    it('should generate a complete schema with multiple related types', async () => {
       const classes = [
         {
           id: '1',
@@ -498,7 +498,7 @@ describe('generateGraphQLSchema', () => {
         },
       ];
 
-      const schema = generateGraphQLSchema(classes, {
+      const schema = await generateGraphQLSchema(classes, {
         projectName: 'Blog API',
         version: '2.0.0',
         description: 'A comprehensive blog platform',
@@ -534,7 +534,7 @@ describe('generateGraphQLSchema', () => {
   });
 
   describe('OpenAPI to GraphQL Conversion', () => {
-    it('should convert OpenAPI schema properties to GraphQL types', () => {
+    it('should convert OpenAPI schema properties to GraphQL types', async () => {
       const classes = [
         {
           id: '1',
@@ -553,7 +553,7 @@ describe('generateGraphQLSchema', () => {
         },
       ];
 
-      const schema = generateGraphQLSchema(classes);
+      const schema = await generateGraphQLSchema(classes);
 
       expect(schema).toContain('id: ID!');
       expect(schema).toContain('name: String!');
@@ -565,7 +565,7 @@ describe('generateGraphQLSchema', () => {
       expect(schema).toContain('createdAt: String!');
     });
 
-    it('should handle OpenAPI 3.1.0 nullable fields', () => {
+    it('should handle OpenAPI 3.1.0 nullable fields', async () => {
       const classes = [
         {
           id: '1',
@@ -577,7 +577,7 @@ describe('generateGraphQLSchema', () => {
         },
       ];
 
-      const schema = generateGraphQLSchema(classes);
+      const schema = await generateGraphQLSchema(classes);
 
       expect(schema).toContain('name: String');
       expect(schema).toContain('email: String!');


### PR DESCRIPTION
## What
Studio **GraphQL SDL** generation (Code tab) now uses the same **Handlebars** approach as OpenAPI and Arazzo: output is rendered from `src/app/utils/templates/graphql/graphql-schema.hbs` with a typed view model built in `graphql.ts` (type mapping stays in TypeScript).

`template-loader` no longer uses **top-level await** for registering helpers (helpers are synchronous). That avoids Jest parse errors when tests import modules that pull in the loader, and keeps initialization explicit.

## How to test
1. `yarn build` and `yarn test` from repo root (already run).
2. In Studio **Code** tab, choose **GraphQL** and confirm SDL still matches prior shape (header comments, types, Query/Mutation, inputs, scalars).

## Risk / notes
- `generateGraphQLSchema` is now **async**; the Code page awaits it (same pattern as OpenAPI/Arazzo).
- Template edits change output whitespace only if the `.hbs` file is edited; behavior is covered by `tests/utils/graphql.test.ts`.

Closes #147

Made with [Cursor](https://cursor.com)