### PR TITLE
Fix #502 - Version revision notes and changelogs

### DIFF
--- a/docs/PLANNED_FEATURE_ROADMAP_VERSIONING.md
+++ b/docs/PLANNED_FEATURE_ROADMAP_VERSIONING.md
@@ -10,14 +10,13 @@ This represents the different versions of the Objectified specification and thei
 - ✅ Visual diff with highlights
 - ✅ Branch and merge workflows (named branch tips, merge preview, merge apply with two parents when auto-mergeable; merge-base #2593 follow-up)
 - ✅ Tag versions (v1.0, stable, beta) — #501
-- 📋 Version notes and changelogs
+- ✅ Version notes and changelogs (#502)
 - 📋 Fork versions for experiments
 - 📋 Protected versions (can't be deleted)
 - Show branches when creating copies of schemas
 
 | Ticket  | Feature Description                           |
 |---------|-----------------------------------------------|
-| #502    | Add and modify version notes and changelogs   |
 | #503    | Add ability to fork versions for testing      |
 | #504    | Implement protected versions feature          |
 | #505    | Show branches when creating copies of schemas |

--- a/objectified-rest/pyproject.toml
+++ b/objectified-rest/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "objectified-rest"
-version = "1.0.2"
+version = "1.0.3"
 description = "REST API for serving OpenAPI specifications from the Objectified database"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/objectified-rest/src/app/database.py
+++ b/objectified-rest/src/app/database.py
@@ -1373,13 +1373,26 @@ class Database:
             conn.rollback()
             raise e
 
-    def publish_version(self, version_record_id: str, tenant_id: str, user_id: str, visibility: str = "private") -> Optional[Dict[str, Any]]:
-        """Publish a version (only owner or tenant admin can publish). Captures class schemas to odb.class_schema."""
+    def publish_version(
+        self,
+        version_record_id: str,
+        tenant_id: str,
+        user_id: str,
+        visibility: str = "private",
+        description: Optional[str] = None,
+        change_log: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """Publish a version (only owner or tenant admin can publish). Captures class schemas to odb.class_schema.
+
+        description and change_log are written in the same update as publish (validated in routes).
+        """
         query = """
             UPDATE odb.versions v
             SET published = true,
                 published_at = CURRENT_TIMESTAMP,
                 visibility = %s,
+                description = %s,
+                change_log = %s,
                 updated_at = CURRENT_TIMESTAMP
             FROM odb.projects p
             WHERE v.id = %s
@@ -1401,7 +1414,10 @@ class Database:
         conn = self.connect()
         try:
             with conn.cursor() as cursor:
-                cursor.execute(query, (visibility, version_record_id, tenant_id, user_id, user_id))
+                cursor.execute(
+                    query,
+                    (visibility, description, change_log, version_record_id, tenant_id, user_id, user_id),
+                )
                 result = cursor.fetchone()
                 if result:
                     # Capture frozen JSON Schema 2020-12 per class into class_schema

--- a/objectified-rest/src/app/models.py
+++ b/objectified-rest/src/app/models.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, AliasChoices, ConfigDict
 from typing import Optional, Dict, Any, List, Union, Literal
 
 
@@ -210,13 +210,25 @@ class ProjectUpdateRequest(BaseModel):
 # ==================== Version Models ====================
 
 class VersionSchema(BaseModel):
-    """Pydantic model for a version."""
+    """Schema revision: shortMessage = commit-style note; changelog = release notes (markdown)."""
+
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
+
     id: str
     project_id: str
     creator_id: Optional[str] = None
     version_id: str
-    description: Optional[str] = None
-    change_log: Optional[str] = None
+    short_message: Optional[str] = Field(
+        default=None,
+        validation_alias=AliasChoices("shortMessage", "description"),
+        serialization_alias="shortMessage",
+        description="Human-readable revision note (stored as description in DB).",
+    )
+    changelog: Optional[str] = Field(
+        default=None,
+        validation_alias=AliasChoices("changelog", "change_log"),
+        description="Markdown changelog / release notes (stored as change_log in DB).",
+    )
     visibility: str = "private"
     published: bool = False
     published_at: Optional[Union[datetime, str]] = None
@@ -230,38 +242,56 @@ class VersionSchema(BaseModel):
     created_at: Optional[Union[datetime, str]] = None
     updated_at: Optional[Union[datetime, str]] = None
 
-    class Config:
-        from_attributes = True
-
 
 class VersionCreateRequest(BaseModel):
     """Request model for creating a version."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
     version_id: Optional[str] = None  # Optional - auto-generated if not provided
-    description: Optional[str] = None
-    change_log: Optional[str] = None
+    short_message: Optional[str] = Field(
+        default=None,
+        validation_alias=AliasChoices("shortMessage", "description"),
+        description="Revision note (commit message analog).",
+    )
+    changelog: Optional[str] = Field(
+        default=None,
+        validation_alias=AliasChoices("changelog", "change_log"),
+    )
     source_version_id: Optional[str] = None  # Copy classes from this version
     bump_strategy: Optional[str] = None  # 'patch' or 'minor' for auto-versioning
-
-    class Config:
-        from_attributes = True
 
 
 class VersionUpdateRequest(BaseModel):
     """Request model for updating a version."""
-    description: Optional[str] = None
-    change_log: Optional[str] = None
-    enabled: Optional[bool] = None
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(populate_by_name=True)
+
+    short_message: Optional[str] = Field(
+        default=None,
+        validation_alias=AliasChoices("shortMessage", "description"),
+    )
+    changelog: Optional[str] = Field(
+        default=None,
+        validation_alias=AliasChoices("changelog", "change_log"),
+    )
+    enabled: Optional[bool] = None
 
 
 class VersionPublishRequest(BaseModel):
-    """Request model for publishing a version."""
-    visibility: Optional[str] = "private"  # 'public' or 'private'
+    """Publish: optional last-minute revision note / changelog applied before freeze."""
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(populate_by_name=True)
+
+    visibility: Optional[str] = "private"  # 'public' or 'private'
+    short_message: Optional[str] = Field(
+        default=None,
+        validation_alias=AliasChoices("shortMessage", "description"),
+    )
+    changelog: Optional[str] = Field(
+        default=None,
+        validation_alias=AliasChoices("changelog", "change_log"),
+    )
 
 
 class VersionTagSchema(BaseModel):

--- a/objectified-rest/src/app/version_notes.py
+++ b/objectified-rest/src/app/version_notes.py
@@ -1,0 +1,76 @@
+"""Revision note + changelog validation (git-like commit / annotated tag analog).
+
+Size limits are tenant-scoped in the API contract; defaults apply until per-tenant
+policy is stored on tenants (future).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+
+@dataclass(frozen=True)
+class VersionNotesLimits:
+    max_short_message_chars: int
+    max_changelog_chars: int
+    require_short_message: bool
+
+
+DEFAULT_VERSION_NOTES_LIMITS = VersionNotesLimits(
+    max_short_message_chars=2000,
+    max_changelog_chars=65535,
+    require_short_message=True,
+)
+
+
+def limits_for_tenant(_tenant_id: str) -> VersionNotesLimits:
+    """Return effective limits for a tenant (defaults until DB-backed policy exists)."""
+    return DEFAULT_VERSION_NOTES_LIMITS
+
+
+def validate_version_notes(
+    short_message: Optional[str],
+    changelog: Optional[str],
+    limits: VersionNotesLimits,
+    *,
+    require_short_message: Optional[bool] = None,
+) -> Tuple[Optional[str], Optional[str]]:
+    """
+    Strip and validate revision note + changelog.
+
+    Returns (short_message, changelog) with None for empty optional strings.
+    Raises ValueError with a human-readable message on violation.
+    """
+    req = limits.require_short_message if require_short_message is None else require_short_message
+    sm = short_message.strip() if short_message else None
+    cl = changelog.strip() if changelog else None
+    if req and not sm:
+        raise ValueError("Revision note (shortMessage) is required")
+    if sm and len(sm) > limits.max_short_message_chars:
+        raise ValueError(
+            f"Revision note exceeds maximum length ({limits.max_short_message_chars} characters)"
+        )
+    if cl and len(cl) > limits.max_changelog_chars:
+        raise ValueError(
+            f"Changelog exceeds maximum length ({limits.max_changelog_chars} characters)"
+        )
+    return sm, cl
+
+
+def extract_breaking_hints_from_changelog(changelog: Optional[str]) -> list[str]:
+    """
+    Lines in markdown changelog that look like breaking-change bullets, for downstream
+    docs (#746 / migration guides). Best-effort; does not parse full Markdown.
+    """
+    if not changelog:
+        return []
+    out: list[str] = []
+    for raw in changelog.splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        lower = line.lower().lstrip("-*•").strip()
+        if lower.startswith("breaking:") or lower.startswith("breaking "):
+            out.append(raw.strip())
+    return out

--- a/objectified-rest/src/app/versions_routes.py
+++ b/objectified-rest/src/app/versions_routes.py
@@ -307,13 +307,14 @@ async def update_version(
         if request.enabled is not None:
             updates["enabled"] = request.enabled
 
-        if request.short_message is not None or request.changelog is not None:
-            merged_sm = (
-                request.short_message if request.short_message is not None else existing.get("description")
-            )
-            merged_cl = (
-                request.changelog if request.changelog is not None else existing.get("change_log")
-            )
+        note_keys = {"short_message", "changelog"}
+        if request.model_fields_set & note_keys:
+            merged_sm = existing.get("description")
+            merged_cl = existing.get("change_log")
+            if "short_message" in request.model_fields_set:
+                merged_sm = request.short_message
+            if "changelog" in request.model_fields_set:
+                merged_cl = request.changelog
             try:
                 merged_sm, merged_cl = validate_version_notes(
                     merged_sm,
@@ -323,9 +324,9 @@ async def update_version(
                 )
             except ValueError as ve:
                 raise HTTPException(status_code=400, detail=str(ve)) from ve
-            if request.short_message is not None:
+            if "short_message" in request.model_fields_set:
                 updates["description"] = merged_sm
-            if request.changelog is not None:
+            if "changelog" in request.model_fields_set:
                 updates["change_log"] = merged_cl
 
         # Update version

--- a/objectified-rest/src/app/versions_routes.py
+++ b/objectified-rest/src/app/versions_routes.py
@@ -6,7 +6,7 @@ All endpoints are tenant and project-scoped and require authentication via JWT t
 """
 
 import re
-from fastapi import APIRouter, HTTPException, Query, Depends
+from fastapi import APIRouter, HTTPException, Query, Depends, Body
 from typing import Optional, List, Dict, Any
 
 from .database import db
@@ -17,6 +17,7 @@ from .models import (
     VersionPublishRequest
 )
 from .auth import validate_authentication, get_authenticated_user_id
+from .version_notes import limits_for_tenant, validate_version_notes
 
 router = APIRouter(prefix="/v1/versions", tags=["versions"])
 
@@ -215,13 +216,24 @@ async def create_version(
         # Get creator_id from auth data (will be None for API key auth)
         creator_id = get_authenticated_user_id(auth_data)
 
+        limits = limits_for_tenant(auth_data["tenant_id"])
+        try:
+            sm, cl = validate_version_notes(
+                request.short_message,
+                request.changelog,
+                limits,
+                require_short_message=limits.require_short_message,
+            )
+        except ValueError as ve:
+            raise HTTPException(status_code=400, detail=str(ve)) from ve
+
         # Create version
         version = db.create_version(
             project_id=project_id,
             creator_id=creator_id,
             version_id=version_id,
-            description=request.description.strip() if request.description else None,
-            change_log=request.change_log.strip() if request.change_log else None
+            description=sm,
+            change_log=cl,
         )
 
         response_data = {**version}
@@ -290,14 +302,31 @@ async def update_version(
         )
 
     try:
-        # Build updates dict from request
-        updates = {}
-        if request.description is not None:
-            updates['description'] = request.description.strip() if request.description else None
-        if request.change_log is not None:
-            updates['change_log'] = request.change_log.strip() if request.change_log else None
+        limits = limits_for_tenant(auth_data["tenant_id"])
+        updates: Dict[str, Any] = {}
         if request.enabled is not None:
-            updates['enabled'] = request.enabled
+            updates["enabled"] = request.enabled
+
+        if request.short_message is not None or request.changelog is not None:
+            merged_sm = (
+                request.short_message if request.short_message is not None else existing.get("description")
+            )
+            merged_cl = (
+                request.changelog if request.changelog is not None else existing.get("change_log")
+            )
+            try:
+                merged_sm, merged_cl = validate_version_notes(
+                    merged_sm,
+                    merged_cl,
+                    limits,
+                    require_short_message=limits.require_short_message,
+                )
+            except ValueError as ve:
+                raise HTTPException(status_code=400, detail=str(ve)) from ve
+            if request.short_message is not None:
+                updates["description"] = merged_sm
+            if request.changelog is not None:
+                updates["change_log"] = merged_cl
 
         # Update version
         version = db.update_version(
@@ -329,8 +358,8 @@ async def publish_version(
     tenant_slug: str,
     project_id: str,
     version_record_id: str,
-    request: VersionPublishRequest = None,
-    auth_data: Dict[str, Any] = Depends(validate_authentication)
+    request: VersionPublishRequest = Body(default_factory=VersionPublishRequest),
+    auth_data: Dict[str, Any] = Depends(validate_authentication),
 ) -> VersionSchema:
     """
     Publish a version.
@@ -377,11 +406,37 @@ async def publish_version(
             detail="Publishing requires user authentication (JWT token)"
         )
 
-    visibility = request.visibility if request else "private"
+    visibility = request.visibility if request.visibility is not None else "private"
     if visibility not in ("public", "private"):
         visibility = "private"
 
-    version = db.publish_version(version_record_id, auth_data['tenant_id'], user_id, visibility)
+    limits = limits_for_tenant(auth_data["tenant_id"])
+    merged_sm = existing.get("description")
+    merged_cl = existing.get("change_log")
+    note_keys = {"short_message", "changelog"}
+    if request.model_fields_set & note_keys:
+        if "short_message" in request.model_fields_set:
+            merged_sm = request.short_message
+        if "changelog" in request.model_fields_set:
+            merged_cl = request.changelog
+    try:
+        merged_sm, merged_cl = validate_version_notes(
+            merged_sm,
+            merged_cl,
+            limits,
+            require_short_message=limits.require_short_message,
+        )
+    except ValueError as ve:
+        raise HTTPException(status_code=400, detail=str(ve)) from ve
+
+    version = db.publish_version(
+        version_record_id,
+        auth_data["tenant_id"],
+        user_id,
+        visibility,
+        description=merged_sm,
+        change_log=merged_cl,
+    )
 
     if not version:
         raise HTTPException(

--- a/objectified-rest/test_version_notes.py
+++ b/objectified-rest/test_version_notes.py
@@ -1,0 +1,29 @@
+import pytest
+
+from src.app.version_notes import (
+    DEFAULT_VERSION_NOTES_LIMITS,
+    extract_breaking_hints_from_changelog,
+    validate_version_notes,
+)
+
+
+def test_validate_version_notes_requires_short_message_when_policy_says_so():
+    with pytest.raises(ValueError, match="Revision note"):
+        validate_version_notes(None, None, DEFAULT_VERSION_NOTES_LIMITS)
+    sm, cl = validate_version_notes("x", None, DEFAULT_VERSION_NOTES_LIMITS)
+    assert sm == "x" and cl is None
+
+
+def test_validate_version_notes_max_length():
+    lim = DEFAULT_VERSION_NOTES_LIMITS
+    with pytest.raises(ValueError, match="Revision note exceeds"):
+        validate_version_notes("a" * (lim.max_short_message_chars + 1), None, lim)
+    with pytest.raises(ValueError, match="Changelog exceeds"):
+        validate_version_notes("ok", "b" * (lim.max_changelog_chars + 1), lim)
+
+
+def test_extract_breaking_hints_from_changelog():
+    text = "- breaking: foo\n- doc: bar\n* Breaking: baz"
+    hints = extract_breaking_hints_from_changelog(text)
+    assert "- breaking: foo" in hints
+    assert "* Breaking: baz" in hints

--- a/objectified-ui/lib/version-notes.ts
+++ b/objectified-ui/lib/version-notes.ts
@@ -1,0 +1,45 @@
+/** Align with objectified-rest `version_notes.DEFAULT_VERSION_NOTES_LIMITS` until tenant policy is loaded from the API. */
+export const VERSION_NOTES_LIMITS = {
+  maxShortMessageChars: 2000,
+  maxChangelogChars: 65535,
+  requireShortMessage: true,
+} as const;
+
+export function validateVersionNotesClient(
+  shortMessage: string,
+  changelog: string
+): { ok: true } | { ok: false; error: string } {
+  const sm = shortMessage.trim();
+  const cl = changelog.trim();
+  if (VERSION_NOTES_LIMITS.requireShortMessage && !sm) {
+    return { ok: false, error: 'Revision note is required' };
+  }
+  if (sm.length > VERSION_NOTES_LIMITS.maxShortMessageChars) {
+    return {
+      ok: false,
+      error: `Revision note exceeds ${VERSION_NOTES_LIMITS.maxShortMessageChars} characters`,
+    };
+  }
+  if (cl.length > VERSION_NOTES_LIMITS.maxChangelogChars) {
+    return {
+      ok: false,
+      error: `Changelog exceeds ${VERSION_NOTES_LIMITS.maxChangelogChars} characters`,
+    };
+  }
+  return { ok: true };
+}
+
+/** Best-effort lines for downstream breaking-changes / migration docs (#746, #747). */
+export function extractBreakingHintsFromChangelog(changelog: string | null | undefined): string[] {
+  if (!changelog) return [];
+  const out: string[] = [];
+  for (const raw of changelog.split('\n')) {
+    const line = raw.trim();
+    if (!line) continue;
+    const lower = line.replace(/^[-*•]\s*/, '').trim().toLowerCase();
+    if (lower.startsWith('breaking:') || lower.startsWith('breaking ')) {
+      out.push(line);
+    }
+  }
+  return out;
+}

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.9.33",
+  "version": "0.9.34",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -25,6 +25,7 @@ We continue to improve the platform based on your feedback with improvements and
 - **OpenAPI import:** one shared rule for “direct” schema properties — specs that mix top-level `properties` with inline `allOf` fragments now pick up both (aligned with the unified class importer)
 
 ## Versioning
+- **Revision notes & changelogs (#502):** **REST** returns `shortMessage` / `changelog` (aliases for `description` / `change_log`) with **tenant-default size limits**; **publish** applies last-minute notes in one transaction; **ADE → Versions** uses **Revision note** / **Changelog** labels, validation before create/edit/publish, **compare** shows both sides’ notes and **breaking:** bullets for downstream docs
 - **Version tags (#501):** **Git-like tags** on schema revisions — create/list/delete from **ADE → Versions** (optional message, channel, **immutable** lock); **REST** `GET/POST /v1/version-tags/{tenant}/{project}` and `PATCH/DELETE .../{tag_id}`; compare dialog can **set base/compare from a tag**; history table filters by tag
 - **Versions (#500):** **Named branches** (tip = version snapshot), **merge preview** and **apply merge** with optimistic `baseRevisionId` / target tip; merge revisions record **two parent** version ids; conflict banner when overlapping schema paths differ (merge-base LCA planned in #2593)
 

--- a/objectified-ui/src/app/ade/dashboard/versions/page.tsx
+++ b/objectified-ui/src/app/ade/dashboard/versions/page.tsx
@@ -57,8 +57,8 @@ interface Version {
   project_id: string;
   creator_id: string;
   version_id: string;
-  description: string | null;
-  change_log: string | null;
+  shortMessage: string | null;
+  changelog: string | null;
   enabled: boolean;
   published: boolean;
   deleted_at: string | null;
@@ -342,7 +342,7 @@ const Versions = () => {
   const handleEditClick = (version: Version) => {
     if (version.published) { setErrorMessage('Cannot edit published version'); return; }
     setSelectedVersion(version); setVersionId(version.version_id);
-    setDescription(version.description || ''); setChangeLog(version.change_log || '');
+    setDescription(version.shortMessage || ''); setChangeLog(version.changelog || '');
     setEnabled(version.enabled); setErrorMessage(''); setShowEditDialog(true);
   };
 
@@ -366,8 +366,8 @@ const Versions = () => {
     if (ver.creator_id !== currentUserId && !effectiveIsAdmin) return;
     setPublishVersionId(versionRecordId);
     setPublishVisibility('private');
-    setPublishShortMessage(ver.description?.trim() ?? '');
-    setPublishChangelog(ver.change_log?.trim() ?? '');
+    setPublishShortMessage(ver.shortMessage?.trim() ?? '');
+    setPublishChangelog(ver.changelog?.trim() ?? '');
     setShowPublishDialog(true);
   };
 
@@ -484,7 +484,7 @@ const Versions = () => {
         return { ...cls, properties: JSON.parse(propsResult) };
       }));
       const project = projects.find(p => p.id === version.project_id);
-      const spec = await generateOpenApiSpec(classesWithProperties, { projectName: project?.name, version: version.version_id, description: version.description || undefined });
+      const spec = await generateOpenApiSpec(classesWithProperties, { projectName: project?.name, version: version.version_id, description: version.shortMessage || undefined });
       setOpenApiSpec(spec);
     } catch (error) { setOpenApiSpec(JSON.stringify({ openapi: '3.1.0', info: { title: 'Error Loading Spec', version: version.version_id }, components: { schemas: {} } }, null, 2)); }
     finally { setIsLoadingSpec(false); }
@@ -520,7 +520,7 @@ const Versions = () => {
       return { ...cls, properties: JSON.parse(propsResult) };
     }));
     const project = projects.find(p => p.id === version.project_id);
-    return generateOpenApiSpec(classesWithProperties, { projectName: project?.name, version: version.version_id, description: version.description || undefined });
+    return generateOpenApiSpec(classesWithProperties, { projectName: project?.name, version: version.version_id, description: version.shortMessage || undefined });
   };
 
   const handleCompareVersions = async () => {
@@ -1080,8 +1080,8 @@ const Versions = () => {
                     </div>
                   </td>
                   <td className="px-6 py-4">
-                    <div className="text-sm text-gray-900 dark:text-white max-w-xs truncate">{version.description || '—'}</div>
-                    {version.change_log && <div className="text-xs text-gray-500 dark:text-gray-400 mt-1 max-w-xs truncate">{version.change_log}</div>}
+                    <div className="text-sm text-gray-900 dark:text-white max-w-xs truncate">{version.shortMessage || '—'}</div>
+                    {version.changelog && <div className="text-xs text-gray-500 dark:text-gray-400 mt-1 max-w-xs truncate">{version.changelog}</div>}
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap">
                     <div className="flex gap-2">
@@ -1273,7 +1273,7 @@ const Versions = () => {
                 <SelectTrigger><SelectValue placeholder={versions.length === 0 ? 'No versions available' : 'Create blank version'} /></SelectTrigger>
                 <SelectContent>
                   <SelectItem value="__blank__">Create blank version</SelectItem>
-                  {versions.map((v) => <SelectItem key={v.id} value={v.id}>{v.published ? '🔒 ' : ''}v{v.version_id} - {v.description || 'No description'}</SelectItem>)}
+                  {versions.map((v) => <SelectItem key={v.id} value={v.id}>{v.published ? '🔒 ' : ''}v{v.version_id} - {v.shortMessage || 'No description'}</SelectItem>)}
                 </SelectContent>
               </Select>
             </div>
@@ -1562,8 +1562,8 @@ const Versions = () => {
                   const vBase = versions.find((v) => v.id === compareVersion1Id);
                   const vTo = versions.find((v) => v.id === compareVersion2Id);
                   if (!vBase || !vTo) return null;
-                  const breakBase = extractBreakingHintsFromChangelog(vBase.change_log);
-                  const breakTo = extractBreakingHintsFromChangelog(vTo.change_log);
+                  const breakBase = extractBreakingHintsFromChangelog(vBase.changelog);
+                  const breakTo = extractBreakingHintsFromChangelog(vTo.changelog);
                   return (
                     <div className="mb-4 space-y-3 flex-shrink-0">
                       <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
@@ -1573,11 +1573,11 @@ const Versions = () => {
                           </div>
                           <div className="text-gray-600 dark:text-gray-400">
                             <span className="text-gray-500 dark:text-gray-500">Revision note:</span>{' '}
-                            {vBase.description?.trim() || '—'}
+                            {vBase.shortMessage?.trim() || '—'}
                           </div>
-                          {vBase.change_log?.trim() ? (
+                          {vBase.changelog?.trim() ? (
                             <pre className="mt-2 whitespace-pre-wrap text-xs text-gray-700 dark:text-gray-300 font-sans max-h-32 overflow-y-auto">
-                              {vBase.change_log}
+                              {vBase.changelog}
                             </pre>
                           ) : (
                             <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">No changelog</p>
@@ -1594,11 +1594,11 @@ const Versions = () => {
                           </div>
                           <div className="text-gray-600 dark:text-gray-400">
                             <span className="text-gray-500 dark:text-gray-500">Revision note:</span>{' '}
-                            {vTo.description?.trim() || '—'}
+                            {vTo.shortMessage?.trim() || '—'}
                           </div>
-                          {vTo.change_log?.trim() ? (
+                          {vTo.changelog?.trim() ? (
                             <pre className="mt-2 whitespace-pre-wrap text-xs text-gray-700 dark:text-gray-300 font-sans max-h-32 overflow-y-auto">
-                              {vTo.change_log}
+                              {vTo.changelog}
                             </pre>
                           ) : (
                             <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">No changelog</p>

--- a/objectified-ui/src/app/ade/dashboard/versions/page.tsx
+++ b/objectified-ui/src/app/ade/dashboard/versions/page.tsx
@@ -34,6 +34,7 @@ import { generateOpenApiSpec } from '../../../utils/openapi';
 import YAML from 'yaml';
 import { diffLines, Change } from 'diff';
 import { compareSchemas, type DiffSummary, getPathLabel } from '../../../../../lib/schema-diff';
+import { extractBreakingHintsFromChangelog, validateVersionNotesClient } from '../../../../../lib/version-notes';
 import RelationshipGraphDialog from './RelationshipGraphDialog';
 import { toast } from 'sonner';
 
@@ -101,6 +102,8 @@ const Versions = () => {
   const [showPublishDialog, setShowPublishDialog] = useState(false);
   const [publishVersionId, setPublishVersionId] = useState<string | null>(null);
   const [publishVisibility, setPublishVisibility] = useState<'private' | 'public'>('private');
+  const [publishShortMessage, setPublishShortMessage] = useState('');
+  const [publishChangelog, setPublishChangelog] = useState('');
   const [selectedVersion, setSelectedVersion] = useState<Version | null>(null);
   const [versionId, setVersionId] = useState('');
   const [autoGenerate, setAutoGenerate] = useState(true);
@@ -320,7 +323,8 @@ const Versions = () => {
 
   const handleCreateSubmit = async () => {
     if (!autoGenerate && !versionId.trim()) { setErrorMessage('Version ID is required when not auto-generating'); return; }
-    if (!description.trim()) { setErrorMessage('Description is required'); return; }
+    const notesCheck = validateVersionNotesClient(description, changeLog);
+    if (!notesCheck.ok) { setErrorMessage(notesCheck.error); return; }
     setIsLoading(true); setErrorMessage('');
     try {
       const result = await createVersion(selectedProjectId, currentUserId, autoGenerate ? null : versionId, description, changeLog, sourceVersionId || null, autoGenerate ? bumpStrategy : undefined);
@@ -344,7 +348,8 @@ const Versions = () => {
 
   const handleEditSubmit = async () => {
     if (!selectedVersion) return;
-    if (!description.trim()) { setErrorMessage('Description is required'); return; }
+    const notesCheck = validateVersionNotesClient(description, changeLog);
+    if (!notesCheck.ok) { setErrorMessage(notesCheck.error); return; }
     setIsLoading(true); setErrorMessage('');
     try {
       const result = await updateVersion(selectedVersion.id, description, changeLog, enabled);
@@ -361,6 +366,8 @@ const Versions = () => {
     if (ver.creator_id !== currentUserId && !effectiveIsAdmin) return;
     setPublishVersionId(versionRecordId);
     setPublishVisibility('private');
+    setPublishShortMessage(ver.description?.trim() ?? '');
+    setPublishChangelog(ver.change_log?.trim() ?? '');
     setShowPublishDialog(true);
   };
 
@@ -371,11 +378,21 @@ const Versions = () => {
       await alertDialog({ message: 'Version not found', variant: 'error' });
       return;
     }
+    const notesCheck = validateVersionNotesClient(publishShortMessage, publishChangelog);
+    if (!notesCheck.ok) {
+      await alertDialog({ message: notesCheck.error, variant: 'error' });
+      return;
+    }
     try {
       const res = await fetch(`/api/versions/${publishVersionId}/publish`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ projectId: version.project_id, visibility: publishVisibility }),
+        body: JSON.stringify({
+          projectId: version.project_id,
+          visibility: publishVisibility,
+          shortMessage: publishShortMessage.trim(),
+          changelog: publishChangelog.trim() || null,
+        }),
       });
       const response = await res.json();
       if (response.success) {
@@ -1037,7 +1054,7 @@ const Versions = () => {
             <thead className="bg-gradient-to-r from-gray-50 to-slate-50 dark:from-gray-900 dark:to-gray-800">
               <tr>
                 <th className="px-6 py-4 text-left text-xs font-bold text-gray-500 dark:text-gray-400 uppercase tracking-wider">Version</th>
-                <th className="px-6 py-4 text-left text-xs font-bold text-gray-500 dark:text-gray-400 uppercase tracking-wider">Description</th>
+                <th className="px-6 py-4 text-left text-xs font-bold text-gray-500 dark:text-gray-400 uppercase tracking-wider">Revision / changelog</th>
                 <th className="px-6 py-4 text-left text-xs font-bold text-gray-500 dark:text-gray-400 uppercase tracking-wider">Status</th>
                 <th className="px-6 py-4 text-left text-xs font-bold text-gray-500 dark:text-gray-400 uppercase tracking-wider">Created By</th>
                 <th className="px-6 py-4 text-left text-xs font-bold text-gray-500 dark:text-gray-400 uppercase tracking-wider">Created</th>
@@ -1292,12 +1309,12 @@ const Versions = () => {
               </div>
             )}
             <div className="space-y-2">
-              <Label>Description *</Label>
-              <Input value={description} onChange={(e) => setDescription(e.target.value)} disabled={isLoading} />
+              <Label>Revision note *</Label>
+              <Input value={description} onChange={(e) => setDescription(e.target.value)} disabled={isLoading} placeholder="Short summary (commit message)" />
             </div>
             <div className="space-y-2">
-              <Label>Change Log</Label>
-              <Textarea value={changeLog} onChange={(e) => setChangeLog(e.target.value)} rows={3} disabled={isLoading} />
+              <Label>Changelog (markdown)</Label>
+              <Textarea value={changeLog} onChange={(e) => setChangeLog(e.target.value)} rows={3} disabled={isLoading} placeholder="Release notes, breaking bullets (- breaking: …)" />
             </div>
           </div>
           <DialogFooter>
@@ -1318,12 +1335,12 @@ const Versions = () => {
               <Input value={versionId} disabled className="font-mono" />
             </div>
             <div className="space-y-2">
-              <Label>Description *</Label>
-              <Input value={description} onChange={(e) => setDescription(e.target.value)} disabled={isLoading} autoFocus />
+              <Label>Revision note *</Label>
+              <Input value={description} onChange={(e) => setDescription(e.target.value)} disabled={isLoading} autoFocus placeholder="Short summary (commit message)" />
             </div>
             <div className="space-y-2">
-              <Label>Change Log</Label>
-              <Textarea value={changeLog} onChange={(e) => setChangeLog(e.target.value)} rows={4} disabled={isLoading} />
+              <Label>Changelog (markdown)</Label>
+              <Textarea value={changeLog} onChange={(e) => setChangeLog(e.target.value)} rows={4} disabled={isLoading} placeholder="Release notes, breaking bullets (- breaking: …)" />
             </div>
           </div>
           <DialogFooter>
@@ -1357,6 +1374,24 @@ const Versions = () => {
               <p className="text-sm text-gray-500 dark:text-gray-400">
                 {publishVisibility === 'private' ? 'Access requires an API Key.' : 'OpenAPI Specification will be public without requiring an API Key.'}
               </p>
+            </div>
+            <div className="space-y-2">
+              <Label>Revision note *</Label>
+              <Input
+                value={publishShortMessage}
+                onChange={(e) => setPublishShortMessage(e.target.value)}
+                placeholder="Short summary frozen with this publish"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>Changelog (markdown)</Label>
+              <Textarea
+                value={publishChangelog}
+                onChange={(e) => setPublishChangelog(e.target.value)}
+                rows={5}
+                placeholder="Release notes; use - breaking: lines for migration docs"
+                className="font-mono text-sm"
+              />
             </div>
           </div>
           <DialogFooter>
@@ -1523,6 +1558,61 @@ const Versions = () => {
               </div>
             ) : (
               <div className="flex flex-col h-full">
+                {(() => {
+                  const vBase = versions.find((v) => v.id === compareVersion1Id);
+                  const vTo = versions.find((v) => v.id === compareVersion2Id);
+                  if (!vBase || !vTo) return null;
+                  const breakBase = extractBreakingHintsFromChangelog(vBase.change_log);
+                  const breakTo = extractBreakingHintsFromChangelog(vTo.change_log);
+                  return (
+                    <div className="mb-4 space-y-3 flex-shrink-0">
+                      <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                        <div className="rounded-lg border border-gray-200 dark:border-gray-600 bg-gray-50 dark:bg-gray-900/40 p-3 text-sm">
+                          <div className="font-semibold text-gray-900 dark:text-gray-100 mb-1">
+                            v{vBase.version_id} (base)
+                          </div>
+                          <div className="text-gray-600 dark:text-gray-400">
+                            <span className="text-gray-500 dark:text-gray-500">Revision note:</span>{' '}
+                            {vBase.description?.trim() || '—'}
+                          </div>
+                          {vBase.change_log?.trim() ? (
+                            <pre className="mt-2 whitespace-pre-wrap text-xs text-gray-700 dark:text-gray-300 font-sans max-h-32 overflow-y-auto">
+                              {vBase.change_log}
+                            </pre>
+                          ) : (
+                            <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">No changelog</p>
+                          )}
+                          {breakBase.length > 0 && (
+                            <p className="mt-2 text-xs text-amber-700 dark:text-amber-300">
+                              Breaking hints: {breakBase.join(' · ')}
+                            </p>
+                          )}
+                        </div>
+                        <div className="rounded-lg border border-gray-200 dark:border-gray-600 bg-gray-50 dark:bg-gray-900/40 p-3 text-sm">
+                          <div className="font-semibold text-gray-900 dark:text-gray-100 mb-1">
+                            v{vTo.version_id} (compare to)
+                          </div>
+                          <div className="text-gray-600 dark:text-gray-400">
+                            <span className="text-gray-500 dark:text-gray-500">Revision note:</span>{' '}
+                            {vTo.description?.trim() || '—'}
+                          </div>
+                          {vTo.change_log?.trim() ? (
+                            <pre className="mt-2 whitespace-pre-wrap text-xs text-gray-700 dark:text-gray-300 font-sans max-h-32 overflow-y-auto">
+                              {vTo.change_log}
+                            </pre>
+                          ) : (
+                            <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">No changelog</p>
+                          )}
+                          {breakTo.length > 0 && (
+                            <p className="mt-2 text-xs text-amber-700 dark:text-amber-300">
+                              Breaking hints: {breakTo.join(' · ')}
+                            </p>
+                          )}
+                        </div>
+                      </div>
+                    </div>
+                  );
+                })()}
                 {/* Tab Navigation */}
                 <div className="flex border-b border-gray-200 dark:border-gray-700 mb-4">
                   <button

--- a/objectified-ui/src/app/api/versions/[versionId]/publish/route.ts
+++ b/objectified-ui/src/app/api/versions/[versionId]/publish/route.ts
@@ -110,7 +110,12 @@ export async function POST(
 
     const tenantSlug = tenant.slug;
     const body = await request.json();
-    const { projectId, visibility } = body;
+    const { projectId, visibility, shortMessage, changelog } = body as {
+      projectId?: string;
+      visibility?: string;
+      shortMessage?: string | null;
+      changelog?: string | null;
+    };
 
     if (!projectId) {
       return NextResponse.json(
@@ -126,10 +131,14 @@ export async function POST(
       current_tenant_id: tenantId,
     });
 
+    const payload: Record<string, unknown> = { visibility: visibility || 'private' };
+    if (shortMessage !== undefined) payload.shortMessage = shortMessage;
+    if (changelog !== undefined) payload.changelog = changelog;
+
     const response = await fetch(`${REST_API_BASE_URL}/versions/${tenantSlug}/${projectId}/${versionId}/publish`, {
       method: 'POST',
       headers,
-      body: JSON.stringify({ visibility: visibility || 'private' }),
+      body: JSON.stringify(payload),
     });
 
     const { data, error, status } = await handleRestResponse(response, 'Failed to publish version');

--- a/objectified-ui/tests/version-notes.test.ts
+++ b/objectified-ui/tests/version-notes.test.ts
@@ -1,0 +1,26 @@
+import {
+  extractBreakingHintsFromChangelog,
+  validateVersionNotesClient,
+} from '../lib/version-notes';
+
+describe('version-notes', () => {
+  it('validateVersionNotesClient requires non-empty revision note', () => {
+    expect(validateVersionNotesClient('', '')).toEqual({
+      ok: false,
+      error: 'Revision note is required',
+    });
+    expect(validateVersionNotesClient('  ', 'x').ok).toBe(false);
+  });
+
+  it('validateVersionNotesClient accepts note with optional empty changelog', () => {
+    expect(validateVersionNotesClient('Ship v2', '')).toEqual({ ok: true });
+  });
+
+  it('extractBreakingHintsFromChangelog finds breaking bullets', () => {
+    const md = `- breaking: renamed id field\n- doc: readme\n* Breaking: API path`;
+    expect(extractBreakingHintsFromChangelog(md)).toEqual([
+      '- breaking: renamed id field',
+      '* Breaking: API path',
+    ]);
+  });
+});


### PR DESCRIPTION
## What / why
- **REST:** Single source of truth remains `odb.versions.description` / `change_log`; API exposes **`shortMessage`** and **`changelog`** (aliases `description` / `change_log` on input) with **validation and default size limits** (tenant hook `limits_for_tenant` for future policy).
- **Publish:** Merged revision note + changelog in the **same publish transaction**; optional last-minute overrides via `model_fields_set` on the publish body.
- **UI (ADE → Versions):** Labels **Revision note** / **Changelog (markdown)**; client validation aligned with REST; **Publish** dialog edits notes before freeze; **Compare** shows both revisions’ notes + **breaking:** bullet hints for downstream docs (#746/#747).

## How to test
1. `cd objectified-rest && . .venv/bin/activate && pytest test_version_notes.py test_versions_api.py -q`
2. `cd objectified-ui && yarn test tests/version-notes.test.ts && yarn build`
3. Manually: create/edit version with notes; open **Publish** and confirm notes persist; **Compare** two versions and verify notes panel above diff.

## Risk / notes
- **API response shape:** JSON responses now use `shortMessage` / `changelog` keys instead of `description` / `change_log` for version objects. Clients that still expect the old keys may need updates (or call with aliases on input; output is the new names).

Closes #502

Made with [Cursor](https://cursor.com)