### PR TITLE
Fix #2595 (v2) - Suppress group toolbars and sidebar deletes before C…

### DIFF
--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.9.31",
+  "version": "0.9.32",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -5,7 +5,7 @@ We continue to improve the platform based on your feedback with improvements and
 ---
 
 ## UI:
-- **Canvas ↔ Code (#2595):** Switching to **Code** view now **clears canvas selection** first so group floating actions (including **delete all classes in group**) are not hit by stray pointer events during the transition
+- **Canvas ↔ Code (#2595):** Switching to **Code** now **synchronously hides group floating toolbars** (including hover/settings/export), **clears flow selection**, and **blocks sidebar group delete row actions** while the Code tab is active so nothing in that stack can take a stray click during the transition
 - **Studio Code / GraphQL (#147):** GraphQL SDL in the Code tab is generated from a **Handlebars template** (`templates/graphql/graphql-schema.hbs`) instead of inlined string building, aligned with OpenAPI and Arazzo; template loader init is synchronous so tooling can import it safely
 - **Schema quality details (#2548):** **Studio header** Schema quality is **clickable** — opens a dialog with **letter grade (A–F)**, weighted **factor table**, and the same **score band guide** as import quality. **Schema Metrics** shows the same **overall schema quality** block (numeric score + letter + guide) above the per-metric controls
 - **Studio schema quality (#245):** **Overall score (0–100)** in the Studio header — weighted blend of documentation, naming, structural load (inverted complexity), and canvas layout quality; updates live on the Canvas

--- a/objectified-ui/src/app/ade/studio/StudioContext.tsx
+++ b/objectified-ui/src/app/ade/studio/StudioContext.tsx
@@ -164,6 +164,12 @@ interface StudioContextType {
   /** Clears React Flow selection on the editor canvas (registered by editor); used before leaving canvas view (#2595). */
   clearCanvasSelectionFn: (() => void) | null;
   setClearCanvasSelectionFn: (fn: (() => void) | null) => void;
+  /** Hides group floating toolbars (hover/settings/export still open); set before switching to Code so no stray clicks (#2595). */
+  suppressGroupFloatingToolbars: boolean;
+  setSuppressGroupFloatingToolbars: (value: boolean) => void;
+  /** While editor is on the Code tab, pathname can still be /editor — disable sidebar group destructive row actions (#2595). */
+  suppressGroupSidebarDestructive: boolean;
+  setSuppressGroupSidebarDestructive: (value: boolean) => void;
   /** When true, studio chrome (sidebar, studio header) is hidden for canvas presentation mode (#517). */
   canvasPresentationMode: boolean;
   setCanvasPresentationMode: (value: boolean) => void;
@@ -465,6 +471,8 @@ export function StudioProvider({ children }: { children: ReactNode }) {
   const [deleteAllClassesInGroupFn, setDeleteAllClassesInGroupFn] = useState<((groupId: string, classIds?: string[], groupName?: string) => Promise<void>) | null>(null);
   const [deleteGroupFn, setDeleteGroupFn] = useState<((groupId: string) => Promise<void>) | null>(null);
   const [clearCanvasSelectionFn, setClearCanvasSelectionFn] = useState<(() => void) | null>(null);
+  const [suppressGroupFloatingToolbars, setSuppressGroupFloatingToolbars] = useState(false);
+  const [suppressGroupSidebarDestructive, setSuppressGroupSidebarDestructive] = useState(false);
 
   const addNodeToGroup = (groupId: string, nodeId: string) => {
     setGroups(prev => prev.map(g => {
@@ -551,6 +559,10 @@ export function StudioProvider({ children }: { children: ReactNode }) {
       setClearSearchHistoryFn,
       clearCanvasSelectionFn,
       setClearCanvasSelectionFn,
+      suppressGroupFloatingToolbars,
+      setSuppressGroupFloatingToolbars,
+      suppressGroupSidebarDestructive,
+      setSuppressGroupSidebarDestructive,
       canvasPresentationMode,
       setCanvasPresentationMode,
       schemaQualityScore,

--- a/objectified-ui/src/app/ade/studio/components/StudioHeader.tsx
+++ b/objectified-ui/src/app/ade/studio/components/StudioHeader.tsx
@@ -253,7 +253,6 @@ export default function StudioHeader({ onProjectTagsLoaded }: StudioHeaderProps)
     } else if (value === 'paths') {
       router.push('/ade/studio/paths');
     } else if (value === 'code') {
-      // #2595: Same as inline editor toggle — clear canvas selection before route change.
       clearCanvasSelectionFn?.();
       router.push('/ade/studio/code');
     }

--- a/objectified-ui/src/app/ade/studio/editor/page.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useCallback, useState, useEffect, useRef, useMemo, type ChangeEvent, type SetStateAction } from 'react';
+import { flushSync } from 'react-dom';
 import { useSession } from 'next-auth/react';
 import { useSearchParams } from 'next/navigation';
 import dynamic from 'next/dynamic';
@@ -355,6 +356,8 @@ const StudioContent = () => {
     setSearchHistoryCount,
     setClearSearchHistoryFn,
     setClearCanvasSelectionFn,
+    setSuppressGroupFloatingToolbars,
+    setSuppressGroupSidebarDestructive,
     setCanvasPresentationMode,
     setSchemaQualityScore,
     setSchemaQualityDetail,
@@ -764,21 +767,30 @@ const StudioContent = () => {
     return () => setClearSearchHistoryFn(null);
   }, [clearSearchHistory, setClearSearchHistoryFn]);
 
-  const clearCanvasSelection = useCallback(() => {
-    setNodes((nds) => {
-      if (!nds.some((n) => n.selected)) {
-        return nds;
-      }
-
-      return nds.map((n) => (n.selected ? { ...n, selected: false } : n));
+  const prepareCanvasForCodeView = useCallback(() => {
+    flushSync(() => {
+      setSuppressGroupFloatingToolbars(true);
+      setSuppressGroupSidebarDestructive(true);
+      setNodes((nds) => nds.map((n) => ({ ...n, selected: false })));
+      setSelectedNodeIds([]);
     });
-    setSelectedNodeIds([]);
-  }, [setNodes]);
+  }, [
+    setSuppressGroupFloatingToolbars,
+    setSuppressGroupSidebarDestructive,
+    setNodes,
+  ]);
 
   useEffect(() => {
-    setClearCanvasSelectionFn(() => clearCanvasSelection);
+    setClearCanvasSelectionFn(() => prepareCanvasForCodeView);
     return () => setClearCanvasSelectionFn(null);
-  }, [clearCanvasSelection, setClearCanvasSelectionFn]);
+  }, [prepareCanvasForCodeView, setClearCanvasSelectionFn]);
+
+  useEffect(() => {
+    if (viewMode === 'canvas') {
+      setSuppressGroupFloatingToolbars(false);
+      setSuppressGroupSidebarDestructive(false);
+    }
+  }, [viewMode, setSuppressGroupFloatingToolbars, setSuppressGroupSidebarDestructive]);
 
   // Memory profiler state
   const [memoryProfilerOpen, setMemoryProfilerOpen] = useState(false);
@@ -7871,10 +7883,8 @@ const StudioContent = () => {
                 onValueChange={(value) => {
                   if (!value) return;
                   const next = value as ViewMode;
-                  // #2595: Drop selection before leaving canvas so group toolbars (delete-all, etc.)
-                  // unmount and cannot receive a stray click/focus during the view transition.
                   if (next === 'code') {
-                    clearCanvasSelection();
+                    prepareCanvasForCodeView();
                   }
                   setViewMode(next);
                 }}

--- a/objectified-ui/src/app/ade/studio/layout.tsx
+++ b/objectified-ui/src/app/ade/studio/layout.tsx
@@ -53,6 +53,7 @@ function StudioLayoutContent({ children }: Readonly<{ children: React.ReactNode 
     deleteGroupFn,
     updateGroup,
     canvasPresentationMode,
+    suppressGroupSidebarDestructive,
   } = useStudio();
 
   // Check if we're on the code or paths view - hide sidebar for these views
@@ -447,7 +448,8 @@ function StudioLayoutContent({ children }: Readonly<{ children: React.ReactNode 
           selectedVersionId && (
           <StudioSideNav classes={classes} properties={properties} groups={sidebarGroups} callbacks={callbacks} refreshKey={refreshKey}
                          hiddenClassIds={hiddenClassIds}
-                         selectedProjectId={selectedProjectId} selectedVersionId={selectedVersionId} isReadOnly={isReadOnly} />
+                         selectedProjectId={selectedProjectId} selectedVersionId={selectedVersionId} isReadOnly={isReadOnly}
+                         suppressGroupDestructiveActions={suppressGroupSidebarDestructive} />
         )}
 
         <main style={{ flex: 1, overflow: "hidden", position: "relative", zIndex: 100, display: "flex", flexDirection: "column" }}>

--- a/objectified-ui/src/app/components/ade/studio/GroupNode.tsx
+++ b/objectified-ui/src/app/components/ade/studio/GroupNode.tsx
@@ -20,6 +20,7 @@ import {
   SelectItem,
   SelectTrigger,
 } from '@/app/components/ui/Select';
+import { useStudio } from '@/app/ade/studio/StudioContext';
 
 // Available group icons
 export const GROUP_ICONS = [
@@ -163,9 +164,11 @@ const GroupNode = memo((props: NodeProps) => {
   const [bulkDialogOpen, setBulkDialogOpen] = useState(false);
   const [isFrameHovered, setIsFrameHovered] = useState(false);
   const [customHexDraft, setCustomHexDraft] = useState('');
+  const { suppressGroupFloatingToolbars } = useStudio();
 
   const showFloatingToolbar = useMemo(
     () =>
+      !suppressGroupFloatingToolbars &&
       !groupData.isReadOnly &&
       !isEditing &&
       (selected ||
@@ -174,6 +177,7 @@ const GroupNode = memo((props: NodeProps) => {
         colorPickerOpen ||
         exportPopoverOpen),
     [
+      suppressGroupFloatingToolbars,
       groupData.isReadOnly,
       isEditing,
       selected,

--- a/objectified-ui/src/app/components/ade/studio/StudioSideNav.tsx
+++ b/objectified-ui/src/app/components/ade/studio/StudioSideNav.tsx
@@ -90,6 +90,8 @@ interface StudioSideNavProps {
   selectedVersionId?: string | null; // Currently selected version from canvas
   isReadOnly?: boolean; // Whether the current version is published (read-only)
   hiddenClassIds?: string[];
+  /** #2595: Data Designer Code tab keeps /editor URL — block group row delete actions during layout/pointer transitions */
+  suppressGroupDestructiveActions?: boolean;
   // classWarnings?: Record<string, boolean>; // removed, computed locally
   [key: string]: any; // allow future, non-breaking props from parent
 }
@@ -104,6 +106,7 @@ const StudioSideNav: React.FC<StudioSideNavProps> = ({
   selectedVersionId = null,
   isReadOnly = false,
   hiddenClassIds = [],
+  suppressGroupDestructiveActions = false,
 }) => {
   // Dark mode detection using shared hook
   const isDark = useDarkMode();
@@ -738,7 +741,13 @@ const StudioSideNav: React.FC<StudioSideNavProps> = ({
                                 </div>
                               </button>
                               {!isReadOnly && (
-                                <div className="flex items-center opacity-60 group-hover:opacity-100">
+                                <div
+                                  className={`flex items-center ${
+                                    suppressGroupDestructiveActions
+                                      ? 'pointer-events-none opacity-30'
+                                      : 'opacity-60 group-hover:opacity-100'
+                                  }`}
+                                >
                                   {nodeCount > 0 && (
                                     <button
                                       type="button"

--- a/objectified-ui/tests/unit/GroupNode-toolbar.test.tsx
+++ b/objectified-ui/tests/unit/GroupNode-toolbar.test.tsx
@@ -8,6 +8,7 @@ import '@testing-library/jest-dom';
 import { ReactFlowProvider } from '@xyflow/react';
 
 import GroupNode, { type GroupNodeData } from '../../src/app/components/ade/studio/GroupNode';
+import { StudioProvider } from '../../src/app/ade/studio/StudioContext';
 
 jest.mock('../../src/app/components/ade/studio/GroupBulkEditDialog', () => ({
   __esModule: true,
@@ -31,14 +32,16 @@ const baseData: GroupNodeData = {
 function renderGroup(overrides?: Partial<GroupNodeData>, selected = false) {
   const data = { ...baseData, ...overrides };
   return render(
-    <ReactFlowProvider>
-      <GroupNode
-        id="g1"
-        type="groupNode"
-        data={data as unknown as Record<string, unknown>}
-        selected={selected}
-      />
-    </ReactFlowProvider>
+    <StudioProvider>
+      <ReactFlowProvider>
+        <GroupNode
+          id="g1"
+          type="groupNode"
+          data={data as unknown as Record<string, unknown>}
+          selected={selected}
+        />
+      </ReactFlowProvider>
+    </StudioProvider>
   );
 }
 


### PR DESCRIPTION
…ode view

Selection-only clearing was insufficient: group floating actions stay visible on hover, settings, export, and color popovers. Sync flushSync + context flags hide that chrome and pointer-block sidebar row destructives while Code tab is active.

Made-with: Cursor