### PR TITLE
Fix #257 - Add Studio AI chatbot panel placement chrome

### DIFF
--- a/docs/PLANNED_FEATURE_ROADMAP_AI.md
+++ b/docs/PLANNED_FEATURE_ROADMAP_AI.md
@@ -24,12 +24,12 @@ This outlines the planned features for integrating AI capabilities into Objectif
 ### Studio AI Chatbot
 
 **Chatbot Panel** 📋 PLANNED
-- 📋 **Panel Location**:
-    - 📋 Slide-out panel from right side of Studio
-    - 📋 Floating chat bubble option
-    - 📋 Full-screen chat mode for complex conversations
-    - 📋 Keyboard shortcut to toggle (`Cmd+Shift+A`)
-    - 📋 Bottom right-hand corner of the canvas opens the AI Chatbot
+- ✅ **Panel Location**:
+    - ✅ Slide-out panel from right side of Studio
+    - ✅ Floating chat bubble option
+    - ✅ Full-screen chat mode for complex conversations
+    - ✅ Keyboard shortcut to toggle (`Cmd+Shift+A`)
+    - ✅ Bottom right-hand corner of the canvas opens the AI Chatbot
 - 📋 **Chat Interface**:
     - 📋 Modern chat UI with message bubbles
     - 📋 User messages vs AI responses clearly distinguished
@@ -43,7 +43,6 @@ This outlines the planned features for integrating AI capabilities into Objectif
 
 | Ticket | Feature Description              |
 |--------|----------------------------------|
-| #257   | AI Chatbot Placement             |
 | #258   | AI Chatbot Guidelines for design |
 
 **Conversation Features** 📋 PLANNED

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.10.13",
+  "version": "0.10.14",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -20,6 +20,11 @@ We continue to improve the platform based on your feedback with improvements and
 
 ---
 
