### PR TITLE
Fix #2727 - GLI-08: Auto-protect default branch (merge path)

### DIFF
--- a/docs/PLANNED_FEATURE_ROADMAP_GITLIKE_IMPROVEMENTS.md
+++ b/docs/PLANNED_FEATURE_ROADMAP_GITLIKE_IMPROVEMENTS.md
@@ -78,7 +78,7 @@ on the ones above it to be meaningful in isolation.
 | ~~GLI-05~~ | ~~Prominent "Commit…" action on the canvas toolbar~~ ([#2724](https://github.com/KenSuenobu/objectified-commercial/issues/2724)) | **MVP** (completed) | GLI-03 |
 | ~~GLI-06~~ | ~~"Sync from main" one-click action~~ ([#2725](https://github.com/KenSuenobu/objectified-commercial/issues/2725)) | **MVP** (completed) | GLI-02, GLI-03 |
 | ~~GLI-07~~ | ~~Branch status popover (`git status` style summary)~~ ([#2726](https://github.com/KenSuenobu/objectified-commercial/issues/2726)) | **MVP** (completed) | GLI-02, GLI-03, GLI-05 |
-| GLI-08 | Auto-protect the default branch (require merge path) | **Enterprise** | GLI-01 |
+| ~~GLI-08~~ | ~~Auto-protect the default branch (require merge path)~~ ([#2727](https://github.com/KenSuenobu/objectified-commercial/issues/2727)) | **Enterprise** (completed) | GLI-01 |
 | GLI-09 | Recent-activity ticker for current branch | **Enterprise** | GLI-03 |
 | GLI-10 | Keyboard palette for git actions (CLI muscle memory) | **Enterprise** | GLI-03, GLI-05, GLI-06 |
 
@@ -98,7 +98,7 @@ MVP (first major release) = GLI-01 → GLI-07. Enterprise (later releases)
 | 5 | GLI-05 | #2718 | [#2724](https://github.com/KenSuenobu/objectified-commercial/issues/2724) ✅ |
 | 6 | GLI-06 | #2718 | [#2725](https://github.com/KenSuenobu/objectified-commercial/issues/2725) ✅ |
 | 7 | GLI-07 | #2718 | [#2726](https://github.com/KenSuenobu/objectified-commercial/issues/2726) ✅ |
-| 8 | GLI-08 | #2719 | [#2727](https://github.com/KenSuenobu/objectified-commercial/issues/2727) |
+| 8 | GLI-08 | #2719 | [#2727](https://github.com/KenSuenobu/objectified-commercial/issues/2727) ✅ |
 | 9 | GLI-09 | #2719 | [#2728](https://github.com/KenSuenobu/objectified-commercial/issues/2728) |
 | 10 | GLI-10 | #2719 | [#2729](https://github.com/KenSuenobu/objectified-commercial/issues/2729) |
 

--- a/objectified-rest/pyproject.toml
+++ b/objectified-rest/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "objectified-rest"
-version = "1.0.48"
+version = "1.0.49"
 description = "REST API for serving OpenAPI specifications from the Objectified database"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/objectified-rest/src/app/database.py
+++ b/objectified-rest/src/app/database.py
@@ -4139,10 +4139,17 @@ class Database:
         protected: Optional[bool] = None,
         is_default: Optional[bool] = None,
         require_merge_path: Optional[bool] = None,
+        actor_id: Optional[str] = None,
     ) -> Optional[Dict[str, Any]]:
         """
-        Tenant-admin policy fields on a branch (#504, #2583). At least one of protected or
+        Tenant-admin policy fields on a branch (#504, #2583, #2727). At least one of protected or
         require_merge_path or is_default must be set.
+
+        When the default branch changes (promotion), ``require_merge_path`` is set to true in the
+        same transaction unless the request explicitly sets ``require_merge_path`` false. If the
+        target branch is already default, merge-path is only updated when ``require_merge_path`` is
+        present in the request. Optionally records ``version.default_branch_promoted`` in
+        ``workflow_audit`` when ``actor_id`` is set.
         """
         if protected is None and require_merge_path is None and is_default is None:
             return None
@@ -4165,6 +4172,35 @@ class Database:
                     conn.rollback()
                     return None
 
+                prior_default_id: Optional[str] = None
+                is_promotion = False
+                merge_path_auto_enabled = False
+                rmp_for_set: Optional[bool] = None
+
+                if is_default is True:
+                    cursor.execute(
+                        """
+                        SELECT id FROM odb.version_branches
+                        WHERE project_id = %s AND is_default = true
+                        FOR UPDATE
+                        """,
+                        (project_id,),
+                    )
+                    prow = cursor.fetchone()
+                    pid = prow.get("id") if prow else None
+                    prior_default_id = str(pid) if pid is not None else None
+                    is_promotion = prior_default_id is None or prior_default_id != str(branch_id)
+                    if is_promotion:
+                        if require_merge_path is None:
+                            rmp_for_set = True
+                            merge_path_auto_enabled = True
+                        else:
+                            rmp_for_set = require_merge_path
+                    elif require_merge_path is not None:
+                        rmp_for_set = require_merge_path
+                elif require_merge_path is not None:
+                    rmp_for_set = require_merge_path
+
                 if is_default is True:
                     cursor.execute(
                         """
@@ -4183,9 +4219,9 @@ class Database:
                 if is_default is not None:
                     sets.append("is_default = %s")
                     params.append(is_default)
-                if require_merge_path is not None:
+                if rmp_for_set is not None:
                     sets.append("require_merge_path = %s")
-                    params.append(require_merge_path)
+                    params.append(rmp_for_set)
                 sets.append("updated_at = CURRENT_TIMESTAMP")
                 params.extend([branch_id, project_id, tenant_id])
 
@@ -4201,6 +4237,30 @@ class Database:
                     tuple(params),
                 )
                 row = cursor.fetchone()
+
+                if row and is_default is True and is_promotion and actor_id:
+                    detail = {
+                        "priorDefaultBranchId": prior_default_id,
+                        "newDefaultBranchId": str(branch_id),
+                        "mergePathAutoEnabled": merge_path_auto_enabled,
+                    }
+                    cursor.execute(
+                        """
+                        INSERT INTO odb.workflow_audit
+                          (tenant_id, project_id, version_id, action, outcome, actor_id, detail)
+                        VALUES (%s, %s, %s, %s, %s, %s, %s::jsonb)
+                        """,
+                        (
+                            tenant_id,
+                            project_id,
+                            None,
+                            "version.default_branch_promoted",
+                            "success",
+                            actor_id,
+                            json.dumps(detail),
+                        ),
+                    )
+
             conn.commit()
             return dict(row) if row else None
         except Exception as e:
@@ -4823,16 +4883,18 @@ class Database:
                         (new_id, str(branch_row["id"])),
                     )
                 elif no_prior_revision:
-                    # First commit in a brand-new project: bootstrap a default main branch.
+                    # First commit in a brand-new project: bootstrap a default main branch (#2727).
                     cursor.execute(
                         """
                         INSERT INTO odb.version_branches
-                            (project_id, name, tip_version_id, created_by, branched_from_revision_id, is_default)
-                        VALUES (%s, 'main', %s, %s, %s, true)
+                            (project_id, name, tip_version_id, created_by, branched_from_revision_id,
+                             is_default, require_merge_path)
+                        VALUES (%s, 'main', %s, %s, %s, true, true)
                         ON CONFLICT (project_id, name)
                         DO UPDATE SET
                             tip_version_id = EXCLUDED.tip_version_id,
                             is_default = true,
+                            require_merge_path = true,
                             updated_at = CURRENT_TIMESTAMP
                         """,
                         (project_id, new_id, creator_id, new_id),

--- a/objectified-rest/src/app/version_merge_routes.py
+++ b/objectified-rest/src/app/version_merge_routes.py
@@ -513,6 +513,7 @@ async def patch_version_branch_policy(
             protected=body.protected,
             is_default=body.is_default,
             require_merge_path=body.require_merge_path,
+            actor_id=uid,
         )
     except BranchDefaultConflictError as e:
         raise HTTPException(

--- a/objectified-rest/tests/test_branch_policy_patch_api.py
+++ b/objectified-rest/tests/test_branch_policy_patch_api.py
@@ -170,7 +170,10 @@ def test_patch_branch_policy_passes_actor_id_to_database():
         mdb.is_user_tenant_admin.return_value = True
         mdb.get_project_by_id.return_value = {"id": _PROJECT_ID}
         mdb.update_version_branch_protection_policy.return_value = dict(_BRANCH_ROW)
-        client.patch(_PATCH_URL, json={"protected": False})
+        r = client.patch(_PATCH_URL, json={"protected": False})
+    assert r.status_code == 200
+    data = r.json()
+    assert data["branch"]["id"] == _BRANCH_ID
     assert mdb.update_version_branch_protection_policy.call_args.kwargs.get("actor_id") == _USER
 
 

--- a/objectified-rest/tests/test_branch_policy_patch_api.py
+++ b/objectified-rest/tests/test_branch_policy_patch_api.py
@@ -151,15 +151,27 @@ def test_patch_branch_policy_is_default_only_200():
     with patch("src.app.version_merge_routes.db") as mdb:
         mdb.is_user_tenant_admin.return_value = True
         mdb.get_project_by_id.return_value = {"id": _PROJECT_ID}
-        updated_row = dict(_BRANCH_ROW, is_default=True)
+        updated_row = dict(_BRANCH_ROW, is_default=True, require_merge_path=True)
         mdb.update_version_branch_protection_policy.return_value = updated_row
         r = client.patch(_PATCH_URL, json={"isDefault": True})
     assert r.status_code == 200
     data = r.json()
     assert data["branch"]["isDefault"] is True
+    assert data["branch"]["requireMergePath"] is True
+    mdb.update_version_branch_protection_policy.assert_called_once()
+    assert mdb.update_version_branch_protection_policy.call_args.kwargs.get("actor_id") == _USER
     mdb.insert_version_protection_audit.assert_called_once()
     audit_detail = mdb.insert_version_protection_audit.call_args.args[7]
     assert audit_detail["isDefault"] is True
+
+
+def test_patch_branch_policy_passes_actor_id_to_database():
+    with patch("src.app.version_merge_routes.db") as mdb:
+        mdb.is_user_tenant_admin.return_value = True
+        mdb.get_project_by_id.return_value = {"id": _PROJECT_ID}
+        mdb.update_version_branch_protection_policy.return_value = dict(_BRANCH_ROW)
+        client.patch(_PATCH_URL, json={"protected": False})
+    assert mdb.update_version_branch_protection_policy.call_args.kwargs.get("actor_id") == _USER
 
 
 # ---------------------------------------------------------------------------

--- a/objectified-rest/tests/test_default_branch_promotion_db.py
+++ b/objectified-rest/tests/test_default_branch_promotion_db.py
@@ -1,0 +1,124 @@
+"""GLI-08 / #2727: default-branch promotion sets merge path and workflow_audit."""
+
+from unittest.mock import MagicMock, patch
+
+from src.app.database import Database
+
+_PID = "00000000-0000-0000-0000-0000000000a1"
+_TID = "tenant-1"
+_B_NEW = "00000000-0000-0000-0000-0000000000b1"
+_B_OLD = "00000000-0000-0000-0000-0000000000c1"
+
+
+def _out_row(*, rmp: bool) -> dict:
+    return {
+        "id": _B_NEW,
+        "project_id": _PID,
+        "name": "feature",
+        "tip_version_id": "00000000-0000-0000-0000-0000000000v1",
+        "branched_from_revision_id": None,
+        "protected": True,
+        "is_default": True,
+        "require_merge_path": rmp,
+        "created_by": "u1",
+        "created_at": None,
+        "updated_at": None,
+    }
+
+
+def _run_policy(
+    *,
+    fetch_queue: list,
+    is_default: bool = True,
+    require_merge_path=None,
+    actor_id: str = "u1",
+):
+    db = Database()
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+    mock_cursor.fetchone.side_effect = lambda: fetch_queue.pop(0)
+    mock_cm = MagicMock()
+    mock_cm.__enter__.return_value = mock_cursor
+    mock_cm.__exit__.return_value = None
+    mock_conn.cursor.return_value = mock_cm
+
+    with patch.object(db, "connect", return_value=mock_conn):
+        with patch.object(db, "_begin_tx", return_value=False):
+            return db.update_version_branch_protection_policy(
+                _PID,
+                _TID,
+                _B_NEW,
+                is_default=is_default,
+                require_merge_path=require_merge_path,
+                actor_id=actor_id,
+            ), mock_cursor
+
+
+def test_promotion_auto_enables_merge_path_and_audits():
+    fq = [
+        {"id": _B_NEW},
+        {"id": _B_OLD},
+        _out_row(rmp=True),
+    ]
+    row, mock_cursor = _run_policy(fetch_queue=fq)
+    assert row is not None
+    assert row["require_merge_path"] is True
+    calls = str(mock_cursor.execute.call_args_list)
+    assert "version.default_branch_promoted" in calls
+    assert '"mergePathAutoEnabled": true' in calls
+
+
+def test_promotion_explicit_merge_path_false_audits_without_auto_flag():
+    fq = [
+        {"id": _B_NEW},
+        {"id": _B_OLD},
+        _out_row(rmp=False),
+    ]
+    row, mock_cursor = _run_policy(
+        fetch_queue=fq,
+        require_merge_path=False,
+    )
+    assert row["require_merge_path"] is False
+    calls = str(mock_cursor.execute.call_args_list)
+    assert "version.default_branch_promoted" in calls
+    assert '"mergePathAutoEnabled": false' in calls
+
+
+def test_already_default_no_workflow_audit_on_is_default_only():
+    fq = [
+        {"id": _B_NEW},
+        {"id": _B_NEW},
+        _out_row(rmp=False),
+    ]
+    row, mock_cursor = _run_policy(fetch_queue=fq)
+    assert row is not None
+    calls = str(mock_cursor.execute.call_args_list)
+    assert "version.default_branch_promoted" not in calls
+
+
+def test_promotion_skips_workflow_audit_without_actor():
+    q = [
+        {"id": _B_NEW},
+        {"id": _B_OLD},
+        _out_row(rmp=True),
+    ]
+    db = Database()
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+    mock_cursor.fetchone.side_effect = lambda: q.pop(0)
+    mock_cm = MagicMock()
+    mock_cm.__enter__.return_value = mock_cursor
+    mock_cm.__exit__.return_value = None
+    mock_conn.cursor.return_value = mock_cm
+
+    with patch.object(db, "connect", return_value=mock_conn):
+        with patch.object(db, "_begin_tx", return_value=False):
+            db.update_version_branch_protection_policy(
+                _PID,
+                _TID,
+                _B_NEW,
+                is_default=True,
+                actor_id=None,
+            )
+
+    assert "version.default_branch_promoted" not in str(mock_cursor.execute.call_args_list)

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -5,6 +5,7 @@ We continue to improve the platform based on your feedback with improvements and
 ---
 
 ## Git-like Functionality
+- Default branch promotion and first-commit `main` bootstrap now turn on merge-path protection automatically (unless explicitly overridden); promotions are recorded in workflow audit as `version.default_branch_promoted`.
 - Added default-branch foundations for git-like workflows: branch rows now support a single project default (`isDefault`) with promotion support and first-commit auto-bootstrap of `main`.
 - Added branch divergence REST support with merge-base, ahead/behind counts, commit samples, and strong ETag-based 304 responses for stable canvas sync indicators.
 - Added a canvas branch picker: check out any named branch from the floating toolbar or git menu, with a current-branch chip, unsaved-layout guard, and refreshed tips after commit or merge.


### PR DESCRIPTION
## What changed
Implements **GLI-08** (#2727): when a branch is **promoted** to project default via `PATCH .../version-branches/{id}` with `isDefault: true`, the server sets `require_merge_path = true` in the **same transaction** unless the request explicitly sets `requireMergePath: false`. If the branch is **already** the default, merge-path is unchanged unless `requireMergePath` is sent.

First-commit bootstrap of `main` (GLI-01 path) now sets `require_merge_path = true` on insert/upsert.

When the default **actually changes**, a `workflow_audit` row is written with action `version.default_branch_promoted` and detail `priorDefaultBranchId`, `newDefaultBranchId`, `mergePathAutoEnabled` (same transaction as the branch update). The route passes `actor_id` for this audit.

## How to test
1. From `objectified-rest` with dev deps: `PYTHONPATH=src pytest tests/test_default_branch_promotion_db.py tests/test_branch_policy_patch_api.py -q`
2. Promote a non-default branch with `{ "isDefault": true }`; confirm returned branch has `requireMergePath: true`.
3. Promote with `{ "isDefault": true, "requireMergePath": false }`; confirm `requireMergePath: false`.
4. First commit on a new project; confirm `main` has merge-path protection.

## Risk / notes
- **Enterprise**-scoped behavior; no UI changes.
- Relies on existing merge-path enforcement for non-admin direct push.

Closes #2727

Made with [Cursor](https://cursor.com)