### PR TITLE
Fix #259 - Context Awareness for Chat

### DIFF
--- a/docs/PLANNED_FEATURE_ROADMAP_AI.md
+++ b/docs/PLANNED_FEATURE_ROADMAP_AI.md
@@ -30,12 +30,12 @@ This outlines the planned features for integrating AI capabilities into Objectif
     - 📋 Search conversation history
     - 📋 Export conversations as markdown
     - 📋 Clear conversation option
-- 📋 **Context Awareness**:
-    - 📋 AI knows current project, version, classes
-    - 📋 AI can reference existing schemas in responses
-    - 📋 AI understands selected items on canvas
-    - 📋 AI can see property definitions
-    - 📋 Automatic context injection into prompts
+- ✅ **Context Awareness** (#259):
+    - ✅ AI knows current project, version, classes
+    - ✅ AI can reference existing schemas in responses
+    - ✅ AI understands selected items on canvas
+    - ✅ AI can see property definitions
+    - ✅ Automatic context injection into prompts
 - 📋 **Multi-Turn Conversations**:
     - 📋 Follow-up questions with context
     - 📋 Clarification requests
@@ -46,7 +46,6 @@ This outlines the planned features for integrating AI capabilities into Objectif
 
 | Ticket | Feature Description                                |
 |--------|----------------------------------------------------|
-| #259   | AI Chat Context Awareness                          |
 | #260   | AI Multi-Turn Conversation with History            |
 | #261   | AI Conversation history actions                    |
 | #262   | Install guardrails.ai server                       |

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.10.15",
+  "version": "0.10.16",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -23,6 +23,7 @@ We continue to improve the platform based on your feedback with improvements and
 ## Studio AI
 - Added the Studio AI chatbot launcher and panel: a floating bubble in the bottom right of the canvas opens a slide-out panel with full-screen mode, toggled with `Cmd+Shift+A` / `Ctrl+Shift+A`.
 - Filled out the Studio AI chat surface to the design guidelines: distinct user/assistant bubbles, typing indicator, markdown rendering, syntax-highlighted code blocks with a copy button, regenerate / thumbs up / thumbs down message actions, and a one-click import button when an assistant reply contains an OpenAPI spec in a ```json``` block.
+- The Studio AI chatbot is now context-aware: each message you send carries a snapshot of your current project, version, classes, reusable properties, and canvas selection, and a "Sharing context" chip in the panel lets you inspect exactly what the assistant can see.
 
 ---
 

--- a/objectified-ui/src/app/ade/studio/StudioContext.tsx
+++ b/objectified-ui/src/app/ade/studio/StudioContext.tsx
@@ -231,6 +231,14 @@ interface StudioContextType {
   /** Registered by Paths canvas: zoom to a node by React Flow id (DB operation id or path-node-*). */
   focusPathsCanvasNodeFn: ((nodeId: string) => void) | null;
   setFocusPathsCanvasNodeFn: (fn: ((nodeId: string) => void) | null) => void;
+  /**
+   * Class node IDs currently selected on the editor canvas (#259). Published
+   * by the editor's React Flow `onSelectionChange` so chrome surfaces — most
+   * notably the Studio AI chatbot — can ground their behaviour in what the
+   * user is looking at.
+   */
+  selectedCanvasNodeIds: string[];
+  setSelectedCanvasNodeIds: (ids: string[]) => void;
 }
 
 export const PATHS_VIEW_MODE_STORAGE_KEY = 'studio.paths.viewMode';
@@ -436,6 +444,14 @@ export function StudioProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const [focusPathsCanvasNodeFn, setFocusPathsCanvasNodeFn] = useState<((nodeId: string) => void) | null>(null);
+
+  const [selectedCanvasNodeIds, setSelectedCanvasNodeIdsState] = useState<string[]>([]);
+  const setSelectedCanvasNodeIds = useCallback((ids: string[]) => {
+    setSelectedCanvasNodeIdsState((prev) => {
+      if (prev.length === ids.length && prev.every((id, i) => id === ids[i])) return prev;
+      return ids;
+    });
+  }, []);
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
@@ -716,7 +732,9 @@ export function StudioProvider({ children }: { children: ReactNode }) {
       pathsQualityRevision,
       bumpPathsQualityRevision,
       focusPathsCanvasNodeFn,
-      setFocusPathsCanvasNodeFn
+      setFocusPathsCanvasNodeFn,
+      selectedCanvasNodeIds,
+      setSelectedCanvasNodeIds,
     }}>
       {children}
     </StudioContext.Provider>

--- a/objectified-ui/src/app/ade/studio/components/StudioAiChatbot.tsx
+++ b/objectified-ui/src/app/ade/studio/components/StudioAiChatbot.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 /**
- * Studio AI Chatbot — placement chrome + chat surface (#257, #258).
+ * Studio AI Chatbot — placement chrome + chat surface (#257, #258, #259).
  *
  * Provides the launcher and panel surfaces for the studio chatbot:
  *   - Floating launcher bubble in the bottom right corner of the canvas
@@ -15,9 +15,14 @@
  * regenerate / thumbs up / thumbs down message actions, and one-click import
  * for ```json``` blocks that look like OpenAPI specs.
  *
- * Backend wiring (Ollama transport, context awareness, history) lands in
- * follow-up tickets (#259, #260, #265). Until those land the panel uses an
- * offline demo responder so reviewers can exercise the full UI today.
+ * Context awareness (#259): callers can pass a `studioContext` snapshot
+ * (project, version, classes, properties, canvas selection) which is
+ * forwarded to the responder on every send, and surfaced in-panel via a
+ * "Sharing context" chip so users always see what the assistant can see.
+ *
+ * Live model wiring (Ollama transport, history) lands in follow-up tickets
+ * (#260, #265). Until those land the panel uses an offline demo responder
+ * so reviewers can exercise the full UI today.
  */
 
 import * as React from 'react';
@@ -26,6 +31,7 @@ import { toast } from 'sonner';
 import { Bot, Maximize2, Minimize2, Sparkles, X } from 'lucide-react';
 import { matchesStudioAiChatbotShortcut } from '@/app/utils/studio-keybindings';
 import { ChatConversation } from './chatbot/ChatConversation';
+import type { ChatStudioContext } from './chatbot/chat-context';
 import type { DetectedOpenApiSpec } from './chatbot/openapi-detection';
 
 /**
@@ -60,13 +66,23 @@ export interface StudioAiChatbotProps {
   forceVisible?: boolean;
   /** Optional initial mode (defaults to `closed`). */
   initialMode?: StudioAiChatbotMode;
+  /**
+   * Snapshot of the user's Studio workspace (#259). Forwarded to the chat
+   * conversation so the responder can ground its replies in the active
+   * project, version, classes, properties, and canvas selection.
+   */
+  studioContext?: ChatStudioContext;
 }
 
 /**
  * Mounts the chatbot launcher and panel. Safe to render once at the studio
  * layout level; it gates itself based on the current pathname.
  */
