### PR TITLE
Fix #2641 - Paths canvas prefs namespaced; Designer parity for React Flow

### DIFF
--- a/docs/PLANNED_FEATURE_ROADMAP_PATHS.md
+++ b/docs/PLANNED_FEATURE_ROADMAP_PATHS.md
@@ -23,7 +23,7 @@ This document defines **epics and ordered, single-scope issues** to deliver a **
 |----|------|-----|
 | P-00 | [#2639](https://github.com/KenSuenobu/objectified-commercial/issues/2639) (shipped) | Yes |
 | P-01 | [#2640](https://github.com/KenSuenobu/objectified-commercial/issues/2640) (shipped) | Yes |
-| P-02 | [#2641](https://github.com/KenSuenobu/objectified-commercial/issues/2641) | Yes |
+| P-02 | [#2641](https://github.com/KenSuenobu/objectified-commercial/issues/2641) (shipped) | Yes |
 | P-03 | [#2642](https://github.com/KenSuenobu/objectified-commercial/issues/2642) | Yes |
 | P-04 | [#2643](https://github.com/KenSuenobu/objectified-commercial/issues/2643) | Yes |
 | P-05 | [#2644](https://github.com/KenSuenobu/objectified-commercial/issues/2644) | Yes |
@@ -54,7 +54,7 @@ This document defines **epics and ordered, single-scope issues** to deliver a **
 |---|--------|-----|
 | ~~2639~~ | ~~P-00 Navigation: header “Paths” + Home grid card~~ **(shipped)** | Yes |
 | ~~2640~~ | ~~P-01 Paths shell: header, PATH QUALITY placeholder, Canvas/Code~~ **(shipped)** | Yes |
-| 2641 | P-02 Canvas defaults parity with Designer | Yes |
+| ~~2641~~ | ~~P-02 Canvas defaults parity with Designer~~ **(shipped)** | Yes |
 | 2642 | P-03 Persist canvas JSON per version | Yes |
 
 **E2 — [#2634](https://github.com/KenSuenobu/objectified-commercial/issues/2634)**

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.9.83",
+  "version": "0.9.84",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -5,6 +5,7 @@ We continue to improve the platform based on your feedback with improvements and
 ---
 
 ## UI:
+- **Paths canvas prefs (#2641):** Studio canvas settings use **separate storage** (`studio.designer.*` vs `studio.paths.*`) so Designer and Paths keep **independent** grid, snap, guides, background, and edge options; **Paths** matches Designer-style **React Flow** wiring (snap grid, default edge stroke, connection line, smart alignment guides on drag)
 - **Paths studio shell (#2640):** On **`/ade/studio/paths`**, the studio sub-header shows **PATH QUALITY** (placeholder score until P-17), a **Canvas | Code** toggle for the Paths editor (session-persisted), and the same **project / version / canvas settings** pattern as Designer; **Paths** is also on the **Canvas | Paths | Code** switcher when you are not on the Paths route
 - **Paths navigation (#2639):** **Paths** appears in the main Studio nav **next to Designer** (tenant/project context preserved); **Home** uses a **four-column** app grid on large screens with a **Paths** card **immediately to the right of Data Designer**, linking to **`/ade/studio/paths`**
 - **Version merge (#738):** Branch merge **preview** and **apply** run through **objectified-rest** — **merge-base (LCA)** plus **three-way** `components.schemas` merge, structured conflict paths, **two parents** on the merge revision, **`baseRevisionId`** optimistic lock on the target tip; Studio API routes proxy to REST

--- a/objectified-ui/src/app/ade/studio/StudioContext.tsx
+++ b/objectified-ui/src/app/ade/studio/StudioContext.tsx
@@ -274,6 +274,7 @@ export function StudioProvider({ children }: { children: ReactNode }) {
   );
 
   const prevCanvasSurfaceRef = useRef<StudioCanvasSurface | null>(null);
+  const isSurfaceSwitchingRef = useRef(false);
   useEffect(() => {
     if (typeof window === 'undefined') return;
     if (prevCanvasSurfaceRef.current === null) {
@@ -283,6 +284,7 @@ export function StudioProvider({ children }: { children: ReactNode }) {
     if (prevCanvasSurfaceRef.current === canvasSurface) return;
     prevCanvasSurfaceRef.current = canvasSurface;
     const bundle = loadCanvasPrefsBundle(canvasSurface);
+    isSurfaceSwitchingRef.current = true;
     queueMicrotask(() => {
       setClickToFocusEnabled(bundle.clickToFocusEnabled);
       setLodEnabled(bundle.lodEnabled);
@@ -297,6 +299,7 @@ export function StudioProvider({ children }: { children: ReactNode }) {
       setEdgeRouting(bundle.edgeRouting);
       setEdgeAnimation(bundle.edgeAnimation);
       setCanvasBackground(bundle.canvasBackground);
+      isSurfaceSwitchingRef.current = false;
     });
   }, [canvasSurface]);
 
@@ -335,6 +338,7 @@ export function StudioProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
+    if (isSurfaceSwitchingRef.current) return;
     try {
       localStorage.setItem(studioCanvasPrefStorageKey(canvasSurface, 'gridSize'), gridSize.toString());
     } catch {
@@ -344,6 +348,7 @@ export function StudioProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
+    if (isSurfaceSwitchingRef.current) return;
     try {
       localStorage.setItem(studioCanvasPrefStorageKey(canvasSurface, 'snapToGrid'), JSON.stringify(snapToGrid));
     } catch {
@@ -353,6 +358,7 @@ export function StudioProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
+    if (isSurfaceSwitchingRef.current) return;
     try {
       localStorage.setItem(studioCanvasPrefStorageKey(canvasSurface, 'gridStyle'), gridStyle);
     } catch {
@@ -362,6 +368,7 @@ export function StudioProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
+    if (isSurfaceSwitchingRef.current) return;
     try {
       localStorage.setItem(studioCanvasPrefStorageKey(canvasSurface, 'showGrid'), JSON.stringify(showGrid));
     } catch {
@@ -371,6 +378,7 @@ export function StudioProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
+    if (isSurfaceSwitchingRef.current) return;
     try {
       localStorage.setItem(studioCanvasPrefStorageKey(canvasSurface, 'smartGuidesEnabled'), JSON.stringify(smartGuidesEnabled));
     } catch {
@@ -380,6 +388,7 @@ export function StudioProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
+    if (isSurfaceSwitchingRef.current) return;
     try {
       localStorage.setItem(studioCanvasPrefStorageKey(canvasSurface, 'clickToFocusEnabled'), JSON.stringify(clickToFocusEnabled));
     } catch {
@@ -389,6 +398,7 @@ export function StudioProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
+    if (isSurfaceSwitchingRef.current) return;
     try {
       localStorage.setItem(studioCanvasPrefStorageKey(canvasSurface, 'lodEnabled'), JSON.stringify(lodEnabled));
     } catch {
@@ -398,6 +408,7 @@ export function StudioProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
+    if (isSurfaceSwitchingRef.current) return;
     try {
       localStorage.setItem(studioCanvasPrefStorageKey(canvasSurface, 'autoSaveLayoutEnabled'), JSON.stringify(autoSaveLayoutEnabled));
     } catch {
@@ -407,6 +418,7 @@ export function StudioProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
+    if (isSurfaceSwitchingRef.current) return;
     try {
       localStorage.setItem(
         studioCanvasPrefStorageKey(canvasSurface, 'autoSaveLayoutIntervalSeconds'),
@@ -419,6 +431,7 @@ export function StudioProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
+    if (isSurfaceSwitchingRef.current) return;
     try {
       localStorage.setItem(studioCanvasPrefStorageKey(canvasSurface, 'edgeStyling'), JSON.stringify(edgeStyling));
     } catch {
@@ -428,6 +441,7 @@ export function StudioProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
+    if (isSurfaceSwitchingRef.current) return;
     try {
       localStorage.setItem(studioCanvasPrefStorageKey(canvasSurface, 'edgeRouting'), edgeRouting);
     } catch {
@@ -437,6 +451,7 @@ export function StudioProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
+    if (isSurfaceSwitchingRef.current) return;
     try {
       localStorage.setItem(studioCanvasPrefStorageKey(canvasSurface, 'edgeAnimation'), edgeAnimation);
     } catch {
@@ -446,6 +461,7 @@ export function StudioProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
+    if (isSurfaceSwitchingRef.current) return;
     try {
       localStorage.setItem(studioCanvasPrefStorageKey(canvasSurface, 'canvasBackground'), JSON.stringify(canvasBackground));
     } catch {

--- a/objectified-ui/src/app/ade/studio/StudioContext.tsx
+++ b/objectified-ui/src/app/ade/studio/StudioContext.tsx
@@ -1,6 +1,14 @@
 'use client';
 
-import React, { createContext, useContext, useState, useEffect, useCallback, ReactNode, Dispatch, SetStateAction } from 'react';
+import React, { createContext, useContext, useState, useEffect, useCallback, useMemo, useRef, ReactNode, Dispatch, SetStateAction } from 'react';
+import { usePathname } from 'next/navigation';
+import {
+  getCachedInitialCanvasPrefsBundle,
+  getCanvasSurfaceFromPathname,
+  loadCanvasPrefsBundle,
+  studioCanvasPrefStorageKey,
+  type StudioCanvasSurface,
+} from './lib/studio-canvas-prefs-storage';
 import type { OverallSchemaQualityDetail } from '@/app/utils/overall-schema-quality';
 
 // Group style options
@@ -192,6 +200,12 @@ export const PATHS_VIEW_MODE_STORAGE_KEY = 'studio.paths.viewMode';
 const StudioContext = createContext<StudioContextType | undefined>(undefined);
 
 export function StudioProvider({ children }: { children: ReactNode }) {
+  const pathname = usePathname();
+  const canvasSurface: StudioCanvasSurface = useMemo(
+    () => getCanvasSurfaceFromPathname(pathname),
+    [pathname]
+  );
+
   const [selectedProjectId, setSelectedProjectId] = useState<string | null>(null);
   const [selectedVersionId, setSelectedVersionId] = useState<string | null>(null);
   const [canvasRefreshKey, setCanvasRefreshKey] = useState<number>(0);
@@ -202,182 +216,89 @@ export function StudioProvider({ children }: { children: ReactNode }) {
   const [hiddenClassIds, setHiddenClassIds] = useState<string[]>([]);
   const [createGroupFn, setCreateGroupFn] = useState<(() => void) | null>(null);
   const [createGroupAtPositionFn, setCreateGroupAtPositionFn] = useState<((position: { x: number; y: number }) => void) | null>(null);
-  const [clickToFocusEnabled, setClickToFocusEnabled] = useState<boolean>(() => {
-    if (typeof window !== 'undefined') {
-      const saved = localStorage.getItem('clickToFocusEnabled');
-      return saved ? JSON.parse(saved) : true; // Default to enabled
-    }
-    return true;
-  });
-  const [lodEnabled, setLodEnabled] = useState<boolean>(() => {
-    if (typeof window !== 'undefined') {
-      const saved = localStorage.getItem('lodEnabled');
-      return saved ? JSON.parse(saved) : false; // Default to disabled
-    }
-    return false;
-  });
 
-  // Grid settings
-  const [gridSize, setGridSize] = useState<number>(() => {
-    if (typeof window !== 'undefined') {
-      const saved = localStorage.getItem('gridSize');
-      return saved ? parseInt(saved, 10) : 20; // Default to 20px
-    }
-    return 20;
-  });
+  /** Namespaced per-surface prefs — see lib/studio-canvas-prefs-storage.ts (#2641). */
+  const [clickToFocusEnabled, setClickToFocusEnabled] = useState<boolean>(
+    () => getCachedInitialCanvasPrefsBundle(typeof window !== 'undefined' ? window.location.pathname : null).clickToFocusEnabled
+  );
+  const [lodEnabled, setLodEnabled] = useState<boolean>(
+    () => getCachedInitialCanvasPrefsBundle(typeof window !== 'undefined' ? window.location.pathname : null).lodEnabled
+  );
 
-  const [snapToGrid, setSnapToGrid] = useState<boolean>(() => {
-    if (typeof window !== 'undefined') {
-      const saved = localStorage.getItem('snapToGrid');
-      return saved ? JSON.parse(saved) : true; // Default to enabled
-    }
-    return true;
-  });
+  const [gridSize, setGridSize] = useState<number>(
+    () => getCachedInitialCanvasPrefsBundle(typeof window !== 'undefined' ? window.location.pathname : null).gridSize
+  );
 
-  const [gridStyle, setGridStyle] = useState<'dots' | 'lines' | 'cross'>(() => {
-    if (typeof window !== 'undefined') {
-      const saved = localStorage.getItem('gridStyle');
-      return (saved as 'dots' | 'lines' | 'cross') || 'dots'; // Default to dots
-    }
-    return 'dots';
-  });
+  const [snapToGrid, setSnapToGrid] = useState<boolean>(
+    () => getCachedInitialCanvasPrefsBundle(typeof window !== 'undefined' ? window.location.pathname : null).snapToGrid
+  );
 
-  const [showGrid, setShowGrid] = useState<boolean>(() => {
-    if (typeof window !== 'undefined') {
-      const saved = localStorage.getItem('showGrid');
-      return saved ? JSON.parse(saved) : true; // Default to visible
-    }
-    return true;
-  });
+  const [gridStyle, setGridStyle] = useState<'dots' | 'lines' | 'cross'>(
+    () => getCachedInitialCanvasPrefsBundle(typeof window !== 'undefined' ? window.location.pathname : null).gridStyle
+  );
+
+  const [showGrid, setShowGrid] = useState<boolean>(
+    () => getCachedInitialCanvasPrefsBundle(typeof window !== 'undefined' ? window.location.pathname : null).showGrid
+  );
 
   /** Temporary override for grid visibility during export (#407). Not persisted. */
   const [exportGridOverride, setExportGridOverride] = useState<boolean | null>(null);
 
-  const [smartGuidesEnabled, setSmartGuidesEnabled] = useState<boolean>(() => {
-    if (typeof window !== 'undefined') {
-      const saved = localStorage.getItem('smartGuidesEnabled');
-      return saved ? JSON.parse(saved) : true; // Default to enabled
-    }
-    return true;
-  });
-  const [autoSaveLayoutEnabled, setAutoSaveLayoutEnabled] = useState<boolean>(() => {
-    if (typeof window !== 'undefined') {
-      const saved = localStorage.getItem('autoSaveLayoutEnabled');
-      if (saved) {
-        try {
-          return JSON.parse(saved);
-        } catch (e) {
-          console.error('Failed to parse autoSaveLayoutEnabled from localStorage:', e);
-          return false;
-        }
-      }
-    }
-    return false;
-  });
-  const [autoSaveLayoutIntervalSeconds, setAutoSaveLayoutIntervalSecondsRaw] = useState<number>(() => {
-    if (typeof window !== 'undefined') {
-      const saved = localStorage.getItem('autoSaveLayoutIntervalSeconds');
-      const parsed = saved ? parseInt(saved, 10) : 30;
-      if (Number.isFinite(parsed)) {
-        return Math.min(300, Math.max(10, parsed));
-      }
-    }
-    return 30;
-  });
+  const [smartGuidesEnabled, setSmartGuidesEnabled] = useState<boolean>(
+    () => getCachedInitialCanvasPrefsBundle(typeof window !== 'undefined' ? window.location.pathname : null).smartGuidesEnabled
+  );
+  const [autoSaveLayoutEnabled, setAutoSaveLayoutEnabled] = useState<boolean>(
+    () => getCachedInitialCanvasPrefsBundle(typeof window !== 'undefined' ? window.location.pathname : null).autoSaveLayoutEnabled
+  );
+  const [autoSaveLayoutIntervalSeconds, setAutoSaveLayoutIntervalSecondsRaw] = useState<number>(
+    () => getCachedInitialCanvasPrefsBundle(typeof window !== 'undefined' ? window.location.pathname : null).autoSaveLayoutIntervalSeconds
+  );
   const setAutoSaveLayoutIntervalSeconds = useCallback((seconds: number) => {
     setAutoSaveLayoutIntervalSecondsRaw(Math.min(300, Math.max(10, seconds)));
   }, []);
 
-  const [edgeStyling, setEdgeStyling] = useState<EdgeStylingOptions>(() => {
-    const defaults: EdgeStylingOptions = {
-      directReferences: 'solid' as const,
-      optionalReferences: 'dashed' as const,
-      weakReferences: 'dotted' as const,
-      bidirectional: 'double' as const,
-      directColor: '#64748b', // Slate (first color in palette)
-      optionalColor: '#f97316', // Orange
-      weakColor: '#8b5cf6', // Purple
-      bidirectionalColor: '#ec4899', // Pink
-      // Arrow styles - default to standard arrow
-      directArrowStyle: 'arrow' as const,
-      optionalArrowStyle: 'arrow' as const,
-      weakArrowStyle: 'arrow' as const,
-      bidirectionalArrowStyle: 'arrow' as const,
-    };
+  const [edgeStyling, setEdgeStyling] = useState<EdgeStylingOptions>(
+    () => getCachedInitialCanvasPrefsBundle(typeof window !== 'undefined' ? window.location.pathname : null).edgeStyling
+  );
 
-    if (typeof window !== 'undefined') {
-      const saved = localStorage.getItem('edgeStyling');
-      if (saved) {
-        try {
-          const parsed = JSON.parse(saved);
-          // Merge with defaults to ensure all properties exist
-          return {
-            ...defaults,
-            ...parsed,
-          };
-        } catch (e) {
-          console.error('Failed to parse edge styling from localStorage:', e);
-          return defaults;
-        }
-      }
+  const [edgeRouting, setEdgeRouting] = useState<EdgeRoutingType>(
+    () => getCachedInitialCanvasPrefsBundle(typeof window !== 'undefined' ? window.location.pathname : null).edgeRouting
+  );
+
+  const [edgeAnimation, setEdgeAnimation] = useState<EdgeAnimationType>(
+    () => getCachedInitialCanvasPrefsBundle(typeof window !== 'undefined' ? window.location.pathname : null).edgeAnimation
+  );
+
+  const [canvasBackground, setCanvasBackground] = useState<CanvasBackgroundOptions>(
+    () => getCachedInitialCanvasPrefsBundle(typeof window !== 'undefined' ? window.location.pathname : null).canvasBackground
+  );
+
+  const prevCanvasSurfaceRef = useRef<StudioCanvasSurface | null>(null);
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    if (prevCanvasSurfaceRef.current === null) {
+      prevCanvasSurfaceRef.current = canvasSurface;
+      return;
     }
-    return defaults;
-  });
-
-  const [edgeRouting, setEdgeRouting] = useState<EdgeRoutingType>(() => {
-    if (typeof window !== 'undefined') {
-      const saved = localStorage.getItem('edgeRouting');
-      if (saved && ['straight', 'bezier', 'orthogonal', 'smart'].includes(saved)) {
-        return saved as EdgeRoutingType;
-      }
-    }
-    return 'bezier'; // Default to curved/bezier
-  });
-
-  const [edgeAnimation, setEdgeAnimation] = useState<EdgeAnimationType>(() => {
-    if (typeof window !== 'undefined') {
-      const saved = localStorage.getItem('edgeAnimation');
-      if (saved && ['none', 'flow', 'pulse', 'dash'].includes(saved)) {
-        return saved as EdgeAnimationType;
-      }
-    }
-    return 'none'; // Default to no animation
-  });
-
-  // Canvas background settings
-  const defaultCanvasBackground: CanvasBackgroundOptions = {
-    type: 'grid',
-    solidColor: '#f8fafc',
-    gridColor: '#6366f1',
-    gridOpacity: 0.15,
-    imageUrl: '',
-    imageOpacity: 0.5,
-    imageFit: 'cover',
-    gradientFrom: '#f8fafc',
-    gradientTo: '#e2e8f0',
-    gradientDirection: 'to-br',
-    textureType: 'noise',
-    textureOpacity: 0.1,
-    textureColor: '#64748b',
-    backgroundOpacity: 1,
-    backgroundBlur: 0,
-  };
-
-  const [canvasBackground, setCanvasBackground] = useState<CanvasBackgroundOptions>(() => {
-    if (typeof window !== 'undefined') {
-      const saved = localStorage.getItem('canvasBackground');
-      if (saved) {
-        try {
-          const parsed = JSON.parse(saved);
-          return { ...defaultCanvasBackground, ...parsed };
-        } catch (e) {
-          console.error('Failed to parse canvas background from localStorage:', e);
-          return defaultCanvasBackground;
-        }
-      }
-    }
-    return defaultCanvasBackground;
-  });
+    if (prevCanvasSurfaceRef.current === canvasSurface) return;
+    prevCanvasSurfaceRef.current = canvasSurface;
+    const bundle = loadCanvasPrefsBundle(canvasSurface);
+    queueMicrotask(() => {
+      setClickToFocusEnabled(bundle.clickToFocusEnabled);
+      setLodEnabled(bundle.lodEnabled);
+      setGridSize(bundle.gridSize);
+      setSnapToGrid(bundle.snapToGrid);
+      setGridStyle(bundle.gridStyle);
+      setShowGrid(bundle.showGrid);
+      setSmartGuidesEnabled(bundle.smartGuidesEnabled);
+      setAutoSaveLayoutEnabled(bundle.autoSaveLayoutEnabled);
+      setAutoSaveLayoutIntervalSecondsRaw(bundle.autoSaveLayoutIntervalSeconds);
+      setEdgeStyling(bundle.edgeStyling);
+      setEdgeRouting(bundle.edgeRouting);
+      setEdgeAnimation(bundle.edgeAnimation);
+      setCanvasBackground(bundle.canvasBackground);
+    });
+  }, [canvasSurface]);
 
   const [groups, setGroups] = useState<CanvasGroup[]>([]);
 
@@ -390,19 +311,16 @@ export function StudioProvider({ children }: { children: ReactNode }) {
   const [schemaQualityDetail, setSchemaQualityDetail] = useState<OverallSchemaQualityDetail | null>(null);
   const [syncLocalDirty, setSyncLocalDirty] = useState(false);
 
-  const [pathsViewMode, setPathsViewModeState] = useState<'canvas' | 'code'>('canvas');
-
-  useEffect(() => {
-    if (typeof window === 'undefined') return;
+  const [pathsViewMode, setPathsViewModeState] = useState<'canvas' | 'code'>(() => {
+    if (typeof window === 'undefined') return 'canvas';
     try {
       const raw = sessionStorage.getItem(PATHS_VIEW_MODE_STORAGE_KEY);
-      if (raw === 'canvas' || raw === 'code') {
-        setPathsViewModeState(raw);
-      }
+      if (raw === 'canvas' || raw === 'code') return raw;
     } catch {
       /* ignore */
     }
-  }, []);
+    return 'canvas';
+  });
 
   const setPathsViewMode = useCallback((mode: 'canvas' | 'code') => {
     setPathsViewModeState(mode);
@@ -415,70 +333,125 @@ export function StudioProvider({ children }: { children: ReactNode }) {
     }
   }, []);
 
-  // Persist grid settings to localStorage
   useEffect(() => {
-    if (typeof window !== 'undefined') {
-      localStorage.setItem('gridSize', gridSize.toString());
+    if (typeof window === 'undefined') return;
+    try {
+      localStorage.setItem(studioCanvasPrefStorageKey(canvasSurface, 'gridSize'), gridSize.toString());
+    } catch {
+      /* ignore */
     }
-  }, [gridSize]);
+  }, [canvasSurface, gridSize]);
 
   useEffect(() => {
-    if (typeof window !== 'undefined') {
-      localStorage.setItem('snapToGrid', JSON.stringify(snapToGrid));
+    if (typeof window === 'undefined') return;
+    try {
+      localStorage.setItem(studioCanvasPrefStorageKey(canvasSurface, 'snapToGrid'), JSON.stringify(snapToGrid));
+    } catch {
+      /* ignore */
     }
-  }, [snapToGrid]);
+  }, [canvasSurface, snapToGrid]);
 
   useEffect(() => {
-    if (typeof window !== 'undefined') {
-      localStorage.setItem('gridStyle', gridStyle);
+    if (typeof window === 'undefined') return;
+    try {
+      localStorage.setItem(studioCanvasPrefStorageKey(canvasSurface, 'gridStyle'), gridStyle);
+    } catch {
+      /* ignore */
     }
-  }, [gridStyle]);
+  }, [canvasSurface, gridStyle]);
 
   useEffect(() => {
-    if (typeof window !== 'undefined') {
-      localStorage.setItem('showGrid', JSON.stringify(showGrid));
+    if (typeof window === 'undefined') return;
+    try {
+      localStorage.setItem(studioCanvasPrefStorageKey(canvasSurface, 'showGrid'), JSON.stringify(showGrid));
+    } catch {
+      /* ignore */
     }
-  }, [showGrid]);
+  }, [canvasSurface, showGrid]);
 
   useEffect(() => {
-    if (typeof window !== 'undefined') {
-      localStorage.setItem('smartGuidesEnabled', JSON.stringify(smartGuidesEnabled));
+    if (typeof window === 'undefined') return;
+    try {
+      localStorage.setItem(studioCanvasPrefStorageKey(canvasSurface, 'smartGuidesEnabled'), JSON.stringify(smartGuidesEnabled));
+    } catch {
+      /* ignore */
     }
-  }, [smartGuidesEnabled]);
-  useEffect(() => {
-    if (typeof window !== 'undefined') {
-      localStorage.setItem('autoSaveLayoutEnabled', JSON.stringify(autoSaveLayoutEnabled));
-    }
-  }, [autoSaveLayoutEnabled]);
-  useEffect(() => {
-    if (typeof window !== 'undefined') {
-      localStorage.setItem('autoSaveLayoutIntervalSeconds', String(autoSaveLayoutIntervalSeconds));
-    }
-  }, [autoSaveLayoutIntervalSeconds]);
+  }, [canvasSurface, smartGuidesEnabled]);
 
   useEffect(() => {
-    if (typeof window !== 'undefined') {
-      localStorage.setItem('edgeStyling', JSON.stringify(edgeStyling));
+    if (typeof window === 'undefined') return;
+    try {
+      localStorage.setItem(studioCanvasPrefStorageKey(canvasSurface, 'clickToFocusEnabled'), JSON.stringify(clickToFocusEnabled));
+    } catch {
+      /* ignore */
     }
-  }, [edgeStyling]);
+  }, [canvasSurface, clickToFocusEnabled]);
 
   useEffect(() => {
-    if (typeof window !== 'undefined') {
-      localStorage.setItem('edgeRouting', edgeRouting);
+    if (typeof window === 'undefined') return;
+    try {
+      localStorage.setItem(studioCanvasPrefStorageKey(canvasSurface, 'lodEnabled'), JSON.stringify(lodEnabled));
+    } catch {
+      /* ignore */
     }
-  }, [edgeRouting]);
+  }, [canvasSurface, lodEnabled]);
 
   useEffect(() => {
-    if (typeof window !== 'undefined') {
-      localStorage.setItem('edgeAnimation', edgeAnimation);
+    if (typeof window === 'undefined') return;
+    try {
+      localStorage.setItem(studioCanvasPrefStorageKey(canvasSurface, 'autoSaveLayoutEnabled'), JSON.stringify(autoSaveLayoutEnabled));
+    } catch {
+      /* ignore */
     }
-  }, [edgeAnimation]);
+  }, [canvasSurface, autoSaveLayoutEnabled]);
 
   useEffect(() => {
-    if (typeof window !== 'undefined') {
-      localStorage.setItem('canvasBackground', JSON.stringify(canvasBackground));
+    if (typeof window === 'undefined') return;
+    try {
+      localStorage.setItem(
+        studioCanvasPrefStorageKey(canvasSurface, 'autoSaveLayoutIntervalSeconds'),
+        String(autoSaveLayoutIntervalSeconds)
+      );
+    } catch {
+      /* ignore */
     }
-  }, [canvasBackground]);
+  }, [canvasSurface, autoSaveLayoutIntervalSeconds]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      localStorage.setItem(studioCanvasPrefStorageKey(canvasSurface, 'edgeStyling'), JSON.stringify(edgeStyling));
+    } catch {
+      /* ignore */
+    }
+  }, [canvasSurface, edgeStyling]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      localStorage.setItem(studioCanvasPrefStorageKey(canvasSurface, 'edgeRouting'), edgeRouting);
+    } catch {
+      /* ignore */
+    }
+  }, [canvasSurface, edgeRouting]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      localStorage.setItem(studioCanvasPrefStorageKey(canvasSurface, 'edgeAnimation'), edgeAnimation);
+    } catch {
+      /* ignore */
+    }
+  }, [canvasSurface, edgeAnimation]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      localStorage.setItem(studioCanvasPrefStorageKey(canvasSurface, 'canvasBackground'), JSON.stringify(canvasBackground));
+    } catch {
+      /* ignore */
+    }
+  }, [canvasSurface, canvasBackground]);
 
   const triggerCanvasRefresh = () => {
     setCanvasRefreshKey(prev => prev + 1);

--- a/objectified-ui/src/app/ade/studio/components/StudioHeader.tsx
+++ b/objectified-ui/src/app/ade/studio/components/StudioHeader.tsx
@@ -131,34 +131,16 @@ export default function StudioHeader({ onProjectTagsLoaded }: StudioHeaderProps)
     edgeAnimation: typeof edgeAnimation;
   }) => {
     setClickToFocusEnabled(settings.clickToFocusEnabled);
-    localStorage.setItem('clickToFocusEnabled', JSON.stringify(settings.clickToFocusEnabled));
-
     setSnapToGrid(settings.snapToGrid);
-    localStorage.setItem('snapToGrid', JSON.stringify(settings.snapToGrid));
-
     setSmartGuidesEnabled(settings.smartGuidesEnabled);
-    localStorage.setItem('smartGuidesEnabled', JSON.stringify(settings.smartGuidesEnabled));
-
     setShowGrid(settings.showGrid);
-    localStorage.setItem('showGrid', JSON.stringify(settings.showGrid));
-
     setGridSize(settings.gridSize);
-    localStorage.setItem('gridSize', String(settings.gridSize));
-
     setGridStyle(settings.gridStyle);
-    localStorage.setItem('gridStyle', settings.gridStyle);
-
     setCanvasBackground(settings.canvasBackground);
-    localStorage.setItem('canvasBackground', JSON.stringify(settings.canvasBackground));
-
     setEdgeStyling(settings.edgeStyling);
-    localStorage.setItem('edgeStyling', JSON.stringify(settings.edgeStyling));
-
     setEdgeRouting(settings.edgeRouting);
-    localStorage.setItem('edgeRouting', settings.edgeRouting);
-
     setEdgeAnimation(settings.edgeAnimation);
-    localStorage.setItem('edgeAnimation', settings.edgeAnimation);
+    /* Persistence: namespaced studio.designer.* / studio.paths.* via StudioContext (#2641). */
   }, [setClickToFocusEnabled, setSnapToGrid, setSmartGuidesEnabled, setShowGrid, setGridSize, setGridStyle, setCanvasBackground, setEdgeStyling, setEdgeRouting, setEdgeAnimation]);
 
   // Sync local state with context

--- a/objectified-ui/src/app/ade/studio/editor/page.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/page.tsx
@@ -367,7 +367,6 @@ const StudioContent = () => {
   // Toggle click-to-focus mode (defined after useStudio to access setContextClickToFocusEnabled)
   const toggleClickToFocus = useCallback(() => {
     const newValue = !clickToFocusEnabled;
-    localStorage.setItem('clickToFocusEnabled', JSON.stringify(newValue));
     setContextClickToFocusEnabled(newValue);
     return newValue;
   }, [clickToFocusEnabled, setContextClickToFocusEnabled]);
@@ -3673,7 +3672,7 @@ const StudioContent = () => {
       return;
     }
 
-    // Calculate smart guides for alignment
+    // Calculate smart guides for alignment (#2641: shared math lives in lib/smart-alignment-guides.ts for Paths — keep in sync)
     const SNAP_THRESHOLD = 8; // pixels
     const newHorizontalGuides: Array<{ y: number; x1: number; x2: number }> = [];
     const newVerticalGuides: Array<{ x: number; y1: number; y2: number }> = [];

--- a/objectified-ui/src/app/ade/studio/lib/smart-alignment-guides.ts
+++ b/objectified-ui/src/app/ade/studio/lib/smart-alignment-guides.ts
@@ -1,0 +1,91 @@
+import type { Node } from '@xyflow/react';
+
+export interface AlignmentGuidesState {
+  horizontal: Array<{ y: number; x1: number; x2: number }>;
+  vertical: Array<{ x: number; y1: number; y2: number }>;
+}
+
+const SNAP_THRESHOLD = 8;
+
+/**
+ * Alignment guides for node drag (shared math with Designer editor/page.tsx — #2641).
+ * If Designer drag logic changes, update this function and the cross-reference in editor.
+ */
+export function computeAlignmentGuidesForNode(
+  node: Node,
+  otherNodes: Node[],
+  options?: { defaultWidth?: number; defaultHeight?: number; excludeTypes?: string[] }
+): AlignmentGuidesState {
+  const defaultWidth = options?.defaultWidth ?? 260;
+  const defaultHeight = options?.defaultHeight ?? 200;
+  const excludeTypes = new Set(options?.excludeTypes ?? []);
+
+  const nodeWidth = (node.measured?.width as number) || (node.width as number) || defaultWidth;
+  const nodeHeight = (node.measured?.height as number) || (node.height as number) || defaultHeight;
+  const nodeCenterX = node.position.x + nodeWidth / 2;
+  const nodeCenterY = node.position.y + nodeHeight / 2;
+  const nodeLeft = node.position.x;
+  const nodeRight = node.position.x + nodeWidth;
+  const nodeTop = node.position.y;
+  const nodeBottom = node.position.y + nodeHeight;
+
+  const newHorizontalGuides: AlignmentGuidesState['horizontal'] = [];
+  const newVerticalGuides: AlignmentGuidesState['vertical'] = [];
+
+  const filtered = otherNodes.filter(
+    (n) => n.id !== node.id && !excludeTypes.has(String(n.type ?? ''))
+  );
+
+  filtered.forEach((otherNode) => {
+    const otherWidth =
+      (otherNode.measured?.width as number) || (otherNode.width as number) || defaultWidth;
+    const otherHeight =
+      (otherNode.measured?.height as number) || (otherNode.height as number) || defaultHeight;
+    const otherCenterX = otherNode.position.x + otherWidth / 2;
+    const otherCenterY = otherNode.position.y + otherHeight / 2;
+    const otherLeft = otherNode.position.x;
+    const otherRight = otherNode.position.x + otherWidth;
+    const otherTop = otherNode.position.y;
+    const otherBottom = otherNode.position.y + otherHeight;
+
+    const minX = Math.min(nodeLeft, otherLeft) - 20;
+    const maxX = Math.max(nodeRight, otherRight) + 20;
+
+    const minY = Math.min(nodeTop, otherTop) - 20;
+    const maxY = Math.max(nodeBottom, otherBottom) + 20;
+
+    if (Math.abs(nodeTop - otherTop) < SNAP_THRESHOLD) {
+      newHorizontalGuides.push({ y: otherTop, x1: minX, x2: maxX });
+    }
+    if (Math.abs(nodeBottom - otherBottom) < SNAP_THRESHOLD) {
+      newHorizontalGuides.push({ y: otherBottom, x1: minX, x2: maxX });
+    }
+    if (Math.abs(nodeCenterY - otherCenterY) < SNAP_THRESHOLD) {
+      newHorizontalGuides.push({ y: otherCenterY, x1: minX, x2: maxX });
+    }
+    if (Math.abs(nodeTop - otherBottom) < SNAP_THRESHOLD) {
+      newHorizontalGuides.push({ y: otherBottom, x1: minX, x2: maxX });
+    }
+    if (Math.abs(nodeBottom - otherTop) < SNAP_THRESHOLD) {
+      newHorizontalGuides.push({ y: otherTop, x1: minX, x2: maxX });
+    }
+
+    if (Math.abs(nodeLeft - otherLeft) < SNAP_THRESHOLD) {
+      newVerticalGuides.push({ x: otherLeft, y1: minY, y2: maxY });
+    }
+    if (Math.abs(nodeRight - otherRight) < SNAP_THRESHOLD) {
+      newVerticalGuides.push({ x: otherRight, y1: minY, y2: maxY });
+    }
+    if (Math.abs(nodeCenterX - otherCenterX) < SNAP_THRESHOLD) {
+      newVerticalGuides.push({ x: otherCenterX, y1: minY, y2: maxY });
+    }
+    if (Math.abs(nodeLeft - otherRight) < SNAP_THRESHOLD) {
+      newVerticalGuides.push({ x: otherRight, y1: minY, y2: maxY });
+    }
+    if (Math.abs(nodeRight - otherLeft) < SNAP_THRESHOLD) {
+      newVerticalGuides.push({ x: otherLeft, y1: minY, y2: maxY });
+    }
+  });
+
+  return { horizontal: newHorizontalGuides, vertical: newVerticalGuides };
+}

--- a/objectified-ui/src/app/ade/studio/lib/studio-canvas-prefs-storage.ts
+++ b/objectified-ui/src/app/ade/studio/lib/studio-canvas-prefs-storage.ts
@@ -332,8 +332,10 @@ export function getCachedInitialCanvasPrefsBundle(
     return cachedInitialBundle;
   }
   migrateLegacyCanvasPrefsToDesignerNamespace(storage);
-  seedPathsCanvasPrefsFromDesignerIfEmpty(storage);
   const surface = getCanvasSurfaceFromPathname(pathname ?? window.location.pathname);
+  if (surface === 'paths') {
+    seedPathsCanvasPrefsFromDesignerIfEmpty(storage);
+  }
   cachedInitialBundle = loadCanvasPrefsBundle(surface, storage);
   return cachedInitialBundle;
 }

--- a/objectified-ui/src/app/ade/studio/lib/studio-canvas-prefs-storage.ts
+++ b/objectified-ui/src/app/ade/studio/lib/studio-canvas-prefs-storage.ts
@@ -1,0 +1,343 @@
+/**
+ * Namespaced localStorage keys for Studio canvas preferences (#2641).
+ * Keep in sync with Designer defaults in StudioContext — if Designer defaults change, update Paths seeding and this comment.
+ *
+ * | Preference              | Designer key                         | Paths key                         |
+ * |-------------------------|--------------------------------------|-----------------------------------|
+ * | Grid size (px)          | studio.designer.gridSize             | studio.paths.gridSize             |
+ * | Snap to grid            | studio.designer.snapToGrid           | studio.paths.snapToGrid           |
+ * | Grid style              | studio.designer.gridStyle            | studio.paths.gridStyle            |
+ * | Show grid               | studio.designer.showGrid             | studio.paths.showGrid             |
+ * | Smart guides            | studio.designer.smartGuidesEnabled   | studio.paths.smartGuidesEnabled   |
+ * | Click-to-focus          | studio.designer.clickToFocusEnabled  | studio.paths.clickToFocusEnabled  |
+ * | LOD                     | studio.designer.lodEnabled           | studio.paths.lodEnabled           |
+ * | Auto-save layout        | studio.designer.autoSaveLayoutEnabled| studio.paths.autoSaveLayoutEnabled|
+ * | Auto-save interval (s)  | studio.designer.autoSaveLayoutIntervalSeconds | studio.paths.autoSaveLayoutIntervalSeconds |
+ * | Edge styling (JSON)     | studio.designer.edgeStyling          | studio.paths.edgeStyling          |
+ * | Edge routing            | studio.designer.edgeRouting          | studio.paths.edgeRouting          |
+ * | Edge animation          | studio.designer.edgeAnimation        | studio.paths.edgeAnimation        |
+ * | Canvas background (JSON)| studio.designer.canvasBackground     | studio.paths.canvasBackground     |
+ */
+
+import type {
+  CanvasBackgroundOptions,
+  EdgeAnimationType,
+  EdgeRoutingType,
+  EdgeStylingOptions,
+} from '../StudioContext';
+
+export type StudioCanvasSurface = 'designer' | 'paths';
+
+export const STUDIO_DESIGNER_PREFIX = 'studio.designer';
+export const STUDIO_PATHS_PREFIX = 'studio.paths';
+
+/** Legacy keys (pre-#2641) shared by Designer and Paths — migrate into studio.designer.* once. */
+export const LEGACY_CANVAS_PREF_KEYS = [
+  'gridSize',
+  'snapToGrid',
+  'gridStyle',
+  'showGrid',
+  'smartGuidesEnabled',
+  'clickToFocusEnabled',
+  'lodEnabled',
+  'autoSaveLayoutEnabled',
+  'autoSaveLayoutIntervalSeconds',
+  'edgeStyling',
+  'edgeRouting',
+  'edgeAnimation',
+  'canvasBackground',
+] as const;
+
+const MIGRATION_FLAG_KEY = 'studio.designer.migratedFromLegacyV1';
+
+export function getCanvasSurfaceFromPathname(pathname: string | null): StudioCanvasSurface {
+  if (pathname?.includes('/paths')) {
+    return 'paths';
+  }
+  return 'designer';
+}
+
+export function studioCanvasPrefStorageKey(surface: StudioCanvasSurface, suffix: string): string {
+  return surface === 'paths' ? `${STUDIO_PATHS_PREFIX}.${suffix}` : `${STUDIO_DESIGNER_PREFIX}.${suffix}`;
+}
+
+function nsKey(surface: StudioCanvasSurface, suffix: string): string {
+  return studioCanvasPrefStorageKey(surface, suffix);
+}
+
+function defaultEdgeStyling(): EdgeStylingOptions {
+  return {
+    directReferences: 'solid',
+    optionalReferences: 'dashed',
+    weakReferences: 'dotted',
+    bidirectional: 'double',
+    directColor: '#64748b',
+    optionalColor: '#f97316',
+    weakColor: '#8b5cf6',
+    bidirectionalColor: '#ec4899',
+    directArrowStyle: 'arrow',
+    optionalArrowStyle: 'arrow',
+    weakArrowStyle: 'arrow',
+    bidirectionalArrowStyle: 'arrow',
+  };
+}
+
+function defaultCanvasBackground(): CanvasBackgroundOptions {
+  return {
+    type: 'grid',
+    solidColor: '#f8fafc',
+    gridColor: '#6366f1',
+    gridOpacity: 0.15,
+    imageUrl: '',
+    imageOpacity: 0.5,
+    imageFit: 'cover',
+    gradientFrom: '#f8fafc',
+    gradientTo: '#e2e8f0',
+    gradientDirection: 'to-br',
+    textureType: 'noise',
+    textureOpacity: 0.1,
+    textureColor: '#64748b',
+    backgroundOpacity: 1,
+    backgroundBlur: 0,
+  };
+}
+
+export interface LoadedCanvasPrefsBundle {
+  gridSize: number;
+  snapToGrid: boolean;
+  gridStyle: 'dots' | 'lines' | 'cross';
+  showGrid: boolean;
+  smartGuidesEnabled: boolean;
+  clickToFocusEnabled: boolean;
+  lodEnabled: boolean;
+  autoSaveLayoutEnabled: boolean;
+  autoSaveLayoutIntervalSeconds: number;
+  edgeStyling: EdgeStylingOptions;
+  edgeRouting: EdgeRoutingType;
+  edgeAnimation: EdgeAnimationType;
+  canvasBackground: CanvasBackgroundOptions;
+}
+
+export const DEFAULT_LOADED_CANVAS_PREFS: LoadedCanvasPrefsBundle = {
+  gridSize: 20,
+  snapToGrid: true,
+  gridStyle: 'dots',
+  showGrid: true,
+  smartGuidesEnabled: true,
+  clickToFocusEnabled: true,
+  lodEnabled: false,
+  autoSaveLayoutEnabled: false,
+  autoSaveLayoutIntervalSeconds: 30,
+  edgeStyling: defaultEdgeStyling(),
+  edgeRouting: 'bezier',
+  edgeAnimation: 'none',
+  canvasBackground: defaultCanvasBackground(),
+};
+
+function parseBool(raw: string | null, fallback: boolean): boolean {
+  if (raw == null) return fallback;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return fallback;
+  }
+}
+
+function readEdgeStyling(storage: Storage, surface: StudioCanvasSurface): EdgeStylingOptions {
+  const defaults = defaultEdgeStyling();
+  const raw = storage.getItem(nsKey(surface, 'edgeStyling'));
+  if (!raw) return defaults;
+  try {
+    const parsed = JSON.parse(raw);
+    return { ...defaults, ...parsed };
+  } catch {
+    return defaults;
+  }
+}
+
+function readCanvasBackground(storage: Storage, surface: StudioCanvasSurface): CanvasBackgroundOptions {
+  const defaults = defaultCanvasBackground();
+  const raw = storage.getItem(nsKey(surface, 'canvasBackground'));
+  if (!raw) return defaults;
+  try {
+    const parsed = JSON.parse(raw);
+    return { ...defaults, ...parsed };
+  } catch {
+    return defaults;
+  }
+}
+
+/** One-time copy from legacy keys into studio.designer.* (browser only). */
+export function migrateLegacyCanvasPrefsToDesignerNamespace(storage: Storage = localStorage): void {
+  if (typeof window === 'undefined') return;
+  try {
+    if (storage.getItem(MIGRATION_FLAG_KEY) === '1') return;
+    if (storage.getItem(nsKey('designer', 'gridSize'))) {
+      storage.setItem(MIGRATION_FLAG_KEY, '1');
+      return;
+    }
+    const hasLegacy = LEGACY_CANVAS_PREF_KEYS.some((k) => storage.getItem(k) != null);
+    if (!hasLegacy) {
+      storage.setItem(MIGRATION_FLAG_KEY, '1');
+      return;
+    }
+
+    const g = storage.getItem('gridSize');
+    if (g) storage.setItem(nsKey('designer', 'gridSize'), g);
+    const sg = storage.getItem('snapToGrid');
+    if (sg != null) storage.setItem(nsKey('designer', 'snapToGrid'), sg);
+    const gs = storage.getItem('gridStyle');
+    if (gs) storage.setItem(nsKey('designer', 'gridStyle'), gs);
+    const sh = storage.getItem('showGrid');
+    if (sh != null) storage.setItem(nsKey('designer', 'showGrid'), sh);
+    const sm = storage.getItem('smartGuidesEnabled');
+    if (sm != null) storage.setItem(nsKey('designer', 'smartGuidesEnabled'), sm);
+    const cf = storage.getItem('clickToFocusEnabled');
+    if (cf != null) storage.setItem(nsKey('designer', 'clickToFocusEnabled'), cf);
+    const lod = storage.getItem('lodEnabled');
+    if (lod != null) storage.setItem(nsKey('designer', 'lodEnabled'), lod);
+    const as = storage.getItem('autoSaveLayoutEnabled');
+    if (as != null) storage.setItem(nsKey('designer', 'autoSaveLayoutEnabled'), as);
+    const asi = storage.getItem('autoSaveLayoutIntervalSeconds');
+    if (asi) storage.setItem(nsKey('designer', 'autoSaveLayoutIntervalSeconds'), asi);
+    const es = storage.getItem('edgeStyling');
+    if (es) storage.setItem(nsKey('designer', 'edgeStyling'), es);
+    const er = storage.getItem('edgeRouting');
+    if (er) storage.setItem(nsKey('designer', 'edgeRouting'), er);
+    const ea = storage.getItem('edgeAnimation');
+    if (ea) storage.setItem(nsKey('designer', 'edgeAnimation'), ea);
+    const cb = storage.getItem('canvasBackground');
+    if (cb) storage.setItem(nsKey('designer', 'canvasBackground'), cb);
+
+    storage.setItem(MIGRATION_FLAG_KEY, '1');
+  } catch {
+    /* ignore quota / private mode */
+  }
+}
+
+/**
+ * If Paths has no saved prefs, copy Designer namespace so first visit matches Designer (#2641).
+ */
+export function seedPathsCanvasPrefsFromDesignerIfEmpty(storage: Storage = localStorage): void {
+  if (typeof window === 'undefined') return;
+  try {
+    if (storage.getItem(nsKey('paths', 'gridSize')) != null) return;
+
+    const suffixes = [
+      'gridSize',
+      'snapToGrid',
+      'gridStyle',
+      'showGrid',
+      'smartGuidesEnabled',
+      'clickToFocusEnabled',
+      'lodEnabled',
+      'autoSaveLayoutEnabled',
+      'autoSaveLayoutIntervalSeconds',
+      'edgeStyling',
+      'edgeRouting',
+      'edgeAnimation',
+      'canvasBackground',
+    ] as const;
+
+    for (const s of suffixes) {
+      const fromDesigner = storage.getItem(nsKey('designer', s));
+      if (fromDesigner != null) {
+        storage.setItem(nsKey('paths', s), fromDesigner);
+      }
+    }
+  } catch {
+    /* ignore */
+  }
+}
+
+export function loadCanvasPrefsBundle(
+  surface: StudioCanvasSurface,
+  storage: Storage = localStorage
+): LoadedCanvasPrefsBundle {
+  const base = DEFAULT_LOADED_CANVAS_PREFS;
+
+  const gridSizeRaw = storage.getItem(nsKey(surface, 'gridSize'));
+  const gridSize = gridSizeRaw ? parseInt(gridSizeRaw, 10) : base.gridSize;
+  const snapToGrid = parseBool(storage.getItem(nsKey(surface, 'snapToGrid')), base.snapToGrid);
+  const gridStyleRaw = storage.getItem(nsKey(surface, 'gridStyle'));
+  const gridStyle =
+    gridStyleRaw === 'dots' || gridStyleRaw === 'lines' || gridStyleRaw === 'cross'
+      ? gridStyleRaw
+      : base.gridStyle;
+  const showGrid = parseBool(storage.getItem(nsKey(surface, 'showGrid')), base.showGrid);
+  const smartGuidesEnabled = parseBool(
+    storage.getItem(nsKey(surface, 'smartGuidesEnabled')),
+    base.smartGuidesEnabled
+  );
+  const clickToFocusEnabled = parseBool(
+    storage.getItem(nsKey(surface, 'clickToFocusEnabled')),
+    base.clickToFocusEnabled
+  );
+  const lodEnabled = parseBool(storage.getItem(nsKey(surface, 'lodEnabled')), base.lodEnabled);
+  const autoSaveLayoutEnabled = parseBool(
+    storage.getItem(nsKey(surface, 'autoSaveLayoutEnabled')),
+    base.autoSaveLayoutEnabled
+  );
+  const intervalRaw = storage.getItem(nsKey(surface, 'autoSaveLayoutIntervalSeconds'));
+  let autoSaveLayoutIntervalSeconds = base.autoSaveLayoutIntervalSeconds;
+  if (intervalRaw) {
+    const parsed = parseInt(intervalRaw, 10);
+    if (Number.isFinite(parsed)) {
+      autoSaveLayoutIntervalSeconds = Math.min(300, Math.max(10, parsed));
+    }
+  }
+
+  const edgeStyling = readEdgeStyling(storage, surface);
+
+  const erRaw = storage.getItem(nsKey(surface, 'edgeRouting'));
+  const edgeRouting: EdgeRoutingType =
+    erRaw && ['straight', 'bezier', 'orthogonal', 'smart'].includes(erRaw)
+      ? (erRaw as EdgeRoutingType)
+      : base.edgeRouting;
+
+  const eaRaw = storage.getItem(nsKey(surface, 'edgeAnimation'));
+  const edgeAnimation: EdgeAnimationType =
+    eaRaw && ['none', 'flow', 'pulse', 'dash'].includes(eaRaw)
+      ? (eaRaw as EdgeAnimationType)
+      : base.edgeAnimation;
+
+  const canvasBackground = readCanvasBackground(storage, surface);
+
+  return {
+    gridSize: Number.isFinite(gridSize) ? gridSize : base.gridSize,
+    snapToGrid,
+    gridStyle,
+    showGrid,
+    smartGuidesEnabled,
+    clickToFocusEnabled,
+    lodEnabled,
+    autoSaveLayoutEnabled,
+    autoSaveLayoutIntervalSeconds,
+    edgeStyling,
+    edgeRouting,
+    edgeAnimation,
+    canvasBackground,
+  };
+}
+
+let cachedInitialBundle: LoadedCanvasPrefsBundle | null = null;
+
+export function getCachedInitialCanvasPrefsBundle(
+  pathname: string | null,
+  storage: Storage = localStorage
+): LoadedCanvasPrefsBundle {
+  if (cachedInitialBundle) return cachedInitialBundle;
+  if (typeof window === 'undefined') {
+    cachedInitialBundle = DEFAULT_LOADED_CANVAS_PREFS;
+    return cachedInitialBundle;
+  }
+  migrateLegacyCanvasPrefsToDesignerNamespace(storage);
+  seedPathsCanvasPrefsFromDesignerIfEmpty(storage);
+  const surface = getCanvasSurfaceFromPathname(pathname ?? window.location.pathname);
+  cachedInitialBundle = loadCanvasPrefsBundle(surface, storage);
+  return cachedInitialBundle;
+}
+
+export function resetCachedInitialCanvasPrefsBundleForTests(): void {
+  cachedInitialBundle = null;
+}

--- a/objectified-ui/src/app/ade/studio/paths/components/PathsCanvasView.tsx
+++ b/objectified-ui/src/app/ade/studio/paths/components/PathsCanvasView.tsx
@@ -21,6 +21,7 @@ import '@xyflow/react/dist/style.css';
 import { useStudio } from '../../StudioContext';
 import { useDialog } from '../../../../components/providers/DialogProvider';
 import { getCanvasBackgroundStyle } from '../../../../utils/canvas-background-style';
+import { computeAlignmentGuidesForNode } from '../../lib/smart-alignment-guides';
 import SmartEdge from '../../../../components/ade/studio/SmartEdge';
 import {
   getOperationsForPath,
@@ -378,7 +379,9 @@ function PathsCanvasInner({ selectedPathId, pathname, onOperationSelect, onParam
     gridStyle,
     showGrid,
     snapToGrid,
+    smartGuidesEnabled,
     canvasBackground,
+    edgeStyling,
     edgeRouting,
     edgeAnimation,
     selectedVersionId,
@@ -389,7 +392,11 @@ function PathsCanvasInner({ selectedPathId, pathname, onOperationSelect, onParam
   const [nodes, setNodes, onNodesChange] = useNodesState<Node>([]);
   const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>([]);
   const [isDark, setIsDark] = useState(false);
-  const { screenToFlowPosition, getNodes } = useReactFlow();
+  const { screenToFlowPosition, getNodes, getViewport } = useReactFlow();
+  const [alignmentGuides, setAlignmentGuides] = useState<{
+    horizontal: Array<{ y: number; x1: number; x2: number }>;
+    vertical: Array<{ x: number; y1: number; y2: number }>;
+  }>({ horizontal: [], vertical: [] });
 
   const canvasBackgroundStyle = React.useMemo(
     () => getCanvasBackgroundStyle(canvasBackground, isDark),
@@ -2241,7 +2248,7 @@ function PathsCanvasInner({ selectedPathId, pathname, onOperationSelect, onParam
                 type: edgeType,
                 animated: edgeAnimation !== 'none',
                 style: {
-                  stroke: '#9ca3af',
+                  stroke: edgeStyling.directColor,
                   strokeWidth: 2,
                   strokeDasharray: edgeAnimation === 'dash' ? '5,5' : undefined,
                 },
@@ -2822,7 +2829,7 @@ function PathsCanvasInner({ selectedPathId, pathname, onOperationSelect, onParam
     };
 
     loadOperationsAndParameters();
-  }, [selectedPathId, selectedVersionId, setNodes, setEdges, refreshKey, edgeRouting, edgeAnimation, handleDeleteOperation, handleDeleteParameter, handleDeleteResponse, handleDeleteSharedResponse, handleUnlinkResponse, handleClassDropOnResponse, handlePropertyDropOnResponse, handleClassUnlinkFromResponse, handleSchemaTypeChange, handleDeleteRequestBody, handleAddRequestBodyContentType, handleUpdateRequestBodyDescription, handleUpdateRequestBodyExamples, handleUpdateRequestBodyEncoding, stableHandleRequestBodyPropertyDrop, stableHandleRequestBodyPropertyDelete, stableHandleRequestBodyClassDrop, stableHandleResponseBodyPropertyDrop, stableHandleResponseBodyPropertyDelete, stableHandleResponseBodyClassDrop, stableHandleCreateContentTypeWithProperty, stableHandleCreateContentTypeWithClass, handleShowClassDropDialog]);
+  }, [selectedPathId, selectedVersionId, setNodes, setEdges, refreshKey, edgeRouting, edgeAnimation, edgeStyling, handleDeleteOperation, handleDeleteParameter, handleDeleteResponse, handleDeleteSharedResponse, handleUnlinkResponse, handleClassDropOnResponse, handlePropertyDropOnResponse, handleClassUnlinkFromResponse, handleSchemaTypeChange, handleDeleteRequestBody, handleAddRequestBodyContentType, handleUpdateRequestBodyDescription, handleUpdateRequestBodyExamples, handleUpdateRequestBodyEncoding, stableHandleRequestBodyPropertyDrop, stableHandleRequestBodyPropertyDelete, stableHandleRequestBodyClassDrop, stableHandleResponseBodyPropertyDrop, stableHandleResponseBodyPropertyDelete, stableHandleResponseBodyClassDrop, stableHandleCreateContentTypeWithProperty, stableHandleCreateContentTypeWithClass, handleShowClassDropDialog]);
 
   // Detect dark mode
   useEffect(() => {
@@ -2848,6 +2855,22 @@ function PathsCanvasInner({ selectedPathId, pathname, onOperationSelect, onParam
       case 'cross': return BackgroundVariant.Cross;
       default: return BackgroundVariant.Dots;
     }
+  }, []);
+
+  /** Smart alignment guides — same behavior categories as Designer; math in smart-alignment-guides.ts (#2641). */
+  const handlePathsNodeDrag = useCallback(
+    (_event: React.MouseEvent, node: Node) => {
+      if (!smartGuidesEnabled) {
+        setAlignmentGuides({ horizontal: [], vertical: [] });
+        return;
+      }
+      setAlignmentGuides(computeAlignmentGuidesForNode(node, nodes));
+    },
+    [smartGuidesEnabled, nodes]
+  );
+
+  const handlePathsNodeDragStop = useCallback(() => {
+    setAlignmentGuides({ horizontal: [], vertical: [] });
   }, []);
 
   // Handle drag over
@@ -2992,7 +3015,7 @@ function PathsCanvasInner({ selectedPathId, pathname, onOperationSelect, onParam
         type: edgeType,
         animated: edgeAnimation !== 'none',
         style: {
-          stroke: '#9ca3af',
+          stroke: edgeStyling.directColor,
           strokeWidth: 2,
           strokeDasharray: edgeAnimation === 'dash' ? '5,5' : undefined,
         },
@@ -3126,7 +3149,7 @@ function PathsCanvasInner({ selectedPathId, pathname, onOperationSelect, onParam
         }
       }
     },
-    [setEdges, setNodes, nodes, alertDialog, edgeRouting, edgeAnimation, handleShowClassDropDialog, handleClassDropOnResponse, selectedPathId, selectedVersionId]
+    [setEdges, setNodes, nodes, alertDialog, edgeRouting, edgeAnimation, edgeStyling, handleShowClassDropDialog, handleClassDropOnResponse, selectedPathId, selectedVersionId]
   );
 
   // Handle deleting edges (unlinking parameters and responses from operations)
@@ -3719,9 +3742,15 @@ function PathsCanvasInner({ selectedPathId, pathname, onOperationSelect, onParam
         onDrop={onDrop}
         onDragOver={onDragOver}
         onNodeClick={onNodeClick}
+        onNodeDrag={handlePathsNodeDrag}
+        onNodeDragStop={handlePathsNodeDragStop}
         nodeTypes={nodeTypes}
         edgeTypes={edgeTypes}
-        defaultEdgeOptions={{ zIndex: 0 }}
+        defaultEdgeOptions={{
+          zIndex: 0,
+          style: { stroke: edgeStyling.directColor, strokeWidth: 2 },
+        }}
+        connectionLineStyle={{ stroke: edgeStyling.directColor, strokeWidth: 2 }}
         snapToGrid={snapToGrid}
         snapGrid={[gridSize, gridSize]}
         fitView
@@ -3757,6 +3786,45 @@ function PathsCanvasInner({ selectedPathId, pathname, onOperationSelect, onParam
               : '0 4px 24px rgba(0, 0, 0, 0.08), 0 0 0 1px rgba(0, 0, 0, 0.04)',
           }}
         />
+        {(alignmentGuides.horizontal.length > 0 || alignmentGuides.vertical.length > 0) && (() => {
+          const viewport = getViewport();
+          return (
+            <div
+              className="pointer-events-none absolute inset-0 z-[1000] overflow-hidden"
+            >
+              <svg className="pointer-events-none absolute inset-0 overflow-visible" aria-hidden>
+                <g transform={`translate(${viewport.x}, ${viewport.y}) scale(${viewport.zoom})`}>
+                  {alignmentGuides.horizontal.map((guide, index) => (
+                    <line
+                      key={`h-${index}`}
+                      x1={guide.x1}
+                      y1={guide.y}
+                      x2={guide.x2}
+                      y2={guide.y}
+                      stroke="#f472b6"
+                      strokeWidth={2 / viewport.zoom}
+                      strokeDasharray={`${6 / viewport.zoom} ${4 / viewport.zoom}`}
+                      style={{ filter: 'drop-shadow(0 0 2px rgba(244, 114, 182, 0.5))' }}
+                    />
+                  ))}
+                  {alignmentGuides.vertical.map((guide, index) => (
+                    <line
+                      key={`v-${index}`}
+                      x1={guide.x}
+                      y1={guide.y1}
+                      x2={guide.x}
+                      y2={guide.y2}
+                      stroke="#f472b6"
+                      strokeWidth={2 / viewport.zoom}
+                      strokeDasharray={`${6 / viewport.zoom} ${4 / viewport.zoom}`}
+                      style={{ filter: 'drop-shadow(0 0 2px rgba(244, 114, 182, 0.5))' }}
+                    />
+                  ))}
+                </g>
+              </svg>
+            </div>
+          );
+        })()}
       </ReactFlow>
 
       {/* Class Drop Choice Dialog */}

--- a/objectified-ui/src/app/ade/studio/paths/components/PathsCanvasView.tsx
+++ b/objectified-ui/src/app/ade/studio/paths/components/PathsCanvasView.tsx
@@ -21,7 +21,7 @@ import '@xyflow/react/dist/style.css';
 import { useStudio } from '../../StudioContext';
 import { useDialog } from '../../../../components/providers/DialogProvider';
 import { getCanvasBackgroundStyle } from '../../../../utils/canvas-background-style';
-import { computeAlignmentGuidesForNode } from '../../lib/smart-alignment-guides';
+import { computeAlignmentGuidesForNode, type AlignmentGuidesState } from '../../lib/smart-alignment-guides';
 import SmartEdge from '../../../../components/ade/studio/SmartEdge';
 import {
   getOperationsForPath,
@@ -393,10 +393,7 @@ function PathsCanvasInner({ selectedPathId, pathname, onOperationSelect, onParam
   const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>([]);
   const [isDark, setIsDark] = useState(false);
   const { screenToFlowPosition, getNodes, getViewport } = useReactFlow();
-  const [alignmentGuides, setAlignmentGuides] = useState<{
-    horizontal: Array<{ y: number; x1: number; x2: number }>;
-    vertical: Array<{ x: number; y1: number; y2: number }>;
-  }>({ horizontal: [], vertical: [] });
+  const [alignmentGuides, setAlignmentGuides] = useState<AlignmentGuidesState>({ horizontal: [], vertical: [] });
 
   const canvasBackgroundStyle = React.useMemo(
     () => getCanvasBackgroundStyle(canvasBackground, isDark),

--- a/objectified-ui/tests/studio-canvas-prefs-storage.test.ts
+++ b/objectified-ui/tests/studio-canvas-prefs-storage.test.ts
@@ -3,6 +3,7 @@
  */
 import {
   getCanvasSurfaceFromPathname,
+  getCachedInitialCanvasPrefsBundle,
   loadCanvasPrefsBundle,
   migrateLegacyCanvasPrefsToDesignerNamespace,
   resetCachedInitialCanvasPrefsBundleForTests,
@@ -36,6 +37,21 @@ describe('studio-canvas-prefs-storage', () => {
   it('seeds paths from designer when paths has no prefs', () => {
     localStorage.setItem(studioCanvasPrefStorageKey('designer', 'gridSize'), '32');
     seedPathsCanvasPrefsFromDesignerIfEmpty(localStorage);
+    expect(localStorage.getItem(studioCanvasPrefStorageKey('paths', 'gridSize'))).toBe('32');
+  });
+
+  it('does not seed paths on designer surface load, so paths gets current designer prefs on first paths visit', () => {
+    // Simulate: user opens Designer surface first (no prefs yet) — seeding should NOT happen
+    const designerBundle = getCachedInitialCanvasPrefsBundle('/ade/studio/editor', localStorage);
+    expect(designerBundle.gridSize).toBe(20); // default
+
+    // User then changes Designer settings (persisted externally)
+    localStorage.setItem(studioCanvasPrefStorageKey('designer', 'gridSize'), '32');
+
+    // First visit to Paths — seeding should happen now and pick up the updated Designer value
+    resetCachedInitialCanvasPrefsBundleForTests();
+    const pathsBundle = getCachedInitialCanvasPrefsBundle('/ade/studio/paths', localStorage);
+    expect(pathsBundle.gridSize).toBe(32);
     expect(localStorage.getItem(studioCanvasPrefStorageKey('paths', 'gridSize'))).toBe('32');
   });
 

--- a/objectified-ui/tests/studio-canvas-prefs-storage.test.ts
+++ b/objectified-ui/tests/studio-canvas-prefs-storage.test.ts
@@ -1,0 +1,49 @@
+/**
+ * @jest-environment jsdom
+ */
+import {
+  getCanvasSurfaceFromPathname,
+  loadCanvasPrefsBundle,
+  migrateLegacyCanvasPrefsToDesignerNamespace,
+  resetCachedInitialCanvasPrefsBundleForTests,
+  studioCanvasPrefStorageKey,
+  seedPathsCanvasPrefsFromDesignerIfEmpty,
+} from '../src/app/ade/studio/lib/studio-canvas-prefs-storage';
+
+describe('studio-canvas-prefs-storage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    resetCachedInitialCanvasPrefsBundleForTests();
+  });
+
+  it('maps /ade/studio/paths to paths surface', () => {
+    expect(getCanvasSurfaceFromPathname('/ade/studio/paths')).toBe('paths');
+  });
+
+  it('maps editor routes to designer surface', () => {
+    expect(getCanvasSurfaceFromPathname('/ade/studio/editor')).toBe('designer');
+    expect(getCanvasSurfaceFromPathname('/ade/studio/code')).toBe('designer');
+  });
+
+  it('migrates legacy keys into studio.designer namespace', () => {
+    localStorage.setItem('gridSize', '24');
+    localStorage.setItem('snapToGrid', 'false');
+    migrateLegacyCanvasPrefsToDesignerNamespace(localStorage);
+    expect(localStorage.getItem(studioCanvasPrefStorageKey('designer', 'gridSize'))).toBe('24');
+    expect(localStorage.getItem(studioCanvasPrefStorageKey('designer', 'snapToGrid'))).toBe('false');
+  });
+
+  it('seeds paths from designer when paths has no prefs', () => {
+    localStorage.setItem(studioCanvasPrefStorageKey('designer', 'gridSize'), '32');
+    seedPathsCanvasPrefsFromDesignerIfEmpty(localStorage);
+    expect(localStorage.getItem(studioCanvasPrefStorageKey('paths', 'gridSize'))).toBe('32');
+  });
+
+  it('loadCanvasPrefsBundle reads namespaced values', () => {
+    localStorage.setItem(studioCanvasPrefStorageKey('paths', 'gridSize'), '40');
+    localStorage.setItem(studioCanvasPrefStorageKey('paths', 'snapToGrid'), 'true');
+    const bundle = loadCanvasPrefsBundle('paths', localStorage);
+    expect(bundle.gridSize).toBe(40);
+    expect(bundle.snapToGrid).toBe(true);
+  });
+});


### PR DESCRIPTION
## What / why
Implements **P-02** ([#2641](https://github.com/KenSuenobu/objectified-commercial/issues/2641)): Studio canvas preferences are stored under **namespaced** `localStorage` keys so **Designer** and **Paths** no longer overwrite each other. Paths **React Flow** is aligned with Designer for snap grid, default edge stroke, connection line style, and **smart alignment guides** on node drag.

## Storage keys (documented in code)
See table in `objectified-ui/src/app/ade/studio/lib/studio-canvas-prefs-storage.ts` — e.g. `studio.designer.gridSize` / `studio.paths.gridSize`, `studio.designer.edgeStyling` / `studio.paths.edgeStyling`, etc. One-time migration copies legacy unprefixed keys into `studio.designer.*`; first Paths use seeds `studio.paths.*` from Designer when empty.

## How to test
1. Open **Designer** (`/ade/studio/editor`), open **Canvas settings**, change grid size / snap / guides / edge direct color; save.
2. Open **Paths** (`/ade/studio/paths`), open settings, set **different** values; save.
3. Switch **Paths → Designer → Paths** and confirm each surface shows its **last** settings.
4. Drag a node on Paths with guides enabled — pink alignment lines appear (same visual category as Designer).
5. Confirm no console errors on first load.

## Risk / notes
- Persist effects are keyed by route-derived surface (`pathname` includes `/paths` ⇒ paths). Code tab under studio still uses **designer** namespace (same as before for non-Paths routes).
- Shared guide **math** is in `lib/smart-alignment-guides.ts`; Designer inline logic has a **cross-reference** comment to keep drift visible.

Closes #2641

Made with [Cursor](https://cursor.com)