### PR TITLE
Fix #2647 - Path/query parameters: Designer schema, inline JSON, template coverage

### DIFF
--- a/docs/PLANNED_FEATURE_ROADMAP_PATHS.md
+++ b/docs/PLANNED_FEATURE_ROADMAP_PATHS.md
@@ -29,7 +29,7 @@ This document defines **epics and ordered, single-scope issues** to deliver a **
 | P-05 | [#2644](https://github.com/KenSuenobu/objectified-commercial/issues/2644) **(shipped)** | Yes |
 | P-06 | [#2645](https://github.com/KenSuenobu/objectified-commercial/issues/2645) **(shipped)** | Yes |
 | P-07 | [#2646](https://github.com/KenSuenobu/objectified-commercial/issues/2646) **(shipped)** | Yes |
-| P-08 | [#2647](https://github.com/KenSuenobu/objectified-commercial/issues/2647) | Yes |
+| P-08 | [#2647](https://github.com/KenSuenobu/objectified-commercial/issues/2647) **(shipped)** | Yes |
 | P-09 | [#2648](https://github.com/KenSuenobu/objectified-commercial/issues/2648) | Yes |
 | P-10 | [#2649](https://github.com/KenSuenobu/objectified-commercial/issues/2649) | Yes |
 | P-11 | [#2650](https://github.com/KenSuenobu/objectified-commercial/issues/2650) | Yes |
@@ -71,7 +71,7 @@ This document defines **epics and ordered, single-scope issues** to deliver a **
 
 | # | Issue | MVP |
 |---|--------|-----|
-| 2647 | P-08 Path/query parameters + schema | Yes |
+| ~~2647~~ | ~~P-08 Path/query parameters + schema~~ **(shipped)** | Yes |
 | 2648 | P-09 Request body + content types | Yes |
 | 2649 | P-10 Header/cookie parameters | Yes |
 

--- a/objectified-ui/lib/utils/openapi-paths-generator.ts
+++ b/objectified-ui/lib/utils/openapi-paths-generator.ts
@@ -130,9 +130,36 @@ export function buildParameterForOpenAPI(param: PathParameter): Record<string, u
     result.required = true;
   }
 
+  // Inline JSON Schema mode (P-08): full Schema Object stored in data.inlineSchema
+  if (data.schemaMode === 'inline' && data.inlineSchema && typeof data.inlineSchema === 'object') {
+    result.schema = { ...(data.inlineSchema as Record<string, unknown>) };
+    if (data.deprecated) {
+      result.deprecated = true;
+    }
+    if (data.allowEmptyValue !== undefined) {
+      result.allowEmptyValue = data.allowEmptyValue;
+    }
+    if (data.style) {
+      result.style = data.style;
+    }
+    if (data.explode !== undefined) {
+      result.explode = data.explode;
+    }
+    if (data.example !== undefined) {
+      result.example = data.example;
+    }
+    if (data.examples !== undefined) {
+      result.examples = data.examples;
+    }
+    return result;
+  }
+
   // Build schema from data (excluding non-schema fields)
   const schemaData = { ...data };
   delete schemaData.required;
+  delete schemaData.schemaMode;
+  delete schemaData.inlineSchema;
+  delete schemaData.propertyRef;
 
   // Handle deprecated
   if (schemaData.deprecated) {

--- a/objectified-ui/lib/utils/path-parameter-schema.ts
+++ b/objectified-ui/lib/utils/path-parameter-schema.ts
@@ -1,0 +1,22 @@
+/**
+ * Map a Designer class property `data` object to a JSON Schema fragment suitable for
+ * OpenAPI ParameterObject.schema (path parameters are limited to primitive/array shapes).
+ */
+export function propertyDataToParameterSchema(
+  propertyData: Record<string, unknown> | undefined
+): Record<string, unknown> {
+  const data = propertyData || { type: 'string' };
+  const type = (data.type as string) || 'string';
+  const pathParamTypes = ['string', 'integer', 'number', 'boolean', 'array'];
+  const paramType = pathParamTypes.includes(type) ? type : 'string';
+  const schema: Record<string, unknown> = { type: paramType, required: true };
+  if (data.format != null) schema.format = data.format;
+  if (Array.isArray(data.enum)) schema.enum = data.enum;
+  if (data.minimum != null) schema.minimum = data.minimum;
+  if (data.maximum != null) schema.maximum = data.maximum;
+  if (data.minLength != null) schema.minLength = data.minLength;
+  if (data.maxLength != null) schema.maxLength = data.maxLength;
+  if (data.pattern != null) schema.pattern = data.pattern;
+  if (paramType === 'array' && data.items != null) schema.items = data.items;
+  return schema;
+}

--- a/objectified-ui/lib/utils/path-params.ts
+++ b/objectified-ui/lib/utils/path-params.ts
@@ -126,3 +126,54 @@ export function getPathTemplateValidationError(pathname: string): string | null 
 export function isValidPath(pathname: string): boolean {
   return getPathTemplateValidationError(pathname) === null;
 }
+
+export interface PathParamCoverageRow {
+  name: string;
+  in_location: string;
+}
+
+/**
+ * Ensures OpenAPI path template `{segments}` align with shared path parameters where
+ * `in_location === 'path'`: every template variable has exactly one matching parameter,
+ * and every path parameter appears in the template (no orphans).
+ * Returns `null` when valid; otherwise a user-facing error message.
+ */
+export function getPathParameterCoverageError(
+  pathname: string,
+  parameters: PathParamCoverageRow[]
+): string | null {
+  const templateError = getPathTemplateValidationError(pathname);
+  if (templateError) {
+    return templateError;
+  }
+
+  const templateNames = extractPathParameters(pathname);
+  const pathParams = parameters.filter((p) => p.in_location === 'path');
+  const byName = new Map<string, number>();
+  for (const p of pathParams) {
+    byName.set(p.name, (byName.get(p.name) || 0) + 1);
+  }
+
+  for (const n of templateNames) {
+    const count = byName.get(n) ?? 0;
+    if (count === 0) {
+      return `Path template includes {${n}} but there is no path parameter with that name and location "path". Add or restore a path parameter named "${n}".`;
+    }
+    if (count > 1) {
+      return `Path parameter "${n}" is defined more than once for this path. Remove duplicates so each {${n}} matches exactly one parameter.`;
+    }
+  }
+
+  const templateSet = new Set(templateNames);
+  const orphans: string[] = [];
+  for (const p of pathParams) {
+    if (!templateSet.has(p.name)) {
+      orphans.push(p.name);
+    }
+  }
+  if (orphans.length > 0) {
+    return `These path parameters are not in the URL template: ${orphans.join(', ')}. Remove them or add matching {name} segments to the path.`;
+  }
+
+  return null;
+}

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.9.90",
+  "version": "0.9.91",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -5,6 +5,7 @@ We continue to improve the platform based on your feedback with improvements and
 ---
 
 ## UI:
+- **Path & query parameters (#2647):** **Parameter** panel supports **Designer property** binding, **form** vs **inline JSON Schema**, and **path-template coverage** checks so `{segments}` match **`in: path`** parameters; **path template** and **sidebar** path saves block on mismatch
 - **OPTIONS operations (#2653):** **Paths** export emits OpenAPI **`options`** on the path item; default **204 No Content** when no responses are modeled; operation inspector shows a **warning** if a **request body** is linked (export still omits `requestBody` for OPTIONS per common practice)
 - **Paths canvas edges (#2646):** **Path → operation** and **operation → parameter / request body / response** edges use **semantic labels** (`has`, `hasParam`, `requestBody`, `response <code>`); **request body** links render **operation → request body** (tree from the operation); **manual** connect / **delete edge** syncs **request body** link like parameters and responses; **`edge.data.semantic`** tags role for layout persistence (**P-03**)
 - **Paths operation inspector (#2645):** **Operation** side panel uses **Radix Tabs** (**General**, **Docs**, **Tags**, **Advanced**) for OpenAPI **Operation Object** fields; **Docs** includes **Markdown** preview; **Tags** edits **`metadata.tags`**; **operationId** must be **unique across all operations in the API version** (server validation with a clear error naming the conflicting **method** and **path**)

--- a/objectified-ui/src/app/ade/studio/paths/components/OperationPropertiesPanel.tsx
+++ b/objectified-ui/src/app/ade/studio/paths/components/OperationPropertiesPanel.tsx
@@ -498,6 +498,21 @@ export default function OperationPropertiesPanel({
   const handleSaveParameter = async () => {
     if (!operationId || !newParamName.trim() || !versionPathId) return;
 
+    if (newParamLocation === 'path') {
+      const segments = extractPathParameters(pathname);
+      if (!segments.includes(newParamName.trim())) {
+        await alertDialog({
+          title: 'Path parameter name mismatch',
+          message:
+            segments.length === 0
+              ? 'This path template has no {segments}. Use a name that appears in the path (e.g. /users/{id}) or edit the path template first.'
+              : `The name must match a segment in the path template. Expected one of: ${segments.map((s) => `{${s}}`).join(', ')}.`,
+          variant: 'warning',
+        });
+        return;
+      }
+    }
+
     setIsSaving(true);
     try {
       // Schema with required field included

--- a/objectified-ui/src/app/ade/studio/paths/components/ParameterPropertiesPanel.tsx
+++ b/objectified-ui/src/app/ade/studio/paths/components/ParameterPropertiesPanel.tsx
@@ -23,7 +23,10 @@ import {
   updateSharedPathParameter,
   unlinkParameterFromOperation,
 } from '../../../../../../lib/db/helper-shared-path-parameters';
-import { extractPathParameters } from '../../../../../../lib/utils/path-params';
+import { getClassesWithPropertiesAndTags } from '../../../../../../lib/db/helper';
+import { extractPathParameters, getPathParameterCoverageError } from '../../../../../../lib/utils/path-params';
+import { propertyDataToParameterSchema } from '../../../../../../lib/utils/path-parameter-schema';
+import { useStudio } from '../../StudioContext';
 
 // Simple types allowed for path parameters (no 'object')
 const SCHEMA_TYPES = [
@@ -103,6 +106,24 @@ interface PrimitiveTemplate {
   usage_count: number;
 }
 
+interface DesignerPropOption {
+  key: string;
+  classId: string;
+  className: string;
+  propertyId: string;
+  propertyName: string;
+  data: Record<string, unknown>;
+}
+
+interface LoadedSharedParameter {
+  id: string;
+  name: string;
+  in_location: 'path' | 'query' | 'header' | 'cookie';
+  summary?: string | null;
+  description?: string | null;
+  data?: unknown;
+}
+
 interface ParameterPropertiesPanelProps {
   parameterId: string | null;
   operationId?: string; // Optional when opened from path variable click
@@ -121,6 +142,7 @@ export default function ParameterPropertiesPanel({
   onRefresh,
 }: ParameterPropertiesPanelProps) {
   const isDark = useDarkMode();
+  const { selectedVersionId } = useStudio();
   const { alert: alertDialog, confirm: confirmDialog } = useDialog();
   const [name, setName] = useState('');
   const [inLocation, setInLocation] = useState<'path' | 'query' | 'header' | 'cookie'>('path');
@@ -145,6 +167,17 @@ export default function ParameterPropertiesPanel({
   const [schemaArrayItemType, setSchemaArrayItemType] = useState<'string' | 'integer' | 'number' | 'boolean'>('string');
   const [paramStyle, setParamStyle] = useState<ParamStyle>(PARAM_STYLE_DEFAULT);
   const [paramExplode, setParamExplode] = useState(false);
+
+  const [schemaMode, setSchemaMode] = useState<'form' | 'inline'>('form');
+  const [inlineSchemaText, setInlineSchemaText] = useState('{\n  "type": "string"\n}');
+  const [designerProps, setDesignerProps] = useState<DesignerPropOption[]>([]);
+  const [designerPropSearch, setDesignerPropSearch] = useState('');
+  const [propertyRef, setPropertyRef] = useState<{
+    classId: string;
+    className: string;
+    propertyId: string;
+    propertyName: string;
+  } | null>(null);
 
   // Primitive template dialog state (Apply from REST primitives)
   const [primitiveDialogOpen, setPrimitiveDialogOpen] = useState(false);
@@ -177,25 +210,35 @@ export default function ParameterPropertiesPanel({
       setSchemaArrayItemType('string');
       setParamStyle(PARAM_STYLE_DEFAULT);
       setParamExplode(false);
+      setSchemaMode('form');
+      setInlineSchemaText('{\n  "type": "string"\n}');
+      setPropertyRef(null);
+      setDesignerPropSearch('');
       return;
     }
 
     const loadParameter = async () => {
       setIsLoading(true);
       try {
-        let param: any = null;
+        let param: LoadedSharedParameter | null = null;
 
         if (operationId) {
           const result = await getLinkedParametersForOperation(operationId);
-          const data = JSON.parse(result);
+          const data = JSON.parse(result) as {
+            success?: boolean;
+            parameters?: LoadedSharedParameter[];
+          };
           if (data.success && data.parameters) {
-            param = data.parameters.find((p: any) => p.id === parameterId);
+            param = data.parameters.find((p) => p.id === parameterId) ?? null;
           }
         } else if (versionPathId) {
           const result = await getSharedPathParameters(versionPathId);
-          const data = JSON.parse(result);
+          const data = JSON.parse(result) as {
+            success?: boolean;
+            parameters?: LoadedSharedParameter[];
+          };
           if (data.success && data.parameters) {
-            param = data.parameters.find((p: any) => p.id === parameterId);
+            param = data.parameters.find((p) => p.id === parameterId) ?? null;
           }
         }
 
@@ -208,16 +251,44 @@ export default function ParameterPropertiesPanel({
           // Load schema from param.data column (JSONB may be object or string)
           const schema = typeof param.data === 'string' ? JSON.parse(param.data) : param.data;
           if (schema && typeof schema === 'object') {
-            setSchemaType(schema.type || 'string');
-            setSchemaFormat(schema.format || '');
-            setSchemaMinimum(schema.minimum !== undefined ? String(schema.minimum) : '');
-            setSchemaMaximum(schema.maximum !== undefined ? String(schema.maximum) : '');
-            setSchemaMinLength(schema.minLength !== undefined ? String(schema.minLength) : '');
-            setSchemaMaxLength(schema.maxLength !== undefined ? String(schema.maxLength) : '');
-            setSchemaPattern(schema.pattern || '');
-            setSchemaDefault(schema.default !== undefined ? String(schema.default) : '');
-            setSchemaEnum(schema.enum ? schema.enum.join(', ') : '');
-            setSchemaArrayItemType(schema.items?.type || 'string');
+            if (schema.schemaMode === 'inline' && schema.inlineSchema && typeof schema.inlineSchema === 'object') {
+              setSchemaMode('inline');
+              setInlineSchemaText(JSON.stringify(schema.inlineSchema, null, 2));
+            } else {
+              setSchemaMode('form');
+              setInlineSchemaText('{\n  "type": "string"\n}');
+            }
+            const pr = schema.propertyRef;
+            if (pr && typeof pr === 'object' && pr.propertyId && pr.classId) {
+              setPropertyRef({
+                classId: String(pr.classId),
+                className: String(pr.className || ''),
+                propertyId: String(pr.propertyId),
+                propertyName: String(pr.propertyName || ''),
+              });
+            } else {
+              setPropertyRef(null);
+            }
+            const isInlineSchema =
+              schema.schemaMode === 'inline' && schema.inlineSchema && typeof schema.inlineSchema === 'object';
+            if (!isInlineSchema) {
+              const t = String(schema.type || 'string');
+              const allowed = ['string', 'integer', 'number', 'boolean', 'array'] as const;
+              setSchemaType(
+                (allowed as readonly string[]).includes(t)
+                  ? (t as (typeof allowed)[number])
+                  : 'string'
+              );
+              setSchemaFormat(schema.format || '');
+              setSchemaMinimum(schema.minimum !== undefined ? String(schema.minimum) : '');
+              setSchemaMaximum(schema.maximum !== undefined ? String(schema.maximum) : '');
+              setSchemaMinLength(schema.minLength !== undefined ? String(schema.minLength) : '');
+              setSchemaMaxLength(schema.maxLength !== undefined ? String(schema.maxLength) : '');
+              setSchemaPattern(schema.pattern || '');
+              setSchemaDefault(schema.default !== undefined ? String(schema.default) : '');
+              setSchemaEnum(schema.enum ? schema.enum.join(', ') : '');
+              setSchemaArrayItemType(schema.items?.type || 'string');
+            }
             // Read required from data field
             setRequired(schema.required ?? (param.in_location === 'path'));
             // Serialization style (default form)
@@ -226,6 +297,9 @@ export default function ParameterPropertiesPanel({
             setParamExplode(schema.explode === true);
           } else {
             // Reset to defaults if no schema
+            setSchemaMode('form');
+            setInlineSchemaText('{\n  "type": "string"\n}');
+            setPropertyRef(null);
             setSchemaType('string');
             setSchemaFormat('');
             setSchemaMinimum('');
@@ -259,6 +333,62 @@ export default function ParameterPropertiesPanel({
       setAvailablePathParams(params);
     }
   }, [pathname]);
+
+  // Designer class properties (same catalog as Schema Builder) for schema binding
+  useEffect(() => {
+    if (!selectedVersionId) {
+      setDesignerProps([]);
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        const raw = await getClassesWithPropertiesAndTags(selectedVersionId);
+        const classes: Array<{
+          id: string;
+          name: string;
+          properties?: Array<{
+            id: string;
+            name: string;
+            parent_id?: string | null;
+            data?: Record<string, unknown> | string;
+          }>;
+        }> = JSON.parse(raw as string);
+        const opts: DesignerPropOption[] = [];
+        for (const cls of classes || []) {
+          for (const p of cls.properties || []) {
+            if (p.parent_id) continue;
+            const pdata = typeof p.data === 'string' ? JSON.parse(p.data) : p.data || {};
+            opts.push({
+              key: `${cls.id}:${p.id}`,
+              classId: cls.id,
+              className: cls.name,
+              propertyId: p.id,
+              propertyName: p.name,
+              data: pdata,
+            });
+          }
+        }
+        opts.sort((a, b) => a.propertyName.localeCompare(b.propertyName));
+        if (!cancelled) setDesignerProps(opts);
+      } catch {
+        if (!cancelled) setDesignerProps([]);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedVersionId]);
+
+  const filteredDesignerProps = useMemo(() => {
+    const q = designerPropSearch.trim().toLowerCase();
+    if (!q) return designerProps;
+    return designerProps.filter(
+      (o) =>
+        o.propertyName.toLowerCase().includes(q) ||
+        o.className.toLowerCase().includes(q)
+    );
+  }, [designerProps, designerPropSearch]);
 
   // Fetch primitives when primitive dialog opens (from REST service)
   useEffect(() => {
@@ -302,6 +432,32 @@ export default function ParameterPropertiesPanel({
     return list.sort((a, b) => (a.is_system === b.is_system ? 0 : a.is_system ? 1 : -1));
   }, [primitives, primitiveSearch, showSystemPrimitives, showTenantPrimitives]);
 
+  const applyDesignerProperty = (opt: DesignerPropOption) => {
+    const mapped = propertyDataToParameterSchema(opt.data);
+    const t = (mapped.type as string) || 'string';
+    if (['string', 'integer', 'number', 'boolean', 'array'].includes(t)) {
+      setSchemaType(t as 'string' | 'integer' | 'number' | 'boolean' | 'array');
+    }
+    if (mapped.format !== undefined) setSchemaFormat(String(mapped.format));
+    setSchemaMinimum(mapped.minimum !== undefined ? String(mapped.minimum) : '');
+    setSchemaMaximum(mapped.maximum !== undefined ? String(mapped.maximum) : '');
+    setSchemaMinLength(mapped.minLength !== undefined ? String(mapped.minLength) : '');
+    setSchemaMaxLength(mapped.maxLength !== undefined ? String(mapped.maxLength) : '');
+    setSchemaPattern(mapped.pattern !== undefined ? String(mapped.pattern) : '');
+    setSchemaEnum(mapped.enum && Array.isArray(mapped.enum) ? (mapped.enum as unknown[]).map(String).join(', ') : '');
+    if (mapped.items && typeof mapped.items === 'object' && mapped.items !== null && 'type' in mapped.items) {
+      setSchemaArrayItemType((mapped.items as { type: string }).type as 'string' | 'integer' | 'number' | 'boolean');
+    }
+    setSchemaMode('form');
+    setPropertyRef({
+      classId: opt.classId,
+      className: opt.className,
+      propertyId: opt.propertyId,
+      propertyName: opt.propertyName,
+    });
+    setDesignerPropSearch('');
+  };
+
   // Apply primitive schema to parameter form (type, format, pattern, constraints)
   const applyPrimitiveToParameter = (primitive: PrimitiveTemplate) => {
     const schema = primitive.schema as Record<string, unknown>;
@@ -320,56 +476,109 @@ export default function ParameterPropertiesPanel({
       setSchemaArrayItemType((schema.items as { type: string }).type as 'string' | 'integer' | 'number' | 'boolean');
     }
     if (primitive.description && !description) setDescription(primitive.description);
+    setPropertyRef(null);
     setPrimitiveDialogOpen(false);
     setSelectedPrimitive(null);
   };
 
   const handleSave = async () => {
-    if (!parameterId || !name.trim()) return;
+    if (!parameterId || !name.trim() || !versionPathId) return;
 
     setIsSaving(true);
     setSaveStatus('idle');
     try {
-      // Build the JSON Schema for the parameter
-      const schemaData: Record<string, any> = { type: schemaType };
-
-      if (schemaType === 'string') {
-        if (schemaFormat) schemaData.format = schemaFormat;
-        if (schemaMinLength) schemaData.minLength = parseInt(schemaMinLength, 10);
-        if (schemaMaxLength) schemaData.maxLength = parseInt(schemaMaxLength, 10);
-        if (schemaPattern) schemaData.pattern = schemaPattern;
-      } else if (schemaType === 'integer' || schemaType === 'number') {
-        if (schemaMinimum) schemaData.minimum = schemaType === 'integer' ? parseInt(schemaMinimum, 10) : parseFloat(schemaMinimum);
-        if (schemaMaximum) schemaData.maximum = schemaType === 'integer' ? parseInt(schemaMaximum, 10) : parseFloat(schemaMaximum);
-      } else if (schemaType === 'array') {
-        schemaData.items = { type: schemaArrayItemType };
-      }
-
-      // Handle enum values (comma-separated)
-      if (schemaEnum.trim()) {
-        schemaData.enum = schemaEnum.split(',').map(v => v.trim()).filter(v => v);
-      }
-
-      // Handle default value
-      if (schemaDefault.trim()) {
-        if (schemaType === 'integer') {
-          schemaData.default = parseInt(schemaDefault, 10);
-        } else if (schemaType === 'number') {
-          schemaData.default = parseFloat(schemaDefault);
-        } else if (schemaType === 'boolean') {
-          schemaData.default = schemaDefault.toLowerCase() === 'true';
-        } else {
-          schemaData.default = schemaDefault;
+      const allRaw = await getSharedPathParameters(versionPathId);
+      const allParsed = JSON.parse(allRaw) as {
+        success?: boolean;
+        parameters?: Array<{ id: string; name: string; in_location: string }>;
+      };
+      if (allParsed.success && allParsed.parameters) {
+        const simulated = allParsed.parameters.map((p) =>
+          p.id === parameterId
+            ? { name: name.trim(), in_location: inLocation }
+            : { name: p.name, in_location: p.in_location }
+        );
+        const cov = getPathParameterCoverageError(pathname, simulated);
+        if (cov) {
+          await alertDialog({
+            title: 'Path template mismatch',
+            message: cov,
+            variant: 'warning',
+          });
+          return;
         }
       }
 
-      // Add required to schema data (path params are always required in OpenAPI)
-      schemaData.required = inLocation === 'path' ? true : required;
+      let schemaData: Record<string, unknown>;
 
-      // Serialization style (OpenAPI 3.0 parameter style; default form)
-      schemaData.style = paramStyle;
-      // Explode (arrays/objects)
-      schemaData.explode = paramExplode;
+      if (schemaMode === 'inline') {
+        let parsedInline: unknown;
+        try {
+          parsedInline = JSON.parse(inlineSchemaText);
+        } catch {
+          await alertDialog({
+            title: 'Invalid JSON',
+            message: 'Fix the inline JSON Schema object before saving.',
+            variant: 'error',
+          });
+          return;
+        }
+        if (!parsedInline || typeof parsedInline !== 'object' || Array.isArray(parsedInline)) {
+          await alertDialog({
+            title: 'Invalid schema',
+            message: 'Inline schema must be a JSON object (for example {"type":"string"}).',
+            variant: 'error',
+          });
+          return;
+        }
+        schemaData = {
+          schemaMode: 'inline',
+          inlineSchema: parsedInline as Record<string, unknown>,
+          required: inLocation === 'path' ? true : required,
+          style: paramStyle,
+          explode: paramExplode,
+        };
+        if (propertyRef) {
+          schemaData.propertyRef = propertyRef;
+        }
+      } else {
+        schemaData = { type: schemaType };
+
+        if (schemaType === 'string') {
+          if (schemaFormat) schemaData.format = schemaFormat;
+          if (schemaMinLength) schemaData.minLength = parseInt(schemaMinLength, 10);
+          if (schemaMaxLength) schemaData.maxLength = parseInt(schemaMaxLength, 10);
+          if (schemaPattern) schemaData.pattern = schemaPattern;
+        } else if (schemaType === 'integer' || schemaType === 'number') {
+          if (schemaMinimum) schemaData.minimum = schemaType === 'integer' ? parseInt(schemaMinimum, 10) : parseFloat(schemaMinimum);
+          if (schemaMaximum) schemaData.maximum = schemaType === 'integer' ? parseInt(schemaMaximum, 10) : parseFloat(schemaMaximum);
+        } else if (schemaType === 'array') {
+          schemaData.items = { type: schemaArrayItemType };
+        }
+
+        if (schemaEnum.trim()) {
+          schemaData.enum = schemaEnum.split(',').map((v) => v.trim()).filter(Boolean);
+        }
+
+        if (schemaDefault.trim()) {
+          if (schemaType === 'integer') {
+            schemaData.default = parseInt(schemaDefault, 10);
+          } else if (schemaType === 'number') {
+            schemaData.default = parseFloat(schemaDefault);
+          } else if (schemaType === 'boolean') {
+            schemaData.default = schemaDefault.toLowerCase() === 'true';
+          } else {
+            schemaData.default = schemaDefault;
+          }
+        }
+
+        schemaData.required = inLocation === 'path' ? true : required;
+        schemaData.style = paramStyle;
+        schemaData.explode = paramExplode;
+        if (propertyRef) {
+          schemaData.propertyRef = propertyRef;
+        }
+      }
 
       const result = await updateSharedPathParameter(parameterId, {
         name: name.trim(),
@@ -396,7 +605,7 @@ export default function ParameterPropertiesPanel({
           variant: 'error',
         });
       }
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error('Error saving parameter:', error);
       await alertDialog({
         title: 'Error',
@@ -645,7 +854,100 @@ export default function ParameterPropertiesPanel({
                   Schema Definition
                 </Label>
 
-                {/* Apply from primitive template (REST service primitives) */}
+                <div
+                  className={`flex rounded-md border overflow-hidden mb-3 text-xs ${
+                    isDark ? 'border-slate-600' : 'border-slate-300'
+                  }`}
+                  role="group"
+                  aria-label="Schema editor mode"
+                >
+                  <button
+                    type="button"
+                    className={`flex-1 px-2 py-1.5 font-medium transition-colors ${
+                      schemaMode === 'form'
+                        ? 'bg-violet-600 text-white'
+                        : isDark
+                          ? 'bg-slate-800 text-slate-300 hover:bg-slate-700'
+                          : 'bg-white text-slate-700 hover:bg-slate-50'
+                    }`}
+                    onClick={() => setSchemaMode('form')}
+                  >
+                    Form builder
+                  </button>
+                  <button
+                    type="button"
+                    className={`flex-1 px-2 py-1.5 font-medium transition-colors border-l ${
+                      schemaMode === 'inline'
+                        ? 'bg-violet-600 text-white border-violet-500'
+                        : isDark
+                          ? 'bg-slate-800 text-slate-300 border-slate-600 hover:bg-slate-700'
+                          : 'bg-white text-slate-700 border-slate-300 hover:bg-slate-50'
+                    }`}
+                    onClick={() => {
+                      setSchemaMode('inline');
+                      setPropertyRef(null);
+                    }}
+                  >
+                    Inline JSON Schema
+                  </button>
+                </div>
+
+                {propertyRef && schemaMode === 'form' && (
+                  <p className="text-[11px] text-slate-600 dark:text-slate-400 mb-2">
+                    Designer link:{' '}
+                    <span className="font-mono">
+                      {propertyRef.className}.{propertyRef.propertyName}
+                    </span>
+                  </p>
+                )}
+
+                {schemaMode === 'form' && selectedVersionId && designerProps.length > 0 && (
+                  <div className="mb-3">
+                    <Label className="text-xs font-medium text-gray-700 dark:text-gray-300 mb-1 block">
+                      Apply from Designer property
+                    </Label>
+                    <div className="relative">
+                      <Search
+                        size={14}
+                        className="absolute left-2.5 top-1/2 -translate-y-1/2 text-gray-500 dark:text-gray-400 pointer-events-none"
+                      />
+                      <Input
+                        value={designerPropSearch}
+                        onChange={(e) => setDesignerPropSearch(e.target.value)}
+                        placeholder="Search class properties…"
+                        className="h-9 text-sm pl-8"
+                        autoComplete="off"
+                      />
+                    </div>
+                    <div
+                      className={`mt-1 max-h-28 overflow-y-auto rounded border text-xs ${
+                        isDark ? 'border-slate-600 bg-slate-900/50' : 'border-slate-200 bg-slate-50'
+                      }`}
+                    >
+                      {filteredDesignerProps.length === 0 ? (
+                        <p className="p-2 text-gray-500 dark:text-gray-400">No matching properties</p>
+                      ) : (
+                        filteredDesignerProps.slice(0, 40).map((opt) => (
+                          <button
+                            key={opt.key}
+                            type="button"
+                            onClick={() => applyDesignerProperty(opt)}
+                            className={`w-full text-left px-2 py-1.5 border-b last:border-b-0 transition-colors ${
+                              isDark
+                                ? 'border-slate-700 hover:bg-slate-800 text-slate-200'
+                                : 'border-slate-100 hover:bg-white text-slate-800'
+                            }`}
+                          >
+                            <span className="font-medium">{opt.propertyName}</span>
+                            <span className="text-gray-500 dark:text-gray-400"> · {opt.className}</span>
+                          </button>
+                        ))
+                      )}
+                    </div>
+                  </div>
+                )}
+
+                {schemaMode === 'form' && (
                 <div className="mb-4">
                   <Button
                     type="button"
@@ -664,7 +966,10 @@ export default function ParameterPropertiesPanel({
                     ⓘ
                   </span>
                 </div>
+                )}
 
+                {schemaMode === 'form' && (
+                <>
                 {/* Schema Type */}
                 <div className="mb-4">
                   <Label className="text-xs font-medium text-gray-700 dark:text-gray-300 mb-1 block">
@@ -836,6 +1141,26 @@ export default function ParameterPropertiesPanel({
                     Optional. Used when the client omits this parameter.
                   </p>
                 </div>
+                </>
+                )}
+
+                {schemaMode === 'inline' && (
+                  <div>
+                    <Label className="text-xs font-medium text-gray-700 dark:text-gray-300 mb-1 block">
+                      Parameter schema (JSON)
+                    </Label>
+                    <Textarea
+                      value={inlineSchemaText}
+                      onChange={(e) => setInlineSchemaText(e.target.value)}
+                      rows={12}
+                      spellCheck={false}
+                      className="text-xs font-mono resize-y min-h-[140px]"
+                    />
+                    <p className="text-[11px] text-gray-500 dark:text-gray-400 mt-1">
+                      OpenAPI Schema Object subset (e.g. type, format, enum). Required, style, and explode are saved separately.
+                    </p>
+                  </div>
+                )}
               </div>
             </div>
           </div>

--- a/objectified-ui/src/app/ade/studio/paths/components/PathTemplateNode.tsx
+++ b/objectified-ui/src/app/ade/studio/paths/components/PathTemplateNode.tsx
@@ -3,7 +3,8 @@
 import React, { memo, useState, useEffect, useCallback } from 'react';
 import { Handle, Position, type NodeProps } from '@xyflow/react';
 import { updatePath } from '../../../../../../lib/api/paths-client';
-import { getPathTemplateValidationError } from '../../../../../../lib/utils/path-params';
+import { getSharedPathParameters } from '../../../../../../lib/db/helper-shared-path-parameters';
+import { getPathParameterCoverageError, getPathTemplateValidationError } from '../../../../../../lib/utils/path-params';
 
 export interface PathTemplateNodeData {
   versionPathId: string;
@@ -30,6 +31,25 @@ function PathTemplateNode({ data, selected }: NodeProps) {
       setError(validationError);
       return;
     }
+
+    try {
+      const paramsRaw = await getSharedPathParameters(d.versionPathId);
+      const paramsParsed = JSON.parse(paramsRaw) as {
+        success?: boolean;
+        parameters?: { name: string; in_location: string }[];
+      };
+      if (paramsParsed.success && paramsParsed.parameters) {
+        const coverageError = getPathParameterCoverageError(trimmed, paramsParsed.parameters);
+        if (coverageError) {
+          setError(coverageError);
+          return;
+        }
+      }
+    } catch {
+      setError('Could not validate path parameters against the template. Try again.');
+      return;
+    }
+
     if (trimmed === d.pathname.trim()) {
       setError(null);
       return;

--- a/objectified-ui/src/app/ade/studio/paths/components/PathsCanvasView.tsx
+++ b/objectified-ui/src/app/ade/studio/paths/components/PathsCanvasView.tsx
@@ -45,6 +45,7 @@ import {
   deleteSharedPathParameter,
 } from '../../../../../../lib/db/helper-shared-path-parameters';
 import { extractPathParameters, isValidPath, getPathWithSampleValues } from '../../../../../../lib/utils/path-params';
+import { propertyDataToParameterSchema } from '../../../../../../lib/utils/path-parameter-schema';
 import {
   getLinkedResponsesForOperation,
   getSharedPathResponses,
@@ -914,24 +915,6 @@ function PathsCanvasInner({
     [selectedPathId, onParameterSelect, onRefresh, alertDialog]
   );
 
-  // Map property schema to path parameter schema (path params: string, integer, number, boolean, array only)
-  const propertyDataToParameterSchema = useCallback((propertyData: Record<string, any> | undefined): Record<string, any> => {
-    const data = propertyData || { type: 'string' };
-    const type = data.type || 'string';
-    const pathParamTypes = ['string', 'integer', 'number', 'boolean', 'array'];
-    const paramType = pathParamTypes.includes(type) ? type : 'string';
-    const schema: Record<string, any> = { type: paramType, required: true };
-    if (data.format != null) schema.format = data.format;
-    if (Array.isArray(data.enum)) schema.enum = data.enum;
-    if (data.minimum != null) schema.minimum = data.minimum;
-    if (data.maximum != null) schema.maximum = data.maximum;
-    if (data.minLength != null) schema.minLength = data.minLength;
-    if (data.maxLength != null) schema.maxLength = data.maxLength;
-    if (data.pattern != null) schema.pattern = data.pattern;
-    if (paramType === 'array' && data.items != null) schema.items = data.items;
-    return schema;
-  }, []);
-
   // Handle property drop on path variable: bind property type/schema to the parameter
   const handlePropertyDropOnPathVariable = useCallback(
     async (variableName: string, dropData: any) => {
@@ -990,7 +973,7 @@ function PathsCanvasInner({
         });
       }
     },
-    [selectedPathId, propertyDataToParameterSchema, onRefresh, onParameterSelect, alertDialog]
+    [selectedPathId, onRefresh, onParameterSelect, alertDialog]
   );
 
   // Handle delete response

--- a/objectified-ui/src/app/ade/studio/paths/components/PathsSidebar.tsx
+++ b/objectified-ui/src/app/ade/studio/paths/components/PathsSidebar.tsx
@@ -24,7 +24,8 @@ import {
   deletePath as deletePathRest,
   createOperation as createOperationRest,
 } from '../../../../../../lib/api/paths-client';
-import { getPathTemplateValidationError, isValidPath } from '../../../../../../lib/utils/path-params';
+import { getSharedPathParameters } from '../../../../../../lib/db/helper-shared-path-parameters';
+import { getPathParameterCoverageError, getPathTemplateValidationError, isValidPath } from '../../../../../../lib/utils/path-params';
 import { useDarkMode } from '../../../../hooks/useDarkMode';
 import { AVAILABLE_OPERATIONS } from './paths-operation-colors';
 import { parseOpenAPISpec } from '../../../../utils/openapi-import';
@@ -218,7 +219,8 @@ export default function PathsSidebar({
   const handleSavePath = async () => {
     if (!selectedVersionId || !pathNameInput.trim()) return;
 
-    const templateError = getPathTemplateValidationError(pathNameInput.trim());
+    const trimmedPath = pathNameInput.trim();
+    const templateError = getPathTemplateValidationError(trimmedPath);
     if (templateError) {
       await alertDialog({
         title: 'Invalid path template',
@@ -228,10 +230,31 @@ export default function PathsSidebar({
       return;
     }
 
+    let paramsForCoverage: { name: string; in_location: string }[] = [];
+    if (editingPath) {
+      const paramsRaw = await getSharedPathParameters(editingPath.id);
+      const paramsParsed = JSON.parse(paramsRaw) as {
+        success?: boolean;
+        parameters?: { name: string; in_location: string }[];
+      };
+      if (paramsParsed.success && paramsParsed.parameters) {
+        paramsForCoverage = paramsParsed.parameters;
+      }
+    }
+    const coverageError = getPathParameterCoverageError(trimmedPath, paramsForCoverage);
+    if (coverageError) {
+      await alertDialog({
+        title: 'Path parameters do not match template',
+        message: coverageError,
+        variant: 'warning',
+      });
+      return;
+    }
+
     try {
       if (editingPath) {
         // Update existing path
-        const result = await updatePathRest(selectedVersionId, editingPath.id, { pathname: pathNameInput.trim() });
+        const result = await updatePathRest(selectedVersionId, editingPath.id, { pathname: trimmedPath });
         if (result.success && result.data) {
           const updatedPath = result.data as PathItem;
           setPaths(prevPaths =>
@@ -242,7 +265,7 @@ export default function PathsSidebar({
         }
       } else {
         // Create new path
-        const result = await createPathRest(selectedVersionId, pathNameInput.trim());
+        const result = await createPathRest(selectedVersionId, trimmedPath);
         if (result.success && result.data) {
           const newPath = result.data as PathItem;
           setPaths(prevPaths => [...prevPaths, newPath].sort((a, b) => a.pathname.localeCompare(b.pathname)));

--- a/objectified-ui/tests/unit/path-parameter-coverage.test.ts
+++ b/objectified-ui/tests/unit/path-parameter-coverage.test.ts
@@ -1,0 +1,48 @@
+import {
+  extractPathParameters,
+  getPathParameterCoverageError,
+  getPathTemplateValidationError,
+} from '../../lib/utils/path-params';
+
+describe('getPathParameterCoverageError', () => {
+  it('returns null when template has no segments and no path params', () => {
+    expect(getPathParameterCoverageError('/api/users', [])).toBeNull();
+  });
+
+  it('errors when template has {id} but no path parameter', () => {
+    const msg = getPathParameterCoverageError('/users/{id}', []);
+    expect(msg).toContain('{id}');
+    expect(msg).toContain('no path parameter');
+  });
+
+  it('errors when path parameter exists but is not in the template', () => {
+    const msg = getPathParameterCoverageError('/users', [
+      { name: 'id', in_location: 'path' },
+    ]);
+    expect(msg).toContain('not in the URL template');
+  });
+
+  it('returns null when template and path params align', () => {
+    expect(
+      getPathParameterCoverageError('/users/{id}', [
+        { name: 'id', in_location: 'path' },
+        { name: 'page', in_location: 'query' },
+      ])
+    ).toBeNull();
+  });
+
+  it('delegates to template validation first', () => {
+    expect(getPathParameterCoverageError('no-slash', [])).toBe(getPathTemplateValidationError('no-slash'));
+  });
+
+  it('matches extractPathParameters names', () => {
+    const path = '/a/{x}/b/{y}';
+    expect(extractPathParameters(path)).toEqual(['x', 'y']);
+    expect(
+      getPathParameterCoverageError(path, [
+        { name: 'x', in_location: 'path' },
+        { name: 'y', in_location: 'path' },
+      ])
+    ).toBeNull();
+  });
+});

--- a/objectified-ui/tests/utils/openapi-paths-generator.test.ts
+++ b/objectified-ui/tests/utils/openapi-paths-generator.test.ts
@@ -15,7 +15,6 @@ import {
   type PathParameter,
   type ResponseInfo,
   type RequestBodyInfo,
-  type ContentTypeInfo,
 } from '../../lib/utils/openapi-paths-generator';
 
 describe('OpenAPI Paths Generator', () => {
@@ -85,6 +84,27 @@ describe('OpenAPI Paths Generator', () => {
 
       expect(result.style).toBe('form');
       expect(result.explode).toBe(true);
+    });
+
+    it('should use inline JSON Schema when schemaMode is inline', () => {
+      const param: PathParameter = {
+        id: 'param-inline',
+        name: 'filter',
+        in_location: 'query',
+        data: {
+          schemaMode: 'inline',
+          inlineSchema: { type: 'string', pattern: '^[a-z]+$' },
+          required: false,
+          style: 'form',
+          explode: false,
+        },
+      };
+
+      const result = buildParameterForOpenAPI(param);
+
+      expect(result.schema).toEqual({ type: 'string', pattern: '^[a-z]+$' });
+      expect(result.required).toBeUndefined();
+      expect(result.style).toBe('form');
     });
   });
 


### PR DESCRIPTION
## What was done and why

Implements **P-08** (**#2647**): path/query parameter authoring against `shared_path_parameter` / `path_operation_parameter_link` with:

- **Designer property picker** in the parameter side panel (class properties from `getClassesWithPropertiesAndTags`, same catalog as Schema Builder) to map property `data` → parameter schema via shared `propertyDataToParameterSchema`.
- **Form builder vs inline JSON Schema** toggle; `schemaMode: 'inline'` + `inlineSchema` in `data` exports correctly via `buildParameterForOpenAPI`.
- **Path template ↔ path parameters** validation (`getPathParameterCoverageError`): every `{segment}` must have exactly one `in: path` parameter and path parameters must appear in the template. **Path template node** (blur save), **Paths sidebar** create/edit dialog, and **parameter save** block with explicit errors when mismatched.
- **Operation panel**: adding a **path** parameter validates the name against segments in the pathname.

Also: `path-parameter-schema.ts` for reusable property→schema mapping (used by canvas drop + panel).

## How to test

1. `yarn workspace objectified-ui build` and `yarn test` (or run `path-parameter-coverage` + `openapi-paths-generator` Jest suites).
2. In **Paths**, open a path with `/users/{id}`, create/link path parameters, open **Parameter** panel: pick a **Designer property**, toggle **Inline JSON Schema**, save; export OpenAPI and confirm `parameters[]` and `schema`.
3. Edit path template to add `{foo}` without a parameter → save should be **blocked** with a clear message. Create orphan path param not in URL → blocked on parameter save / path save as appropriate.

## Risk / notes

- Stricter path saves: users must keep **`{var}`** and **path-parameter** rows in sync (by design per acceptance criteria).
- UI-only + generator helpers; **objectified-ui** version **0.9.91**.

Closes #2647

Made with [Cursor](https://cursor.com)