### PR TITLE
Fix #2595 - Clear canvas selection when switching to Code view

### DIFF
--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.9.30",
+  "version": "0.9.31",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -5,6 +5,7 @@ We continue to improve the platform based on your feedback with improvements and
 ---
 
 ## UI:
+- **Canvas ↔ Code (#2595):** Switching to **Code** view now **clears canvas selection** first so group floating actions (including **delete all classes in group**) are not hit by stray pointer events during the transition
 - **Studio Code / GraphQL (#147):** GraphQL SDL in the Code tab is generated from a **Handlebars template** (`templates/graphql/graphql-schema.hbs`) instead of inlined string building, aligned with OpenAPI and Arazzo; template loader init is synchronous so tooling can import it safely
 - **Schema quality details (#2548):** **Studio header** Schema quality is **clickable** — opens a dialog with **letter grade (A–F)**, weighted **factor table**, and the same **score band guide** as import quality. **Schema Metrics** shows the same **overall schema quality** block (numeric score + letter + guide) above the per-metric controls
 - **Studio schema quality (#245):** **Overall score (0–100)** in the Studio header — weighted blend of documentation, naming, structural load (inverted complexity), and canvas layout quality; updates live on the Canvas

--- a/objectified-ui/src/app/ade/studio/StudioContext.tsx
+++ b/objectified-ui/src/app/ade/studio/StudioContext.tsx
@@ -161,6 +161,9 @@ interface StudioContextType {
   setSearchHistoryCount: (count: number) => void;
   clearSearchHistoryFn: (() => void) | null;
   setClearSearchHistoryFn: (fn: (() => void) | null) => void;
+  /** Clears React Flow selection on the editor canvas (registered by editor); used before leaving canvas view (#2595). */
+  clearCanvasSelectionFn: (() => void) | null;
+  setClearCanvasSelectionFn: (fn: (() => void) | null) => void;
   /** When true, studio chrome (sidebar, studio header) is hidden for canvas presentation mode (#517). */
   canvasPresentationMode: boolean;
   setCanvasPresentationMode: (value: boolean) => void;
@@ -461,6 +464,7 @@ export function StudioProvider({ children }: { children: ReactNode }) {
 
   const [deleteAllClassesInGroupFn, setDeleteAllClassesInGroupFn] = useState<((groupId: string, classIds?: string[], groupName?: string) => Promise<void>) | null>(null);
   const [deleteGroupFn, setDeleteGroupFn] = useState<((groupId: string) => Promise<void>) | null>(null);
+  const [clearCanvasSelectionFn, setClearCanvasSelectionFn] = useState<(() => void) | null>(null);
 
   const addNodeToGroup = (groupId: string, nodeId: string) => {
     setGroups(prev => prev.map(g => {
@@ -545,6 +549,8 @@ export function StudioProvider({ children }: { children: ReactNode }) {
       setSearchHistoryCount,
       clearSearchHistoryFn,
       setClearSearchHistoryFn,
+      clearCanvasSelectionFn,
+      setClearCanvasSelectionFn,
       canvasPresentationMode,
       setCanvasPresentationMode,
       schemaQualityScore,

--- a/objectified-ui/src/app/ade/studio/components/StudioHeader.tsx
+++ b/objectified-ui/src/app/ade/studio/components/StudioHeader.tsx
@@ -71,6 +71,7 @@ export default function StudioHeader({ onProjectTagsLoaded }: StudioHeaderProps)
     setEdgeAnimation,
     searchHistoryCount,
     clearSearchHistoryFn,
+    clearCanvasSelectionFn,
     schemaQualityScore,
     schemaQualityDetail
   } = useStudio();
@@ -252,6 +253,8 @@ export default function StudioHeader({ onProjectTagsLoaded }: StudioHeaderProps)
     } else if (value === 'paths') {
       router.push('/ade/studio/paths');
     } else if (value === 'code') {
+      // #2595: Same as inline editor toggle — clear canvas selection before route change.
+      clearCanvasSelectionFn?.();
       router.push('/ade/studio/code');
     }
   };

--- a/objectified-ui/src/app/ade/studio/editor/page.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/page.tsx
@@ -354,6 +354,7 @@ const StudioContent = () => {
     setDeleteGroupFn,
     setSearchHistoryCount,
     setClearSearchHistoryFn,
+    setClearCanvasSelectionFn,
     setCanvasPresentationMode,
     setSchemaQualityScore,
     setSchemaQualityDetail,
@@ -762,6 +763,16 @@ const StudioContent = () => {
     setClearSearchHistoryFn(() => clearSearchHistory);
     return () => setClearSearchHistoryFn(null);
   }, [clearSearchHistory, setClearSearchHistoryFn]);
+
+  const clearCanvasSelection = useCallback(() => {
+    setNodes((nds) => nds.map((n) => ({ ...n, selected: false })));
+    setSelectedNodeIds([]);
+  }, [setNodes]);
+
+  useEffect(() => {
+    setClearCanvasSelectionFn(() => clearCanvasSelection);
+    return () => setClearCanvasSelectionFn(null);
+  }, [clearCanvasSelection, setClearCanvasSelectionFn]);
 
   // Memory profiler state
   const [memoryProfilerOpen, setMemoryProfilerOpen] = useState(false);
@@ -7852,7 +7863,14 @@ const StudioContent = () => {
                 type="single"
                 value={viewMode}
                 onValueChange={(value) => {
-                  if (value) setViewMode(value as ViewMode);
+                  if (!value) return;
+                  const next = value as ViewMode;
+                  // #2595: Drop selection before leaving canvas so group toolbars (delete-all, etc.)
+                  // unmount and cannot receive a stray click/focus during the view transition.
+                  if (next === 'code') {
+                    clearCanvasSelection();
+                  }
+                  setViewMode(next);
                 }}
                 className="inline-flex bg-gray-100 dark:bg-gray-700/50 rounded-lg p-1 shadow-inner"
               >

--- a/objectified-ui/src/app/ade/studio/editor/page.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/page.tsx
@@ -765,7 +765,13 @@ const StudioContent = () => {
   }, [clearSearchHistory, setClearSearchHistoryFn]);
 
   const clearCanvasSelection = useCallback(() => {
-    setNodes((nds) => nds.map((n) => ({ ...n, selected: false })));
+    setNodes((nds) => {
+      if (!nds.some((n) => n.selected)) {
+        return nds;
+      }
+
+      return nds.map((n) => (n.selected ? { ...n, selected: false } : n));
+    });
     setSelectedNodeIds([]);
   }, [setNodes]);
 


### PR DESCRIPTION
## What / why
Switching Canvas ↔ Code could surface the **Delete all classes in group** confirm dialog even though the user only changed views. Group frames show a floating toolbar when selected; that toolbar sits above the frame (`-top-6`) and could receive a stray click during the view transition. We now **clear React Flow node selection** (and sidebar spacing selection state) **before** entering Code view, so the toolbar unmounts safely.

## How to test
1. Open Studio editor with a project/version that has at least one **group** with classes.
2. Select the group on the canvas so the floating actions (including delete-all) are visible.
3. Click **Code** in the toolbar (editor page toggle) and back to **Canvas** — confirm the delete dialog does **not** appear.
4. Repeat using the **Studio header** Canvas/Code control that navigates to `/ade/studio/code` if you use that path.

## Risk / notes
- Selection is cleared when leaving Canvas for Code only; returning to Canvas starts with no node selected.
- `yarn build` passes. Root `yarn test` still reports existing `db-helper` failures in this environment (unchanged by this PR).

Closes #2595

Made with [Cursor](https://cursor.com)