+## Studio AI
+- Added the Studio AI chatbot launcher and panel: a floating bubble in the bottom right of the canvas opens a slide-out panel with full-screen mode, toggled with `Cmd+Shift+A` / `Ctrl+Shift+A`.
+
+---
+
 View our YouTube channel [here](https://www.youtube.com/@objectifieddev) for detailed tutorials and walkthroughs!
 
 ---

--- a/objectified-ui/src/app/ade/studio/components/StudioAiChatbot.tsx
+++ b/objectified-ui/src/app/ade/studio/components/StudioAiChatbot.tsx
@@ -1,0 +1,244 @@
+'use client';
+
+/**
+ * Studio AI Chatbot — placement chrome (#257).
+ *
+ * Provides the launcher and panel surfaces for the studio chatbot:
+ *   - Floating launcher bubble in the bottom right corner of the canvas
+ *   - Slide-out panel anchored to the right edge of the studio
+ *   - Full-screen chat mode for complex conversations
+ *   - Keyboard shortcut to toggle (⌘+Shift+A on macOS, Ctrl+Shift+A elsewhere)
+ *
+ * The actual chat content (model selection, prompts, streaming, context awareness)
+ * lands in subsequent tickets (#258, #259, ...). For now the panel renders a
+ * focused placeholder so the placement, controls, and shortcuts can be exercised
+ * end-to-end.
+ */
+
+import * as React from 'react';
+import { usePathname } from 'next/navigation';
+import { Bot, Maximize2, Minimize2, Sparkles, X } from 'lucide-react';
+import { matchesStudioAiChatbotShortcut } from '@/app/utils/studio-keybindings';
+
+/**
+ * Open/closed state for the chatbot panel. `slide` is the default expanded mode
+ * (right-anchored drawer); `fullscreen` covers the canvas area for longer
+ * conversations.
+ */
+export type StudioAiChatbotMode = 'closed' | 'slide' | 'fullscreen';
+
+/**
+ * Pathname prefixes where the chatbot launcher is allowed to appear. Restricted
+ * to canvas-style surfaces so the bubble does not float above the dashboard,
+ * admin, or auth pages.
+ */
+const CHATBOT_CANVAS_PATH_PREFIXES: readonly string[] = [
+  '/ade/studio/editor',
+  '/ade/studio/paths',
+];
+
+const SLIDE_PANEL_WIDTH_CLASSES = 'w-full max-w-md sm:w-[26rem]';
+
+export function isStudioAiChatbotPath(pathname: string | null | undefined): boolean {
+  if (!pathname) return false;
+  return CHATBOT_CANVAS_PATH_PREFIXES.some((prefix) => pathname.startsWith(prefix));
+}
+
+export interface StudioAiChatbotProps {
+  /**
+   * Override the path-based gating used in production. Useful for tests and
+   * for previewing the placement on other surfaces.
+   */
+  forceVisible?: boolean;
+  /** Optional initial mode (defaults to `closed`). */
+  initialMode?: StudioAiChatbotMode;
+}
+
+/**
+ * Mounts the chatbot launcher and panel. Safe to render once at the studio
+ * layout level; it gates itself based on the current pathname.
+ */
+export function StudioAiChatbot({ forceVisible, initialMode = 'closed' }: StudioAiChatbotProps = {}) {
+  const pathname = usePathname();
+  const [mode, setMode] = React.useState<StudioAiChatbotMode>(initialMode);
+
+  const visible = forceVisible || isStudioAiChatbotPath(pathname);
+
+  const open = mode !== 'closed';
+  const close = React.useCallback(() => setMode('closed'), []);
+  const toggle = React.useCallback(() => {
+    setMode((prev) => (prev === 'closed' ? 'slide' : 'closed'));
+  }, []);
+
+  React.useEffect(() => {
+    if (!visible) return;
+    const handler = (ev: KeyboardEvent) => {
+      if (!matchesStudioAiChatbotShortcut(ev)) return;
+      ev.preventDefault();
+      toggle();
+    };
+    window.addEventListener('keydown', handler, true);
+    return () => window.removeEventListener('keydown', handler, true);
+  }, [visible, toggle]);
+
+  React.useEffect(() => {
+    if (!open) return;
+    const handler = (ev: KeyboardEvent) => {
+      if (ev.key !== 'Escape' || ev.defaultPrevented) return;
+      ev.preventDefault();
+      close();
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [open, close]);
+
+  if (!visible) return null;
+
+  return (
+    <>
+      {!open && <ChatbotLauncher onOpen={() => setMode('slide')} />}
+      {open && (
+        <ChatbotPanel
+          mode={mode}
+          onModeChange={setMode}
+          onClose={close}
+        />
+      )}
+    </>
+  );
+}
+
+interface ChatbotLauncherProps {
+  onOpen: () => void;
+}
+
+function ChatbotLauncher({ onOpen }: ChatbotLauncherProps) {
+  return (
+    <button
+      type="button"
+      onClick={onOpen}
+      aria-label="Open AI chatbot"
+      data-testid="studio-ai-chatbot-launcher"
+      className="fixed bottom-8 right-6 z-[1300] inline-flex h-14 w-14 items-center justify-center rounded-full bg-gradient-to-br from-purple-500 to-indigo-600 text-white shadow-xl ring-1 ring-black/10 transition-transform hover:scale-105 hover:shadow-2xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 dark:ring-white/10"
+    >
+      <Sparkles className="h-6 w-6" />
+    </button>
+  );
+}
+
+interface ChatbotPanelProps {
+  mode: Exclude<StudioAiChatbotMode, 'closed'>;
+  onModeChange: (mode: StudioAiChatbotMode) => void;
+  onClose: () => void;
+}
+
+function ChatbotPanel({ mode, onModeChange, onClose }: ChatbotPanelProps) {
+  const isFullscreen = mode === 'fullscreen';
+
+  const containerClasses = isFullscreen
+    ? 'fixed inset-4 sm:inset-8'
+    : `fixed bottom-8 right-6 top-32 ${SLIDE_PANEL_WIDTH_CLASSES}`;
+
+  const toggleFullscreen = () =>
+    onModeChange(isFullscreen ? 'slide' : 'fullscreen');
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="false"
+      aria-label="AI chatbot"
+      data-testid="studio-ai-chatbot-panel"
+      data-mode={mode}
+      className={`${containerClasses} z-[1301] flex flex-col overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-2xl dark:border-gray-700 dark:bg-gray-900`}
+    >
+      <header className="flex items-center justify-between gap-3 border-b border-gray-200 bg-gradient-to-r from-purple-50 to-indigo-50 px-4 py-3 dark:border-gray-700 dark:from-purple-950/40 dark:to-indigo-950/40">
+        <div className="flex items-center gap-2">
+          <span className="inline-flex h-8 w-8 items-center justify-center rounded-lg bg-gradient-to-br from-purple-500 to-indigo-600 text-white">
+            <Bot className="h-4 w-4" />
+          </span>
+          <div className="leading-tight">
+            <p className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+              AI Chatbot
+            </p>
+            <p className="text-xs text-gray-500 dark:text-gray-400">
+              {isFullscreen ? 'Full-screen chat' : 'Studio side panel'}
+            </p>
+          </div>
+        </div>
+        <div className="flex items-center gap-1">
+          <button
+            type="button"
+            onClick={toggleFullscreen}
+            aria-label={isFullscreen ? 'Exit full-screen chat' : 'Expand chat to full screen'}
+            data-testid="studio-ai-chatbot-toggle-fullscreen"
+            className="inline-flex h-8 w-8 items-center justify-center rounded-md text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-100"
+          >
+            {isFullscreen ? <Minimize2 className="h-4 w-4" /> : <Maximize2 className="h-4 w-4" />}
+          </button>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close AI chatbot"
+            data-testid="studio-ai-chatbot-close"
+            className="inline-flex h-8 w-8 items-center justify-center rounded-md text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-100"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+      </header>
+
+      <div className="flex-1 overflow-y-auto p-6">
+        <ChatbotComingSoon />
+      </div>
+
+      <footer className="border-t border-gray-200 bg-gray-50 px-4 py-2 text-[11px] text-gray-500 dark:border-gray-700 dark:bg-gray-900/60 dark:text-gray-400">
+        Toggle this panel any time with{' '}
+        <kbd className="rounded border border-gray-300 bg-white px-1.5 py-0.5 font-mono text-[10px] text-gray-700 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200">
+          ⌘⇧A
+        </kbd>
+        {' / '}
+        <kbd className="rounded border border-gray-300 bg-white px-1.5 py-0.5 font-mono text-[10px] text-gray-700 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200">
+          Ctrl+Shift+A
+        </kbd>
+        .
+      </footer>
+    </div>
+  );
+}
+
+const COMING_SOON_FEATURES: readonly string[] = [
+  'Natural-language schema design and refinement',
+  'Context-aware responses about your current project and version',
+  'One-click "create class" and "add properties" actions',
+  'Conversation history per project, with export and search',
+];
+
+function ChatbotComingSoon() {
+  return (
+    <div className="flex h-full flex-col items-center justify-center text-center">
+      <span className="mb-4 inline-flex h-16 w-16 items-center justify-center rounded-2xl bg-gradient-to-br from-purple-100 to-indigo-100 text-purple-600 dark:from-purple-900/40 dark:to-indigo-900/40 dark:text-purple-300">
+        <Sparkles className="h-8 w-8" />
+      </span>
+      <h2 className="mb-2 text-lg font-semibold text-gray-900 dark:text-gray-100">
+        Studio AI is on the way
+      </h2>
+      <p className="mb-6 max-w-sm text-sm text-gray-600 dark:text-gray-400">
+        This panel is the new home for the Studio chatbot. The conversation surface
+        ships in the next release; for now it gives you a stable place to expect it.
+      </p>
+      <ul className="w-full max-w-sm space-y-2 text-left text-sm text-gray-600 dark:text-gray-400">
+        {COMING_SOON_FEATURES.map((feature) => (
+          <li key={feature} className="flex items-start gap-2">
+            <span
+              aria-hidden
+              className="mt-1.5 inline-block h-1.5 w-1.5 shrink-0 rounded-full bg-indigo-500 dark:bg-indigo-400"
+            />
+            <span>{feature}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default StudioAiChatbot;

--- a/objectified-ui/src/app/ade/studio/layout.tsx
+++ b/objectified-ui/src/app/ade/studio/layout.tsx
@@ -23,6 +23,7 @@ import { deleteClassWithSession } from '../../../../lib/api/rest-client';
 import * as Dialog from '@radix-ui/react-dialog';
 import { ADE_SUBHEADER_RESERVE_PX } from '../constants/subheader-layout';
 import { GitCommandPalette } from './components/GitCommandPalette';
+import { StudioAiChatbot } from './components/StudioAiChatbot';
 import StudioFooterBar from './components/StudioFooterBar';
 import { FEATURE_GITLIKE } from '@lib/feature-flags';
 
@@ -591,6 +592,12 @@ function StudioLayoutContent({ children }: Readonly<{ children: React.ReactNode 
       />
 
       {FEATURE_GITLIKE && <GitCommandPalette />}
+
+      {/* AI chatbot launcher + slide-out / fullscreen panel (#257). Mounted at the
+          studio layout level so the floating bubble and ⌘⇧A shortcut are available
+          across the canvas and paths surfaces. Hidden in presentation mode to keep
+          the canvas chrome-free. */}
+      {!canvasPresentationMode && <StudioAiChatbot />}
 
       {/* Programmatic state of the canvas — pinned to the bottom of the studio layout.
           Hidden in presentation mode for chrome consistency with StudioHeader. */}

--- a/objectified-ui/src/app/utils/studio-keybindings.ts
+++ b/objectified-ui/src/app/utils/studio-keybindings.ts
@@ -15,6 +15,23 @@ export function matchesStudioGitPaletteShortcut(ev: KeyboardEvent): boolean {
   return true;
 }
 
+/** Toggle key for the Studio AI chatbot panel (#257). */
+export const STUDIO_AI_CHATBOT_KEY = 'a' as const;
+
+/**
+ * Modifier combo for the Studio AI chatbot panel: ⌘+Shift+A on macOS, Ctrl+Shift+A on
+ * Windows/Linux. Either modifier is accepted so Linux users get the same affordance.
+ */
+export function matchesStudioAiChatbotShortcut(ev: KeyboardEvent): boolean {
+  if (ev.defaultPrevented) return false;
+  if (ev.repeat) return false;
+  if (ev.key?.toLowerCase() !== STUDIO_AI_CHATBOT_KEY) return false;
+  if (!(ev.metaKey || ev.ctrlKey)) return false;
+  if (!ev.shiftKey) return false;
+  if (ev.altKey) return false;
+  return true;
+}
+
 export type StudioGitPaletteActionId =
   | 'commit'
   | 'branch'
@@ -50,6 +67,7 @@ export const STUDIO_GIT_PALETTE_LABELS: Record<StudioGitPaletteActionId, { title
 export const STUDIO_KEYBINDING_CHEATSHEET_LINES: { keys: string; description: string }[] = [
   { keys: '⌘G / Ctrl+G', description: 'Open git command palette' },
   { keys: '⌘Enter / Ctrl+Enter', description: 'Commit new revision (Designer toolbar, when available)' },
+  { keys: '⌘⇧A / Ctrl+Shift+A', description: 'Toggle the AI chatbot panel on the canvas' },
   { keys: 'Esc', description: 'Close git palette' },
   { keys: '?', description: 'Toggle this cheatsheet inside the palette' },
 ];

--- a/objectified-ui/tests/StudioAiChatbot.test.tsx
+++ b/objectified-ui/tests/StudioAiChatbot.test.tsx
@@ -1,0 +1,157 @@
+/**
+ * Unit tests for the Studio AI chatbot placement chrome (#257).
+ *
+ * Covers:
+ *   - Visibility gating against the current pathname (canvas surfaces only).
+ *   - Launcher → slide-out panel transition on click.
+ *   - Slide-out → fullscreen toggle and back.
+ *   - Closing via the close button and via the Escape key.
+ *   - ⌘+Shift+A / Ctrl+Shift+A keyboard toggle.
+ */
+
+import React from 'react';
+import { render, screen, act, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import {
+  StudioAiChatbot,
+  isStudioAiChatbotPath,
+} from '../src/app/ade/studio/components/StudioAiChatbot';
+
+const mockUsePathname = jest.fn<string | null, []>();
+jest.mock('next/navigation', () => ({
+  usePathname: () => mockUsePathname(),
+}));
+
+beforeEach(() => {
+  mockUsePathname.mockReset();
+});
+
+describe('isStudioAiChatbotPath', () => {
+  it('matches studio canvas surfaces', () => {
+    expect(isStudioAiChatbotPath('/ade/studio/editor')).toBe(true);
+    expect(isStudioAiChatbotPath('/ade/studio/editor?foo=bar')).toBe(true);
+    expect(isStudioAiChatbotPath('/ade/studio/paths')).toBe(true);
+    expect(isStudioAiChatbotPath('/ade/studio/paths/123')).toBe(true);
+  });
+
+  it('does not match unrelated surfaces', () => {
+    expect(isStudioAiChatbotPath('/ade/studio')).toBe(false);
+    expect(isStudioAiChatbotPath('/ade/studio/code')).toBe(false);
+    expect(isStudioAiChatbotPath('/ade/dashboard')).toBe(false);
+    expect(isStudioAiChatbotPath('/admin/users')).toBe(false);
+    expect(isStudioAiChatbotPath(null)).toBe(false);
+    expect(isStudioAiChatbotPath(undefined)).toBe(false);
+  });
+});
+
+describe('StudioAiChatbot', () => {
+  it('renders nothing on non-canvas pathnames', () => {
+    mockUsePathname.mockReturnValue('/ade/dashboard');
+    const { container } = render(<StudioAiChatbot />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders only the launcher when closed on a canvas page', () => {
+    mockUsePathname.mockReturnValue('/ade/studio/editor');
+    render(<StudioAiChatbot />);
+
+    expect(screen.getByTestId('studio-ai-chatbot-launcher')).toBeInTheDocument();
+    expect(screen.queryByTestId('studio-ai-chatbot-panel')).not.toBeInTheDocument();
+  });
+
+  it('opens the slide-out panel when the launcher is clicked', () => {
+    mockUsePathname.mockReturnValue('/ade/studio/editor');
+    render(<StudioAiChatbot />);
+
+    fireEvent.click(screen.getByTestId('studio-ai-chatbot-launcher'));
+
+    const panel = screen.getByTestId('studio-ai-chatbot-panel');
+    expect(panel).toBeInTheDocument();
+    expect(panel).toHaveAttribute('data-mode', 'slide');
+    expect(screen.queryByTestId('studio-ai-chatbot-launcher')).not.toBeInTheDocument();
+  });
+
+  it('toggles between slide-out and fullscreen', () => {
+    mockUsePathname.mockReturnValue('/ade/studio/editor');
+    render(<StudioAiChatbot initialMode="slide" />);
+
+    const toggle = screen.getByTestId('studio-ai-chatbot-toggle-fullscreen');
+    fireEvent.click(toggle);
+    expect(screen.getByTestId('studio-ai-chatbot-panel')).toHaveAttribute('data-mode', 'fullscreen');
+
+    fireEvent.click(screen.getByTestId('studio-ai-chatbot-toggle-fullscreen'));
+    expect(screen.getByTestId('studio-ai-chatbot-panel')).toHaveAttribute('data-mode', 'slide');
+  });
+
+  it('closes via the close button', () => {
+    mockUsePathname.mockReturnValue('/ade/studio/paths');
+    render(<StudioAiChatbot initialMode="slide" />);
+
+    fireEvent.click(screen.getByTestId('studio-ai-chatbot-close'));
+
+    expect(screen.queryByTestId('studio-ai-chatbot-panel')).not.toBeInTheDocument();
+    expect(screen.getByTestId('studio-ai-chatbot-launcher')).toBeInTheDocument();
+  });
+
+  it('closes when Escape is pressed', () => {
+    mockUsePathname.mockReturnValue('/ade/studio/editor');
+    render(<StudioAiChatbot initialMode="slide" />);
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    });
+
+    expect(screen.queryByTestId('studio-ai-chatbot-panel')).not.toBeInTheDocument();
+  });
+
+  it('toggles open/closed with Ctrl+Shift+A', () => {
+    mockUsePathname.mockReturnValue('/ade/studio/editor');
+    render(<StudioAiChatbot />);
+
+    act(() => {
+      window.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'a', ctrlKey: true, shiftKey: true })
+      );
+    });
+    expect(screen.getByTestId('studio-ai-chatbot-panel')).toHaveAttribute('data-mode', 'slide');
+
+    act(() => {
+      window.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'a', ctrlKey: true, shiftKey: true })
+      );
+    });
+    expect(screen.queryByTestId('studio-ai-chatbot-panel')).not.toBeInTheDocument();
+  });
+
+  it('also responds to the ⌘+Shift+A combination', () => {
+    mockUsePathname.mockReturnValue('/ade/studio/editor');
+    render(<StudioAiChatbot />);
+
+    act(() => {
+      window.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'a', metaKey: true, shiftKey: true })
+      );
+    });
+    expect(screen.getByTestId('studio-ai-chatbot-panel')).toHaveAttribute('data-mode', 'slide');
+  });
+
+  it('ignores the keyboard shortcut on non-canvas pages', () => {
+    mockUsePathname.mockReturnValue('/ade/dashboard');
+    render(<StudioAiChatbot />);
+
+    act(() => {
+      window.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'a', ctrlKey: true, shiftKey: true })
+      );
+    });
+    expect(screen.queryByTestId('studio-ai-chatbot-panel')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('studio-ai-chatbot-launcher')).not.toBeInTheDocument();
+  });
+
+  it('respects forceVisible when the pathname would otherwise hide the chatbot', () => {
+    mockUsePathname.mockReturnValue('/ade/dashboard');
+    render(<StudioAiChatbot forceVisible />);
+    expect(screen.getByTestId('studio-ai-chatbot-launcher')).toBeInTheDocument();
+  });
+});

