### PR TITLE
Fix #2726 - GLI-07 Branch status popover

### DIFF
--- a/docs/PLANNED_FEATURE_ROADMAP_GITLIKE_IMPROVEMENTS.md
+++ b/docs/PLANNED_FEATURE_ROADMAP_GITLIKE_IMPROVEMENTS.md
@@ -77,7 +77,7 @@ on the ones above it to be meaningful in isolation.
 | ~~GLI-04~~ | ~~Ahead / behind-main chip in canvas header~~ ([#2723](https://github.com/KenSuenobu/objectified-commercial/issues/2723)) | **MVP** (completed) | GLI-02, GLI-03 |
 | ~~GLI-05~~ | ~~Prominent "Commit…" action on the canvas toolbar~~ ([#2724](https://github.com/KenSuenobu/objectified-commercial/issues/2724)) | **MVP** (completed) | GLI-03 |
 | ~~GLI-06~~ | ~~"Sync from main" one-click action~~ ([#2725](https://github.com/KenSuenobu/objectified-commercial/issues/2725)) | **MVP** (completed) | GLI-02, GLI-03 |
-| GLI-07 | Branch status popover (`git status` style summary) | MVP (trailing) | GLI-02, GLI-03, GLI-05 |
+| ~~GLI-07~~ | ~~Branch status popover (`git status` style summary)~~ ([#2726](https://github.com/KenSuenobu/objectified-commercial/issues/2726)) | **MVP** (completed) | GLI-02, GLI-03, GLI-05 |
 | GLI-08 | Auto-protect the default branch (require merge path) | **Enterprise** | GLI-01 |
 | GLI-09 | Recent-activity ticker for current branch | **Enterprise** | GLI-03 |
 | GLI-10 | Keyboard palette for git actions (CLI muscle memory) | **Enterprise** | GLI-03, GLI-05, GLI-06 |
@@ -97,7 +97,7 @@ MVP (first major release) = GLI-01 → GLI-07. Enterprise (later releases)
 | 4 | GLI-04 | #2718 | [#2723](https://github.com/KenSuenobu/objectified-commercial/issues/2723) ✅ |
 | 5 | GLI-05 | #2718 | [#2724](https://github.com/KenSuenobu/objectified-commercial/issues/2724) ✅ |
 | 6 | GLI-06 | #2718 | [#2725](https://github.com/KenSuenobu/objectified-commercial/issues/2725) ✅ |
-| 7 | GLI-07 | #2718 | [#2726](https://github.com/KenSuenobu/objectified-commercial/issues/2726) |
+| 7 | GLI-07 | #2718 | [#2726](https://github.com/KenSuenobu/objectified-commercial/issues/2726) ✅ |
 | 8 | GLI-08 | #2719 | [#2727](https://github.com/KenSuenobu/objectified-commercial/issues/2727) |
 | 9 | GLI-09 | #2719 | [#2728](https://github.com/KenSuenobu/objectified-commercial/issues/2728) |
 | 10 | GLI-10 | #2719 | [#2729](https://github.com/KenSuenobu/objectified-commercial/issues/2729) |

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -11,6 +11,7 @@ We continue to improve the platform based on your feedback with improvements and
 - Added an ahead/behind default-branch chip on the canvas (feature branches only): live divergence from the REST API, commit samples in the tooltip, refresh on sidebar sync, and one-click deep link into Compare Version Schemas (merge base → branch tip).
 - Added a prominent **Commit** control on the canvas toolbar (with unsaved-layout dot, ⌘/Ctrl+Enter from the flow surface, read-only guardrails) that opens the existing commit dialog locked to the active branch when named branches exist.
 - Added **Sync from main** under the canvas git menu (feature branches): one-click merge preview with the default branch as source and the active branch as target, disabled with an up-to-date hint when divergence behind is zero; successful merge refreshes the branch list and divergence chip.
+- Added a **branch status** summary on the branch chip: hover (with delay) or click opens a popover with branch identity, divergence vs default, working-copy hints, draft-lock status, recent commits on the branch lineage, and a deep link to the Versions dashboard—composed from existing canvas data without new REST endpoints.
 
 ---
 

--- a/objectified-ui/src/app/ade/studio/components/BranchPickerChip.tsx
+++ b/objectified-ui/src/app/ade/studio/components/BranchPickerChip.tsx
@@ -2,14 +2,18 @@
 
 /**
  * Branch picker (checkout) for the canvas toolbar and git menu (#2722 GLI-03).
+ * Branch status summary popover (#2726 GLI-07).
  */
 
 import * as Popover from '@radix-ui/react-popover';
 import { ChevronDown, GitBranch, Plus } from 'lucide-react';
+import Link from 'next/link';
+import { useSession } from 'next-auth/react';
 import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
   type Dispatch,
   type KeyboardEvent,
@@ -17,10 +21,19 @@ import {
 } from 'react';
 import { toast } from 'sonner';
 import { useStudio } from '../StudioContext';
+import { useDraftLockShared } from '@/app/ade/studio/hooks/useDraftLockShared';
+import { useStudioBranchDivergence } from '@/app/ade/studio/hooks/useStudioBranchDivergence';
+import { formatShortRelativeTime } from '@/app/ade/studio/lib/format-short-relative-time';
+import {
+  branchDivergenceChipToneClasses,
+  getBranchDivergenceChipPresentation,
+} from '@/app/ade/studio/lib/branch-divergence-chip-copy';
+import { collectRecentRevisionsOnLineage, type VersionLineageRow } from '@/app/ade/studio/lib/studio-branch-status-recent';
 import { Spinner } from '@/app/components/ui/Spinner';
 import type { VersionBranchRow } from '@/app/components/ade/version-dialogs/types';
 import type { Version } from '../editor/components/types';
 import { formatVersionSelectorLabel } from '@/app/utils/version-display';
+import { countAuthoredRevisionsTowardHead } from '@/app/utils/studio-sync-indicators';
 import {
   sortBranchesForPicker,
   resolveActiveBranchForRevision,
@@ -35,6 +48,24 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@/app/components/ui/AlertDialog';
+
+const HOVER_OPEN_MS = 250;
+const HOVER_CLOSE_MS = 320;
+
+function shortRev(id: string): string {
+  const t = id.trim();
+  if (t.length <= 10) return t;
+  return `${t.slice(0, 8)}…`;
+}
+
+function formatRemaining(ms: number): string {
+  if (!Number.isFinite(ms) || ms <= 0) return '0s';
+  const totalSec = Math.floor(ms / 1000);
+  const m = Math.floor(totalSec / 60);
+  const s = totalSec % 60;
+  if (m > 0) return `${m}m ${s}s`;
+  return `${s}s`;
+}
 
 export type BranchPickerChipProps = {
   versions: Version[];
@@ -51,6 +82,9 @@ export function BranchPickerChip({
   variant,
   showCreateBranch = true,
 }: BranchPickerChipProps) {
+  const { data: session } = useSession();
+  const sessionUserId = (session?.user as { user_id?: string } | undefined)?.user_id;
+
   const {
     selectedProjectId,
     selectedVersionId,
@@ -67,6 +101,15 @@ export function BranchPickerChip({
     canvasPresentationMode,
   } = useStudio();
 
+  const {
+    displayBranch,
+    defaultBranchName,
+    showDivergence,
+    data: divergenceData,
+    loading: divergenceLoading,
+    error: divergenceError,
+  } = useStudioBranchDivergence();
+
   const [open, setOpen] = useState(false);
   const [loading, setLoading] = useState(false);
   const [list, setList] = useState<VersionBranchRow[]>([]);
@@ -74,9 +117,21 @@ export function BranchPickerChip({
   const [highlight, setHighlight] = useState(0);
   const [pendingCheckout, setPendingCheckout] = useState<VersionBranchRow | null>(null);
 
+  const hoverOpenTimerRef = useRef<number | null>(null);
+  const hoverCloseTimerRef = useRef<number | null>(null);
+  const openedFromHoverRef = useRef(false);
+
   const currentVersion = useMemo(
     () => versions.find((v) => String(v.id) === String(selectedVersionId)),
     [versions, selectedVersionId]
+  );
+
+  const currentVersionPublished = currentVersion?.published ?? true;
+
+  const { payload: draftLock, nowMs: draftLockNowMs } = useDraftLockShared(
+    selectedProjectId,
+    selectedVersionId,
+    currentVersionPublished
   );
 
   const branchesForLabel = useMemo(
@@ -89,7 +144,7 @@ export function BranchPickerChip({
     return resolveActiveBranchForRevision(selectedVersionId, branchesForLabel);
   }, [selectedVersionId, branchesForLabel]);
 
-  const displayBranch: VersionBranchRow | null = useMemo(() => {
+  const displayBranchLocal: VersionBranchRow | null = useMemo(() => {
     if (selectedBranchId && branchesForLabel.length) {
       const byId = branchesForLabel.find((b) => b.id === selectedBranchId);
       if (byId) return byId;
@@ -97,7 +152,60 @@ export function BranchPickerChip({
     return resolvedBranch;
   }, [selectedBranchId, branchesForLabel, resolvedBranch]);
 
+  const effectiveBranch = displayBranch ?? displayBranchLocal;
+
   const sortedBranches = useMemo(() => sortBranchesForPicker(list), [list]);
+
+  const syncVersionRows = useMemo(
+    () =>
+      versions.map((v) => {
+        const row = v as VersionLineageRow;
+        return {
+          id: v.id,
+          parent_version_id: row.parent_version_id ?? null,
+          creator_id: row.creator_id ?? null,
+        };
+      }),
+    [versions]
+  );
+
+  const authoredTowardHead = useMemo(
+    () => countAuthoredRevisionsTowardHead(syncVersionRows, selectedVersionId ?? '', sessionUserId),
+    [syncVersionRows, selectedVersionId, sessionUserId]
+  );
+
+  const tipVersionRow = useMemo(() => {
+    const tipId = effectiveBranch?.tip_version_id;
+    if (!tipId) return null;
+    return versions.find((v) => String(v.id) === String(tipId)) as VersionLineageRow | undefined;
+  }, [effectiveBranch?.tip_version_id, versions]);
+
+  const recentOnBranch = useMemo(() => {
+    const tipId = effectiveBranch?.tip_version_id?.trim();
+    if (!tipId) return [];
+    return collectRecentRevisionsOnLineage(
+      versions as VersionLineageRow[],
+      tipId,
+      5
+    );
+  }, [effectiveBranch?.tip_version_id, versions]);
+
+  const divergencePresentation = useMemo(() => {
+    if (!showDivergence) {
+      return { label: 'On default branch — no divergence vs default.', tone: 'muted' as const };
+    }
+    if (divergenceError) return { label: 'Divergence unavailable', tone: 'muted' as const };
+    if (!divergenceData) {
+      return { label: divergenceLoading ? 'Loading…' : '—', tone: 'muted' as const };
+    }
+    return getBranchDivergenceChipPresentation(
+      divergenceData.ahead ?? 0,
+      divergenceData.behind ?? 0,
+      defaultBranchName?.trim() || 'default'
+    );
+  }, [showDivergence, divergenceError, divergenceData, divergenceLoading, defaultBranchName]);
+
+  const divergenceToneClass = branchDivergenceChipToneClasses(divergencePresentation.tone);
 
   const refreshVersions = useCallback(async (): Promise<Version[] | null> => {
     if (!selectedProjectId) return null;
@@ -155,6 +263,34 @@ export function BranchPickerChip({
     const max = Math.max(0, sortedBranches.length - 1);
     setHighlight((h) => Math.min(h, max));
   }, [open, sortedBranches.length]);
+
+  useEffect(() => {
+    return () => {
+      if (hoverOpenTimerRef.current) clearTimeout(hoverOpenTimerRef.current);
+      if (hoverCloseTimerRef.current) clearTimeout(hoverCloseTimerRef.current);
+    };
+  }, []);
+
+  const clearHoverOpenTimer = () => {
+    if (hoverOpenTimerRef.current) {
+      clearTimeout(hoverOpenTimerRef.current);
+      hoverOpenTimerRef.current = null;
+    }
+  };
+
+  const clearHoverCloseTimer = () => {
+    if (hoverCloseTimerRef.current) {
+      clearTimeout(hoverCloseTimerRef.current);
+      hoverCloseTimerRef.current = null;
+    }
+  };
+
+  const scheduleClose = () => {
+    clearHoverCloseTimer();
+    hoverCloseTimerRef.current = window.setTimeout(() => {
+      setOpen(false);
+    }, HOVER_CLOSE_MS);
+  };
 
   const performCheckout = useCallback(
     async (branch: VersionBranchRow) => {
@@ -249,10 +385,10 @@ export function BranchPickerChip({
     return null;
   }
 
-  const chipLabel = displayBranch?.name ?? '—';
+  const chipLabel = effectiveBranch?.name ?? '—';
   const tooltipBits: string[] = [];
-  if (displayBranch?.tip_version_id) {
-    tooltipBits.push(`Tip revision: ${displayBranch.tip_version_id}`);
+  if (effectiveBranch?.tip_version_id) {
+    tooltipBits.push(`Tip revision: ${effectiveBranch.tip_version_id}`);
   }
   if (currentVersion) {
     tooltipBits.push(`Canvas: ${formatVersionSelectorLabel(currentVersion)}`);
@@ -264,15 +400,70 @@ export function BranchPickerChip({
       ? `inline-flex max-w-[min(14rem,46vw)] items-center gap-1.5 rounded-lg border border-gray-200/55 bg-white/45 px-2.5 py-2 text-sm font-medium text-gray-800 shadow-md backdrop-blur-md transition-all hover:border-indigo-300/60 hover:bg-white/65 hover:shadow-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500/30 dark:border-gray-600/45 dark:bg-gray-900/40 dark:text-gray-200 dark:hover:border-indigo-500/45 dark:hover:bg-gray-900/55`
       : `flex w-full max-w-full items-center justify-between gap-2 rounded-lg border border-gray-200/80 bg-white/60 px-2.5 py-2 text-left text-sm font-medium text-gray-900 shadow-sm backdrop-blur-sm transition-all hover:border-indigo-300/50 hover:bg-white/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500/30 dark:border-gray-600/60 dark:bg-gray-900/50 dark:text-gray-100 dark:hover:border-indigo-500/40`;
 
+  const tipAuthor =
+    tipVersionRow?.creator_id?.trim() ?
+      tipVersionRow.creator_id === sessionUserId ?
+        'You'
+      : `${tipVersionRow.creator_id.slice(0, 8)}…`
+    : '—';
+
+  const lockLine = (() => {
+    if (currentVersionPublished) return 'Published revision — no draft lock.';
+    if (!draftLock?.active) return 'No active draft lock.';
+    const exp = draftLock.expiresAt;
+    const owner = draftLock.ownerUserId;
+    if (!exp || !owner) return 'Lock active.';
+    const rem = formatRemaining(new Date(exp).getTime() - draftLockNowMs);
+    const who = owner === sessionUserId ? 'You' : `${owner.slice(0, 8)}…`;
+    return `Held by ${who} · expires in ${rem}`;
+  })();
+
+  const dashboardHref =
+    selectedProjectId ?
+      `/ade/dashboard/versions?projectId=${encodeURIComponent(selectedProjectId)}`
+    : '/ade/dashboard/versions';
+
   return (
     <>
-      <Popover.Root open={open} onOpenChange={setOpen}>
+      <Popover.Root
+        open={open}
+        onOpenChange={(o) => {
+          setOpen(o);
+          if (!o) {
+            openedFromHoverRef.current = false;
+            clearHoverOpenTimer();
+            clearHoverCloseTimer();
+          }
+        }}
+        modal={false}
+      >
         <Popover.Trigger asChild>
           <button
             type="button"
             className={triggerClass}
             title={title}
-            aria-label={`Current branch: ${chipLabel}. Open branch picker.`}
+            aria-label={`Current branch: ${chipLabel}. Open branch status and branch picker.`}
+            aria-expanded={open}
+            onPointerEnter={() => {
+              clearHoverCloseTimer();
+              clearHoverOpenTimer();
+              hoverOpenTimerRef.current = window.setTimeout(() => {
+                openedFromHoverRef.current = true;
+                setOpen(true);
+              }, HOVER_OPEN_MS);
+            }}
+            onPointerLeave={() => {
+              clearHoverOpenTimer();
+              scheduleClose();
+            }}
+            onPointerDown={() => {
+              openedFromHoverRef.current = false;
+            }}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                openedFromHoverRef.current = false;
+              }
+            }}
           >
             <GitBranch className="h-4 w-4 shrink-0 text-indigo-600 dark:text-indigo-400" aria-hidden />
             <span className="min-w-0 flex-1 truncate">
@@ -286,70 +477,215 @@ export function BranchPickerChip({
         </Popover.Trigger>
         <Popover.Portal>
           <Popover.Content
-            className="z-[10060] w-[min(20rem,calc(100vw-2rem))] rounded-xl border border-gray-200 bg-white p-1 shadow-lg dark:border-gray-600 dark:bg-gray-800"
+            className="z-[10060] w-[min(22.5rem,calc(100vw-2rem))] max-h-[min(70vh,36rem)] overflow-y-auto rounded-xl border border-gray-200 bg-white shadow-lg dark:border-gray-600 dark:bg-gray-800"
             sideOffset={6}
             align={variant === 'toolbar' ? 'end' : 'start'}
             onKeyDown={onKeyDown}
+            onOpenAutoFocus={(e) => {
+              if (openedFromHoverRef.current) {
+                e.preventDefault();
+                openedFromHoverRef.current = false;
+              }
+            }}
+            onPointerEnter={() => {
+              clearHoverCloseTimer();
+              clearHoverOpenTimer();
+            }}
+            onPointerLeave={() => {
+              scheduleClose();
+            }}
           >
-            {loading && (
-              <div className="flex items-center gap-2 px-3 py-4 text-sm text-gray-600 dark:text-gray-300">
-                <Spinner size="sm" className="shrink-0" />
-                Loading branches…
-              </div>
-            )}
-            {!loading && fetchError && (
-              <div className="px-3 py-3 text-sm text-red-600 dark:text-red-400">{fetchError}</div>
-            )}
-            {!loading && !fetchError && sortedBranches.length === 0 && (
-              <div className="px-3 py-3 text-sm text-gray-600 dark:text-gray-400">No named branches yet.</div>
-            )}
-            {!loading &&
-              !fetchError &&
-              sortedBranches.map((b, i) => {
-                const active = String(b.tip_version_id) === String(selectedVersionId);
-                const isSel = selectedBranchId === b.id;
-                const isHi = i === highlight;
-                return (
-                  <button
-                    key={b.id}
-                    type="button"
-                    className={`flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-sm ${
-                      isHi ? 'bg-indigo-50 dark:bg-indigo-950/50' : 'hover:bg-gray-50 dark:hover:bg-gray-700/50'
-                    } ${active ? 'font-semibold text-indigo-800 dark:text-indigo-200' : 'text-gray-800 dark:text-gray-200'}`}
-                    onClick={() => requestCheckout(b)}
-                    onMouseEnter={() => setHighlight(i)}
-                  >
-                    <span className="min-w-0 flex-1 truncate">
-                      {active ? '✓ ' : ''}
-                      {b.name}
-                    </span>
-                    {b.is_default && (
-                      <span className="shrink-0 rounded bg-slate-100 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-slate-700 dark:bg-slate-700 dark:text-slate-200">
+            <div className="border-b border-gray-100 px-3 py-3 dark:border-gray-700">
+              <h2 className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                Branch status
+              </h2>
+
+              <div className="mt-3 space-y-3 text-sm text-gray-800 dark:text-gray-200">
+                <div>
+                  <div className="text-[10px] font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                    Branch
+                  </div>
+                  <div className="mt-1 flex flex-wrap items-center gap-2">
+                    <span className="font-medium text-gray-900 dark:text-gray-100">{effectiveBranch?.name ?? '—'}</span>
+                    {effectiveBranch?.is_default ?
+                      <span className="rounded bg-slate-100 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-slate-700 dark:bg-slate-700 dark:text-slate-200">
                         default
                       </span>
-                    )}
-                    {isSel && (
-                      <span className="shrink-0 text-[10px] text-gray-500 dark:text-gray-400">current</span>
-                    )}
-                  </button>
-                );
-              })}
-            {showCreateBranch && !loading && (
-              <>
-                <div className="my-1 h-px bg-gray-100 dark:bg-gray-700" />
-                <button
-                  type="button"
-                  className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-sm text-gray-800 hover:bg-gray-50 dark:text-gray-200 dark:hover:bg-gray-700/50"
-                  onClick={() => {
-                    setOpen(false);
-                    openBranchFromRevisionDialog();
-                  }}
+                    : null}
+                  </div>
+                  <div className="mt-1 text-xs text-gray-600 dark:text-gray-400">
+                    Tip{' '}
+                    <span className="font-mono text-[11px]">
+                      {effectiveBranch?.tip_version_id ? shortRev(String(effectiveBranch.tip_version_id)) : '—'}
+                    </span>
+                    {tipVersionRow?.created_at ?
+                      <>
+                        {' '}
+                        · {tipAuthor} · {formatShortRelativeTime(tipVersionRow.created_at)}
+                      </>
+                    : null}
+                  </div>
+                </div>
+
+                <div>
+                  <div className="text-[10px] font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                    Divergence{defaultBranchName ? ` vs ${defaultBranchName}` : ''}
+                  </div>
+                  <p className={`mt-1 text-sm ${divergenceToneClass}`}>{divergencePresentation.label}</p>
+                  {showDivergence && divergenceData?.mergeBase?.revisionId?.trim() ?
+                    <p className="mt-1 text-xs text-gray-600 dark:text-gray-400">
+                      Merge base{' '}
+                      <span className="font-mono text-[11px]">
+                        {shortRev(divergenceData.mergeBase.revisionId.trim())}
+                      </span>
+                    </p>
+                  : null}
+                  {showDivergence && divergenceData && (divergenceData.aheadSample?.length || divergenceData.behindSample?.length) ?
+                    <ul className="mt-2 space-y-1 text-xs text-gray-600 dark:text-gray-400">
+                      {(divergenceData.aheadSample ?? []).slice(0, 3).map((row, i) => (
+                        <li key={row.revisionId ?? `a-${i}`}>
+                          ↑ {row.shortMessage?.trim() || '(no message)'}
+                          {row.revisionId ?
+                            <span className="ml-1 font-mono text-[10px] opacity-80">
+                              ({shortRev(row.revisionId)})
+                            </span>
+                          : null}
+                        </li>
+                      ))}
+                      {(divergenceData.behindSample ?? []).slice(0, 3).map((row, i) => (
+                        <li key={row.revisionId ?? `b-${i}`}>
+                          ↓ {row.shortMessage?.trim() || '(no message)'}
+                          {row.revisionId ?
+                            <span className="ml-1 font-mono text-[10px] opacity-80">
+                              ({shortRev(row.revisionId)})
+                            </span>
+                          : null}
+                        </li>
+                      ))}
+                    </ul>
+                  : null}
+                </div>
+
+                <div>
+                  <div className="text-[10px] font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                    Working copy
+                  </div>
+                  <ul className="mt-1 space-y-1 text-xs text-gray-700 dark:text-gray-300">
+                    <li>Dirty layout: {syncLocalDirty ? 'Yes' : 'No'}</li>
+                    <li>
+                      Uncommitted schema edits (lineage){' '}
+                      {authoredTowardHead > 0 ? `Yes — ${authoredTowardHead} toward head` : 'No'}
+                    </li>
+                  </ul>
+                </div>
+
+                <div>
+                  <div className="text-[10px] font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                    Locks
+                  </div>
+                  <p className="mt-1 text-xs text-gray-700 dark:text-gray-300">{lockLine}</p>
+                </div>
+
+                <div>
+                  <div className="text-[10px] font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                    Recent commits
+                  </div>
+                  {recentOnBranch.length === 0 ?
+                    <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">No revision history in session.</p>
+                  : <ul className="mt-1 space-y-1.5 text-xs text-gray-700 dark:text-gray-300">
+                      {recentOnBranch.map((row) => (
+                        <li key={row.id} className="flex flex-wrap gap-x-2 gap-y-0.5">
+                          <span className="font-mono text-[11px] text-gray-600 dark:text-gray-400">
+                            {shortRev(row.id)}
+                          </span>
+                          <span className="min-w-0 flex-1">
+                            {(row.shortMessage ?? row.description ?? '').trim() || '(no message)'}
+                          </span>
+                          <span className="shrink-0 text-gray-500 dark:text-gray-400">
+                            {row.created_at ? formatShortRelativeTime(row.created_at) : '—'}
+                          </span>
+                        </li>
+                      ))}
+                    </ul>
+                  }
+                </div>
+              </div>
+
+              <div className="mt-3 border-t border-gray-100 pt-3 dark:border-gray-700">
+                <Link
+                  href={dashboardHref}
+                  className="inline-flex w-full items-center justify-center gap-1 rounded-lg border border-indigo-200 bg-indigo-50 px-2 py-2 text-xs font-medium text-indigo-900 transition hover:bg-indigo-100 dark:border-indigo-500/40 dark:bg-indigo-950/40 dark:text-indigo-100 dark:hover:bg-indigo-900/50"
+                  onClick={() => setOpen(false)}
                 >
-                  <Plus className="h-4 w-4 shrink-0 opacity-80" aria-hidden />
-                  Create new branch…
-                </button>
-              </>
-            )}
+                  Open Versions dashboard
+                  <span aria-hidden className="text-indigo-700 dark:text-indigo-200">
+                    ▸
+                  </span>
+                </Link>
+              </div>
+            </div>
+
+            <div className="p-1">
+              {loading && (
+                <div className="flex items-center gap-2 px-3 py-4 text-sm text-gray-600 dark:text-gray-300">
+                  <Spinner size="sm" className="shrink-0" />
+                  Loading branches…
+                </div>
+              )}
+              {!loading && fetchError && (
+                <div className="px-3 py-3 text-sm text-red-600 dark:text-red-400">{fetchError}</div>
+              )}
+              {!loading && !fetchError && sortedBranches.length === 0 && (
+                <div className="px-3 py-3 text-sm text-gray-600 dark:text-gray-400">No named branches yet.</div>
+              )}
+              {!loading &&
+                !fetchError &&
+                sortedBranches.map((b, i) => {
+                  const active = String(b.tip_version_id) === String(selectedVersionId);
+                  const isSel = selectedBranchId === b.id;
+                  const isHi = i === highlight;
+                  return (
+                    <button
+                      key={b.id}
+                      type="button"
+                      className={`flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-sm ${
+                        isHi ? 'bg-indigo-50 dark:bg-indigo-950/50' : 'hover:bg-gray-50 dark:hover:bg-gray-700/50'
+                      } ${active ? 'font-semibold text-indigo-800 dark:text-indigo-200' : 'text-gray-800 dark:text-gray-200'}`}
+                      onClick={() => requestCheckout(b)}
+                      onMouseEnter={() => setHighlight(i)}
+                    >
+                      <span className="min-w-0 flex-1 truncate">
+                        {active ? '✓ ' : ''}
+                        {b.name}
+                      </span>
+                      {b.is_default && (
+                        <span className="shrink-0 rounded bg-slate-100 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-slate-700 dark:bg-slate-700 dark:text-slate-200">
+                          default
+                        </span>
+                      )}
+                      {isSel && (
+                        <span className="shrink-0 text-[10px] text-gray-500 dark:text-gray-400">current</span>
+                      )}
+                    </button>
+                  );
+                })}
+              {showCreateBranch && !loading && (
+                <>
+                  <div className="my-1 h-px bg-gray-100 dark:bg-gray-700" />
+                  <button
+                    type="button"
+                    className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-sm text-gray-800 hover:bg-gray-50 dark:text-gray-200 dark:hover:bg-gray-700/50"
+                    onClick={() => {
+                      setOpen(false);
+                      openBranchFromRevisionDialog();
+                    }}
+                  >
+                    <Plus className="h-4 w-4 shrink-0 opacity-80" aria-hidden />
+                    Create new branch…
+                  </button>
+                </>
+              )}
+            </div>
           </Popover.Content>
         </Popover.Portal>
       </Popover.Root>

--- a/objectified-ui/src/app/ade/studio/components/BranchPickerChip.tsx
+++ b/objectified-ui/src/app/ade/studio/components/BranchPickerChip.tsx
@@ -454,7 +454,9 @@ export function BranchPickerChip({
             }}
             onPointerLeave={() => {
               clearHoverOpenTimer();
-              scheduleClose();
+              if (openedFromHoverRef.current) {
+                scheduleClose();
+              }
             }}
             onPointerDown={() => {
               openedFromHoverRef.current = false;
@@ -492,7 +494,9 @@ export function BranchPickerChip({
               clearHoverOpenTimer();
             }}
             onPointerLeave={() => {
-              scheduleClose();
+              if (openedFromHoverRef.current) {
+                scheduleClose();
+              }
             }}
           >
             <div className="border-b border-gray-100 px-3 py-3 dark:border-gray-700">

--- a/objectified-ui/src/app/ade/studio/components/DraftLockHeaderChip.tsx
+++ b/objectified-ui/src/app/ade/studio/components/DraftLockHeaderChip.tsx
@@ -4,15 +4,9 @@ import * as React from 'react';
 import * as Tooltip from '@radix-ui/react-tooltip';
 import { Lock } from 'lucide-react';
 import { cn } from '@lib/utils';
+import { useDraftLockShared } from '@/app/ade/studio/hooks/useDraftLockShared';
 
-const POLL_INTERVAL_MS = 10_000;
-const TICK_MS = 1_000;
-
-export type DraftLockStatusPayload = {
-  active: boolean;
-  ownerUserId?: string;
-  expiresAt?: string;
-};
+export type { DraftLockStatusPayload } from '@/app/ade/studio/lib/studio-draft-lock-shared';
 
 function formatRemaining(ms: number): string {
   if (!Number.isFinite(ms) || ms <= 0) return '0s';
@@ -46,53 +40,7 @@ export function DraftLockHeaderChip({
   sessionUserId,
   className,
 }: DraftLockHeaderChipProps) {
-  const [remote, setRemote] = React.useState<DraftLockStatusPayload | null>(null);
-  const [nowMs, setNowMs] = React.useState(() => Date.now());
-
-  const fetchStatus = React.useCallback(async () => {
-    try {
-      const qs = new URLSearchParams({ projectId });
-      const res = await fetch(`/api/versions/${encodeURIComponent(versionId)}/draft-lock?${qs.toString()}`);
-      const json = (await res.json()) as {
-        success?: boolean;
-        status?: { active?: boolean; ownerUserId?: string; expiresAt?: string };
-        error?: string;
-      };
-      if (!res.ok || !json.success || !json.status) {
-        setRemote(null);
-        return;
-      }
-      const st = json.status;
-      setRemote({
-        active: Boolean(st.active),
-        ownerUserId: typeof st.ownerUserId === 'string' ? st.ownerUserId : undefined,
-        expiresAt: typeof st.expiresAt === 'string' ? st.expiresAt : undefined,
-      });
-    } catch {
-      setRemote(null);
-    }
-  }, [projectId, versionId]);
-
-  React.useEffect(() => {
-    if (published || !projectId || !versionId) {
-      setRemote(null);
-      return;
-    }
-    void fetchStatus();
-    const id = window.setInterval(() => {
-      void fetchStatus();
-    }, POLL_INTERVAL_MS);
-    return () => window.clearInterval(id);
-  }, [published, projectId, versionId, fetchStatus]);
-
-  React.useEffect(() => {
-    if (!remote?.active || !remote.expiresAt) return;
-    setNowMs(Date.now());
-    const id = window.setInterval(() => {
-      setNowMs(Date.now());
-    }, TICK_MS);
-    return () => window.clearInterval(id);
-  }, [remote?.active, remote?.expiresAt]);
+  const { payload: remote, nowMs } = useDraftLockShared(projectId, versionId, published);
 
   if (published || !remote?.active || !remote?.ownerUserId || !remote?.expiresAt) {
     return null;

--- a/objectified-ui/src/app/ade/studio/hooks/useDraftLockShared.ts
+++ b/objectified-ui/src/app/ade/studio/hooks/useDraftLockShared.ts
@@ -1,0 +1,26 @@
+'use client';
+
+import { useEffect, useSyncExternalStore } from 'react';
+import {
+  acquireDraftLockShared,
+  getDraftLockSharedSnapshot,
+  releaseDraftLockShared,
+  subscribeDraftLockShared,
+  type DraftLockSharedSnapshot,
+} from '@/app/ade/studio/lib/studio-draft-lock-shared';
+
+export function useDraftLockShared(
+  projectId: string | null | undefined,
+  versionId: string | null | undefined,
+  published: boolean
+): DraftLockSharedSnapshot {
+  const snap = useSyncExternalStore(subscribeDraftLockShared, getDraftLockSharedSnapshot, getDraftLockSharedSnapshot);
+
+  useEffect(() => {
+    if (!projectId || !versionId || published) return;
+    acquireDraftLockShared(projectId, versionId, false);
+    return () => releaseDraftLockShared(projectId, versionId, false);
+  }, [projectId, versionId, published]);
+
+  return snap;
+}

--- a/objectified-ui/src/app/ade/studio/hooks/useStudioBranchDivergence.ts
+++ b/objectified-ui/src/app/ade/studio/hooks/useStudioBranchDivergence.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useSyncExternalStore } from 'react';
 import { useStudio } from '../StudioContext';
 import { resolveActiveBranchForRevision } from '@/app/ade/studio/lib/studio-branch-resolve';
 import type { VersionBranchRow } from '@/app/components/ade/version-dialogs/types';
@@ -15,9 +15,48 @@ export type BranchDivergencePayload = {
   behindSample?: Array<{ revisionId?: string; shortMessage?: string | null }>;
 };
 
+type DivergenceEntry = {
+  data: BranchDivergencePayload | null;
+  error: string | null;
+  loading: boolean;
+  etag: string | null;
+};
+
+const EMPTY_DIVERGENCE: DivergenceEntry = {
+  data: null,
+  error: null,
+  loading: false,
+  etag: null,
+};
+
+const divergenceByKey = new Map<string, DivergenceEntry>();
+const divergenceListeners = new Set<() => void>();
+
+function divergenceNotify() {
+  divergenceListeners.forEach((l) => l());
+}
+
+function divergenceGet(key: string): DivergenceEntry {
+  if (!key) return EMPTY_DIVERGENCE;
+  return divergenceByKey.get(key) ?? EMPTY_DIVERGENCE;
+}
+
+function divergenceSet(key: string, patch: Partial<DivergenceEntry>) {
+  const prev = divergenceGet(key);
+  divergenceByKey.set(key, { ...prev, ...patch });
+  divergenceNotify();
+}
+
+function subscribeDivergence(cb: () => void) {
+  divergenceListeners.add(cb);
+  return () => divergenceListeners.delete(cb);
+}
+
+const divergenceInflight = new Map<string, Promise<void>>();
+
 /**
  * Fetches default-branch vs active-branch divergence for the current canvas revision (#2723 GLI-04).
- * Used by `BranchDivergenceChip` and `DesignerCanvasGitMenu` sync-from-default (#2725 GLI-06).
+ * Shared across subscribers (#2726) so toolbar + git menu do not duplicate GET …/divergence.
  */
 export function useStudioBranchDivergence() {
   const {
@@ -28,11 +67,6 @@ export function useStudioBranchDivergence() {
     canvasPresentationMode,
     versionBranchesByProjectId,
   } = useStudio();
-
-  const [data, setData] = useState<BranchDivergencePayload | null>(null);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const etagRef = useRef<string | null>(null);
 
   const branchesForLabel = useMemo(
     () => (selectedProjectId ? (versionBranchesByProjectId[selectedProjectId] ?? []) : []),
@@ -62,29 +96,38 @@ export function useStudioBranchDivergence() {
 
   const branchIdForFetch = displayBranch?.id ?? '';
 
-  useEffect(() => {
-    etagRef.current = null;
-    setData(null);
-    setError(null);
-  }, [branchIdForFetch, selectedProjectId]);
+  const fetchKey = useMemo(() => {
+    if (!showDivergence || !selectedProjectId || !branchIdForFetch) return '';
+    return `${selectedProjectId}:${branchIdForFetch}:${sidebarRefreshKey}`;
+  }, [showDivergence, selectedProjectId, branchIdForFetch, sidebarRefreshKey]);
+
+  const snapshot = useSyncExternalStore(
+    subscribeDivergence,
+    () => divergenceGet(fetchKey),
+    () => divergenceGet(fetchKey)
+  );
 
   useEffect(() => {
-    if (!showDivergence || !selectedProjectId || !branchIdForFetch) return;
+    if (!fetchKey || !selectedProjectId || !branchIdForFetch) return;
 
-    const ac = new AbortController();
+    if (divergenceInflight.has(fetchKey)) {
+      return;
+    }
 
-    (async () => {
-      setLoading(true);
-      setError(null);
+    const run = (async () => {
+      const prevEntry = divergenceGet(fetchKey);
+      divergenceSet(fetchKey, { loading: true, error: null });
+
       try {
         const url = `/api/projects/${encodeURIComponent(selectedProjectId)}/version-branches/${encodeURIComponent(branchIdForFetch)}/divergence`;
         const headers: Record<string, string> = {};
-        if (etagRef.current) {
-          headers['If-None-Match'] = etagRef.current;
+        if (prevEntry.etag) {
+          headers['If-None-Match'] = prevEntry.etag;
         }
-        const r = await fetch(url, { signal: ac.signal, headers });
+        const r = await fetch(url, { headers });
         const etag = r.headers.get('etag');
         if (r.status === 304) {
+          divergenceSet(fetchKey, { loading: false });
           return;
         }
         if (!r.ok) {
@@ -95,43 +138,41 @@ export function useStudioBranchDivergence() {
               : typeof j?.detail === 'object' && j.detail !== null && 'message' in j.detail
                 ? String((j.detail as { message?: string }).message ?? 'Request failed')
                 : 'Could not load branch divergence';
-          setError(msg);
-          setData(null);
+          divergenceSet(fetchKey, { error: msg, data: null, loading: false });
           return;
         }
-        if (etag) {
-          etagRef.current = etag;
-        }
         const json = (await r.json()) as BranchDivergencePayload;
-        setData(json);
-      } catch (e) {
-        if ((e as Error)?.name === 'AbortError') return;
-        setError('Could not load branch divergence');
-        setData(null);
-      } finally {
-        if (!ac.signal.aborted) {
-          setLoading(false);
-        }
+        divergenceSet(fetchKey, {
+          data: json,
+          error: null,
+          loading: false,
+          etag: etag ?? prevEntry.etag,
+        });
+      } catch {
+        divergenceSet(fetchKey, { error: 'Could not load branch divergence', data: null, loading: false });
       }
     })();
 
-    return () => ac.abort();
-  }, [showDivergence, selectedProjectId, branchIdForFetch, sidebarRefreshKey]);
+    divergenceInflight.set(fetchKey, run);
+    void run.finally(() => {
+      divergenceInflight.delete(fetchKey);
+    });
+  }, [fetchKey, selectedProjectId, branchIdForFetch]);
 
   const defaultBranchName = useMemo(() => {
     const fromBranches = branchesForLabel.find((b) => b.is_default)?.name?.trim() ?? '';
     if (fromBranches) return fromBranches;
-    return data?.against?.name?.trim() ?? '';
-  }, [branchesForLabel, data?.against?.name]);
+    return snapshot.data?.against?.name?.trim() ?? '';
+  }, [branchesForLabel, snapshot.data?.against?.name]);
 
   const activeBranchName = displayBranch?.name?.trim() ?? '';
 
   return {
     selectedProjectId,
     showDivergence,
-    data,
-    loading,
-    error,
+    data: snapshot.data,
+    loading: snapshot.loading,
+    error: snapshot.error,
     displayBranch,
     branchesForLabel,
     defaultBranchName,

--- a/objectified-ui/src/app/ade/studio/hooks/useStudioBranchDivergence.ts
+++ b/objectified-ui/src/app/ade/studio/hooks/useStudioBranchDivergence.ts
@@ -98,8 +98,8 @@ export function useStudioBranchDivergence() {
 
   const fetchKey = useMemo(() => {
     if (!showDivergence || !selectedProjectId || !branchIdForFetch) return '';
-    return `${selectedProjectId}:${branchIdForFetch}:${sidebarRefreshKey}`;
-  }, [showDivergence, selectedProjectId, branchIdForFetch, sidebarRefreshKey]);
+    return `${selectedProjectId}:${branchIdForFetch}`;
+  }, [showDivergence, selectedProjectId, branchIdForFetch]);
 
   const snapshot = useSyncExternalStore(
     subscribeDivergence,
@@ -146,7 +146,7 @@ export function useStudioBranchDivergence() {
           data: json,
           error: null,
           loading: false,
-          etag: etag ?? prevEntry.etag,
+          etag: etag ?? null,
         });
       } catch {
         divergenceSet(fetchKey, { error: 'Could not load branch divergence', data: null, loading: false });
@@ -157,7 +157,7 @@ export function useStudioBranchDivergence() {
     void run.finally(() => {
       divergenceInflight.delete(fetchKey);
     });
-  }, [fetchKey, selectedProjectId, branchIdForFetch]);
+  }, [fetchKey, selectedProjectId, branchIdForFetch, sidebarRefreshKey]);
 
   const defaultBranchName = useMemo(() => {
     const fromBranches = branchesForLabel.find((b) => b.is_default)?.name?.trim() ?? '';

--- a/objectified-ui/src/app/ade/studio/lib/format-short-relative-time.ts
+++ b/objectified-ui/src/app/ade/studio/lib/format-short-relative-time.ts
@@ -1,0 +1,21 @@
+/**
+ * Compact relative time for branch status popover (#2726).
+ */
+
+export function formatShortRelativeTime(iso?: string | null): string {
+  if (!iso?.trim()) return '—';
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '—';
+  const rtf = new Intl.RelativeTimeFormat('en', { numeric: 'auto' });
+  const diffSec = Math.round((d.getTime() - Date.now()) / 1000);
+  const absSec = Math.abs(diffSec);
+  if (absSec < 60) return rtf.format(diffSec, 'second');
+  const diffMin = Math.round(diffSec / 60);
+  const absMin = Math.abs(diffMin);
+  if (absMin < 60) return rtf.format(diffMin, 'minute');
+  const diffHr = Math.round(diffSec / 3600);
+  const absHr = Math.abs(diffHr);
+  if (absHr < 24) return rtf.format(diffHr, 'hour');
+  const diffDay = Math.round(diffSec / 86400);
+  return rtf.format(diffDay, 'day');
+}

--- a/objectified-ui/src/app/ade/studio/lib/studio-branch-status-recent.ts
+++ b/objectified-ui/src/app/ade/studio/lib/studio-branch-status-recent.ts
@@ -1,0 +1,30 @@
+/**
+ * Last N revisions on the main parent chain from a tip revision (#2726 GLI-07).
+ * Uses `parent_version_id` only (merge parents ignored for this summary list).
+ */
+
+export type VersionLineageRow = {
+  id: string;
+  parent_version_id?: string | null;
+  shortMessage?: string | null;
+  description?: string | null;
+  created_at?: string;
+  creator_id?: string | null;
+};
+
+export function collectRecentRevisionsOnLineage(
+  versions: VersionLineageRow[],
+  tipId: string,
+  limit: number
+): VersionLineageRow[] {
+  if (!tipId.trim() || limit <= 0) return [];
+  const byId = new Map(versions.map((v) => [v.id, v]));
+  const out: VersionLineageRow[] = [];
+  let cur: VersionLineageRow | undefined = byId.get(tipId);
+  for (let i = 0; i < limit && cur; i++) {
+    out.push(cur);
+    const pid = cur.parent_version_id?.trim();
+    cur = pid ? byId.get(pid) : undefined;
+  }
+  return out;
+}

--- a/objectified-ui/src/app/ade/studio/lib/studio-draft-lock-shared.ts
+++ b/objectified-ui/src/app/ade/studio/lib/studio-draft-lock-shared.ts
@@ -88,9 +88,14 @@ async function fetchOnce(projectId: string, versionId: string) {
 function ensurePolling(projectId: string, versionId: string) {
   const key = `${projectId}:${versionId}`;
   if (activeKey === key && pollTimer !== null) return;
+  const keyChanged = activeKey !== key;
   stopTimers();
   activeKey = key;
   nowMs = Date.now();
+  if (keyChanged) {
+    payload = null;
+    emit();
+  }
   void fetchOnce(projectId, versionId);
   pollTimer = window.setInterval(() => {
     void fetchOnce(projectId, versionId);

--- a/objectified-ui/src/app/ade/studio/lib/studio-draft-lock-shared.ts
+++ b/objectified-ui/src/app/ade/studio/lib/studio-draft-lock-shared.ts
@@ -1,0 +1,157 @@
+'use client';
+
+/**
+ * Single ref-counted draft-lock poll per project+revision (#2585, #2726 GLI-07).
+ * Avoids duplicate GET /draft-lock when header chip and branch status popover both mount.
+ */
+
+export type DraftLockStatusPayload = {
+  active: boolean;
+  ownerUserId?: string;
+  expiresAt?: string;
+};
+
+export type DraftLockSharedSnapshot = {
+  payload: DraftLockStatusPayload | null;
+  /** Monotonic tick for countdown labels (ms since epoch). */
+  nowMs: number;
+};
+
+type Subscriber = () => void;
+
+const POLL_MS = 10_000;
+const TICK_MS = 1_000;
+
+const refCounts = new Map<string, number>();
+let pollTimer: number | null = null;
+let tickTimer: number | null = null;
+let activeKey = '';
+let payload: DraftLockStatusPayload | null = null;
+let nowMs = Date.now();
+const listeners = new Set<Subscriber>();
+
+/** Cached snapshot for `useSyncExternalStore` — must keep referential stability when values are unchanged. */
+let snapshotCache: DraftLockSharedSnapshot = { payload: null, nowMs };
+
+function syncSnapshotCache() {
+  if (snapshotCache.payload === payload && snapshotCache.nowMs === nowMs) return;
+  snapshotCache = { payload, nowMs };
+}
+
+function emit() {
+  syncSnapshotCache();
+  listeners.forEach((l) => l());
+}
+
+function stopTimers() {
+  if (pollTimer !== null) {
+    clearInterval(pollTimer);
+    pollTimer = null;
+  }
+  if (tickTimer !== null) {
+    clearInterval(tickTimer);
+    tickTimer = null;
+  }
+}
+
+async function fetchOnce(projectId: string, versionId: string) {
+  try {
+    const qs = new URLSearchParams({ projectId });
+    const res = await fetch(`/api/versions/${encodeURIComponent(versionId)}/draft-lock?${qs.toString()}`);
+    const json = (await res.json()) as {
+      success?: boolean;
+      status?: { active?: boolean; ownerUserId?: string; expiresAt?: string };
+      error?: string;
+    };
+    if (!res.ok || !json.success || !json.status) {
+      payload = null;
+      stopTickIfIdle();
+      emit();
+      return;
+    }
+    const st = json.status;
+    payload = {
+      active: Boolean(st.active),
+      ownerUserId: typeof st.ownerUserId === 'string' ? st.ownerUserId : undefined,
+      expiresAt: typeof st.expiresAt === 'string' ? st.expiresAt : undefined,
+    };
+    if (payload.active && payload.expiresAt) ensureTick();
+    else stopTickIfIdle();
+    emit();
+  } catch {
+    payload = null;
+    stopTickIfIdle();
+    emit();
+  }
+}
+
+function ensurePolling(projectId: string, versionId: string) {
+  const key = `${projectId}:${versionId}`;
+  if (activeKey === key && pollTimer !== null) return;
+  stopTimers();
+  activeKey = key;
+  nowMs = Date.now();
+  void fetchOnce(projectId, versionId);
+  pollTimer = window.setInterval(() => {
+    void fetchOnce(projectId, versionId);
+  }, POLL_MS);
+}
+
+function ensureTick() {
+  if (tickTimer !== null) return;
+  tickTimer = window.setInterval(() => {
+    nowMs = Date.now();
+    if (payload?.active && payload.expiresAt) emit();
+  }, TICK_MS);
+}
+
+function stopTickIfIdle() {
+  if (!payload?.active || !payload.expiresAt) {
+    if (tickTimer !== null) {
+      clearInterval(tickTimer);
+      tickTimer = null;
+    }
+  }
+}
+
+export function subscribeDraftLockShared(cb: Subscriber) {
+  listeners.add(cb);
+  return () => {
+    listeners.delete(cb);
+  };
+}
+
+export function getDraftLockSharedSnapshot(): DraftLockSharedSnapshot {
+  syncSnapshotCache();
+  return snapshotCache;
+}
+
+export function acquireDraftLockShared(projectId: string, versionId: string, published: boolean) {
+  if (published || !projectId || !versionId) {
+    return;
+  }
+  const key = `${projectId}:${versionId}`;
+  refCounts.set(key, (refCounts.get(key) ?? 0) + 1);
+  ensurePolling(projectId, versionId);
+  if (payload?.active && payload.expiresAt) ensureTick();
+}
+
+export function releaseDraftLockShared(projectId: string, versionId: string, published: boolean) {
+  if (published || !projectId || !versionId) {
+    return;
+  }
+  const key = `${projectId}:${versionId}`;
+  const next = (refCounts.get(key) ?? 1) - 1;
+  if (next <= 0) {
+    refCounts.delete(key);
+    if (activeKey === key) {
+      stopTimers();
+      activeKey = '';
+      payload = null;
+      emit();
+    }
+  } else {
+    refCounts.set(key, next);
+  }
+  stopTickIfIdle();
+}

--- a/objectified-ui/tests/unit/studio-branch-status-recent.test.ts
+++ b/objectified-ui/tests/unit/studio-branch-status-recent.test.ts
@@ -1,0 +1,24 @@
+import {
+  collectRecentRevisionsOnLineage,
+  type VersionLineageRow,
+} from '@/app/ade/studio/lib/studio-branch-status-recent';
+
+describe('collectRecentRevisionsOnLineage', () => {
+  const versions: VersionLineageRow[] = [
+    { id: 't3', parent_version_id: 't2', shortMessage: 'third' },
+    { id: 't2', parent_version_id: 't1', shortMessage: 'second' },
+    { id: 't1', parent_version_id: null, shortMessage: 'root' },
+  ];
+
+  it('walks parent_version_id from tip', () => {
+    expect(collectRecentRevisionsOnLineage(versions, 't3', 5).map((r) => r.id)).toEqual(['t3', 't2', 't1']);
+  });
+
+  it('respects limit', () => {
+    expect(collectRecentRevisionsOnLineage(versions, 't3', 2).map((r) => r.id)).toEqual(['t3', 't2']);
+  });
+
+  it('returns empty when tip missing', () => {
+    expect(collectRecentRevisionsOnLineage(versions, 'nope', 3)).toEqual([]);
+  });
+});

--- a/objectified-ui/tests/unit/studio-branch-status-recent.test.ts
+++ b/objectified-ui/tests/unit/studio-branch-status-recent.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect } from '@jest/globals';
 import {
   collectRecentRevisionsOnLineage,
   type VersionLineageRow,


### PR DESCRIPTION
## What / why
Implements GLI-07: a Radix popover on the branch chip that summarizes branch identity, divergence vs default (reusing existing divergence data), working-copy hints (`syncLocalDirty` + authored-revisions-toward-head), draft lock status (shared poll with the header chip), recent commits along `parent_version_id` from the branch tip, and a link to `/ade/dashboard/versions?projectId=…`. Branch checkout list remains below the status panel in the same popover.

Shared stores avoid duplicate GETs when multiple subscribers mount: ref-counted draft-lock polling and a deduplicated divergence fetch keyed by project/branch/refresh.

## How to test
1. Open Designer canvas with a project + revision; hover the branch chip ~300ms — popover opens; move pointer into the panel — it stays open; Escape or click outside closes; focus returns to the chip.
2. Click the branch chip — popover toggles; keyboard Tab + Enter opens; focus moves into the panel unless opened from hover (hover skips initial auto-focus into content).
3. Confirm sections match canvas state (dirty layout, lock when draft lock API reports active, divergence on non-default branches).
4. Open DevTools Network — opening the popover should not introduce new API routes beyond what GLI-02/03/P2-03 already use (divergence + draft-lock + branch list when opening).

## Risk / notes
- Recent commits walk the linear `parent_version_id` chain only (merge parents not expanded).
- `Uncommitted schema edits` uses the same `countAuthoredRevisionsTowardHead` signal as the header sync chips (lineage), not a separate schema dirty flag.

Closes #2726

Made with [Cursor](https://cursor.com)