### PR TITLE
Fix #2642 - Persist Paths React Flow canvas per path (tenant-safe REST)

### DIFF
--- a/docs/PLANNED_FEATURE_ROADMAP_PATHS.md
+++ b/docs/PLANNED_FEATURE_ROADMAP_PATHS.md
@@ -24,7 +24,7 @@ This document defines **epics and ordered, single-scope issues** to deliver a **
 | P-00 | [#2639](https://github.com/KenSuenobu/objectified-commercial/issues/2639) (shipped) | Yes |
 | P-01 | [#2640](https://github.com/KenSuenobu/objectified-commercial/issues/2640) (shipped) | Yes |
 | P-02 | [#2641](https://github.com/KenSuenobu/objectified-commercial/issues/2641) (shipped) | Yes |
-| P-03 | [#2642](https://github.com/KenSuenobu/objectified-commercial/issues/2642) | Yes |
+| P-03 | [#2642](https://github.com/KenSuenobu/objectified-commercial/issues/2642) (shipped) | Yes |
 | P-04 | [#2643](https://github.com/KenSuenobu/objectified-commercial/issues/2643) | Yes |
 | P-05 | [#2644](https://github.com/KenSuenobu/objectified-commercial/issues/2644) | Yes |
 | P-06 | [#2645](https://github.com/KenSuenobu/objectified-commercial/issues/2645) | Yes |
@@ -55,7 +55,7 @@ This document defines **epics and ordered, single-scope issues** to deliver a **
 | ~~2639~~ | ~~P-00 Navigation: header “Paths” + Home grid card~~ **(shipped)** | Yes |
 | ~~2640~~ | ~~P-01 Paths shell: header, PATH QUALITY placeholder, Canvas/Code~~ **(shipped)** | Yes |
 | ~~2641~~ | ~~P-02 Canvas defaults parity with Designer~~ **(shipped)** | Yes |
-| 2642 | P-03 Persist canvas JSON per version | Yes |
+| ~~2642~~ | ~~P-03 Persist canvas JSON per version~~ **(shipped)** | Yes |
 
 **E2 — [#2634](https://github.com/KenSuenobu/objectified-commercial/issues/2634)**
 

--- a/objectified-db/scripts/20260413-120000.sql
+++ b/objectified-db/scripts/20260413-120000.sql
@@ -1,0 +1,19 @@
+-- P-03 / #2642: Paths designer React Flow canvas (presentation layer only; OpenAPI paths remain SoT)
+-- ROLLBACK: DROP TABLE IF EXISTS odb.version_path_canvas;
+
+SET search_path TO odb, public;
+
+CREATE TABLE IF NOT EXISTS version_path_canvas (
+  version_path_id UUID NOT NULL PRIMARY KEY REFERENCES odb.version_path(id) ON DELETE CASCADE,
+  canvas JSONB NOT NULL DEFAULT '{"nodes": [], "edges": [], "viewport": {"x": 0, "y": 0, "zoom": 1}}'::jsonb,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_version_path_canvas_updated_at
+  ON odb.version_path_canvas(updated_at);
+
+COMMENT ON TABLE odb.version_path_canvas IS
+  'Paths tab React Flow layout JSON per version_path; semantic paths/ops live in version_path / path_operation (#2642)';
+
+COMMENT ON COLUMN odb.version_path_canvas.canvas IS
+  'Canonical shape: { "nodes": [], "edges": [], "viewport": { "x", "y", "zoom" } }';

--- a/objectified-rest/pyproject.toml
+++ b/objectified-rest/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "objectified-rest"
-version = "1.0.37"
+version = "1.0.38"
 description = "REST API for serving OpenAPI specifications from the Objectified database"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/objectified-rest/src/app/database.py
+++ b/objectified-rest/src/app/database.py
@@ -2892,6 +2892,119 @@ class Database:
             conn.rollback()
             raise e
 
+    def get_path_canvas(self, version_id: str, path_id: str, tenant_id: str) -> Optional[Dict[str, Any]]:
+        """
+        Load Paths React Flow canvas JSON for a version_path row (tenant-scoped).
+        Returns None if the path is missing or not under the given version.
+        """
+        path = self.get_path_by_id(path_id, tenant_id)
+        if not path or str(path["version_id"]) != str(version_id):
+            return None
+
+        query = """
+            SELECT canvas, updated_at
+            FROM odb.version_path_canvas
+            WHERE version_path_id = %s
+        """
+        rows = self.execute_query(query, (path_id,))
+        default_canvas = {
+            "nodes": [],
+            "edges": [],
+            "viewport": {"x": 0, "y": 0, "zoom": 1},
+        }
+        if not rows:
+            return {
+                **default_canvas,
+                "updated_at": None,
+            }
+
+        row = rows[0]
+        canvas = row["canvas"]
+        if isinstance(canvas, str):
+            canvas = json.loads(canvas)
+        if not isinstance(canvas, dict):
+            canvas = default_canvas
+        nodes = canvas.get("nodes")
+        edges = canvas.get("edges")
+        viewport = canvas.get("viewport")
+        if not isinstance(nodes, list):
+            nodes = []
+        if not isinstance(edges, list):
+            edges = []
+        if not isinstance(viewport, dict):
+            viewport = {"x": 0, "y": 0, "zoom": 1}
+
+        return {
+            "nodes": nodes,
+            "edges": edges,
+            "viewport": {
+                "x": float(viewport.get("x", 0)),
+                "y": float(viewport.get("y", 0)),
+                "zoom": float(viewport.get("zoom", 1)),
+            },
+            "updated_at": row.get("updated_at"),
+        }
+
+    def upsert_path_canvas(
+        self,
+        version_id: str,
+        path_id: str,
+        tenant_id: str,
+        canvas: Dict[str, Any],
+    ) -> Optional[Dict[str, Any]]:
+        """
+        Insert or update Paths canvas JSON (last-write-wins). Returns None if path/version/tenant mismatch.
+        """
+        path = self.get_path_by_id(path_id, tenant_id)
+        if not path or str(path["version_id"]) != str(version_id):
+            return None
+
+        payload = {
+            "nodes": canvas.get("nodes") if isinstance(canvas.get("nodes"), list) else [],
+            "edges": canvas.get("edges") if isinstance(canvas.get("edges"), list) else [],
+            "viewport": canvas.get("viewport")
+            if isinstance(canvas.get("viewport"), dict)
+            else {"x": 0, "y": 0, "zoom": 1},
+        }
+        vp = payload["viewport"]
+        try:
+            payload["viewport"] = {
+                "x": float(vp.get("x", 0)),
+                "y": float(vp.get("y", 0)),
+                "zoom": float(vp.get("zoom", 1)),
+            }
+        except (TypeError, ValueError):
+            payload["viewport"] = {"x": 0, "y": 0, "zoom": 1}
+
+        query = """
+            INSERT INTO odb.version_path_canvas (version_path_id, canvas, updated_at)
+            VALUES (%s, %s::jsonb, CURRENT_TIMESTAMP)
+            ON CONFLICT (version_path_id) DO UPDATE SET
+                canvas = EXCLUDED.canvas,
+                updated_at = CURRENT_TIMESTAMP
+            RETURNING canvas, updated_at
+        """
+        conn = self.connect()
+        try:
+            with conn.cursor() as cursor:
+                cursor.execute(query, (path_id, Json(payload)))
+                result = cursor.fetchone()
+                conn.commit()
+                if not result:
+                    return None
+                out_canvas = result["canvas"]
+                if isinstance(out_canvas, str):
+                    out_canvas = json.loads(out_canvas)
+                return {
+                    "nodes": out_canvas.get("nodes", []),
+                    "edges": out_canvas.get("edges", []),
+                    "viewport": out_canvas.get("viewport", {"x": 0, "y": 0, "zoom": 1}),
+                    "updated_at": result.get("updated_at"),
+                }
+        except Exception as e:
+            conn.rollback()
+            raise e
+
     # ==================== Path Operation CRUD ====================
 
     def get_operation_by_id(self, operation_id: str, tenant_id: str) -> Optional[Dict[str, Any]]:

--- a/objectified-rest/src/app/models.py
+++ b/objectified-rest/src/app/models.py
@@ -1168,6 +1168,25 @@ class PathUpdateRequest(BaseModel):
         from_attributes = True
 
 
+class PathsCanvasViewport(BaseModel):
+    """React Flow viewport for Paths designer canvas (#2642)."""
+
+    x: float = 0
+    y: float = 0
+    zoom: float = 1
+
+
+class PathsCanvasPayload(BaseModel):
+    """Persisted React Flow graph snapshot (layout only; path/ops remain in OpenAPI tables)."""
+
+    nodes: List[Any] = Field(default_factory=list)
+    edges: List[Any] = Field(default_factory=list)
+    viewport: PathsCanvasViewport = Field(default_factory=PathsCanvasViewport)
+
+    class Config:
+        from_attributes = True
+
+
 class OperationSchema(BaseModel):
     """Pydantic model for a path operation."""
     id: str

--- a/objectified-rest/src/app/paths_routes.py
+++ b/objectified-rest/src/app/paths_routes.py
@@ -13,6 +13,7 @@ from .models import (
     PathSchema,
     PathCreateRequest,
     PathUpdateRequest,
+    PathsCanvasPayload,
     OperationSchema,
     OperationCreateRequest,
     OperationUpdateRequest,
@@ -96,6 +97,59 @@ async def get_path(
     return {
         **path,
         "operations": operations
+    }
+
+
+@router.get("/{tenant_slug}/{version_id}/{path_id}/canvas")
+async def get_path_canvas(
+    tenant_slug: str,
+    version_id: str,
+    path_id: str,
+    auth_data: Dict[str, Any] = Depends(validate_authentication),
+) -> Dict[str, Any]:
+    """
+    Load persisted React Flow canvas (nodes, edges, viewport) for a path (#2642).
+    Tenant-safe; returns defaults when no row exists.
+    """
+    version = db.get_version_for_tenant(auth_data["tenant_id"], version_id)
+    if not version:
+        raise HTTPException(status_code=404, detail=f"Version not found: {version_id}")
+
+    canvas = db.get_path_canvas(version_id, path_id, auth_data["tenant_id"])
+    if canvas is None:
+        raise HTTPException(status_code=404, detail=f"Path not found: {path_id}")
+
+    return {
+        "nodes": canvas["nodes"],
+        "edges": canvas["edges"],
+        "viewport": canvas["viewport"],
+        "updated_at": canvas.get("updated_at"),
+    }
+
+
+@router.put("/{tenant_slug}/{version_id}/{path_id}/canvas")
+async def put_path_canvas(
+    tenant_slug: str,
+    version_id: str,
+    path_id: str,
+    request: PathsCanvasPayload,
+    auth_data: Dict[str, Any] = Depends(validate_authentication),
+) -> Dict[str, Any]:
+    """Replace Paths canvas JSON for this path (last-write-wins, #2642)."""
+    version = db.get_version_for_tenant(auth_data["tenant_id"], version_id)
+    if not version:
+        raise HTTPException(status_code=404, detail=f"Version not found: {version_id}")
+
+    body = request.model_dump()
+    updated = db.upsert_path_canvas(version_id, path_id, auth_data["tenant_id"], body)
+    if updated is None:
+        raise HTTPException(status_code=404, detail=f"Path not found: {path_id}")
+
+    return {
+        "nodes": updated["nodes"],
+        "edges": updated["edges"],
+        "viewport": updated["viewport"],
+        "updated_at": updated.get("updated_at"),
     }
 
 

--- a/objectified-rest/tests/test_path_canvas_api.py
+++ b/objectified-rest/tests/test_path_canvas_api.py
@@ -1,0 +1,83 @@
+"""Paths canvas persistence API (#2642)."""
+
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.auth import validate_authentication
+from app.main import app
+
+client = TestClient(app)
+
+_MOCK_JWT = {
+    "tenant_id": "t1",
+    "user_id": "user-a",
+    "auth_method": "jwt",
+}
+
+
+@pytest.fixture(autouse=True)
+def _auth():
+    app.dependency_overrides[validate_authentication] = lambda: _MOCK_JWT
+    yield
+    app.dependency_overrides.pop(validate_authentication, None)
+
+
+def test_get_canvas_ok_defaults():
+    with patch("app.paths_routes.db") as mdb:
+        mdb.get_version_for_tenant.return_value = {"id": "ver-1"}
+        mdb.get_path_canvas.return_value = {
+            "nodes": [],
+            "edges": [],
+            "viewport": {"x": 0, "y": 0, "zoom": 1},
+            "updated_at": None,
+        }
+        r = client.get("/v1/paths/acme/ver-1/path-a/canvas")
+        assert r.status_code == 200
+        d = r.json()
+        assert d["nodes"] == []
+        assert d["edges"] == []
+        assert d["viewport"]["zoom"] == 1
+        mdb.get_path_canvas.assert_called_once_with("ver-1", "path-a", "t1")
+
+
+def test_get_canvas_version_404():
+    with patch("app.paths_routes.db") as mdb:
+        mdb.get_version_for_tenant.return_value = None
+        r = client.get("/v1/paths/acme/ver-1/path-a/canvas")
+        assert r.status_code == 404
+
+
+def test_put_canvas_ok():
+    with patch("app.paths_routes.db") as mdb:
+        mdb.get_version_for_tenant.return_value = {"id": "ver-1"}
+        mdb.upsert_path_canvas.return_value = {
+            "nodes": [{"id": "n1"}],
+            "edges": [],
+            "viewport": {"x": 1, "y": 2, "zoom": 0.5},
+            "updated_at": "2026-04-13T12:00:00Z",
+        }
+        r = client.put(
+            "/v1/paths/acme/ver-1/path-a/canvas",
+            json={
+                "nodes": [{"id": "n1"}],
+                "edges": [],
+                "viewport": {"x": 1, "y": 2, "zoom": 0.5},
+            },
+        )
+        assert r.status_code == 200
+        d = r.json()
+        assert d["nodes"][0]["id"] == "n1"
+        mdb.upsert_path_canvas.assert_called_once()
+
+
+def test_put_canvas_path_mismatch_404():
+    with patch("app.paths_routes.db") as mdb:
+        mdb.get_version_for_tenant.return_value = {"id": "ver-1"}
+        mdb.upsert_path_canvas.return_value = None
+        r = client.put(
+            "/v1/paths/acme/ver-1/path-a/canvas",
+            json={"nodes": [], "edges": [], "viewport": {"x": 0, "y": 0, "zoom": 1}},
+        )
+        assert r.status_code == 404

--- a/objectified-ui/lib/api/paths-client.ts
+++ b/objectified-ui/lib/api/paths-client.ts
@@ -216,9 +216,6 @@ export async function updatePath(
 }
 
 /**
- * Delete a path
- */
-/**
  * Load persisted Paths React Flow canvas for a version_path (#2642).
  */
 export async function getPathCanvas(
@@ -278,6 +275,9 @@ export async function putPathCanvas(
   }
 }
 
+/**
+ * Delete a path
+ */
 export async function deletePath(
   versionId: string,
   pathId: string

--- a/objectified-ui/lib/api/paths-client.ts
+++ b/objectified-ui/lib/api/paths-client.ts
@@ -73,6 +73,13 @@ export interface ApiResponse<T = any> {
   error?: string;
 }
 
+export interface PathsCanvasBlob {
+  nodes: Record<string, unknown>[];
+  edges: Record<string, unknown>[];
+  viewport: { x: number; y: number; zoom: number };
+  updated_at?: string | null;
+}
+
 // ==================== Path CRUD ====================
 
 /**
@@ -211,6 +218,66 @@ export async function updatePath(
 /**
  * Delete a path
  */
+/**
+ * Load persisted Paths React Flow canvas for a version_path (#2642).
+ */
+export async function getPathCanvas(
+  versionId: string,
+  pathId: string
+): Promise<ApiResponse<PathsCanvasBlob>> {
+  try {
+    const response = await fetch(`/api/paths/${versionId}/${pathId}/canvas`, {
+      method: 'GET',
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({ error: 'Failed to load canvas' }));
+      return { success: false, error: errorData.error || `HTTP ${response.status}` };
+    }
+
+    const data = await response.json();
+    const canvas = data.canvas ?? data;
+    return { success: true, data: canvas };
+  } catch (error: any) {
+    console.error('Error loading path canvas:', error);
+    return { success: false, error: error.message || 'Failed to load canvas' };
+  }
+}
+
+/**
+ * Save Paths React Flow canvas (last-write-wins, #2642).
+ */
+export async function putPathCanvas(
+  versionId: string,
+  pathId: string,
+  body: Omit<PathsCanvasBlob, 'updated_at'>
+): Promise<ApiResponse<PathsCanvasBlob>> {
+  try {
+    const response = await fetch(`/api/paths/${versionId}/${pathId}/canvas`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        nodes: body.nodes,
+        edges: body.edges,
+        viewport: body.viewport,
+      }),
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({ error: 'Failed to save canvas' }));
+      return { success: false, error: errorData.error || `HTTP ${response.status}` };
+    }
+
+    const data = await response.json();
+    const canvas = data.canvas ?? data;
+    return { success: true, data: canvas };
+  } catch (error: any) {
+    console.error('Error saving path canvas:', error);
+    return { success: false, error: error.message || 'Failed to save canvas' };
+  }
+}
+
 export async function deletePath(
   versionId: string,
   pathId: string

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.9.84",
+  "version": "0.9.85",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -5,6 +5,7 @@ We continue to improve the platform based on your feedback with improvements and
 ---
 
 ## UI:
+- **Paths canvas persistence (#2642):** **Paths** tab **React Flow** layout (**nodes**, **edges**, **viewport**) is saved **per path** via tenant-scoped **GET/PUT** (Postgres **`odb.version_path_canvas`**); reload or version switch restores positions when graph **ids** are unchanged
 - **Paths canvas prefs (#2641):** Studio canvas settings use **separate storage** (`studio.designer.*` vs `studio.paths.*`) so Designer and Paths keep **independent** grid, snap, guides, background, and edge options; **Paths** matches Designer-style **React Flow** wiring (snap grid, default edge stroke, connection line, smart alignment guides on drag)
 - **Paths studio shell (#2640):** On **`/ade/studio/paths`**, the studio sub-header shows **PATH QUALITY** (placeholder score until P-17), a **Canvas | Code** toggle for the Paths editor (session-persisted), and the same **project / version / canvas settings** pattern as Designer; **Paths** is also on the **Canvas | Paths | Code** switcher when you are not on the Paths route
 - **Paths navigation (#2639):** **Paths** appears in the main Studio nav **next to Designer** (tenant/project context preserved); **Home** uses a **four-column** app grid on large screens with a **Paths** card **immediately to the right of Data Designer**, linking to **`/ade/studio/paths`**

--- a/objectified-ui/src/app/ade/studio/paths/components/PathsCanvasView.tsx
+++ b/objectified-ui/src/app/ade/studio/paths/components/PathsCanvasView.tsx
@@ -91,6 +91,12 @@ import {
   copyClassPropertiesToContentType,
   setResponseContentTypeClassReference,
 } from '../../../../../../lib/db/helper-shared-path-responses-content';
+import { getPathCanvas, putPathCanvas } from '../../../../../../lib/api/paths-client';
+import {
+  mergePathsCanvasLayout,
+  serializePathsCanvas,
+  type PathsCanvasBlob,
+} from '../lib/paths-canvas-persist';
 
 // Enhanced Operation Node Component with Schema Drop Zones - Vertical Layout
 function OperationNode({ data }: {
@@ -392,8 +398,12 @@ function PathsCanvasInner({ selectedPathId, pathname, onOperationSelect, onParam
   const [nodes, setNodes, onNodesChange] = useNodesState<Node>([]);
   const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>([]);
   const [isDark, setIsDark] = useState(false);
-  const { screenToFlowPosition, getNodes, getViewport } = useReactFlow();
+  const { screenToFlowPosition, getNodes, getViewport, setViewport, fitView } = useReactFlow();
   const [alignmentGuides, setAlignmentGuides] = useState<AlignmentGuidesState>({ horizontal: [], vertical: [] });
+  const [canvasPersistReady, setCanvasPersistReady] = useState(false);
+  const canvasSaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const viewportToApplyRef = useRef<{ x: number; y: number; zoom: number } | null>(null);
+  const shouldFitAfterLoadRef = useRef(false);
 
   const canvasBackgroundStyle = React.useMemo(
     () => getCanvasBackgroundStyle(canvasBackground, isDark),
@@ -1935,8 +1945,11 @@ function PathsCanvasInner({ selectedPathId, pathname, onOperationSelect, onParam
     if (!selectedPathId) {
       setNodes([]);
       setEdges([]);
+      setCanvasPersistReady(false);
       return;
     }
+
+    setCanvasPersistReady(false);
 
     console.log('[PathsCanvasView] useEffect triggered - loading nodes. refreshKey:', refreshKey);
 
@@ -2818,15 +2831,86 @@ function PathsCanvasInner({ selectedPathId, pathname, onOperationSelect, onParam
         // Response body nodes are created for responses that have content types with inline schemas
         // These allow users to add/edit properties in the inline schema
 
-        setNodes([...operationNodes, ...allParameterNodes, ...allResponseNodes, ...allResponseBodyNodes, ...allClassNodes, ...allRequestBodyNodes]);
-        setEdges(allEdges);
+        const computedNodes = [
+          ...operationNodes,
+          ...allParameterNodes,
+          ...allResponseNodes,
+          ...allResponseBodyNodes,
+          ...allClassNodes,
+          ...allRequestBodyNodes,
+        ];
+
+        let blob: PathsCanvasBlob | null = null;
+        let canvasUpdatedAt: string | null | undefined;
+        if (selectedVersionId && selectedPathId) {
+          const canvasRes = await getPathCanvas(selectedVersionId, selectedPathId);
+          if (canvasRes.success && canvasRes.data) {
+            canvasUpdatedAt = canvasRes.data.updated_at;
+            blob = {
+              nodes: (canvasRes.data.nodes || []) as Record<string, unknown>[],
+              edges: (canvasRes.data.edges || []) as Record<string, unknown>[],
+              viewport: canvasRes.data.viewport || { x: 0, y: 0, zoom: 1 },
+            };
+          }
+        }
+
+        const merged = mergePathsCanvasLayout(computedNodes, allEdges, blob);
+        const noSavedCanvas =
+          canvasUpdatedAt == null &&
+          (!blob?.nodes?.length || blob.nodes.length === 0);
+        viewportToApplyRef.current = noSavedCanvas ? null : merged.viewport;
+        shouldFitAfterLoadRef.current = noSavedCanvas;
+
+        setNodes(merged.nodes);
+        setEdges(merged.edges);
+        setCanvasPersistReady(true);
       } catch (error) {
         console.error('Error loading operations and parameters:', error);
+        setCanvasPersistReady(false);
       }
     };
 
     loadOperationsAndParameters();
   }, [selectedPathId, selectedVersionId, setNodes, setEdges, refreshKey, edgeRouting, edgeAnimation, edgeStyling, handleDeleteOperation, handleDeleteParameter, handleDeleteResponse, handleDeleteSharedResponse, handleUnlinkResponse, handleClassDropOnResponse, handlePropertyDropOnResponse, handleClassUnlinkFromResponse, handleSchemaTypeChange, handleDeleteRequestBody, handleAddRequestBodyContentType, handleUpdateRequestBodyDescription, handleUpdateRequestBodyExamples, handleUpdateRequestBodyEncoding, stableHandleRequestBodyPropertyDrop, stableHandleRequestBodyPropertyDelete, stableHandleRequestBodyClassDrop, stableHandleResponseBodyPropertyDrop, stableHandleResponseBodyPropertyDelete, stableHandleResponseBodyClassDrop, stableHandleCreateContentTypeWithProperty, stableHandleCreateContentTypeWithClass, handleShowClassDropDialog]);
+
+  // Apply persisted viewport or initial fitView once after graph load (#2642).
+  useEffect(() => {
+    if (!canvasPersistReady || !selectedPathId) return;
+
+    const t = window.setTimeout(() => {
+      if (viewportToApplyRef.current) {
+        setViewport(viewportToApplyRef.current, { duration: 0 });
+        viewportToApplyRef.current = null;
+      } else if (shouldFitAfterLoadRef.current) {
+        shouldFitAfterLoadRef.current = false;
+        fitView({ padding: 0.2 });
+      }
+    }, 0);
+
+    return () => clearTimeout(t);
+  }, [canvasPersistReady, selectedPathId, setViewport, fitView]);
+
+  const schedulePersistPathsCanvas = useCallback(() => {
+    if (!canvasPersistReady || !selectedVersionId || !selectedPathId) return;
+    if (canvasSaveTimerRef.current) {
+      clearTimeout(canvasSaveTimerRef.current);
+    }
+    canvasSaveTimerRef.current = setTimeout(() => {
+      canvasSaveTimerRef.current = null;
+      const vp = getViewport();
+      const payload = serializePathsCanvas(nodes, edges, vp);
+      void putPathCanvas(selectedVersionId, selectedPathId, payload);
+    }, 650);
+  }, [canvasPersistReady, selectedVersionId, selectedPathId, getViewport, nodes, edges]);
+
+  useEffect(() => {
+    schedulePersistPathsCanvas();
+    return () => {
+      if (canvasSaveTimerRef.current) {
+        clearTimeout(canvasSaveTimerRef.current);
+      }
+    };
+  }, [schedulePersistPathsCanvas]);
 
   // Detect dark mode
   useEffect(() => {
@@ -3750,7 +3834,8 @@ function PathsCanvasInner({ selectedPathId, pathname, onOperationSelect, onParam
         connectionLineStyle={{ stroke: edgeStyling.directColor, strokeWidth: 2 }}
         snapToGrid={snapToGrid}
         snapGrid={[gridSize, gridSize]}
-        fitView
+        fitView={false}
+        onMoveEnd={schedulePersistPathsCanvas}
         attributionPosition="bottom-left"
         className={isDark ? 'bg-gray-900' : ''}
         nodesDraggable={true}

--- a/objectified-ui/src/app/ade/studio/paths/lib/paths-canvas-persist.ts
+++ b/objectified-ui/src/app/ade/studio/paths/lib/paths-canvas-persist.ts
@@ -1,0 +1,147 @@
+import type { Edge, Node, Viewport } from '@xyflow/react';
+
+export interface PathsCanvasBlob {
+  nodes: Record<string, unknown>[];
+  edges: Record<string, unknown>[];
+  viewport: { x: number; y: number; zoom: number };
+}
+
+const defaultViewport = (): { x: number; y: number; zoom: number } => ({
+  x: 0,
+  y: 0,
+  zoom: 1,
+});
+
+/** Strip React Flow state to JSON-safe layout fields (no function data). */
+export function serializePathsCanvas(
+  nodes: Node[],
+  edges: Edge[],
+  viewport: Viewport
+): PathsCanvasBlob {
+  return {
+    nodes: nodes.map((n) => ({
+      id: n.id,
+      type: n.type,
+      position: n.position,
+      width: n.width,
+      height: n.height,
+      style: n.style,
+      zIndex: n.zIndex,
+      hidden: n.hidden,
+    })),
+    edges: edges.map((e) => ({
+      id: e.id,
+      source: e.source,
+      target: e.target,
+      sourceHandle: e.sourceHandle,
+      targetHandle: e.targetHandle,
+      type: e.type,
+      animated: e.animated,
+      style: e.style,
+      label: e.label,
+      labelStyle: e.labelStyle,
+      labelBgStyle: e.labelBgStyle,
+      data: e.data,
+      zIndex: e.zIndex,
+    })),
+    viewport: { x: viewport.x, y: viewport.y, zoom: viewport.zoom },
+  };
+}
+
+function savedNodePosition(
+  saved: PathsCanvasBlob,
+  id: string
+): { x: number; y: number } | undefined {
+  for (const raw of saved.nodes) {
+    if (raw && typeof raw === 'object' && (raw as { id?: string }).id === id) {
+      const pos = (raw as { position?: { x?: number; y?: number } }).position;
+      if (
+        pos &&
+        typeof pos.x === 'number' &&
+        typeof pos.y === 'number' &&
+        !Number.isNaN(pos.x) &&
+        !Number.isNaN(pos.y)
+      ) {
+        return { x: pos.x, y: pos.y };
+      }
+    }
+  }
+  return undefined;
+}
+
+function savedEdgeMap(saved: PathsCanvasBlob): Map<string, Record<string, unknown>> {
+  const m = new Map<string, Record<string, unknown>>();
+  for (const raw of saved.edges) {
+    if (raw && typeof raw === 'object' && typeof (raw as { id?: string }).id === 'string') {
+      m.set((raw as { id: string }).id, raw as Record<string, unknown>);
+    }
+  }
+  return m;
+}
+
+/**
+ * Merge persisted layout onto freshly computed graph from OpenAPI/path data.
+ * — Node positions win by id when present in saved.
+ * — Edges: overlay visual props from saved when id matches; append saved-only edges if endpoints exist.
+ */
+export function mergePathsCanvasLayout(
+  computedNodes: Node[],
+  computedEdges: Edge[],
+  saved: PathsCanvasBlob | null | undefined
+): { nodes: Node[]; edges: Edge[]; viewport: { x: number; y: number; zoom: number } } {
+  if (!saved) {
+    return { nodes: computedNodes, edges: computedEdges, viewport: defaultViewport() };
+  }
+
+  const nodeIds = new Set(computedNodes.map((n) => n.id));
+  const mergedNodes = computedNodes.map((n) => {
+    const p = savedNodePosition(saved, n.id);
+    if (!p) return n;
+    return { ...n, position: p };
+  });
+
+  const byId = savedEdgeMap(saved);
+  const computedIds = new Set(computedEdges.map((e) => e.id));
+
+  const mergedEdges: Edge[] = computedEdges.map((e) => {
+    const s = byId.get(e.id);
+    if (!s) return e;
+    return {
+      ...e,
+      ...(typeof s.type === 'string' ? { type: s.type as Edge['type'] } : {}),
+      ...(typeof s.animated === 'boolean' ? { animated: s.animated } : {}),
+      ...(s.style && typeof s.style === 'object' ? { style: s.style as Edge['style'] } : {}),
+      ...(s.label !== undefined ? { label: s.label as Edge['label'] } : {}),
+      ...(s.labelStyle && typeof s.labelStyle === 'object'
+        ? { labelStyle: s.labelStyle as Edge['labelStyle'] }
+        : {}),
+      ...(s.labelBgStyle && typeof s.labelBgStyle === 'object'
+        ? { labelBgStyle: s.labelBgStyle as Edge['labelBgStyle'] }
+        : {}),
+      ...(s.data && typeof s.data === 'object' ? { data: { ...e.data, ...s.data } as Edge['data'] } : {}),
+    };
+  });
+
+  for (const raw of saved.edges) {
+    if (!raw || typeof raw !== 'object') continue;
+    const id = (raw as { id?: string }).id;
+    if (!id || computedIds.has(id)) continue;
+    const source = (raw as { source?: string }).source;
+    const target = (raw as { target?: string }).target;
+    if (typeof source !== 'string' || typeof target !== 'string') continue;
+    if (!nodeIds.has(source) || !nodeIds.has(target)) continue;
+    mergedEdges.push(raw as Edge);
+  }
+
+  const vp = saved.viewport;
+  const viewport =
+    vp && typeof vp === 'object'
+      ? {
+          x: Number(vp.x) || 0,
+          y: Number(vp.y) || 0,
+          zoom: Number(vp.zoom) || 1,
+        }
+      : defaultViewport();
+
+  return { nodes: mergedNodes, edges: mergedEdges, viewport };
+}

--- a/objectified-ui/src/app/api/paths/[versionId]/[pathId]/canvas/route.ts
+++ b/objectified-ui/src/app/api/paths/[versionId]/[pathId]/canvas/route.ts
@@ -1,0 +1,178 @@
+/**
+ * API proxy: Paths designer React Flow canvas (#2642).
+ * GET/PUT → REST /v1/paths/{tenant}/{versionId}/{pathId}/canvas
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import jwt from 'jsonwebtoken';
+import { authOptions } from '../../../../auth/[...nextauth]/route';
+import { getTenantById } from '@lib/db/helper';
+
+const REST_API_BASE_URL = process.env.NEXT_PUBLIC_REST_API_BASE_URL || 'http://localhost:8000/v1';
+
+interface SessionUser {
+  user_id?: string;
+  email?: string | null;
+  name?: string | null;
+  current_tenant_id?: string;
+}
+
+function createAuthHeaders(user: SessionUser): Record<string, string> {
+  if (!user.user_id) {
+    return { 'Content-Type': 'application/json' };
+  }
+
+  const secret = process.env.NEXTAUTH_SECRET;
+  if (!secret) {
+    return { 'Content-Type': 'application/json' };
+  }
+
+  const encodedToken = jwt.sign(
+    {
+      user_id: user.user_id,
+      sub: user.user_id,
+      email: user.email,
+      name: user.name,
+      current_tenant_id: user.current_tenant_id,
+    },
+    secret,
+    { algorithm: 'HS256', expiresIn: '1h' }
+  );
+
+  return {
+    'Content-Type': 'application/json',
+    Authorization: `Bearer ${encodedToken}`,
+  };
+}
+
+async function handleRestResponse(
+  response: Response,
+  defaultError: string
+): Promise<{ data: unknown; error: string | null; status: number }> {
+  const contentType = response.headers.get('content-type');
+
+  if (!contentType || !contentType.includes('application/json')) {
+    const text = await response.text();
+    return { data: null, error: text || defaultError, status: response.status || 500 };
+  }
+
+  const data = await response.json();
+
+  if (!response.ok) {
+    return { data: null, error: data.detail || defaultError, status: response.status };
+  }
+
+  return { data, error: null, status: response.status };
+}
+
+/**
+ * GET /api/paths/[versionId]/[pathId]/canvas
+ */
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ versionId: string; pathId: string }> }
+) {
+  try {
+    const { versionId, pathId } = await params;
+    const session = await getServerSession(authOptions);
+
+    if (!session?.user) {
+      return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const user = session.user as { current_tenant_id?: string; user_id?: string };
+    const tenantId = user.current_tenant_id;
+
+    if (!tenantId) {
+      return NextResponse.json({ success: false, error: 'No tenant selected' }, { status: 400 });
+    }
+
+    const tenant = await getTenantById(tenantId);
+    if (!tenant || !tenant.slug) {
+      return NextResponse.json({ success: false, error: 'Tenant not found' }, { status: 404 });
+    }
+
+    const headers = createAuthHeaders({
+      user_id: user.user_id,
+      email: session.user.email,
+      name: session.user.name,
+      current_tenant_id: tenantId,
+    });
+
+    const response = await fetch(
+      `${REST_API_BASE_URL}/paths/${tenant.slug}/${versionId}/${pathId}/canvas`,
+      { method: 'GET', headers }
+    );
+
+    const { data, error, status } = await handleRestResponse(response, 'Failed to load canvas');
+
+    if (error) {
+      return NextResponse.json({ success: false, error }, { status });
+    }
+
+    return NextResponse.json({ success: true, canvas: data });
+  } catch (error) {
+    console.error('Error loading path canvas:', error);
+    const errorMessage = error instanceof Error ? error.message : 'Internal server error';
+    return NextResponse.json({ success: false, error: errorMessage }, { status: 500 });
+  }
+}
+
+/**
+ * PUT /api/paths/[versionId]/[pathId]/canvas
+ */
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ versionId: string; pathId: string }> }
+) {
+  try {
+    const { versionId, pathId } = await params;
+    const session = await getServerSession(authOptions);
+
+    if (!session?.user) {
+      return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const user = session.user as { current_tenant_id?: string; user_id?: string };
+    const tenantId = user.current_tenant_id;
+
+    if (!tenantId) {
+      return NextResponse.json({ success: false, error: 'No tenant selected' }, { status: 400 });
+    }
+
+    const tenant = await getTenantById(tenantId);
+    if (!tenant || !tenant.slug) {
+      return NextResponse.json({ success: false, error: 'Tenant not found' }, { status: 404 });
+    }
+
+    const body = await request.json();
+    const headers = createAuthHeaders({
+      user_id: user.user_id,
+      email: session.user.email,
+      name: session.user.name,
+      current_tenant_id: tenantId,
+    });
+
+    const response = await fetch(
+      `${REST_API_BASE_URL}/paths/${tenant.slug}/${versionId}/${pathId}/canvas`,
+      {
+        method: 'PUT',
+        headers,
+        body: JSON.stringify(body),
+      }
+    );
+
+    const { data, error, status } = await handleRestResponse(response, 'Failed to save canvas');
+
+    if (error) {
+      return NextResponse.json({ success: false, error }, { status });
+    }
+
+    return NextResponse.json({ success: true, canvas: data });
+  } catch (error) {
+    console.error('Error saving path canvas:', error);
+    const errorMessage = error instanceof Error ? error.message : 'Internal server error';
+    return NextResponse.json({ success: false, error: errorMessage }, { status: 500 });
+  }
+}

--- a/objectified-ui/src/app/api/paths/[versionId]/[pathId]/canvas/route.ts
+++ b/objectified-ui/src/app/api/paths/[versionId]/[pathId]/canvas/route.ts
@@ -5,46 +5,9 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
-import jwt from 'jsonwebtoken';
 import { authOptions } from '../../../../auth/[...nextauth]/route';
 import { getTenantById } from '@lib/db/helper';
-
-const REST_API_BASE_URL = process.env.NEXT_PUBLIC_REST_API_BASE_URL || 'http://localhost:8000/v1';
-
-interface SessionUser {
-  user_id?: string;
-  email?: string | null;
-  name?: string | null;
-  current_tenant_id?: string;
-}
-
-function createAuthHeaders(user: SessionUser): Record<string, string> {
-  if (!user.user_id) {
-    return { 'Content-Type': 'application/json' };
-  }
-
-  const secret = process.env.NEXTAUTH_SECRET;
-  if (!secret) {
-    return { 'Content-Type': 'application/json' };
-  }
-
-  const encodedToken = jwt.sign(
-    {
-      user_id: user.user_id,
-      sub: user.user_id,
-      email: user.email,
-      name: user.name,
-      current_tenant_id: user.current_tenant_id,
-    },
-    secret,
-    { algorithm: 'HS256', expiresIn: '1h' }
-  );
-
-  return {
-    'Content-Type': 'application/json',
-    Authorization: `Bearer ${encodedToken}`,
-  };
-}
+import { createRestAuthHeaders, REST_API_BASE_URL } from '@lib/rest-auth';
 
 async function handleRestResponse(
   response: Response,
@@ -93,7 +56,7 @@ export async function GET(
       return NextResponse.json({ success: false, error: 'Tenant not found' }, { status: 404 });
     }
 
-    const headers = createAuthHeaders({
+    const headers = createRestAuthHeaders({
       user_id: user.user_id,
       email: session.user.email,
       name: session.user.name,
@@ -147,7 +110,7 @@ export async function PUT(
     }
 
     const body = await request.json();
-    const headers = createAuthHeaders({
+    const headers = createRestAuthHeaders({
       user_id: user.user_id,
       email: session.user.email,
       name: session.user.name,

--- a/objectified-ui/tests/unit/paths-canvas-persist.test.ts
+++ b/objectified-ui/tests/unit/paths-canvas-persist.test.ts
@@ -1,0 +1,40 @@
+import type { Edge, Node } from '@xyflow/react';
+import {
+  mergePathsCanvasLayout,
+  serializePathsCanvas,
+} from '../../src/app/ade/studio/paths/lib/paths-canvas-persist';
+
+describe('paths-canvas-persist', () => {
+  it('mergePathsCanvasLayout applies saved positions by node id', () => {
+    const computed: Node[] = [
+      { id: 'op-1', type: 'operation', position: { x: 0, y: 0 }, data: {} },
+      { id: 'param-1', type: 'parameter', position: { x: 10, y: 10 }, data: {} },
+    ];
+    const edges: Edge[] = [{ id: 'e1', source: 'op-1', target: 'param-1', data: {} }];
+    const saved = {
+      nodes: [{ id: 'op-1', position: { x: 99, y: 88 } }],
+      edges: [],
+      viewport: { x: 1, y: 2, zoom: 0.5 },
+    };
+    const out = mergePathsCanvasLayout(computed, edges, saved);
+    expect(out.nodes[0].position).toEqual({ x: 99, y: 88 });
+    expect(out.nodes[1].position).toEqual({ x: 10, y: 10 });
+    expect(out.viewport).toEqual({ x: 1, y: 2, zoom: 0.5 });
+  });
+
+  it('serializePathsCanvas keeps layout fields and preserves viewport zoom', () => {
+    const nodes: Node[] = [
+      {
+        id: 'n1',
+        type: 'operation',
+        position: { x: 1, y: 2 },
+        data: { onDelete: () => {} },
+      } as Node,
+    ];
+    const edges: Edge[] = [];
+    const vp = { x: 3, y: 4, zoom: 0.25 };
+    const ser = serializePathsCanvas(nodes, edges, vp);
+    expect(ser.nodes[0]).not.toHaveProperty('data');
+    expect(ser.viewport.zoom).toBe(0.25);
+  });
+});

--- a/objectified-ui/tests/unit/paths-canvas-persist.test.ts
+++ b/objectified-ui/tests/unit/paths-canvas-persist.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect } from '@jest/globals';
 import type { Edge, Node } from '@xyflow/react';
 import {
   mergePathsCanvasLayout,


### PR DESCRIPTION
## What & why
Implements **P-03 / #2642**: persist **Paths** tab **React Flow** layout (`nodes`, `edges`, `viewport`) so arrangement survives refresh. OpenAPI path/operation data stays the source of truth; canvas JSON is presentation-only.

## How
- **DB:** `odb.version_path_canvas` (`version_path_id` PK → `version_path`, `canvas` JSONB, `updated_at`). Migration: `objectified-db/scripts/20260413-120000.sql`. Rollback: `DROP TABLE IF EXISTS odb.version_path_canvas;`.
- **REST:** `GET/PUT /v1/paths/{tenant}/{version_id}/{path_id}/canvas` with `validate_authentication` and version/path consistency checks.
- **UI:** Next.js proxy `/api/paths/[versionId]/[pathId]/canvas`; `PathsCanvasView` loads merged layout, debounced save, `onMoveEnd` for viewport; `fitView` only when nothing saved.

## How to test
1. Apply DB migration on a dev database.
2. Open **Studio → Paths**, select a path, move nodes / pan / zoom, refresh — layout should restore.
3. Switch version/path — each path keeps its own blob; wrong tenant/version returns 404.

## Risk / notes
- Last-write-wins; large JSON payloads possible (monitor size in prod).
- Python tests in `tests/test_path_canvas_api.py` use mocks; run with `pytest` where the env has dependencies.

Closes #2642

Made with [Cursor](https://cursor.com)