### PR TITLE
Fix #2722 - Canvas branch picker (checkout) with current-branch chip (GLI-03)

### DIFF
--- a/docs/PLANNED_FEATURE_ROADMAP_GITLIKE_IMPROVEMENTS.md
+++ b/docs/PLANNED_FEATURE_ROADMAP_GITLIKE_IMPROVEMENTS.md
@@ -73,7 +73,7 @@ on the ones above it to be meaningful in isolation.
 |---|---|---|---|
 | ~~GLI-01~~ | ~~Designate a default (main) branch per project~~ ([#2720](https://github.com/KenSuenobu/objectified-commercial/issues/2720)) | **MVP** (completed) | — |
 | ~~GLI-02~~ | ~~Branch divergence API (`ahead` / `behind` / `mergeBase`)~~ ([#2721](https://github.com/KenSuenobu/objectified-commercial/issues/2721)) | **MVP** (completed) | GLI-01 |
-| GLI-03 | Canvas branch picker (`checkout`) with current-branch chip | **MVP** | GLI-01 |
+| ~~GLI-03~~ | ~~Canvas branch picker (`checkout`) with current-branch chip~~ ([#2722](https://github.com/KenSuenobu/objectified-commercial/issues/2722)) | **MVP** (completed) | GLI-01 |
 | GLI-04 | Ahead / behind-main chip in canvas header | **MVP** | GLI-02, GLI-03 |
 | GLI-05 | Prominent "Commit…" action on the canvas toolbar | **MVP** | GLI-03 |
 | GLI-06 | "Sync from main" one-click action | **MVP** | GLI-02, GLI-03 |
@@ -93,7 +93,7 @@ MVP (first major release) = GLI-01 → GLI-07. Enterprise (later releases)
 | E2 | Enterprise Branch Workflow Epic | — | [#2719](https://github.com/KenSuenobu/objectified-commercial/issues/2719) |
 | 1 | GLI-01 | #2718 | [#2720](https://github.com/KenSuenobu/objectified-commercial/issues/2720) ✅ |
 | 2 | GLI-02 | #2718 | [#2721](https://github.com/KenSuenobu/objectified-commercial/issues/2721) ✅ |
-| 3 | GLI-03 | #2718 | [#2722](https://github.com/KenSuenobu/objectified-commercial/issues/2722) |
+| 3 | GLI-03 | #2718 | [#2722](https://github.com/KenSuenobu/objectified-commercial/issues/2722) ✅ |
 | 4 | GLI-04 | #2718 | [#2723](https://github.com/KenSuenobu/objectified-commercial/issues/2723) |
 | 5 | GLI-05 | #2718 | [#2724](https://github.com/KenSuenobu/objectified-commercial/issues/2724) |
 | 6 | GLI-06 | #2718 | [#2725](https://github.com/KenSuenobu/objectified-commercial/issues/2725) |

--- a/objectified-ui/lib/db/helper.ts
+++ b/objectified-ui/lib/db/helper.ts
@@ -5484,7 +5484,7 @@ export async function listVersionBranches(projectId: string, tenantId: string) {
     const ok = await assertProjectInTenant(projectId, tenantId);
     if (!ok) return JSON.stringify({ success: false, error: 'Project not found' });
     const result = await connectionPool.query(
-      `SELECT b.id, b.project_id, b.name, b.tip_version_id, b.protected, b.require_merge_path, b.created_by, b.created_at, b.updated_at,
+      `SELECT b.id, b.project_id, b.name, b.tip_version_id, b.is_default, b.protected, b.require_merge_path, b.created_by, b.created_at, b.updated_at,
               v.version_id AS tip_version_string
        FROM odb.version_branches b
        JOIN odb.versions v ON v.id = b.tip_version_id AND v.project_id = b.project_id

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -7,6 +7,7 @@ We continue to improve the platform based on your feedback with improvements and
 ## Git-like Functionality
 - Added default-branch foundations for git-like workflows: branch rows now support a single project default (`isDefault`) with promotion support and first-commit auto-bootstrap of `main`.
 - Added branch divergence REST support with merge-base, ahead/behind counts, commit samples, and strong ETag-based 304 responses for stable canvas sync indicators.
+- Added a canvas branch picker: check out any named branch from the floating toolbar or git menu, with a current-branch chip, unsaved-layout guard, and refreshed tips after commit or merge.
 
 ---
 

--- a/objectified-ui/src/app/ade/studio/StudioContext.tsx
+++ b/objectified-ui/src/app/ade/studio/StudioContext.tsx
@@ -10,6 +10,7 @@ import {
   type StudioCanvasSurface,
 } from './lib/studio-canvas-prefs-storage';
 import type { OverallSchemaQualityDetail } from '@/app/utils/overall-schema-quality';
+import type { VersionBranchRow } from '@/app/components/ade/version-dialogs/types';
 
 // Group style options
 export interface GroupStyleOptions {
@@ -98,6 +99,15 @@ interface StudioContextType {
   setSelectedProjectId: (id: string | null) => void;
   selectedVersionId: string | null;
   setSelectedVersionId: (id: string | null) => void;
+  /** Named version branch whose tip matches the current revision when applicable (#2722 GLI-03). */
+  selectedBranchId: string | null;
+  setSelectedBranchId: (id: string | null) => void;
+  /** Cached GET /version-branches per project for branch chip + resolution. */
+  versionBranchesByProjectId: Record<string, VersionBranchRow[]>;
+  setVersionBranchesForProject: (projectId: string, branches: VersionBranchRow[]) => void;
+  /** Registered by `DesignerCanvasGitMenu` so toolbar `BranchPickerChip` can open "Create branch from here…". */
+  registerBranchFromRevisionOpener: (fn: (() => void) | null) => void;
+  openBranchFromRevisionDialog: () => void;
   canvasRefreshKey: number;
   triggerCanvasRefresh: () => void;
   sidebarRefreshKey: number;
@@ -217,6 +227,22 @@ export function StudioProvider({ children }: { children: ReactNode }) {
 
   const [selectedProjectId, setSelectedProjectId] = useState<string | null>(null);
   const [selectedVersionId, setSelectedVersionId] = useState<string | null>(null);
+  const [selectedBranchId, setSelectedBranchId] = useState<string | null>(null);
+  const [versionBranchesByProjectId, setVersionBranchesByProjectId] = useState<
+    Record<string, VersionBranchRow[]>
+  >({});
+  const branchFromRevisionOpenerRef = useRef<(() => void) | null>(null);
+  const registerBranchFromRevisionOpener = useCallback((fn: (() => void) | null) => {
+    branchFromRevisionOpenerRef.current = fn;
+  }, []);
+  const openBranchFromRevisionDialog = useCallback(() => {
+    branchFromRevisionOpenerRef.current?.();
+  }, []);
+
+  const setVersionBranchesForProject = useCallback((projectId: string, branches: VersionBranchRow[]) => {
+    setVersionBranchesByProjectId((prev) => ({ ...prev, [projectId]: branches }));
+  }, []);
+
   const [canvasRefreshKey, setCanvasRefreshKey] = useState<number>(0);
   const [sidebarRefreshKey, setSidebarRefreshKey] = useState<number>(0);
   const [isReadOnly, setIsReadOnly] = useState<boolean>(false);
@@ -545,6 +571,12 @@ export function StudioProvider({ children }: { children: ReactNode }) {
       setSelectedProjectId,
       selectedVersionId,
       setSelectedVersionId,
+      selectedBranchId,
+      setSelectedBranchId,
+      versionBranchesByProjectId,
+      setVersionBranchesForProject,
+      registerBranchFromRevisionOpener,
+      openBranchFromRevisionDialog,
       canvasRefreshKey,
       triggerCanvasRefresh,
       sidebarRefreshKey,

--- a/objectified-ui/src/app/ade/studio/components/BranchPickerChip.tsx
+++ b/objectified-ui/src/app/ade/studio/components/BranchPickerChip.tsx
@@ -1,0 +1,377 @@
+'use client';
+
+/**
+ * Branch picker (checkout) for the canvas toolbar and git menu (#2722 GLI-03).
+ */
+
+import * as Popover from '@radix-ui/react-popover';
+import { ChevronDown, GitBranch, Plus } from 'lucide-react';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type Dispatch,
+  type KeyboardEvent,
+  type SetStateAction,
+} from 'react';
+import { toast } from 'sonner';
+import { useStudio } from '../StudioContext';
+import { Spinner } from '@/app/components/ui/Spinner';
+import type { VersionBranchRow } from '@/app/components/ade/version-dialogs/types';
+import type { Version } from '../editor/components/types';
+import { formatVersionSelectorLabel } from '@/app/utils/version-display';
+import {
+  sortBranchesForPicker,
+  resolveActiveBranchForRevision,
+} from '@/app/ade/studio/lib/studio-branch-resolve';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/app/components/ui/AlertDialog';
+
+export type BranchPickerChipProps = {
+  versions: Version[];
+  setVersions: Dispatch<SetStateAction<Version[]>>;
+  /** Compact label for the floating toolbar; wider block inside the git dropdown. */
+  variant: 'toolbar' | 'menu';
+  /** Show the "+ Create new branch…" row (uses studio opener from `DesignerCanvasGitMenu`). */
+  showCreateBranch?: boolean;
+};
+
+export function BranchPickerChip({
+  versions,
+  setVersions,
+  variant,
+  showCreateBranch = true,
+}: BranchPickerChipProps) {
+  const {
+    selectedProjectId,
+    selectedVersionId,
+    setSelectedVersionId,
+    setSelectedBranchId,
+    selectedBranchId,
+    setIsReadOnly,
+    triggerCanvasRefresh,
+    triggerSidebarRefresh,
+    syncLocalDirty,
+    setVersionBranchesForProject,
+    versionBranchesByProjectId,
+    openBranchFromRevisionDialog,
+    canvasPresentationMode,
+  } = useStudio();
+
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [list, setList] = useState<VersionBranchRow[]>([]);
+  const [fetchError, setFetchError] = useState<string | null>(null);
+  const [highlight, setHighlight] = useState(0);
+  const [pendingCheckout, setPendingCheckout] = useState<VersionBranchRow | null>(null);
+
+  const cached = selectedProjectId ? versionBranchesByProjectId[selectedProjectId] : undefined;
+
+  const currentVersion = useMemo(
+    () => versions.find((v) => String(v.id) === String(selectedVersionId)),
+    [versions, selectedVersionId]
+  );
+
+  const branchesForLabel = useMemo(() => {
+    if (cached?.length) return cached;
+    return list;
+  }, [cached, list]);
+
+  const resolvedBranch = useMemo(() => {
+    if (!selectedVersionId || !branchesForLabel.length) return null;
+    return resolveActiveBranchForRevision(selectedVersionId, branchesForLabel);
+  }, [selectedVersionId, branchesForLabel]);
+
+  const displayBranch: VersionBranchRow | null = useMemo(() => {
+    if (selectedBranchId && branchesForLabel.length) {
+      const byId = branchesForLabel.find((b) => b.id === selectedBranchId);
+      if (byId) return byId;
+    }
+    return resolvedBranch;
+  }, [selectedBranchId, branchesForLabel, resolvedBranch]);
+
+  const sortedBranches = useMemo(() => sortBranchesForPicker(list), [list]);
+
+  const refreshVersions = useCallback(async (): Promise<Version[] | null> => {
+    if (!selectedProjectId) return null;
+    try {
+      const response = await fetch(`/api/versions?projectId=${encodeURIComponent(selectedProjectId)}`);
+      const result = await response.json();
+      if (!response.ok || !result.success || !Array.isArray(result.versions)) {
+        return null;
+      }
+      const next = result.versions as Version[];
+      setVersions(next);
+      return next;
+    } catch {
+      return null;
+    }
+  }, [selectedProjectId, setVersions]);
+
+  const loadBranches = useCallback(async () => {
+    if (!selectedProjectId) return;
+    setLoading(true);
+    setFetchError(null);
+    try {
+      const r = await fetch(`/api/projects/${encodeURIComponent(selectedProjectId)}/version-branches`);
+      const d = (await r.json()) as {
+        success?: boolean;
+        branches?: VersionBranchRow[];
+        error?: string;
+      };
+      if (!r.ok || !d.success || !Array.isArray(d.branches)) {
+        setFetchError(typeof d.error === 'string' ? d.error : 'Could not load branches');
+        setList([]);
+        return;
+      }
+      const sorted = sortBranchesForPicker(d.branches);
+      setList(sorted);
+      setVersionBranchesForProject(selectedProjectId, d.branches);
+      const cur = selectedVersionId;
+      const idx = sorted.findIndex((b) => String(b.tip_version_id) === String(cur));
+      setHighlight(idx >= 0 ? idx : 0);
+    } catch {
+      setFetchError('Could not load branches');
+      setList([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [selectedProjectId, selectedVersionId, setVersionBranchesForProject]);
+
+  useEffect(() => {
+    if (!open) return;
+    void loadBranches();
+  }, [open, loadBranches]);
+
+  useEffect(() => {
+    if (!open) return;
+    const max = Math.max(0, sortedBranches.length - 1);
+    setHighlight((h) => Math.min(h, max));
+  }, [open, sortedBranches.length]);
+
+  const performCheckout = useCallback(
+    async (branch: VersionBranchRow) => {
+      if (!selectedProjectId) return;
+      const tipId = branch.tip_version_id;
+      if (String(tipId) === String(selectedVersionId)) {
+        setOpen(false);
+        return;
+      }
+      let nextVersions = versions;
+      let tip = versions.find((v) => String(v.id) === String(tipId));
+      if (!tip) {
+        const refreshed = await refreshVersions();
+        if (refreshed) nextVersions = refreshed;
+        tip = nextVersions.find((v) => String(v.id) === String(tipId));
+      }
+      if (!tip) {
+        toast.error('Branch tip revision is not available in this session. Refresh the revision list.');
+        return;
+      }
+      setSelectedVersionId(tipId);
+      setSelectedBranchId(branch.id);
+      setIsReadOnly(tip.published ?? false);
+      const r = await fetch(`/api/projects/${encodeURIComponent(selectedProjectId)}/version-branches`);
+      const d = (await r.json()) as { success?: boolean; branches?: VersionBranchRow[] };
+      if (d.success && Array.isArray(d.branches)) {
+        setVersionBranchesForProject(selectedProjectId, d.branches);
+      }
+      triggerCanvasRefresh();
+      triggerSidebarRefresh();
+      toast.success(`Checked out ${branch.name}`);
+      setOpen(false);
+    },
+    [
+      selectedProjectId,
+      selectedVersionId,
+      versions,
+      refreshVersions,
+      setSelectedVersionId,
+      setSelectedBranchId,
+      setIsReadOnly,
+      setVersionBranchesForProject,
+      triggerCanvasRefresh,
+      triggerSidebarRefresh,
+    ]
+  );
+
+  const requestCheckout = useCallback(
+    (branch: VersionBranchRow) => {
+      if (String(branch.tip_version_id) === String(selectedVersionId)) {
+        setOpen(false);
+        return;
+      }
+      if (syncLocalDirty) {
+        setPendingCheckout(branch);
+        return;
+      }
+      void performCheckout(branch);
+    },
+    [syncLocalDirty, selectedVersionId, performCheckout]
+  );
+
+  const onKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (!sortedBranches.length) return;
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        setHighlight((h) => Math.min(sortedBranches.length - 1, h + 1));
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        setHighlight((h) => Math.max(0, h - 1));
+      } else if (e.key === 'Enter') {
+        e.preventDefault();
+        const b = sortedBranches[highlight];
+        if (b) requestCheckout(b);
+      } else if (e.key === 'Escape') {
+        e.preventDefault();
+        setOpen(false);
+      }
+    },
+    [sortedBranches, highlight, requestCheckout]
+  );
+
+  if (!selectedProjectId || !selectedVersionId || canvasPresentationMode) {
+    return null;
+  }
+
+  const chipLabel = displayBranch?.name ?? '—';
+  const tooltipBits: string[] = [];
+  if (displayBranch?.tip_version_id) {
+    tooltipBits.push(`Tip revision: ${displayBranch.tip_version_id}`);
+  }
+  if (currentVersion) {
+    tooltipBits.push(`Canvas: ${formatVersionSelectorLabel(currentVersion)}`);
+  }
+  const title = tooltipBits.join('\n');
+
+  const triggerClass =
+    variant === 'toolbar'
+      ? `inline-flex max-w-[min(14rem,46vw)] items-center gap-1.5 rounded-lg border border-gray-200/55 bg-white/45 px-2.5 py-2 text-sm font-medium text-gray-800 shadow-md backdrop-blur-md transition-all hover:border-indigo-300/60 hover:bg-white/65 hover:shadow-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500/30 dark:border-gray-600/45 dark:bg-gray-900/40 dark:text-gray-200 dark:hover:border-indigo-500/45 dark:hover:bg-gray-900/55`
+      : `flex w-full max-w-full items-center justify-between gap-2 rounded-lg border border-gray-200/80 bg-white/60 px-2.5 py-2 text-left text-sm font-medium text-gray-900 shadow-sm backdrop-blur-sm transition-all hover:border-indigo-300/50 hover:bg-white/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500/30 dark:border-gray-600/60 dark:bg-gray-900/50 dark:text-gray-100 dark:hover:border-indigo-500/40`;
+
+  return (
+    <>
+      <Popover.Root open={open} onOpenChange={setOpen}>
+        <Popover.Trigger asChild>
+          <button
+            type="button"
+            className={triggerClass}
+            title={title}
+            aria-label={`Current branch: ${chipLabel}. Open branch picker.`}
+          >
+            <GitBranch className="h-4 w-4 shrink-0 text-indigo-600 dark:text-indigo-400" aria-hidden />
+            <span className="min-w-0 flex-1 truncate">
+              <span className="text-[10px] font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                Branch
+              </span>
+              <span className="block truncate leading-tight">{chipLabel}</span>
+            </span>
+            <ChevronDown className="h-4 w-4 shrink-0 text-gray-500 dark:text-gray-400" aria-hidden />
+          </button>
+        </Popover.Trigger>
+        <Popover.Portal>
+          <Popover.Content
+            className="z-[10060] w-[min(20rem,calc(100vw-2rem))] rounded-xl border border-gray-200 bg-white p-1 shadow-lg dark:border-gray-600 dark:bg-gray-800"
+            sideOffset={6}
+            align={variant === 'toolbar' ? 'end' : 'start'}
+            onKeyDown={onKeyDown}
+          >
+            {loading && (
+              <div className="flex items-center gap-2 px-3 py-4 text-sm text-gray-600 dark:text-gray-300">
+                <Spinner size="sm" className="shrink-0" />
+                Loading branches…
+              </div>
+            )}
+            {!loading && fetchError && (
+              <div className="px-3 py-3 text-sm text-red-600 dark:text-red-400">{fetchError}</div>
+            )}
+            {!loading && !fetchError && sortedBranches.length === 0 && (
+              <div className="px-3 py-3 text-sm text-gray-600 dark:text-gray-400">No named branches yet.</div>
+            )}
+            {!loading &&
+              !fetchError &&
+              sortedBranches.map((b, i) => {
+                const active = String(b.tip_version_id) === String(selectedVersionId);
+                const isSel = selectedBranchId === b.id;
+                const isHi = i === highlight;
+                return (
+                  <button
+                    key={b.id}
+                    type="button"
+                    className={`flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-sm ${
+                      isHi ? 'bg-indigo-50 dark:bg-indigo-950/50' : 'hover:bg-gray-50 dark:hover:bg-gray-700/50'
+                    } ${active ? 'font-semibold text-indigo-800 dark:text-indigo-200' : 'text-gray-800 dark:text-gray-200'}`}
+                    onClick={() => requestCheckout(b)}
+                    onMouseEnter={() => setHighlight(i)}
+                  >
+                    <span className="min-w-0 flex-1 truncate">
+                      {active ? '✓ ' : ''}
+                      {b.name}
+                    </span>
+                    {b.is_default && (
+                      <span className="shrink-0 rounded bg-slate-100 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-slate-700 dark:bg-slate-700 dark:text-slate-200">
+                        default
+                      </span>
+                    )}
+                    {isSel && (
+                      <span className="shrink-0 text-[10px] text-gray-500 dark:text-gray-400">current</span>
+                    )}
+                  </button>
+                );
+              })}
+            {showCreateBranch && !loading && (
+              <>
+                <div className="my-1 h-px bg-gray-100 dark:bg-gray-700" />
+                <button
+                  type="button"
+                  className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-sm text-gray-800 hover:bg-gray-50 dark:text-gray-200 dark:hover:bg-gray-700/50"
+                  onClick={() => {
+                    setOpen(false);
+                    openBranchFromRevisionDialog();
+                  }}
+                >
+                  <Plus className="h-4 w-4 shrink-0 opacity-80" aria-hidden />
+                  Create new branch…
+                </button>
+              </>
+            )}
+          </Popover.Content>
+        </Popover.Portal>
+      </Popover.Root>
+
+      <AlertDialog open={pendingCheckout !== null} onOpenChange={(o) => !o && setPendingCheckout(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Unsaved layout changes</AlertDialogTitle>
+            <AlertDialogDescription>
+              Switching branches will reload the canvas from the branch tip and you may lose unsaved canvas layout
+              changes. Continue?
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                const b = pendingCheckout;
+                setPendingCheckout(null);
+                if (b) void performCheckout(b);
+              }}
+            >
+              Switch branch
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/objectified-ui/src/app/ade/studio/components/BranchPickerChip.tsx
+++ b/objectified-ui/src/app/ade/studio/components/BranchPickerChip.tsx
@@ -74,17 +74,15 @@ export function BranchPickerChip({
   const [highlight, setHighlight] = useState(0);
   const [pendingCheckout, setPendingCheckout] = useState<VersionBranchRow | null>(null);
 
-  const cached = selectedProjectId ? versionBranchesByProjectId[selectedProjectId] : undefined;
-
   const currentVersion = useMemo(
     () => versions.find((v) => String(v.id) === String(selectedVersionId)),
     [versions, selectedVersionId]
   );
 
-  const branchesForLabel = useMemo(() => {
-    if (cached?.length) return cached;
-    return list;
-  }, [cached, list]);
+  const branchesForLabel = useMemo(
+    () => (selectedProjectId ? (versionBranchesByProjectId[selectedProjectId] ?? []) : []),
+    [selectedProjectId, versionBranchesByProjectId]
+  );
 
   const resolvedBranch = useMemo(() => {
     if (!selectedVersionId || !branchesForLabel.length) return null;
@@ -180,10 +178,16 @@ export function BranchPickerChip({
       setSelectedVersionId(tipId);
       setSelectedBranchId(branch.id);
       setIsReadOnly(tip.published ?? false);
-      const r = await fetch(`/api/projects/${encodeURIComponent(selectedProjectId)}/version-branches`);
-      const d = (await r.json()) as { success?: boolean; branches?: VersionBranchRow[] };
-      if (d.success && Array.isArray(d.branches)) {
-        setVersionBranchesForProject(selectedProjectId, d.branches);
+      try {
+        const r = await fetch(`/api/projects/${encodeURIComponent(selectedProjectId)}/version-branches`);
+        if (r.ok) {
+          const d = (await r.json()) as { success?: boolean; branches?: VersionBranchRow[] };
+          if (d.success && Array.isArray(d.branches)) {
+            setVersionBranchesForProject(selectedProjectId, d.branches);
+          }
+        }
+      } catch {
+        // Best-effort branch refresh; checkout should still complete even if this fails.
       }
       triggerCanvasRefresh();
       triggerSidebarRefresh();
@@ -211,6 +215,7 @@ export function BranchPickerChip({
         return;
       }
       if (syncLocalDirty) {
+        setOpen(false);
         setPendingCheckout(branch);
         return;
       }

--- a/objectified-ui/src/app/ade/studio/components/DesignerCanvasGitMenu.tsx
+++ b/objectified-ui/src/app/ade/studio/components/DesignerCanvasGitMenu.tsx
@@ -13,7 +13,7 @@
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
-import { useCallback, useMemo, useState, type Dispatch, type SetStateAction } from 'react';
+import { useCallback, useEffect, useMemo, useState, type Dispatch, type SetStateAction } from 'react';
 import { toast } from 'sonner';
 import {
   Download,
@@ -37,12 +37,14 @@ import {
 } from '@/app/utils/studio-sync-indicators';
 import { Spinner } from '@/app/components/ui/Spinner';
 import type { Version } from '../editor/components/types';
+import type { VersionBranchRow } from '@/app/components/ade/version-dialogs/types';
 import { CommitRevisionDialog } from '@/app/components/ade/version-dialogs/CommitRevisionDialog';
 import { BranchFromRevisionDialog } from '@/app/components/ade/version-dialogs/BranchFromRevisionDialog';
 import { VersionTagDialog } from '@/app/components/ade/version-dialogs/VersionTagDialog';
 import { MergeBranchesDialog } from '@/app/components/ade/version-dialogs/MergeBranchesDialog';
 import { RollbackBranchDialog } from '@/app/components/ade/version-dialogs/RollbackBranchDialog';
 import { CanvasHistoryGraphDialog } from './CanvasHistoryGraphDialog';
+import { BranchPickerChip } from './BranchPickerChip';
 
 export type DesignerCanvasGitMenuProps = {
   versions: Version[];
@@ -85,7 +87,31 @@ export function DesignerCanvasGitMenu({ versions, setVersions }: DesignerCanvasG
     triggerSidebarRefresh,
     syncLocalDirty,
     canvasPresentationMode,
+    setVersionBranchesForProject,
+    registerBranchFromRevisionOpener,
   } = useStudio();
+
+  useEffect(() => {
+    registerBranchFromRevisionOpener(() => {
+      setOpenDialog('branch');
+    });
+    return () => {
+      registerBranchFromRevisionOpener(null);
+    };
+  }, [registerBranchFromRevisionOpener]);
+
+  const refreshBranchList = useCallback(async () => {
+    if (!selectedProjectId) return;
+    try {
+      const r = await fetch(`/api/projects/${encodeURIComponent(selectedProjectId)}/version-branches`);
+      const d = (await r.json()) as { success?: boolean; branches?: unknown[] };
+      if (r.ok && d.success && Array.isArray(d.branches)) {
+        setVersionBranchesForProject(selectedProjectId, d.branches as VersionBranchRow[]);
+      }
+    } catch {
+      /* chip / sync will refetch */
+    }
+  }, [selectedProjectId, setVersionBranchesForProject]);
 
   const sessionUserId = (session?.user as { user_id?: string } | undefined)?.user_id;
   const isTenantAdmin = Boolean((session?.user as { is_tenant_admin?: boolean } | undefined)?.is_tenant_admin);
@@ -249,7 +275,7 @@ export function DesignerCanvasGitMenu({ versions, setVersions }: DesignerCanvasG
 
   return (
     <>
-      <DropdownMenu.Root>
+      <DropdownMenu.Root modal={false}>
         <DropdownMenu.Trigger asChild>
           <button
             type="button"
@@ -267,7 +293,8 @@ export function DesignerCanvasGitMenu({ versions, setVersions }: DesignerCanvasG
             align="end"
           >
             <div className="border-b border-gray-100 px-3 py-2 dark:border-gray-700">
-              <div className="text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">
+              <BranchPickerChip versions={versions} setVersions={setVersions} variant="menu" showCreateBranch />
+              <div className="mt-2 text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">
                 Current revision
               </div>
               <div className="mt-0.5 text-sm font-medium text-gray-900 dark:text-gray-100">
@@ -454,6 +481,7 @@ export function DesignerCanvasGitMenu({ versions, setVersions }: DesignerCanvasG
             }}
             onCreated={async (result) => {
               const list = await refreshVersionList();
+              await refreshBranchList();
               if (result.id) {
                 setSelectedVersionId(result.id);
                 setIsReadOnly(result.published ?? false);
@@ -494,6 +522,7 @@ export function DesignerCanvasGitMenu({ versions, setVersions }: DesignerCanvasG
             isTenantAdmin={isTenantAdmin}
             onMerged={async (result) => {
               const list = await refreshVersionList();
+              await refreshBranchList();
               if (result.version?.id && list?.some((v) => v.id === result.version?.id)) {
                 setSelectedVersionId(result.version.id);
                 const next = list.find((v) => v.id === result.version?.id);

--- a/objectified-ui/src/app/ade/studio/editor/page.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/page.tsx
@@ -220,6 +220,8 @@ import SchemaMetricsPanel from '../components/SchemaMetricsPanel';
 import SchemaTimelinePanel from '../components/SchemaTimelinePanel';
 import SchemaVersionScoringPanel from '../components/SchemaVersionScoringPanel';
 import { DesignerCanvasGitMenu } from '../components/DesignerCanvasGitMenu';
+import { BranchPickerChip } from '../components/BranchPickerChip';
+import { useStudioBranchSync } from '../lib/use-studio-branch-sync';
 import { useSearchHistory } from '../hooks/useSearchHistory';
 import {
   loadPresentationBookmarks,
@@ -364,7 +366,18 @@ const StudioContent = () => {
     setSchemaQualityScore,
     setSchemaQualityDetail,
     setSyncLocalDirty,
+    setSelectedBranchId,
+    versionBranchesByProjectId,
+    setVersionBranchesForProject,
   } = useStudio();
+
+  useStudioBranchSync({
+    projectId: contextProjectId ?? '',
+    revisionId: contextVersionId ?? '',
+    versionBranchesByProjectId,
+    setVersionBranchesForProject,
+    setSelectedBranchId,
+  });
 
   // Toggle click-to-focus mode (defined after useStudio to access setContextClickToFocusEnabled)
   const toggleClickToFocus = useCallback(() => {
@@ -9390,6 +9403,12 @@ const StudioContent = () => {
             {/* Branch, layout, and export — one toolbar (top-right) */}
             {!canvasPresentationActive && (
             <Panel position="top-right" className="flex items-center gap-1.5 z-[1002] border-0 bg-transparent p-0 shadow-none">
+              <BranchPickerChip
+                versions={versions}
+                setVersions={setVersions}
+                variant="toolbar"
+                showCreateBranch={false}
+              />
               <DesignerCanvasGitMenu versions={versions} setVersions={setVersions} />
               <div className="relative" ref={layoutDropdownRef}>
                 <input

--- a/objectified-ui/src/app/ade/studio/lib/studio-branch-resolve.ts
+++ b/objectified-ui/src/app/ade/studio/lib/studio-branch-resolve.ts
@@ -1,0 +1,24 @@
+import type { VersionBranchRow } from '@/app/components/ade/version-dialogs/types';
+
+/**
+ * Prefer the project default when several branches share the same tip revision.
+ */
+export function resolveActiveBranchForRevision(
+  revisionId: string,
+  branches: VersionBranchRow[]
+): VersionBranchRow | null {
+  const tips = branches.filter((b) => String(b.tip_version_id) === String(revisionId));
+  if (tips.length === 0) return null;
+  const preferred = tips.find((b) => b.is_default);
+  return preferred ?? tips[0] ?? null;
+}
+
+/** Default branch first, then alphabetical by name. */
+export function sortBranchesForPicker(branches: VersionBranchRow[]): VersionBranchRow[] {
+  return [...branches].sort((a, b) => {
+    const ad = a.is_default ? 0 : 1;
+    const bd = b.is_default ? 0 : 1;
+    if (ad !== bd) return ad - bd;
+    return a.name.localeCompare(b.name, undefined, { sensitivity: 'base' });
+  });
+}

--- a/objectified-ui/src/app/ade/studio/lib/use-studio-branch-sync.ts
+++ b/objectified-ui/src/app/ade/studio/lib/use-studio-branch-sync.ts
@@ -1,0 +1,57 @@
+'use client';
+
+import { useEffect } from 'react';
+import type { VersionBranchRow } from '@/app/components/ade/version-dialogs/types';
+import { resolveActiveBranchForRevision } from '@/app/ade/studio/lib/studio-branch-resolve';
+
+/**
+ * Loads named branches when the studio project changes and keeps `selectedBranchId`
+ * aligned with the current revision when it matches a branch tip (#2722).
+ */
+export function useStudioBranchSync(options: {
+  projectId: string;
+  revisionId: string;
+  versionBranchesByProjectId: Record<string, VersionBranchRow[]>;
+  setVersionBranchesForProject: (projectId: string, branches: VersionBranchRow[]) => void;
+  setSelectedBranchId: (id: string | null) => void;
+}): void {
+  const {
+    projectId,
+    revisionId,
+    versionBranchesByProjectId,
+    setVersionBranchesForProject,
+    setSelectedBranchId,
+  } = options;
+
+  useEffect(() => {
+    if (!projectId) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const r = await fetch(`/api/projects/${encodeURIComponent(projectId)}/version-branches`);
+        const d = (await r.json()) as {
+          success?: boolean;
+          branches?: VersionBranchRow[];
+        };
+        if (cancelled || !r.ok || !d.success || !Array.isArray(d.branches)) return;
+        setVersionBranchesForProject(projectId, d.branches);
+      } catch {
+        /* branch chip will retry on open */
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [projectId, setVersionBranchesForProject]);
+
+  useEffect(() => {
+    if (!projectId || !revisionId) {
+      setSelectedBranchId(null);
+      return;
+    }
+    const branches = versionBranchesByProjectId[projectId];
+    if (!branches?.length) return;
+    const row = resolveActiveBranchForRevision(revisionId, branches);
+    setSelectedBranchId(row?.id ?? null);
+  }, [projectId, revisionId, versionBranchesByProjectId, setSelectedBranchId]);
+}

--- a/objectified-ui/src/app/components/ade/version-dialogs/types.ts
+++ b/objectified-ui/src/app/components/ade/version-dialogs/types.ts
@@ -14,6 +14,8 @@ export interface VersionBranchRow {
   created_at?: string;
   created_by?: string | null;
   protected?: boolean;
+  /** GLI-01 — exactly one default branch per project. */
+  is_default?: boolean;
 }
 
 /** Minimal revision shape needed by dialogs for labels and branch-from operations. */

--- a/objectified-ui/tests/unit/studio-branch-resolve.test.ts
+++ b/objectified-ui/tests/unit/studio-branch-resolve.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from '@jest/globals';
+import {
+  resolveActiveBranchForRevision,
+  sortBranchesForPicker,
+} from '@/app/ade/studio/lib/studio-branch-resolve';
+import type { VersionBranchRow } from '@/app/components/ade/version-dialogs/types';
+
+describe('resolveActiveBranchForRevision', () => {
+  it('returns null when no branch tip matches', () => {
+    expect(
+      resolveActiveBranchForRevision('rev-1', [
+        { id: 'b1', name: 'a', tip_version_id: 'other' },
+      ])
+    ).toBeNull();
+  });
+
+  it('returns the matching branch when unique', () => {
+    const main: VersionBranchRow = { id: 'b-main', name: 'main', tip_version_id: 'rev-x', is_default: true };
+    expect(resolveActiveBranchForRevision('rev-x', [main])).toEqual(main);
+  });
+
+  it('prefers is_default when multiple branches share a tip', () => {
+    const a: VersionBranchRow = { id: 'b1', name: 'feature', tip_version_id: 'rev-x' };
+    const b: VersionBranchRow = { id: 'b2', name: 'main', tip_version_id: 'rev-x', is_default: true };
+    expect(resolveActiveBranchForRevision('rev-x', [a, b])).toEqual(b);
+  });
+});
+
+describe('sortBranchesForPicker', () => {
+  it('orders default first, then name', () => {
+    const rows: VersionBranchRow[] = [
+      { id: 'z', name: 'zebra', tip_version_id: '1' },
+      { id: 'm', name: 'main', tip_version_id: '2', is_default: true },
+      { id: 'a', name: 'aardvark', tip_version_id: '3' },
+    ];
+    expect(sortBranchesForPicker(rows).map((b) => b.name)).toEqual(['main', 'aardvark', 'zebra']);
+  });
+});


### PR DESCRIPTION
## Summary
Implements GLI-03 / #2722: a first-class branch picker on the Designer canvas so users can check out named branches without leaving the canvas.

## What changed
- **StudioContext**: `selectedBranchId`, `setSelectedBranchId`, per-project `versionBranchesByProjectId` cache, `setVersionBranchesForProject`, and registration for opening **Create branch from here…** from the branch chip.
- **BranchPickerChip**: Radix popover (keyboard ↑/↓, Enter, Esc), default-branch badge (`is_default` from API), dirty-canvas `AlertDialog` when `syncLocalDirty` is true, checkout → revision tip + read-only from `published`, canvas/sidebar refresh.
- **Designer canvas**: toolbar chip next to the git menu; git menu header uses the same picker + current revision block. `DropdownMenu` uses `modal={false}` so the nested branch popover works smoothly.
- **Data**: `listVersionBranches` SELECT includes `is_default`; `VersionBranchRow` documents the field.
- **Sync hook** (`useStudioBranchSync`): loads branches when the project changes and keeps `selectedBranchId` aligned when the canvas revision matches a branch tip.
- **Docs/release**: roadmap row GLI-03 marked complete, `WHATS_NEW`, `objectified-ui` patch bump.

## How to test
1. Open a project with two named branches; confirm the toolbar chip shows the branch whose tip matches the selected revision (or `—` if not on any tip).
2. Open the chip → pick another branch → canvas should reload at that tip; published tips should force read-only.
3. Dirty the canvas (`syncLocalDirty`) → try switching branch → confirm the unsaved warning.
4. Commit on the active branch → chip name stable, tooltip still shows tip id; merge branches → branch list/tips refresh after `refreshBranchList`.

## Risks / notes
- Nested popover inside the git dropdown: `modal={false}` on the dropdown root mitigates focus-trap issues; if anything still closes unexpectedly, we can add `onInteractOutside` handling.

Closes #2722

Made with [Cursor](https://cursor.com)