### PR TITLE
Fix #500 - Branch and merge workflows (git-like DAG)

### DIFF
--- a/docs/PLANNED_FEATURE_ROADMAP_VERSIONING.md
+++ b/docs/PLANNED_FEATURE_ROADMAP_VERSIONING.md
@@ -8,7 +8,7 @@ This represents the different versions of the Objectified specification and thei
 - ✅ Full version history
 - ✅ Compare any two versions
 - ✅ Visual diff with highlights
-- 📋 Branch and merge workflows
+- ✅ Branch and merge workflows (named branch tips, merge preview, merge apply with two parents when auto-mergeable; merge-base #2593 follow-up)
 - 📋 Tag versions (v1.0, stable, beta)
 - 📋 Version notes and changelogs
 - 📋 Fork versions for experiments
@@ -17,7 +17,7 @@ This represents the different versions of the Objectified specification and thei
 
 | Ticket  | Feature Description                           |
 |---------|-----------------------------------------------|
-| #500    | Implemented full version history tracking     |
+| #500    | Branch and merge workflows (git-like DAG edges on versions) |
 | #501    | Add tagging functionality for versions        |
 | #502    | Add and modify version notes and changelogs   |
 | #503    | Add ability to fork versions for testing      |

--- a/objectified-db/scripts/20260409-140000.sql
+++ b/objectified-db/scripts/20260409-140000.sql
@@ -1,0 +1,31 @@
+-- Git-like version branches and merge lineage (DAG edges on versions rows)
+SET search_path TO odb, public;
+
+ALTER TABLE versions
+  ADD COLUMN IF NOT EXISTS parent_version_id UUID REFERENCES versions(id) ON DELETE SET NULL;
+
+ALTER TABLE versions
+  ADD COLUMN IF NOT EXISTS merge_parent_version_id UUID REFERENCES versions(id) ON DELETE SET NULL;
+
+COMMENT ON COLUMN versions.parent_version_id IS 'Linear parent revision (first parent) for history; NULL for roots';
+COMMENT ON COLUMN versions.merge_parent_version_id IS 'Second parent for merge commits; NULL unless this row is a merge revision';
+
+CREATE INDEX IF NOT EXISTS idx_versions_parent_version_id ON versions(parent_version_id) WHERE parent_version_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_versions_merge_parent_version_id ON versions(merge_parent_version_id) WHERE merge_parent_version_id IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS version_branches (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    project_id UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    name VARCHAR(255) NOT NULL,
+    tip_version_id UUID NOT NULL REFERENCES versions(id) ON DELETE RESTRICT,
+    created_by UUID REFERENCES users(id) ON DELETE SET NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT version_branches_project_name_unique UNIQUE (project_id, name)
+);
+
+CREATE INDEX IF NOT EXISTS idx_version_branches_project_id ON version_branches(project_id);
+CREATE INDEX IF NOT EXISTS idx_version_branches_tip_version_id ON version_branches(tip_version_id);
+
+COMMENT ON TABLE version_branches IS 'Named branch whose tip points at a version row (schema revision)';
+COMMENT ON COLUMN version_branches.tip_version_id IS 'Current head version id for this branch';

--- a/objectified-rest/pyproject.toml
+++ b/objectified-rest/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "objectified-rest"
-version = "1.0.0"
+version = "1.0.1"
 description = "REST API for serving OpenAPI specifications from the Objectified database"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/objectified-rest/src/app/database.py
+++ b/objectified-rest/src/app/database.py
@@ -1211,7 +1211,8 @@ class Database:
         query = """
             SELECT v.id, v.project_id, v.creator_id, v.version_id, v.description,
                    v.change_log, v.visibility, v.published, v.published_at,
-                   v.enabled, v.created_at, v.updated_at,
+                   v.enabled, v.parent_version_id, v.merge_parent_version_id,
+                   v.created_at, v.updated_at,
                    u.name as creator_name, u.email as creator_email,
                    p.name as project_name, p.slug as project_slug
             FROM odb.versions v
@@ -1230,7 +1231,8 @@ class Database:
         query = """
             SELECT v.id, v.project_id, v.creator_id, v.version_id, v.description,
                    v.change_log, v.visibility, v.published, v.published_at,
-                   v.enabled, v.created_at, v.updated_at,
+                   v.enabled, v.parent_version_id, v.merge_parent_version_id,
+                   v.created_at, v.updated_at,
                    u.name as creator_name, u.email as creator_email,
                    p.name as project_name, p.slug as project_slug
             FROM odb.versions v
@@ -1249,7 +1251,8 @@ class Database:
         query = """
             SELECT v.id, v.project_id, v.creator_id, v.version_id, v.description,
                    v.change_log, v.visibility, v.published, v.published_at,
-                   v.enabled, v.created_at, v.updated_at,
+                   v.enabled, v.parent_version_id, v.merge_parent_version_id,
+                   v.created_at, v.updated_at,
                    u.name as creator_name, u.email as creator_email,
                    p.name as project_name, p.slug as project_slug
             FROM odb.versions v
@@ -1295,7 +1298,8 @@ class Database:
             VALUES (%s, %s, %s, %s, %s)
             RETURNING id, project_id, creator_id, version_id, description,
                       change_log, visibility, published, published_at,
-                      enabled, created_at, updated_at
+                      enabled, parent_version_id, merge_parent_version_id,
+                      created_at, updated_at
         """
 
         conn = self.connect()

--- a/objectified-rest/src/app/models.py
+++ b/objectified-rest/src/app/models.py
@@ -221,6 +221,8 @@ class VersionSchema(BaseModel):
     published: bool = False
     published_at: Optional[Union[datetime, str]] = None
     enabled: bool = True
+    parent_version_id: Optional[str] = None
+    merge_parent_version_id: Optional[str] = None
     creator_name: Optional[str] = None
     creator_email: Optional[str] = None
     project_name: Optional[str] = None

--- a/objectified-ui/lib/db/helper.ts
+++ b/objectified-ui/lib/db/helper.ts
@@ -5384,7 +5384,7 @@ export async function listVersionBranches(projectId: string, tenantId: string) {
       `SELECT b.id, b.project_id, b.name, b.tip_version_id, b.created_by, b.created_at, b.updated_at,
               v.version_id AS tip_version_string
        FROM odb.version_branches b
-       JOIN odb.versions v ON v.id = b.tip_version_id
+       JOIN odb.versions v ON v.id = b.tip_version_id AND v.project_id = b.project_id
        JOIN odb.projects p ON b.project_id = p.id
        WHERE b.project_id = $1 AND p.tenant_id = $2 AND v.deleted_at IS NULL
        ORDER BY b.name ASC`,
@@ -5641,56 +5641,64 @@ export async function mergeVersionBranchesServer(input: {
       return JSON.stringify({ success: false, error: planErr, status: 403 });
     }
 
-    const insVer = await connectionPool.query(
-      `INSERT INTO odb.versions (project_id, creator_id, version_id, description, change_log,
-        parent_version_id, merge_parent_version_id)
-       VALUES ($1, $2, $3, $4, $5, $6, $7)
-       RETURNING *`,
-      [
-        projectId,
-        userId,
-        newVersionString,
-        `Merge ${sourceBranchName} into ${targetBranchName}`,
-        null,
-        targetTipId,
-        sourceTipId,
-      ]
-    );
-    const newVersion = insVer.rows[0];
+    await connectionPool.query(`BEGIN`);
+    try {
+      const insVer = await connectionPool.query(
+        `INSERT INTO odb.versions (project_id, creator_id, version_id, description, change_log,
+          parent_version_id, merge_parent_version_id)
+         VALUES ($1, $2, $3, $4, $5, $6, $7)
+         RETURNING *`,
+        [
+          projectId,
+          userId,
+          newVersionString,
+          `Merge ${sourceBranchName} into ${targetBranchName}`,
+          null,
+          targetTipId,
+          sourceTipId,
+        ]
+      );
+      const newVersion = insVer.rows[0];
 
-    const copyAll = await copyClassesFromVersion(targetTipId, newVersion.id);
-    const copyAllParsed = JSON.parse(copyAll);
-    if (!copyAllParsed.success) {
-      await connectionPool.query(`DELETE FROM odb.versions WHERE id = $1`, [newVersion.id]);
-      return JSON.stringify({
-        success: false,
-        error: copyAllParsed.error || 'Failed to copy target schema classes',
-        status: 500,
-      });
-    }
-
-    for (const schemaName of [...new Set(classification.addedSchemaNames)]) {
-      const one = await copySingleClassBetweenVersions(sourceTipId, newVersion.id, schemaName);
-      if (!one.success) {
-        await connectionPool.query(`DELETE FROM odb.versions WHERE id = $1`, [newVersion.id]);
+      const copyAll = await copyClassesFromVersion(targetTipId, newVersion.id);
+      const copyAllParsed = JSON.parse(copyAll);
+      if (!copyAllParsed.success) {
+        await connectionPool.query(`ROLLBACK`);
         return JSON.stringify({
           success: false,
-          error: one.error || `Failed to copy added class ${schemaName}`,
+          error: copyAllParsed.error || 'Failed to copy target schema classes',
           status: 500,
         });
       }
+
+      for (const schemaName of [...new Set(classification.addedSchemaNames)]) {
+        const one = await copySingleClassBetweenVersions(sourceTipId, newVersion.id, schemaName);
+        if (!one.success) {
+          await connectionPool.query(`ROLLBACK`);
+          return JSON.stringify({
+            success: false,
+            error: one.error || `Failed to copy added class ${schemaName}`,
+            status: 500,
+          });
+        }
+      }
+
+      await connectionPool.query(
+        `UPDATE odb.version_branches SET tip_version_id = $1, updated_at = CURRENT_TIMESTAMP WHERE id = $2`,
+        [newVersion.id, tgtBranch.rows[0].id]
+      );
+
+      await connectionPool.query(`COMMIT`);
+
+      return JSON.stringify({
+        success: true,
+        version: newVersion,
+        mergedAddedSchemas: classification.addedSchemaNames,
+      });
+    } catch (transactionError) {
+      await connectionPool.query(`ROLLBACK`);
+      throw transactionError;
     }
-
-    await connectionPool.query(
-      `UPDATE odb.version_branches SET tip_version_id = $1, updated_at = CURRENT_TIMESTAMP WHERE id = $2`,
-      [newVersion.id, tgtBranch.rows[0].id]
-    );
-
-    return JSON.stringify({
-      success: true,
-      version: newVersion,
-      mergedAddedSchemas: classification.addedSchemaNames,
-    });
   } catch (error: any) {
     console.error('mergeVersionBranchesServer:', error);
     if (error.code === '23505') {

--- a/objectified-ui/lib/db/helper.ts
+++ b/objectified-ui/lib/db/helper.ts
@@ -1,5 +1,7 @@
 'use server';
 
+import { generateOpenApiSpec } from '@/app/utils/openapi';
+import { mergePreviewFromSpecs } from '../version-merge';
 import { getPlanBlockMessageForNewProject, getPlanBlockMessageForNewVersion } from './plan-entitlements';
 import { getAuthSession } from '../auth/server-session';
 import { buildGroupMetadataForSync } from '../utils/group-metadata';
@@ -5337,6 +5339,449 @@ export async function importPrimitivesFromSchema(
   } catch (error: any) {
     console.error('Error importing primitives from schema:', error);
     return JSON.stringify({ success: false, error: error.message });
+  }
+}
+
+const VERSION_BRANCH_NAME_RE = /^[a-zA-Z][a-zA-Z0-9._\-/]{0,254}$/;
+
+export async function buildOpenApiSpecJsonForVersion(
+  versionRow: { id: string; version_id: string; description?: string | null; project_id: string },
+  projectName: string | null
+): Promise<string> {
+  const classesResult = await getClassesForVersion(versionRow.id);
+  const classesData = JSON.parse(classesResult) as unknown[];
+  const classesWithProperties = await Promise.all(
+    classesData.map(async (cls: any) => {
+      const propsResult = await getPropertiesForClass(cls.id);
+      return { ...cls, properties: JSON.parse(propsResult) };
+    })
+  );
+  return generateOpenApiSpec(classesWithProperties, {
+    projectName: projectName ?? undefined,
+    version: versionRow.version_id,
+    description: versionRow.description || undefined,
+  });
+}
+
+export function isValidVersionBranchName(name: string): boolean {
+  return VERSION_BRANCH_NAME_RE.test(name.trim());
+}
+
+export async function assertProjectInTenant(projectId: string, tenantId: string): Promise<boolean> {
+  const r = await connectionPool.query(
+    `SELECT 1 FROM odb.projects p WHERE p.id = $1 AND p.tenant_id = $2 AND p.deleted_at IS NULL`,
+    [projectId, tenantId]
+  );
+  return (r.rowCount ?? 0) > 0;
+}
+
+/** List named branches for a project (tips are version row ids). */
+export async function listVersionBranches(projectId: string, tenantId: string) {
+  try {
+    const ok = await assertProjectInTenant(projectId, tenantId);
+    if (!ok) return JSON.stringify({ success: false, error: 'Project not found' });
+    const result = await connectionPool.query(
+      `SELECT b.id, b.project_id, b.name, b.tip_version_id, b.created_by, b.created_at, b.updated_at,
+              v.version_id AS tip_version_string
+       FROM odb.version_branches b
+       JOIN odb.versions v ON v.id = b.tip_version_id
+       JOIN odb.projects p ON b.project_id = p.id
+       WHERE b.project_id = $1 AND p.tenant_id = $2 AND v.deleted_at IS NULL
+       ORDER BY b.name ASC`,
+      [projectId, tenantId]
+    );
+    return JSON.stringify({ success: true, branches: result.rows });
+  } catch (error: any) {
+    console.error('listVersionBranches:', error);
+    return JSON.stringify({ success: false, error: error.message });
+  }
+}
+
+/** Create a named branch whose tip is an existing version (revision). */
+export async function createVersionBranch(
+  projectId: string,
+  tenantId: string,
+  name: string,
+  fromVersionId: string,
+  userId: string
+) {
+  try {
+    const trimmed = name.trim();
+    if (!isValidVersionBranchName(trimmed)) {
+      return JSON.stringify({
+        success: false,
+        error:
+          'Branch name must start with a letter and contain only letters, digits, . _ - / (max 255 chars)',
+      });
+    }
+    const ok = await assertProjectInTenant(projectId, tenantId);
+    if (!ok) return JSON.stringify({ success: false, error: 'Project not found' });
+    const ver = await connectionPool.query(
+      `SELECT v.id, v.project_id FROM odb.versions v
+       JOIN odb.projects p ON v.project_id = p.id
+       WHERE v.id = $1 AND v.project_id = $2 AND p.tenant_id = $3 AND v.deleted_at IS NULL`,
+      [fromVersionId, projectId, tenantId]
+    );
+    if (ver.rowCount === 0) {
+      return JSON.stringify({ success: false, error: 'Source version not found in this project' });
+    }
+    const ins = await connectionPool.query(
+      `INSERT INTO odb.version_branches (project_id, name, tip_version_id, created_by)
+       VALUES ($1, $2, $3, $4)
+       RETURNING id, project_id, name, tip_version_id, created_by, created_at, updated_at`,
+      [projectId, trimmed, fromVersionId, userId]
+    );
+    return JSON.stringify({ success: true, branch: ins.rows[0] });
+  } catch (error: any) {
+    if (error.code === '23505') {
+      return JSON.stringify({ success: false, error: 'A branch with this name already exists for this project' });
+    }
+    console.error('createVersionBranch:', error);
+    return JSON.stringify({ success: false, error: error.message });
+  }
+}
+
+export async function deleteVersionBranch(
+  branchId: string,
+  projectId: string,
+  tenantId: string,
+  userId: string,
+  isTenantAdmin: boolean
+) {
+  try {
+    const ok = await assertProjectInTenant(projectId, tenantId);
+    if (!ok) return JSON.stringify({ success: false, error: 'Project not found' });
+    const row = await connectionPool.query(
+      `SELECT b.id, b.created_by FROM odb.version_branches b
+       JOIN odb.projects p ON b.project_id = p.id
+       WHERE b.id = $1 AND b.project_id = $2 AND p.tenant_id = $3`,
+      [branchId, projectId, tenantId]
+    );
+    if (row.rowCount === 0) return JSON.stringify({ success: false, error: 'Branch not found' });
+    if (!isTenantAdmin && row.rows[0].created_by !== userId) {
+      return JSON.stringify({ success: false, error: 'Only the branch creator or a tenant admin can delete this branch' });
+    }
+    await connectionPool.query(`DELETE FROM odb.version_branches WHERE id = $1`, [branchId]);
+    return JSON.stringify({ success: true });
+  } catch (error: any) {
+    console.error('deleteVersionBranch:', error);
+    return JSON.stringify({ success: false, error: error.message });
+  }
+}
+
+async function copySingleClassBetweenVersions(
+  sourceVersionId: string,
+  targetVersionId: string,
+  className: string
+): Promise<{ success: boolean; error?: string }> {
+  try {
+    const result = await connectionPool.query(
+      `INSERT INTO odb.classes (version_id, name, description, schema, enabled, canvas_metadata)
+       SELECT $1, name, description, schema, enabled, canvas_metadata
+       FROM odb.classes
+       WHERE version_id = $2 AND name = $3 AND deleted_at IS NULL
+       RETURNING id, name`,
+      [targetVersionId, sourceVersionId, className]
+    );
+    if (result.rowCount === 0) {
+      return { success: false, error: `Class ${className} not found on source version` };
+    }
+    const copiedClass = result.rows[0];
+    const originalClassResult = await connectionPool.query(
+      `SELECT id FROM odb.classes
+       WHERE version_id = $1 AND name = $2 AND deleted_at IS NULL`,
+      [sourceVersionId, copiedClass.name]
+    );
+    if (originalClassResult.rowCount === 0) {
+      return { success: false, error: 'Original class missing' };
+    }
+    const originalClassId = originalClassResult.rows[0].id;
+    const newClassId = copiedClass.id;
+    const originalPropertiesResult = await connectionPool.query(
+      `SELECT id, property_id, name, description, data, parent_id
+       FROM odb.class_properties
+       WHERE class_id = $1`,
+      [originalClassId]
+    );
+    const oldToNewIdMap = new Map<string, string>();
+    const allProperties = originalPropertiesResult.rows;
+    const processedIds = new Set<string>();
+
+    const copyPropertiesRecursively = async (parentId: string | null) => {
+      const propsAtThisLevel = allProperties.filter(
+        (p: any) =>
+          (p.parent_id === parentId || (p.parent_id === null && parentId === null)) && !processedIds.has(p.id)
+      );
+      for (const prop of propsAtThisLevel) {
+        const newParentId = prop.parent_id ? oldToNewIdMap.get(prop.parent_id) || null : null;
+        const insertResult = await connectionPool.query(
+          `INSERT INTO odb.class_properties (class_id, property_id, name, description, data, parent_id)
+           VALUES ($1, $2, $3, $4, $5, $6)
+           RETURNING id`,
+          [newClassId, prop.property_id, prop.name, prop.description, prop.data, newParentId]
+        );
+        const newId = insertResult.rows[0].id;
+        oldToNewIdMap.set(prop.id, newId);
+        processedIds.add(prop.id);
+        await copyPropertiesRecursively(prop.id);
+      }
+    };
+    await copyPropertiesRecursively(null);
+    return { success: true };
+  } catch (error: any) {
+    console.error('copySingleClassBetweenVersions:', error);
+    return { success: false, error: error.message };
+  }
+}
+
+/**
+ * Merge source branch into target branch (server-side, after session auth).
+ * Creates a new version row with both parents when auto-merge succeeds (no overlapping modified/removed paths).
+ */
+export async function mergeVersionBranchesServer(input: {
+  projectId: string;
+  tenantId: string;
+  userId: string;
+  sourceBranchName: string;
+  targetBranchName: string;
+  baseRevisionId: string;
+}) {
+  try {
+    const { projectId, tenantId, userId, sourceBranchName, targetBranchName, baseRevisionId } = input;
+    const ok = await assertProjectInTenant(projectId, tenantId);
+    if (!ok) return JSON.stringify({ success: false, error: 'Project not found', status: 404 });
+
+    const srcBranch = await connectionPool.query(
+      `SELECT b.id, b.tip_version_id, b.name FROM odb.version_branches b
+       JOIN odb.projects p ON b.project_id = p.id
+       WHERE b.project_id = $1 AND p.tenant_id = $2 AND b.name = $3`,
+      [projectId, tenantId, sourceBranchName.trim()]
+    );
+    const tgtBranch = await connectionPool.query(
+      `SELECT b.id, b.tip_version_id, b.name FROM odb.version_branches b
+       JOIN odb.projects p ON b.project_id = p.id
+       WHERE b.project_id = $1 AND p.tenant_id = $2 AND b.name = $3`,
+      [projectId, tenantId, targetBranchName.trim()]
+    );
+    if (srcBranch.rowCount === 0 || tgtBranch.rowCount === 0) {
+      return JSON.stringify({ success: false, error: 'Source or target branch not found', status: 404 });
+    }
+    const sourceTipId: string = srcBranch.rows[0].tip_version_id;
+    const targetTipId: string = tgtBranch.rows[0].tip_version_id;
+
+    if (targetTipId !== baseRevisionId) {
+      return JSON.stringify({
+        success: false,
+        error: 'Target branch tip does not match baseRevisionId (stale head or wrong base).',
+        status: 409,
+        code: 'STALE_HEAD',
+      });
+    }
+
+    const tips = await connectionPool.query(
+      `SELECT v.id, v.project_id, v.version_id, v.description, v.published, p.name AS project_name
+       FROM odb.versions v
+       JOIN odb.projects p ON v.project_id = p.id
+       WHERE v.id = ANY($1::uuid[]) AND p.tenant_id = $2 AND v.deleted_at IS NULL`,
+      [[sourceTipId, targetTipId], tenantId]
+    );
+    if (tips.rowCount !== 2) {
+      return JSON.stringify({ success: false, error: 'Version tip not accessible', status: 403 });
+    }
+    const byId = new Map(tips.rows.map((r: any) => [r.id, r]));
+    const sourceRow = byId.get(sourceTipId);
+    const targetRow = byId.get(targetTipId);
+    if (!sourceRow || !targetRow) {
+      return JSON.stringify({ success: false, error: 'Version tip not accessible', status: 403 });
+    }
+    if (sourceRow.published || targetRow.published) {
+      return JSON.stringify({
+        success: false,
+        error: 'Cannot merge published or frozen versions',
+        status: 409,
+        code: 'PUBLISHED_VERSION',
+      });
+    }
+
+    const targetSpec = await buildOpenApiSpecJsonForVersion(
+      {
+        id: targetRow.id,
+        version_id: targetRow.version_id,
+        description: targetRow.description,
+        project_id: targetRow.project_id,
+      },
+      targetRow.project_name
+    );
+    const sourceSpec = await buildOpenApiSpecJsonForVersion(
+      {
+        id: sourceRow.id,
+        version_id: sourceRow.version_id,
+        description: sourceRow.description,
+        project_id: sourceRow.project_id,
+      },
+      sourceRow.project_name
+    );
+
+    const { classification } = await mergePreviewFromSpecs(targetSpec, sourceSpec);
+    if (!classification.canAutoMerge) {
+      return JSON.stringify({
+        success: false,
+        error: 'Merge blocked: overlapping schema changes detected',
+        status: 409,
+        code: 'MERGE_CONFLICT',
+        conflictPaths: classification.conflictPaths,
+      });
+    }
+
+    const latest = await getLatestVersionForProject(projectId);
+    const newVersionString = latest ? bumpPatchVersion(latest) : '0.1.0';
+
+    const planErr = await getPlanBlockMessageForNewVersion(userId);
+    if (planErr) {
+      return JSON.stringify({ success: false, error: planErr, status: 403 });
+    }
+
+    const insVer = await connectionPool.query(
+      `INSERT INTO odb.versions (project_id, creator_id, version_id, description, change_log,
+        parent_version_id, merge_parent_version_id)
+       VALUES ($1, $2, $3, $4, $5, $6, $7)
+       RETURNING *`,
+      [
+        projectId,
+        userId,
+        newVersionString,
+        `Merge ${sourceBranchName} into ${targetBranchName}`,
+        null,
+        targetTipId,
+        sourceTipId,
+      ]
+    );
+    const newVersion = insVer.rows[0];
+
+    const copyAll = await copyClassesFromVersion(targetTipId, newVersion.id);
+    const copyAllParsed = JSON.parse(copyAll);
+    if (!copyAllParsed.success) {
+      await connectionPool.query(`DELETE FROM odb.versions WHERE id = $1`, [newVersion.id]);
+      return JSON.stringify({
+        success: false,
+        error: copyAllParsed.error || 'Failed to copy target schema classes',
+        status: 500,
+      });
+    }
+
+    for (const schemaName of [...new Set(classification.addedSchemaNames)]) {
+      const one = await copySingleClassBetweenVersions(sourceTipId, newVersion.id, schemaName);
+      if (!one.success) {
+        await connectionPool.query(`DELETE FROM odb.versions WHERE id = $1`, [newVersion.id]);
+        return JSON.stringify({
+          success: false,
+          error: one.error || `Failed to copy added class ${schemaName}`,
+          status: 500,
+        });
+      }
+    }
+
+    await connectionPool.query(
+      `UPDATE odb.version_branches SET tip_version_id = $1, updated_at = CURRENT_TIMESTAMP WHERE id = $2`,
+      [newVersion.id, tgtBranch.rows[0].id]
+    );
+
+    return JSON.stringify({
+      success: true,
+      version: newVersion,
+      mergedAddedSchemas: classification.addedSchemaNames,
+    });
+  } catch (error: any) {
+    console.error('mergeVersionBranchesServer:', error);
+    if (error.code === '23505') {
+      return JSON.stringify({
+        success: false,
+        error: 'Version id collision after bump; retry merge',
+        status: 409,
+      });
+    }
+    return JSON.stringify({ success: false, error: error.message, status: 500 });
+  }
+}
+
+/** Dry-run merge preview (no DB writes). */
+export async function mergeVersionBranchesPreviewServer(input: {
+  projectId: string;
+  tenantId: string;
+  sourceBranchName: string;
+  targetBranchName: string;
+}) {
+  try {
+    const { projectId, tenantId, sourceBranchName, targetBranchName } = input;
+    const ok = await assertProjectInTenant(projectId, tenantId);
+    if (!ok) return JSON.stringify({ success: false, error: 'Project not found', status: 404 });
+
+    const srcBranch = await connectionPool.query(
+      `SELECT b.tip_version_id FROM odb.version_branches b
+       JOIN odb.projects p ON b.project_id = p.id
+       WHERE b.project_id = $1 AND p.tenant_id = $2 AND b.name = $3`,
+      [projectId, tenantId, sourceBranchName.trim()]
+    );
+    const tgtBranch = await connectionPool.query(
+      `SELECT b.tip_version_id FROM odb.version_branches b
+       JOIN odb.projects p ON b.project_id = p.id
+       WHERE b.project_id = $1 AND p.tenant_id = $2 AND b.name = $3`,
+      [projectId, tenantId, targetBranchName.trim()]
+    );
+    if (srcBranch.rowCount === 0 || tgtBranch.rowCount === 0) {
+      return JSON.stringify({ success: false, error: 'Source or target branch not found', status: 404 });
+    }
+    const sourceTipId = srcBranch.rows[0].tip_version_id;
+    const targetTipId = tgtBranch.rows[0].tip_version_id;
+
+    const tips = await connectionPool.query(
+      `SELECT v.id, v.project_id, v.version_id, v.description, p.name AS project_name
+       FROM odb.versions v
+       JOIN odb.projects p ON v.project_id = p.id
+       WHERE v.id = ANY($1::uuid[]) AND p.tenant_id = $2 AND v.deleted_at IS NULL`,
+      [[sourceTipId, targetTipId], tenantId]
+    );
+    if (tips.rowCount !== 2) {
+      return JSON.stringify({ success: false, error: 'Version tip not accessible', status: 403 });
+    }
+    const byId = new Map(tips.rows.map((r: any) => [r.id, r]));
+    const sourceRow = byId.get(sourceTipId);
+    const targetRow = byId.get(targetTipId);
+    if (!sourceRow || !targetRow) {
+      return JSON.stringify({ success: false, error: 'Version tip not accessible', status: 403 });
+    }
+
+    const targetSpec = await buildOpenApiSpecJsonForVersion(
+      {
+        id: targetRow.id,
+        version_id: targetRow.version_id,
+        description: targetRow.description,
+        project_id: targetRow.project_id,
+      },
+      targetRow.project_name
+    );
+    const sourceSpec = await buildOpenApiSpecJsonForVersion(
+      {
+        id: sourceRow.id,
+        version_id: sourceRow.version_id,
+        description: sourceRow.description,
+        project_id: sourceRow.project_id,
+      },
+      sourceRow.project_name
+    );
+
+    const { summary, classification } = await mergePreviewFromSpecs(targetSpec, sourceSpec);
+    return JSON.stringify({
+      success: true,
+      sourceTipVersionId: sourceTipId,
+      targetTipVersionId: targetTipId,
+      summary,
+      classification,
+      mergeBaseVersionId: null,
+    });
+  } catch (error: any) {
+    console.error('mergeVersionBranchesPreviewServer:', error);
+    return JSON.stringify({ success: false, error: error.message, status: 500 });
   }
 }
 

--- a/objectified-ui/lib/version-merge.ts
+++ b/objectified-ui/lib/version-merge.ts
@@ -1,0 +1,33 @@
+/**
+ * Git-like merge preview helpers: compare OpenAPI snapshots and classify conflicts.
+ */
+
+import { compareSchemas, type DiffSummary } from './schema-diff';
+
+/** Compare target vs source specs: merge source into target; blocking = modified + removed paths. */
+export function classifyMergeDiff(summary: DiffSummary): {
+  canAutoMerge: boolean;
+  conflictPaths: string[];
+  addedSchemaNames: string[];
+} {
+  const conflictPaths = [
+    ...summary.modified.map((d) => d.path),
+    ...summary.removed.map((d) => d.path),
+  ];
+  const addedSchemaNames = summary.added
+    .filter((d) => d.itemType === 'schema' && d.path.startsWith('schemas.'))
+    .map((d) => d.path.replace(/^schemas\./, ''));
+  return {
+    canAutoMerge: conflictPaths.length === 0,
+    conflictPaths,
+    addedSchemaNames,
+  };
+}
+
+export async function mergePreviewFromSpecs(targetSpecJson: string, sourceSpecJson: string): Promise<{
+  summary: DiffSummary;
+  classification: ReturnType<typeof classifyMergeDiff>;
+}> {
+  const summary = compareSchemas(targetSpecJson, sourceSpecJson);
+  return { summary, classification: classifyMergeDiff(summary) };
+}

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.9.30",
+  "version": "0.9.31",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -5,6 +5,7 @@ We continue to improve the platform based on your feedback with improvements and
 ---
 
 ## UI:
+- **Versions (#500):** **Named branches** (tip = version snapshot), **merge preview** and **apply merge** with optimistic `baseRevisionId` / target tip; merge revisions record **two parent** version ids; conflict banner when overlapping schema paths differ (merge-base LCA planned in #2593)
 - **Studio Code / GraphQL (#147):** GraphQL SDL in the Code tab is generated from a **Handlebars template** (`templates/graphql/graphql-schema.hbs`) instead of inlined string building, aligned with OpenAPI and Arazzo; template loader init is synchronous so tooling can import it safely
 - **Schema quality details (#2548):** **Studio header** Schema quality is **clickable** — opens a dialog with **letter grade (A–F)**, weighted **factor table**, and the same **score band guide** as import quality. **Schema Metrics** shows the same **overall schema quality** block (numeric score + letter + guide) above the per-metric controls
 - **Studio schema quality (#245):** **Overall score (0–100)** in the Studio header — weighted blend of documentation, naming, structural load (inverted complexity), and canvas layout quality; updates live on the Canvas

--- a/objectified-ui/src/app/ade/dashboard/versions/page.tsx
+++ b/objectified-ui/src/app/ade/dashboard/versions/page.tsx
@@ -672,7 +672,7 @@ const Versions = () => {
         if (r.status === 409 && d.code === 'MERGE_CONFLICT') {
           toast.error('Merge blocked: overlapping changes. Resolve conflicts using a future merge flow.');
           setMergePreviewData((prev) => ({
-            ...prev,
+            ...(prev ?? {}),
             classification: {
               canAutoMerge: false,
               conflictPaths: d.conflictPaths ?? [],

--- a/objectified-ui/src/app/ade/dashboard/versions/page.tsx
+++ b/objectified-ui/src/app/ade/dashboard/versions/page.tsx
@@ -2,7 +2,7 @@
 
 import { useSession } from 'next-auth/react';
 import { useEffect, useState, useRef } from 'react';
-import { Plus, Edit2, Trash2, Package, AlertCircle, Lock, Unlock, CheckCircle, Eye, Copy, MoreVertical, Network, Snowflake } from 'lucide-react';
+import { Plus, Edit2, Trash2, Package, AlertCircle, Lock, Unlock, CheckCircle, Eye, Copy, MoreVertical, Network, Snowflake, GitBranch, GitMerge } from 'lucide-react';
 import dynamic from 'next/dynamic';
 import {
   Dialog,
@@ -66,6 +66,17 @@ interface Version {
   published_at: string | null;
   creator_name: string;
   creator_email: string;
+  parent_version_id?: string | null;
+  merge_parent_version_id?: string | null;
+}
+
+interface VersionBranchRow {
+  id: string;
+  name: string;
+  tip_version_id: string;
+  tip_version_string?: string;
+  created_at?: string;
+  created_by?: string | null;
 }
 
 const Versions = () => {
@@ -126,6 +137,24 @@ const Versions = () => {
   const [hasClassSchemaMap, setHasClassSchemaMap] = useState<Record<string, boolean>>({});
   const [freezingSchemaVersionId, setFreezingSchemaVersionId] = useState<string | null>(null);
 
+  const [versionBranches, setVersionBranches] = useState<VersionBranchRow[]>([]);
+  const [showBranchDialog, setShowBranchDialog] = useState(false);
+  const [branchFromVersionId, setBranchFromVersionId] = useState<string>('');
+  const [branchNameInput, setBranchNameInput] = useState('');
+  const [branchSaving, setBranchSaving] = useState(false);
+
+  const [showMergeDialog, setShowMergeDialog] = useState(false);
+  const [mergeSourceBranch, setMergeSourceBranch] = useState('');
+  const [mergeTargetBranch, setMergeTargetBranch] = useState('');
+  const [mergePreviewLoading, setMergePreviewLoading] = useState(false);
+  const [mergeApplyLoading, setMergeApplyLoading] = useState(false);
+  const [mergePreviewData, setMergePreviewData] = useState<{
+    classification?: { canAutoMerge: boolean; conflictPaths: string[]; addedSchemaNames: string[] };
+    sourceTipVersionId?: string;
+    targetTipVersionId?: string;
+    mergeBaseVersionId?: string | null;
+  } | null>(null);
+
   const leftPanelRef = useRef<HTMLDivElement>(null);
   const rightPanelRef = useRef<HTMLDivElement>(null);
   const isSyncingScroll = useRef(false);
@@ -153,6 +182,23 @@ const Versions = () => {
 
   useEffect(() => { if (currentTenantId) loadProjects(); }, [currentTenantId]);
   useEffect(() => { if (selectedProjectId) loadVersions(); else setVersions([]); }, [selectedProjectId]);
+
+  const loadBranches = async () => {
+    if (!selectedProjectId) return;
+    try {
+      const r = await fetch(`/api/projects/${selectedProjectId}/version-branches`);
+      const d = await r.json();
+      if (d.success && Array.isArray(d.branches)) setVersionBranches(d.branches);
+      else setVersionBranches([]);
+    } catch {
+      setVersionBranches([]);
+    }
+  };
+
+  useEffect(() => {
+    if (selectedProjectId) loadBranches();
+    else setVersionBranches([]);
+  }, [selectedProjectId]);
 
   useEffect(() => {
     if (!currentTenantId || versions.length === 0) {
@@ -487,6 +533,160 @@ const Versions = () => {
       case 'unpublish': if (canUnpub) await handleUnpublish(version.id); else toast.warning('Only owner or admin can unpublish'); break;
       case 'freezeSchema': if (canModify(version)) await handleFreezeSchema(version); else toast.warning('Only owner or admin can freeze schema'); break;
       case 'delete': await handleDelete(version.id); break;
+      case 'branchFrom':
+        setBranchFromVersionId(version.id);
+        setBranchNameInput('');
+        setShowBranchDialog(true);
+        break;
+    }
+  };
+
+  const handleCreateBranchSubmit = async () => {
+    const name = branchNameInput.trim();
+    if (!name || !branchFromVersionId || !selectedProjectId) {
+      toast.warning('Enter a branch name');
+      return;
+    }
+    setBranchSaving(true);
+    try {
+      const r = await fetch(`/api/projects/${selectedProjectId}/version-branches`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name, fromVersionId: branchFromVersionId }),
+      });
+      const d = await r.json();
+      if (d.success) {
+        toast.success(`Branch "${name}" created`);
+        setShowBranchDialog(false);
+        await loadBranches();
+      } else {
+        toast.error(d.error || 'Could not create branch');
+      }
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'Could not create branch');
+    } finally {
+      setBranchSaving(false);
+    }
+  };
+
+  const handleDeleteBranch = async (branchId: string) => {
+    if (!selectedProjectId) return;
+    const ok = await confirmDialog({
+      title: 'Delete branch',
+      message: 'Remove this named branch? The version records are not deleted.',
+      variant: 'danger',
+      confirmLabel: 'Delete',
+      cancelLabel: 'Cancel',
+    });
+    if (!ok) return;
+    try {
+      const r = await fetch(`/api/projects/${selectedProjectId}/version-branches/${branchId}`, {
+        method: 'DELETE',
+      });
+      const d = await r.json();
+      if (d.success) {
+        toast.success('Branch removed');
+        await loadBranches();
+      } else {
+        toast.error(d.error || 'Could not delete branch');
+      }
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'Could not delete branch');
+    }
+  };
+
+  const runMergePreview = async () => {
+    if (!selectedProjectId || !mergeSourceBranch.trim() || !mergeTargetBranch.trim()) {
+      toast.warning('Select source and target branch names');
+      return;
+    }
+    if (mergeSourceBranch.trim() === mergeTargetBranch.trim()) {
+      toast.warning('Source and target must be different branches');
+      return;
+    }
+    setMergePreviewLoading(true);
+    setMergePreviewData(null);
+    try {
+      const r = await fetch(`/api/projects/${selectedProjectId}/version-branches/merge-preview`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          sourceBranchName: mergeSourceBranch.trim(),
+          targetBranchName: mergeTargetBranch.trim(),
+        }),
+      });
+      const d = await r.json();
+      if (d.success) {
+        setMergePreviewData({
+          classification: d.classification,
+          sourceTipVersionId: d.sourceTipVersionId,
+          targetTipVersionId: d.targetTipVersionId,
+          mergeBaseVersionId: d.mergeBaseVersionId ?? null,
+        });
+        if (!d.classification?.canAutoMerge) {
+          toast.info('Merge preview: conflicts detected — apply is blocked until resolved.');
+        }
+      } else {
+        toast.error(d.error || 'Preview failed');
+      }
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'Preview failed');
+    } finally {
+      setMergePreviewLoading(false);
+    }
+  };
+
+  const runMergeApply = async () => {
+    if (!selectedProjectId || !mergeSourceBranch.trim() || !mergeTargetBranch.trim()) {
+      toast.warning('Select source and target branch names');
+      return;
+    }
+    if (mergeSourceBranch.trim() === mergeTargetBranch.trim()) {
+      toast.warning('Source and target must be different branches');
+      return;
+    }
+    const target = versionBranches.find((b) => b.name === mergeTargetBranch.trim());
+    if (!target) {
+      toast.error('Target branch not found in list — refresh branches');
+      return;
+    }
+    setMergeApplyLoading(true);
+    try {
+      const r = await fetch(`/api/projects/${selectedProjectId}/version-branches/merge`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          sourceBranchName: mergeSourceBranch.trim(),
+          targetBranchName: mergeTargetBranch.trim(),
+          baseRevisionId: target.tip_version_id,
+        }),
+      });
+      const d = await r.json();
+      if (d.success) {
+        toast.success(`Merged into ${mergeTargetBranch.trim()} — new version ${d.version?.version_id ?? ''}`);
+        setShowMergeDialog(false);
+        setMergePreviewData(null);
+        await loadVersions();
+        await loadBranches();
+      } else {
+        if (r.status === 409 && d.code === 'MERGE_CONFLICT') {
+          toast.error('Merge blocked: overlapping changes. Resolve conflicts using a future merge flow.');
+          setMergePreviewData((prev) => ({
+            ...prev,
+            classification: {
+              canAutoMerge: false,
+              conflictPaths: d.conflictPaths ?? [],
+              addedSchemaNames: prev?.classification?.addedSchemaNames ?? [],
+            },
+          }));
+        } else {
+          toast.error(typeof d.error === 'string' ? d.error : 'Merge failed');
+        }
+      }
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'Merge failed');
+    } finally {
+      setMergeApplyLoading(false);
     }
   };
 
@@ -561,6 +761,20 @@ const Versions = () => {
                 <Copy className="h-4 w-4 mr-2" />
                 Compare
               </Button>
+              <Button
+                variant="secondary"
+                onClick={() => {
+                  setMergeSourceBranch('');
+                  setMergeTargetBranch('');
+                  setMergePreviewData(null);
+                  setShowMergeDialog(true);
+                }}
+                disabled={!selectedProjectId || versionBranches.length < 2}
+                title={versionBranches.length < 2 ? 'Create at least two named branches to merge' : undefined}
+              >
+                <GitMerge className="h-4 w-4 mr-2" />
+                Merge branches
+              </Button>
               <Button onClick={handleCreateClick} disabled={!selectedProjectId}>
                 <Plus className="h-4 w-4 mr-2" />
                 Add Version
@@ -571,7 +785,40 @@ const Versions = () => {
       </header>
 
       <main className="flex-1 overflow-y-auto p-6">
-        <div className="max-w-7xl mx-auto">
+        <div className="max-w-7xl mx-auto space-y-6">
+      {selectedProjectId && versionBranches.length > 0 && (
+        <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-sm border border-gray-100 dark:border-gray-700 p-4">
+          <div className="flex items-center gap-2 mb-3">
+            <GitBranch className="h-5 w-5 text-indigo-600 dark:text-indigo-400" />
+            <h3 className="text-sm font-semibold text-gray-900 dark:text-white">Named branches</h3>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {versionBranches.map((b) => (
+              <div
+                key={b.id}
+                className="inline-flex items-center gap-2 rounded-lg border border-gray-200 dark:border-gray-600 px-3 py-1.5 text-sm bg-gray-50 dark:bg-gray-900/50"
+              >
+                <span className="font-mono font-medium text-gray-900 dark:text-white">{b.name}</span>
+                <span className="text-gray-500 dark:text-gray-400">→ v{b.tip_version_string ?? '?'}</span>
+                {(effectiveIsAdmin || b.created_by === currentUserId) && (
+                  <button
+                    type="button"
+                    onClick={() => handleDeleteBranch(b.id)}
+                    className="text-red-600 dark:text-red-400 hover:underline text-xs"
+                  >
+                    Remove
+                  </button>
+                )}
+              </div>
+            ))}
+          </div>
+          <p className="text-xs text-gray-500 dark:text-gray-400 mt-2">
+            Use &quot;Branch from here&quot; on a version row to create a pointer. Merge uses optimistic concurrency on the target tip (
+            <code className="text-xs">baseRevisionId</code>).
+          </p>
+        </div>
+      )}
+
       {/* Versions List */}
       {versions.length === 0 ? (
         <EmptyState
@@ -652,7 +899,7 @@ const Versions = () => {
                             }}
                           />
                           <div
-                            className="fixed w-48 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg z-20"
+                            className="fixed w-56 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg z-20"
                             style={{
                               top: `${dropdownPosition.top}px`,
                               right: `${dropdownPosition.right}px`
@@ -679,6 +926,17 @@ const Versions = () => {
                               >
                                 <Network className="w-4 h-4 text-teal-500" />
                                 Relationship graph
+                              </button>
+                              <button
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  setOpenVersionDropdown(null);
+                                  handleRowAction('branchFrom', version);
+                                }}
+                                className="w-full px-4 py-2 text-left text-sm hover:bg-gray-100 dark:hover:bg-gray-800 flex items-center gap-3 text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white transition-colors"
+                              >
+                                <GitBranch className="w-4 h-4 text-indigo-500" />
+                                Branch from here
                               </button>
                               <button
                                 onClick={(e) => {
@@ -1283,6 +1541,104 @@ const Versions = () => {
           <DialogFooter className="flex-shrink-0">
             {diffResult.length > 0 && <Button variant="outline" onClick={() => { setDiffResult([]); setCompareSpec1(''); setCompareSpec2(''); }}>Compare Different Versions</Button>}
             <Button variant="outline" onClick={() => setShowCompareDialog(false)}>Close</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={showBranchDialog} onOpenChange={(open) => !branchSaving && setShowBranchDialog(open)}>
+        <DialogContent className="max-w-md" aria-describedby={undefined}>
+          <DialogHeader>
+            <DialogTitle>Create named branch</DialogTitle>
+            <DialogDescription>
+              Point a new branch name at this version snapshot. Further work can advance the tip via merge workflows.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-3 py-2">
+            <div className="space-y-1">
+              <Label htmlFor="branch-name">Branch name</Label>
+              <Input
+                id="branch-name"
+                value={branchNameInput}
+                onChange={(e) => setBranchNameInput(e.target.value)}
+                placeholder="e.g. feature/payments"
+                autoComplete="off"
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setShowBranchDialog(false)} disabled={branchSaving}>
+              Cancel
+            </Button>
+            <Button onClick={handleCreateBranchSubmit} disabled={branchSaving || !branchNameInput.trim()}>
+              {branchSaving ? 'Saving…' : 'Create branch'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={showMergeDialog} onOpenChange={(open) => !mergePreviewLoading && !mergeApplyLoading && setShowMergeDialog(open)}>
+        <DialogContent className="max-w-lg" aria-describedby={undefined}>
+          <DialogHeader>
+            <DialogTitle>Merge branches</DialogTitle>
+            <DialogDescription>
+              Preview compares branch tips (merge-base from #2593 not yet applied). Apply creates a merge revision with two parents when there are no overlapping schema conflicts.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-3 py-2">
+            <div className="space-y-1">
+              <Label>Source branch</Label>
+              <Select value={mergeSourceBranch || '__pick__'} onValueChange={(v) => setMergeSourceBranch(v === '__pick__' ? '' : v)}>
+                <SelectTrigger><SelectValue placeholder="Choose branch" /></SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="__pick__">Choose branch</SelectItem>
+                  {versionBranches.map((b) => (
+                    <SelectItem key={b.id} value={b.name}>{b.name}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-1">
+              <Label>Target branch</Label>
+              <Select value={mergeTargetBranch || '__pick__'} onValueChange={(v) => setMergeTargetBranch(v === '__pick__' ? '' : v)}>
+                <SelectTrigger><SelectValue placeholder="Choose branch" /></SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="__pick__">Choose branch</SelectItem>
+                  {versionBranches.map((b) => (
+                    <SelectItem key={`t-${b.id}`} value={b.name}>{b.name}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            {mergePreviewData?.classification && (
+              <Alert variant={mergePreviewData.classification.canAutoMerge ? 'success' : 'error'}>
+                {mergePreviewData.classification.canAutoMerge
+                  ? 'No overlapping modified or removed paths — apply is allowed if the target tip has not moved.'
+                  : `Conflicts: ${mergePreviewData.classification.conflictPaths.length} path(s). Apply is blocked.`}
+              </Alert>
+            )}
+            {mergePreviewData?.mergeBaseVersionId === null && mergePreviewData?.classification && (
+              <p className="text-xs text-gray-500 dark:text-gray-400">Merge-base (LCA) is not computed yet (#2593); preview uses two-way diff between tips.</p>
+            )}
+          </div>
+          <DialogFooter className="gap-2 flex-wrap">
+            <Button variant="outline" onClick={() => setShowMergeDialog(false)} disabled={mergePreviewLoading || mergeApplyLoading}>
+              Close
+            </Button>
+            <Button variant="secondary" onClick={runMergePreview} disabled={mergePreviewLoading || mergeApplyLoading || !mergeSourceBranch || !mergeTargetBranch}>
+              {mergePreviewLoading ? 'Previewing…' : 'Preview merge'}
+            </Button>
+            <Button
+              onClick={runMergeApply}
+              disabled={
+                mergeApplyLoading ||
+                mergePreviewLoading ||
+                !mergeSourceBranch ||
+                !mergeTargetBranch ||
+                mergePreviewData?.classification?.canAutoMerge === false
+              }
+            >
+              {mergeApplyLoading ? 'Merging…' : 'Apply merge'}
+            </Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>

--- a/objectified-ui/src/app/api/projects/[projectId]/version-branches/[branchId]/route.ts
+++ b/objectified-ui/src/app/api/projects/[projectId]/version-branches/[branchId]/route.ts
@@ -23,9 +23,17 @@ export async function DELETE(
     }
     const { projectId, branchId } = await params;
     const raw = await deleteVersionBranch(branchId, projectId, tenantId, userId, isTenantAdmin);
-    const data = JSON.parse(raw) as { success: boolean; error?: string };
+    const data = JSON.parse(raw) as { success: boolean; error?: string; status?: number };
     if (!data.success) {
-      const st = data.error?.includes('not found') ? 404 : 403;
+      const error = data.error?.toLowerCase() ?? '';
+      const st =
+        typeof data.status === 'number'
+          ? data.status
+          : error.includes('not found')
+            ? 404
+            : error.includes('unauthorized') || error.includes('forbidden')
+              ? 403
+              : 500;
       return NextResponse.json(data, { status: st });
     }
     return NextResponse.json({ success: true });

--- a/objectified-ui/src/app/api/projects/[projectId]/version-branches/[branchId]/route.ts
+++ b/objectified-ui/src/app/api/projects/[projectId]/version-branches/[branchId]/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/app/api/auth/[...nextauth]/route';
+import { deleteVersionBranch } from '@lib/db/helper';
+
+/**
+ * DELETE /api/projects/[projectId]/version-branches/[branchId]
+ */
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ projectId: string; branchId: string }> }
+) {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session?.user) {
+      return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
+    }
+    const tenantId = (session.user as { current_tenant_id?: string }).current_tenant_id;
+    const userId = (session.user as { user_id?: string }).user_id;
+    const isTenantAdmin = Boolean((session.user as { is_tenant_admin?: boolean }).is_tenant_admin);
+    if (!tenantId || !userId) {
+      return NextResponse.json({ success: false, error: 'No tenant or user' }, { status: 400 });
+    }
+    const { projectId, branchId } = await params;
+    const raw = await deleteVersionBranch(branchId, projectId, tenantId, userId, isTenantAdmin);
+    const data = JSON.parse(raw) as { success: boolean; error?: string };
+    if (!data.success) {
+      const st = data.error?.includes('not found') ? 404 : 403;
+      return NextResponse.json(data, { status: st });
+    }
+    return NextResponse.json({ success: true });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : 'Internal server error';
+    return NextResponse.json({ success: false, error: msg }, { status: 500 });
+  }
+}

--- a/objectified-ui/src/app/api/projects/[projectId]/version-branches/merge-preview/route.ts
+++ b/objectified-ui/src/app/api/projects/[projectId]/version-branches/merge-preview/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/app/api/auth/[...nextauth]/route';
+import { mergeVersionBranchesPreviewServer } from '@lib/db/helper';
+
+/**
+ * POST /api/projects/[projectId]/version-branches/merge-preview
+ * Body: { sourceBranchName, targetBranchName }
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ projectId: string }> }
+) {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session?.user) {
+      return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
+    }
+    const tenantId = (session.user as { current_tenant_id?: string }).current_tenant_id;
+    if (!tenantId) {
+      return NextResponse.json({ success: false, error: 'No tenant selected' }, { status: 400 });
+    }
+    const { projectId } = await params;
+    const body = await request.json();
+    const sourceBranchName = typeof body.sourceBranchName === 'string' ? body.sourceBranchName : '';
+    const targetBranchName = typeof body.targetBranchName === 'string' ? body.targetBranchName : '';
+    if (!sourceBranchName.trim() || !targetBranchName.trim()) {
+      return NextResponse.json(
+        { success: false, error: 'sourceBranchName and targetBranchName are required' },
+        { status: 400 }
+      );
+    }
+    const raw = await mergeVersionBranchesPreviewServer({
+      projectId,
+      tenantId,
+      sourceBranchName,
+      targetBranchName,
+    });
+    const data = JSON.parse(raw) as { success: boolean; status?: number; error?: string; [k: string]: unknown };
+    const st = typeof data.status === 'number' ? data.status : data.success ? 200 : 500;
+    const { status: _s, ...rest } = data;
+    return NextResponse.json(rest, { status: st });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : 'Internal server error';
+    return NextResponse.json({ success: false, error: msg }, { status: 500 });
+  }
+}

--- a/objectified-ui/src/app/api/projects/[projectId]/version-branches/merge/route.ts
+++ b/objectified-ui/src/app/api/projects/[projectId]/version-branches/merge/route.ts
@@ -1,0 +1,59 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/app/api/auth/[...nextauth]/route';
+import { mergeVersionBranchesServer } from '@lib/db/helper';
+
+/**
+ * POST /api/projects/[projectId]/version-branches/merge
+ * Body: { sourceBranchName, targetBranchName, baseRevisionId } — baseRevisionId must match current target tip.
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ projectId: string }> }
+) {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session?.user) {
+      return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
+    }
+    const tenantId = (session.user as { current_tenant_id?: string }).current_tenant_id;
+    const userId = (session.user as { user_id?: string }).user_id;
+    if (!tenantId || !userId) {
+      return NextResponse.json({ success: false, error: 'No tenant or user' }, { status: 400 });
+    }
+    const { projectId } = await params;
+    const body = await request.json();
+    const sourceBranchName = typeof body.sourceBranchName === 'string' ? body.sourceBranchName : '';
+    const targetBranchName = typeof body.targetBranchName === 'string' ? body.targetBranchName : '';
+    const baseRevisionId = typeof body.baseRevisionId === 'string' ? body.baseRevisionId : '';
+    if (!sourceBranchName.trim() || !targetBranchName.trim() || !baseRevisionId.trim()) {
+      return NextResponse.json(
+        { success: false, error: 'sourceBranchName, targetBranchName, and baseRevisionId are required' },
+        { status: 400 }
+      );
+    }
+    const raw = await mergeVersionBranchesServer({
+      projectId,
+      tenantId,
+      userId,
+      sourceBranchName,
+      targetBranchName,
+      baseRevisionId,
+    });
+    const data = JSON.parse(raw) as {
+      success: boolean;
+      status?: number;
+      error?: string;
+      code?: string;
+      conflictPaths?: string[];
+      version?: unknown;
+      [k: string]: unknown;
+    };
+    const st = typeof data.status === 'number' ? data.status : data.success ? 200 : 500;
+    const { status: _s, ...rest } = data;
+    return NextResponse.json(rest, { status: st });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : 'Internal server error';
+    return NextResponse.json({ success: false, error: msg }, { status: 500 });
+  }
+}

--- a/objectified-ui/src/app/api/projects/[projectId]/version-branches/route.ts
+++ b/objectified-ui/src/app/api/projects/[projectId]/version-branches/route.ts
@@ -25,9 +25,16 @@ export async function GET(
     }
     const { projectId } = await params;
     const raw = await listVersionBranches(projectId, tenantId);
-    const data = JSON.parse(raw) as { success: boolean; branches?: unknown; error?: string };
+    const data = JSON.parse(raw) as { success: boolean; branches?: unknown; error?: string; status?: number };
     if (!data.success) {
-      return NextResponse.json(data, { status: 404 });
+      const error = data.error?.toLowerCase() ?? '';
+      const st =
+        typeof data.status === 'number'
+          ? data.status
+          : error.includes('not found')
+            ? 404
+            : 500;
+      return NextResponse.json(data, { status: st });
     }
     return NextResponse.json({ success: true, branches: data.branches });
   } catch (e) {

--- a/objectified-ui/src/app/api/projects/[projectId]/version-branches/route.ts
+++ b/objectified-ui/src/app/api/projects/[projectId]/version-branches/route.ts
@@ -1,0 +1,73 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/app/api/auth/[...nextauth]/route';
+import {
+  listVersionBranches,
+  createVersionBranch,
+} from '@lib/db/helper';
+
+/**
+ * GET /api/projects/[projectId]/version-branches
+ * POST /api/projects/[projectId]/version-branches — body: { name, fromVersionId }
+ */
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ projectId: string }> }
+) {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session?.user) {
+      return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
+    }
+    const tenantId = (session.user as { current_tenant_id?: string }).current_tenant_id;
+    if (!tenantId) {
+      return NextResponse.json({ success: false, error: 'No tenant selected' }, { status: 400 });
+    }
+    const { projectId } = await params;
+    const raw = await listVersionBranches(projectId, tenantId);
+    const data = JSON.parse(raw) as { success: boolean; branches?: unknown; error?: string };
+    if (!data.success) {
+      return NextResponse.json(data, { status: 404 });
+    }
+    return NextResponse.json({ success: true, branches: data.branches });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : 'Internal server error';
+    return NextResponse.json({ success: false, error: msg }, { status: 500 });
+  }
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ projectId: string }> }
+) {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session?.user) {
+      return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
+    }
+    const tenantId = (session.user as { current_tenant_id?: string }).current_tenant_id;
+    const userId = (session.user as { user_id?: string }).user_id;
+    if (!tenantId || !userId) {
+      return NextResponse.json({ success: false, error: 'No tenant or user' }, { status: 400 });
+    }
+    const { projectId } = await params;
+    const body = await request.json();
+    const name = typeof body.name === 'string' ? body.name : '';
+    const fromVersionId = typeof body.fromVersionId === 'string' ? body.fromVersionId : '';
+    if (!name.trim() || !fromVersionId.trim()) {
+      return NextResponse.json(
+        { success: false, error: 'name and fromVersionId are required' },
+        { status: 400 }
+      );
+    }
+    const raw = await createVersionBranch(projectId, tenantId, name, fromVersionId, userId);
+    const data = JSON.parse(raw) as { success: boolean; branch?: unknown; error?: string };
+    if (!data.success) {
+      return NextResponse.json(data, { status: data.error?.includes('already exists') ? 409 : 400 });
+    }
+    return NextResponse.json({ success: true, branch: data.branch });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : 'Internal server error';
+    return NextResponse.json({ success: false, error: msg }, { status: 500 });
+  }
+}

--- a/objectified-ui/tests/unit/version-branches.test.ts
+++ b/objectified-ui/tests/unit/version-branches.test.ts
@@ -454,7 +454,7 @@ describe('mergeVersionBranchesServer', () => {
     );
 
     // Verify BEGIN and COMMIT were called
-    const queryCalls = (getDbMock().query.mock.calls as string[][]).map((c) => (c[0] as string).trim());
+    const queryCalls = getDbMock().query.mock.calls.map((c) => String(c[0]).trim());
     expect(queryCalls).toContain('BEGIN');
     expect(queryCalls).toContain('COMMIT');
     expect(result.success).toBe(true);
@@ -497,7 +497,7 @@ describe('mergeVersionBranchesServer', () => {
       })
     );
 
-    const queryCalls = (getDbMock().query.mock.calls as string[][]).map((c) => (c[0] as string).trim());
+    const queryCalls = getDbMock().query.mock.calls.map((c) => String(c[0]).trim());
     expect(queryCalls).toContain('BEGIN');
     expect(queryCalls).toContain('ROLLBACK');
     expect(result.success).toBe(false);

--- a/objectified-ui/tests/unit/version-branches.test.ts
+++ b/objectified-ui/tests/unit/version-branches.test.ts
@@ -1,0 +1,505 @@
+/**
+ * Unit tests for version branch and merge helper functions in lib/db/helper.ts.
+ * Covers: isValidVersionBranchName, listVersionBranches, createVersionBranch,
+ * deleteVersionBranch, mergeVersionBranchesPreviewServer, and mergeVersionBranchesServer.
+ */
+
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+
+// Mock DB pool
+jest.mock('../../lib/db/db', () => ({
+  query: jest.fn(),
+}));
+
+// Mock bcrypt and crypto (required by helper.ts)
+jest.mock('bcrypt', () => ({ compare: jest.fn(), hash: jest.fn() }));
+jest.mock('crypto', () => ({ randomBytes: jest.fn(() => Buffer.from('test')) }));
+
+// Mock Next.js server-only headers
+jest.mock('next/headers', () => ({
+  cookies: jest.fn(() => ({ getAll: () => [] })),
+}));
+
+// Mock plan entitlements
+jest.mock('../../lib/db/plan-entitlements', () => ({
+  getPlanBlockMessageForNewProject: jest.fn(async () => null),
+  getPlanBlockMessageForNewVersion: jest.fn(async () => null),
+}));
+
+// Mock version-merge so we can control classification without real spec diffing
+jest.mock('../../lib/version-merge', () => ({
+  mergePreviewFromSpecs: jest.fn(),
+}));
+
+// Mock OpenAPI generation used by buildOpenApiSpecJsonForVersion
+jest.mock('../../src/app/utils/openapi', () => ({
+  generateOpenApiSpec: jest.fn(() => '{}'),
+}));
+
+import {
+  isValidVersionBranchName,
+  listVersionBranches,
+  createVersionBranch,
+  deleteVersionBranch,
+  mergeVersionBranchesPreviewServer,
+  mergeVersionBranchesServer,
+} from '../../lib/db/helper';
+import { mergePreviewFromSpecs } from '../../lib/version-merge';
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+function getDbMock() {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  return require('../../lib/db/db') as { query: jest.Mock };
+}
+
+const PROJECT_ID = 'proj-uuid-1';
+const TENANT_ID = 'tenant-uuid-1';
+const USER_ID = 'user-uuid-1';
+const BRANCH_ID = 'branch-uuid-1';
+const VERSION_ID = 'ver-uuid-1';
+const VERSION_ID_2 = 'ver-uuid-2';
+
+// ─── isValidVersionBranchName ─────────────────────────────────────────────────
+
+describe('isValidVersionBranchName', () => {
+  it('accepts simple alpha name', () => {
+    expect(isValidVersionBranchName('main')).toBe(true);
+  });
+
+  it('accepts names with digits, dots, dashes and slashes', () => {
+    expect(isValidVersionBranchName('feature/my-branch.1')).toBe(true);
+  });
+
+  it('rejects names starting with a digit', () => {
+    expect(isValidVersionBranchName('1-bad')).toBe(false);
+  });
+
+  it('rejects empty string', () => {
+    expect(isValidVersionBranchName('')).toBe(false);
+  });
+
+  it('rejects names with spaces', () => {
+    expect(isValidVersionBranchName('bad name')).toBe(false);
+  });
+
+  it('rejects names longer than 255 chars', () => {
+    expect(isValidVersionBranchName('a' + 'x'.repeat(255))).toBe(false);
+  });
+
+  it('accepts exactly 255-char name', () => {
+    expect(isValidVersionBranchName('a' + 'x'.repeat(254))).toBe(true);
+  });
+});
+
+// ─── listVersionBranches ─────────────────────────────────────────────────────
+
+describe('listVersionBranches', () => {
+  beforeEach(() => {
+    getDbMock().query.mockClear();
+  });
+
+  it('returns success:false when project not in tenant', async () => {
+    getDbMock().query.mockResolvedValueOnce({ rowCount: 0, rows: [] });
+    const result = JSON.parse(await listVersionBranches(PROJECT_ID, TENANT_ID));
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/not found/i);
+  });
+
+  it('returns branch list on success', async () => {
+    // assertProjectInTenant → 1 row
+    getDbMock().query.mockResolvedValueOnce({ rowCount: 1, rows: [{}] });
+    // list query → branches
+    const fakeBranch = {
+      id: BRANCH_ID,
+      project_id: PROJECT_ID,
+      name: 'main',
+      tip_version_id: VERSION_ID,
+      tip_version_string: '1.0.0',
+    };
+    getDbMock().query.mockResolvedValueOnce({ rowCount: 1, rows: [fakeBranch] });
+
+    const result = JSON.parse(await listVersionBranches(PROJECT_ID, TENANT_ID));
+    expect(result.success).toBe(true);
+    expect(result.branches).toHaveLength(1);
+    expect(result.branches[0].name).toBe('main');
+  });
+
+  it('uses AND v.project_id = b.project_id in the JOIN', async () => {
+    getDbMock().query.mockResolvedValueOnce({ rowCount: 1, rows: [{}] });
+    getDbMock().query.mockResolvedValueOnce({ rowCount: 0, rows: [] });
+    await listVersionBranches(PROJECT_ID, TENANT_ID);
+    const listCall = getDbMock().query.mock.calls[1];
+    expect((listCall[0] as string).toLowerCase()).toContain('v.project_id = b.project_id');
+  });
+
+  it('returns success:false on DB error', async () => {
+    getDbMock().query.mockResolvedValueOnce({ rowCount: 1, rows: [{}] });
+    getDbMock().query.mockRejectedValueOnce(new Error('DB down'));
+    const result = JSON.parse(await listVersionBranches(PROJECT_ID, TENANT_ID));
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/DB down/);
+  });
+});
+
+// ─── createVersionBranch ─────────────────────────────────────────────────────
+
+describe('createVersionBranch', () => {
+  beforeEach(() => {
+    getDbMock().query.mockClear();
+  });
+
+  it('rejects invalid branch name', async () => {
+    const result = JSON.parse(
+      await createVersionBranch(PROJECT_ID, TENANT_ID, '123bad', VERSION_ID, USER_ID)
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/letter/i);
+  });
+
+  it('returns success:false when project not in tenant', async () => {
+    getDbMock().query.mockResolvedValueOnce({ rowCount: 0, rows: [] });
+    const result = JSON.parse(
+      await createVersionBranch(PROJECT_ID, TENANT_ID, 'feature', VERSION_ID, USER_ID)
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/not found/i);
+  });
+
+  it('returns success:false when source version not found', async () => {
+    getDbMock().query.mockResolvedValueOnce({ rowCount: 1, rows: [{}] }); // project OK
+    getDbMock().query.mockResolvedValueOnce({ rowCount: 0, rows: [] });    // version missing
+    const result = JSON.parse(
+      await createVersionBranch(PROJECT_ID, TENANT_ID, 'feature', VERSION_ID, USER_ID)
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/version not found/i);
+  });
+
+  it('creates branch and returns success', async () => {
+    getDbMock().query.mockResolvedValueOnce({ rowCount: 1, rows: [{}] }); // project OK
+    getDbMock().query.mockResolvedValueOnce({ rowCount: 1, rows: [{ id: VERSION_ID }] }); // version found
+    const fakeBranch = { id: BRANCH_ID, name: 'feature', tip_version_id: VERSION_ID };
+    getDbMock().query.mockResolvedValueOnce({ rowCount: 1, rows: [fakeBranch] }); // insert
+    const result = JSON.parse(
+      await createVersionBranch(PROJECT_ID, TENANT_ID, 'feature', VERSION_ID, USER_ID)
+    );
+    expect(result.success).toBe(true);
+    expect(result.branch.name).toBe('feature');
+  });
+
+  it('returns duplicate error on unique constraint violation', async () => {
+    getDbMock().query.mockResolvedValueOnce({ rowCount: 1, rows: [{}] });
+    getDbMock().query.mockResolvedValueOnce({ rowCount: 1, rows: [{ id: VERSION_ID }] });
+    const pgError = Object.assign(new Error('duplicate key'), { code: '23505' });
+    getDbMock().query.mockRejectedValueOnce(pgError);
+    const result = JSON.parse(
+      await createVersionBranch(PROJECT_ID, TENANT_ID, 'feature', VERSION_ID, USER_ID)
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/already exists/i);
+  });
+});
+
+// ─── deleteVersionBranch ─────────────────────────────────────────────────────
+
+describe('deleteVersionBranch', () => {
+  beforeEach(() => {
+    getDbMock().query.mockClear();
+  });
+
+  it('returns success:false when project not in tenant', async () => {
+    getDbMock().query.mockResolvedValueOnce({ rowCount: 0, rows: [] });
+    const result = JSON.parse(
+      await deleteVersionBranch(BRANCH_ID, PROJECT_ID, TENANT_ID, USER_ID, false)
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/not found/i);
+  });
+
+  it('returns success:false when branch not found', async () => {
+    getDbMock().query.mockResolvedValueOnce({ rowCount: 1, rows: [{}] }); // project OK
+    getDbMock().query.mockResolvedValueOnce({ rowCount: 0, rows: [] });    // branch missing
+    const result = JSON.parse(
+      await deleteVersionBranch(BRANCH_ID, PROJECT_ID, TENANT_ID, USER_ID, false)
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/not found/i);
+  });
+
+  it('returns unauthorized when non-creator non-admin tries to delete', async () => {
+    getDbMock().query.mockResolvedValueOnce({ rowCount: 1, rows: [{}] }); // project OK
+    getDbMock().query.mockResolvedValueOnce({ rowCount: 1, rows: [{ id: BRANCH_ID, created_by: 'other-user' }] });
+    const result = JSON.parse(
+      await deleteVersionBranch(BRANCH_ID, PROJECT_ID, TENANT_ID, USER_ID, false)
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/creator|admin/i);
+  });
+
+  it('allows tenant admin to delete any branch', async () => {
+    getDbMock().query.mockResolvedValueOnce({ rowCount: 1, rows: [{}] });
+    getDbMock().query.mockResolvedValueOnce({ rowCount: 1, rows: [{ id: BRANCH_ID, created_by: 'other-user' }] });
+    getDbMock().query.mockResolvedValueOnce({ rowCount: 1, rows: [] }); // DELETE
+    const result = JSON.parse(
+      await deleteVersionBranch(BRANCH_ID, PROJECT_ID, TENANT_ID, USER_ID, true)
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it('allows creator to delete their own branch', async () => {
+    getDbMock().query.mockResolvedValueOnce({ rowCount: 1, rows: [{}] });
+    getDbMock().query.mockResolvedValueOnce({ rowCount: 1, rows: [{ id: BRANCH_ID, created_by: USER_ID }] });
+    getDbMock().query.mockResolvedValueOnce({ rowCount: 1, rows: [] });
+    const result = JSON.parse(
+      await deleteVersionBranch(BRANCH_ID, PROJECT_ID, TENANT_ID, USER_ID, false)
+    );
+    expect(result.success).toBe(true);
+  });
+});
+
+// ─── mergeVersionBranchesPreviewServer ───────────────────────────────────────
+
+describe('mergeVersionBranchesPreviewServer', () => {
+  beforeEach(() => {
+    getDbMock().query.mockClear();
+    (mergePreviewFromSpecs as jest.Mock).mockClear();
+  });
+
+  it('returns error when project not found', async () => {
+    getDbMock().query.mockResolvedValueOnce({ rowCount: 0, rows: [] });
+    const result = JSON.parse(
+      await mergeVersionBranchesPreviewServer({
+        projectId: PROJECT_ID,
+        tenantId: TENANT_ID,
+        sourceBranchName: 'src',
+        targetBranchName: 'tgt',
+      })
+    );
+    expect(result.success).toBe(false);
+    expect(result.status).toBe(404);
+  });
+
+  it('returns error when branches not found', async () => {
+    getDbMock().query.mockResolvedValueOnce({ rowCount: 1, rows: [{}] }); // project
+    getDbMock().query.mockResolvedValueOnce({ rowCount: 0, rows: [] });    // src branch
+    getDbMock().query.mockResolvedValueOnce({ rowCount: 0, rows: [] });    // tgt branch
+    const result = JSON.parse(
+      await mergeVersionBranchesPreviewServer({
+        projectId: PROJECT_ID,
+        tenantId: TENANT_ID,
+        sourceBranchName: 'src',
+        targetBranchName: 'tgt',
+      })
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/branch not found/i);
+  });
+
+  it('returns preview classification on success', async () => {
+    getDbMock().query.mockResolvedValueOnce({ rowCount: 1, rows: [{}] }); // project
+    getDbMock().query.mockResolvedValueOnce({ rowCount: 1, rows: [{ tip_version_id: VERSION_ID }] }); // src
+    getDbMock().query.mockResolvedValueOnce({ rowCount: 1, rows: [{ tip_version_id: VERSION_ID_2 }] }); // tgt
+    // tips query
+    getDbMock().query.mockResolvedValueOnce({
+      rowCount: 2,
+      rows: [
+        { id: VERSION_ID, project_id: PROJECT_ID, version_id: '1.0.0', description: null, project_name: 'P' },
+        { id: VERSION_ID_2, project_id: PROJECT_ID, version_id: '1.1.0', description: null, project_name: 'P' },
+      ],
+    });
+    // getClassesForVersion called for each tip (mock returns empty list)
+    getDbMock().query.mockResolvedValue({ rowCount: 0, rows: [] });
+
+    (mergePreviewFromSpecs as jest.Mock).mockResolvedValueOnce({
+      summary: { added: [], modified: [], removed: [] },
+      classification: { canAutoMerge: true, conflictPaths: [], addedSchemaNames: [] },
+    });
+
+    const result = JSON.parse(
+      await mergeVersionBranchesPreviewServer({
+        projectId: PROJECT_ID,
+        tenantId: TENANT_ID,
+        sourceBranchName: 'src',
+        targetBranchName: 'tgt',
+      })
+    );
+    expect(result.success).toBe(true);
+    expect(result.classification.canAutoMerge).toBe(true);
+  });
+});
+
+// ─── mergeVersionBranchesServer ──────────────────────────────────────────────
+
+describe('mergeVersionBranchesServer', () => {
+  beforeEach(() => {
+    getDbMock().query.mockClear();
+    (mergePreviewFromSpecs as jest.Mock).mockClear();
+  });
+
+  it('returns error when project not found', async () => {
+    getDbMock().query.mockResolvedValueOnce({ rowCount: 0, rows: [] });
+    const result = JSON.parse(
+      await mergeVersionBranchesServer({
+        projectId: PROJECT_ID,
+        tenantId: TENANT_ID,
+        userId: USER_ID,
+        sourceBranchName: 'src',
+        targetBranchName: 'tgt',
+        baseRevisionId: VERSION_ID_2,
+      })
+    );
+    expect(result.success).toBe(false);
+    expect(result.status).toBe(404);
+  });
+
+  it('returns STALE_HEAD when baseRevisionId does not match target tip', async () => {
+    getDbMock().query.mockResolvedValueOnce({ rowCount: 1, rows: [{}] }); // project
+    getDbMock().query.mockResolvedValueOnce({ rowCount: 1, rows: [{ id: BRANCH_ID, tip_version_id: VERSION_ID, name: 'src' }] }); // src branch
+    getDbMock().query.mockResolvedValueOnce({ rowCount: 1, rows: [{ id: BRANCH_ID, tip_version_id: 'different-id', name: 'tgt' }] }); // tgt branch
+    const result = JSON.parse(
+      await mergeVersionBranchesServer({
+        projectId: PROJECT_ID,
+        tenantId: TENANT_ID,
+        userId: USER_ID,
+        sourceBranchName: 'src',
+        targetBranchName: 'tgt',
+        baseRevisionId: VERSION_ID_2,
+      })
+    );
+    expect(result.success).toBe(false);
+    expect(result.code).toBe('STALE_HEAD');
+  });
+
+  it('returns MERGE_CONFLICT when classification has overlapping paths', async () => {
+    getDbMock().query.mockResolvedValueOnce({ rowCount: 1, rows: [{}] }); // project
+    getDbMock().query.mockResolvedValueOnce({ rowCount: 1, rows: [{ id: BRANCH_ID, tip_version_id: VERSION_ID, name: 'src' }] });
+    getDbMock().query.mockResolvedValueOnce({ rowCount: 1, rows: [{ id: BRANCH_ID, tip_version_id: VERSION_ID_2, name: 'tgt' }] });
+    // tips
+    getDbMock().query.mockResolvedValueOnce({
+      rowCount: 2,
+      rows: [
+        { id: VERSION_ID, project_id: PROJECT_ID, version_id: '1.0.0', description: null, project_name: 'P', published: false },
+        { id: VERSION_ID_2, project_id: PROJECT_ID, version_id: '1.1.0', description: null, project_name: 'P', published: false },
+      ],
+    });
+    // getClassesForVersion calls
+    getDbMock().query.mockResolvedValue({ rowCount: 0, rows: [] });
+
+    (mergePreviewFromSpecs as jest.Mock).mockResolvedValueOnce({
+      summary: { added: [], modified: [{ path: 'schemas.User' }], removed: [] },
+      classification: { canAutoMerge: false, conflictPaths: ['schemas.User'], addedSchemaNames: [] },
+    });
+
+    const result = JSON.parse(
+      await mergeVersionBranchesServer({
+        projectId: PROJECT_ID,
+        tenantId: TENANT_ID,
+        userId: USER_ID,
+        sourceBranchName: 'src',
+        targetBranchName: 'tgt',
+        baseRevisionId: VERSION_ID_2,
+      })
+    );
+    expect(result.success).toBe(false);
+    expect(result.code).toBe('MERGE_CONFLICT');
+    expect(result.conflictPaths).toContain('schemas.User');
+  });
+
+  it('wraps apply in a transaction and commits on success', async () => {
+    getDbMock().query.mockResolvedValueOnce({ rowCount: 1, rows: [{}] }); // project
+    getDbMock().query.mockResolvedValueOnce({ rowCount: 1, rows: [{ id: BRANCH_ID, tip_version_id: VERSION_ID, name: 'src' }] });
+    getDbMock().query.mockResolvedValueOnce({ rowCount: 1, rows: [{ id: BRANCH_ID, tip_version_id: VERSION_ID_2, name: 'tgt' }] });
+    // tips
+    getDbMock().query.mockResolvedValueOnce({
+      rowCount: 2,
+      rows: [
+        { id: VERSION_ID, project_id: PROJECT_ID, version_id: '1.0.0', description: null, project_name: 'P', published: false },
+        { id: VERSION_ID_2, project_id: PROJECT_ID, version_id: '1.1.0', description: null, project_name: 'P', published: false },
+      ],
+    });
+    // getClassesForVersion x2 (for buildOpenApiSpec)
+    getDbMock().query.mockResolvedValueOnce({ rowCount: 0, rows: [] });
+    getDbMock().query.mockResolvedValueOnce({ rowCount: 0, rows: [] });
+
+    (mergePreviewFromSpecs as jest.Mock).mockResolvedValueOnce({
+      summary: { added: [], modified: [], removed: [] },
+      classification: { canAutoMerge: true, conflictPaths: [], addedSchemaNames: [] },
+    });
+
+    // getLatestVersionForProject
+    getDbMock().query.mockResolvedValueOnce({ rowCount: 1, rows: [{ version_id: '1.1.0' }] });
+    // getPlanBlockMessageForNewVersion (mocked above to null, no DB call needed)
+    // BEGIN
+    getDbMock().query.mockResolvedValueOnce({});
+    // INSERT INTO versions
+    const newVer = { id: 'new-ver-id', version_id: '1.1.1', project_id: PROJECT_ID };
+    getDbMock().query.mockResolvedValueOnce({ rows: [newVer] });
+    // copyClassesFromVersion inner query (SELECT+INSERT classes)
+    getDbMock().query.mockResolvedValueOnce({ rowCount: 0, rows: [] }); // list classes
+    // COMMIT
+    getDbMock().query.mockResolvedValueOnce({});
+    // UPDATE version_branches
+    getDbMock().query.mockResolvedValueOnce({});
+
+    const result = JSON.parse(
+      await mergeVersionBranchesServer({
+        projectId: PROJECT_ID,
+        tenantId: TENANT_ID,
+        userId: USER_ID,
+        sourceBranchName: 'src',
+        targetBranchName: 'tgt',
+        baseRevisionId: VERSION_ID_2,
+      })
+    );
+
+    // Verify BEGIN and COMMIT were called
+    const queryCalls = (getDbMock().query.mock.calls as string[][]).map((c) => (c[0] as string).trim());
+    expect(queryCalls).toContain('BEGIN');
+    expect(queryCalls).toContain('COMMIT');
+    expect(result.success).toBe(true);
+  });
+
+  it('rolls back transaction on copy failure', async () => {
+    getDbMock().query.mockResolvedValueOnce({ rowCount: 1, rows: [{}] }); // project
+    getDbMock().query.mockResolvedValueOnce({ rowCount: 1, rows: [{ id: BRANCH_ID, tip_version_id: VERSION_ID, name: 'src' }] });
+    getDbMock().query.mockResolvedValueOnce({ rowCount: 1, rows: [{ id: BRANCH_ID, tip_version_id: VERSION_ID_2, name: 'tgt' }] });
+    getDbMock().query.mockResolvedValueOnce({
+      rowCount: 2,
+      rows: [
+        { id: VERSION_ID, project_id: PROJECT_ID, version_id: '1.0.0', description: null, project_name: 'P', published: false },
+        { id: VERSION_ID_2, project_id: PROJECT_ID, version_id: '1.1.0', description: null, project_name: 'P', published: false },
+      ],
+    });
+    getDbMock().query.mockResolvedValueOnce({ rowCount: 0, rows: [] });
+    getDbMock().query.mockResolvedValueOnce({ rowCount: 0, rows: [] });
+
+    (mergePreviewFromSpecs as jest.Mock).mockResolvedValueOnce({
+      summary: { added: [], modified: [], removed: [] },
+      classification: { canAutoMerge: true, conflictPaths: [], addedSchemaNames: [] },
+    });
+
+    getDbMock().query.mockResolvedValueOnce({ rowCount: 1, rows: [{ version_id: '1.1.0' }] }); // latest
+    getDbMock().query.mockResolvedValueOnce({}); // BEGIN
+    getDbMock().query.mockResolvedValueOnce({ rows: [{ id: 'new-ver-id', version_id: '1.1.1' }] }); // INSERT version
+    // copyClassesFromVersion throws
+    getDbMock().query.mockRejectedValueOnce(new Error('copy failed'));
+    getDbMock().query.mockResolvedValueOnce({}); // ROLLBACK
+
+    const result = JSON.parse(
+      await mergeVersionBranchesServer({
+        projectId: PROJECT_ID,
+        tenantId: TENANT_ID,
+        userId: USER_ID,
+        sourceBranchName: 'src',
+        targetBranchName: 'tgt',
+        baseRevisionId: VERSION_ID_2,
+      })
+    );
+
+    const queryCalls = (getDbMock().query.mock.calls as string[][]).map((c) => (c[0] as string).trim());
+    expect(queryCalls).toContain('BEGIN');
+    expect(queryCalls).toContain('ROLLBACK');
+    expect(result.success).toBe(false);
+  });
+});

--- a/objectified-ui/tests/version-merge.test.ts
+++ b/objectified-ui/tests/version-merge.test.ts
@@ -1,0 +1,29 @@
+import { classifyMergeDiff } from '../lib/version-merge';
+import type { DiffSummary } from '../lib/schema-diff';
+
+describe('classifyMergeDiff', () => {
+  test('treats modified and removed paths as blocking conflicts', () => {
+    const summary: DiffSummary = {
+      added: [],
+      removed: [{ type: 'removed', path: 'schemas.Gone', itemType: 'schema' }],
+      modified: [{ type: 'modified', path: 'schemas.Pet', itemType: 'schema', changes: ['type'] }],
+      unchanged: [],
+    };
+    const c = classifyMergeDiff(summary);
+    expect(c.canAutoMerge).toBe(false);
+    expect(c.conflictPaths).toContain('schemas.Pet');
+    expect(c.conflictPaths).toContain('schemas.Gone');
+  });
+
+  test('extracts added schema names from added entries', () => {
+    const summary: DiffSummary = {
+      added: [{ type: 'added', path: 'schemas.NewThing', itemType: 'schema' }],
+      removed: [],
+      modified: [],
+      unchanged: [],
+    };
+    const c = classifyMergeDiff(summary);
+    expect(c.canAutoMerge).toBe(true);
+    expect(c.addedSchemaNames).toContain('NewThing');
+  });
+});


### PR DESCRIPTION
## What
- Database: `versions.parent_version_id`, `versions.merge_parent_version_id`, and `version_branches` (named tip pointers).
- API (Next): list/create/delete branches; merge preview (no mutation); merge apply with `baseRevisionId` = target tip (optimistic concurrency).
- Merge uses schema diff between branch tips; blocks on modified/removed path overlaps (409 + `MERGE_CONFLICT`); auto-merge copies target then adds source-only schemas.
- REST: version list/get responses include parent ids (optional).
- UI: Versions dashboard — branch from row, branch list, merge dialog (preview + apply).

## How to test
1. Apply migration `objectified-db/scripts/20260409-140000.sql`.
2. Open **Dashboard → Versions**, create two branches from different version rows, run **Merge branches** — preview then apply when clean.

## Risk / notes
- Merge-base / LCA not computed yet (`mergeBaseVersionId: null`; see #2593).
- Full conflict-resolution UI is follow-up; overlapping changes return 409.

Closes #500

Made with [Cursor](https://cursor.com)