-export function StudioAiChatbot({ forceVisible, initialMode = 'closed' }: StudioAiChatbotProps = {}) {
+export function StudioAiChatbot({
+  forceVisible,
+  initialMode = 'closed',
+  studioContext,
+}: StudioAiChatbotProps = {}) {
   const pathname = usePathname();
   const [mode, setMode] = React.useState<StudioAiChatbotMode>(initialMode);
 
@@ -110,6 +126,7 @@ export function StudioAiChatbot({ forceVisible, initialMode = 'closed' }: Studio
           mode={mode}
           onModeChange={setMode}
           onClose={close}
+          studioContext={studioContext}
         />
       )}
     </>
@@ -138,9 +155,10 @@ interface ChatbotPanelProps {
   mode: Exclude<StudioAiChatbotMode, 'closed'>;
   onModeChange: (mode: StudioAiChatbotMode) => void;
   onClose: () => void;
+  studioContext?: ChatStudioContext;
 }
 
-function ChatbotPanel({ mode, onModeChange, onClose }: ChatbotPanelProps) {
+function ChatbotPanel({ mode, onModeChange, onClose, studioContext }: ChatbotPanelProps) {
   const isFullscreen = mode === 'fullscreen';
 
   const containerClasses = isFullscreen
@@ -150,8 +168,8 @@ function ChatbotPanel({ mode, onModeChange, onClose }: ChatbotPanelProps) {
   const toggleFullscreen = () =>
     onModeChange(isFullscreen ? 'slide' : 'fullscreen');
 
-  // Until project-aware import lands (#259), surface the detected spec via a
-  // toast so reviewers see the affordance fire end-to-end.
+  // Until project-aware import lands in a follow-up, surface the detected
+  // spec via a toast so reviewers see the affordance fire end-to-end.
   const handleImportSpec = React.useCallback((spec: DetectedOpenApiSpec) => {
     const title = (spec.spec.info as { title?: string } | undefined)?.title ?? 'OpenAPI spec';
     toast.success(`Ready to import: ${title}`, {
@@ -205,7 +223,7 @@ function ChatbotPanel({ mode, onModeChange, onClose }: ChatbotPanelProps) {
       </header>
 
       <div className="flex min-h-0 flex-1 flex-col">
-        <ChatConversation onImportSpec={handleImportSpec} />
+        <ChatConversation onImportSpec={handleImportSpec} studioContext={studioContext} />
       </div>
 
       <footer className="border-t border-gray-200 bg-gray-50 px-4 py-2 text-[11px] text-gray-500 dark:border-gray-700 dark:bg-gray-900/60 dark:text-gray-400">

--- a/objectified-ui/src/app/ade/studio/components/chatbot/ChatContextChip.tsx
+++ b/objectified-ui/src/app/ade/studio/components/chatbot/ChatContextChip.tsx
@@ -1,0 +1,197 @@
+'use client';
+
+import * as React from 'react';
+import * as Popover from '@radix-ui/react-popover';
+import { Sparkles } from 'lucide-react';
+
+import {
+  CHAT_CONTEXT_CLASS_CAP,
+  CHAT_CONTEXT_PROPERTY_CAP,
+  CHAT_CONTEXT_SELECTION_CAP,
+  getSelectedClasses,
+  isChatStudioContextEmpty,
+  type ChatStudioContext,
+} from './chat-context';
+
+/**
+ * "Sharing context" chip rendered just above the chat composer (#259).
+ *
+ * Surfaces the snapshot the chat will inject into the next prompt so the
+ * user is never surprised by what the assistant can see. Clicking the chip
+ * opens a popover with a structured breakdown:
+ *   - Project / version (one line each)
+ *   - Selected classes (capped, with overflow marker)
+ *   - All classes in the version (capped, with overflow marker)
+ *   - Reusable property definitions (capped, with overflow marker)
+ *
+ * Renders nothing for an empty context so the chip never shows up on a
+ * blank workspace.
+ */
+export interface ChatContextChipProps {
+  studioContext: ChatStudioContext;
+  /** Allows callers to override the default popover side (defaults to `top`). */
+  side?: 'top' | 'bottom' | 'left' | 'right';
+}
+
+export function ChatContextChip({ studioContext, side = 'top' }: ChatContextChipProps) {
+  if (isChatStudioContextEmpty(studioContext)) return null;
+
+  const summary = describeSummary(studioContext);
+
+  return (
+    <Popover.Root>
+      <Popover.Trigger asChild>
+        <button
+          type="button"
+          aria-label={`Sharing context with the assistant: ${summary}`}
+          data-testid="studio-ai-chat-context-chip"
+          className="inline-flex items-center gap-1.5 rounded-full border border-indigo-200 bg-indigo-50 px-2.5 py-1 text-xs font-medium text-indigo-700 transition-colors hover:bg-indigo-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 dark:border-indigo-700 dark:bg-indigo-900/40 dark:text-indigo-200 dark:hover:bg-indigo-900/60"
+        >
+          <Sparkles className="h-3.5 w-3.5" aria-hidden />
+          <span className="truncate max-w-[18rem]">Sharing context · {summary}</span>
+        </button>
+      </Popover.Trigger>
+      <Popover.Portal>
+        <Popover.Content
+          side={side}
+          align="start"
+          sideOffset={8}
+          collisionPadding={12}
+          data-testid="studio-ai-chat-context-popover"
+          className="z-[1400] w-[22rem] max-w-[calc(100vw-1.5rem)] rounded-xl border border-gray-200 bg-white p-4 text-xs text-gray-700 shadow-xl dark:border-gray-700 dark:bg-gray-900 dark:text-gray-200"
+        >
+          <ContextDetails studioContext={studioContext} />
+          <Popover.Arrow className="fill-white stroke-gray-200 dark:fill-gray-900 dark:stroke-gray-700" />
+        </Popover.Content>
+      </Popover.Portal>
+    </Popover.Root>
+  );
+}
+
+function describeSummary(ctx: ChatStudioContext): string {
+  const bits: string[] = [];
+  if (ctx.project?.name) bits.push(ctx.project.name);
+  if (ctx.version?.label) bits.push(ctx.version.label);
+  const counts: string[] = [];
+  if (ctx.classes.length > 0) {
+    counts.push(`${ctx.classes.length} class${ctx.classes.length === 1 ? '' : 'es'}`);
+  }
+  if (ctx.properties.length > 0) {
+    counts.push(`${ctx.properties.length} propert${ctx.properties.length === 1 ? 'y' : 'ies'}`);
+  }
+  if (ctx.selectedClassIds.length > 0) {
+    counts.push(`${ctx.selectedClassIds.length} selected`);
+  }
+  if (counts.length > 0) bits.push(counts.join(', '));
+  return bits.length > 0 ? bits.join(' • ') : 'workspace state';
+}
+
+interface ContextDetailsProps {
+  studioContext: ChatStudioContext;
+}
+
+function ContextDetails({ studioContext }: ContextDetailsProps) {
+  const selectedClasses = getSelectedClasses(studioContext);
+  return (
+    <div className="space-y-3">
+      <header>
+        <p className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+          What the assistant can see
+        </p>
+        <p className="mt-0.5 text-[11px] leading-snug text-gray-500 dark:text-gray-400">
+          Each message you send includes the snapshot below so replies stay grounded in this workspace.
+        </p>
+      </header>
+
+      <DetailSection
+        label="Project"
+        value={studioContext.project?.name ?? studioContext.project?.id ?? null}
+      />
+      <DetailSection
+        label="Version"
+        value={studioContext.version?.label ?? studioContext.version?.id ?? null}
+      />
+
+      {selectedClasses.length > 0 && (
+        <DetailListSection
+          label={`Selected on canvas (${selectedClasses.length})`}
+          items={selectedClasses.map((cls) => cls.name)}
+          cap={CHAT_CONTEXT_SELECTION_CAP}
+          testId="studio-ai-chat-context-selection"
+        />
+      )}
+
+      {studioContext.classes.length > 0 && (
+        <DetailListSection
+          label={`Classes (${studioContext.classes.length})`}
+          items={studioContext.classes.map((cls) => cls.name)}
+          cap={CHAT_CONTEXT_CLASS_CAP}
+          testId="studio-ai-chat-context-classes"
+        />
+      )}
+
+      {studioContext.properties.length > 0 && (
+        <DetailListSection
+          label={`Properties (${studioContext.properties.length})`}
+          items={studioContext.properties.map((prop) =>
+            prop.type ? `${prop.name} (${prop.type})` : prop.name
+          )}
+          cap={CHAT_CONTEXT_PROPERTY_CAP}
+          testId="studio-ai-chat-context-properties"
+        />
+      )}
+    </div>
+  );
+}
+
+interface DetailSectionProps {
+  label: string;
+  value: string | null;
+}
+
+function DetailSection({ label, value }: DetailSectionProps) {
+  if (!value) return null;
+  return (
+    <div>
+      <p className="text-[11px] font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+        {label}
+      </p>
+      <p className="mt-0.5 text-sm text-gray-900 dark:text-gray-100">{value}</p>
+    </div>
+  );
+}
+
+interface DetailListSectionProps {
+  label: string;
+  items: string[];
+  cap: number;
+  testId?: string;
+}
+
+function DetailListSection({ label, items, cap, testId }: DetailListSectionProps) {
+  if (items.length === 0) return null;
+  const visible = items.slice(0, cap);
+  const overflow = items.length - visible.length;
+  return (
+    <div data-testid={testId}>
+      <p className="text-[11px] font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+        {label}
+      </p>
+      <ul className="mt-1 flex flex-wrap gap-1">
+        {visible.map((item) => (
+          <li
+            key={item}
+            className="rounded-md bg-gray-100 px-1.5 py-0.5 font-mono text-[11px] text-gray-700 dark:bg-gray-800 dark:text-gray-200"
+          >
+            {item}
+          </li>
+        ))}
+        {overflow > 0 && (
+          <li className="rounded-md bg-gray-100 px-1.5 py-0.5 text-[11px] italic text-gray-500 dark:bg-gray-800 dark:text-gray-400">
+            +{overflow} more
+          </li>
+        )}
+      </ul>
+    </div>
+  );
+}

--- a/objectified-ui/src/app/ade/studio/components/chatbot/ChatContextChip.tsx
+++ b/objectified-ui/src/app/ade/studio/components/chatbot/ChatContextChip.tsx
@@ -178,9 +178,9 @@ function DetailListSection({ label, items, cap, testId }: DetailListSectionProps
         {label}
       </p>
       <ul className="mt-1 flex flex-wrap gap-1">
-        {visible.map((item) => (
+        {visible.map((item, index) => (
           <li
-            key={item}
+            key={`${item}-${index}`}
             className="rounded-md bg-gray-100 px-1.5 py-0.5 font-mono text-[11px] text-gray-700 dark:bg-gray-800 dark:text-gray-200"
           >
             {item}

--- a/objectified-ui/src/app/ade/studio/components/chatbot/ChatConversation.tsx
+++ b/objectified-ui/src/app/ade/studio/components/chatbot/ChatConversation.tsx
@@ -5,12 +5,15 @@ import { Sparkles } from 'lucide-react';
 
 import { ChatBubble } from './ChatBubble';
 import { ChatComposer } from './ChatComposer';
+import { ChatContextChip } from './ChatContextChip';
+import type { ChatStudioContext } from './chat-context';
+import { isChatStudioContextEmpty } from './chat-context';
 import { createDemoChatResponder } from './demo-responder';
 import type { DetectedOpenApiSpec } from './openapi-detection';
 import type { ChatFeedback, ChatMessage, ChatSendFn } from './types';
 
 /**
- * Studio AI chat conversation surface (#258).
+ * Studio AI chat conversation surface (#258, #259).
  *
  * Owns the message transcript, scroll behaviour, and request lifecycle for
  * the chatbot panel. Stateless from the caller's perspective: pass an
@@ -20,6 +23,9 @@ import type { ChatFeedback, ChatMessage, ChatSendFn } from './types';
  *   - User and assistant bubbles are visually distinct
  *   - Typing indicator is shown while the assistant is composing
  *   - Markdown / code / OpenAPI affordances are delegated to `ChatBubble`
+ *   - When a `studioContext` snapshot is provided (#259), each send captures
+ *     the snapshot at that moment and forwards it to the responder, and a
+ *     small "Sharing context" chip lets the user inspect what is being sent
  */
 export interface ChatConversationProps {
   /** Adapter invoked to produce assistant replies. Defaults to the demo responder. */
@@ -30,6 +36,13 @@ export interface ChatConversationProps {
   initialMessages?: ChatMessage[];
   /** Optional empty-state body copy. */
   emptyStateMessage?: string;
+  /**
+   * Optional Studio workspace snapshot (#259). When supplied, the snapshot is
+   * captured on every send and threaded through the responder so it can
+   * ground its replies in the user's project, version, classes, properties,
+   * and current canvas selection.
+   */
+  studioContext?: ChatStudioContext;
 }
 
 const PROMPT_SUGGESTIONS: readonly string[] = [
@@ -43,12 +56,22 @@ export function ChatConversation({
   onImportSpec,
   initialMessages,
   emptyStateMessage,
+  studioContext,
 }: ChatConversationProps) {
   const responder = React.useMemo(() => onSendMessage ?? createDemoChatResponder(), [onSendMessage]);
   const [messages, setMessages] = React.useState<ChatMessage[]>(() => initialMessages ?? []);
   const [isBusy, setIsBusy] = React.useState(false);
   const messagesEndRef = React.useRef<HTMLDivElement>(null);
   const requestIdRef = React.useRef(0);
+  // Hold the current snapshot in a ref so each send captures the latest state
+  // without re-creating the send callback on every studio change (which would
+  // thrash effects in the composer / message list).
+  const studioContextRef = React.useRef<ChatStudioContext | undefined>(studioContext);
+  React.useEffect(() => {
+    studioContextRef.current = studioContext;
+  }, [studioContext]);
+
+  const hasStudioContext = !!studioContext && !isChatStudioContextEmpty(studioContext);
 
   React.useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth', block: 'end' });
@@ -78,7 +101,12 @@ export function ChatConversation({
 
       let reply: string;
       try {
-        reply = await responder({ messages: transcript, prompt, isRegenerate });
+        reply = await responder({
+          messages: transcript,
+          prompt,
+          isRegenerate,
+          studioContext: studioContextRef.current,
+        });
       } catch (error) {
         console.error('Chat assistant failed to respond', error);
         reply = 'Sorry — the assistant could not respond. Please try again.';
@@ -164,6 +192,12 @@ export function ChatConversation({
           </div>
         )}
       </div>
+
+      {hasStudioContext && (
+        <div className="border-t border-gray-200 bg-white px-3 py-2 dark:border-gray-700 dark:bg-gray-900">
+          <ChatContextChip studioContext={studioContext!} />
+        </div>
+      )}
 
       <ChatComposer onSend={handleSend} isBusy={isBusy} />
     </div>

--- a/objectified-ui/src/app/ade/studio/components/chatbot/chat-context.ts
+++ b/objectified-ui/src/app/ade/studio/components/chatbot/chat-context.ts
@@ -1,0 +1,274 @@
+/**
+ * Studio chat context — gather + summarize (#259).
+ *
+ * The chatbot needs to talk about the user's actual workspace, not generic
+ * schemas. This module owns the small, UI-agnostic data structure that the
+ * Studio layout assembles from `useStudio()` plus the loaded classes and
+ * properties, and the helpers that turn that snapshot into:
+ *
+ *   - a compact human-readable summary used by the in-chat "context" chip
+ *   - a system-style preamble that gets injected into prompts so the
+ *     responder (today the offline demo, tomorrow Ollama) can reference the
+ *     active project, version, classes, schemas, and selection
+ *
+ * The summary is *capped* on every dimension so a large project cannot blow
+ * the prompt budget on the eventual model call. The caps live here as
+ * exported constants so tests pin the contract.
+ */
+
+export interface ChatStudioProject {
+  id: string;
+  name: string | null;
+}
+
+export interface ChatStudioVersion {
+  id: string;
+  label: string | null;
+}
+
+export interface ChatStudioClass {
+  id: string;
+  name: string;
+  description?: string | null;
+  /**
+   * Raw class schema as stored in the DB — may be a string, object, or null.
+   * Kept loose so callers don't have to pre-normalise.
+   */
+  schema?: unknown;
+}
+
+export interface ChatStudioProperty {
+  id: string;
+  name: string;
+  description?: string | null;
+  /** JSON Schema type, e.g. `string`, `integer`, `boolean`. */
+  type?: string | null;
+  /** JSON Schema format, e.g. `email`, `date-time`. */
+  format?: string | null;
+  /** True if this property requires a value when used on a class. */
+  required?: boolean | null;
+}
+
+export interface ChatStudioContext {
+  project: ChatStudioProject | null;
+  version: ChatStudioVersion | null;
+  classes: ChatStudioClass[];
+  properties: ChatStudioProperty[];
+  /** IDs of nodes the user has selected on the canvas. */
+  selectedClassIds: string[];
+}
+
+/** Token-budget caps. Conservative defaults so prompts stay small. */
+export const CHAT_CONTEXT_CLASS_CAP = 30;
+export const CHAT_CONTEXT_PROPERTY_CAP = 30;
+export const CHAT_CONTEXT_SELECTION_CAP = 10;
+export const CHAT_CONTEXT_SCHEMA_CHAR_CAP = 600;
+export const CHAT_CONTEXT_DESCRIPTION_CHAR_CAP = 160;
+
+/** An empty snapshot — useful as a default and for the no-context branch. */
+export const EMPTY_CHAT_STUDIO_CONTEXT: ChatStudioContext = {
+  project: null,
+  version: null,
+  classes: [],
+  properties: [],
+  selectedClassIds: [],
+};
+
+/**
+ * True when the snapshot contains nothing the assistant can use. Cheap guard
+ * so callers can skip emitting the "Sharing context" chip and prompt
+ * preamble entirely when the user is on a fresh / empty workspace.
+ */
+export function isChatStudioContextEmpty(ctx: ChatStudioContext | null | undefined): boolean {
+  if (!ctx) return true;
+  return (
+    !ctx.project &&
+    !ctx.version &&
+    ctx.classes.length === 0 &&
+    ctx.properties.length === 0 &&
+    ctx.selectedClassIds.length === 0
+  );
+}
+
+/**
+ * Selected classes, materialised against the class list. Selection IDs that
+ * don't resolve (stale canvas state) are silently dropped so we never
+ * pollute the prompt with phantom names.
+ */
+export function getSelectedClasses(ctx: ChatStudioContext): ChatStudioClass[] {
+  if (ctx.selectedClassIds.length === 0) return [];
+  const byId = new Map(ctx.classes.map((cls) => [cls.id, cls]));
+  const out: ChatStudioClass[] = [];
+  for (const id of ctx.selectedClassIds) {
+    const cls = byId.get(id);
+    if (cls) out.push(cls);
+  }
+  return out;
+}
+
+/**
+ * Render the snapshot as a compact bullet list suitable for the "Sharing
+ * context" popover. Returns an empty string when nothing is shareable so the
+ * caller can render a fallback line.
+ */
+export function summarizeChatStudioContext(ctx: ChatStudioContext): string {
+  if (isChatStudioContextEmpty(ctx)) return '';
+
+  const lines: string[] = [];
+  if (ctx.project) {
+    lines.push(`- **Project:** ${ctx.project.name ?? ctx.project.id}`);
+  }
+  if (ctx.version) {
+    lines.push(`- **Version:** ${ctx.version.label ?? ctx.version.id}`);
+  }
+
+  const selected = getSelectedClasses(ctx);
+  if (selected.length > 0) {
+    const visible = selected.slice(0, CHAT_CONTEXT_SELECTION_CAP);
+    const overflow = selected.length - visible.length;
+    const names = visible.map((cls) => cls.name).join(', ');
+    const suffix = overflow > 0 ? ` (+${overflow} more)` : '';
+    lines.push(`- **Selected on canvas:** ${names}${suffix}`);
+  }
+
+  if (ctx.classes.length > 0) {
+    lines.push(`- **Classes (${ctx.classes.length}):** ${formatNameList(ctx.classes, CHAT_CONTEXT_CLASS_CAP)}`);
+  }
+
+  if (ctx.properties.length > 0) {
+    lines.push(`- **Properties (${ctx.properties.length}):** ${formatNameList(ctx.properties, CHAT_CONTEXT_PROPERTY_CAP)}`);
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Build the system-style preamble that the responder receives alongside the
+ * user prompt. Keeps schema bodies short, names capped, and selection
+ * highlighted so the model can prioritise the user's current focus.
+ */
+export function buildChatContextPreamble(ctx: ChatStudioContext): string {
+  if (isChatStudioContextEmpty(ctx)) return '';
+
+  const sections: string[] = ['### Current Studio context'];
+
+  if (ctx.project) {
+    sections.push(`- Project: ${ctx.project.name ?? '(unnamed)'} (id: ${ctx.project.id})`);
+  }
+  if (ctx.version) {
+    sections.push(`- Version: ${ctx.version.label ?? '(unlabeled)'} (id: ${ctx.version.id})`);
+  }
+
+  const selected = getSelectedClasses(ctx);
+  if (selected.length > 0) {
+    sections.push('');
+    sections.push('#### Selected on canvas');
+    for (const cls of selected.slice(0, CHAT_CONTEXT_SELECTION_CAP)) {
+      sections.push(formatClassEntry(cls, { includeSchema: true }));
+    }
+    if (selected.length > CHAT_CONTEXT_SELECTION_CAP) {
+      sections.push(`- … and ${selected.length - CHAT_CONTEXT_SELECTION_CAP} more selected`);
+    }
+  }
+
+  if (ctx.classes.length > 0) {
+    sections.push('');
+    sections.push(`#### Classes in this version (${ctx.classes.length})`);
+    const visible = ctx.classes.slice(0, CHAT_CONTEXT_CLASS_CAP);
+    for (const cls of visible) {
+      sections.push(formatClassEntry(cls, { includeSchema: false }));
+    }
+    if (ctx.classes.length > visible.length) {
+      sections.push(`- … and ${ctx.classes.length - visible.length} more classes not shown`);
+    }
+  }
+
+  if (ctx.properties.length > 0) {
+    sections.push('');
+    sections.push(`#### Reusable property definitions (${ctx.properties.length})`);
+    const visible = ctx.properties.slice(0, CHAT_CONTEXT_PROPERTY_CAP);
+    for (const prop of visible) {
+      sections.push(formatPropertyEntry(prop));
+    }
+    if (ctx.properties.length > visible.length) {
+      sections.push(`- … and ${ctx.properties.length - visible.length} more properties not shown`);
+    }
+  }
+
+  sections.push('');
+  sections.push('Use this context to ground answers in the user\'s actual project. Reference class and property names from the lists above when relevant.');
+
+  return sections.join('\n');
+}
+
+/**
+ * Inject the preamble in front of the user prompt. Returns the prompt
+ * untouched when there is no context worth injecting, so calling this is
+ * always safe.
+ */
+export function injectChatContext(prompt: string, ctx: ChatStudioContext | null | undefined): string {
+  if (!ctx || isChatStudioContextEmpty(ctx)) return prompt;
+  const preamble = buildChatContextPreamble(ctx);
+  if (!preamble) return prompt;
+  return `${preamble}\n\n---\n\n### User request\n${prompt}`;
+}
+
+function formatNameList(items: Array<{ name: string }>, cap: number): string {
+  const visible = items.slice(0, cap).map((item) => item.name);
+  const overflow = items.length - visible.length;
+  return overflow > 0 ? `${visible.join(', ')} (+${overflow} more)` : visible.join(', ');
+}
+
+function formatClassEntry(cls: ChatStudioClass, opts: { includeSchema: boolean }): string {
+  const parts: string[] = [`- \`${cls.name}\``];
+  const desc = truncate(cls.description, CHAT_CONTEXT_DESCRIPTION_CHAR_CAP);
+  if (desc) parts.push(`— ${desc}`);
+
+  if (opts.includeSchema) {
+    const schemaText = stringifySchema(cls.schema);
+    if (schemaText) {
+      return `${parts.join(' ')}\n  schema: ${schemaText}`;
+    }
+  }
+
+  return parts.join(' ');
+}
+
+function formatPropertyEntry(prop: ChatStudioProperty): string {
+  const parts: string[] = [`- \`${prop.name}\``];
+  const typeBits: string[] = [];
+  if (prop.type) typeBits.push(prop.type);
+  if (prop.format) typeBits.push(`format: ${prop.format}`);
+  if (prop.required) typeBits.push('required');
+  if (typeBits.length > 0) parts.push(`(${typeBits.join(', ')})`);
+  const desc = truncate(prop.description, CHAT_CONTEXT_DESCRIPTION_CHAR_CAP);
+  if (desc) parts.push(`— ${desc}`);
+  return parts.join(' ');
+}
+
+function truncate(value: string | null | undefined, cap: number): string | null {
+  if (!value) return null;
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return null;
+  if (trimmed.length <= cap) return trimmed;
+  return `${trimmed.slice(0, cap - 1).trimEnd()}…`;
+}
+
+function stringifySchema(schema: unknown): string | null {
+  if (schema == null) return null;
+  let text: string;
+  try {
+    if (typeof schema === 'string') {
+      const trimmed = schema.trim();
+      if (trimmed.length === 0) return null;
+      text = trimmed;
+    } else {
+      text = JSON.stringify(schema);
+    }
+  } catch {
+    return null;
+  }
+  if (text.length === 0) return null;
+  if (text.length <= CHAT_CONTEXT_SCHEMA_CHAR_CAP) return text;
+  return `${text.slice(0, CHAT_CONTEXT_SCHEMA_CHAR_CAP - 1)}…`;
+}

--- a/objectified-ui/src/app/ade/studio/components/chatbot/demo-responder.ts
+++ b/objectified-ui/src/app/ade/studio/components/chatbot/demo-responder.ts
@@ -1,6 +1,6 @@
 /**
  * Default offline responder used by the Studio AI chatbot until the Ollama
- * adapter lands (#259, #265).
+ * adapter lands (#265).
  *
  * The replies are deterministic and intentionally cover every UI affordance
  * the interface guidelines call for so designers and reviewers can see the
@@ -9,34 +9,47 @@
  *   - A fenced code block with copy + syntax highlighting
  *   - A ```json``` block holding a small but valid OpenAPI 3.1 spec so the
  *     "Import OpenAPI spec" affordance lights up
+ *
+ * As of #259 the responder is also context-aware: when the chat shell hands
+ * us a `studioContext` snapshot we mention the user's project / version,
+ * acknowledge canvas selection, and reuse existing class / property names
+ * inside the demo OpenAPI spec. The intent is to give reviewers a faithful
+ * preview of how a real backend will ground its replies in the workspace.
  */
 
+import type { ChatStudioContext, ChatStudioProperty } from './chat-context';
+import { getSelectedClasses, isChatStudioContextEmpty } from './chat-context';
 import type { ChatSendFn } from './types';
 
 const SPEC_DEMO_PROMPTS = ['openapi', 'spec', 'schema', 'api'];
 
-export const createDemoChatResponder = (): ChatSendFn => async ({ prompt, isRegenerate }) => {
+export const createDemoChatResponder = (): ChatSendFn => async ({
+  prompt,
+  isRegenerate,
+  studioContext,
+}) => {
   const lower = prompt.toLowerCase();
   const wantsSpec = SPEC_DEMO_PROMPTS.some((needle) => lower.includes(needle));
   const variation = isRegenerate ? '\n\n_Regenerated with a slightly different angle._' : '';
+  const groundingLine = describeGrounding(studioContext);
 
   if (wantsSpec) {
+    const spec = buildSampleSpec(studioContext);
+    const suggestions = buildContextAwareSuggestions(studioContext);
     return [
-      "Here's a small OpenAPI 3.1 sketch for what you described — review the JSON below and click **Import OpenAPI spec** to load it into Studio.",
+      `Here's a small OpenAPI 3.1 sketch for what you described${groundingLine ? ` ${groundingLine}` : ''} — review the JSON below and click **Import OpenAPI spec** to load it into Studio.`,
       '',
       '```json',
-      JSON.stringify(SAMPLE_SPEC, null, 2),
+      JSON.stringify(spec, null, 2),
       '```',
       '',
       'A few things to consider next:',
-      '- Tighten property descriptions for documentation scoring',
-      '- Add `examples` arrays where missing',
-      '- Decide whether to expose this through a path operation in a follow-up',
+      ...suggestions,
     ].join('\n') + variation;
   }
 
   return [
-    "I'm the offline preview of the Studio AI assistant — the live model lands in a follow-up ticket. Until then, here's what the chat surface supports today:",
+    `I'm the offline preview of the Studio AI assistant${groundingLine ? ` ${groundingLine}` : ''} — the live model lands in a follow-up ticket. Until then, here's what the chat surface supports today:`,
     '',
     '- **Markdown** rendering with headings, lists, and inline `code`',
     '- Code blocks with copy + syntax highlighting:',
@@ -51,25 +64,147 @@ export const createDemoChatResponder = (): ChatSendFn => async ({ prompt, isRege
   ].join('\n') + variation;
 };
 
-const SAMPLE_SPEC = {
-  openapi: '3.1.0',
+function describeGrounding(ctx: ChatStudioContext | undefined): string | null {
+  if (!ctx || isChatStudioContextEmpty(ctx)) return null;
+  const parts: string[] = [];
+  const projectName = ctx.project?.name;
+  const versionLabel = ctx.version?.label;
+  if (projectName && versionLabel) {
+    parts.push(`for **${projectName}** ${versionLabel}`);
+  } else if (projectName) {
+    parts.push(`for **${projectName}**`);
+  } else if (versionLabel) {
+    parts.push(`on version ${versionLabel}`);
+  }
+  const selected = getSelectedClasses(ctx).map((cls) => cls.name);
+  if (selected.length === 1) {
+    parts.push(`while looking at \`${selected[0]}\``);
+  } else if (selected.length > 1) {
+    const visible = selected.slice(0, 3).map((name) => `\`${name}\``).join(', ');
+    const overflow = selected.length - Math.min(selected.length, 3);
+    parts.push(`while looking at ${visible}${overflow > 0 ? ` (+${overflow} more)` : ''}`);
+  }
+  return parts.length > 0 ? `(${parts.join(' ')})` : null;
+}
+
+function buildContextAwareSuggestions(ctx: ChatStudioContext | undefined): string[] {
+  const suggestions = [
+    '- Tighten property descriptions for documentation scoring',
+    '- Add `examples` arrays where missing',
+    '- Decide whether to expose this through a path operation in a follow-up',
+  ];
+  if (!ctx || isChatStudioContextEmpty(ctx)) return suggestions;
+  const selected = getSelectedClasses(ctx);
+  if (selected.length > 0) {
+    const names = selected.slice(0, 3).map((cls) => `\`${cls.name}\``).join(', ');
+    suggestions.unshift(`- Cross-check the new schema against your selected ${selected.length === 1 ? 'class' : 'classes'} (${names})`);
+  } else if (ctx.classes.length > 0) {
+    const sample = ctx.classes.slice(0, 3).map((cls) => `\`${cls.name}\``).join(', ');
+    suggestions.unshift(`- Reuse the names already in this version when possible (e.g. ${sample})`);
+  }
+  return suggestions;
+}
+
+interface SampleSpec {
+  openapi: string;
   info: {
-    title: 'Sample Catalog API',
-    version: '0.1.0',
-    description: 'Tiny catalog API generated by the Studio AI demo responder.',
-  },
+    title: string;
+    version: string;
+    description: string;
+  };
   components: {
-    schemas: {
-      Product: {
-        type: 'object',
-        description: 'A purchasable item in the catalog.',
-        properties: {
-          id: { type: 'string', format: 'uuid', description: 'Catalog identifier' },
-          name: { type: 'string', description: 'Display name shown to shoppers' },
-          priceCents: { type: 'integer', minimum: 0, description: 'Price in cents' },
+    schemas: Record<string, {
+      type: string;
+      description: string;
+      properties: Record<string, { type: string; format?: string; description: string; minimum?: number }>;
+      required: string[];
+    }>;
+  };
+}
+
+function buildSampleSpec(ctx: ChatStudioContext | undefined): SampleSpec {
+  const title = ctx?.project?.name ? `${ctx.project.name} (Studio AI sketch)` : 'Sample Catalog API';
+  const version = ctx?.version?.label ?? '0.1.0';
+  const className = pickReferenceClassName(ctx) ?? 'Product';
+  const properties = buildSpecProperties(ctx);
+
+  return {
+    openapi: '3.1.0',
+    info: {
+      title,
+      version,
+      description: ctx?.project?.name
+        ? `Sketch generated by the Studio AI demo responder, grounded in ${ctx.project.name}.`
+        : 'Tiny catalog API generated by the Studio AI demo responder.',
+    },
+    components: {
+      schemas: {
+        [className]: {
+          type: 'object',
+          description: ctx?.project?.name
+            ? `A representative ${className} for ${ctx.project.name}.`
+            : 'A purchasable item in the catalog.',
+          properties,
+          required: deriveRequired(properties),
         },
-        required: ['id', 'name', 'priceCents'],
       },
     },
-  },
-};
+  };
+}
+
+function pickReferenceClassName(ctx: ChatStudioContext | undefined): string | null {
+  if (!ctx) return null;
+  const selected = getSelectedClasses(ctx);
+  if (selected.length > 0) return selected[0].name;
+  if (ctx.classes.length > 0) return ctx.classes[0].name;
+  return null;
+}
+
+function buildSpecProperties(
+  ctx: ChatStudioContext | undefined
+): Record<string, { type: string; format?: string; description: string; minimum?: number }> {
+  const fallback: Record<string, { type: string; format?: string; description: string; minimum?: number }> = {
+    id: { type: 'string', format: 'uuid', description: 'Catalog identifier' },
+    name: { type: 'string', description: 'Display name shown to shoppers' },
+    priceCents: { type: 'integer', minimum: 0, description: 'Price in cents' },
+  };
+
+  if (!ctx || ctx.properties.length === 0) return fallback;
+
+  const properties: Record<string, { type: string; format?: string; description: string; minimum?: number }> = {};
+  for (const prop of ctx.properties.slice(0, 4)) {
+    properties[prop.name] = describeReusableProperty(prop);
+  }
+  if (Object.keys(properties).length === 0) return fallback;
+  // Always make sure there's an id-shaped field so the spec is useful as a starting point.
+  if (!properties.id) {
+    properties.id = { type: 'string', format: 'uuid', description: 'Identifier reused from Studio properties.' };
+  }
+  return properties;
+}
+
+function describeReusableProperty(prop: ChatStudioProperty): {
+  type: string;
+  format?: string;
+  description: string;
+  minimum?: number;
+} {
+  const type = prop.type ?? 'string';
+  const description = prop.description?.trim().length
+    ? prop.description.trim()
+    : `Reused Studio property "${prop.name}".`;
+  const entry: { type: string; format?: string; description: string; minimum?: number } = {
+    type,
+    description,
+  };
+  if (prop.format) entry.format = prop.format;
+  if (type === 'integer' || type === 'number') entry.minimum = 0;
+  return entry;
+}
+
+function deriveRequired(
+  properties: Record<string, { type: string }>
+): string[] {
+  const required = Object.keys(properties).filter((name) => name === 'id' || name === 'name');
+  return required.length > 0 ? required : Object.keys(properties).slice(0, 1);
+}

--- a/objectified-ui/src/app/ade/studio/components/chatbot/index.ts
+++ b/objectified-ui/src/app/ade/studio/components/chatbot/index.ts
@@ -1,4 +1,4 @@
-/** Barrel exports for the Studio AI chatbot building blocks (#258). */
+/** Barrel exports for the Studio AI chatbot building blocks (#258, #259). */
 
 export { ChatBubble } from './ChatBubble';
 export type { ChatBubbleProps } from './ChatBubble';
@@ -6,9 +6,31 @@ export { ChatCodeBlock, renderHighlighted } from './ChatCodeBlock';
 export type { ChatCodeBlockProps } from './ChatCodeBlock';
 export { ChatComposer } from './ChatComposer';
 export type { ChatComposerProps } from './ChatComposer';
+export { ChatContextChip } from './ChatContextChip';
+export type { ChatContextChipProps } from './ChatContextChip';
 export { ChatConversation } from './ChatConversation';
 export type { ChatConversationProps } from './ChatConversation';
 export { ChatTypingIndicator } from './ChatTypingIndicator';
+export {
+  buildChatContextPreamble,
+  CHAT_CONTEXT_CLASS_CAP,
+  CHAT_CONTEXT_DESCRIPTION_CHAR_CAP,
+  CHAT_CONTEXT_PROPERTY_CAP,
+  CHAT_CONTEXT_SCHEMA_CHAR_CAP,
+  CHAT_CONTEXT_SELECTION_CAP,
+  EMPTY_CHAT_STUDIO_CONTEXT,
+  getSelectedClasses,
+  injectChatContext,
+  isChatStudioContextEmpty,
+  summarizeChatStudioContext,
+} from './chat-context';
+export type {
+  ChatStudioClass,
+  ChatStudioContext,
+  ChatStudioProject,
+  ChatStudioProperty,
+  ChatStudioVersion,
+} from './chat-context';
 export { createDemoChatResponder } from './demo-responder';
 export {
   detectOpenApiSpecs,

--- a/objectified-ui/src/app/ade/studio/components/chatbot/types.ts
+++ b/objectified-ui/src/app/ade/studio/components/chatbot/types.ts
@@ -1,10 +1,12 @@
 /**
- * Studio AI chatbot — shared types (#258).
+ * Studio AI chatbot — shared types (#258, #259).
  *
  * The chat surface is intentionally backend-agnostic so the same UI can host
  * the offline demo responder today and a streaming Ollama transport later
  * (#259, #265). Anything UI-facing lives here.
  */
+
+import type { ChatStudioContext } from './chat-context';
 
 export type ChatRole = 'user' | 'assistant';
 
@@ -29,6 +31,14 @@ export interface ChatSendContext {
   prompt: string;
   /** True when the caller asked the assistant to redo its previous answer. */
   isRegenerate: boolean;
+  /**
+   * Snapshot of the user's Studio workspace (#259): current project / version,
+   * loaded classes and properties, and any canvas selection. Responders should
+   * treat this as authoritative grounding for the user's request — it is
+   * captured at the moment the message is sent so later edits don't leak
+   * back into earlier turns.
+   */
+  studioContext?: ChatStudioContext;
 }
 
 /**

--- a/objectified-ui/src/app/ade/studio/editor/page.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/page.tsx
@@ -391,6 +391,7 @@ const StudioContent = () => {
     versionBranchesByProjectId,
     setVersionBranchesForProject,
     setCanvasViewport,
+    setSelectedCanvasNodeIds,
   } = useStudio();
 
   /* When git-like is disabled, pass empty ids so the hook short-circuits and
@@ -842,17 +843,25 @@ const StudioContent = () => {
       setSuppressGroupSidebarDestructive(true);
       setNodes((nds) => nds.map((n) => ({ ...n, selected: false })));
       setSelectedNodeIds([]);
+      setSelectedCanvasNodeIds([]);
     });
   }, [
     setSuppressGroupFloatingToolbars,
     setSuppressGroupSidebarDestructive,
     setNodes,
+    setSelectedCanvasNodeIds,
   ]);
 
   useEffect(() => {
     setClearCanvasSelectionFn(() => prepareCanvasForCodeView);
     return () => setClearCanvasSelectionFn(null);
   }, [prepareCanvasForCodeView, setClearCanvasSelectionFn]);
+
+  // Clear the published canvas selection on unmount (#259) so the chatbot
+  // context never shows stale node IDs after navigating away from the editor.
+  useEffect(() => {
+    return () => setSelectedCanvasNodeIds([]);
+  }, [setSelectedCanvasNodeIds]);
 
   useEffect(() => {
     if (viewMode === 'canvas') {
@@ -7576,6 +7585,9 @@ const StudioContent = () => {
       .filter(n => n.type !== 'groupNode')
       .map(n => n.id);
     setSelectedNodeIds(classNodeIds);
+    // Publish to studio context (#259) so the AI chatbot can ground replies
+    // in whatever the user has selected on the canvas.
+    setSelectedCanvasNodeIds(classNodeIds);
 
     // Update spacing indicators when selection changes
     if (showSpacingIndicators && classNodeIds.length >= 2) {
@@ -7583,7 +7595,7 @@ const StudioContent = () => {
     } else {
       setSpacingIndicators({ horizontal: [], vertical: [] });
     }
-  }, [showSpacingIndicators]);
+  }, [showSpacingIndicators, setSelectedCanvasNodeIds]);
 
   // Calculate spacing indicators between selected nodes
   const calculateSpacingIndicators = useCallback((nodeIds: string[]) => {

--- a/objectified-ui/src/app/ade/studio/layout.tsx
+++ b/objectified-ui/src/app/ade/studio/layout.tsx
@@ -24,6 +24,7 @@ import * as Dialog from '@radix-ui/react-dialog';
 import { ADE_SUBHEADER_RESERVE_PX } from '../constants/subheader-layout';
 import { GitCommandPalette } from './components/GitCommandPalette';
 import { StudioAiChatbot } from './components/StudioAiChatbot';
+import type { ChatStudioContext, ChatStudioProperty } from './components/chatbot/chat-context';
 import StudioFooterBar from './components/StudioFooterBar';
 import { FEATURE_GITLIKE } from '@lib/feature-flags';
 
@@ -45,6 +46,9 @@ function StudioLayoutContent({ children }: Readonly<{ children: React.ReactNode 
   const {
     selectedProjectId,
     selectedVersionId,
+    selectedProjectName,
+    selectedVersionLabel,
+    selectedCanvasNodeIds,
     triggerCanvasRefresh,
     triggerSidebarRefresh,
     sidebarRefreshKey,
@@ -414,6 +418,53 @@ function StudioLayoutContent({ children }: Readonly<{ children: React.ReactNode 
     });
   }, [groups, sidebarRefreshKey]);
 
+  // Snapshot of the studio workspace assembled for the AI chatbot (#259).
+  // Recomputed only when its inputs change so the chatbot doesn't re-render
+  // on unrelated layout state churn.
+  const chatbotStudioContext = React.useMemo<ChatStudioContext>(() => {
+    const chatProperties: ChatStudioProperty[] = properties.map((prop) => {
+      const propAny = prop as unknown as Record<string, unknown>;
+      const dataObj = (propAny['data'] && typeof propAny['data'] === 'object'
+        ? (propAny['data'] as Record<string, unknown>)
+        : propAny) as Record<string, unknown>;
+      const type = typeof dataObj['type'] === 'string' ? (dataObj['type'] as string) : null;
+      const format = typeof dataObj['format'] === 'string' ? (dataObj['format'] as string) : null;
+      const required = typeof dataObj['required'] === 'boolean' ? (dataObj['required'] as boolean) : null;
+      return {
+        id: prop.id,
+        name: prop.name,
+        description: prop.description ?? null,
+        type,
+        format,
+        required,
+      };
+    });
+    return {
+      project: selectedProjectId
+        ? { id: selectedProjectId, name: selectedProjectName ?? null }
+        : null,
+      version: selectedVersionId
+        ? { id: selectedVersionId, label: selectedVersionLabel ?? null }
+        : null,
+      classes: classes.map((cls) => ({
+        id: cls.id,
+        name: cls.name,
+        description: cls.description ?? null,
+        schema: cls.schema,
+      })),
+      properties: chatProperties,
+      selectedClassIds: selectedCanvasNodeIds,
+    };
+  }, [
+    selectedProjectId,
+    selectedProjectName,
+    selectedVersionId,
+    selectedVersionLabel,
+    classes,
+    properties,
+    selectedCanvasNodeIds,
+  ]);
+
   // Convert classes to nodes format expected by ClassEditDialog
   const classNodes = React.useMemo(() => {
     return classes.map(cls => ({
@@ -597,7 +648,7 @@ function StudioLayoutContent({ children }: Readonly<{ children: React.ReactNode 
           studio layout level so the floating bubble and ⌘⇧A shortcut are available
           across the canvas and paths surfaces. Hidden in presentation mode to keep
           the canvas chrome-free. */}
-      {!canvasPresentationMode && <StudioAiChatbot />}
+      {!canvasPresentationMode && <StudioAiChatbot studioContext={chatbotStudioContext} />}
 
       {/* Programmatic state of the canvas — pinned to the bottom of the studio layout.
           Hidden in presentation mode for chrome consistency with StudioHeader. */}

--- a/objectified-ui/tests/StudioAiChatbot.test.tsx
+++ b/objectified-ui/tests/StudioAiChatbot.test.tsx
@@ -19,6 +19,13 @@ import {
   StudioAiChatbot,
   isStudioAiChatbotPath,
 } from '../src/app/ade/studio/components/StudioAiChatbot';
+import type { ChatStudioContext } from '../src/app/ade/studio/components/chatbot/chat-context';
+
+(global as { ResizeObserver: typeof ResizeObserver }).ResizeObserver = class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+} as unknown as typeof ResizeObserver;
 
 const mockUsePathname = jest.fn<string | null, []>();
 jest.mock('next/navigation', () => ({
@@ -171,5 +178,46 @@ describe('StudioAiChatbot', () => {
     expect(screen.getByTestId('studio-ai-chat-send')).toBeInTheDocument();
     // Empty-state suggestions surface the prompt patterns the panel ships with.
     expect(screen.getAllByTestId('studio-ai-chat-suggestion').length).toBeGreaterThan(0);
+  });
+
+  it('does not render the context chip when no studio context is provided', () => {
+    mockUsePathname.mockReturnValue('/ade/studio/editor');
+    render(<StudioAiChatbot initialMode="slide" />);
+    expect(screen.queryByTestId('studio-ai-chat-context-chip')).not.toBeInTheDocument();
+  });
+
+  it('does not render the context chip when the supplied context is empty (#259)', () => {
+    mockUsePathname.mockReturnValue('/ade/studio/editor');
+    const emptyContext: ChatStudioContext = {
+      project: null,
+      version: null,
+      classes: [],
+      properties: [],
+      selectedClassIds: [],
+    };
+    render(<StudioAiChatbot initialMode="slide" studioContext={emptyContext} />);
+    expect(screen.queryByTestId('studio-ai-chat-context-chip')).not.toBeInTheDocument();
+  });
+
+  it('renders the context chip with project + class summary when context is supplied (#259)', () => {
+    mockUsePathname.mockReturnValue('/ade/studio/editor');
+    const populatedContext: ChatStudioContext = {
+      project: { id: 'proj-1', name: 'Acme Catalog' },
+      version: { id: 'ver-1', label: 'v1.0.0' },
+      classes: [
+        { id: 'cls-1', name: 'Product', description: 'Sellable item', schema: null },
+        { id: 'cls-2', name: 'Customer', description: null, schema: null },
+      ],
+      properties: [
+        { id: 'prop-1', name: 'sku', type: 'string', format: null, required: true },
+      ],
+      selectedClassIds: ['cls-1'],
+    };
+    render(<StudioAiChatbot initialMode="slide" studioContext={populatedContext} />);
+
+    const chip = screen.getByTestId('studio-ai-chat-context-chip');
+    expect(chip).toBeInTheDocument();
+    expect(chip).toHaveTextContent('Acme Catalog');
+    expect(chip).toHaveTextContent('v1.0.0');
   });
 });

--- a/objectified-ui/tests/chatbot/ChatContextChip.test.tsx
+++ b/objectified-ui/tests/chatbot/ChatContextChip.test.tsx
@@ -1,0 +1,107 @@
+/**
+ * Tests for the chat context chip (#259).
+ *
+ * The chip is the user-visible affordance that surfaces what the assistant
+ * can see in the current conversation. These tests pin:
+ *   - Empty contexts render nothing (no chip on a fresh workspace)
+ *   - The chip summary mentions project / version / counts
+ *   - Opening the popover reveals selection, classes, and properties
+ *   - Caps render an overflow marker so big workspaces stay tidy
+ */
+
+import React from 'react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+// Radix Popover uses ResizeObserver internally; provide a no-op stub for jsdom.
+(global as { ResizeObserver: typeof ResizeObserver }).ResizeObserver = class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+} as unknown as typeof ResizeObserver;
+
+import { ChatContextChip } from '../../src/app/ade/studio/components/chatbot/ChatContextChip';
+import {
+  CHAT_CONTEXT_CLASS_CAP,
+  CHAT_CONTEXT_PROPERTY_CAP,
+  EMPTY_CHAT_STUDIO_CONTEXT,
+  type ChatStudioContext,
+} from '../../src/app/ade/studio/components/chatbot/chat-context';
+
+const baseContext: ChatStudioContext = {
+  project: { id: 'proj-1', name: 'Acme Catalog' },
+  version: { id: 'ver-1', label: 'v1.4.0' },
+  classes: [
+    { id: 'cls-user', name: 'User', schema: {} },
+    { id: 'cls-product', name: 'Product', schema: {} },
+  ],
+  properties: [
+    { id: 'prop-email', name: 'email', type: 'string' },
+    { id: 'prop-id', name: 'id', type: 'string' },
+  ],
+  selectedClassIds: ['cls-user'],
+};
+
+describe('ChatContextChip', () => {
+  it('renders nothing when the context is empty', () => {
+    const { container } = render(<ChatContextChip studioContext={EMPTY_CHAT_STUDIO_CONTEXT} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('summarises project, version, and counts in the chip label', () => {
+    render(<ChatContextChip studioContext={baseContext} />);
+    const chip = screen.getByTestId('studio-ai-chat-context-chip');
+    expect(chip).toHaveTextContent('Acme Catalog');
+    expect(chip).toHaveTextContent('v1.4.0');
+    expect(chip).toHaveTextContent('2 classes');
+    expect(chip).toHaveTextContent('2 properties');
+    expect(chip).toHaveTextContent('1 selected');
+  });
+
+  it('opens the popover and surfaces selection, classes, and properties', () => {
+    render(<ChatContextChip studioContext={baseContext} />);
+    fireEvent.click(screen.getByTestId('studio-ai-chat-context-chip'));
+
+    const popover = screen.getByTestId('studio-ai-chat-context-popover');
+    expect(within(popover).getByText('Acme Catalog')).toBeInTheDocument();
+    expect(within(popover).getByText('v1.4.0')).toBeInTheDocument();
+
+    const selection = within(popover).getByTestId('studio-ai-chat-context-selection');
+    expect(selection).toHaveTextContent('User');
+
+    const classes = within(popover).getByTestId('studio-ai-chat-context-classes');
+    expect(classes).toHaveTextContent('User');
+    expect(classes).toHaveTextContent('Product');
+
+    const properties = within(popover).getByTestId('studio-ai-chat-context-properties');
+    expect(properties).toHaveTextContent('email (string)');
+    expect(properties).toHaveTextContent('id (string)');
+  });
+
+  it('renders an overflow marker for very large class lists', () => {
+    const classes = Array.from({ length: CHAT_CONTEXT_CLASS_CAP + 5 }, (_, i) => ({
+      id: `c${i}`,
+      name: `C${i}`,
+    }));
+    render(
+      <ChatContextChip
+        studioContext={{ ...baseContext, classes, selectedClassIds: [] }}
+      />
+    );
+    fireEvent.click(screen.getByTestId('studio-ai-chat-context-chip'));
+    const classesSection = screen.getByTestId('studio-ai-chat-context-classes');
+    expect(classesSection).toHaveTextContent('+5 more');
+  });
+
+  it('renders an overflow marker for very large property lists', () => {
+    const properties = Array.from({ length: CHAT_CONTEXT_PROPERTY_CAP + 3 }, (_, i) => ({
+      id: `p${i}`,
+      name: `p${i}`,
+      type: 'string',
+    }));
+    render(<ChatContextChip studioContext={{ ...baseContext, properties }} />);
+    fireEvent.click(screen.getByTestId('studio-ai-chat-context-chip'));
+    const propertiesSection = screen.getByTestId('studio-ai-chat-context-properties');
+    expect(propertiesSection).toHaveTextContent('+3 more');
+  });
+});

--- a/objectified-ui/tests/chatbot/ChatConversation.test.tsx
+++ b/objectified-ui/tests/chatbot/ChatConversation.test.tsx
@@ -15,17 +15,24 @@ import { act, fireEvent, render, screen, waitFor, within } from '@testing-librar
 import '@testing-library/jest-dom';
 
 import { ChatConversation } from '../../src/app/ade/studio/components/chatbot/ChatConversation';
+import type { ChatStudioContext } from '../../src/app/ade/studio/components/chatbot/chat-context';
 import type { ChatSendFn } from '../../src/app/ade/studio/components/chatbot/types';
+
+type ResponderCall = {
+  prompt: string;
+  isRegenerate: boolean;
+  studioContext?: ChatStudioContext;
+};
 
 function createDeferredResponder(): {
   responder: ChatSendFn;
   resolveWith: (text: string) => void;
-  calls: Array<{ prompt: string; isRegenerate: boolean }>;
+  calls: ResponderCall[];
 } {
-  const calls: Array<{ prompt: string; isRegenerate: boolean }> = [];
+  const calls: ResponderCall[] = [];
   let pendingResolve: ((text: string) => void) | null = null;
-  const responder: ChatSendFn = ({ prompt, isRegenerate }) => {
-    calls.push({ prompt, isRegenerate });
+  const responder: ChatSendFn = ({ prompt, isRegenerate, studioContext }) => {
+    calls.push({ prompt, isRegenerate, studioContext });
     return new Promise<string>((resolve) => {
       pendingResolve = resolve;
     });
@@ -153,6 +160,76 @@ describe('ChatConversation', () => {
       expect(screen.getByText(/the assistant could not respond/i)).toBeInTheDocument();
     });
     expect(screen.getByTestId('studio-ai-chat-input')).not.toBeDisabled();
+  });
+
+  it('does not render the context chip when no studio context is supplied', () => {
+    render(<ChatConversation />);
+    expect(screen.queryByTestId('studio-ai-chat-context-chip')).not.toBeInTheDocument();
+  });
+
+  it('renders the context chip when a non-empty studio context is supplied', () => {
+    const studioContext: ChatStudioContext = {
+      project: { id: 'p', name: 'Acme' },
+      version: { id: 'v', label: 'v1.0' },
+      classes: [{ id: 'c', name: 'User' }],
+      properties: [],
+      selectedClassIds: [],
+    };
+    render(<ChatConversation studioContext={studioContext} />);
+    expect(screen.getByTestId('studio-ai-chat-context-chip')).toBeInTheDocument();
+  });
+
+  it('forwards the studio context snapshot to the responder on each send', async () => {
+    const studioContext: ChatStudioContext = {
+      project: { id: 'p', name: 'Acme' },
+      version: { id: 'v', label: 'v1.0' },
+      classes: [{ id: 'c', name: 'User' }],
+      properties: [],
+      selectedClassIds: ['c'],
+    };
+    const { responder, calls, resolveWith } = createDeferredResponder();
+    render(<ChatConversation onSendMessage={responder} studioContext={studioContext} />);
+
+    fireEvent.change(screen.getByTestId('studio-ai-chat-input'), { target: { value: 'hi' } });
+    fireEvent.click(screen.getByTestId('studio-ai-chat-send'));
+
+    await waitFor(() => expect(calls).toHaveLength(1));
+    expect(calls[0].studioContext).toEqual(studioContext);
+
+    await act(async () => {
+      resolveWith('ok');
+    });
+  });
+
+  it('captures the latest studio context snapshot at send time, not at mount time', async () => {
+    const initial: ChatStudioContext = {
+      project: { id: 'p', name: 'Acme' },
+      version: null,
+      classes: [],
+      properties: [],
+      selectedClassIds: [],
+    };
+    const updated: ChatStudioContext = {
+      ...initial,
+      version: { id: 'v', label: 'v2.0' },
+      selectedClassIds: ['c'],
+    };
+    const { responder, calls, resolveWith } = createDeferredResponder();
+    const { rerender } = render(
+      <ChatConversation onSendMessage={responder} studioContext={initial} />
+    );
+
+    rerender(<ChatConversation onSendMessage={responder} studioContext={updated} />);
+
+    fireEvent.change(screen.getByTestId('studio-ai-chat-input'), { target: { value: 'hi' } });
+    fireEvent.click(screen.getByTestId('studio-ai-chat-send'));
+
+    await waitFor(() => expect(calls).toHaveLength(1));
+    expect(calls[0].studioContext).toEqual(updated);
+
+    await act(async () => {
+      resolveWith('ok');
+    });
   });
 
   it('forwards the import callback when the assistant returns an OpenAPI spec', async () => {

--- a/objectified-ui/tests/chatbot/chat-context.test.ts
+++ b/objectified-ui/tests/chatbot/chat-context.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Tests for the Studio chat context module (#259).
+ *
+ * Pins the contract that downstream callers (ChatConversation, demo
+ * responder, eventual Ollama transport) rely on:
+ *   - Empty / null snapshots short-circuit cleanly
+ *   - Project / version / classes / properties / selection all surface
+ *   - Caps are honoured so big workspaces don't blow the prompt budget
+ *   - `injectChatContext` is a no-op when the context is empty
+ */
+
+import {
+  buildChatContextPreamble,
+  CHAT_CONTEXT_CLASS_CAP,
+  CHAT_CONTEXT_DESCRIPTION_CHAR_CAP,
+  CHAT_CONTEXT_PROPERTY_CAP,
+  CHAT_CONTEXT_SCHEMA_CHAR_CAP,
+  CHAT_CONTEXT_SELECTION_CAP,
+  EMPTY_CHAT_STUDIO_CONTEXT,
+  getSelectedClasses,
+  injectChatContext,
+  isChatStudioContextEmpty,
+  summarizeChatStudioContext,
+  type ChatStudioContext,
+  type ChatStudioProperty,
+} from '../../src/app/ade/studio/components/chatbot/chat-context';
+
+function makeContext(overrides: Partial<ChatStudioContext> = {}): ChatStudioContext {
+  return {
+    project: { id: 'proj-1', name: 'Acme Catalog' },
+    version: { id: 'ver-1', label: 'v1.4.0' },
+    classes: [
+      { id: 'cls-user', name: 'User', description: 'Authenticated principal', schema: { type: 'object' } },
+      { id: 'cls-product', name: 'Product', description: 'Catalog item', schema: { type: 'object' } },
+    ],
+    properties: [
+      { id: 'prop-email', name: 'email', type: 'string', format: 'email', required: true, description: 'Login email' },
+      { id: 'prop-id', name: 'id', type: 'string', format: 'uuid' },
+    ],
+    selectedClassIds: ['cls-user'],
+    ...overrides,
+  };
+}
+
+describe('isChatStudioContextEmpty', () => {
+  it('treats null / undefined / empty snapshots as empty', () => {
+    expect(isChatStudioContextEmpty(null)).toBe(true);
+    expect(isChatStudioContextEmpty(undefined)).toBe(true);
+    expect(isChatStudioContextEmpty(EMPTY_CHAT_STUDIO_CONTEXT)).toBe(true);
+  });
+
+  it('returns false when any field has data', () => {
+    expect(isChatStudioContextEmpty({ ...EMPTY_CHAT_STUDIO_CONTEXT, project: { id: 'p', name: 'P' } })).toBe(false);
+    expect(isChatStudioContextEmpty({ ...EMPTY_CHAT_STUDIO_CONTEXT, version: { id: 'v', label: null } })).toBe(false);
+    expect(isChatStudioContextEmpty({
+      ...EMPTY_CHAT_STUDIO_CONTEXT,
+      classes: [{ id: 'c', name: 'X' }],
+    })).toBe(false);
+    expect(isChatStudioContextEmpty({
+      ...EMPTY_CHAT_STUDIO_CONTEXT,
+      properties: [{ id: 'p', name: 'q' }],
+    })).toBe(false);
+    expect(isChatStudioContextEmpty({ ...EMPTY_CHAT_STUDIO_CONTEXT, selectedClassIds: ['x'] })).toBe(false);
+  });
+});
+
+describe('getSelectedClasses', () => {
+  it('returns the matching class objects in selection order', () => {
+    const ctx = makeContext({ selectedClassIds: ['cls-product', 'cls-user'] });
+    const selected = getSelectedClasses(ctx);
+    expect(selected.map((c) => c.id)).toEqual(['cls-product', 'cls-user']);
+  });
+
+  it('drops selection IDs that no longer resolve to a class', () => {
+    const ctx = makeContext({ selectedClassIds: ['cls-user', 'ghost'] });
+    const selected = getSelectedClasses(ctx);
+    expect(selected).toHaveLength(1);
+    expect(selected[0].id).toBe('cls-user');
+  });
+
+  it('returns an empty array when nothing is selected', () => {
+    expect(getSelectedClasses(makeContext({ selectedClassIds: [] }))).toEqual([]);
+  });
+});
+
+describe('summarizeChatStudioContext', () => {
+  it('returns an empty string for empty context', () => {
+    expect(summarizeChatStudioContext(EMPTY_CHAT_STUDIO_CONTEXT)).toBe('');
+  });
+
+  it('mentions project, version, classes, properties, and selection', () => {
+    const summary = summarizeChatStudioContext(makeContext());
+    expect(summary).toMatch(/Project:.*Acme Catalog/);
+    expect(summary).toMatch(/Version:.*v1\.4\.0/);
+    expect(summary).toMatch(/Selected on canvas:.*User/);
+    expect(summary).toMatch(/Classes \(2\):.*User.*Product/);
+    expect(summary).toMatch(/Properties \(2\):.*email.*id/);
+  });
+
+  it('caps the visible class names with an overflow marker', () => {
+    const classes = Array.from({ length: CHAT_CONTEXT_CLASS_CAP + 5 }, (_, i) => ({
+      id: `c${i}`,
+      name: `C${i}`,
+    }));
+    const summary = summarizeChatStudioContext(makeContext({ classes, selectedClassIds: [] }));
+    expect(summary).toMatch(`Classes (${classes.length})`);
+    expect(summary).toMatch('+5 more');
+  });
+});
+
+describe('buildChatContextPreamble', () => {
+  it('returns an empty string when there is no context to share', () => {
+    expect(buildChatContextPreamble(EMPTY_CHAT_STUDIO_CONTEXT)).toBe('');
+  });
+
+  it('includes a schema preview for selected classes only', () => {
+    const ctx = makeContext({
+      classes: [
+        { id: 'cls-user', name: 'User', schema: { type: 'object', properties: { email: { type: 'string' } } } },
+        { id: 'cls-product', name: 'Product', schema: { type: 'object' } },
+      ],
+      selectedClassIds: ['cls-user'],
+    });
+    const preamble = buildChatContextPreamble(ctx);
+    expect(preamble).toMatch(/Selected on canvas/);
+    expect(preamble).toMatch(/`User`/);
+    // Schema preview only attached to the *selected* class to keep payload tight.
+    expect(preamble).toMatch(/schema:.*"email".*"string"/);
+    expect(preamble.split('schema:').length - 1).toBe(1);
+  });
+
+  it('truncates long schemas to the schema cap', () => {
+    const longSchema = { type: 'object', description: 'x'.repeat(CHAT_CONTEXT_SCHEMA_CHAR_CAP * 2) };
+    const ctx = makeContext({
+      classes: [{ id: 'cls-x', name: 'X', schema: longSchema }],
+      selectedClassIds: ['cls-x'],
+    });
+    const preamble = buildChatContextPreamble(ctx);
+    const schemaLine = preamble.split('\n').find((line) => line.includes('schema:'));
+    expect(schemaLine).toBeDefined();
+    expect(schemaLine!.length).toBeLessThanOrEqual(CHAT_CONTEXT_SCHEMA_CHAR_CAP + 'schema:  '.length + 4);
+    expect(schemaLine).toMatch(/…$/);
+  });
+
+  it('truncates long descriptions on properties and classes', () => {
+    const longDesc = 'word '.repeat(CHAT_CONTEXT_DESCRIPTION_CHAR_CAP);
+    const prop: ChatStudioProperty = {
+      id: 'p',
+      name: 'bio',
+      type: 'string',
+      description: longDesc,
+    };
+    const preamble = buildChatContextPreamble(makeContext({ properties: [prop], selectedClassIds: [] }));
+    const propLine = preamble.split('\n').find((line) => line.startsWith('- `bio`'));
+    expect(propLine).toBeDefined();
+    expect(propLine!.length).toBeLessThan(longDesc.length);
+    expect(propLine).toMatch(/…/);
+  });
+
+  it('caps the class and property lists with overflow markers', () => {
+    const classes = Array.from({ length: CHAT_CONTEXT_CLASS_CAP + 3 }, (_, i) => ({ id: `c${i}`, name: `C${i}` }));
+    const properties = Array.from({ length: CHAT_CONTEXT_PROPERTY_CAP + 2 }, (_, i) => ({ id: `p${i}`, name: `p${i}` }));
+    const preamble = buildChatContextPreamble({
+      ...EMPTY_CHAT_STUDIO_CONTEXT,
+      project: { id: 'p', name: 'P' },
+      classes,
+      properties,
+    });
+    expect(preamble).toMatch(`and ${classes.length - CHAT_CONTEXT_CLASS_CAP} more classes not shown`);
+    expect(preamble).toMatch(`and ${properties.length - CHAT_CONTEXT_PROPERTY_CAP} more properties not shown`);
+  });
+
+  it('caps the selected class list with an overflow line', () => {
+    const classes = Array.from({ length: CHAT_CONTEXT_SELECTION_CAP + 4 }, (_, i) => ({
+      id: `c${i}`,
+      name: `C${i}`,
+    }));
+    const selectedClassIds = classes.map((c) => c.id);
+    const preamble = buildChatContextPreamble({
+      ...EMPTY_CHAT_STUDIO_CONTEXT,
+      classes,
+      selectedClassIds,
+    });
+    expect(preamble).toMatch(`and ${selectedClassIds.length - CHAT_CONTEXT_SELECTION_CAP} more selected`);
+  });
+});
+
+describe('injectChatContext', () => {
+  it('returns the prompt unchanged when context is empty', () => {
+    expect(injectChatContext('hello', null)).toBe('hello');
+    expect(injectChatContext('hello', undefined)).toBe('hello');
+    expect(injectChatContext('hello', EMPTY_CHAT_STUDIO_CONTEXT)).toBe('hello');
+  });
+
+  it('prepends the preamble and a divider before the user prompt', () => {
+    const out = injectChatContext('Sketch a Cart class', makeContext());
+    expect(out.startsWith('### Current Studio context')).toBe(true);
+    expect(out).toMatch(/### User request\nSketch a Cart class$/);
+  });
+});

--- a/objectified-ui/tests/chatbot/demo-responder.test.ts
+++ b/objectified-ui/tests/chatbot/demo-responder.test.ts
@@ -1,9 +1,32 @@
 /**
- * Tests for the offline demo responder used by the Studio chatbot (#258).
+ * Tests for the offline demo responder used by the Studio chatbot (#258, #259).
+ *
+ * Covers both the "no context" baseline behaviour designers see in isolated
+ * previews and the context-aware grounding wired up in #259 — project /
+ * version mention, canvas selection acknowledgement, and reuse of existing
+ * class / property names inside the sample OpenAPI spec.
  */
 
 import { createDemoChatResponder } from '../../src/app/ade/studio/components/chatbot/demo-responder';
 import { detectOpenApiSpecs } from '../../src/app/ade/studio/components/chatbot/openapi-detection';
+import {
+  EMPTY_CHAT_STUDIO_CONTEXT,
+  type ChatStudioContext,
+} from '../../src/app/ade/studio/components/chatbot/chat-context';
+
+const richContext: ChatStudioContext = {
+  project: { id: 'proj-1', name: 'Acme Catalog' },
+  version: { id: 'ver-1', label: 'v2.0.0' },
+  classes: [
+    { id: 'cls-cart', name: 'Cart', description: 'Shopping cart' },
+    { id: 'cls-product', name: 'Product', description: 'Catalog item' },
+  ],
+  properties: [
+    { id: 'prop-sku', name: 'sku', type: 'string', description: 'Stock keeping unit' },
+    { id: 'prop-qty', name: 'quantity', type: 'integer', description: 'Units in cart' },
+  ],
+  selectedClassIds: ['cls-cart'],
+};
 
 describe('createDemoChatResponder', () => {
   const responder = createDemoChatResponder();
@@ -35,5 +58,67 @@ describe('createDemoChatResponder', () => {
       isRegenerate: true,
     });
     expect(reply).toMatch(/Regenerated/);
+  });
+
+  it('treats an empty studio context the same as no context', async () => {
+    const reply = await responder({
+      messages: [],
+      prompt: 'tell me a joke',
+      isRegenerate: false,
+      studioContext: EMPTY_CHAT_STUDIO_CONTEXT,
+    });
+    expect(reply).not.toMatch(/Acme Catalog/);
+    expect(reply).not.toMatch(/v2\.0\.0/);
+  });
+
+  it('mentions the project, version, and selection when context is present', async () => {
+    const reply = await responder({
+      messages: [],
+      prompt: 'tell me a joke',
+      isRegenerate: false,
+      studioContext: richContext,
+    });
+    expect(reply).toMatch(/Acme Catalog/);
+    expect(reply).toMatch(/v2\.0\.0/);
+    expect(reply).toMatch(/Cart/);
+  });
+
+  it('embeds the project name and reusable properties in the sample OpenAPI spec', async () => {
+    const reply = await responder({
+      messages: [],
+      prompt: 'sketch a schema for me',
+      isRegenerate: false,
+      studioContext: richContext,
+    });
+    const specs = detectOpenApiSpecs(reply);
+    expect(specs).toHaveLength(1);
+    const spec = specs[0].spec as {
+      info: { title: string; version: string };
+      components: { schemas: Record<string, { properties: Record<string, unknown> }> };
+    };
+    expect(spec.info.title).toMatch(/Acme Catalog/);
+    expect(spec.info.version).toBe('v2.0.0');
+    // The selected class wins as the schema name; reusable properties are inlined.
+    const schemaName = Object.keys(spec.components.schemas)[0];
+    expect(schemaName).toBe('Cart');
+    const props = spec.components.schemas[schemaName].properties;
+    expect(props).toHaveProperty('sku');
+    expect(props).toHaveProperty('quantity');
+  });
+
+  it('falls back to the canonical sample spec when no context is supplied', async () => {
+    const reply = await responder({
+      messages: [],
+      prompt: 'openapi please',
+      isRegenerate: false,
+    });
+    const specs = detectOpenApiSpecs(reply);
+    expect(specs).toHaveLength(1);
+    const spec = specs[0].spec as {
+      info: { title: string };
+      components: { schemas: Record<string, unknown> };
+    };
+    expect(spec.info.title).toBe('Sample Catalog API');
+    expect(Object.keys(spec.components.schemas)).toContain('Product');
   });
 });


### PR DESCRIPTION
## What changed and why

Closes #259. The Studio AI chatbot now grounds its replies in the user's
actual workspace instead of generic boilerplate. Each message the user
sends carries a snapshot of the current project, version, classes,
reusable properties, and canvas selection, and the assistant receives
that snapshot as a capped preamble in front of the prompt.

A new "Sharing context" chip above the composer lets the user inspect
exactly what is being sent so the feature stays transparent.

### Implementation highlights

- **`chat-context` module** (`components/chatbot/chat-context.ts`) owns
  the snapshot type, an `isChatStudioContextEmpty` guard, a popover
  summary, and `buildChatContextPreamble` / `injectChatContext` for
  prompt grounding. Every dimension is capped (classes, properties,
  selection, schema chars, description chars) so a large workspace
  cannot blow the prompt budget.
- **`StudioContext`** now publishes `selectedCanvasNodeIds`. The editor
  page wires it into React Flow's `onSelectionChange`, clears it when
  switching to code view, and clears it on unmount so stale selections
  never leak between turns.
- **Studio layout** assembles the snapshot from `useStudio()` plus the
  loaded `classes` / `properties` and threads it through
  `StudioAiChatbot` → `ChatConversation`. The conversation captures the
  snapshot via a ref at send time so later workspace edits don't leak
  back into earlier turns.
- **`ChatContextChip`** (Radix Popover) surfaces a compact chip
  (`Project • Version • counts`) above the composer that opens a detail
  popover listing project, version, selected classes, and capped
  class/property lists.
- **Demo responder** is now context-aware so reviewers can exercise the
  feature without Ollama: it mentions project / version / selection in
  replies and reuses real property names when generating its sample
  OpenAPI spec.

### How to test

1. `cd objectified-ui && yarn jest tests/chatbot tests/StudioAiChatbot.test.tsx`
   — 88 unit tests cover capping, summary text, popover content,
   prompt injection, demo responder context awareness, and chip
   visibility.
2. From the studio editor with a populated project + version, open the
   chatbot (`Cmd+Shift+A`). Confirm the "Sharing context" chip shows
   the project, version, and class/property counts. Click the chip to
   inspect the full popover.
3. Select one or more class nodes on the canvas — the chip and popover
   should immediately reflect the new selection, and the demo
   responder's replies should mention the selected class names.
4. Switch the editor to Code view and back — the chip should hide while
   on Code (no canvas surface) and reappear on the canvas.

### Risk / notes

- UI-only change; no schema, API, or migration changes.
- Backend AI plumbing (Ollama transport, history) is still a follow-up
  (#260, #265). The snapshot is wired into the responder interface
  today via the offline demo so the contract is in place.
- Pre-existing failure in `tests/llm-streaming.test.ts`
  (`pretty-format` import) is unrelated to this ticket.

Made with [Cursor](https://cursor.com)