### PR TITLE
Fix #2724 - GLI-05 prominent Commit on canvas toolbar

### DIFF
--- a/docs/PLANNED_FEATURE_ROADMAP_GITLIKE_IMPROVEMENTS.md
+++ b/docs/PLANNED_FEATURE_ROADMAP_GITLIKE_IMPROVEMENTS.md
@@ -75,7 +75,7 @@ on the ones above it to be meaningful in isolation.
 | ~~GLI-02~~ | ~~Branch divergence API (`ahead` / `behind` / `mergeBase`)~~ ([#2721](https://github.com/KenSuenobu/objectified-commercial/issues/2721)) | **MVP** (completed) | GLI-01 |
 | ~~GLI-03~~ | ~~Canvas branch picker (`checkout`) with current-branch chip~~ ([#2722](https://github.com/KenSuenobu/objectified-commercial/issues/2722)) | **MVP** (completed) | GLI-01 |
 | ~~GLI-04~~ | ~~Ahead / behind-main chip in canvas header~~ ([#2723](https://github.com/KenSuenobu/objectified-commercial/issues/2723)) | **MVP** (completed) | GLI-02, GLI-03 |
-| GLI-05 | Prominent "Commit…" action on the canvas toolbar | **MVP** | GLI-03 |
+| ~~GLI-05~~ | ~~Prominent "Commit…" action on the canvas toolbar~~ ([#2724](https://github.com/KenSuenobu/objectified-commercial/issues/2724)) | **MVP** (completed) | GLI-03 |
 | GLI-06 | "Sync from main" one-click action | **MVP** | GLI-02, GLI-03 |
 | GLI-07 | Branch status popover (`git status` style summary) | MVP (trailing) | GLI-02, GLI-03, GLI-05 |
 | GLI-08 | Auto-protect the default branch (require merge path) | **Enterprise** | GLI-01 |
@@ -95,7 +95,7 @@ MVP (first major release) = GLI-01 → GLI-07. Enterprise (later releases)
 | 2 | GLI-02 | #2718 | [#2721](https://github.com/KenSuenobu/objectified-commercial/issues/2721) ✅ |
 | 3 | GLI-03 | #2718 | [#2722](https://github.com/KenSuenobu/objectified-commercial/issues/2722) ✅ |
 | 4 | GLI-04 | #2718 | [#2723](https://github.com/KenSuenobu/objectified-commercial/issues/2723) ✅ |
-| 5 | GLI-05 | #2718 | [#2724](https://github.com/KenSuenobu/objectified-commercial/issues/2724) |
+| 5 | GLI-05 | #2718 | [#2724](https://github.com/KenSuenobu/objectified-commercial/issues/2724) ✅ |
 | 6 | GLI-06 | #2718 | [#2725](https://github.com/KenSuenobu/objectified-commercial/issues/2725) |
 | 7 | GLI-07 | #2718 | [#2726](https://github.com/KenSuenobu/objectified-commercial/issues/2726) |
 | 8 | GLI-08 | #2719 | [#2727](https://github.com/KenSuenobu/objectified-commercial/issues/2727) |

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -9,6 +9,7 @@ We continue to improve the platform based on your feedback with improvements and
 - Added branch divergence REST support with merge-base, ahead/behind counts, commit samples, and strong ETag-based 304 responses for stable canvas sync indicators.
 - Added a canvas branch picker: check out any named branch from the floating toolbar or git menu, with a current-branch chip, unsaved-layout guard, and refreshed tips after commit or merge.
 - Added an ahead/behind default-branch chip on the canvas (feature branches only): live divergence from the REST API, commit samples in the tooltip, refresh on sidebar sync, and one-click deep link into Compare Version Schemas (merge base → branch tip).
+- Added a prominent **Commit** control on the canvas toolbar (with unsaved-layout dot, ⌘/Ctrl+Enter from the flow surface, read-only guardrails) that opens the existing commit dialog locked to the active branch when named branches exist.
 
 ---
 

--- a/objectified-ui/src/app/ade/studio/components/CanvasCommitButton.tsx
+++ b/objectified-ui/src/app/ade/studio/components/CanvasCommitButton.tsx
@@ -1,0 +1,192 @@
+'use client';
+
+/**
+ * Toolbar Commit control for the Designer canvas (#2724 GLI-05).
+ */
+
+import { GitCommit } from 'lucide-react';
+import {
+  forwardRef,
+  useCallback,
+  useImperativeHandle,
+  useMemo,
+  useState,
+  type Dispatch,
+  type SetStateAction,
+} from 'react';
+import { toast } from 'sonner';
+import { useStudio } from '../StudioContext';
+import { usePushConflictBanner } from '@/app/providers/PushConflictBannerProvider';
+import { CommitRevisionDialog } from '@/app/components/ade/version-dialogs/CommitRevisionDialog';
+import type { Version } from '../editor/components/types';
+import { resolveActiveBranchForRevision } from '@/app/ade/studio/lib/studio-branch-resolve';
+import type { VersionBranchRow } from '@/app/components/ade/version-dialogs/types';
+
+const toolbarCommitClass =
+  'relative shrink-0 inline-flex items-center gap-1.5 rounded-lg border border-gray-200/55 bg-white/45 px-3 py-2 text-sm font-medium text-gray-800 shadow-md backdrop-blur-md transition-all hover:border-indigo-300/60 hover:bg-white/65 hover:shadow-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500/30 dark:border-gray-600/45 dark:bg-gray-900/40 dark:text-gray-200 dark:hover:border-indigo-500/45 dark:hover:bg-gray-900/55';
+
+export type CanvasCommitButtonProps = {
+  versions: Version[];
+  setVersions: Dispatch<SetStateAction<Version[]>>;
+};
+
+export type CanvasCommitButtonHandle = {
+  open: () => void;
+};
+
+export const CanvasCommitButton = forwardRef<CanvasCommitButtonHandle, CanvasCommitButtonProps>(
+  function CanvasCommitButton({ versions, setVersions }, ref) {
+    const { setPushConflictFrom409 } = usePushConflictBanner();
+    const [commitOpen, setCommitOpen] = useState(false);
+
+    const {
+      selectedProjectId,
+      selectedVersionId,
+      selectedBranchId,
+      setSelectedVersionId,
+      setIsReadOnly,
+      triggerCanvasRefresh,
+      triggerSidebarRefresh,
+      syncLocalDirty,
+      canvasPresentationMode,
+      setVersionBranchesForProject,
+      isReadOnly,
+      versionBranchesByProjectId,
+    } = useStudio();
+
+    const branchesForLabel = useMemo(
+      () => (selectedProjectId ? (versionBranchesByProjectId[selectedProjectId] ?? []) : []),
+      [selectedProjectId, versionBranchesByProjectId]
+    );
+
+    const resolvedBranch = useMemo(() => {
+      if (!selectedVersionId || !branchesForLabel.length) return null;
+      return resolveActiveBranchForRevision(selectedVersionId, branchesForLabel);
+    }, [selectedVersionId, branchesForLabel]);
+
+    const lockBranchId = useMemo(() => {
+      if (selectedBranchId && branchesForLabel.some((b) => b.id === selectedBranchId)) {
+        return selectedBranchId;
+      }
+      return resolvedBranch?.id ?? null;
+    }, [selectedBranchId, branchesForLabel, resolvedBranch]);
+
+    const currentVersion = useMemo(
+      () => versions.find((v) => String(v.id) === String(selectedVersionId)),
+      [versions, selectedVersionId]
+    );
+
+    const currentRevisionRef = useMemo(
+      () =>
+        currentVersion
+          ? {
+              id: currentVersion.id,
+              version_id: currentVersion.version_id,
+              shortMessage: currentVersion.shortMessage ?? currentVersion.description ?? null,
+            }
+          : null,
+      [currentVersion]
+    );
+
+    const refreshVersionList = useCallback(async (): Promise<Version[] | null> => {
+      if (!selectedProjectId) return null;
+      try {
+        const response = await fetch(`/api/versions?projectId=${encodeURIComponent(selectedProjectId)}`);
+        const result = await response.json();
+        if (!response.ok || !result.success || !Array.isArray(result.versions)) {
+          return null;
+        }
+        const list = result.versions as Version[];
+        setVersions(list);
+        return list;
+      } catch {
+        return null;
+      }
+    }, [selectedProjectId, setVersions]);
+
+    const refreshBranchList = useCallback(async () => {
+      if (!selectedProjectId) return;
+      try {
+        const r = await fetch(`/api/projects/${encodeURIComponent(selectedProjectId)}/version-branches`);
+        const d = (await r.json()) as { success?: boolean; branches?: VersionBranchRow[] };
+        if (r.ok && d.success && Array.isArray(d.branches)) {
+          setVersionBranchesForProject(selectedProjectId, d.branches);
+        }
+      } catch {
+        /* best-effort */
+      }
+    }, [selectedProjectId, setVersionBranchesForProject]);
+
+    const tryOpen = useCallback(() => {
+      if (!selectedProjectId || !selectedVersionId) return;
+      if (isReadOnly) {
+        toast.warning('This revision is read-only. Pull the latest to commit new work.');
+        return;
+      }
+      setCommitOpen(true);
+    }, [selectedProjectId, selectedVersionId, isReadOnly]);
+
+    useImperativeHandle(ref, () => ({ open: tryOpen }), [tryOpen]);
+
+    if (!selectedProjectId || !selectedVersionId || canvasPresentationMode) {
+      return null;
+    }
+
+    const readOnlyTitle = 'This revision is read-only. Pull the latest to commit new work.';
+
+    return (
+      <>
+        <button
+          type="button"
+          className={toolbarCommitClass}
+          onClick={() => tryOpen()}
+          aria-disabled={isReadOnly}
+          aria-keyshortcuts="Meta+Enter Control+Enter"
+          title={isReadOnly ? readOnlyTitle : 'Commit a new revision (⌘/Ctrl+Enter)'}
+          aria-label={isReadOnly ? readOnlyTitle : 'Commit new revision'}
+        >
+          {syncLocalDirty ? (
+            <span
+              className="absolute -right-0.5 -top-0.5 h-2 w-2 rounded-full bg-amber-500 shadow-sm ring-2 ring-white dark:ring-gray-900"
+              aria-hidden
+            />
+          ) : null}
+          <GitCommit className="h-4 w-4 shrink-0 text-indigo-600 dark:text-indigo-400" aria-hidden />
+          <span className={isReadOnly ? 'cursor-not-allowed opacity-50' : ''}>Commit</span>
+        </button>
+
+        <CommitRevisionDialog
+          open={commitOpen}
+          onOpenChange={setCommitOpen}
+          projectId={selectedProjectId}
+          currentRevision={currentRevisionRef}
+          lockedBranchId={lockBranchId}
+          onStaleHead={(info) => {
+            if (!selectedProjectId) return;
+            setPushConflictFrom409({
+              projectId: selectedProjectId,
+              message: info.message ?? 'Server has a newer head revision.',
+              currentHeadRevisionId: info.currentHeadRevisionId,
+              currentHead: info.currentHead ?? null,
+            });
+          }}
+          onCreated={async (result) => {
+            const list = await refreshVersionList();
+            await refreshBranchList();
+            if (result.id) {
+              setSelectedVersionId(result.id);
+              setIsReadOnly(result.published ?? false);
+            } else if (list && list[0]) {
+              setSelectedVersionId(list[0].id);
+              setIsReadOnly(list[0].published ?? false);
+            }
+            triggerCanvasRefresh();
+            triggerSidebarRefresh();
+          }}
+        />
+      </>
+    );
+  }
+);
+
+CanvasCommitButton.displayName = 'CanvasCommitButton';

--- a/objectified-ui/src/app/ade/studio/editor/page.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/page.tsx
@@ -222,6 +222,7 @@ import SchemaVersionScoringPanel from '../components/SchemaVersionScoringPanel';
 import { DesignerCanvasGitMenu } from '../components/DesignerCanvasGitMenu';
 import { BranchPickerChip } from '../components/BranchPickerChip';
 import { BranchDivergenceChip } from '../components/BranchDivergenceChip';
+import { CanvasCommitButton, type CanvasCommitButtonHandle } from '../components/CanvasCommitButton';
 import { useStudioBranchSync } from '../lib/use-studio-branch-sync';
 import { useSearchHistory } from '../hooks/useSearchHistory';
 import {
@@ -1665,6 +1666,15 @@ const StudioContent = () => {
         openCanvasSearch();
       }
 
+      // GLI-05 (#2724): commit from canvas when React Flow surface is focused
+      if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+        const el = e.target as HTMLElement | null;
+        if (el?.closest('input, textarea, select, [contenteditable="true"]')) return;
+        if (!el?.closest('.react-flow')) return;
+        e.preventDefault();
+        canvasCommitButtonRef.current?.open();
+      }
+
       // Escape: exit focus mode, then isolate selection, then close search
       if (e.key === 'Escape') {
         if (focusModeEnabled) {
@@ -2772,6 +2782,7 @@ const StudioContent = () => {
   const headerVersionSelectIdRef = useRef(selectedVersionId);
   headerVersionSelectIdRef.current = selectedVersionId;
   const headerVersionsRef = useRef(versions);
+  const canvasCommitButtonRef = useRef<CanvasCommitButtonHandle>(null);
   headerVersionsRef.current = versions;
 
   const handleHeaderProjectSelectChange = useCallback(
@@ -9411,6 +9422,7 @@ const StudioContent = () => {
                 showCreateBranch={false}
               />
               <BranchDivergenceChip variant="toolbar" />
+              <CanvasCommitButton ref={canvasCommitButtonRef} versions={versions} setVersions={setVersions} />
               <DesignerCanvasGitMenu versions={versions} setVersions={setVersions} />
               <div className="relative" ref={layoutDropdownRef}>
                 <input

--- a/objectified-ui/src/app/components/ade/version-dialogs/CommitRevisionDialog.tsx
+++ b/objectified-ui/src/app/components/ade/version-dialogs/CommitRevisionDialog.tsx
@@ -39,11 +39,10 @@ type BumpStrategy = 'patch' | 'minor' | 'major';
  * **valid** studio lock (#2724 GLI-05). Invalid locks fall back to the picker.
  */
 export function commitRevisionDialogShowsBranchPicker(
-  branchCount: number,
   lockedBranchId: string | null | undefined,
   branches: Array<{ id: string }>
 ): boolean {
-  if (branchCount <= 1) return false;
+  if (branches.length <= 1) return false;
   const lock = String(lockedBranchId ?? '').trim();
   if (!lock) return true;
   return !branches.some((b) => b.id === lock);
@@ -198,18 +197,20 @@ export function CommitRevisionDialog({
       setErrorMessage(`External reference must be at most ${COMMIT_EXTERNAL_REF_MAX_CHARS} characters`);
       return;
     }
-    if (branches.length > 1) {
-      const lock = String(lockedBranchId ?? '').trim();
-      if (lock) {
-        const locked = branches.find((b) => b.id === lock);
-        if (!locked) {
-          setErrorMessage('Locked branch is no longer available. Refresh and try again.');
-          return;
-        }
-      } else if (!selectedBranch) {
-        setErrorMessage('Select a branch to commit on.');
+    const lock = String(lockedBranchId ?? '').trim();
+    if (lock) {
+      if (branchesLoading) {
+        setErrorMessage('Branch information is still loading. Please wait and try again.');
         return;
       }
+      const locked = branches.find((b) => b.id === lock);
+      if (!locked) {
+        setErrorMessage('Locked branch is no longer available. Refresh and try again.');
+        return;
+      }
+    } else if (branches.length > 1 && !selectedBranch) {
+      setErrorMessage('Select a branch to commit on.');
+      return;
     }
 
     setSubmitting(true);
@@ -318,7 +319,7 @@ export function CommitRevisionDialog({
             </Alert>
           )}
 
-          {commitRevisionDialogShowsBranchPicker(branches.length, lockedBranchId, branches) && (
+          {commitRevisionDialogShowsBranchPicker(lockedBranchId, branches) && (
             <div className="space-y-1">
               <Label>Branch</Label>
               <Select
@@ -343,7 +344,7 @@ export function CommitRevisionDialog({
           )}
 
           {branches.length > 1 &&
-            !commitRevisionDialogShowsBranchPicker(branches.length, lockedBranchId, branches) &&
+            !commitRevisionDialogShowsBranchPicker(lockedBranchId, branches) &&
             selectedBranch && (
               <div className="rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 text-sm text-gray-800 dark:border-gray-600 dark:bg-gray-900/40 dark:text-gray-200">
                 <span className="font-medium">Branch</span>

--- a/objectified-ui/src/app/components/ade/version-dialogs/CommitRevisionDialog.tsx
+++ b/objectified-ui/src/app/components/ade/version-dialogs/CommitRevisionDialog.tsx
@@ -34,12 +34,31 @@ import type { VersionBranchRow, CreatedRevisionResult, DialogRevisionRef } from 
 
 type BumpStrategy = 'patch' | 'minor' | 'major';
 
+/**
+ * Multi-branch commit UI: show the branch dropdown when there is more than one branch and there is no
+ * **valid** studio lock (#2724 GLI-05). Invalid locks fall back to the picker.
+ */
+export function commitRevisionDialogShowsBranchPicker(
+  branchCount: number,
+  lockedBranchId: string | null | undefined,
+  branches: Array<{ id: string }>
+): boolean {
+  if (branchCount <= 1) return false;
+  const lock = String(lockedBranchId ?? '').trim();
+  if (!lock) return true;
+  return !branches.some((b) => b.id === lock);
+}
+
 export interface CommitRevisionDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   projectId: string;
   /** Current canvas revision (used as fallback base when no named branches exist). */
   currentRevision: DialogRevisionRef | null;
+  /**
+   * When set, commit targets this branch tip and the branch dropdown is hidden (canvas toolbar / #2724).
+   */
+  lockedBranchId?: string | null;
   onCreated?: (result: CreatedRevisionResult) => void;
   /**
    * Fired on 409 STALE_HEAD so the caller can hydrate the shared PushConflictBanner.
@@ -62,6 +81,7 @@ export function CommitRevisionDialog({
   onOpenChange,
   projectId,
   currentRevision,
+  lockedBranchId,
   onCreated,
   onStaleHead,
 }: CommitRevisionDialogProps) {
@@ -102,12 +122,18 @@ export function CommitRevisionDialog({
         const d = (await r.json()) as { success?: boolean; branches?: VersionBranchRow[]; error?: string };
         if (d.success && Array.isArray(d.branches)) {
           setBranches(d.branches);
-          if (d.branches.length === 1) setSelectedBranchId(d.branches[0].id);
-          else if (d.branches.length > 1) {
-            const matching = d.branches.find(
-              (b) => b.tip_version_id && b.tip_version_id === currentRevision?.id
-            );
-            setSelectedBranchId(matching?.id ?? '');
+          const lock = String(lockedBranchId ?? '').trim();
+          if (d.branches.length === 1) {
+            setSelectedBranchId(d.branches[0].id);
+          } else if (d.branches.length > 1) {
+            if (lock && d.branches.some((b) => b.id === lock)) {
+              setSelectedBranchId(lock);
+            } else {
+              const matching = d.branches.find(
+                (b) => b.tip_version_id && b.tip_version_id === currentRevision?.id
+              );
+              setSelectedBranchId(matching?.id ?? '');
+            }
           }
         } else {
           setBranchError(typeof d.error === 'string' ? d.error : 'Could not load branches');
@@ -122,7 +148,7 @@ export function CommitRevisionDialog({
     return () => {
       cancelled = true;
     };
-  }, [open, projectId, currentRevision?.id]);
+  }, [open, projectId, currentRevision?.id, lockedBranchId]);
 
   const selectedBranch = useMemo(
     () => branches.find((b) => b.id === selectedBranchId) ?? null,
@@ -172,9 +198,18 @@ export function CommitRevisionDialog({
       setErrorMessage(`External reference must be at most ${COMMIT_EXTERNAL_REF_MAX_CHARS} characters`);
       return;
     }
-    if (branches.length > 1 && !selectedBranch) {
-      setErrorMessage('Select a branch to commit on.');
-      return;
+    if (branches.length > 1) {
+      const lock = String(lockedBranchId ?? '').trim();
+      if (lock) {
+        const locked = branches.find((b) => b.id === lock);
+        if (!locked) {
+          setErrorMessage('Locked branch is no longer available. Refresh and try again.');
+          return;
+        }
+      } else if (!selectedBranch) {
+        setErrorMessage('Select a branch to commit on.');
+        return;
+      }
     }
 
     setSubmitting(true);
@@ -283,7 +318,7 @@ export function CommitRevisionDialog({
             </Alert>
           )}
 
-          {branches.length > 1 && (
+          {commitRevisionDialogShowsBranchPicker(branches.length, lockedBranchId, branches) && (
             <div className="space-y-1">
               <Label>Branch</Label>
               <Select
@@ -306,6 +341,19 @@ export function CommitRevisionDialog({
               </Select>
             </div>
           )}
+
+          {branches.length > 1 &&
+            !commitRevisionDialogShowsBranchPicker(branches.length, lockedBranchId, branches) &&
+            selectedBranch && (
+              <div className="rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 text-sm text-gray-800 dark:border-gray-600 dark:bg-gray-900/40 dark:text-gray-200">
+                <span className="font-medium">Branch</span>
+                <span className="mx-1.5 text-gray-400 dark:text-gray-500">·</span>
+                <span>{selectedBranch.name}</span>
+                <span className="ml-1 text-xs text-gray-500 dark:text-gray-400">
+                  (tip v{selectedBranch.tip_version_string ?? '?'})
+                </span>
+              </div>
+            )}
 
           <div className="space-y-1">
             <Label htmlFor="canvas-commit-msg">Message *</Label>

--- a/objectified-ui/tests/unit/commit-revision-dialog-branch-picker.test.ts
+++ b/objectified-ui/tests/unit/commit-revision-dialog-branch-picker.test.ts
@@ -1,0 +1,23 @@
+import { commitRevisionDialogShowsBranchPicker } from '@/app/components/ade/version-dialogs/CommitRevisionDialog';
+
+describe('commitRevisionDialogShowsBranchPicker', () => {
+  const branches = [{ id: 'a' }, { id: 'b' }];
+
+  test('hides picker for 0 or 1 branch', () => {
+    expect(commitRevisionDialogShowsBranchPicker(0, null, [])).toBe(false);
+    expect(commitRevisionDialogShowsBranchPicker(1, null, [{ id: 'a' }])).toBe(false);
+  });
+
+  test('shows picker for multi-branch without lock', () => {
+    expect(commitRevisionDialogShowsBranchPicker(2, null, branches)).toBe(true);
+    expect(commitRevisionDialogShowsBranchPicker(2, '  ', branches)).toBe(true);
+  });
+
+  test('hides picker when lock matches a branch', () => {
+    expect(commitRevisionDialogShowsBranchPicker(2, 'a', branches)).toBe(false);
+  });
+
+  test('shows picker when lock does not match any branch', () => {
+    expect(commitRevisionDialogShowsBranchPicker(2, 'missing', branches)).toBe(true);
+  });
+});

--- a/objectified-ui/tests/unit/commit-revision-dialog-branch-picker.test.ts
+++ b/objectified-ui/tests/unit/commit-revision-dialog-branch-picker.test.ts
@@ -1,23 +1,24 @@
+import { describe, test, expect } from '@jest/globals';
 import { commitRevisionDialogShowsBranchPicker } from '@/app/components/ade/version-dialogs/CommitRevisionDialog';
 
 describe('commitRevisionDialogShowsBranchPicker', () => {
   const branches = [{ id: 'a' }, { id: 'b' }];
 
   test('hides picker for 0 or 1 branch', () => {
-    expect(commitRevisionDialogShowsBranchPicker(0, null, [])).toBe(false);
-    expect(commitRevisionDialogShowsBranchPicker(1, null, [{ id: 'a' }])).toBe(false);
+    expect(commitRevisionDialogShowsBranchPicker(null, [])).toBe(false);
+    expect(commitRevisionDialogShowsBranchPicker(null, [{ id: 'a' }])).toBe(false);
   });
 
   test('shows picker for multi-branch without lock', () => {
-    expect(commitRevisionDialogShowsBranchPicker(2, null, branches)).toBe(true);
-    expect(commitRevisionDialogShowsBranchPicker(2, '  ', branches)).toBe(true);
+    expect(commitRevisionDialogShowsBranchPicker(null, branches)).toBe(true);
+    expect(commitRevisionDialogShowsBranchPicker('  ', branches)).toBe(true);
   });
 
   test('hides picker when lock matches a branch', () => {
-    expect(commitRevisionDialogShowsBranchPicker(2, 'a', branches)).toBe(false);
+    expect(commitRevisionDialogShowsBranchPicker('a', branches)).toBe(false);
   });
 
   test('shows picker when lock does not match any branch', () => {
-    expect(commitRevisionDialogShowsBranchPicker(2, 'missing', branches)).toBe(true);
+    expect(commitRevisionDialogShowsBranchPicker('missing', branches)).toBe(true);
   });
 });


### PR DESCRIPTION
## What
- Add `CanvasCommitButton` on the floating canvas toolbar (after divergence chip, before the git menu) with an amber **dirty** dot when `syncLocalDirty` is true.
- Extend `CommitRevisionDialog` with optional `lockedBranchId`: when it matches a loaded branch, the branch **dropdown is hidden** and a read-only branch summary is shown; invalid locks fall back to the picker.
- Wire **⌘/Ctrl+Enter** from the React Flow surface (`.react-flow`, not inputs) to the same open path via `forwardRef` + `useImperativeHandle`.
- Read-only canvas revisions: click shows a toast; button uses `aria-disabled`, native `title`, and muted styling (per spec tooltip text).

## How to test
1. Open the studio editor on a draft revision with named branches; confirm **Commit** appears beside the branch/divergence controls.
2. Click **Commit** — dialog should show the locked branch line (no branch select) when the studio branch id resolves.
3. Toggle unsaved canvas layout if applicable; confirm the amber dot on **Commit** until a successful commit clears dirty state.
4. Focus the canvas (click background), press **⌘/Ctrl+Enter** — same dialog opens (draft only).
5. Checkout a **published** revision; **Commit** should warn on click / shortcut with the read-only message.

## Risk / notes
- Two `CommitRevisionDialog` instances mount (toolbar + git menu); only one is opened at a time.

Closes #2724

Made with [Cursor](https://cursor.com)