--- a/objectified-ui/tests/studio-git-palette-keybindings.test.ts
+++ b/objectified-ui/tests/studio-git-palette-keybindings.test.ts
@@ -1,5 +1,7 @@
 import {
+  matchesStudioAiChatbotShortcut,
   matchesStudioGitPaletteShortcut,
+  STUDIO_AI_CHATBOT_KEY,
   STUDIO_GIT_PALETTE_KEY,
 } from '../src/app/utils/studio-keybindings';
 
@@ -48,5 +50,61 @@ describe('studio-keybindings (git palette)', () => {
       defaultPrevented: true,
     });
     expect(matchesStudioGitPaletteShortcut(ev)).toBe(false);
+  });
+});
+
+describe('studio-keybindings (AI chatbot)', () => {
+  it('matches ⌘+Shift+A and Ctrl+Shift+A', () => {
+    expect(
+      matchesStudioAiChatbotShortcut(
+        makeKey({ key: STUDIO_AI_CHATBOT_KEY, metaKey: true, ctrlKey: false, altKey: false, shiftKey: true })
+      )
+    ).toBe(true);
+    expect(
+      matchesStudioAiChatbotShortcut(
+        makeKey({ key: STUDIO_AI_CHATBOT_KEY, metaKey: false, ctrlKey: true, altKey: false, shiftKey: true })
+      )
+    ).toBe(true);
+  });
+
+  it('is case-insensitive on key', () => {
+    expect(
+      matchesStudioAiChatbotShortcut(
+        makeKey({ key: 'A', metaKey: true, ctrlKey: false, altKey: false, shiftKey: true })
+      )
+    ).toBe(true);
+  });
+
+  it('does not match without the shift modifier', () => {
+    expect(
+      matchesStudioAiChatbotShortcut(
+        makeKey({ key: 'a', metaKey: true, ctrlKey: false, altKey: false, shiftKey: false })
+      )
+    ).toBe(false);
+  });
+
+  it('does not match plain A or with Alt held', () => {
+    expect(
+      matchesStudioAiChatbotShortcut(
+        makeKey({ key: 'a', metaKey: false, ctrlKey: false, altKey: false, shiftKey: true })
+      )
+    ).toBe(false);
+    expect(
+      matchesStudioAiChatbotShortcut(
+        makeKey({ key: 'a', metaKey: true, ctrlKey: false, altKey: true, shiftKey: true })
+      )
+    ).toBe(false);
+  });
+
+  it('respects defaultPrevented', () => {
+    const ev = makeKey({
+      key: 'a',
+      metaKey: true,
+      ctrlKey: false,
+      altKey: false,
+      shiftKey: true,
+      defaultPrevented: true,
+    });
+    expect(matchesStudioAiChatbotShortcut(ev)).toBe(false);
   });
 });


