### PR TITLE
Fix #2565 - Pre-commit policy (message + max payload)

### DIFF
--- a/docs/PLANNED_FEATURE_ROADMAP_GITLIKE.md
+++ b/docs/PLANNED_FEATURE_ROADMAP_GITLIKE.md
@@ -88,7 +88,7 @@ Workstreams below can proceed in parallel once shared contracts (revision id, he
 
 | Parallel track | Tickets | Notes |
 |----------------|---------|--------|
-| **A — Commit & metadata** | P0-01, P0-02 ✓, P0-03 | P0-02 (ADE **Commit** dialog) shipped after P0-01 API |
+| **A — Commit & metadata** | P0-01, P0-02 ✓, P0-03 ✓ | P0-02 (ADE **Commit** dialog) shipped after P0-01 API |
 | **B — Push & conflict UX** | P0-04, P0-05 | P0-05 can mock 409 until P0-04 stable |
 | **C — Pull efficiency** | P0-06 | Coordinate ETag with P0-04 head semantics |
 | **D — Studio status** | P0-07 | Depends on signals from B/C; can mock |
@@ -140,6 +140,8 @@ Add a Radix dialog for commit action with message, optional external reference, 
 ---
 
 ## P0-03: Add Pre-Commit Policy Enforcement (Message Required + Max Payload)
+
+**Status:** **Done** — REST evaluates policy before persisting revisions; `projects.metadata.commitPolicy` overrides defaults; errors use `POLICY_VIOLATION` / `PAYLOAD_TOO_LARGE`.
 
 **GitHub:** [#2565](https://github.com/KenSuenobu/objectified-commercial/issues/2565) · **Epic:** [#2558](https://github.com/KenSuenobu/objectified-commercial/issues/2558)
 

--- a/objectified-rest/pyproject.toml
+++ b/objectified-rest/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "objectified-rest"
-version = "1.0.15"
+version = "1.0.16"
 description = "REST API for serving OpenAPI specifications from the Objectified database"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/objectified-rest/src/app/config.py
+++ b/objectified-rest/src/app/config.py
@@ -27,6 +27,9 @@ class Settings(BaseSettings):
     # Embedding (Ollama) for data_snapshot vectorization
     ollama_base_url: str = "http://localhost:11434"
 
+    # Pre-commit policy default when project metadata omits maxCommitPayloadBytes (#2565)
+    commit_policy_max_payload_bytes_default: int = 5_242_880
+
     @property
     def effective_database_url(self) -> str:
         """Get the database URL, preferring DATABASE_URL over building from components."""

--- a/objectified-rest/src/app/version_merge_routes.py
+++ b/objectified-rest/src/app/version_merge_routes.py
@@ -39,6 +39,7 @@ from .schema_merge import (
 )
 from .version_notes import (
     CommitPolicyViolation,
+    commit_policy_http_exception,
     effective_commit_policy,
     enforce_max_commit_payload,
     validate_version_notes,
@@ -46,10 +47,6 @@ from .version_notes import (
 
 
 router = APIRouter(prefix="/v1/versions", tags=["versions"])
-
-
-def _commit_policy_http(exc: CommitPolicyViolation) -> HTTPException:
-    return HTTPException(status_code=400, detail={"code": exc.code, "message": exc.message})
 
 
 def _parse_project_metadata(metadata: Any) -> Dict[str, Any]:
@@ -286,7 +283,7 @@ async def version_branch_merge(
     try:
         enforce_max_commit_payload(body, limits)
     except CommitPolicyViolation as pe:
-        raise _commit_policy_http(pe) from pe
+        raise commit_policy_http_exception(pe) from pe
 
     latest = db.get_latest_version_for_project(project_id, tenant_id)
     new_version_string = bump_patch_version(latest) if latest else "0.1.0"
@@ -294,7 +291,7 @@ async def version_branch_merge(
     try:
         short_msg, _ = validate_version_notes(raw_msg, None, limits)
     except CommitPolicyViolation as e:
-        raise _commit_policy_http(e) from e
+        raise commit_policy_http_exception(e) from e
     if not short_msg:
         short_msg = raw_msg
 
@@ -585,7 +582,7 @@ async def version_branch_rollback(
     try:
         enforce_max_commit_payload(body, limits)
     except CommitPolicyViolation as pe:
-        raise _commit_policy_http(pe) from pe
+        raise commit_policy_http_exception(pe) from pe
 
     latest = db.get_latest_version_for_project(project_id, tenant_id)
     new_version_string = bump_patch_version(latest) if latest else "0.1.0"
@@ -596,7 +593,7 @@ async def version_branch_rollback(
     try:
         short_msg, cl = validate_version_notes(raw_msg, raw_cl, limits, require_short_message=limits.require_short_message)
     except CommitPolicyViolation as e:
-        raise _commit_policy_http(e) from e
+        raise commit_policy_http_exception(e) from e
 
     rb_meta = {
         "rollback": {

--- a/objectified-rest/src/app/version_merge_routes.py
+++ b/objectified-rest/src/app/version_merge_routes.py
@@ -37,10 +37,19 @@ from .schema_merge import (
     merge_components_schemas_three_way,
     schema_merge_materializable_paths,
 )
-from .version_notes import limits_for_tenant, validate_version_notes
+from .version_notes import (
+    CommitPolicyViolation,
+    effective_commit_policy,
+    enforce_max_commit_payload,
+    validate_version_notes,
+)
 
 
 router = APIRouter(prefix="/v1/versions", tags=["versions"])
+
+
+def _commit_policy_http(exc: CommitPolicyViolation) -> HTTPException:
+    return HTTPException(status_code=400, detail={"code": exc.code, "message": exc.message})
 
 
 def _parse_project_metadata(metadata: Any) -> Dict[str, Any]:
@@ -273,14 +282,19 @@ async def version_branch_merge(
                 },
             )
 
-    limits = limits_for_tenant(tenant_id)
+    limits = effective_commit_policy(tenant_id, project.get("metadata"))
+    try:
+        enforce_max_commit_payload(body, limits)
+    except CommitPolicyViolation as pe:
+        raise _commit_policy_http(pe) from pe
+
     latest = db.get_latest_version_for_project(project_id, tenant_id)
     new_version_string = bump_patch_version(latest) if latest else "0.1.0"
     raw_msg = f"Merge {body.source_branch_name} into {body.target_branch_name}"
     try:
         short_msg, _ = validate_version_notes(raw_msg, None, limits)
-    except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e)) from e
+    except CommitPolicyViolation as e:
+        raise _commit_policy_http(e) from e
     if not short_msg:
         short_msg = raw_msg
 
@@ -567,7 +581,12 @@ async def version_branch_rollback(
             },
         )
 
-    limits = limits_for_tenant(tenant_id)
+    limits = effective_commit_policy(tenant_id, project.get("metadata"))
+    try:
+        enforce_max_commit_payload(body, limits)
+    except CommitPolicyViolation as pe:
+        raise _commit_policy_http(pe) from pe
+
     latest = db.get_latest_version_for_project(project_id, tenant_id)
     new_version_string = bump_patch_version(latest) if latest else "0.1.0"
 
@@ -576,8 +595,8 @@ async def version_branch_rollback(
     raw_cl = (body.changelog or "").strip() or None
     try:
         short_msg, cl = validate_version_notes(raw_msg, raw_cl, limits, require_short_message=limits.require_short_message)
-    except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e)) from e
+    except CommitPolicyViolation as e:
+        raise _commit_policy_http(e) from e
 
     rb_meta = {
         "rollback": {

--- a/objectified-rest/src/app/version_notes.py
+++ b/objectified-rest/src/app/version_notes.py
@@ -10,6 +10,7 @@ import json
 from dataclasses import dataclass, replace
 from typing import Any, Dict, Optional, Tuple
 
+from fastapi import HTTPException
 from pydantic import BaseModel
 
 from .config import settings
@@ -22,6 +23,11 @@ class CommitPolicyViolation(Exception):
         self.code = code
         self.message = message
         super().__init__(message)
+
+
+def commit_policy_http_exception(exc: CommitPolicyViolation) -> HTTPException:
+    """Convert a :class:`CommitPolicyViolation` to a 400 :class:`HTTPException` with a machine-readable body."""
+    return HTTPException(status_code=400, detail={"code": exc.code, "message": exc.message})
 
 
 @dataclass(frozen=True)
@@ -116,8 +122,8 @@ def limits_for_tenant(tenant_id: str) -> VersionNotesLimits:
 
 
 def commit_request_json_byte_length(model: BaseModel) -> int:
-    """UTF-8 size of the JSON representation (alias keys), for payload policy."""
-    return len(model.model_dump_json(by_alias=True).encode("utf-8"))
+    """UTF-8 size of the JSON representation (alias keys, excluding unset fields), for payload policy."""
+    return len(model.model_dump_json(by_alias=True, exclude_unset=True).encode("utf-8"))
 
 
 def enforce_max_commit_payload(model: BaseModel, limits: VersionNotesLimits) -> None:

--- a/objectified-rest/src/app/version_notes.py
+++ b/objectified-rest/src/app/version_notes.py
@@ -1,13 +1,27 @@
 """Revision note + changelog validation (git-like commit / annotated tag analog).
 
-Size limits are tenant-scoped in the API contract; defaults apply until per-tenant
-policy is stored on tenants (future).
+Policy defaults come from :class:`VersionNotesLimits` and ``Settings``; per-project
+overrides live in ``projects.metadata.commitPolicy`` (JSON).
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Optional, Tuple
+import json
+from dataclasses import dataclass, replace
+from typing import Any, Dict, Optional, Tuple
+
+from pydantic import BaseModel
+
+from .config import settings
+
+
+class CommitPolicyViolation(Exception):
+    """Pre-commit policy rejection; use ``code`` + ``message`` for REST error bodies."""
+
+    def __init__(self, code: str, message: str) -> None:
+        self.code = code
+        self.message = message
+        super().__init__(message)
 
 
 @dataclass(frozen=True)
@@ -15,18 +29,105 @@ class VersionNotesLimits:
     max_short_message_chars: int
     max_changelog_chars: int
     require_short_message: bool
+    max_commit_payload_bytes: int
 
+
+_DEFAULT_MAX_COMMIT_PAYLOAD_BYTES = 5_242_880  # 5 MiB; kept in sync with Settings default
 
 DEFAULT_VERSION_NOTES_LIMITS = VersionNotesLimits(
     max_short_message_chars=2000,
     max_changelog_chars=65535,
     require_short_message=True,
+    max_commit_payload_bytes=_DEFAULT_MAX_COMMIT_PAYLOAD_BYTES,
 )
 
 
-def limits_for_tenant(_tenant_id: str) -> VersionNotesLimits:
-    """Return effective limits for a tenant (defaults until DB-backed policy exists)."""
-    return DEFAULT_VERSION_NOTES_LIMITS
+def _coerce_metadata_dict(metadata: Any) -> Dict[str, Any]:
+    if metadata is None:
+        return {}
+    if isinstance(metadata, dict):
+        return metadata
+    if isinstance(metadata, str):
+        try:
+            parsed = json.loads(metadata)
+            return parsed if isinstance(parsed, dict) else {}
+        except json.JSONDecodeError:
+            return {}
+    return {}
+
+
+def _int_from_policy(raw: Any) -> Optional[int]:
+    if raw is None:
+        return None
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return None
+
+
+def effective_commit_policy(
+    _tenant_id: str,
+    project_metadata: Optional[Any] = None,
+) -> VersionNotesLimits:
+    """
+    Effective limits for a tenant + optional project ``metadata`` (DB JSON).
+
+    Reads ``metadata.commitPolicy`` (or ``commit_policy``) with optional keys:
+    ``requireShortMessage``, ``maxShortMessageChars``, ``maxChangelogChars``,
+    ``maxCommitPayloadBytes`` (camelCase or snake_case).
+    """
+    base = DEFAULT_VERSION_NOTES_LIMITS
+    max_payload = int(
+        getattr(settings, "commit_policy_max_payload_bytes_default", _DEFAULT_MAX_COMMIT_PAYLOAD_BYTES)
+    )
+    lim = replace(base, max_commit_payload_bytes=max_payload)
+
+    md = _coerce_metadata_dict(project_metadata)
+    policy = md.get("commitPolicy") or md.get("commit_policy")
+    if not isinstance(policy, dict):
+        return lim
+
+    updates: Dict[str, Any] = {}
+    if "requireShortMessage" in policy:
+        updates["require_short_message"] = bool(policy["requireShortMessage"])
+    elif "require_short_message" in policy:
+        updates["require_short_message"] = bool(policy["require_short_message"])
+
+    m = _int_from_policy(policy.get("maxShortMessageChars") or policy.get("max_short_message_chars"))
+    if m is not None and m > 0:
+        updates["max_short_message_chars"] = m
+
+    m = _int_from_policy(policy.get("maxChangelogChars") or policy.get("max_changelog_chars"))
+    if m is not None and m > 0:
+        updates["max_changelog_chars"] = m
+
+    m = _int_from_policy(policy.get("maxCommitPayloadBytes") or policy.get("max_commit_payload_bytes"))
+    if m is not None and m > 0:
+        updates["max_commit_payload_bytes"] = m
+
+    if not updates:
+        return lim
+    return replace(lim, **updates)
+
+
+def limits_for_tenant(tenant_id: str) -> VersionNotesLimits:
+    """Backward-compatible: defaults only (no project metadata). Prefer :func:`effective_commit_policy`."""
+    return effective_commit_policy(tenant_id, None)
+
+
+def commit_request_json_byte_length(model: BaseModel) -> int:
+    """UTF-8 size of the JSON representation (alias keys), for payload policy."""
+    return len(model.model_dump_json(by_alias=True).encode("utf-8"))
+
+
+def enforce_max_commit_payload(model: BaseModel, limits: VersionNotesLimits) -> None:
+    """Reject when serialized request JSON exceeds ``limits.max_commit_payload_bytes``."""
+    n = commit_request_json_byte_length(model)
+    if n > limits.max_commit_payload_bytes:
+        raise CommitPolicyViolation(
+            "PAYLOAD_TOO_LARGE",
+            f"Commit request payload exceeds maximum size ({limits.max_commit_payload_bytes} bytes).",
+        )
 
 
 def validate_version_notes(
@@ -40,20 +141,25 @@ def validate_version_notes(
     Strip and validate revision note + changelog.
 
     Returns (short_message, changelog) with None for empty optional strings.
-    Raises ValueError with a human-readable message on violation.
+    Raises CommitPolicyViolation on violation.
     """
     req = limits.require_short_message if require_short_message is None else require_short_message
     sm = short_message.strip() if short_message else None
     cl = changelog.strip() if changelog else None
     if req and not sm:
-        raise ValueError("Revision note (shortMessage) is required")
+        raise CommitPolicyViolation(
+            "POLICY_VIOLATION",
+            "Revision note (shortMessage) is required",
+        )
     if sm and len(sm) > limits.max_short_message_chars:
-        raise ValueError(
-            f"Revision note exceeds maximum length ({limits.max_short_message_chars} characters)"
+        raise CommitPolicyViolation(
+            "POLICY_VIOLATION",
+            f"Revision note exceeds maximum length ({limits.max_short_message_chars} characters)",
         )
     if cl and len(cl) > limits.max_changelog_chars:
-        raise ValueError(
-            f"Changelog exceeds maximum length ({limits.max_changelog_chars} characters)"
+        raise CommitPolicyViolation(
+            "POLICY_VIOLATION",
+            f"Changelog exceeds maximum length ({limits.max_changelog_chars} characters)",
         )
     return sm, cl
 

--- a/objectified-rest/src/app/versions_routes.py
+++ b/objectified-rest/src/app/versions_routes.py
@@ -23,7 +23,12 @@ from .models import (
     SunsetTimelineEntryOut,
 )
 from .auth import validate_authentication, get_authenticated_user_id
-from .version_notes import limits_for_tenant, validate_version_notes
+from .version_notes import (
+    CommitPolicyViolation,
+    effective_commit_policy,
+    enforce_max_commit_payload,
+    validate_version_notes,
+)
 from .revision_deprecation import (
     coerce_metadata,
     parse_calendar_date,
@@ -37,6 +42,10 @@ from .revision_lifecycle import (
 )
 
 router = APIRouter(prefix="/v1/versions", tags=["versions"])
+
+
+def _commit_policy_http(exc: CommitPolicyViolation) -> HTTPException:
+    return HTTPException(status_code=400, detail={"code": exc.code, "message": exc.message})
 
 
 _DEFAULT_COMMIT_METADATA_MAX_CHARS = 10_000
@@ -551,16 +560,17 @@ async def create_version(
         # Get creator_id from auth data (will be None for API key auth)
         creator_id = get_authenticated_user_id(auth_data)
 
-        limits = limits_for_tenant(auth_data["tenant_id"])
+        limits = effective_commit_policy(auth_data["tenant_id"], project.get("metadata"))
         try:
+            enforce_max_commit_payload(request, limits)
             sm, cl = validate_version_notes(
                 request.short_message,
                 request.changelog,
                 limits,
                 require_short_message=limits.require_short_message,
             )
-        except ValueError as ve:
-            raise HTTPException(status_code=400, detail=str(ve)) from ve
+        except CommitPolicyViolation as pe:
+            raise _commit_policy_http(pe) from pe
 
         # Validate and normalize commit metadata before DB call so 400s surface correctly
         commit_author = _optional_commit_metadata_str(
@@ -654,16 +664,17 @@ async def fork_version_from_revision(
     if not creator_id:
         raise HTTPException(status_code=403, detail="Forking requires user authentication (JWT token)")
 
-    limits = limits_for_tenant(auth_data["tenant_id"])
+    limits = effective_commit_policy(auth_data["tenant_id"], target_project.get("metadata"))
     try:
+        enforce_max_commit_payload(request, limits)
         sm, cl = validate_version_notes(
             request.short_message,
             request.changelog,
             limits,
             require_short_message=limits.require_short_message,
         )
-    except ValueError as ve:
-        raise HTTPException(status_code=400, detail=str(ve)) from ve
+    except CommitPolicyViolation as pe:
+        raise _commit_policy_http(pe) from pe
 
     upstream_opt = (request.upstream_project_id or "").strip() or None
 
@@ -737,6 +748,13 @@ async def update_version(
         )
 
     try:
+        proj_row = db.get_project_by_id(project_id, auth_data["tenant_id"])
+        limits = effective_commit_policy(auth_data["tenant_id"], proj_row.get("metadata") if proj_row else None)
+        try:
+            enforce_max_commit_payload(request, limits)
+        except CommitPolicyViolation as pe:
+            raise _commit_policy_http(pe) from pe
+
         existing_lc = effective_lifecycle(existing.get("metadata"))
         tenant_id = auth_data["tenant_id"]
         uid_session = get_authenticated_user_id(auth_data)
@@ -760,7 +778,6 @@ async def update_version(
                     detail="Cannot edit version notes on an archived revision.",
                 )
 
-        limits = limits_for_tenant(auth_data["tenant_id"])
         updates: Dict[str, Any] = {}
         if request.enabled is not None:
             updates["enabled"] = request.enabled
@@ -789,8 +806,8 @@ async def update_version(
                     limits,
                     require_short_message=limits.require_short_message,
                 )
-            except ValueError as ve:
-                raise HTTPException(status_code=400, detail=str(ve)) from ve
+            except CommitPolicyViolation as pe:
+                raise _commit_policy_http(pe) from pe
             if "short_message" in request.model_fields_set:
                 updates["description"] = merged_sm
             if "changelog" in request.model_fields_set:
@@ -838,6 +855,8 @@ async def update_version(
         return VersionSchema(**version)
     except HTTPException:
         raise
+    except CommitPolicyViolation as pe:
+        raise _commit_policy_http(pe) from pe
     except ValueError as ve:
         raise HTTPException(status_code=400, detail=str(ve)) from ve
     except Exception as e:
@@ -906,24 +925,26 @@ async def publish_version(
     if visibility not in ("public", "private"):
         visibility = "private"
 
-    limits = limits_for_tenant(auth_data["tenant_id"])
-    merged_sm = existing.get("description")
-    merged_cl = existing.get("change_log")
-    note_keys = {"short_message", "changelog"}
-    if request.model_fields_set & note_keys:
-        if "short_message" in request.model_fields_set:
-            merged_sm = request.short_message
-        if "changelog" in request.model_fields_set:
-            merged_cl = request.changelog
+    proj_pub = db.get_project_by_id(project_id, auth_data["tenant_id"])
+    limits = effective_commit_policy(auth_data["tenant_id"], proj_pub.get("metadata") if proj_pub else None)
     try:
+        enforce_max_commit_payload(request, limits)
+        merged_sm = existing.get("description")
+        merged_cl = existing.get("change_log")
+        note_keys = {"short_message", "changelog"}
+        if request.model_fields_set & note_keys:
+            if "short_message" in request.model_fields_set:
+                merged_sm = request.short_message
+            if "changelog" in request.model_fields_set:
+                merged_cl = request.changelog
         merged_sm, merged_cl = validate_version_notes(
             merged_sm,
             merged_cl,
             limits,
             require_short_message=limits.require_short_message,
         )
-    except ValueError as ve:
-        raise HTTPException(status_code=400, detail=str(ve)) from ve
+    except CommitPolicyViolation as pe:
+        raise _commit_policy_http(pe) from pe
 
     version = db.publish_version(
         version_record_id,

--- a/objectified-rest/src/app/versions_routes.py
+++ b/objectified-rest/src/app/versions_routes.py
@@ -25,6 +25,7 @@ from .models import (
 from .auth import validate_authentication, get_authenticated_user_id
 from .version_notes import (
     CommitPolicyViolation,
+    commit_policy_http_exception,
     effective_commit_policy,
     enforce_max_commit_payload,
     validate_version_notes,
@@ -42,10 +43,6 @@ from .revision_lifecycle import (
 )
 
 router = APIRouter(prefix="/v1/versions", tags=["versions"])
-
-
-def _commit_policy_http(exc: CommitPolicyViolation) -> HTTPException:
-    return HTTPException(status_code=400, detail={"code": exc.code, "message": exc.message})
 
 
 _DEFAULT_COMMIT_METADATA_MAX_CHARS = 10_000
@@ -570,7 +567,7 @@ async def create_version(
                 require_short_message=limits.require_short_message,
             )
         except CommitPolicyViolation as pe:
-            raise _commit_policy_http(pe) from pe
+            raise commit_policy_http_exception(pe) from pe
 
         # Validate and normalize commit metadata before DB call so 400s surface correctly
         commit_author = _optional_commit_metadata_str(
@@ -674,7 +671,7 @@ async def fork_version_from_revision(
             require_short_message=limits.require_short_message,
         )
     except CommitPolicyViolation as pe:
-        raise _commit_policy_http(pe) from pe
+        raise commit_policy_http_exception(pe) from pe
 
     upstream_opt = (request.upstream_project_id or "").strip() or None
 
@@ -753,7 +750,7 @@ async def update_version(
         try:
             enforce_max_commit_payload(request, limits)
         except CommitPolicyViolation as pe:
-            raise _commit_policy_http(pe) from pe
+            raise commit_policy_http_exception(pe) from pe
 
         existing_lc = effective_lifecycle(existing.get("metadata"))
         tenant_id = auth_data["tenant_id"]
@@ -807,7 +804,7 @@ async def update_version(
                     require_short_message=limits.require_short_message,
                 )
             except CommitPolicyViolation as pe:
-                raise _commit_policy_http(pe) from pe
+                raise commit_policy_http_exception(pe) from pe
             if "short_message" in request.model_fields_set:
                 updates["description"] = merged_sm
             if "changelog" in request.model_fields_set:
@@ -856,7 +853,7 @@ async def update_version(
     except HTTPException:
         raise
     except CommitPolicyViolation as pe:
-        raise _commit_policy_http(pe) from pe
+        raise commit_policy_http_exception(pe) from pe
     except ValueError as ve:
         raise HTTPException(status_code=400, detail=str(ve)) from ve
     except Exception as e:
@@ -944,7 +941,7 @@ async def publish_version(
             require_short_message=limits.require_short_message,
         )
     except CommitPolicyViolation as pe:
-        raise _commit_policy_http(pe) from pe
+        raise commit_policy_http_exception(pe) from pe
 
     version = db.publish_version(
         version_record_id,

--- a/objectified-rest/test_version_notes.py
+++ b/objectified-rest/test_version_notes.py
@@ -2,13 +2,14 @@ import pytest
 
 from src.app.version_notes import (
     DEFAULT_VERSION_NOTES_LIMITS,
+    CommitPolicyViolation,
     extract_breaking_hints_from_changelog,
     validate_version_notes,
 )
 
 
 def test_validate_version_notes_requires_short_message_when_policy_says_so():
-    with pytest.raises(ValueError, match="Revision note"):
+    with pytest.raises(CommitPolicyViolation, match="Revision note"):
         validate_version_notes(None, None, DEFAULT_VERSION_NOTES_LIMITS)
     sm, cl = validate_version_notes("x", None, DEFAULT_VERSION_NOTES_LIMITS)
     assert sm == "x" and cl is None
@@ -16,9 +17,9 @@ def test_validate_version_notes_requires_short_message_when_policy_says_so():
 
 def test_validate_version_notes_max_length():
     lim = DEFAULT_VERSION_NOTES_LIMITS
-    with pytest.raises(ValueError, match="Revision note exceeds"):
+    with pytest.raises(CommitPolicyViolation, match="Revision note exceeds"):
         validate_version_notes("a" * (lim.max_short_message_chars + 1), None, lim)
-    with pytest.raises(ValueError, match="Changelog exceeds"):
+    with pytest.raises(CommitPolicyViolation, match="Changelog exceeds"):
         validate_version_notes("ok", "b" * (lim.max_changelog_chars + 1), lim)
 
 

--- a/objectified-rest/tests/test_commit_policy.py
+++ b/objectified-rest/tests/test_commit_policy.py
@@ -1,0 +1,192 @@
+"""Pre-commit policy: message required, max payload (#2565)."""
+
+from dataclasses import replace
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.auth import validate_authentication
+from app.main import app
+from app.models import VersionCreateRequest
+from app.version_notes import (
+    DEFAULT_VERSION_NOTES_LIMITS,
+    CommitPolicyViolation,
+    effective_commit_policy,
+    enforce_max_commit_payload,
+    validate_version_notes,
+)
+
+client = TestClient(app)
+
+_MOCK_AUTH = {
+    "tenant_id": "test-tenant-id",
+    "user_id": "test-user-id",
+    "auth_method": "jwt",
+}
+
+
+def _override_auth():
+    return _MOCK_AUTH
+
+
+@pytest.fixture(autouse=True)
+def _auth():
+    app.dependency_overrides[validate_authentication] = _override_auth
+    yield
+    app.dependency_overrides.pop(validate_authentication, None)
+
+
+def test_effective_commit_policy_reads_project_metadata():
+    md = {"commitPolicy": {"requireShortMessage": False, "maxCommitPayloadBytes": 999999}}
+    lim = effective_commit_policy("tid", md)
+    assert lim.require_short_message is False
+    assert lim.max_commit_payload_bytes == 999999
+
+
+def test_enforce_max_commit_payload_raises_payload_too_large():
+    lim = DEFAULT_VERSION_NOTES_LIMITS
+    small = VersionCreateRequest(short_message="x" * 100, version_id="1.0.0")
+    enforce_max_commit_payload(small, lim)  # no raise
+
+    lim2 = replace(lim, max_commit_payload_bytes=50)
+    big = VersionCreateRequest(short_message="y" * 200, version_id="1.0.0")
+    with pytest.raises(CommitPolicyViolation) as ei:
+        enforce_max_commit_payload(big, lim2)
+    assert ei.value.code == "PAYLOAD_TOO_LARGE"
+
+
+def test_validate_version_notes_policy_violation_code():
+    with pytest.raises(CommitPolicyViolation) as ei:
+        validate_version_notes(None, None, DEFAULT_VERSION_NOTES_LIMITS)
+    assert ei.value.code == "POLICY_VIOLATION"
+
+
+def test_post_create_empty_short_message_returns_policy_envelope():
+    row = {
+        "id": "rev-1",
+        "project_id": "proj-1",
+        "creator_id": "test-user-id",
+        "version_id": "1.0.0",
+        "description": None,
+        "change_log": None,
+        "visibility": "private",
+        "published": False,
+        "published_at": None,
+        "enabled": True,
+        "parent_version_id": None,
+        "merge_parent_version_id": None,
+        "forked_from_revision_id": None,
+        "upstream_project_id": None,
+        "revision_locked": False,
+        "metadata": None,
+        "commit_author": None,
+        "commit_message": None,
+        "external_ref": None,
+        "creator_name": None,
+        "creator_email": None,
+        "project_name": "P",
+        "project_slug": "p",
+        "created_at": None,
+        "updated_at": None,
+    }
+    with patch("app.versions_routes.db") as mdb:
+        mdb.get_project_by_id.return_value = {"id": "proj-1", "metadata": {}}
+        mdb.get_latest_version_for_project.return_value = None
+        mdb.create_version.return_value = row
+        r = client.post(
+            "/v1/versions/tn/proj-1",
+            json={"version_id": "1.0.0", "shortMessage": ""},
+        )
+    assert r.status_code == 400
+    body = r.json()
+    assert body["detail"]["code"] == "POLICY_VIOLATION"
+    assert "shortMessage" in body["detail"]["message"] or "Revision note" in body["detail"]["message"]
+
+
+def test_post_create_respects_require_short_message_false_in_project_metadata():
+    row = {
+        "id": "rev-1",
+        "project_id": "proj-1",
+        "creator_id": "test-user-id",
+        "version_id": "1.0.0",
+        "description": None,
+        "change_log": None,
+        "visibility": "private",
+        "published": False,
+        "published_at": None,
+        "enabled": True,
+        "parent_version_id": None,
+        "merge_parent_version_id": None,
+        "forked_from_revision_id": None,
+        "upstream_project_id": None,
+        "revision_locked": False,
+        "metadata": None,
+        "commit_author": None,
+        "commit_message": None,
+        "external_ref": None,
+        "creator_name": None,
+        "creator_email": None,
+        "project_name": "P",
+        "project_slug": "p",
+        "created_at": None,
+        "updated_at": None,
+    }
+    with patch("app.versions_routes.db") as mdb:
+        mdb.get_project_by_id.return_value = {
+            "id": "proj-1",
+            "metadata": {"commitPolicy": {"requireShortMessage": False}},
+        }
+        mdb.get_latest_version_for_project.return_value = None
+        mdb.create_version.return_value = row
+        r = client.post(
+            "/v1/versions/tn/proj-1",
+            json={"version_id": "1.0.0", "shortMessage": ""},
+        )
+    assert r.status_code == 200
+
+
+def test_post_create_payload_too_large_envelope():
+    row = {
+        "id": "rev-1",
+        "project_id": "proj-1",
+        "creator_id": "test-user-id",
+        "version_id": "1.0.0",
+        "description": "ok",
+        "change_log": None,
+        "visibility": "private",
+        "published": False,
+        "published_at": None,
+        "enabled": True,
+        "parent_version_id": None,
+        "merge_parent_version_id": None,
+        "forked_from_revision_id": None,
+        "upstream_project_id": None,
+        "revision_locked": False,
+        "metadata": None,
+        "commit_author": None,
+        "commit_message": None,
+        "external_ref": None,
+        "creator_name": None,
+        "creator_email": None,
+        "project_name": "P",
+        "project_slug": "p",
+        "created_at": None,
+        "updated_at": None,
+    }
+    with patch("app.versions_routes.db") as mdb:
+        mdb.get_project_by_id.return_value = {
+            "id": "proj-1",
+            "metadata": {"commitPolicy": {"maxCommitPayloadBytes": 80}},
+        }
+        mdb.get_latest_version_for_project.return_value = None
+        mdb.create_version.return_value = row
+        r = client.post(
+            "/v1/versions/tn/proj-1",
+            json={
+                "version_id": "1.0.0",
+                "shortMessage": "x" * 200,
+            },
+        )
+    assert r.status_code == 400
+    assert r.json()["detail"]["code"] == "PAYLOAD_TOO_LARGE"

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.9.54",
+  "version": "0.9.55",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -26,6 +26,7 @@ We continue to improve the platform based on your feedback with improvements and
 - **OpenAPI import:** one shared rule for “direct” schema properties — specs that mix top-level `properties` with inline `allOf` fragments now pick up both (aligned with the unified class importer)
 
 ## Git Behavior
+- **Pre-commit policy (#2565):** **REST** enforces **revision note** rules and **max JSON payload** size before persisting commits (create/fork/update/publish/merge/rollback); optional per-project **`metadata.commitPolicy`** (`requireShortMessage`, `maxCommitPayloadBytes`, char caps); **`400`** responses use **`POLICY_VIOLATION`** or **`PAYLOAD_TOO_LARGE`** with a message (global default payload cap via **`COMMIT_POLICY_MAX_PAYLOAD_BYTES_DEFAULT`**)
 - **Commit metadata (#2563):** Schema revisions persist optional **`author`**, **`message`**, and **`externalRef`** (REST create/fork + revision list/detail); stored as `commit_author`, `commit_message`, `external_ref` — existing rows surface **null** safely
 - **Commit dialog (#2564):** ADE **Versions** **Commit** opens a Radix dialog with required **Message**, optional **External reference** (max 500 chars), inline validation, disabled submit until valid, and **sonner** toasts; new revisions post to **REST** via `/api/versions` with commit metadata
 


### PR DESCRIPTION
## Summary
Implements configurable pre-commit policy evaluated before revision rows persist: required revision note (shortMessage) when enabled, maximum serialized JSON body size, and consistent HTTP 400 bodies with machine-readable codes.

## Changes
- **Policy source:** `projects.metadata.commitPolicy` (optional): `requireShortMessage`, `maxCommitPayloadBytes`, `maxShortMessageChars`, `maxChangelogChars` (camelCase or snake_case).
- **Defaults:** Global max payload default `5_242_880` bytes via `Settings.commit_policy_max_payload_bytes_default` (override with env `COMMIT_POLICY_MAX_PAYLOAD_BYTES_DEFAULT` per pydantic-settings).
- **Endpoints:** Create version, fork, update version (payload + notes), publish, merge branch, rollback — all run `enforce_max_commit_payload` and `validate_version_notes` with the effective policy.
- **Errors:** `POLICY_VIOLATION` and `PAYLOAD_TOO_LARGE`; body shape `{"code": "...", "message": "..."}`.

## How to test
- `cd objectified-rest && . .venv/bin/activate && pytest`
- POST create revision with empty `shortMessage` and default policy → 400 + `POLICY_VIOLATION`.
- Set project `metadata.commitPolicy.maxCommitPayloadBytes` low and POST a large body → 400 + `PAYLOAD_TOO_LARGE`.

## Risk / notes
- Payload size is measured as UTF-8 length of `model_dump_json(by_alias=True)` for the request model (same serialization the client effectively sends).

Closes #2565

Made with [Cursor](https://cursor.com)