### PR TITLE
Fix #2640 - Paths studio shell (PATH QUALITY, Canvas/Code)

### DIFF
--- a/docs/PLANNED_FEATURES.md
+++ b/docs/PLANNED_FEATURES.md
@@ -131,25 +131,24 @@ Implement and verify in this order so each step stays testable. **Issue → road
 
 | Order | Issue | ID |
 |------:|------|-----|
-| 1 | [#2640](https://github.com/KenSuenobu/objectified-commercial/issues/2640) | P-01 |
-| 2 | [#2641](https://github.com/KenSuenobu/objectified-commercial/issues/2641) | P-02 |
-| 3 | [#2642](https://github.com/KenSuenobu/objectified-commercial/issues/2642) | P-03 |
-| 4 | [#2643](https://github.com/KenSuenobu/objectified-commercial/issues/2643) | P-04 |
-| 5 | [#2644](https://github.com/KenSuenobu/objectified-commercial/issues/2644) | P-05 |
-| 6 | [#2645](https://github.com/KenSuenobu/objectified-commercial/issues/2645) | P-06 |
-| 7 | [#2646](https://github.com/KenSuenobu/objectified-commercial/issues/2646) | P-07 |
-| 8 | [#2653](https://github.com/KenSuenobu/objectified-commercial/issues/2653) | P-14 (OPTIONS first-class; sequenced after P-07 in dependency charts—keep graph order if conflicts) |
-| 9 | [#2647](https://github.com/KenSuenobu/objectified-commercial/issues/2647) | P-08 |
-| 10 | [#2648](https://github.com/KenSuenobu/objectified-commercial/issues/2648) | P-09 |
-| 11 | [#2649](https://github.com/KenSuenobu/objectified-commercial/issues/2649) | P-10 |
-| 12 | [#2650](https://github.com/KenSuenobu/objectified-commercial/issues/2650) | P-11 |
-| 13 | [#2651](https://github.com/KenSuenobu/objectified-commercial/issues/2651) | P-12 |
-| 14 | [#2652](https://github.com/KenSuenobu/objectified-commercial/issues/2652) | P-13 |
-| 15 | [#2654](https://github.com/KenSuenobu/objectified-commercial/issues/2654) | P-15 |
-| 16 | [#2655](https://github.com/KenSuenobu/objectified-commercial/issues/2655) | P-16 |
-| 17 | [#2656](https://github.com/KenSuenobu/objectified-commercial/issues/2656) | P-17 |
+| 1 | [#2641](https://github.com/KenSuenobu/objectified-commercial/issues/2641) | P-02 |
+| 2 | [#2642](https://github.com/KenSuenobu/objectified-commercial/issues/2642) | P-03 |
+| 3 | [#2643](https://github.com/KenSuenobu/objectified-commercial/issues/2643) | P-04 |
+| 4 | [#2644](https://github.com/KenSuenobu/objectified-commercial/issues/2644) | P-05 |
+| 5 | [#2645](https://github.com/KenSuenobu/objectified-commercial/issues/2645) | P-06 |
+| 6 | [#2646](https://github.com/KenSuenobu/objectified-commercial/issues/2646) | P-07 |
+| 7 | [#2653](https://github.com/KenSuenobu/objectified-commercial/issues/2653) | P-14 (OPTIONS first-class; sequenced after P-07 in dependency charts—keep graph order if conflicts) |
+| 8 | [#2647](https://github.com/KenSuenobu/objectified-commercial/issues/2647) | P-08 |
+| 9 | [#2648](https://github.com/KenSuenobu/objectified-commercial/issues/2648) | P-09 |
+| 10 | [#2649](https://github.com/KenSuenobu/objectified-commercial/issues/2649) | P-10 |
+| 11 | [#2650](https://github.com/KenSuenobu/objectified-commercial/issues/2650) | P-11 |
+| 12 | [#2651](https://github.com/KenSuenobu/objectified-commercial/issues/2651) | P-12 |
+| 13 | [#2652](https://github.com/KenSuenobu/objectified-commercial/issues/2652) | P-13 |
+| 14 | [#2654](https://github.com/KenSuenobu/objectified-commercial/issues/2654) | P-15 |
+| 15 | [#2655](https://github.com/KenSuenobu/objectified-commercial/issues/2655) | P-16 |
+| 16 | [#2656](https://github.com/KenSuenobu/objectified-commercial/issues/2656) | P-17 |
 
-**Shipped:** P-00 ([#2639](https://github.com/KenSuenobu/objectified-commercial/issues/2639)) — Studio header **Paths** link and Home four-wide grid with **Paths** beside **Designer**.
+**Shipped:** P-00 ([#2639](https://github.com/KenSuenobu/objectified-commercial/issues/2639)) — Studio header **Paths** link and Home four-wide grid with **Paths** beside **Designer**. P-01 ([#2640](https://github.com/KenSuenobu/objectified-commercial/issues/2640)) — Paths **PATH QUALITY** placeholder, **Canvas | Code** (Paths editor), **Canvas | Paths | Code** navigation when not on Paths.
 
 **Excluded from first MVP (roadmap):** [#2657](https://github.com/KenSuenobu/objectified-commercial/issues/2657) (P-18), [#2658](https://github.com/KenSuenobu/objectified-commercial/issues/2658)–[#2662](https://github.com/KenSuenobu/objectified-commercial/issues/2662) (V2-01 → V2-05).
 

--- a/docs/PLANNED_FEATURE_ROADMAP_PATHS.md
+++ b/docs/PLANNED_FEATURE_ROADMAP_PATHS.md
@@ -22,7 +22,7 @@ This document defines **epics and ordered, single-scope issues** to deliver a **
 | ID | Issue | MVP |
 |----|------|-----|
 | P-00 | [#2639](https://github.com/KenSuenobu/objectified-commercial/issues/2639) (shipped) | Yes |
-| P-01 | [#2640](https://github.com/KenSuenobu/objectified-commercial/issues/2640) | Yes |
+| P-01 | [#2640](https://github.com/KenSuenobu/objectified-commercial/issues/2640) (shipped) | Yes |
 | P-02 | [#2641](https://github.com/KenSuenobu/objectified-commercial/issues/2641) | Yes |
 | P-03 | [#2642](https://github.com/KenSuenobu/objectified-commercial/issues/2642) | Yes |
 | P-04 | [#2643](https://github.com/KenSuenobu/objectified-commercial/issues/2643) | Yes |
@@ -53,7 +53,7 @@ This document defines **epics and ordered, single-scope issues** to deliver a **
 | # | Issue | MVP |
 |---|--------|-----|
 | ~~2639~~ | ~~P-00 Navigation: header “Paths” + Home grid card~~ **(shipped)** | Yes |
-| 2640 | P-01 Paths shell: header, PATH QUALITY placeholder, Canvas/Code | Yes |
+| ~~2640~~ | ~~P-01 Paths shell: header, PATH QUALITY placeholder, Canvas/Code~~ **(shipped)** | Yes |
 | 2641 | P-02 Canvas defaults parity with Designer | Yes |
 | 2642 | P-03 Persist canvas JSON per version | Yes |
 
@@ -216,9 +216,9 @@ Expose **Paths** next to **Designer** in the top Studio selector row (**“Paths
 
 ---
 
-### P-01 — Paths page shell: shared header, PATH QUALITY, Canvas/Code
+### P-01 — Paths page shell: shared header, PATH QUALITY, Canvas/Code ✅
 
-**Epic:** E1 · **Labels:** `paths`, `mvp`, `ui`
+**Epic:** E1 · **Labels:** `paths`, `mvp`, `ui` · **Status:** shipped
 
 **Title:** Paths Studio shell with project/version, settings, PATH QUALITY label, Canvas/Code toggle
 

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.9.82",
+  "version": "0.9.83",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -5,6 +5,7 @@ We continue to improve the platform based on your feedback with improvements and
 ---
 
 ## UI:
+- **Paths studio shell (#2640):** On **`/ade/studio/paths`**, the studio sub-header shows **PATH QUALITY** (placeholder score until P-17), a **Canvas | Code** toggle for the Paths editor (session-persisted), and the same **project / version / canvas settings** pattern as Designer; **Paths** is also on the **Canvas | Paths | Code** switcher when you are not on the Paths route
 - **Paths navigation (#2639):** **Paths** appears in the main Studio nav **next to Designer** (tenant/project context preserved); **Home** uses a **four-column** app grid on large screens with a **Paths** card **immediately to the right of Data Designer**, linking to **`/ade/studio/paths`**
 - **Version merge (#738):** Branch merge **preview** and **apply** run through **objectified-rest** — **merge-base (LCA)** plus **three-way** `components.schemas` merge, structured conflict paths, **two parents** on the merge revision, **`baseRevisionId`** optimistic lock on the target tip; Studio API routes proxy to REST
 - **Canvas ↔ Code (#2595):** Switching to **Code** now **synchronously hides group floating toolbars** (including hover/settings/export), **clears flow selection**, and **blocks sidebar group delete row actions** while the Code tab is active so nothing in that stack can take a stray click during the transition

--- a/objectified-ui/src/app/ade/studio/StudioContext.tsx
+++ b/objectified-ui/src/app/ade/studio/StudioContext.tsx
@@ -187,7 +187,7 @@ interface StudioContextType {
   setPathsViewMode: (mode: 'canvas' | 'code') => void;
 }
 
-const PATHS_VIEW_MODE_STORAGE_KEY = 'studio.paths.viewMode';
+export const PATHS_VIEW_MODE_STORAGE_KEY = 'studio.paths.viewMode';
 
 const StudioContext = createContext<StudioContextType | undefined>(undefined);
 

--- a/objectified-ui/src/app/ade/studio/StudioContext.tsx
+++ b/objectified-ui/src/app/ade/studio/StudioContext.tsx
@@ -182,7 +182,12 @@ interface StudioContextType {
   /** Canvas / studio edits not yet persisted (#2569). */
   syncLocalDirty: boolean;
   setSyncLocalDirty: (value: boolean) => void;
+  /** Paths editor: canvas vs code (sessionStorage `studio.paths.viewMode`; #2640 P-01). */
+  pathsViewMode: 'canvas' | 'code';
+  setPathsViewMode: (mode: 'canvas' | 'code') => void;
 }
+
+const PATHS_VIEW_MODE_STORAGE_KEY = 'studio.paths.viewMode';
 
 const StudioContext = createContext<StudioContextType | undefined>(undefined);
 
@@ -385,6 +390,31 @@ export function StudioProvider({ children }: { children: ReactNode }) {
   const [schemaQualityDetail, setSchemaQualityDetail] = useState<OverallSchemaQualityDetail | null>(null);
   const [syncLocalDirty, setSyncLocalDirty] = useState(false);
 
+  const [pathsViewMode, setPathsViewModeState] = useState<'canvas' | 'code'>('canvas');
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      const raw = sessionStorage.getItem(PATHS_VIEW_MODE_STORAGE_KEY);
+      if (raw === 'canvas' || raw === 'code') {
+        setPathsViewModeState(raw);
+      }
+    } catch {
+      /* ignore */
+    }
+  }, []);
+
+  const setPathsViewMode = useCallback((mode: 'canvas' | 'code') => {
+    setPathsViewModeState(mode);
+    if (typeof window !== 'undefined') {
+      try {
+        sessionStorage.setItem(PATHS_VIEW_MODE_STORAGE_KEY, mode);
+      } catch {
+        /* ignore */
+      }
+    }
+  }, []);
+
   // Persist grid settings to localStorage
   useEffect(() => {
     if (typeof window !== 'undefined') {
@@ -574,7 +604,9 @@ export function StudioProvider({ children }: { children: ReactNode }) {
       schemaQualityDetail,
       setSchemaQualityDetail,
       syncLocalDirty,
-      setSyncLocalDirty
+      setSyncLocalDirty,
+      pathsViewMode,
+      setPathsViewMode
     }}>
       {children}
     </StudioContext.Provider>

--- a/objectified-ui/src/app/ade/studio/components/StudioHeader.tsx
+++ b/objectified-ui/src/app/ade/studio/components/StudioHeader.tsx
@@ -91,6 +91,8 @@ export default function StudioHeader({ onProjectTagsLoaded }: StudioHeaderProps)
     triggerCanvasRefresh,
     triggerSidebarRefresh,
     syncLocalDirty,
+    pathsViewMode,
+    setPathsViewMode,
   } = useStudio();
 
   const { conflict, clearPushConflict } = usePushConflictBanner();
@@ -112,6 +114,8 @@ export default function StudioHeader({ onProjectTagsLoaded }: StudioHeaderProps)
     : pathname?.includes('/paths')
       ? 'paths'
       : 'editor';
+
+  const isPathsRoute = Boolean(pathname?.includes('/paths'));
 
   // Handle settings save
   const handleSettingsSave = React.useCallback((settings: {
@@ -478,8 +482,26 @@ export default function StudioHeader({ onProjectTagsLoaded }: StudioHeaderProps)
           />
         ) : null}
 
-        {/* Overall schema quality (#245) — live from Canvas; click for breakdown (#2548) */}
-        {localProjectId && localVersionId && (
+        {/* PATH QUALITY placeholder on Paths (#2640 P-01); schema quality on Designer/Code (#245, #2548) */}
+        {localProjectId && localVersionId && isPathsRoute && (
+          <div
+            role="status"
+            className="flex items-center gap-2 rounded-xl border border-gray-200 dark:border-gray-600 bg-white/90 dark:bg-gray-700/40 px-3 py-1 shadow-sm shrink-0"
+            title="Path quality scoring will be available in a future update."
+          >
+            <Gauge className="w-5 h-5 text-indigo-500 shrink-0" aria-hidden />
+            <div className="flex flex-col min-w-0">
+              <span className="text-[10px] uppercase tracking-wide text-gray-500 dark:text-gray-400 leading-none">
+                PATH QUALITY
+              </span>
+              <span className="text-2xl font-bold tabular-nums leading-none text-gray-400 dark:text-gray-500">
+                —
+              </span>
+            </div>
+          </div>
+        )}
+
+        {localProjectId && localVersionId && !isPathsRoute && (
           <>
             {schemaQualityScore != null ? (
               <button
@@ -656,32 +678,72 @@ export default function StudioHeader({ onProjectTagsLoaded }: StudioHeaderProps)
             {/* Separator */}
             <div className="h-6 w-px bg-gray-200 dark:bg-gray-600" />
 
-            <ToggleGroup.Root
-              type="single"
-              value={viewMode}
-              onValueChange={handleViewModeChange}
-              className="inline-flex bg-gray-100 dark:bg-gray-700/50 rounded-lg p-1 shadow-inner"
-            >
-              <ToggleGroup.Item
-                value="editor"
-                className="px-3 py-1.5 text-sm font-medium rounded-md transition-all duration-200 flex items-center gap-1.5 data-[state=on]:bg-white dark:data-[state=on]:bg-gray-600 data-[state=on]:text-indigo-600 dark:data-[state=on]:text-indigo-400 data-[state=on]:shadow-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white"
+            {isPathsRoute ? (
+              <ToggleGroup.Root
+                type="single"
+                value={pathsViewMode}
+                onValueChange={(value) => {
+                  if (value === 'canvas' || value === 'code') {
+                    setPathsViewMode(value);
+                  }
+                }}
+                className="inline-flex bg-gray-100 dark:bg-gray-700/50 rounded-lg p-1 shadow-inner"
               >
-                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 5a1 1 0 011-1h14a1 1 0 011 1v2a1 1 0 01-1 1H5a1 1 0 01-1-1V5zM4 13a1 1 0 011-1h6a1 1 0 011 1v6a1 1 0 01-1 1H5a1 1 0 01-1-1v-6zM16 13a1 1 0 011-1h2a1 1 0 011 1v6a1 1 0 01-1 1h-2a1 1 0 01-1-1v-6z" />
-                </svg>
-                Canvas
-              </ToggleGroup.Item>
-              {/* Paths view disabled for now - selection removed; routes and code remain in place */}
-              <ToggleGroup.Item
-                value="code"
-                className="px-3 py-1.5 text-sm font-medium rounded-md transition-all duration-200 flex items-center gap-1.5 data-[state=on]:bg-white dark:data-[state=on]:bg-gray-600 data-[state=on]:text-indigo-600 dark:data-[state=on]:text-indigo-400 data-[state=on]:shadow-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white"
+                <ToggleGroup.Item
+                  value="canvas"
+                  className="px-3 py-1.5 text-sm font-medium rounded-md transition-all duration-200 flex items-center gap-1.5 data-[state=on]:bg-white dark:data-[state=on]:bg-gray-600 data-[state=on]:text-indigo-600 dark:data-[state=on]:text-indigo-400 data-[state=on]:shadow-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white"
+                >
+                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 5a1 1 0 011-1h14a1 1 0 011 1v2a1 1 0 01-1 1H5a1 1 0 01-1-1V5zM4 13a1 1 0 011-1h6a1 1 0 011 1v6a1 1 0 01-1 1H5a1 1 0 01-1-1v-6zM16 13a1 1 0 011-1h2a1 1 0 011 1v6a1 1 0 01-1 1h-2a1 1 0 01-1-1v-6z" />
+                  </svg>
+                  Canvas
+                </ToggleGroup.Item>
+                <ToggleGroup.Item
+                  value="code"
+                  className="px-3 py-1.5 text-sm font-medium rounded-md transition-all duration-200 flex items-center gap-1.5 data-[state=on]:bg-white dark:data-[state=on]:bg-gray-600 data-[state=on]:text-indigo-600 dark:data-[state=on]:text-indigo-400 data-[state=on]:shadow-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white"
+                >
+                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4" />
+                  </svg>
+                  Code
+                </ToggleGroup.Item>
+              </ToggleGroup.Root>
+            ) : (
+              <ToggleGroup.Root
+                type="single"
+                value={viewMode}
+                onValueChange={handleViewModeChange}
+                className="inline-flex bg-gray-100 dark:bg-gray-700/50 rounded-lg p-1 shadow-inner"
               >
-                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4" />
-                </svg>
-                Code
-              </ToggleGroup.Item>
-            </ToggleGroup.Root>
+                <ToggleGroup.Item
+                  value="editor"
+                  className="px-3 py-1.5 text-sm font-medium rounded-md transition-all duration-200 flex items-center gap-1.5 data-[state=on]:bg-white dark:data-[state=on]:bg-gray-600 data-[state=on]:text-indigo-600 dark:data-[state=on]:text-indigo-400 data-[state=on]:shadow-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white"
+                >
+                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 5a1 1 0 011-1h14a1 1 0 011 1v2a1 1 0 01-1 1H5a1 1 0 01-1-1V5zM4 13a1 1 0 011-1h6a1 1 0 011 1v6a1 1 0 01-1 1H5a1 1 0 01-1-1v-6zM16 13a1 1 0 011-1h2a1 1 0 011 1v6a1 1 0 01-1 1h-2a1 1 0 01-1-1v-6z" />
+                  </svg>
+                  Canvas
+                </ToggleGroup.Item>
+                <ToggleGroup.Item
+                  value="paths"
+                  className="px-3 py-1.5 text-sm font-medium rounded-md transition-all duration-200 flex items-center gap-1.5 data-[state=on]:bg-white dark:data-[state=on]:bg-gray-600 data-[state=on]:text-indigo-600 dark:data-[state=on]:text-indigo-400 data-[state=on]:shadow-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white"
+                >
+                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 20l-5.447-2.724A1 1 0 013 16.382V5.618a1 1 0 011.447-.894L9 7m0 13l6-3m-6 3V7m6 10l4.553 2.276A1 1 0 0021 18.382V7.618a1 1 0 00-.553-.894L15 4m0 13V4m0 0L9 7" />
+                  </svg>
+                  Paths
+                </ToggleGroup.Item>
+                <ToggleGroup.Item
+                  value="code"
+                  className="px-3 py-1.5 text-sm font-medium rounded-md transition-all duration-200 flex items-center gap-1.5 data-[state=on]:bg-white dark:data-[state=on]:bg-gray-600 data-[state=on]:text-indigo-600 dark:data-[state=on]:text-indigo-400 data-[state=on]:shadow-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white"
+                >
+                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4" />
+                  </svg>
+                  Code
+                </ToggleGroup.Item>
+              </ToggleGroup.Root>
+            )}
 
             {/* Settings Button */}
             <div className="ml-auto">

--- a/objectified-ui/src/app/ade/studio/components/StudioHeader.tsx
+++ b/objectified-ui/src/app/ade/studio/components/StudioHeader.tsx
@@ -115,7 +115,7 @@ export default function StudioHeader({ onProjectTagsLoaded }: StudioHeaderProps)
       ? 'paths'
       : 'editor';
 
-  const isPathsRoute = Boolean(pathname?.includes('/paths'));
+  const isPathsRoute = viewMode === 'paths';
 
   // Handle settings save
   const handleSettingsSave = React.useCallback((settings: {

--- a/objectified-ui/src/app/ade/studio/paths/page.tsx
+++ b/objectified-ui/src/app/ade/studio/paths/page.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState } from 'react';
 import { useStudio } from '../StudioContext';
+import { Code2 } from 'lucide-react';
 import PathsSidebar from './components/PathsSidebar';
 import PathsCanvasView from './components/PathsCanvasView';
 import OperationPropertiesPanel from './components/OperationPropertiesPanel';
@@ -9,7 +10,7 @@ import ParameterPropertiesPanel from './components/ParameterPropertiesPanel';
 import ResponsePropertiesPanel from './components/ResponsePropertiesPanel';
 
 export default function PathsPage() {
-  const { selectedProjectId, selectedVersionId } = useStudio();
+  const { selectedProjectId, selectedVersionId, pathsViewMode } = useStudio();
   const [activeTab, setActiveTab] = useState<'paths' | 'operations' | 'classes' | 'properties' | 'security' | 'servers'>('paths');
   const [selectedPathId, setSelectedPathId] = useState<string | null>(null);
   const [selectedPath, setSelectedPath] = useState<{ id: string; pathname: string } | null>(null);
@@ -109,6 +110,20 @@ export default function PathsPage() {
       ) : (
         /* Three-Panel Layout: Sidebar | Canvas | Properties */
         <div className="flex-1 flex h-full overflow-hidden relative">
+          {pathsViewMode === 'code' ? (
+            <div className="flex-1 flex flex-col items-center justify-center gap-4 bg-gray-50 dark:bg-gray-900 px-6 text-center">
+              <div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-indigo-100 dark:bg-indigo-900/40">
+                <Code2 className="h-8 w-8 text-indigo-600 dark:text-indigo-400" aria-hidden />
+              </div>
+              <div>
+                <h2 className="text-lg font-semibold text-gray-900 dark:text-white">Paths code view</h2>
+                <p className="mt-2 max-w-md text-sm text-gray-600 dark:text-gray-400">
+                  OpenAPI paths editing in code will connect here. For now, use <span className="font-medium text-gray-800 dark:text-gray-200">Canvas</span> in the studio header to design on the graph.
+                </p>
+              </div>
+            </div>
+          ) : (
+            <>
           {/* Left Sidebar */}
           <PathsSidebar
             activeTab={activeTab}
@@ -231,6 +246,8 @@ export default function PathsPage() {
                 </div>
               </div>
             </div>
+          )}
+            </>
           )}
         </div>
       )}

--- a/objectified-ui/tests/studio-paths-view-mode.test.tsx
+++ b/objectified-ui/tests/studio-paths-view-mode.test.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
-import { StudioProvider, useStudio } from '../src/app/ade/studio/StudioContext';
+import { StudioProvider, useStudio, PATHS_VIEW_MODE_STORAGE_KEY } from '../src/app/ade/studio/StudioContext';
 
 function PathsModeProbe() {
   const { pathsViewMode, setPathsViewMode } = useStudio();
@@ -36,14 +36,14 @@ describe('StudioContext pathsViewMode', () => {
     );
 
     fireEvent.click(screen.getByRole('button', { name: 'use-code' }));
-    expect(sessionStorage.getItem('studio.paths.viewMode')).toBe('code');
+    expect(sessionStorage.getItem(PATHS_VIEW_MODE_STORAGE_KEY)).toBe('code');
 
     fireEvent.click(screen.getByRole('button', { name: 'use-canvas' }));
-    expect(sessionStorage.getItem('studio.paths.viewMode')).toBe('canvas');
+    expect(sessionStorage.getItem(PATHS_VIEW_MODE_STORAGE_KEY)).toBe('canvas');
   });
 
   it('restores paths view mode from sessionStorage after mount', async () => {
-    sessionStorage.setItem('studio.paths.viewMode', 'code');
+    sessionStorage.setItem(PATHS_VIEW_MODE_STORAGE_KEY, 'code');
 
     render(
       <StudioProvider>

--- a/objectified-ui/tests/studio-paths-view-mode.test.tsx
+++ b/objectified-ui/tests/studio-paths-view-mode.test.tsx
@@ -1,0 +1,58 @@
+/**
+ * Paths editor Canvas / Code session preference (#2640 P-01).
+ */
+
+import React from 'react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import { StudioProvider, useStudio } from '../src/app/ade/studio/StudioContext';
+
+function PathsModeProbe() {
+  const { pathsViewMode, setPathsViewMode } = useStudio();
+  return (
+    <div>
+      <span data-testid="paths-mode">{pathsViewMode}</span>
+      <button type="button" onClick={() => setPathsViewMode('code')}>
+        use-code
+      </button>
+      <button type="button" onClick={() => setPathsViewMode('canvas')}>
+        use-canvas
+      </button>
+    </div>
+  );
+}
+
+describe('StudioContext pathsViewMode', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  it('persists setPathsViewMode to sessionStorage', () => {
+    render(
+      <StudioProvider>
+        <PathsModeProbe />
+      </StudioProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'use-code' }));
+    expect(sessionStorage.getItem('studio.paths.viewMode')).toBe('code');
+
+    fireEvent.click(screen.getByRole('button', { name: 'use-canvas' }));
+    expect(sessionStorage.getItem('studio.paths.viewMode')).toBe('canvas');
+  });
+
+  it('restores paths view mode from sessionStorage after mount', async () => {
+    sessionStorage.setItem('studio.paths.viewMode', 'code');
+
+    render(
+      <StudioProvider>
+        <PathsModeProbe />
+      </StudioProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('paths-mode')).toHaveTextContent('code');
+    });
+  });
+});


### PR DESCRIPTION
## What / why
Implements **P-01** (issue #2640): Paths route uses the same studio sub-header pattern as Designer with **PATH QUALITY** as a non-interactive placeholder (real scoring in P-17), a **Canvas | Code** toggle for the Paths editor (session-persisted via `sessionStorage`), and restores **Paths** on the **Canvas | Paths | Code** switcher when not on the Paths route so navigation stays coherent.

## How to test
1. Open **Paths** (`/ade/studio/paths`) with a project and version selected.
2. Confirm header shows **PATH QUALITY** with **—** (not Schema quality) and no clickable breakdown.
3. Toggle **Canvas | Code** — Code shows the placeholder panel; Canvas restores the graph UI. Reload or navigate away and back: last mode should restore for the browser session.
4. From **Designer** or **Code**, use the studio header **Paths** control to open Paths; confirm no console errors.

## Risk / notes
- **Paths Code** is a stub until P-15 (Monaco / OpenAPI paths code).
- `gh issue view` was unavailable in the automation environment; requirements taken from `docs/PLANNED_FEATURE_ROADMAP_PATHS.md` P-01.

Closes #2640

Made with [Cursor](https://cursor.com)