### PR TITLE
Fix #2721 - add branch divergence API

### DIFF
--- a/docs/PLANNED_FEATURE_ROADMAP_GITLIKE_IMPROVEMENTS.md
+++ b/docs/PLANNED_FEATURE_ROADMAP_GITLIKE_IMPROVEMENTS.md
@@ -72,7 +72,7 @@ on the ones above it to be meaningful in isolation.
 | # | Ticket | MVP / Enterprise | Depends on |
 |---|---|---|---|
 | ~~GLI-01~~ | ~~Designate a default (main) branch per project~~ ([#2720](https://github.com/KenSuenobu/objectified-commercial/issues/2720)) | **MVP** (completed) | — |
-| GLI-02 | Branch divergence API (`ahead` / `behind` / `mergeBase`) | **MVP** | GLI-01 |
+| ~~GLI-02~~ | ~~Branch divergence API (`ahead` / `behind` / `mergeBase`)~~ ([#2721](https://github.com/KenSuenobu/objectified-commercial/issues/2721)) | **MVP** (completed) | GLI-01 |
 | GLI-03 | Canvas branch picker (`checkout`) with current-branch chip | **MVP** | GLI-01 |
 | GLI-04 | Ahead / behind-main chip in canvas header | **MVP** | GLI-02, GLI-03 |
 | GLI-05 | Prominent "Commit…" action on the canvas toolbar | **MVP** | GLI-03 |
@@ -92,7 +92,7 @@ MVP (first major release) = GLI-01 → GLI-07. Enterprise (later releases)
 | E1 | MVP Branch Workflow Epic | — | [#2718](https://github.com/KenSuenobu/objectified-commercial/issues/2718) |
 | E2 | Enterprise Branch Workflow Epic | — | [#2719](https://github.com/KenSuenobu/objectified-commercial/issues/2719) |
 | 1 | GLI-01 | #2718 | [#2720](https://github.com/KenSuenobu/objectified-commercial/issues/2720) ✅ |
-| 2 | GLI-02 | #2718 | [#2721](https://github.com/KenSuenobu/objectified-commercial/issues/2721) |
+| 2 | GLI-02 | #2718 | [#2721](https://github.com/KenSuenobu/objectified-commercial/issues/2721) ✅ |
 | 3 | GLI-03 | #2718 | [#2722](https://github.com/KenSuenobu/objectified-commercial/issues/2722) |
 | 4 | GLI-04 | #2718 | [#2723](https://github.com/KenSuenobu/objectified-commercial/issues/2723) |
 | 5 | GLI-05 | #2718 | [#2724](https://github.com/KenSuenobu/objectified-commercial/issues/2724) |

--- a/objectified-rest/pyproject.toml
+++ b/objectified-rest/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "objectified-rest"
-version = "1.0.47"
+version = "1.0.48"
 description = "REST API for serving OpenAPI specifications from the Objectified database"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/objectified-rest/src/app/database.py
+++ b/objectified-rest/src/app/database.py
@@ -4489,6 +4489,210 @@ class Database:
         """
         return self.execute_query(q, (project_id, tenant_id))
 
+    def compute_branch_divergence(
+        self,
+        *,
+        project_id: str,
+        tenant_id: str,
+        branch_tip_revision_id: str,
+        against_tip_revision_id: str,
+        sample_limit: int = 5,
+    ) -> Dict[str, Any]:
+        """
+        Compute git-like branch divergence from branch tips using recursive CTEs.
+
+        Returns merge base revision metadata, ahead/behind counts, and sampled revisions on each side.
+        """
+        limit = max(1, min(int(sample_limit), 25))
+        q = """
+            WITH RECURSIVE
+            branch_ancestors AS (
+                SELECT
+                    v.id::text AS revision_id,
+                    v.parent_version_id::text AS parent_revision_id,
+                    v.merge_parent_version_id::text AS merge_parent_revision_id
+                FROM odb.versions v
+                JOIN odb.projects p ON v.project_id = p.id
+                WHERE v.id = %s
+                  AND v.project_id = %s
+                  AND p.tenant_id = %s
+                  AND v.deleted_at IS NULL
+                UNION
+                SELECT
+                    v.id::text AS revision_id,
+                    v.parent_version_id::text AS parent_revision_id,
+                    v.merge_parent_version_id::text AS merge_parent_revision_id
+                FROM odb.versions v
+                JOIN branch_ancestors a
+                  ON v.id::text = a.parent_revision_id
+                  OR v.id::text = a.merge_parent_revision_id
+                WHERE v.project_id = %s
+                  AND v.deleted_at IS NULL
+            ),
+            against_ancestors AS (
+                SELECT
+                    v.id::text AS revision_id,
+                    v.parent_version_id::text AS parent_revision_id,
+                    v.merge_parent_version_id::text AS merge_parent_revision_id
+                FROM odb.versions v
+                JOIN odb.projects p ON v.project_id = p.id
+                WHERE v.id = %s
+                  AND v.project_id = %s
+                  AND p.tenant_id = %s
+                  AND v.deleted_at IS NULL
+                UNION
+                SELECT
+                    v.id::text AS revision_id,
+                    v.parent_version_id::text AS parent_revision_id,
+                    v.merge_parent_version_id::text AS merge_parent_revision_id
+                FROM odb.versions v
+                JOIN against_ancestors a
+                  ON v.id::text = a.parent_revision_id
+                  OR v.id::text = a.merge_parent_revision_id
+                WHERE v.project_id = %s
+                  AND v.deleted_at IS NULL
+            ),
+            merge_base AS (
+                SELECT v.id::text AS revision_id, v.created_at
+                FROM odb.versions v
+                JOIN branch_ancestors ba ON ba.revision_id = v.id::text
+                JOIN against_ancestors aa ON aa.revision_id = v.id::text
+                WHERE v.project_id = %s
+                  AND v.deleted_at IS NULL
+                ORDER BY v.created_at DESC, v.id DESC
+                LIMIT 1
+            ),
+            merge_base_ancestors AS (
+                SELECT
+                    v.id::text AS revision_id,
+                    v.parent_version_id::text AS parent_revision_id,
+                    v.merge_parent_version_id::text AS merge_parent_revision_id
+                FROM odb.versions v
+                JOIN merge_base mb ON v.id::text = mb.revision_id
+                UNION
+                SELECT
+                    v.id::text AS revision_id,
+                    v.parent_version_id::text AS parent_revision_id,
+                    v.merge_parent_version_id::text AS merge_parent_revision_id
+                FROM odb.versions v
+                JOIN merge_base_ancestors mba
+                  ON v.id::text = mba.parent_revision_id
+                  OR v.id::text = mba.merge_parent_revision_id
+                WHERE v.project_id = %s
+                  AND v.deleted_at IS NULL
+            ),
+            ahead_set AS (
+                SELECT ba.revision_id
+                FROM branch_ancestors ba
+                LEFT JOIN merge_base_ancestors mba ON mba.revision_id = ba.revision_id
+                WHERE mba.revision_id IS NULL
+            ),
+            behind_set AS (
+                SELECT aa.revision_id
+                FROM against_ancestors aa
+                LEFT JOIN merge_base_ancestors mba ON mba.revision_id = aa.revision_id
+                WHERE mba.revision_id IS NULL
+            ),
+            ahead_sample AS (
+                SELECT
+                    v.id::text AS revision_id,
+                    COALESCE(v.description, '') AS short_message,
+                    v.created_at
+                FROM odb.versions v
+                JOIN ahead_set a ON a.revision_id = v.id::text
+                WHERE v.project_id = %s
+                  AND v.deleted_at IS NULL
+                ORDER BY v.created_at DESC, v.id DESC
+                LIMIT %s
+            ),
+            behind_sample AS (
+                SELECT
+                    v.id::text AS revision_id,
+                    COALESCE(v.description, '') AS short_message,
+                    v.created_at
+                FROM odb.versions v
+                JOIN behind_set b ON b.revision_id = v.id::text
+                WHERE v.project_id = %s
+                  AND v.deleted_at IS NULL
+                ORDER BY v.created_at DESC, v.id DESC
+                LIMIT %s
+            )
+            SELECT
+                (SELECT mb.revision_id FROM merge_base mb) AS merge_base_revision_id,
+                (SELECT mb.created_at FROM merge_base mb) AS merge_base_created_at,
+                (SELECT COUNT(*)::int FROM ahead_set) AS ahead_count,
+                (SELECT COUNT(*)::int FROM behind_set) AS behind_count,
+                COALESCE(
+                    (
+                        SELECT json_agg(
+                            json_build_object(
+                                'revisionId', a.revision_id,
+                                'shortMessage', a.short_message
+                            )
+                            ORDER BY a.created_at DESC, a.revision_id DESC
+                        )
+                        FROM ahead_sample a
+                    ),
+                    '[]'::json
+                ) AS ahead_sample,
+                COALESCE(
+                    (
+                        SELECT json_agg(
+                            json_build_object(
+                                'revisionId', b.revision_id,
+                                'shortMessage', b.short_message
+                            )
+                            ORDER BY b.created_at DESC, b.revision_id DESC
+                        )
+                        FROM behind_sample b
+                    ),
+                    '[]'::json
+                ) AS behind_sample
+        """
+        rows = self.execute_query(
+            q,
+            (
+                branch_tip_revision_id,
+                project_id,
+                tenant_id,
+                project_id,
+                against_tip_revision_id,
+                project_id,
+                tenant_id,
+                project_id,
+                project_id,
+                project_id,
+                project_id,
+                limit,
+                project_id,
+                limit,
+            ),
+        )
+        if not rows:
+            return {
+                "merge_base_revision_id": None,
+                "merge_base_created_at": None,
+                "ahead_count": 0,
+                "behind_count": 0,
+                "ahead_sample": [],
+                "behind_sample": [],
+            }
+        row = rows[0]
+        ahead_sample = row.get("ahead_sample") or []
+        behind_sample = row.get("behind_sample") or []
+        if isinstance(ahead_sample, str):
+            ahead_sample = json.loads(ahead_sample)
+        if isinstance(behind_sample, str):
+            behind_sample = json.loads(behind_sample)
+        return {
+            "merge_base_revision_id": row.get("merge_base_revision_id"),
+            "merge_base_created_at": row.get("merge_base_created_at"),
+            "ahead_count": int(row.get("ahead_count") or 0),
+            "behind_count": int(row.get("behind_count") or 0),
+            "ahead_sample": ahead_sample if isinstance(ahead_sample, list) else [],
+            "behind_sample": behind_sample if isinstance(behind_sample, list) else [],
+        }
+
     def get_latest_revision_id_for_project(
         self, project_id: str, tenant_id: str
     ) -> Optional[str]:

--- a/objectified-rest/src/app/models.py
+++ b/objectified-rest/src/app/models.py
@@ -476,6 +476,64 @@ class VersionBranchRecordOut(BaseModel):
     updated_at: Optional[Union[datetime, str]] = Field(default=None, serialization_alias="updatedAt")
 
 
+class VersionBranchDivergenceBranchOut(BaseModel):
+    """Branch descriptor used in divergence responses (#2721)."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    id: str
+    name: str
+    tip_revision_id: str = Field(serialization_alias="tipRevisionId")
+
+
+class VersionBranchDivergenceMergeBaseOut(BaseModel):
+    """Merge-base revision metadata for branch divergence."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    revision_id: str = Field(serialization_alias="revisionId")
+    created_at: Optional[Union[datetime, str]] = Field(default=None, serialization_alias="createdAt")
+
+
+class VersionBranchDivergenceSampleOut(BaseModel):
+    """Sampled revision entry in ahead/behind lists."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    revision_id: str = Field(
+        validation_alias=AliasChoices("revisionId", "revision_id"),
+        serialization_alias="revisionId",
+    )
+    short_message: Optional[str] = Field(
+        default=None,
+        validation_alias=AliasChoices("shortMessage", "short_message"),
+        serialization_alias="shortMessage",
+    )
+
+
+class VersionBranchDivergenceResponse(BaseModel):
+    """Branch-vs-branch divergence metrics and commit samples (#2721)."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    branch: VersionBranchDivergenceBranchOut
+    against: VersionBranchDivergenceBranchOut
+    merge_base: Optional[VersionBranchDivergenceMergeBaseOut] = Field(
+        default=None,
+        serialization_alias="mergeBase",
+    )
+    ahead: int
+    behind: int
+    ahead_sample: List[VersionBranchDivergenceSampleOut] = Field(
+        default_factory=list,
+        serialization_alias="aheadSample",
+    )
+    behind_sample: List[VersionBranchDivergenceSampleOut] = Field(
+        default_factory=list,
+        serialization_alias="behindSample",
+    )
+
+
 class VersionBranchPolicyPatchRequest(BaseModel):
     """Tenant-admin: branch protection and merge-path policy (#504, #2583)."""
 

--- a/objectified-rest/src/app/version_merge_routes.py
+++ b/objectified-rest/src/app/version_merge_routes.py
@@ -5,12 +5,13 @@ Git-like version branch merge: three-way OpenAPI schema merge + merge-base (#738
 from __future__ import annotations
 
 import copy
+import hashlib
 import json
 import logging
 import re
 from typing import Any, Callable, Dict, List, Optional, Set
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request, Response
 
 from .auth import validate_authentication, get_authenticated_user_id
 from .compatibility_engine import (
@@ -26,6 +27,10 @@ from .models import (
     RevisionDeprecationWarningOut,
     VersionBranchFromRevisionRequest,
     VersionBranchFromRevisionResponse,
+    VersionBranchDivergenceBranchOut,
+    VersionBranchDivergenceMergeBaseOut,
+    VersionBranchDivergenceResponse,
+    VersionBranchDivergenceSampleOut,
     VersionBranchMergePreviewRequest,
     VersionBranchMergeRequest,
     VersionBranchPolicyPatchRequest,
@@ -62,12 +67,41 @@ logger = logging.getLogger(__name__)
 _MERGE_PREVIEW_MAX_JSON_BYTES = 512 * 1024
 
 _VERSION_BRANCH_NAME_RE = re.compile(r"^[a-zA-Z][a-zA-Z0-9._\-/]{0,254}$")
+_DIVERGENCE_SAMPLE_MAX = 5
 
 
 def _is_valid_version_branch_name(name: str) -> bool:
     """Aligned with objectified-ui/lib/version-branch-utils.ts (Git-like branch labels)."""
     s = (name or "").strip()
     return bool(_VERSION_BRANCH_NAME_RE.match(s))
+
+
+def _strong_etag_for_branch_tips(branch_tip_revision_id: str, against_tip_revision_id: str) -> str:
+    raw = f"{str(branch_tip_revision_id).strip()}:{str(against_tip_revision_id).strip()}"
+    digest = hashlib.sha1(raw.encode("utf-8")).hexdigest()
+    return f'"{digest}"'
+
+
+def _if_none_match_matches_etag(etag_value: str, if_none_match: Optional[str]) -> bool:
+    """True when If-None-Match contains this resource ETag (or wildcard)."""
+    if not if_none_match or not str(if_none_match).strip():
+        return False
+    token_target = str(etag_value).strip().strip('"').lower()
+    header = str(if_none_match).strip()
+    if header == "*":
+        return True
+    for raw in header.split(","):
+        token = raw.strip()
+        if not token:
+            continue
+        if token == "*":
+            return True
+        if token.startswith("W/"):
+            token = token[2:].strip()
+        token_norm = token.strip('"').lower()
+        if token_norm == token_target:
+            return True
+    return False
 
 
 def _version_branch_record_out(br: Dict[str, Any]) -> VersionBranchRecordOut:
@@ -518,6 +552,133 @@ async def patch_version_branch_policy(
         detail,
     )
     return {"branch": _version_branch_record_out(row)}
+
+
+@router.get(
+    "/{tenant_slug}/{project_id}/version-branches/{branch_id}/divergence",
+    response_model=VersionBranchDivergenceResponse,
+)
+async def get_version_branch_divergence(
+    request: Request,
+    tenant_slug: str,
+    project_id: str,
+    branch_id: str,
+    against: Optional[str] = None,
+    auth_data: Dict[str, Any] = Depends(validate_authentication),
+):
+    """
+    Branch-vs-branch divergence: merge base, ahead/behind counts, and sampled commits (#2721).
+    """
+    _ = tenant_slug  # preserved for route consistency with other version endpoints
+    tenant_id = auth_data["tenant_id"]
+    project = db.get_project_by_id(project_id, tenant_id)
+    if not project:
+        raise HTTPException(status_code=404, detail=f"Project not found: {project_id}")
+
+    against_id = (against or "").strip() or None
+    if against_id and against_id == branch_id:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "code": "SELF_DIVERGENCE",
+                "message": "branchId and against must be different branch ids",
+            },
+        )
+
+    branch = db.get_version_branch_by_id(branch_id, tenant_id)
+    if not branch:
+        raise HTTPException(status_code=404, detail="Branch not found")
+    if str(branch.get("project_id")) != str(project_id):
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "code": "BRANCHES_PROJECT_MISMATCH",
+                "message": "Branch does not belong to the specified project",
+            },
+        )
+
+    if against_id:
+        against_branch = db.get_version_branch_by_id(against_id, tenant_id)
+        if not against_branch:
+            raise HTTPException(status_code=404, detail="Against branch not found")
+    else:
+        branches = db.list_version_branches_for_project(project_id, tenant_id)
+        against_branch = next((b for b in branches if bool(b.get("is_default"))), None)
+        if not against_branch:
+            raise HTTPException(
+                status_code=404,
+                detail={
+                    "code": "DEFAULT_BRANCH_NOT_FOUND",
+                    "message": "Default branch not found for this project",
+                },
+            )
+    if str(against_branch.get("project_id")) != str(project_id):
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "code": "BRANCHES_PROJECT_MISMATCH",
+                "message": "Compared branches must belong to the same project",
+            },
+        )
+    if str(branch["id"]) == str(against_branch["id"]):
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "code": "SELF_DIVERGENCE",
+                "message": "branchId and against must be different branch ids",
+            },
+        )
+
+    branch_tip = str(branch["tip_version_id"])
+    against_tip = str(against_branch["tip_version_id"])
+    etag = _strong_etag_for_branch_tips(branch_tip, against_tip)
+    if _if_none_match_matches_etag(etag, request.headers.get("if-none-match")):
+        return Response(status_code=304, headers={"ETag": etag})
+
+    divergence = db.compute_branch_divergence(
+        project_id=project_id,
+        tenant_id=tenant_id,
+        branch_tip_revision_id=branch_tip,
+        against_tip_revision_id=against_tip,
+        sample_limit=_DIVERGENCE_SAMPLE_MAX,
+    )
+
+    merge_base = None
+    merge_base_revision_id = divergence.get("merge_base_revision_id")
+    if merge_base_revision_id:
+        merge_base = VersionBranchDivergenceMergeBaseOut(
+            revision_id=str(merge_base_revision_id),
+            created_at=divergence.get("merge_base_created_at"),
+        )
+
+    body = VersionBranchDivergenceResponse(
+        branch=VersionBranchDivergenceBranchOut(
+            id=str(branch["id"]),
+            name=str(branch.get("name") or ""),
+            tip_revision_id=branch_tip,
+        ),
+        against=VersionBranchDivergenceBranchOut(
+            id=str(against_branch["id"]),
+            name=str(against_branch.get("name") or ""),
+            tip_revision_id=against_tip,
+        ),
+        merge_base=merge_base,
+        ahead=int(divergence.get("ahead_count") or 0),
+        behind=int(divergence.get("behind_count") or 0),
+        ahead_sample=[
+            VersionBranchDivergenceSampleOut.model_validate(item)
+            for item in (divergence.get("ahead_sample") or [])
+        ],
+        behind_sample=[
+            VersionBranchDivergenceSampleOut.model_validate(item)
+            for item in (divergence.get("behind_sample") or [])
+        ],
+    )
+    return Response(
+        content=body.model_dump_json(by_alias=True),
+        media_type="application/json",
+        headers={"ETag": etag},
+    )
 
 
 @router.post("/{tenant_slug}/{project_id}/version-branches/merge-preview")

--- a/objectified-rest/tests/test_branch_divergence_api.py
+++ b/objectified-rest/tests/test_branch_divergence_api.py
@@ -1,0 +1,152 @@
+"""Branch divergence API tests (#2721)."""
+
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.app.auth import validate_authentication
+from src.app.main import app
+from src.app.version_merge_routes import _strong_etag_for_branch_tips
+
+client = TestClient(app)
+
+_TENANT = "t1"
+_PROJECT_ID = "00000000-0000-0000-0000-0000000000a1"
+_BRANCH_ID = "00000000-0000-0000-0000-0000000000b1"
+_AGAINST_ID = "00000000-0000-0000-0000-0000000000b2"
+_OTHER_PROJECT_ID = "00000000-0000-0000-0000-0000000000a2"
+
+_MOCK_AUTH = {
+    "tenant_id": _TENANT,
+    "user_id": "u1",
+    "auth_method": "jwt",
+}
+
+
+@pytest.fixture(autouse=True)
+def _auth():
+    app.dependency_overrides[validate_authentication] = lambda: _MOCK_AUTH
+    yield
+    app.dependency_overrides.clear()
+
+
+def _branch_row(branch_id: str, project_id: str, name: str, tip_id: str, *, is_default: bool = False):
+    return {
+        "id": branch_id,
+        "project_id": project_id,
+        "name": name,
+        "tip_version_id": tip_id,
+        "is_default": is_default,
+    }
+
+
+def test_divergence_success_with_against_branch_and_etag():
+    with patch("src.app.version_merge_routes.db") as mdb:
+        mdb.get_project_by_id.return_value = {"id": _PROJECT_ID}
+        mdb.get_version_branch_by_id.side_effect = [
+            _branch_row(_BRANCH_ID, _PROJECT_ID, "feature/x", "rev-feature"),
+            _branch_row(_AGAINST_ID, _PROJECT_ID, "main", "rev-main", is_default=True),
+        ]
+        mdb.compute_branch_divergence.return_value = {
+            "merge_base_revision_id": "rev-base",
+            "merge_base_created_at": "2026-04-20T12:00:00Z",
+            "ahead_count": 3,
+            "behind_count": 1,
+            "ahead_sample": [{"revisionId": "rev-f3", "shortMessage": "feature: add field"}],
+            "behind_sample": [{"revisionId": "rev-m1", "shortMessage": "main: tighten schema"}],
+        }
+
+        r = client.get(
+            f"/v1/versions/acme/{_PROJECT_ID}/version-branches/{_BRANCH_ID}/divergence?against={_AGAINST_ID}"
+        )
+
+    assert r.status_code == 200
+    data = r.json()
+    assert data["branch"]["id"] == _BRANCH_ID
+    assert data["against"]["id"] == _AGAINST_ID
+    assert data["mergeBase"]["revisionId"] == "rev-base"
+    assert data["ahead"] == 3
+    assert data["behind"] == 1
+    assert data["aheadSample"][0]["revisionId"] == "rev-f3"
+    assert data["behindSample"][0]["revisionId"] == "rev-m1"
+    assert r.headers.get("etag") == _strong_etag_for_branch_tips("rev-feature", "rev-main")
+    mdb.compute_branch_divergence.assert_called_once_with(
+        project_id=_PROJECT_ID,
+        tenant_id=_TENANT,
+        branch_tip_revision_id="rev-feature",
+        against_tip_revision_id="rev-main",
+        sample_limit=5,
+    )
+
+
+def test_divergence_defaults_to_project_default_branch():
+    with patch("src.app.version_merge_routes.db") as mdb:
+        mdb.get_project_by_id.return_value = {"id": _PROJECT_ID}
+        mdb.get_version_branch_by_id.return_value = _branch_row(
+            _BRANCH_ID, _PROJECT_ID, "feature/x", "rev-feature"
+        )
+        mdb.list_version_branches_for_project.return_value = [
+            _branch_row(_BRANCH_ID, _PROJECT_ID, "feature/x", "rev-feature"),
+            _branch_row(_AGAINST_ID, _PROJECT_ID, "main", "rev-main", is_default=True),
+        ]
+        mdb.compute_branch_divergence.return_value = {
+            "merge_base_revision_id": "rev-base",
+            "merge_base_created_at": None,
+            "ahead_count": 0,
+            "behind_count": 0,
+            "ahead_sample": [],
+            "behind_sample": [],
+        }
+        r = client.get(f"/v1/versions/acme/{_PROJECT_ID}/version-branches/{_BRANCH_ID}/divergence")
+
+    assert r.status_code == 200
+    assert r.json()["against"]["id"] == _AGAINST_ID
+    mdb.list_version_branches_for_project.assert_called_once_with(_PROJECT_ID, _TENANT)
+
+
+def test_divergence_self_divergence_400():
+    with patch("src.app.version_merge_routes.db") as mdb:
+        mdb.get_project_by_id.return_value = {"id": _PROJECT_ID}
+        r = client.get(
+            f"/v1/versions/acme/{_PROJECT_ID}/version-branches/{_BRANCH_ID}/divergence?against={_BRANCH_ID}"
+        )
+
+    assert r.status_code == 400
+    assert r.json()["detail"]["code"] == "SELF_DIVERGENCE"
+    mdb.compute_branch_divergence.assert_not_called()
+
+
+def test_divergence_against_branch_project_mismatch_400():
+    with patch("src.app.version_merge_routes.db") as mdb:
+        mdb.get_project_by_id.return_value = {"id": _PROJECT_ID}
+        mdb.get_version_branch_by_id.side_effect = [
+            _branch_row(_BRANCH_ID, _PROJECT_ID, "feature/x", "rev-feature"),
+            _branch_row(_AGAINST_ID, _OTHER_PROJECT_ID, "other/main", "rev-other"),
+        ]
+        r = client.get(
+            f"/v1/versions/acme/{_PROJECT_ID}/version-branches/{_BRANCH_ID}/divergence?against={_AGAINST_ID}"
+        )
+
+    assert r.status_code == 400
+    assert r.json()["detail"]["code"] == "BRANCHES_PROJECT_MISMATCH"
+    mdb.compute_branch_divergence.assert_not_called()
+
+
+def test_divergence_returns_304_when_if_none_match_matches_tip_hash():
+    with patch("src.app.version_merge_routes.db") as mdb:
+        mdb.get_project_by_id.return_value = {"id": _PROJECT_ID}
+        mdb.get_version_branch_by_id.side_effect = [
+            _branch_row(_BRANCH_ID, _PROJECT_ID, "feature/x", "rev-feature"),
+            _branch_row(_AGAINST_ID, _PROJECT_ID, "main", "rev-main", is_default=True),
+        ]
+        etag = _strong_etag_for_branch_tips("rev-feature", "rev-main")
+        r = client.get(
+            f"/v1/versions/acme/{_PROJECT_ID}/version-branches/{_BRANCH_ID}/divergence?against={_AGAINST_ID}",
+            headers={"If-None-Match": etag},
+        )
+
+    assert r.status_code == 304
+    assert r.headers.get("etag") == etag
+    assert r.content == b""
+    mdb.compute_branch_divergence.assert_not_called()

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -6,6 +6,7 @@ We continue to improve the platform based on your feedback with improvements and
 
 ## Git-like Functionality
 - Added default-branch foundations for git-like workflows: branch rows now support a single project default (`isDefault`) with promotion support and first-commit auto-bootstrap of `main`.
+- Added branch divergence REST support with merge-base, ahead/behind counts, commit samples, and strong ETag-based 304 responses for stable canvas sync indicators.
 
 ---
 


### PR DESCRIPTION
## Summary
- add `GET /v1/versions/{tenant}/{projectId}/version-branches/{branchId}/divergence` with optional `against` branch id and default-branch fallback
- compute merge base, ahead/behind counts, and sampled commits in `objectified-rest` via recursive CTE logic, and return strong ETag headers with conditional `304 Not Modified`
- add divergence API tests, mark GLI-02 complete in roadmap docs, update `WHATS_NEW`, and bump `objectified-rest` patch version

## Test plan
- [x] `yarn build`
- [x] `yarn test` *(fails in existing UI Jest uuid ESM transform configuration unrelated to this ticket)*
- [ ] `python3 -m pytest objectified-rest/tests/test_branch_divergence_api.py` *(blocked: pytest not installed in environment)*

## Risk / Notes
- recursive CTE performance depends on project graph shape; sample lists are capped to keep payloads bounded
- conditional ETag flow uses tip-hash identity and supports wildcard `If-None-Match`

Closes #2721

Made with [Cursor](https://cursor.com)