### PR DESCRIPTION
## What & Why

Adds the placement chrome for the Studio AI chatbot called for in #257. The
issue scope is panel _location_ — the actual chat content (system prompts,
streaming, context awareness, quick actions) is handled by the follow-up
tickets (#258 onward), so this PR keeps to placement only.

What ships:

- **Floating bubble launcher** in the bottom right corner of the canvas
  (`/ade/studio/editor` and `/ade/studio/paths`).
- **Slide-out panel** anchored to the right edge of the studio (default open
  mode).
- **Full-screen chat mode** for longer conversations, with an in-header
  toggle to flip back to the slide-out.
- **Keyboard shortcut** to toggle the panel open/closed: `Cmd+Shift+A` on
  macOS, `Ctrl+Shift+A` on Windows/Linux. Routed through the central
  `studio-keybindings` registry alongside the existing git palette
  shortcut.
- Hidden in canvas presentation mode and on non-canvas pages so the bubble
  never floats over dashboards, admin, or auth.

The shortcut is also documented in the existing studio cheatsheet lines
(`STUDIO_KEYBINDING_CHEATSHEET_LINES`) so it surfaces wherever the git
palette help is shown.

## How to Test

1. `yarn dev` and sign into the studio.
2. Open `/ade/studio/editor` for any project + version. A purple-indigo
   sparkles bubble appears in the bottom right corner of the canvas.
3. Click the bubble → a right-anchored slide-out panel opens. Click the
   maximize button in the panel header → the panel switches to full-screen
   mode. Click minimize → it returns to the slide-out.
4. Press `Cmd+Shift+A` (macOS) or `Ctrl+Shift+A` (Windows/Linux) to toggle
   the panel. Press `Esc` from anywhere on the page to close it.
5. Navigate to `/ade/studio/paths` — the bubble and shortcut still work.
6. Navigate to `/ade/dashboard` or `/ade/studio/code` — the bubble is
   absent and the shortcut is a no-op.
7. Run the new + adjacent suites:

   ```bash
   cd objectified-ui
   yarn jest StudioAiChatbot studio-git-palette-keybindings --no-coverage
   ```

   21 tests, all pass.

## Risk / Notes

- Pure additive UI; no data-model, REST, or migration changes.
- Self-contained component mounted once at the studio layout level, so
  there is no impact on other studio surfaces.
- z-index `1300` / `1301` keeps the chatbot above the canvas controls but
  below modal dialogs (which use `z-[10001]+`), so existing dialogs cover
  the chatbot if both are open.
- Build (`yarn build`) and the full workspace tests (`yarn test`) pass.
  The pre-existing `tests/llm-streaming.test.ts` failure (jest-circus
  `_prettyFormat.format is not a function`) reproduces on `main` and is
  unrelated to this change.

Closes #257

Made with [Cursor](https://cursor.com)