### PR TITLE
Fix #1332 - Theme engine, CSS custom properties, and appearance settings

### DIFF
--- a/docs/FUTURE_FEATURE_ROADMAP_UI.md
+++ b/docs/FUTURE_FEATURE_ROADMAP_UI.md
@@ -31,7 +31,7 @@
 
 | #   | Title | Description | Labels | Parallel |
 |-----|-------|-------------|--------|----------|
-| 1.1 (#1332) | Theme Engine & CSS Custom Properties | Token-based theming with light/dark/system modes and custom palette support | `enhancement`, `mvp`, `ui`, `ai-generated` | Yes |
+| ~~1.1 (#1332)~~ **Done** | Theme Engine & CSS Custom Properties | Token-based theming with light/dark/system modes and custom palette support | `enhancement`, `mvp`, `ui`, `ai-generated` | Yes |
 | 1.2 (#1338) | Customizable Toolbar & Panel Layout | Drag-and-drop toolbar ordering, sidebar toggling, and panel resizing | `enhancement`, `mvp`, `ui`, `ai-generated` | Yes |
 | 1.3 (#1343) | Keyboard Shortcut Manager | User-configurable keyboard shortcuts with conflict detection and reset | `enhancement`, `mvp`, `ui`, `ai-generated`, `rest` | Yes |
 | 1.4 (#1347) | Workspace Layout Persistence | Save, restore, and switch between named workspace layouts | `enhancement`, `mvp`, `ui`, `ai-generated`, `rest` | No |

--- a/objectified-db/scripts/20260408-133200.sql
+++ b/objectified-db/scripts/20260408-133200.sql
@@ -1,0 +1,16 @@
+-- User theme preferences (issue #1332): persisted appearance and custom palette overrides.
+SET search_path TO odb, public;
+
+CREATE TABLE IF NOT EXISTS user_theme_preferences (
+    user_id UUID PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+    theme_name VARCHAR(32) NOT NULL DEFAULT 'system',
+    overrides JSONB NOT NULL DEFAULT '{}'::jsonb,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_theme_preferences_updated_at
+    ON user_theme_preferences (updated_at DESC);
+
+COMMENT ON TABLE user_theme_preferences IS 'Per-user theme mode (light/dark/system) and optional --obj-* color overrides.';
+COMMENT ON COLUMN user_theme_preferences.theme_name IS 'One of: light, dark, system.';
+COMMENT ON COLUMN user_theme_preferences.overrides IS 'JSON object with optional keys: primary, secondary, accent, background, surface, text (CSS color strings).';

--- a/objectified-ui/lib/db/theme-preferences.ts
+++ b/objectified-ui/lib/db/theme-preferences.ts
@@ -1,0 +1,59 @@
+'use server';
+
+import type { ThemeModeName, ThemePaletteOverrides } from '@lib/theme/types';
+
+// db.ts is CommonJS (`module.exports`); keep require to match the rest of lib/db helpers.
+// eslint-disable-next-line @typescript-eslint/no-require-imports -- CommonJS pool (see lib/db/db.ts)
+const connectionPool = require('./db');
+
+export type UserThemeRow = {
+  theme_name: ThemeModeName;
+  overrides: ThemePaletteOverrides;
+};
+
+function normalizeOverrides(raw: unknown): ThemePaletteOverrides {
+  if (!raw || typeof raw !== 'object') return {};
+  const o = raw as Record<string, unknown>;
+  const pick = (k: keyof ThemePaletteOverrides) =>
+    typeof o[k] === 'string' ? (o[k] as string) : undefined;
+  return {
+    primary: pick('primary'),
+    secondary: pick('secondary'),
+    accent: pick('accent'),
+    background: pick('background'),
+    surface: pick('surface'),
+    text: pick('text'),
+  };
+}
+
+export async function getUserThemePreferences(userId: string): Promise<UserThemeRow | null> {
+  const res = await connectionPool.query(
+    `SELECT theme_name, overrides FROM odb.user_theme_preferences WHERE user_id = $1`,
+    [userId]
+  );
+  if (res.rows.length === 0) return null;
+  const row = res.rows[0];
+  const name = row.theme_name as string;
+  const theme_name: ThemeModeName =
+    name === 'light' || name === 'dark' || name === 'system' ? name : 'system';
+  return {
+    theme_name,
+    overrides: normalizeOverrides(row.overrides),
+  };
+}
+
+export async function upsertUserThemePreferences(
+  userId: string,
+  themeName: ThemeModeName,
+  overrides: ThemePaletteOverrides
+): Promise<void> {
+  await connectionPool.query(
+    `INSERT INTO odb.user_theme_preferences (user_id, theme_name, overrides, updated_at)
+     VALUES ($1, $2, $3::jsonb, CURRENT_TIMESTAMP)
+     ON CONFLICT (user_id) DO UPDATE SET
+       theme_name = EXCLUDED.theme_name,
+       overrides = EXCLUDED.overrides,
+       updated_at = CURRENT_TIMESTAMP`,
+    [userId, themeName, JSON.stringify(overrides)]
+  );
+}

--- a/objectified-ui/lib/theme/apply-obj-tokens.ts
+++ b/objectified-ui/lib/theme/apply-obj-tokens.ts
@@ -1,0 +1,69 @@
+import type { Theme } from '@/app/config/themes';
+import type { ThemePaletteOverrides } from '@lib/theme/types';
+
+/**
+ * Applies design tokens under `--obj-*` for colors, spacing, radius, typography, and shadow.
+ * Color slots may be overridden by the user's custom palette; structural tokens are static.
+ */
+export function applyObjTokens(
+  target: HTMLElement,
+  theme: Theme,
+  overrides: ThemePaletteOverrides
+): void {
+  const c = theme.colors;
+
+  const primary = overrides.primary ?? c.primary;
+  const secondary = overrides.secondary ?? c.secondary;
+  const accent = overrides.accent ?? c.accent;
+  const background = overrides.background ?? c.background;
+  const surface = overrides.surface ?? c.card;
+  const text = overrides.text ?? c.foreground;
+
+  target.style.setProperty('--obj-color-primary', primary);
+  target.style.setProperty('--obj-color-primary-fg', c.primaryForeground);
+  target.style.setProperty('--obj-color-secondary', secondary);
+  target.style.setProperty('--obj-color-secondary-fg', c.secondaryForeground);
+  target.style.setProperty('--obj-color-accent', accent);
+  target.style.setProperty('--obj-color-accent-fg', c.accentForeground);
+  target.style.setProperty('--obj-color-background', background);
+  target.style.setProperty('--obj-color-surface', surface);
+  target.style.setProperty('--obj-color-text', text);
+  target.style.setProperty('--obj-color-muted', c.muted);
+  target.style.setProperty('--obj-color-muted-fg', c.mutedForeground);
+  target.style.setProperty('--obj-color-border', c.border);
+  target.style.setProperty('--obj-color-destructive', c.destructive);
+  target.style.setProperty('--obj-color-destructive-fg', c.destructiveForeground);
+  target.style.setProperty('--obj-color-card', c.card);
+  target.style.setProperty('--obj-color-card-fg', c.cardForeground);
+  target.style.setProperty('--obj-color-popover', c.popover);
+  target.style.setProperty('--obj-color-popover-fg', c.popoverForeground);
+
+  /* Structural tokens (issue: spacing, radius, typography, shadow) */
+  target.style.setProperty('--obj-space-1', '0.25rem');
+  target.style.setProperty('--obj-space-2', '0.5rem');
+  target.style.setProperty('--obj-space-3', '0.75rem');
+  target.style.setProperty('--obj-space-4', '1rem');
+  target.style.setProperty('--obj-space-5', '1.25rem');
+  target.style.setProperty('--obj-space-6', '1.5rem');
+  target.style.setProperty('--obj-space-8', '2rem');
+
+  target.style.setProperty('--obj-radius-sm', '0.25rem');
+  target.style.setProperty('--obj-radius-md', '0.5rem');
+  target.style.setProperty('--obj-radius-lg', '0.75rem');
+  target.style.setProperty('--obj-radius-xl', '1rem');
+
+  target.style.setProperty('--obj-font-size-xs', '0.75rem');
+  target.style.setProperty('--obj-font-size-sm', '0.875rem');
+  target.style.setProperty('--obj-font-size-base', '1rem');
+  target.style.setProperty('--obj-font-size-lg', '1.125rem');
+  target.style.setProperty('--obj-font-size-xl', '1.25rem');
+  target.style.setProperty('--obj-font-size-2xl', '1.5rem');
+
+  target.style.setProperty('--obj-line-tight', '1.25');
+  target.style.setProperty('--obj-line-normal', '1.45');
+  target.style.setProperty('--obj-line-relaxed', '1.6');
+
+  target.style.setProperty('--obj-shadow-sm', '0 1px 2px rgb(15 23 42 / 0.06)');
+  target.style.setProperty('--obj-shadow-md', '0 4px 6px -1px rgb(15 23 42 / 0.08)');
+  target.style.setProperty('--obj-shadow-lg', '0 10px 15px -3px rgb(15 23 42 / 0.08)');
+}

--- a/objectified-ui/lib/theme/color-validation.ts
+++ b/objectified-ui/lib/theme/color-validation.ts
@@ -1,0 +1,16 @@
+/**
+ * Returns a browser-normalized CSS color string if the input is accepted, else null.
+ */
+export function tryParseCssColor(input: string): string | null {
+  const s = input.trim();
+  if (!s) return null;
+  if (typeof document === 'undefined') {
+    if (/^#([0-9a-f]{3}|[0-9a-f]{6})$/i.test(s)) return s;
+    return s;
+  }
+  const el = document.createElement('div');
+  el.style.color = '';
+  el.style.color = s;
+  const out = el.style.color;
+  return out || null;
+}

--- a/objectified-ui/lib/theme/types.ts
+++ b/objectified-ui/lib/theme/types.ts
@@ -1,0 +1,25 @@
+export type ThemeModeName = 'light' | 'dark' | 'system';
+
+/** Optional overrides for the six primary palette tokens from the issue spec. */
+export interface ThemePaletteOverrides {
+  primary?: string;
+  secondary?: string;
+  accent?: string;
+  background?: string;
+  surface?: string;
+  text?: string;
+}
+
+export interface ThemePreferencePayload {
+  theme: ThemeModeName;
+  overrides?: ThemePaletteOverrides;
+}
+
+export const THEME_CHANGED_EVENT = 'theme-changed';
+
+export type ThemeChangedDetail = {
+  theme: ThemeModeName;
+  /** Effective light/dark when mode is system */
+  resolved: 'light' | 'dark';
+  overrides: ThemePaletteOverrides;
+};

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.9.30",
+  "version": "0.9.31",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -5,6 +5,7 @@ We continue to improve the platform based on your feedback with improvements and
 ---
 
 ## UI:
+- **Theme engine (#1332):** **`--obj-*` design tokens** (colors, spacing, radius, typography, shadows) applied from the root `ThemeProvider`; **Light / Dark / System** (follows OS) with instant updates, **`theme-changed`** custom events, and **Appearance** settings at **`/settings/appearance`** with hex/HSL/RGB popover pickers; preferences persist via **`PUT /api/v1/preferences/theme`** and load with the session
 - **Studio Code / GraphQL (#147):** GraphQL SDL in the Code tab is generated from a **Handlebars template** (`templates/graphql/graphql-schema.hbs`) instead of inlined string building, aligned with OpenAPI and Arazzo; template loader init is synchronous so tooling can import it safely
 - **Schema quality details (#2548):** **Studio header** Schema quality is **clickable** — opens a dialog with **letter grade (A–F)**, weighted **factor table**, and the same **score band guide** as import quality. **Schema Metrics** shows the same **overall schema quality** block (numeric score + letter + guide) above the per-metric controls
 - **Studio schema quality (#245):** **Overall score (0–100)** in the Studio header — weighted blend of documentation, naming, structural load (inverted complexity), and canvas layout quality; updates live on the Canvas

--- a/objectified-ui/src/app/(platform)/layout.tsx
+++ b/objectified-ui/src/app/(platform)/layout.tsx
@@ -1,0 +1,5 @@
+import AuthenticatedLayout from '@/app/components/auth/AuthenticatedLayout';
+
+export default function PlatformLayout({ children }: { children: React.ReactNode }) {
+  return <AuthenticatedLayout>{children}</AuthenticatedLayout>;
+}

--- a/objectified-ui/src/app/(platform)/settings/appearance/AppearanceSettingsClient.tsx
+++ b/objectified-ui/src/app/(platform)/settings/appearance/AppearanceSettingsClient.tsx
@@ -1,0 +1,298 @@
+'use client';
+
+import * as React from 'react';
+import * as Popover from '@radix-ui/react-popover';
+import { useTheme } from '@/app/providers/ThemeProvider';
+import type { ThemePaletteOverrides } from '@lib/theme/types';
+import { RadioGroup, RadioGroupItem } from '@/app/components/ui/RadioGroup';
+import { Button } from '@/app/components/ui/Button';
+import { Input } from '@/app/components/ui/Input';
+import { Label } from '@/app/components/ui/Label';
+import { tryParseCssColor } from '@lib/theme/color-validation';
+
+const PALETTE_KEYS: { key: keyof ThemePaletteOverrides; label: string }[] = [
+  { key: 'primary', label: 'Primary' },
+  { key: 'secondary', label: 'Secondary' },
+  { key: 'accent', label: 'Accent' },
+  { key: 'background', label: 'Background' },
+  { key: 'surface', label: 'Surface' },
+  { key: 'text', label: 'Text' },
+];
+
+type FormatTab = 'hex' | 'hsl' | 'rgb';
+
+function rgbToHex(r: number, g: number, b: number): string {
+  const h = (n: number) => n.toString(16).padStart(2, '0');
+  return `#${h(r)}${h(g)}${h(b)}`;
+}
+
+function parseRgbFromComputed(computed: string): { r: number; g: number; b: number } | null {
+  const m = computed.match(/^rgba?\(([^)]+)\)/);
+  if (!m) return null;
+  const parts = m[1].split(',').map((p) => parseFloat(p.trim()));
+  if (parts.length < 3) return null;
+  return { r: parts[0], g: parts[1], b: parts[2] };
+}
+
+function ColorTokenPopover({
+  label,
+  value,
+  fallbackColor,
+  onChange,
+}: {
+  label: string;
+  value: string | undefined;
+  fallbackColor: string;
+  onChange: (v: string | undefined) => void;
+}) {
+  const [open, setOpen] = React.useState(false);
+  const [tab, setTab] = React.useState<FormatTab>('hex');
+  const [hex, setHex] = React.useState('#000000');
+  const [hsl, setHsl] = React.useState('0, 0%, 50%');
+  const [rgb, setRgb] = React.useState('128, 128, 128');
+  const [err, setErr] = React.useState('');
+
+  const syncFromColor = (color: string) => {
+    const ok = tryParseCssColor(color);
+    if (!ok) return;
+    if (typeof document !== 'undefined') {
+      const el = document.createElement('div');
+      el.style.color = ok;
+      document.body.appendChild(el);
+      const computed = getComputedStyle(el).color;
+      document.body.removeChild(el);
+      const rgbObj = parseRgbFromComputed(computed);
+      if (rgbObj) {
+        setRgb(`${rgbObj.r}, ${rgbObj.g}, ${rgbObj.b}`);
+        setHex(rgbToHex(Math.round(rgbObj.r), Math.round(rgbObj.g), Math.round(rgbObj.b)));
+      }
+    }
+  };
+
+  React.useEffect(() => {
+    if (open) {
+      const base = value || '#6366f1';
+      setHex(base.startsWith('#') ? base : '#6366f1');
+      syncFromColor(base);
+      setErr('');
+    }
+  }, [open, value]);
+
+  const apply = () => {
+    let raw = '';
+    if (tab === 'hex') raw = hex;
+    else if (tab === 'hsl') raw = `hsl(${hsl})`;
+    else raw = `rgb(${rgb})`;
+    const parsed = tryParseCssColor(raw);
+    if (!parsed) {
+      setErr('Invalid color');
+      return;
+    }
+    onChange(parsed);
+    setErr('');
+    setOpen(false);
+  };
+
+  const clear = () => {
+    onChange(undefined);
+    setOpen(false);
+  };
+
+  return (
+    <div className="flex flex-col gap-1">
+      <Label className="text-xs font-medium text-slate-600 dark:text-slate-400">{label}</Label>
+      <Popover.Root open={open} onOpenChange={setOpen}>
+        <Popover.Trigger asChild>
+          <button
+            type="button"
+            className="flex h-9 w-full max-w-xs items-center gap-2 rounded-md border border-slate-300 bg-white px-2 text-left text-sm dark:border-slate-600 dark:bg-slate-900"
+          >
+            <span
+              className="h-6 w-6 shrink-0 rounded border border-slate-200 dark:border-slate-600"
+              style={{ backgroundColor: value ?? fallbackColor }}
+            />
+            <span className="truncate text-slate-700 dark:text-slate-200">{value || 'Default'}</span>
+          </button>
+        </Popover.Trigger>
+        <Popover.Portal>
+          <Popover.Content
+            className="z-[3000] w-72 rounded-md border border-slate-200 bg-white p-3 shadow-lg dark:border-slate-600 dark:bg-slate-900"
+            sideOffset={4}
+          >
+            <div className="mb-2 flex gap-1">
+              {(['hex', 'hsl', 'rgb'] as const).map((t) => (
+                <button
+                  key={t}
+                  type="button"
+                  onClick={() => setTab(t)}
+                  className={
+                    tab === t
+                      ? 'rounded bg-indigo-100 px-2 py-1 text-xs font-medium text-indigo-800 dark:bg-indigo-900/50 dark:text-indigo-200'
+                      : 'rounded px-2 py-1 text-xs text-slate-600 hover:bg-slate-100 dark:text-slate-400 dark:hover:bg-slate-800'
+                  }
+                >
+                  {t.toUpperCase()}
+                </button>
+              ))}
+            </div>
+            {tab === 'hex' && (
+              <div className="space-y-2">
+                <input
+                  type="color"
+                  value={hex.startsWith('#') ? hex.slice(0, 7) : '#000000'}
+                  onChange={(e) => {
+                    setHex(e.target.value);
+                    syncFromColor(e.target.value);
+                  }}
+                  className="h-10 w-full cursor-pointer"
+                  aria-label="Pick color"
+                />
+                <Input value={hex} onChange={(e) => setHex(e.target.value)} placeholder="#RRGGBB" />
+              </div>
+            )}
+            {tab === 'hsl' && (
+              <Input
+                value={hsl}
+                onChange={(e) => setHsl(e.target.value)}
+                placeholder="e.g. 250 80% 60%"
+              />
+            )}
+            {tab === 'rgb' && (
+              <Input value={rgb} onChange={(e) => setRgb(e.target.value)} placeholder="e.g. 99, 102, 241" />
+            )}
+            {err && <p className="text-xs text-red-600">{err}</p>}
+            <div className="mt-3 flex justify-end gap-2">
+              <Button type="button" variant="outline" size="sm" onClick={clear}>
+                Clear
+              </Button>
+              <Button type="button" size="sm" onClick={apply}>
+                Apply
+              </Button>
+            </div>
+            <Popover.Arrow className="fill-white dark:fill-slate-900" />
+          </Popover.Content>
+        </Popover.Portal>
+      </Popover.Root>
+    </div>
+  );
+}
+
+export function AppearanceSettingsClient() {
+  const {
+    currentTheme,
+    setTheme,
+    paletteOverrides,
+    setPaletteOverrides,
+    resetPaletteToThemeDefaults,
+    persistThemePreference,
+  } = useTheme();
+
+  const [mode, setMode] = React.useState<'light' | 'dark' | 'system'>('system');
+
+  React.useEffect(() => {
+    const id = currentTheme.id;
+    if (id === 'light' || id === 'dark' || id === 'system') {
+      setMode(id);
+    }
+  }, [currentTheme.id]);
+
+  const [saving, setSaving] = React.useState(false);
+  const [message, setMessage] = React.useState('');
+
+  const onModeChange = (v: string) => {
+    if (v !== 'light' && v !== 'dark' && v !== 'system') return;
+    setMode(v);
+    setTheme(v);
+  };
+
+  const onSave = async () => {
+    setSaving(true);
+    setMessage('');
+    try {
+      await persistThemePreference();
+      setMessage('Saved.');
+    } catch (e) {
+      setMessage(e instanceof Error ? e.message : 'Save failed');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="mt-6 space-y-8">
+      <section aria-labelledby="theme-mode-heading">
+        <h2 id="theme-mode-heading" className="text-lg font-medium text-slate-900 dark:text-slate-100">
+          Theme mode
+        </h2>
+        <p className="mt-1 text-sm text-slate-600 dark:text-slate-400">
+          Light, Dark, or System (follows your OS). Changes apply immediately without reloading.
+        </p>
+        <RadioGroup value={mode} onValueChange={onModeChange} className="mt-4 grid gap-3 sm:grid-cols-3">
+          <div className="flex flex-col gap-2 rounded-lg border border-slate-200 p-3 dark:border-slate-700">
+            <RadioGroupItem value="light" label="Light" />
+            <div className="h-14 rounded-md border border-slate-200 bg-white shadow-sm dark:border-slate-600" />
+          </div>
+          <div className="flex flex-col gap-2 rounded-lg border border-slate-200 p-3 dark:border-slate-700">
+            <RadioGroupItem value="dark" label="Dark" />
+            <div className="h-14 rounded-md border border-slate-600 bg-slate-900 shadow-sm" />
+          </div>
+          <div className="flex flex-col gap-2 rounded-lg border border-slate-200 p-3 dark:border-slate-700">
+            <RadioGroupItem value="system" label="System" />
+            <div className="flex h-14 overflow-hidden rounded-md border border-slate-300 dark:border-slate-600">
+              <div className="w-1/2 bg-white" />
+              <div className="w-1/2 bg-slate-900" />
+            </div>
+          </div>
+        </RadioGroup>
+      </section>
+
+      <section aria-labelledby="custom-palette-heading">
+        <h2 id="custom-palette-heading" className="text-lg font-medium text-slate-900 dark:text-slate-100">
+          Custom palette
+        </h2>
+        <p className="mt-1 text-sm text-slate-600 dark:text-slate-400">
+          Optional overrides for key colors. Use hex, HSL, or RGB in the popover.
+        </p>
+        <div className="mt-4 grid gap-4 sm:grid-cols-2">
+          {PALETTE_KEYS.map(({ key, label }) => (
+            <ColorTokenPopover
+              key={key}
+              label={label}
+              fallbackColor={
+                key === 'primary'
+                  ? currentTheme.colors.primary
+                  : key === 'secondary'
+                    ? currentTheme.colors.secondary
+                    : key === 'accent'
+                      ? currentTheme.colors.accent
+                      : key === 'background'
+                        ? currentTheme.colors.background
+                        : key === 'surface'
+                          ? currentTheme.colors.card
+                          : currentTheme.colors.foreground
+              }
+              value={paletteOverrides[key]}
+              onChange={(v) =>
+                setPaletteOverrides((prev) => {
+                  const next = { ...prev };
+                  if (v === undefined) delete next[key];
+                  else next[key] = v;
+                  return next;
+                })
+              }
+            />
+          ))}
+        </div>
+        <div className="mt-4 flex flex-wrap gap-2">
+          <Button type="button" variant="outline" onClick={resetPaletteToThemeDefaults}>
+            Reset to theme defaults
+          </Button>
+          <Button type="button" onClick={onSave} disabled={saving}>
+            {saving ? 'Saving…' : 'Save preferences'}
+          </Button>
+          {message && <span className="text-sm text-slate-600 dark:text-slate-400">{message}</span>}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/objectified-ui/src/app/(platform)/settings/appearance/page.tsx
+++ b/objectified-ui/src/app/(platform)/settings/appearance/page.tsx
@@ -1,0 +1,17 @@
+import { AppearanceSettingsClient } from './AppearanceSettingsClient';
+
+export const metadata = {
+  title: 'Appearance · Objectified',
+};
+
+export default function AppearanceSettingsPage() {
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-8">
+      <h1 className="text-2xl font-semibold tracking-tight text-slate-900 dark:text-slate-100">Appearance</h1>
+      <p className="mt-2 text-sm text-slate-600 dark:text-slate-400">
+        Choose a built-in theme, tune colors, and save your preferences for this account.
+      </p>
+      <AppearanceSettingsClient />
+    </div>
+  );
+}

--- a/objectified-ui/src/app/ade/dashboard/profile/page.tsx
+++ b/objectified-ui/src/app/ade/dashboard/profile/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useSession } from 'next-auth/react';
+import Link from 'next/link';
 import { User, Mail, Hash, Clock, Building2, Edit2, Key, Shield, LogIn } from 'lucide-react';
 import { useState, useEffect } from 'react';
 import {
@@ -192,6 +193,12 @@ const Profile = () => {
               <p className="text-gray-600 dark:text-gray-400 text-sm mt-1">
                 Manage your account and security settings
               </p>
+              <Link
+                href="/settings/appearance"
+                className="mt-2 inline-block text-sm font-medium text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300"
+              >
+                Appearance settings →
+              </Link>
             </div>
           </div>
         </div>

--- a/objectified-ui/src/app/ade/layout.tsx
+++ b/objectified-ui/src/app/ade/layout.tsx
@@ -4,7 +4,6 @@ import "@radix-ui/themes/styles.css";
 import SessionWrapper from "@/app/components/auth/SessionWrapper";
 import AuthenticatedLayout from "@/app/components/auth/AuthenticatedLayout";
 import ConditionalHeader from '@/app/components/ade/ConditionalHeader';
-import { ThemeProvider } from '@/app/providers/ThemeProvider';
 import { ThemeProvider as NextThemesProvider } from "next-themes";
 import { Theme as RadixTheme } from "@radix-ui/themes";
 import * as React from 'react';
@@ -34,14 +33,12 @@ export default function RootLayout({
           radius="medium"
           scaling="100%"
         >
-          <ThemeProvider>
             <SessionWrapper>
               <AuthenticatedLayout>
                 <ConditionalHeader />
                 {children}
               </AuthenticatedLayout>
             </SessionWrapper>
-          </ThemeProvider>
         </RadixTheme>
       </NextThemesProvider>
     </div>

--- a/objectified-ui/src/app/api/auth/[...nextauth]/route.ts
+++ b/objectified-ui/src/app/api/auth/[...nextauth]/route.ts
@@ -13,6 +13,7 @@ import {
   checkLinkingIntent,
   ICredentials,
 } from '../../../../../lib/auth/credentials';
+import { getUserThemePreferences } from '../../../../../lib/db/theme-preferences';
 
 export const authOptions: NextAuthOptions = {
   providers: [
@@ -126,6 +127,18 @@ export const authOptions: NextAuthOptions = {
         payload.session.user.name = payload.token.name;
       }
 
+      if (payload.token?.theme_name) {
+        payload.session.user.theme_name = payload.token.theme_name as 'light' | 'dark' | 'system';
+      }
+
+      if (payload.token?.theme_overrides) {
+        try {
+          payload.session.user.theme_overrides = JSON.parse(payload.token.theme_overrides as string);
+        } catch {
+          payload.session.user.theme_overrides = {};
+        }
+      }
+
       return payload.session;
     },
     async jwt(payload: any) {
@@ -141,6 +154,14 @@ export const authOptions: NextAuthOptions = {
         if (payload.session?.current_tenant_id) {
           token.current_tenant_id = payload.session.current_tenant_id;
         }
+
+        if (payload.session?.user?.theme_name !== undefined) {
+          token.theme_name = payload.session.user.theme_name;
+        }
+
+        if (payload.session?.user?.theme_overrides !== undefined) {
+          token.theme_overrides = JSON.stringify(payload.session.user.theme_overrides ?? {});
+        }
       }
 
       if (payload.user) {
@@ -148,6 +169,15 @@ export const authOptions: NextAuthOptions = {
         const pendingTenant = (payload.user as { pending_tenant_id?: string }).pending_tenant_id;
         if (pendingTenant) {
           token.current_tenant_id = pendingTenant;
+        }
+
+        try {
+          const prefs = await getUserThemePreferences(payload.user.id as string);
+          token.theme_name = prefs?.theme_name ?? 'system';
+          token.theme_overrides = JSON.stringify(prefs?.overrides ?? {});
+        } catch {
+          token.theme_name = 'system';
+          token.theme_overrides = '{}';
         }
       }
 

--- a/objectified-ui/src/app/api/v1/preferences/theme/route.ts
+++ b/objectified-ui/src/app/api/v1/preferences/theme/route.ts
@@ -1,0 +1,79 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/app/api/auth/[...nextauth]/route';
+import { upsertUserThemePreferences } from '@lib/db/theme-preferences';
+import type { ThemeModeName, ThemePaletteOverrides } from '@lib/theme/types';
+
+const OVERRIDE_KEYS: (keyof ThemePaletteOverrides)[] = [
+  'primary',
+  'secondary',
+  'accent',
+  'background',
+  'surface',
+  'text',
+];
+
+function parseBody(data: unknown): { theme: ThemeModeName; overrides: ThemePaletteOverrides } | null {
+  if (!data || typeof data !== 'object') return null;
+  const o = data as Record<string, unknown>;
+  const rawTheme = o.theme;
+  const theme: ThemeModeName =
+    rawTheme === 'light' || rawTheme === 'dark' || rawTheme === 'system' ? rawTheme : 'system';
+  const overrides: ThemePaletteOverrides = {};
+  const rawOverrides = o.overrides;
+  if (rawOverrides && typeof rawOverrides === 'object') {
+    const ov = rawOverrides as Record<string, unknown>;
+    for (const k of OVERRIDE_KEYS) {
+      const v = ov[k];
+      if (typeof v === 'string' && v.trim().length > 0) {
+        overrides[k] = v.trim().slice(0, 128);
+      }
+    }
+  }
+  return { theme, overrides };
+}
+
+/**
+ * Persists theme mode and optional palette overrides for the signed-in user.
+ */
+export async function PUT(req: NextRequest) {
+  const session = await getServerSession(authOptions);
+  const userId = (session?.user as { user_id?: string } | undefined)?.user_id;
+  if (!userId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  let json: unknown;
+  try {
+    json = await req.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  const parsed = parseBody(json);
+  if (!parsed) {
+    return NextResponse.json({ error: 'Invalid body' }, { status: 400 });
+  }
+
+  try {
+    await upsertUserThemePreferences(userId, parsed.theme, parsed.overrides);
+  } catch (e) {
+    console.error('[preferences/theme] upsert failed', e);
+    return NextResponse.json({ error: 'Failed to save preferences' }, { status: 500 });
+  }
+
+  const res = NextResponse.json({
+    success: true,
+    theme: parsed.theme,
+    overrides: parsed.overrides,
+  });
+
+  const hint = JSON.stringify({ theme: parsed.theme, overrides: parsed.overrides });
+  res.cookies.set('obj-theme-hint', encodeURIComponent(hint), {
+    path: '/',
+    maxAge: 60 * 60 * 24 * 365,
+    sameSite: 'lax',
+  });
+
+  return res;
+}

--- a/objectified-ui/src/app/globals.css
+++ b/objectified-ui/src/app/globals.css
@@ -17,6 +17,49 @@
   --radius-md: 0.5rem;
   --shadow-subtle: 0 1px 2px rgb(15 23 42 / 0.06);
   --control-height: 2.5rem;
+
+  /* Design tokens (--obj-*): overridden live by ThemeProvider for theme + custom palette */
+  --obj-color-primary: #6366f1;
+  --obj-color-primary-fg: #ffffff;
+  --obj-color-secondary: #f1f5f9;
+  --obj-color-secondary-fg: #0f172a;
+  --obj-color-accent: #f1f5f9;
+  --obj-color-accent-fg: #0f172a;
+  --obj-color-background: #ffffff;
+  --obj-color-surface: #ffffff;
+  --obj-color-text: #171717;
+  --obj-color-muted: #f8fafc;
+  --obj-color-muted-fg: #64748b;
+  --obj-color-border: #e2e8f0;
+  --obj-color-destructive: #ef4444;
+  --obj-color-destructive-fg: #ffffff;
+  --obj-color-card: #ffffff;
+  --obj-color-card-fg: #171717;
+  --obj-color-popover: #ffffff;
+  --obj-color-popover-fg: #171717;
+  --obj-space-1: 0.25rem;
+  --obj-space-2: 0.5rem;
+  --obj-space-3: 0.75rem;
+  --obj-space-4: 1rem;
+  --obj-space-5: 1.25rem;
+  --obj-space-6: 1.5rem;
+  --obj-space-8: 2rem;
+  --obj-radius-sm: 0.25rem;
+  --obj-radius-md: 0.5rem;
+  --obj-radius-lg: 0.75rem;
+  --obj-radius-xl: 1rem;
+  --obj-font-size-xs: 0.75rem;
+  --obj-font-size-sm: 0.875rem;
+  --obj-font-size-base: 1rem;
+  --obj-font-size-lg: 1.125rem;
+  --obj-font-size-xl: 1.25rem;
+  --obj-font-size-2xl: 1.5rem;
+  --obj-line-tight: 1.25;
+  --obj-line-normal: 1.45;
+  --obj-line-relaxed: 1.6;
+  --obj-shadow-sm: 0 1px 2px rgb(15 23 42 / 0.06);
+  --obj-shadow-md: 0 4px 6px -1px rgb(15 23 42 / 0.08);
+  --obj-shadow-lg: 0 10px 15px -3px rgb(15 23 42 / 0.08);
 }
 
 /* ===== THEME SYSTEM ===== */

--- a/objectified-ui/src/app/layout.tsx
+++ b/objectified-ui/src/app/layout.tsx
@@ -3,6 +3,7 @@ import "./globals.css";
 import "@radix-ui/themes/styles.css";
 import SessionWrapper from "@/app/components/auth/SessionWrapper";
 import ThemeRegistry from "@/app/components/theme/ThemeRegistry";
+import { ThemeProvider } from "@/app/providers/ThemeProvider";
 import { DialogProvider } from "@/app/components/providers/DialogProvider";
 import { Toaster } from "@/app/components/ui/Toaster";
 import { ThemeProvider as NextThemesProvider } from "next-themes";
@@ -36,10 +37,12 @@ export default function RootLayout({
           >
             <ThemeRegistry>
               <SessionWrapper>
-                <DialogProvider>
-                  {children}
-                  <Toaster />
-                </DialogProvider>
+                <ThemeProvider>
+                  <DialogProvider>
+                    {children}
+                    <Toaster />
+                  </DialogProvider>
+                </ThemeProvider>
               </SessionWrapper>
             </ThemeRegistry>
           </RadixTheme>

--- a/objectified-ui/src/app/providers/ThemeProvider.tsx
+++ b/objectified-ui/src/app/providers/ThemeProvider.tsx
@@ -1,239 +1,205 @@
 'use client';
 
-import React, { createContext, useContext, useEffect, useState, useCallback, useRef } from 'react';
+import React, {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  useCallback,
+  useRef,
+} from 'react';
+import { useSession } from 'next-auth/react';
 import { useTheme as useNextTheme } from 'next-themes';
 import { Theme, themes, getThemeById, getDefaultTheme } from '../config/themes';
+import { applyObjTokens } from '@lib/theme/apply-obj-tokens';
+import type { ThemePaletteOverrides, ThemeModeName, ThemeChangedDetail } from '@lib/theme/types';
+import { THEME_CHANGED_EVENT } from '@lib/theme/types';
 
 interface ThemeContextType {
   currentTheme: Theme;
   setTheme: (themeId: string) => void;
   availableThemes: Theme[];
   isSystemTheme: boolean;
+  paletteOverrides: ThemePaletteOverrides;
+  setPaletteOverrides: React.Dispatch<React.SetStateAction<ThemePaletteOverrides>>;
+  resetPaletteToThemeDefaults: () => void;
+  persistThemePreference: () => Promise<void>;
 }
 
 const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+
+const darkThemeIds = ['dark', 'high-contrast', 'blueprint', 'solarized', 'nord', 'darcula'];
+
+function resolvedLightDark(effectiveTheme: Theme): 'light' | 'dark' {
+  return darkThemeIds.includes(effectiveTheme.id) ? 'dark' : 'light';
+}
+
+function preferenceModeFromThemeId(id: string): ThemeModeName {
+  if (id === 'light' || id === 'dark' || id === 'system') return id;
+  return 'system';
+}
+
+function emitThemeChanged(detail: ThemeChangedDetail) {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(new CustomEvent(THEME_CHANGED_EVENT, { detail }));
+}
 
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
   const [currentTheme, setCurrentTheme] = useState<Theme>(getDefaultTheme());
   const [isSystemTheme, setIsSystemTheme] = useState(false);
   const [mounted, setMounted] = useState(false);
-  const mountedRef = useRef(false);
+  const sessionAppliedRef = useRef(false);
+  const [paletteOverrides, setPaletteOverrides] = useState<ThemePaletteOverrides>({});
   const { setTheme: setNextTheme, resolvedTheme, theme: nextTheme } = useNextTheme();
+  const { data: session, update: updateSession } = useSession();
 
-  // Mark as mounted after hydration
   useEffect(() => {
     setMounted(true);
   }, []);
 
-  // Get the effective theme for system preference.
-  // Prefer matchMedia on the client so we always use the actual OS preference (e.g. when
-  // switching from Dark to System while OS is light, resolvedTheme can still be 'dark').
   const getSystemPreferredTheme = useCallback(() => {
     if (typeof window !== 'undefined') {
       const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-      return prefersDark ? getThemeById('dark') || getDefaultTheme() : getThemeById('light') || getDefaultTheme();
+      return prefersDark
+        ? getThemeById('dark') || getDefaultTheme()
+        : getThemeById('light') || getDefaultTheme();
     }
-    // SSR/fallback: use resolvedTheme from next-themes when available
     const prefersDark = resolvedTheme === 'dark';
-    return prefersDark ? getThemeById('dark') || getDefaultTheme() : getThemeById('light') || getDefaultTheme();
+    return prefersDark
+      ? getThemeById('dark') || getDefaultTheme()
+      : getThemeById('light') || getDefaultTheme();
   }, [resolvedTheme]);
 
-  // Apply theme to DOM
-  const applyTheme = useCallback((theme: Theme, isSystem: boolean = false) => {
-    const html = document.documentElement;
-    const body = document.body;
+  const applyDomTheme = useCallback(
+    (theme: Theme, isSystem: boolean, overrides: ThemePaletteOverrides) => {
+      const html = document.documentElement;
+      const body = document.body;
 
-    // Remove all theme classes from html and body
-    themes.forEach(t => {
-      html.classList.remove(t.cssClass);
-      body.classList.remove(t.cssClass);
-    });
+      themes.forEach((t) => {
+        html.classList.remove(t.cssClass);
+        body.classList.remove(t.cssClass);
+      });
 
-    // For system theme, we apply the actual light/dark theme but mark it as system
-    const effectiveTheme = isSystem ? getSystemPreferredTheme() : theme;
+      const effectiveTheme = isSystem ? getSystemPreferredTheme() : theme;
 
-    // Set data-theme attribute for CSS targeting
-    html.setAttribute('data-theme', effectiveTheme.id);
-    body.setAttribute('data-theme', effectiveTheme.id);
+      html.setAttribute('data-theme', effectiveTheme.id);
+      body.setAttribute('data-theme', effectiveTheme.id);
 
-    // Determine if this is a "dark" based theme (needs .dark class for Tailwind dark: variants)
-    const darkThemes = ['dark', 'high-contrast', 'blueprint', 'solarized', 'nord', 'darcula'];
-    const isDarkBased = darkThemes.includes(effectiveTheme.id);
+      const isDarkBased = darkThemeIds.includes(effectiveTheme.id);
 
-    // Use next-themes: when following system, set 'system' so it tracks OS and updates .dark;
-    // when using a fixed theme, set 'light' or 'dark' so .dark is correct.
-    if (isSystem) {
-      setNextTheme('system');
-    } else if (isDarkBased) {
-      setNextTheme('dark');
-    } else {
-      setNextTheme('light');
-    }
+      if (isSystem) {
+        setNextTheme('system');
+      } else if (isDarkBased) {
+        setNextTheme('dark');
+      } else {
+        setNextTheme('light');
+      }
 
-    // Add new theme class to both html and body
-    html.classList.add(effectiveTheme.cssClass);
-    body.classList.add(effectiveTheme.cssClass);
+      html.classList.add(effectiveTheme.cssClass);
+      body.classList.add(effectiveTheme.cssClass);
 
-    // Set CSS custom properties directly on html style
-    html.style.setProperty('--background', effectiveTheme.colors.background);
-    html.style.setProperty('--foreground', effectiveTheme.colors.foreground);
+      html.style.setProperty('--background', effectiveTheme.colors.background);
+      html.style.setProperty('--foreground', effectiveTheme.colors.foreground);
+      applyObjTokens(html, effectiveTheme, overrides);
 
-    // Force body background and color
-    body.style.backgroundColor = effectiveTheme.colors.background;
-    body.style.color = effectiveTheme.colors.foreground;
-  }, [getSystemPreferredTheme, setNextTheme]);
+      body.style.backgroundColor = effectiveTheme.colors.background;
+      body.style.color = effectiveTheme.colors.foreground;
 
-  // Initialize theme from localStorage or system preference
+      const mode = preferenceModeFromThemeId(theme.id);
+      emitThemeChanged({
+        theme: mode,
+        resolved: resolvedLightDark(effectiveTheme),
+        overrides,
+      });
+    },
+    [getSystemPreferredTheme, setNextTheme]
+  );
+
   useEffect(() => {
     if (!mounted) return;
-    if (mountedRef.current) return;
 
-    mountedRef.current = true;
-    // Use same storage key as next-themes: 'theme'
+    const uid = (session?.user as { user_id?: string })?.user_id;
+    const serverTheme = (session?.user as { theme_name?: ThemeModeName })?.theme_name;
+    const serverOverrides = (session?.user as { theme_overrides?: ThemePaletteOverrides })
+      ?.theme_overrides;
+
+    if (uid && serverTheme && (serverTheme === 'light' || serverTheme === 'dark' || serverTheme === 'system')) {
+      sessionAppliedRef.current = true;
+      const theme = getThemeById(serverTheme);
+      if (theme) {
+        const o = serverOverrides && typeof serverOverrides === 'object' ? serverOverrides : {};
+        setPaletteOverrides(o);
+        setCurrentTheme(theme);
+        setIsSystemTheme(serverTheme === 'system');
+        localStorage.setItem('app-theme', serverTheme);
+        return;
+      }
+    }
+
     const savedThemeId = localStorage.getItem('app-theme');
     const nextThemeSaved = localStorage.getItem('theme');
 
-    // Check if next-themes is set to system or if no preference exists
     const shouldUseSystem = !nextThemeSaved || nextThemeSaved === 'system';
 
     if (savedThemeId === 'system' || shouldUseSystem) {
-      // User chose to follow system
       const systemTheme = getThemeById('system');
       if (systemTheme) {
         setCurrentTheme(systemTheme);
         setIsSystemTheme(true);
-        applyTheme(systemTheme, true);
       }
     } else if (savedThemeId) {
       const theme = getThemeById(savedThemeId);
       if (theme) {
         setCurrentTheme(theme);
         setIsSystemTheme(false);
-        applyTheme(theme, false);
       }
     } else {
-      // No saved preference - default to system
       const systemTheme = getThemeById('system') || getDefaultTheme();
       setCurrentTheme(systemTheme);
       setIsSystemTheme(true);
-      applyTheme(systemTheme, true);
       localStorage.setItem('app-theme', 'system');
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [mounted]);
 
-  // Listen for system preference changes via matchMedia
   useEffect(() => {
-    if (!mounted || !isSystemTheme) return;
+    if (!mounted) return;
+    const uid = (session?.user as { user_id?: string })?.user_id;
+    const serverTheme = (session?.user as { theme_name?: ThemeModeName })?.theme_name;
+    const serverOverrides = (session?.user as { theme_overrides?: ThemePaletteOverrides })
+      ?.theme_overrides;
 
-    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+    if (!uid || !serverTheme || sessionAppliedRef.current) return;
+    if (serverTheme !== 'light' && serverTheme !== 'dark' && serverTheme !== 'system') return;
 
-    const handleChange = (e: MediaQueryListEvent) => {
-      const effectiveTheme = e.matches
-        ? getThemeById('dark') || getDefaultTheme()
-        : getThemeById('light') || getDefaultTheme();
+    const theme = getThemeById(serverTheme);
+    if (!theme) return;
 
-      const html = document.documentElement;
-      const body = document.body;
+    sessionAppliedRef.current = true;
+    const o = serverOverrides && typeof serverOverrides === 'object' ? serverOverrides : {};
+    setPaletteOverrides(o);
+    setCurrentTheme(theme);
+    setIsSystemTheme(serverTheme === 'system');
+    localStorage.setItem('app-theme', serverTheme);
+  }, [mounted, session?.user]);
 
-      // Remove existing theme classes
-      themes.forEach(t => {
-        html.classList.remove(t.cssClass);
-        body.classList.remove(t.cssClass);
-      });
-
-      // Set data-theme attribute
-      html.setAttribute('data-theme', effectiveTheme.id);
-      body.setAttribute('data-theme', effectiveTheme.id);
-
-      // Set dark class based on system preference
-      if (e.matches) {
-        html.classList.add('dark');
-        setNextTheme('dark');
-      } else {
-        html.classList.remove('dark');
-        setNextTheme('light');
-      }
-
-      // Add theme class
-      html.classList.add(effectiveTheme.cssClass);
-      body.classList.add(effectiveTheme.cssClass);
-
-      // Set CSS custom properties
-      html.style.setProperty('--background', effectiveTheme.colors.background);
-      html.style.setProperty('--foreground', effectiveTheme.colors.foreground);
-      body.style.backgroundColor = effectiveTheme.colors.background;
-      body.style.color = effectiveTheme.colors.foreground;
-    };
-
-    mediaQuery.addEventListener('change', handleChange);
-    return () => mediaQuery.removeEventListener('change', handleChange);
-  }, [mounted, isSystemTheme, setNextTheme]);
-
-  // Listen for resolved theme changes from next-themes
   useEffect(() => {
-    if (!mountedRef.current) return;
+    if (!mounted) return;
+    applyDomTheme(currentTheme, isSystemTheme, paletteOverrides);
+  }, [mounted, currentTheme, isSystemTheme, paletteOverrides, applyDomTheme, resolvedTheme]);
 
-    // When resolvedTheme changes and we're using system theme, reapply
-    if (isSystemTheme && resolvedTheme) {
-      const systemTheme = getThemeById('system');
-      if (systemTheme) {
-        // Get the actual theme to apply based on system preference
-        const effectiveTheme = getSystemPreferredTheme();
-
-        // Apply the dark class correctly based on system preference
-        const html = document.documentElement;
-        const body = document.body;
-
-        // Remove existing theme classes
-        themes.forEach(t => {
-          html.classList.remove(t.cssClass);
-          body.classList.remove(t.cssClass);
-        });
-
-        // Set data-theme attribute
-        html.setAttribute('data-theme', effectiveTheme.id);
-        body.setAttribute('data-theme', effectiveTheme.id);
-
-        // Determine if dark mode should be applied
-        const darkThemes = ['dark', 'high-contrast', 'blueprint', 'solarized', 'nord', 'darcula'];
-        const isDarkBased = darkThemes.includes(effectiveTheme.id);
-
-        // Use next-themes to properly set the dark class
-        if (isDarkBased) {
-          setNextTheme('dark');
-        } else {
-          setNextTheme('light');
-        }
-
-        // Add theme class
-        html.classList.add(effectiveTheme.cssClass);
-        body.classList.add(effectiveTheme.cssClass);
-
-        // Set CSS custom properties
-        html.style.setProperty('--background', effectiveTheme.colors.background);
-        html.style.setProperty('--foreground', effectiveTheme.colors.foreground);
-        body.style.backgroundColor = effectiveTheme.colors.background;
-        body.style.color = effectiveTheme.colors.foreground;
-      }
-    }
-  }, [isSystemTheme, resolvedTheme, getSystemPreferredTheme, setNextTheme]);
-
-  // Sync with next-themes when it changes
   useEffect(() => {
-    if (!mountedRef.current) return;
+    if (!mounted) return;
 
-    // If next-themes is set to system, update our theme accordingly
     if (nextTheme === 'system' && !isSystemTheme) {
       const systemTheme = getThemeById('system');
       if (systemTheme) {
         setCurrentTheme(systemTheme);
         setIsSystemTheme(true);
-        applyTheme(systemTheme, true);
         localStorage.setItem('app-theme', 'system');
       }
     }
-  }, [nextTheme, isSystemTheme, applyTheme]);
+  }, [mounted, nextTheme, isSystemTheme]);
 
   const setTheme = (themeId: string) => {
     const theme = getThemeById(themeId);
@@ -241,13 +207,47 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
       const isSystem = themeId === 'system';
       setCurrentTheme(theme);
       setIsSystemTheme(isSystem);
-      applyTheme(theme, isSystem);
       localStorage.setItem('app-theme', themeId);
     }
   };
 
+  const resetPaletteToThemeDefaults = useCallback(() => {
+    setPaletteOverrides({});
+  }, []);
+
+  const persistThemePreference = useCallback(async () => {
+    const mode = preferenceModeFromThemeId(currentTheme.id);
+    const res = await fetch('/api/v1/preferences/theme', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ theme: mode, overrides: paletteOverrides }),
+    });
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
+      throw new Error((err as { error?: string }).error || 'Failed to save theme');
+    }
+    await updateSession({
+      user: {
+        ...session?.user,
+        theme_name: mode,
+        theme_overrides: paletteOverrides,
+      },
+    });
+  }, [currentTheme.id, paletteOverrides, session?.user, updateSession]);
+
   return (
-    <ThemeContext.Provider value={{ currentTheme, setTheme, availableThemes: themes, isSystemTheme }}>
+    <ThemeContext.Provider
+      value={{
+        currentTheme,
+        setTheme,
+        availableThemes: themes,
+        isSystemTheme,
+        paletteOverrides,
+        setPaletteOverrides,
+        resetPaletteToThemeDefaults,
+        persistThemePreference,
+      }}
+    >
       {children}
     </ThemeContext.Provider>
   );
@@ -260,4 +260,3 @@ export function useTheme() {
   }
   return context;
 }
-

--- a/objectified-ui/src/types/next-auth.d.ts
+++ b/objectified-ui/src/types/next-auth.d.ts
@@ -1,0 +1,20 @@
+import type { DefaultSession } from 'next-auth';
+import type { ThemeModeName, ThemePaletteOverrides } from '@lib/theme/types';
+
+declare module 'next-auth' {
+  interface Session extends DefaultSession {
+    user: DefaultSession['user'] & {
+      user_id?: string;
+      current_tenant_id?: string;
+      theme_name?: ThemeModeName;
+      theme_overrides?: ThemePaletteOverrides;
+    };
+  }
+}
+
+declare module 'next-auth/jwt' {
+  interface JWT {
+    theme_name?: string;
+    theme_overrides?: string;
+  }
+}

--- a/objectified-ui/tests/theme/color-validation.test.ts
+++ b/objectified-ui/tests/theme/color-validation.test.ts
@@ -1,0 +1,13 @@
+import { tryParseCssColor } from '@lib/theme/color-validation';
+
+describe('tryParseCssColor', () => {
+  it('accepts hex shorthand and long form', () => {
+    expect(tryParseCssColor('#fff')).toBeTruthy();
+    expect(tryParseCssColor('#6366f1')).toBeTruthy();
+  });
+
+  it('returns null for empty input', () => {
+    expect(tryParseCssColor('')).toBeNull();
+    expect(tryParseCssColor('   ')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
Implements the Theme Engine from #1332: `--obj-*` design tokens on `:root`, root `ThemeProvider` with live Light/Dark/System modes, custom palette overrides, `theme-changed` events, `PUT /api/v1/preferences/theme` persistence, and session-loaded theme preferences. Adds `/settings/appearance` (RadioGroup + Radix Popover color pickers with hex/HSL/RGB), PostgreSQL `user_theme_preferences`, and a profile link to Appearance.

## How to test
1. Apply DB migration `objectified-db/scripts/20260408-133200.sql` to your database.
2. `yarn build` and `yarn dev` in `objectified-ui`.
3. Sign in, open **Profile → Appearance settings** or go to `/settings/appearance`.
4. Switch Light / Dark / System; confirm instant UI update without reload; toggle OS theme in System mode and confirm update.
5. Set custom colors, **Save preferences**, reload; confirm colors and mode persist.
6. In DevTools console: `window.addEventListener('theme-changed', e => console.log(e.detail))` and change theme.

## Risk / notes
- New table requires migration before save/API works; JWT theme load fails open to `system` + empty overrides.
- Full `yarn test` still reports existing `db-helper` failures when DB is unavailable; new `tests/theme/color-validation.test.ts` passes.

Closes #1332

Made with [Cursor](https://cursor.com)