### PR TITLE
Fix #2720 - default branch semantics for version branches

### DIFF
--- a/docs/PLANNED_FEATURE_ROADMAP_GITLIKE_IMPROVEMENTS.md
+++ b/docs/PLANNED_FEATURE_ROADMAP_GITLIKE_IMPROVEMENTS.md
@@ -71,7 +71,7 @@ on the ones above it to be meaningful in isolation.
 
 | # | Ticket | MVP / Enterprise | Depends on |
 |---|---|---|---|
-| GLI-01 | Designate a default (main) branch per project | **MVP** | — |
+| ~~GLI-01~~ | ~~Designate a default (main) branch per project~~ ([#2720](https://github.com/KenSuenobu/objectified-commercial/issues/2720)) | **MVP** (completed) | — |
 | GLI-02 | Branch divergence API (`ahead` / `behind` / `mergeBase`) | **MVP** | GLI-01 |
 | GLI-03 | Canvas branch picker (`checkout`) with current-branch chip | **MVP** | GLI-01 |
 | GLI-04 | Ahead / behind-main chip in canvas header | **MVP** | GLI-02, GLI-03 |
@@ -91,7 +91,7 @@ MVP (first major release) = GLI-01 → GLI-07. Enterprise (later releases)
 |---|---|---|---|
 | E1 | MVP Branch Workflow Epic | — | [#2718](https://github.com/KenSuenobu/objectified-commercial/issues/2718) |
 | E2 | Enterprise Branch Workflow Epic | — | [#2719](https://github.com/KenSuenobu/objectified-commercial/issues/2719) |
-| 1 | GLI-01 | #2718 | [#2720](https://github.com/KenSuenobu/objectified-commercial/issues/2720) |
+| 1 | GLI-01 | #2718 | [#2720](https://github.com/KenSuenobu/objectified-commercial/issues/2720) ✅ |
 | 2 | GLI-02 | #2718 | [#2721](https://github.com/KenSuenobu/objectified-commercial/issues/2721) |
 | 3 | GLI-03 | #2718 | [#2722](https://github.com/KenSuenobu/objectified-commercial/issues/2722) |
 | 4 | GLI-04 | #2718 | [#2723](https://github.com/KenSuenobu/objectified-commercial/issues/2723) |

--- a/objectified-db/scripts/20260418-120000.sql
+++ b/objectified-db/scripts/20260418-120000.sql
@@ -1,0 +1,79 @@
+-- GLI-01 / #2720: Default branch semantics for version branches.
+SET search_path TO odb, public;
+
+ALTER TABLE version_branches
+  ADD COLUMN IF NOT EXISTS is_default BOOLEAN NOT NULL DEFAULT FALSE;
+
+COMMENT ON COLUMN version_branches.is_default IS
+  'True when this row is the project default branch (main-like trunk).';
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_version_branches_default_per_project
+  ON version_branches(project_id)
+  WHERE is_default = TRUE;
+
+WITH latest_revision AS (
+  SELECT DISTINCT ON (v.project_id)
+         v.project_id,
+         v.id AS revision_id
+  FROM odb.versions v
+  WHERE v.deleted_at IS NULL
+  ORDER BY v.project_id, v.created_at DESC, v.id DESC
+),
+candidate_default AS (
+  SELECT p.id AS project_id,
+         COALESCE(
+           (
+             SELECT b.id
+             FROM odb.version_branches b
+             JOIN latest_revision lr ON lr.project_id = b.project_id
+             WHERE b.project_id = p.id
+               AND b.tip_version_id = lr.revision_id
+             ORDER BY b.updated_at DESC NULLS LAST, b.created_at DESC, b.id
+             LIMIT 1
+           ),
+           (
+             SELECT b2.id
+             FROM odb.version_branches b2
+             WHERE b2.project_id = p.id
+             ORDER BY b2.created_at ASC, b2.id
+             LIMIT 1
+           )
+         ) AS branch_id
+  FROM odb.projects p
+  WHERE p.deleted_at IS NULL
+)
+UPDATE odb.version_branches b
+SET is_default = TRUE,
+    updated_at = CURRENT_TIMESTAMP
+FROM candidate_default cd
+WHERE b.id = cd.branch_id
+  AND cd.branch_id IS NOT NULL
+  AND NOT EXISTS (
+    SELECT 1
+    FROM odb.version_branches bx
+    WHERE bx.project_id = b.project_id
+      AND bx.is_default = TRUE
+  );
+
+WITH latest_revision AS (
+  SELECT DISTINCT ON (v.project_id)
+         v.project_id,
+         v.id AS revision_id
+  FROM odb.versions v
+  WHERE v.deleted_at IS NULL
+  ORDER BY v.project_id, v.created_at DESC, v.id DESC
+)
+INSERT INTO odb.version_branches
+  (project_id, name, tip_version_id, created_by, branched_from_revision_id, is_default)
+SELECT lr.project_id,
+       'main',
+       lr.revision_id,
+       NULL,
+       lr.revision_id,
+       TRUE
+FROM latest_revision lr
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM odb.version_branches b
+  WHERE b.project_id = lr.project_id
+);

--- a/objectified-rest/pyproject.toml
+++ b/objectified-rest/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "objectified-rest"
-version = "1.0.46"
+version = "1.0.47"
 description = "REST API for serving OpenAPI specifications from the Objectified database"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/objectified-rest/src/app/database.py
+++ b/objectified-rest/src/app/database.py
@@ -4103,6 +4103,20 @@ class Database:
         rid = rows[0].get("id")
         return str(rid) if rid is not None else None
 
+    def get_version_branch_by_id(
+        self, branch_id: str, tenant_id: str
+    ) -> Optional[Dict[str, Any]]:
+        """Return the branch row for *branch_id* scoped to *tenant_id* (no project filter)."""
+        q = """
+            SELECT b.id, b.project_id, b.name, b.tip_version_id, b.branched_from_revision_id,
+                   b.protected, b.is_default, b.require_merge_path, b.created_by, b.created_at, b.updated_at
+            FROM odb.version_branches b
+            JOIN odb.projects p ON b.project_id = p.id
+            WHERE b.id = %s AND p.tenant_id = %s
+        """
+        rows = self.execute_query(q, (branch_id, tenant_id))
+        return rows[0] if rows else None
+
     def get_version_branch_by_name(
         self, project_id: str, tenant_id: str, name: str
     ) -> Optional[Dict[str, Any]]:

--- a/objectified-rest/src/app/database.py
+++ b/objectified-rest/src/app/database.py
@@ -50,6 +50,10 @@ class BranchNotFoundError(Exception):
         super().__init__(f"branch not found: {branch_id}")
 
 
+class BranchDefaultConflictError(Exception):
+    """Concurrent default-branch promotion conflicted with unique default-per-project invariant."""
+
+
 def _compute_delta(old: Dict[str, Any], new: Dict[str, Any]) -> Dict[str, Any]:
     """
     Compute top-level delta: keys added, removed, or changed.
@@ -4104,7 +4108,7 @@ class Database:
     ) -> Optional[Dict[str, Any]]:
         q = """
             SELECT b.id, b.project_id, b.name, b.tip_version_id, b.branched_from_revision_id,
-                   b.protected, b.require_merge_path, b.created_by, b.created_at, b.updated_at
+                   b.protected, b.is_default, b.require_merge_path, b.created_by, b.created_at, b.updated_at
             FROM odb.version_branches b
             JOIN odb.projects p ON b.project_id = p.id
             WHERE b.project_id = %s AND p.tenant_id = %s AND b.name = %s
@@ -4119,34 +4123,80 @@ class Database:
         branch_id: str,
         *,
         protected: Optional[bool] = None,
+        is_default: Optional[bool] = None,
         require_merge_path: Optional[bool] = None,
     ) -> Optional[Dict[str, Any]]:
         """
         Tenant-admin policy fields on a branch (#504, #2583). At least one of protected or
-        require_merge_path must be set.
+        require_merge_path or is_default must be set.
         """
-        if protected is None and require_merge_path is None:
+        if protected is None and require_merge_path is None and is_default is None:
             return None
-        sets: List[str] = []
-        params: List[Any] = []
-        if protected is not None:
-            sets.append("b.protected = %s")
-            params.append(protected)
-        if require_merge_path is not None:
-            sets.append("b.require_merge_path = %s")
-            params.append(require_merge_path)
-        sets.append("b.updated_at = CURRENT_TIMESTAMP")
-        params.extend([branch_id, project_id, tenant_id])
-        q = f"""
-            UPDATE odb.version_branches b
-            SET {", ".join(sets)}
-            FROM odb.projects p
-            WHERE b.id = %s AND b.project_id = %s AND b.project_id = p.id AND p.tenant_id = %s
-            RETURNING b.id, b.project_id, b.name, b.tip_version_id, b.branched_from_revision_id,
-                      b.protected, b.require_merge_path, b.created_by, b.created_at, b.updated_at
-        """
-        rows = self.execute_query(q, tuple(params))
-        return dict(rows[0]) if rows else None
+        conn = self.connect()
+        prev_autocommit = self._begin_tx(conn)
+        try:
+            with conn.cursor() as cursor:
+                cursor.execute(
+                    """
+                    SELECT b.id
+                    FROM odb.version_branches b
+                    JOIN odb.projects p ON b.project_id = p.id
+                    WHERE b.id = %s AND b.project_id = %s AND p.tenant_id = %s
+                    FOR UPDATE
+                    """,
+                    (branch_id, project_id, tenant_id),
+                )
+                locked = cursor.fetchone()
+                if not locked:
+                    conn.rollback()
+                    return None
+
+                if is_default is True:
+                    cursor.execute(
+                        """
+                        UPDATE odb.version_branches
+                        SET is_default = false, updated_at = CURRENT_TIMESTAMP
+                        WHERE project_id = %s AND id <> %s AND is_default = true
+                        """,
+                        (project_id, branch_id),
+                    )
+
+                sets: List[str] = []
+                params: List[Any] = []
+                if protected is not None:
+                    sets.append("protected = %s")
+                    params.append(protected)
+                if is_default is not None:
+                    sets.append("is_default = %s")
+                    params.append(is_default)
+                if require_merge_path is not None:
+                    sets.append("require_merge_path = %s")
+                    params.append(require_merge_path)
+                sets.append("updated_at = CURRENT_TIMESTAMP")
+                params.extend([branch_id, project_id, tenant_id])
+
+                cursor.execute(
+                    f"""
+                    UPDATE odb.version_branches b
+                    SET {", ".join(sets)}
+                    FROM odb.projects p
+                    WHERE b.id = %s AND b.project_id = %s AND b.project_id = p.id AND p.tenant_id = %s
+                    RETURNING b.id, b.project_id, b.name, b.tip_version_id, b.branched_from_revision_id,
+                              b.protected, b.is_default, b.require_merge_path, b.created_by, b.created_at, b.updated_at
+                    """,
+                    tuple(params),
+                )
+                row = cursor.fetchone()
+            conn.commit()
+            return dict(row) if row else None
+        except Exception as e:
+            conn.rollback()
+            msg = str(e).lower()
+            if "23505" in msg or "uq_version_branches_default_per_project" in msg:
+                raise BranchDefaultConflictError() from e
+            raise
+        finally:
+            conn.autocommit = prev_autocommit
 
     def _branch_from_revision_idempotent_result(
         self,
@@ -4223,7 +4273,7 @@ class Database:
                         (project_id, name, tip_version_id, created_by, branched_from_revision_id)
                     VALUES (%s, %s, %s, %s, %s)
                     RETURNING id, project_id, name, tip_version_id, branched_from_revision_id,
-                              protected, require_merge_path, created_by, created_at, updated_at
+                              protected, is_default, require_merge_path, created_by, created_at, updated_at
                     """,
                     (project_id, bn, src, creator_id, src),
                 )
@@ -4417,11 +4467,11 @@ class Database:
         """Named branches for a project (tenant-scoped)."""
         q = """
             SELECT b.id, b.project_id, b.name, b.tip_version_id, b.branched_from_revision_id,
-                   b.protected, b.require_merge_path, b.created_by
+                   b.protected, b.is_default, b.require_merge_path, b.created_by
             FROM odb.version_branches b
             JOIN odb.projects p ON b.project_id = p.id
             WHERE b.project_id = %s AND p.tenant_id = %s
-            ORDER BY b.name ASC
+            ORDER BY b.is_default DESC, b.name ASC
         """
         return self.execute_query(q, (project_id, tenant_id))
 
@@ -4466,6 +4516,7 @@ class Database:
         copied_count = 0
         new_id: Optional[str] = None
         prev_autocommit = self._begin_tx(conn)
+        no_prior_revision = False
         try:
             with conn.cursor() as cursor:
                 if branch_row is not None:
@@ -4510,6 +4561,7 @@ class Database:
                     )
                     head_row = cursor.fetchone()
                     current_tip: Optional[str] = str(head_row["id"]) if head_row else None
+                    no_prior_revision = current_tip is None
                     if current_tip is None and base:
                         raise ValueError("baseRevisionId must be empty for projects with no existing revisions")
                     if current_tip is not None and base != current_tip:
@@ -4551,6 +4603,21 @@ class Database:
                         WHERE id = %s
                         """,
                         (new_id, str(branch_row["id"])),
+                    )
+                elif no_prior_revision:
+                    # First commit in a brand-new project: bootstrap a default main branch.
+                    cursor.execute(
+                        """
+                        INSERT INTO odb.version_branches
+                            (project_id, name, tip_version_id, created_by, branched_from_revision_id, is_default)
+                        VALUES (%s, 'main', %s, %s, %s, true)
+                        ON CONFLICT (project_id, name)
+                        DO UPDATE SET
+                            tip_version_id = EXCLUDED.tip_version_id,
+                            is_default = true,
+                            updated_at = CURRENT_TIMESTAMP
+                        """,
+                        (project_id, new_id, creator_id, new_id),
                     )
 
             conn.commit()

--- a/objectified-rest/src/app/models.py
+++ b/objectified-rest/src/app/models.py
@@ -461,6 +461,11 @@ class VersionBranchRecordOut(BaseModel):
         description="Revision this branch was created from (lineage; persists when tip advances).",
     )
     protected: bool = False
+    is_default: bool = Field(
+        default=False,
+        serialization_alias="isDefault",
+        description="True when this is the project's default branch.",
+    )
     require_merge_path: bool = Field(
         default=False,
         serialization_alias="requireMergePath",
@@ -477,6 +482,10 @@ class VersionBranchPolicyPatchRequest(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
     protected: Optional[bool] = None
+    is_default: Optional[bool] = Field(
+        default=None,
+        validation_alias=AliasChoices("isDefault", "is_default"),
+    )
     require_merge_path: Optional[bool] = Field(
         default=None,
         validation_alias=AliasChoices("requireMergePath", "require_merge_path"),
@@ -484,8 +493,8 @@ class VersionBranchPolicyPatchRequest(BaseModel):
 
     @model_validator(mode="after")
     def _at_least_one_field(self) -> "VersionBranchPolicyPatchRequest":
-        if self.protected is None and self.require_merge_path is None:
-            raise ValueError("Provide protected and/or requireMergePath")
+        if self.protected is None and self.require_merge_path is None and self.is_default is None:
+            raise ValueError("Provide protected, requireMergePath, and/or isDefault")
         return self
 
 

--- a/objectified-rest/src/app/version_merge_routes.py
+++ b/objectified-rest/src/app/version_merge_routes.py
@@ -19,7 +19,7 @@ from .compatibility_engine import (
     compat_report_fingerprint,
     openapi_for_revision,
 )
-from .database import db
+from .database import BranchDefaultConflictError, db
 from .models import (
     CompatibilityFindingOut,
     MergeSessionStatusPatchRequest,
@@ -80,6 +80,7 @@ def _version_branch_record_out(br: Dict[str, Any]) -> VersionBranchRecordOut:
             str(br["branched_from_revision_id"]) if br.get("branched_from_revision_id") else None
         ),
         protected=bool(br.get("protected")),
+        is_default=bool(br.get("is_default")),
         require_merge_path=bool(br.get("require_merge_path")),
         created_by=str(br["created_by"]) if br.get("created_by") else None,
         created_at=br.get("created_at"),
@@ -451,7 +452,7 @@ async def patch_version_branch_policy(
     auth_data: Dict[str, Any] = Depends(validate_authentication),
 ) -> Dict[str, Any]:
     """
-    Tenant administrators: set ``protected`` and/or ``requireMergePath`` on a branch (#504, #2583).
+    Tenant administrators: set ``protected`` and/or ``requireMergePath`` and/or promote default branch.
     """
     tenant_id = auth_data["tenant_id"]
     uid = get_authenticated_user_id(auth_data)
@@ -464,19 +465,37 @@ async def patch_version_branch_policy(
     if not project:
         raise HTTPException(status_code=404, detail=f"Project not found: {project_id}")
 
-    row = db.update_version_branch_protection_policy(
-        project_id,
-        tenant_id,
-        branch_id,
-        protected=body.protected,
-        require_merge_path=body.require_merge_path,
-    )
+    if body.is_default is not None and body.is_default is not True:
+        raise HTTPException(
+            status_code=400,
+            detail={"code": "INVALID_INPUT", "message": "isDefault only supports true on this endpoint"},
+        )
+
+    try:
+        row = db.update_version_branch_protection_policy(
+            project_id,
+            tenant_id,
+            branch_id,
+            protected=body.protected,
+            is_default=body.is_default,
+            require_merge_path=body.require_merge_path,
+        )
+    except BranchDefaultConflictError as e:
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "code": "BRANCH_DEFAULT_CONFLICT",
+                "message": "Another branch was promoted as default concurrently; retry the request.",
+            },
+        ) from e
     if not row:
         raise HTTPException(status_code=404, detail="Branch not found")
 
     detail: Dict[str, Any] = {}
     if body.protected is not None:
         detail["protected"] = body.protected
+    if body.is_default is not None:
+        detail["isDefault"] = body.is_default
     if body.require_merge_path is not None:
         detail["requireMergePath"] = body.require_merge_path
     db.insert_version_protection_audit(

--- a/objectified-rest/src/app/version_merge_routes.py
+++ b/objectified-rest/src/app/version_merge_routes.py
@@ -489,6 +489,15 @@ async def patch_version_branch_policy(
             },
         ) from e
     if not row:
+        existing_branch = db.get_version_branch_by_id(branch_id, tenant_id)
+        if existing_branch and existing_branch.get("project_id") != project_id:
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "code": "BRANCH_NOT_IN_PROJECT",
+                    "message": "Branch does not belong to the specified project",
+                },
+            )
         raise HTTPException(status_code=404, detail="Branch not found")
 
     detail: Dict[str, Any] = {}

--- a/objectified-rest/tests/test_branch_policy_patch_api.py
+++ b/objectified-rest/tests/test_branch_policy_patch_api.py
@@ -6,6 +6,11 @@ Covers PATCH /v1/versions/{tenant}/{project}/version-branches/{branch_id}:
 - 200 + audit insert when protected is set
 - 200 + audit insert when requireMergePath is set
 - 200 + audit insert when both fields are set
+- 200 + audit insert when isDefault is set to true
+- 400 when isDefault is false (promote-only contract)
+- 400 when branch belongs to a different project (BRANCH_NOT_IN_PROJECT)
+- 404 when branch is not found
+- 409 when concurrent default-branch promotion conflicts (BRANCH_DEFAULT_CONFLICT)
 """
 
 from unittest.mock import patch, call
@@ -180,5 +185,43 @@ def test_patch_branch_policy_branch_not_found_404():
         mdb.is_user_tenant_admin.return_value = True
         mdb.get_project_by_id.return_value = {"id": _PROJECT_ID}
         mdb.update_version_branch_protection_policy.return_value = None
+        mdb.get_version_branch_by_id.return_value = None
         r = client.patch(_PATCH_URL, json={"protected": False})
     assert r.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# 400: branch belongs to a different project
+# ---------------------------------------------------------------------------
+
+_OTHER_PROJECT_ID = "00000000-0000-0000-0000-0000000000a2"
+
+
+def test_patch_branch_policy_branch_not_in_project_400():
+    with patch("src.app.version_merge_routes.db") as mdb:
+        mdb.is_user_tenant_admin.return_value = True
+        mdb.get_project_by_id.return_value = {"id": _PROJECT_ID}
+        mdb.update_version_branch_protection_policy.return_value = None
+        # Branch exists but under a different project
+        mdb.get_version_branch_by_id.return_value = dict(_BRANCH_ROW, project_id=_OTHER_PROJECT_ID)
+        r = client.patch(_PATCH_URL, json={"protected": False})
+    assert r.status_code == 400
+    detail = r.json()["detail"]
+    assert detail["code"] == "BRANCH_NOT_IN_PROJECT"
+
+
+# ---------------------------------------------------------------------------
+# 409: concurrent default-branch promotion conflict
+# ---------------------------------------------------------------------------
+
+def test_patch_branch_policy_default_conflict_409():
+    from src.app.database import BranchDefaultConflictError
+
+    with patch("src.app.version_merge_routes.db") as mdb:
+        mdb.is_user_tenant_admin.return_value = True
+        mdb.get_project_by_id.return_value = {"id": _PROJECT_ID}
+        mdb.update_version_branch_protection_policy.side_effect = BranchDefaultConflictError()
+        r = client.patch(_PATCH_URL, json={"isDefault": True})
+    assert r.status_code == 409
+    detail = r.json()["detail"]
+    assert detail["code"] == "BRANCH_DEFAULT_CONFLICT"

--- a/objectified-rest/tests/test_branch_policy_patch_api.py
+++ b/objectified-rest/tests/test_branch_policy_patch_api.py
@@ -36,6 +36,7 @@ _BRANCH_ROW = {
     "tip_version_id": "00000000-0000-0000-0000-0000000000v1",
     "branched_from_revision_id": None,
     "protected": True,
+    "is_default": False,
     "require_merge_path": False,
     "created_by": _USER,
     "created_at": None,
@@ -135,6 +136,39 @@ def test_patch_branch_policy_both_fields_200():
     audit_detail = mdb.insert_version_protection_audit.call_args.args[7]
     assert "protected" in audit_detail
     assert "requireMergePath" in audit_detail
+
+
+# ---------------------------------------------------------------------------
+# 200 + audit insert: isDefault only
+# ---------------------------------------------------------------------------
+
+def test_patch_branch_policy_is_default_only_200():
+    with patch("src.app.version_merge_routes.db") as mdb:
+        mdb.is_user_tenant_admin.return_value = True
+        mdb.get_project_by_id.return_value = {"id": _PROJECT_ID}
+        updated_row = dict(_BRANCH_ROW, is_default=True)
+        mdb.update_version_branch_protection_policy.return_value = updated_row
+        r = client.patch(_PATCH_URL, json={"isDefault": True})
+    assert r.status_code == 200
+    data = r.json()
+    assert data["branch"]["isDefault"] is True
+    mdb.insert_version_protection_audit.assert_called_once()
+    audit_detail = mdb.insert_version_protection_audit.call_args.args[7]
+    assert audit_detail["isDefault"] is True
+
+
+# ---------------------------------------------------------------------------
+# 400: isDefault false rejected (promote-only endpoint contract)
+# ---------------------------------------------------------------------------
+
+def test_patch_branch_policy_is_default_false_400():
+    with patch("src.app.version_merge_routes.db") as mdb:
+        mdb.is_user_tenant_admin.return_value = True
+        mdb.get_project_by_id.return_value = {"id": _PROJECT_ID}
+        r = client.patch(_PATCH_URL, json={"isDefault": False})
+    assert r.status_code == 400
+    detail = r.json()["detail"]
+    assert detail["code"] == "INVALID_INPUT"
 
 
 # ---------------------------------------------------------------------------

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -4,6 +4,10 @@ We continue to improve the platform based on your feedback with improvements and
 
 ---
 
+- Added default-branch foundations for git-like workflows: branch rows now support a single project default (`isDefault`) with promotion support and first-commit auto-bootstrap of `main`.
+
+---
+
 View our YouTube channel [here](https://www.youtube.com/@objectifieddev) for detailed tutorials and walkthroughs!
 
 ---
@@ -16,5 +20,5 @@ We'd love to hear your thoughts! Your feedback helps us make Objectified better.
 
 **Thank you for using Objectified!**
 
-*Last updated: April 8, 2026*
+*Last updated: April 18, 2026*
 


### PR DESCRIPTION
## What was done and why
- Added `is_default` default-branch semantics to `version_branches`, including a new DB migration with backfill and uniqueness invariant (one default per project).
- Updated REST branch policy PATCH flow to support `isDefault: true` promotion and atomic default flipping at the DB layer.
- Added first-commit bootstrap behavior so brand-new projects automatically get a `main` branch marked default.
- Extended branch REST output models to include `isDefault` so downstream UI workflows can consume default-branch metadata.
- Added REST test coverage for `isDefault` patch behavior and updated roadmap/release-note/version bookkeeping for ticket closure workflow.

## How to test
- Apply DB migration: `objectified-db/scripts/20260418-120000.sql`.
- Call PATCH branch policy endpoint with `{ "isDefault": true }` and verify the selected branch returns `isDefault: true` and prior default is demoted.
- Create first commit on a new project and verify `main` branch exists with `is_default=true`.
- Run automated checks in an environment with required toolchain installed:
  - `yarn build`
  - `yarn test`
  - `pytest objectified-rest/tests/test_branch_policy_patch_api.py`

## Risk / notes
- Environment limitation in this session: `yarn`, `pytest`, `pip`, and `uv` are not installed, so full build/test execution could not be completed here.
- Python syntax for modified REST modules was validated with `python3 -m py_compile` and IDE lints report clean.

Fixes #2720

Made with [Cursor](https://cursor.com)