### PR TITLE
Fix #2648 - Wire request body inspector to shared_path_request_body and links

### DIFF
--- a/docs/PLANNED_FEATURE_ROADMAP_PATHS.md
+++ b/docs/PLANNED_FEATURE_ROADMAP_PATHS.md
@@ -30,7 +30,7 @@ This document defines **epics and ordered, single-scope issues** to deliver a **
 | P-06 | [#2645](https://github.com/KenSuenobu/objectified-commercial/issues/2645) **(shipped)** | Yes |
 | P-07 | [#2646](https://github.com/KenSuenobu/objectified-commercial/issues/2646) **(shipped)** | Yes |
 | P-08 | [#2647](https://github.com/KenSuenobu/objectified-commercial/issues/2647) **(shipped)** | Yes |
-| P-09 | [#2648](https://github.com/KenSuenobu/objectified-commercial/issues/2648) | Yes |
+| P-09 | [#2648](https://github.com/KenSuenobu/objectified-commercial/issues/2648) **(shipped)** | Yes |
 | P-10 | [#2649](https://github.com/KenSuenobu/objectified-commercial/issues/2649) | Yes |
 | P-11 | [#2650](https://github.com/KenSuenobu/objectified-commercial/issues/2650) | Yes |
 | P-12 | [#2651](https://github.com/KenSuenobu/objectified-commercial/issues/2651) | Yes |
@@ -72,7 +72,7 @@ This document defines **epics and ordered, single-scope issues** to deliver a **
 | # | Issue | MVP |
 |---|--------|-----|
 | ~~2647~~ | ~~P-08 Path/query parameters + schema~~ **(shipped)** | Yes |
-| 2648 | P-09 Request body + content types | Yes |
+| ~~2648~~ | ~~P-09 Request body + content types~~ **(shipped)** | Yes |
 | 2649 | P-10 Header/cookie parameters | Yes |
 
 **E4 — [#2636](https://github.com/KenSuenobu/objectified-commercial/issues/2636)**

--- a/objectified-ui/lib/db/helper-shared-path-request-bodies.ts
+++ b/objectified-ui/lib/db/helper-shared-path-request-bodies.ts
@@ -472,6 +472,12 @@ export async function updateRequestBodyContentType(
     return JSON.stringify({ success: true, content: result.rows[0] });
   } catch (error: any) {
     console.error('Error updating request body content type:', error);
+    if (error.code === '23505') {
+      return JSON.stringify({
+        success: false,
+        error: 'A content type with this media type already exists for this request body',
+      });
+    }
     return JSON.stringify({ success: false, error: error.message });
   }
 }

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.9.91",
+  "version": "0.9.92",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -5,6 +5,7 @@ We continue to improve the platform based on your feedback with improvements and
 ---
 
 ## UI:
+- **Request body (#2648):** **Operation** inspector **Advanced** tab uses **`shared_path_request_body`**, per-**media-type** content (`application/json` and more), and **`path_operation_request_body_link`** (one body per operation); duplicates **Content-Type** rows are rejected; canvas link changes refresh the panel
 - **Path & query parameters (#2647):** **Parameter** panel supports **Designer property** binding, **form** vs **inline JSON Schema**, and **path-template coverage** checks so `{segments}` match **`in: path`** parameters; **path template** and **sidebar** path saves block on mismatch
 - **OPTIONS operations (#2653):** **Paths** export emits OpenAPI **`options`** on the path item; default **204 No Content** when no responses are modeled; operation inspector shows a **warning** if a **request body** is linked (export still omits `requestBody` for OPTIONS per common practice)
 - **Paths canvas edges (#2646):** **Path → operation** and **operation → parameter / request body / response** edges use **semantic labels** (`has`, `hasParam`, `requestBody`, `response <code>`); **request body** links render **operation → request body** (tree from the operation); **manual** connect / **delete edge** syncs **request body** link like parameters and responses; **`edge.data.semantic`** tags role for layout persistence (**P-03**)

--- a/objectified-ui/src/app/ade/studio/paths/components/OperationPropertiesPanel.tsx
+++ b/objectified-ui/src/app/ade/studio/paths/components/OperationPropertiesPanel.tsx
@@ -36,8 +36,8 @@ import {
 } from '../../../../../../lib/db/helper-shared-path-responses';
 import { operationHasLinkedRequestBody } from '../../../../../../lib/db/helper-shared-path-request-bodies';
 import { extractPathParameters } from '../../../../../../lib/utils/path-params';
-import SchemaBuilder from './SchemaBuilder';
 import ResponseSection from './ResponseSection';
+import RequestBodySection from './RequestBodySection';
 import { getHttpStatusDescription } from '../../../../../../lib/utils/http-status-codes';
 import type { SecurityRequirement } from '../../../../../../lib/utils/openapi-paths-generator';
 import { ExtensionsEditor } from '../../../../components/ade/studio/ExtensionsEditor';
@@ -112,10 +112,6 @@ export default function OperationPropertiesPanel({
   const [newResponseAutoFillDescription, setNewResponseAutoFillDescription] = useState(true);
   const [newResponseSchemaType, setNewResponseSchemaType] = useState<'object' | 'string' | 'number' | 'integer' | 'boolean' | 'array'>('object');
   const [newResponseArrayItemType, setNewResponseArrayItemType] = useState<'string' | 'number' | 'integer' | 'boolean'>('string');
-
-  // Request body schema state
-  const [requestBodySchema, setRequestBodySchema] = useState<any>(null);
-  const [requestBodyRequired, setRequestBodyRequired] = useState(true);
 
   // Security requirements state (OpenAPI security array)
   const [security, setSecurity] = useState<SecurityRequirement[]>([]);
@@ -1466,29 +1462,14 @@ export default function OperationPropertiesPanel({
                 )}
               </div>
 
-              {/* Request Body Section (for POST/PUT/PATCH) */}
-              {['POST', 'PUT', 'PATCH'].includes(operation) && (
+              {/* Request body: shared_path_request_body + content rows + operation link (#2648) */}
+              {['POST', 'PUT', 'PATCH'].includes(operation) && operationId && versionPathId && (
                 <div className={`mt-4 pt-4 border-t ${isDark ? 'border-slate-700' : 'border-slate-200'}`}>
-                  <div className="flex justify-between items-center mb-3">
-                    <Label className="block text-xs font-semibold text-gray-700 dark:text-gray-300">
-                      Request Body
-                    </Label>
-                    <label className="flex items-center gap-2 cursor-pointer">
-                      <Checkbox
-                        checked={requestBodyRequired}
-                        onCheckedChange={(checked) => setRequestBodyRequired(checked === true)}
-                      />
-                      <span className="text-[10px] text-gray-600 dark:text-gray-400">
-                        Required
-                      </span>
-                    </label>
-                  </div>
-                  <SchemaBuilder
-                    value={requestBodySchema}
-                    onChange={setRequestBodySchema}
-                    label=""
-                    description="Define the request body schema using existing classes or create inline schemas"
-                    allowInline={true}
+                  <RequestBodySection
+                    operationId={operationId}
+                    versionPathId={versionPathId}
+                    onRefresh={onRefresh}
+                    refreshKey={refreshKey}
                   />
                 </div>
               )}

--- a/objectified-ui/src/app/ade/studio/paths/components/RequestBodySection.tsx
+++ b/objectified-ui/src/app/ade/studio/paths/components/RequestBodySection.tsx
@@ -67,6 +67,8 @@ interface RequestBodySectionProps {
   operationId: string;
   versionPathId: string;
   onRefresh?: () => void;
+  /** When the Paths canvas (or parent) refreshes operation links, bump this to reload. */
+  refreshKey?: number;
 }
 
 // =============================================================================
@@ -413,6 +415,7 @@ export default function RequestBodySection({
   operationId,
   versionPathId,
   onRefresh,
+  refreshKey,
 }: RequestBodySectionProps) {
   const isDark = useDarkMode();
   const { alert: alertDialog, confirm: confirmDialog } = useDialog();
@@ -490,7 +493,7 @@ export default function RequestBodySection({
 
   useEffect(() => {
     loadData();
-  }, [loadData]);
+  }, [loadData, refreshKey]);
 
   // Handlers
   const handleCreateRequestBody = async () => {

--- a/objectified-ui/src/app/ade/studio/paths/components/RequestBodySection.tsx
+++ b/objectified-ui/src/app/ade/studio/paths/components/RequestBodySection.tsx
@@ -620,7 +620,7 @@ export default function RequestBodySection({
           await setContentTypeClassReference(contentId, classes[0].id);
         }
       }
-      await loadRequestBodyData();
+      onRefresh?.();
     } catch (error) {
       console.error('Error changing schema type:', error);
     }
@@ -629,7 +629,7 @@ export default function RequestBodySection({
   const handleClassChange = async (contentId: string, classId: string) => {
     try {
       await setContentTypeClassReference(contentId, classId);
-      await loadRequestBodyData();
+      onRefresh?.();
     } catch (error) {
       console.error('Error changing class reference:', error);
     }
@@ -690,7 +690,7 @@ export default function RequestBodySection({
         setNewMediaType('application/json');
         setNewContentSchemaType('inline');
         setNewContentClassId('');
-        await loadRequestBodyData();
+        onRefresh?.();
       } else {
         await alertDialog({
           title: 'Error',
@@ -744,7 +744,7 @@ export default function RequestBodySection({
         setNewPropertyName('');
         setNewPropertyType('string');
         setCurrentContentId(null);
-        await loadRequestBodyData();
+        onRefresh?.();
       } else {
         await alertDialog({
           title: 'Error',
@@ -773,7 +773,7 @@ export default function RequestBodySection({
       const data = JSON.parse(result);
 
       if (data.success) {
-        await loadRequestBodyData();
+        onRefresh?.();
       }
     } catch (error) {
       console.error('Error deleting property:', error);

--- a/objectified-ui/src/app/ade/studio/paths/components/RequestBodySection.tsx
+++ b/objectified-ui/src/app/ade/studio/paths/components/RequestBodySection.tsx
@@ -442,8 +442,10 @@ export default function RequestBodySection({
   const [newPropertyType, setNewPropertyType] = useState('string');
   const [currentContentId, setCurrentContentId] = useState<string | null>(null);
 
-  // Load data
-  const loadData = useCallback(async () => {
+  // Load request-body / link data (does NOT include classes — see loadClasses below).
+  // Keeping this separate means a refreshKey bump only refetches the persisted
+  // request-body rows, not the full class list.
+  const loadRequestBodyData = useCallback(async () => {
     setIsLoading(true);
     try {
       // Load linked request body
@@ -471,29 +473,45 @@ export default function RequestBodySection({
       if (availableData.success) {
         setAvailableRequestBodies(availableData.requestBodies || []);
       }
-
-      // Load classes for reference selection
-      if (selectedVersionId) {
-        const classesResult = await getClassesWithPropertiesAndTags(selectedVersionId);
-        const classesData = JSON.parse(classesResult as string);
-        const uniqueClasses = classesData.reduce((acc: Array<{ id: string; name: string }>, cls: { id: string; name: string }) => {
-          if (!acc.find((c) => c.id === cls.id)) {
-            acc.push({ id: cls.id, name: cls.name });
-          }
-          return acc;
-        }, []);
-        setClasses(uniqueClasses);
-      }
     } catch (error) {
       console.error('Error loading request body data:', error);
     } finally {
       setIsLoading(false);
     }
-  }, [operationId, versionPathId, selectedVersionId]);
+  }, [operationId, versionPathId]);
 
+  // Load classes for reference selection — only needs to run when the version changes.
+  const loadClasses = useCallback(async () => {
+    if (!selectedVersionId) return;
+    try {
+      const classesResult = await getClassesWithPropertiesAndTags(selectedVersionId);
+      const classesData = JSON.parse(classesResult as string);
+      const uniqueClasses = classesData.reduce(
+        (acc: Array<{ id: string; name: string }>, cls: { id: string; name: string }) => {
+          if (!acc.find((c) => c.id === cls.id)) {
+            acc.push({ id: cls.id, name: cls.name });
+          }
+          return acc;
+        },
+        []
+      );
+      setClasses(uniqueClasses);
+    } catch (error) {
+      console.error('Error loading classes:', error);
+    }
+  }, [selectedVersionId]);
+
+  // Reload request-body/link data whenever the operation/path changes OR when the
+  // parent signals a canvas refresh via refreshKey.  Classes are intentionally
+  // excluded here to avoid an extra round-trip on every canvas refresh.
   useEffect(() => {
-    loadData();
-  }, [loadData, refreshKey]);
+    loadRequestBodyData();
+  }, [loadRequestBodyData, refreshKey]);
+
+  // Classes only need to reload when the version changes.
+  useEffect(() => {
+    loadClasses();
+  }, [loadClasses]);
 
   // Handlers
   const handleCreateRequestBody = async () => {
@@ -531,7 +549,6 @@ export default function RequestBodySection({
         setNewName('');
         setNewDescription('');
         setNewRequired(true);
-        await loadData();
         onRefresh?.();
       } else {
         await alertDialog({
@@ -556,7 +573,6 @@ export default function RequestBodySection({
       const data = JSON.parse(result);
 
       if (data.success) {
-        await loadData();
         onRefresh?.();
       } else {
         await alertDialog({
@@ -587,7 +603,6 @@ export default function RequestBodySection({
 
       if (data.success) {
         setLinkedRequestBody(null);
-        await loadData();
         onRefresh?.();
       }
     } catch (error) {
@@ -605,7 +620,7 @@ export default function RequestBodySection({
           await setContentTypeClassReference(contentId, classes[0].id);
         }
       }
-      await loadData();
+      await loadRequestBodyData();
     } catch (error) {
       console.error('Error changing schema type:', error);
     }
@@ -614,7 +629,7 @@ export default function RequestBodySection({
   const handleClassChange = async (contentId: string, classId: string) => {
     try {
       await setContentTypeClassReference(contentId, classId);
-      await loadData();
+      await loadRequestBodyData();
     } catch (error) {
       console.error('Error changing class reference:', error);
     }
@@ -636,7 +651,6 @@ export default function RequestBodySection({
       const data = JSON.parse(result);
 
       if (data.success) {
-        await loadData();
         onRefresh?.();
       } else {
         await alertDialog({
@@ -676,7 +690,7 @@ export default function RequestBodySection({
         setNewMediaType('application/json');
         setNewContentSchemaType('inline');
         setNewContentClassId('');
-        await loadData();
+        await loadRequestBodyData();
       } else {
         await alertDialog({
           title: 'Error',
@@ -705,7 +719,6 @@ export default function RequestBodySection({
       const data = JSON.parse(result);
 
       if (data.success) {
-        await loadData();
         onRefresh?.();
       }
     } catch (error) {
@@ -731,7 +744,7 @@ export default function RequestBodySection({
         setNewPropertyName('');
         setNewPropertyType('string');
         setCurrentContentId(null);
-        await loadData();
+        await loadRequestBodyData();
       } else {
         await alertDialog({
           title: 'Error',
@@ -760,7 +773,7 @@ export default function RequestBodySection({
       const data = JSON.parse(result);
 
       if (data.success) {
-        await loadData();
+        await loadRequestBodyData();
       }
     } catch (error) {
       console.error('Error deleting property:', error);
@@ -798,7 +811,7 @@ export default function RequestBodySection({
           <div className="flex gap-1">
             <button
               type="button"
-              onClick={loadData}
+              onClick={loadRequestBodyData}
               className="p-1.5 rounded hover:bg-gray-100 dark:hover:bg-gray-700"
               title="Refresh"
             >


### PR DESCRIPTION
## What was done and why
The Paths **operation** inspector still used a non-persisting `SchemaBuilder` for **request body** on POST/PUT/PATCH. This replaces it with the existing `RequestBodySection`, which reads and writes `shared_path_request_body`, `shared_path_request_body_content`, and `path_operation_request_body_link` (same data as the canvas).

**Also:** `updateRequestBodyContentType` now returns a clear message on unique-constraint violations when renaming a content row to a duplicate media type (same as insert).

## How to test
1. Open **Paths**, select a path, select a **POST** / **PUT** / **PATCH** operation.
2. Open the **Advanced** tab — **Request Body** should list linked bodies, content types (`application/json`, etc.), class vs inline schema, and match the canvas after linking/unlinking on the graph.
3. Change request body on the canvas; bump `refreshKey` reloads the panel (or switch operation and back).

## Risk / notes
- Removes the old local-only schema UI; persisted request bodies are the single source of truth (aligned with P-09).

Closes #2648

Made with [Cursor](https://cursor.com)