### PR TITLE
Fix #2639 - Paths navigation in Studio header and Home grid

### DIFF
--- a/docs/PLANNED_FEATURES.md
+++ b/docs/PLANNED_FEATURES.md
@@ -131,24 +131,25 @@ Implement and verify in this order so each step stays testable. **Issue → road
 
 | Order | Issue | ID |
 |------:|------|-----|
-| 1 | [#2639](https://github.com/KenSuenobu/objectified-commercial/issues/2639) | P-00 |
-| 2 | [#2640](https://github.com/KenSuenobu/objectified-commercial/issues/2640) | P-01 |
-| 3 | [#2641](https://github.com/KenSuenobu/objectified-commercial/issues/2641) | P-02 |
-| 4 | [#2642](https://github.com/KenSuenobu/objectified-commercial/issues/2642) | P-03 |
-| 5 | [#2643](https://github.com/KenSuenobu/objectified-commercial/issues/2643) | P-04 |
-| 6 | [#2644](https://github.com/KenSuenobu/objectified-commercial/issues/2644) | P-05 |
-| 7 | [#2645](https://github.com/KenSuenobu/objectified-commercial/issues/2645) | P-06 |
-| 8 | [#2646](https://github.com/KenSuenobu/objectified-commercial/issues/2646) | P-07 |
-| 9 | [#2653](https://github.com/KenSuenobu/objectified-commercial/issues/2653) | P-14 (OPTIONS first-class; sequenced after P-07 in dependency charts—keep graph order if conflicts) |
-| 10 | [#2647](https://github.com/KenSuenobu/objectified-commercial/issues/2647) | P-08 |
-| 11 | [#2648](https://github.com/KenSuenobu/objectified-commercial/issues/2648) | P-09 |
-| 12 | [#2649](https://github.com/KenSuenobu/objectified-commercial/issues/2649) | P-10 |
-| 13 | [#2650](https://github.com/KenSuenobu/objectified-commercial/issues/2650) | P-11 |
-| 14 | [#2651](https://github.com/KenSuenobu/objectified-commercial/issues/2651) | P-12 |
-| 15 | [#2652](https://github.com/KenSuenobu/objectified-commercial/issues/2652) | P-13 |
-| 16 | [#2654](https://github.com/KenSuenobu/objectified-commercial/issues/2654) | P-15 |
-| 17 | [#2655](https://github.com/KenSuenobu/objectified-commercial/issues/2655) | P-16 |
-| 18 | [#2656](https://github.com/KenSuenobu/objectified-commercial/issues/2656) | P-17 |
+| 1 | [#2640](https://github.com/KenSuenobu/objectified-commercial/issues/2640) | P-01 |
+| 2 | [#2641](https://github.com/KenSuenobu/objectified-commercial/issues/2641) | P-02 |
+| 3 | [#2642](https://github.com/KenSuenobu/objectified-commercial/issues/2642) | P-03 |
+| 4 | [#2643](https://github.com/KenSuenobu/objectified-commercial/issues/2643) | P-04 |
+| 5 | [#2644](https://github.com/KenSuenobu/objectified-commercial/issues/2644) | P-05 |
+| 6 | [#2645](https://github.com/KenSuenobu/objectified-commercial/issues/2645) | P-06 |
+| 7 | [#2646](https://github.com/KenSuenobu/objectified-commercial/issues/2646) | P-07 |
+| 8 | [#2653](https://github.com/KenSuenobu/objectified-commercial/issues/2653) | P-14 (OPTIONS first-class; sequenced after P-07 in dependency charts—keep graph order if conflicts) |
+| 9 | [#2647](https://github.com/KenSuenobu/objectified-commercial/issues/2647) | P-08 |
+| 10 | [#2648](https://github.com/KenSuenobu/objectified-commercial/issues/2648) | P-09 |
+| 11 | [#2649](https://github.com/KenSuenobu/objectified-commercial/issues/2649) | P-10 |
+| 12 | [#2650](https://github.com/KenSuenobu/objectified-commercial/issues/2650) | P-11 |
+| 13 | [#2651](https://github.com/KenSuenobu/objectified-commercial/issues/2651) | P-12 |
+| 14 | [#2652](https://github.com/KenSuenobu/objectified-commercial/issues/2652) | P-13 |
+| 15 | [#2654](https://github.com/KenSuenobu/objectified-commercial/issues/2654) | P-15 |
+| 16 | [#2655](https://github.com/KenSuenobu/objectified-commercial/issues/2655) | P-16 |
+| 17 | [#2656](https://github.com/KenSuenobu/objectified-commercial/issues/2656) | P-17 |
+
+**Shipped:** P-00 ([#2639](https://github.com/KenSuenobu/objectified-commercial/issues/2639)) — Studio header **Paths** link and Home four-wide grid with **Paths** beside **Designer**.
 
 **Excluded from first MVP (roadmap):** [#2657](https://github.com/KenSuenobu/objectified-commercial/issues/2657) (P-18), [#2658](https://github.com/KenSuenobu/objectified-commercial/issues/2658)–[#2662](https://github.com/KenSuenobu/objectified-commercial/issues/2662) (V2-01 → V2-05).
 
@@ -159,8 +160,6 @@ Implement and verify in this order so each step stays testable. **Issue → road
 - **Current route:** Paths live at **`/ade/studio/paths`** (`objectified-ui/src/app/ade/studio/paths/page.tsx`) with **sidebar + canvas + panels** and REST integration—see also `objectified-ui/docs/PATHS_IMPLEMENTATION_SUMMARY.md` (may be **ahead** or **divergent** from P-00–P-17 acceptance text).
 - **REST / DB:** `objectified-rest/src/app/paths_routes.py` and UI BFF routes back paths data; roadmap stresses mapping to **`odb.version_path`**, **`odb.path_operation`**, and related tables—**reconcile** any **stale internal docs** vs current **Postgres/REST** path.
 - **PATH QUALITY / OpenAPI 3.2:** P-16/P-17 require a clear **validation/export** story; `lib/db/helper-paths-export.ts` and OpenAPI generators are relevant—gaps should be **closed inside P-15–P-17**, not via silent one-off scripts.
-
-**Consider creating an issue for:** **navigation parity** if product expects **Paths** next to **Designer** on **dashboard** chrome (**#2639**) but routing remains **studio-only**.
 
 ### B.3 Testing checkpoint 1 — After P-03 (persist canvas JSON per version)
 

--- a/docs/PLANNED_FEATURE_ROADMAP_PATHS.md
+++ b/docs/PLANNED_FEATURE_ROADMAP_PATHS.md
@@ -21,7 +21,7 @@ This document defines **epics and ordered, single-scope issues** to deliver a **
 
 | ID | Issue | MVP |
 |----|------|-----|
-| P-00 | [#2639](https://github.com/KenSuenobu/objectified-commercial/issues/2639) | Yes |
+| P-00 | [#2639](https://github.com/KenSuenobu/objectified-commercial/issues/2639) (shipped) | Yes |
 | P-01 | [#2640](https://github.com/KenSuenobu/objectified-commercial/issues/2640) | Yes |
 | P-02 | [#2641](https://github.com/KenSuenobu/objectified-commercial/issues/2641) | Yes |
 | P-03 | [#2642](https://github.com/KenSuenobu/objectified-commercial/issues/2642) | Yes |
@@ -52,7 +52,7 @@ This document defines **epics and ordered, single-scope issues** to deliver a **
 
 | # | Issue | MVP |
 |---|--------|-----|
-| 2639 | P-00 Navigation: header “Paths” + Home grid card | Yes |
+| ~~2639~~ | ~~P-00 Navigation: header “Paths” + Home grid card~~ **(shipped)** | Yes |
 | 2640 | P-01 Paths shell: header, PATH QUALITY placeholder, Canvas/Code | Yes |
 | 2641 | P-02 Canvas defaults parity with Designer | Yes |
 | 2642 | P-03 Persist canvas JSON per version | Yes |
@@ -203,9 +203,9 @@ Each issue is intentionally small enough to ship independently. After each issue
 
 ---
 
-### P-00 — Navigation: Studio header “Paths” link and Home grid card
+### P-00 — Navigation: Studio header “Paths” link and Home grid card ✅
 
-**Epic:** E1 · **GitHub:** [#2639](https://github.com/KenSuenobu/objectified-commercial/issues/2639) · **Labels:** `paths`, `mvp`, `ui`, `roadmap-paths`
+**Epic:** E1 · **GitHub:** [#2639](https://github.com/KenSuenobu/objectified-commercial/issues/2639) · **Labels:** `paths`, `mvp`, `ui`, `roadmap-paths` · **Status:** shipped
 
 **Title:** Add Paths navigation in Studio header and a four-wide Home card grid entry to the right of Designer
 

--- a/objectified-ui/lib/ade-studio-nav.ts
+++ b/objectified-ui/lib/ade-studio-nav.ts
@@ -1,0 +1,15 @@
+/**
+ * Studio main-nav active states: Designer and Paths share `/ade/studio` prefix;
+ * Paths must not highlight Designer.
+ */
+
+export function isDesignerStudioNavActive(pathname: string): boolean {
+  return (
+    pathname === '/ade/studio' ||
+    (pathname.startsWith('/ade/studio/') && !pathname.startsWith('/ade/studio/paths'))
+  );
+}
+
+export function isPathsStudioNavActive(pathname: string): boolean {
+  return pathname === '/ade/studio/paths' || pathname.startsWith('/ade/studio/paths/');
+}

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.9.81",
+  "version": "0.9.82",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -5,6 +5,7 @@ We continue to improve the platform based on your feedback with improvements and
 ---
 
 ## UI:
+- **Paths navigation (#2639):** **Paths** appears in the main Studio nav **next to Designer** (tenant/project context preserved); **Home** uses a **four-column** app grid on large screens with a **Paths** card **immediately to the right of Data Designer**, linking to **`/ade/studio/paths`**
 - **Version merge (#738):** Branch merge **preview** and **apply** run through **objectified-rest** — **merge-base (LCA)** plus **three-way** `components.schemas` merge, structured conflict paths, **two parents** on the merge revision, **`baseRevisionId`** optimistic lock on the target tip; Studio API routes proxy to REST
 - **Canvas ↔ Code (#2595):** Switching to **Code** now **synchronously hides group floating toolbars** (including hover/settings/export), **clears flow selection**, and **blocks sidebar group delete row actions** while the Code tab is active so nothing in that stack can take a stray click during the transition
 - **Studio Code / GraphQL (#147):** GraphQL SDL in the Code tab is generated from a **Handlebars template** (`templates/graphql/graphql-schema.hbs`) instead of inlined string building, aligned with OpenAPI and Arazzo; template loader init is synchronous so tooling can import it safely

--- a/objectified-ui/src/app/ade/page.tsx
+++ b/objectified-ui/src/app/ade/page.tsx
@@ -6,8 +6,7 @@ import {
   LayoutDashboard,
   Palette,
   Globe,
-  ArrowRightLeft,
-  Search,
+  Route,
   Shield,
   ClipboardList,
   HelpCircle,
@@ -38,16 +37,6 @@ const Ade = () => {
 
   const mainApps: AppTile[] = [
     {
-      id: 'control-panel',
-      name: 'Control Panel',
-      description: 'Manage tenants, projects, and settings',
-      icon: <LayoutDashboard className="w-8 h-8" />,
-      href: '/ade/dashboard',
-      enabled: true,
-      color: 'text-indigo-600 dark:text-indigo-400',
-      gradient: 'from-indigo-500 to-purple-600',
-    },
-    {
       id: 'studio',
       name: 'Data Designer',
       description: 'Design schemas and API specifications',
@@ -56,6 +45,26 @@ const Ade = () => {
       enabled: true,
       color: 'text-purple-600 dark:text-purple-400',
       gradient: 'from-purple-500 to-pink-600',
+    },
+    {
+      id: 'paths',
+      name: 'Paths',
+      description: 'Author OpenAPI paths and operations for your API',
+      icon: <Route className="w-8 h-8" />,
+      href: '/ade/studio/paths',
+      enabled: true,
+      color: 'text-amber-600 dark:text-amber-400',
+      gradient: 'from-amber-500 to-orange-600',
+    },
+    {
+      id: 'control-panel',
+      name: 'Control Panel',
+      description: 'Manage tenants, projects, and settings',
+      icon: <LayoutDashboard className="w-8 h-8" />,
+      href: '/ade/dashboard',
+      enabled: true,
+      color: 'text-indigo-600 dark:text-indigo-400',
+      gradient: 'from-indigo-500 to-purple-600',
     },
     {
       id: 'browser',
@@ -183,6 +192,8 @@ const Ade = () => {
   const renderAppTile = (tile: AppTile) => (
     <button
       key={tile.id}
+      type="button"
+      aria-label={tile.enabled ? `Open ${tile.name}` : `${tile.name} (coming soon)`}
       onClick={() => handleTileClick(tile)}
       disabled={!tile.enabled}
       className={cn(
@@ -255,8 +266,8 @@ const Ade = () => {
           </p>
         </div>
 
-        {/* Main Apps Row */}
-        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-6">
+        {/* Main Apps Row — four-wide on large screens; Designer then Paths (issue #2639) */}
+        <div className="mb-6 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
           {mainApps.map(renderAppTile)}
         </div>
 

--- a/objectified-ui/src/app/components/ade/TopHeader.tsx
+++ b/objectified-ui/src/app/components/ade/TopHeader.tsx
@@ -11,16 +11,42 @@ import { useTheme } from '../../providers/ThemeProvider';
 import { useDarkMode } from '../../hooks/useDarkMode';
 import { getTenantsForUser } from '../../../../lib/db/helper';
 import packageJson from '../../../../package.json';
+import { isDesignerStudioNavActive, isPathsStudioNavActive } from '../../../../lib/ade-studio-nav';
 
 // Import version from package.json
 const APP_VERSION = `03-2026-v${packageJson.version}`;
 
-type NavItem = { label: string; href: string; enabled?: boolean; opensNewBrowser?: boolean };
+type NavItem = {
+  label: string;
+  href: string;
+  enabled?: boolean;
+  opensNewBrowser?: boolean;
+  /** When set, overrides default prefix matching (e.g. Designer vs Paths under `/ade/studio`). */
+  isActive?: (pathname: string) => boolean;
+};
+
+function navItemIsActive(item: NavItem, pathname: string | null): boolean {
+  if (!pathname) return false;
+  if (item.isActive) return item.isActive(pathname);
+  return (
+    pathname === item.href ||
+    (item.href !== "/ade" && pathname.startsWith(item.href + "/"))
+  );
+}
 
 const NAV_ITEMS: NavItem[] = [
   { label: "Home", href: "/ade" },
   { label: "Control Panel", href: "/ade/dashboard" },
-  { label: "Designer", href: "/ade/studio" },
+  {
+    label: "Designer",
+    href: "/ade/studio",
+    isActive: isDesignerStudioNavActive,
+  },
+  {
+    label: "Paths",
+    href: "/ade/studio/paths",
+    isActive: isPathsStudioNavActive,
+  },
   // { label: "Database", href: "/ade/database", enabled: false },
   // { label: "Migration", href: "/ade/migration", enabled: false },
   // { label: "ETL", href: "/ade/etl", enabled: false },
@@ -105,11 +131,7 @@ const TopHeader = () => {
           className="m-0 inline-flex list-none items-center gap-2 p-0 text-[13px]"
         >
           {NAV_ITEMS.map((item) => {
-            // Check if current path matches or is a subdirectory of this nav item
-            // For exact matches, always activate
-            // For subdirectory matches, only activate if the path continues with a slash
-            const isActive = pathname === item.href ||
-                            (item.href !== '/ade' && pathname?.startsWith(item.href + '/'));
+            const isActive = navItemIsActive(item, pathname);
 
             return (
               <li key={item.href}>
@@ -125,6 +147,7 @@ const TopHeader = () => {
                     href={item.href}
                     target={item.opensNewBrowser ? '_blank' : undefined}
                     rel={item.opensNewBrowser ? 'noopener noreferrer' : undefined}
+                    aria-current={isActive ? 'page' : undefined}
                     className={`rounded-md px-2 py-1 text-[13px] text-slate-700 transition-colors hover:bg-slate-100 hover:text-indigo-600 dark:text-slate-200 dark:hover:bg-slate-700 dark:hover:text-indigo-400 ${
                       isActive ? 'bg-slate-200/80 font-medium text-slate-900 dark:bg-slate-700 dark:text-white' : ''
                     }`}

--- a/objectified-ui/tests/unit/ade-studio-nav.test.ts
+++ b/objectified-ui/tests/unit/ade-studio-nav.test.ts
@@ -1,0 +1,21 @@
+import {
+  isDesignerStudioNavActive,
+  isPathsStudioNavActive,
+} from '../../lib/ade-studio-nav';
+
+describe('ade-studio-nav active states', () => {
+  it('Designer: root studio and editor, not Paths', () => {
+    expect(isDesignerStudioNavActive('/ade/studio')).toBe(true);
+    expect(isDesignerStudioNavActive('/ade/studio/editor')).toBe(true);
+    expect(isDesignerStudioNavActive('/ade/studio/code')).toBe(true);
+    expect(isDesignerStudioNavActive('/ade/studio/paths')).toBe(false);
+    expect(isDesignerStudioNavActive('/ade/studio/paths/foo')).toBe(false);
+  });
+
+  it('Paths: paths route only', () => {
+    expect(isPathsStudioNavActive('/ade/studio/paths')).toBe(true);
+    expect(isPathsStudioNavActive('/ade/studio/paths/')).toBe(true);
+    expect(isPathsStudioNavActive('/ade/studio/editor')).toBe(false);
+    expect(isPathsStudioNavActive('/ade/studio')).toBe(false);
+  });
+});

--- a/objectified-ui/tests/unit/ade-studio-nav.test.ts
+++ b/objectified-ui/tests/unit/ade-studio-nav.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect } from '@jest/globals';
 import {
   isDesignerStudioNavActive,
   isPathsStudioNavActive,


### PR DESCRIPTION
## What changed
- **Studio header (`TopHeader`):** Added a **Paths** link immediately after **Designer**, routing to `/ade/studio/paths`. **Designer** and **Paths** use distinct active states so `/ade/studio/paths` does not highlight Designer.
- **Home (`/ade`):** Main app row is **four columns** on large screens (`sm:grid-cols-2` `lg:grid-cols-4`). Reordered tiles so **Data Designer** and **Paths** are the **first two** cards (Paths directly to the right of Designer), followed by Control Panel and Browser.
- **Helpers:** `lib/ade-studio-nav.ts` + unit tests for active-path rules.

## How to test
1. Sign in → open ADE Home: confirm first row shows **Designer | Paths | Control Panel | Browser** at `lg` width; narrow view stacks / two columns as expected.
2. Open **Paths** from the header → lands on `/ade/studio/paths`; **Paths** nav shows active styling; **Designer** does not.
3. From Paths, click **Designer** in the header → editor/studio; browser Back returns to Paths.

## Risk / notes
- Home tile order changed (Control Panel moved after Designer/Paths). Visual parity with existing card styling; no REST/DB changes.

Closes #2639

Made with [Cursor](https://cursor.com)