### PR TITLE
Fix #260 - Multi-turn conversations with context history

### DIFF
--- a/docs/PLANNED_FEATURE_ROADMAP_AI.md
+++ b/docs/PLANNED_FEATURE_ROADMAP_AI.md
@@ -36,17 +36,16 @@ This outlines the planned features for integrating AI capabilities into Objectif
     - ✅ AI understands selected items on canvas
     - ✅ AI can see property definitions
     - ✅ Automatic context injection into prompts
-- 📋 **Multi-Turn Conversations**:
-    - 📋 Follow-up questions with context
-    - 📋 Clarification requests
-    - 📋 Iterative refinement of schemas
-    - 📋 "Make it more like X" type instructions
+- ✅ **Multi-Turn Conversations** (#260):
+    - ✅ Follow-up questions with context
+    - ✅ Clarification requests
+    - ✅ Iterative refinement of schemas
+    - ✅ "Make it more like X" type instructions
 - Add guardrails to prevent sensitive data exposure
 - Add guardrails to prevent malicious code generation
 
 | Ticket | Feature Description                                |
 |--------|----------------------------------------------------|
-| #260   | AI Multi-Turn Conversation with History            |
 | #261   | AI Conversation history actions                    |
 | #262   | Install guardrails.ai server                       |
 | #263   | Add guardrails to prevent sensitive data exposure  |

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.10.16",
+  "version": "0.10.17",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -24,6 +24,7 @@ We continue to improve the platform based on your feedback with improvements and
 - Added the Studio AI chatbot launcher and panel: a floating bubble in the bottom right of the canvas opens a slide-out panel with full-screen mode, toggled with `Cmd+Shift+A` / `Ctrl+Shift+A`.
 - Filled out the Studio AI chat surface to the design guidelines: distinct user/assistant bubbles, typing indicator, markdown rendering, syntax-highlighted code blocks with a copy button, regenerate / thumbs up / thumbs down message actions, and a one-click import button when an assistant reply contains an OpenAPI spec in a ```json``` block.
 - The Studio AI chatbot is now context-aware: each message you send carries a snapshot of your current project, version, classes, reusable properties, and canvas selection, and a "Sharing context" chip in the panel lets you inspect exactly what the assistant can see.
+- The Studio AI chatbot now handles multi-turn conversations: follow-up prompts like "add a phone field", "remove priceCents", "make name required", "rename id to productId", "make it more like Stripe Charges", or simple clarification questions are recognized as edits to the previous reply, and the refined OpenAPI spec is re-shipped so you can keep iterating without restarting the thread.
 
 ---
 

--- a/objectified-ui/src/app/ade/studio/components/chatbot/conversation-history.ts
+++ b/objectified-ui/src/app/ade/studio/components/chatbot/conversation-history.ts
@@ -1,0 +1,476 @@
+/**
+ * Multi-turn conversation history helpers for the Studio AI chatbot (#260).
+ *
+ * The chat surface always passes the full transcript into the responder, but
+ * a deterministic responder needs more than the raw array — it needs to know
+ * whether the user is starting a new thread, asking a follow-up question,
+ * or refining a previously generated schema. This module owns that
+ * vocabulary so the demo responder (and the eventual Ollama transport in
+ * #265) can speak about prior turns consistently.
+ *
+ * Three things live here:
+ *
+ *   1. {@link summarizeConversationHistory} parses the transcript + the just-
+ *      sent prompt and returns a {@link ChatHistorySummary} containing the
+ *      detected intent, the most recent assistant OpenAPI spec, any
+ *      refinement operations the user requested, and short excerpts useful
+ *      for prompt injection.
+ *   2. {@link applyRefinementsToSpec} mutates a deep clone of an OpenAPI
+ *      spec to add / remove / require / rename properties on its first
+ *      schema — the operation set the demo responder advertises today.
+ *   3. {@link buildConversationHistoryPreamble} renders a compact summary
+ *      that backends can prepend to prompts so models see the same picture
+ *      the UI does.
+ *
+ * Caps are exported as named constants so tests pin the contract.
+ */
+
+import { detectOpenApiSpecs, type DetectedOpenApiSpec } from './openapi-detection';
+import type { ChatMessage } from './types';
+
+/** Number of trailing turns kept in the prompt-injection excerpt list. */
+export const CHAT_HISTORY_TURN_CAP = 8;
+/** Per-excerpt character budget — keeps the preamble small. */
+export const CHAT_HISTORY_EXCERPT_CHAR_CAP = 280;
+
+export type ChatFollowUpIntent =
+  /** No prior assistant turn exists yet. */
+  | 'first-turn'
+  /** Prior turns exist but this prompt doesn't reference them. */
+  | 'standalone'
+  /** User wants to modify the previously generated spec. */
+  | 'refine-spec'
+  /** User asked to make the spec/answer "more like X". */
+  | 'comparison'
+  /** User is asking a question about the previous reply. */
+  | 'clarification'
+  /** Open-ended re-roll ("actually", "instead", "try again"). */
+  | 'iteration';
+
+export type ChatRefinementOp =
+  | { kind: 'add-property'; name: string; type?: string }
+  | { kind: 'remove-property'; name: string }
+  | { kind: 'require-property'; name: string }
+  | { kind: 'rename-property'; from: string; to: string };
+
+export interface ChatHistoryExcerpt {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+export interface ChatHistorySummary {
+  /** Number of user turns INCLUDING the just-sent prompt. */
+  userTurnCount: number;
+  /** Number of completed (non-pending) assistant turns BEFORE this one. */
+  assistantTurnCount: number;
+  intent: ChatFollowUpIntent;
+  /** Most recent importable assistant OpenAPI spec, if any. */
+  lastAssistantSpec: DetectedOpenApiSpec | null;
+  /** When intent === 'comparison', the subject the user referenced. */
+  comparisonSubject: string | null;
+  /** Refinement operations parsed out of the prompt, in source order. */
+  refinementOps: ChatRefinementOp[];
+  /** Trimmed conversation excerpts (most recent last) for prompt injection. */
+  recentExcerpts: ChatHistoryExcerpt[];
+}
+
+const REFINE_WORDS = [
+  'refine', 'tweak', 'update', 'change', 'modify', 'adjust',
+  'extend', 'iterate', 'improve', 'rework',
+];
+const ITERATION_WORDS = [
+  'actually', 'instead', 'wait', 'try again', 'another version',
+  'do it again', 'redo',
+];
+const CLARIFICATION_LEADERS = [
+  'what', 'why', 'how', 'when', 'where', 'who',
+  'can you explain', 'could you explain', 'tell me more',
+  'what does', 'what is', 'what are', 'what do you mean',
+];
+
+/**
+ * Build a {@link ChatHistorySummary} from prior transcript + the new prompt.
+ *
+ * `priorMessages` is the transcript BEFORE the user's just-sent message —
+ * matching the shape the {@link ChatSendContext.messages} field carries when
+ * the chat shell invokes the responder.
+ */
+export function summarizeConversationHistory(
+  priorMessages: ChatMessage[],
+  prompt: string,
+): ChatHistorySummary {
+  const trimmedPrompt = prompt.trim();
+  const lower = trimmedPrompt.toLowerCase();
+
+  const userTurns = priorMessages.filter((m) => m.role === 'user').length + 1;
+  const assistantTurns = priorMessages.filter(
+    (m) => m.role === 'assistant' && !m.pending && m.content.trim().length > 0,
+  ).length;
+
+  const lastAssistantSpec = findLastAssistantSpec(priorMessages);
+  const comparisonSubject = detectComparisonSubject(lower, trimmedPrompt);
+  const refinementOps = extractRefinementOps(trimmedPrompt);
+
+  const intent = detectIntent({
+    assistantTurns,
+    lower,
+    hasSpec: lastAssistantSpec !== null,
+    refinementOps,
+    comparisonSubject,
+  });
+
+  const recentExcerpts = buildRecentExcerpts(priorMessages);
+
+  return {
+    userTurnCount: userTurns,
+    assistantTurnCount: assistantTurns,
+    intent,
+    lastAssistantSpec,
+    comparisonSubject,
+    refinementOps,
+    recentExcerpts,
+  };
+}
+
+interface DetectIntentInput {
+  assistantTurns: number;
+  lower: string;
+  hasSpec: boolean;
+  refinementOps: ChatRefinementOp[];
+  comparisonSubject: string | null;
+}
+
+function detectIntent({
+  assistantTurns,
+  lower,
+  hasSpec,
+  refinementOps,
+  comparisonSubject,
+}: DetectIntentInput): ChatFollowUpIntent {
+  if (assistantTurns === 0) return 'first-turn';
+
+  if (comparisonSubject) return 'comparison';
+
+  if (hasSpec && (refinementOps.length > 0 || matchesAny(lower, REFINE_WORDS))) {
+    return 'refine-spec';
+  }
+
+  if (matchesAny(lower, ITERATION_WORDS)) return 'iteration';
+
+  if (looksLikeClarification(lower)) return 'clarification';
+
+  return 'standalone';
+}
+
+function looksLikeClarification(lower: string): boolean {
+  if (!lower.endsWith('?')) {
+    // Allow leading question phrases even without the trailing punctuation.
+    const startsWithLeader = CLARIFICATION_LEADERS.some((leader) =>
+      lower === leader || lower.startsWith(`${leader} `),
+    );
+    if (!startsWithLeader) return false;
+  }
+  return CLARIFICATION_LEADERS.some((leader) =>
+    lower === leader || lower.startsWith(`${leader} `) || lower.startsWith(`${leader}'s `),
+  );
+}
+
+function matchesAny(haystack: string, needles: readonly string[]): boolean {
+  return needles.some((needle) => haystack.includes(needle));
+}
+
+const COMPARISON_PATTERN =
+  /\b(?:more like|similar to|like the|like a|like an)\s+([a-z0-9][a-z0-9 _-]{0,40}?)(?=[.!?,;]|$)/i;
+
+function detectComparisonSubject(lower: string, original: string): string | null {
+  const match = lower.match(COMPARISON_PATTERN);
+  if (!match) return null;
+  // Recover the original casing for the captured subject.
+  const start = match.index! + match[0].length - match[1].length;
+  const subject = original.slice(start, start + match[1].length).trim();
+  return subject.length > 0 ? subject : null;
+}
+
+const IDENTIFIER = '[A-Za-z_][A-Za-z0-9_]*';
+
+const REFINE_PATTERNS: ReadonlyArray<{
+  regex: RegExp;
+  build: (m: RegExpMatchArray) => ChatRefinementOp | null;
+}> = [
+  {
+    regex: new RegExp(
+      `\\b(?:rename|change)\\s+(?:property\\s+|field\\s+)?(${IDENTIFIER})\\s+to\\s+(${IDENTIFIER})`,
+      'gi',
+    ),
+    build: (m) => ({ kind: 'rename-property', from: m[1], to: m[2] }),
+  },
+  {
+    regex: new RegExp(
+      `\\b(?:remove|drop|delete)\\s+(?:the\\s+)?(?:property\\s+|field\\s+)?(${IDENTIFIER})(?:\\s+(?:property|field))?`,
+      'gi',
+    ),
+    build: (m) => ({ kind: 'remove-property', name: m[1] }),
+  },
+  {
+    regex: new RegExp(
+      `\\b(?:make|mark)\\s+(${IDENTIFIER})\\s+required\\b`,
+      'gi',
+    ),
+    build: (m) => ({ kind: 'require-property', name: m[1] }),
+  },
+  {
+    regex: new RegExp(
+      `\\brequire\\s+(?:the\\s+)?(?:property\\s+|field\\s+)?(${IDENTIFIER})(?:\\s+(?:property|field))?`,
+      'gi',
+    ),
+    build: (m) => ({ kind: 'require-property', name: m[1] }),
+  },
+  {
+    regex: new RegExp(
+      `\\b(?:add|include)\\s+(?:an?\\s+|the\\s+)?(${IDENTIFIER})\\s+(?:property|field)(?:\\s+(?:as|of\\s+type)\\s+(${IDENTIFIER}))?`,
+      'gi',
+    ),
+    build: (m) => ({ kind: 'add-property', name: m[1], type: m[2]?.toLowerCase() }),
+  },
+  {
+    regex: new RegExp(
+      `\\b(?:add|include)\\s+(?:an?\\s+|the\\s+)?(${IDENTIFIER})\\s+(${IDENTIFIER})(?:\\s+(?:property|field))?`,
+      'gi',
+    ),
+    build: (m) => {
+      // Patterns like "add a phone string" / "add timestamp string"
+      const possibleType = m[2].toLowerCase();
+      if (!isJsonSchemaType(possibleType)) return null;
+      return { kind: 'add-property', name: m[1], type: possibleType };
+    },
+  },
+];
+
+const JSON_SCHEMA_TYPES = new Set([
+  'string', 'integer', 'number', 'boolean', 'object', 'array', 'null',
+]);
+
+function isJsonSchemaType(value: string): boolean {
+  return JSON_SCHEMA_TYPES.has(value);
+}
+
+function extractRefinementOps(prompt: string): ChatRefinementOp[] {
+  const ops: ChatRefinementOp[] = [];
+  const seen = new Set<string>();
+  for (const { regex, build } of REFINE_PATTERNS) {
+    regex.lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = regex.exec(prompt)) !== null) {
+      const op = build(match);
+      if (!op) continue;
+      const key = opKey(op);
+      if (seen.has(key)) continue;
+      seen.add(key);
+      ops.push(op);
+    }
+  }
+  return ops;
+}
+
+function opKey(op: ChatRefinementOp): string {
+  switch (op.kind) {
+    case 'rename-property':
+      return `${op.kind}:${op.from.toLowerCase()}->${op.to.toLowerCase()}`;
+    default:
+      return `${op.kind}:${op.name.toLowerCase()}`;
+  }
+}
+
+function findLastAssistantSpec(priorMessages: ChatMessage[]): DetectedOpenApiSpec | null {
+  for (let i = priorMessages.length - 1; i >= 0; i -= 1) {
+    const m = priorMessages[i];
+    if (m.role !== 'assistant' || m.pending) continue;
+    const specs = detectOpenApiSpecs(m.content);
+    if (specs.length > 0) return specs[specs.length - 1];
+  }
+  return null;
+}
+
+function buildRecentExcerpts(priorMessages: ChatMessage[]): ChatHistoryExcerpt[] {
+  const usable = priorMessages.filter(
+    (m) => !m.pending && m.content.trim().length > 0,
+  );
+  const slice = usable.slice(-CHAT_HISTORY_TURN_CAP);
+  return slice.map((m) => ({
+    role: m.role,
+    content: trimExcerpt(m.content),
+  }));
+}
+
+function trimExcerpt(content: string): string {
+  // Strip fenced code blocks so excerpts stay readable in a single line.
+  const stripped = content.replace(/```[\s\S]*?```/g, '[code block omitted]');
+  const compact = stripped.replace(/\s+/g, ' ').trim();
+  if (compact.length <= CHAT_HISTORY_EXCERPT_CHAR_CAP) return compact;
+  return `${compact.slice(0, CHAT_HISTORY_EXCERPT_CHAR_CAP - 1).trimEnd()}…`;
+}
+
+/**
+ * Compact preamble describing the conversation so far. Returns an empty
+ * string when there is nothing useful to inject (e.g. first turn).
+ */
+export function buildConversationHistoryPreamble(summary: ChatHistorySummary): string {
+  if (summary.assistantTurnCount === 0 && summary.recentExcerpts.length === 0) {
+    return '';
+  }
+
+  const lines: string[] = ['### Conversation so far'];
+  lines.push(
+    `- Turn ${summary.userTurnCount} of an ongoing thread (${summary.assistantTurnCount} prior assistant ${
+      summary.assistantTurnCount === 1 ? 'reply' : 'replies'
+    }).`,
+  );
+
+  switch (summary.intent) {
+    case 'refine-spec':
+      lines.push('- Treat this turn as a refinement of the last generated schema.');
+      break;
+    case 'comparison':
+      if (summary.comparisonSubject) {
+        lines.push(`- The user wants the answer to look more like: ${summary.comparisonSubject}.`);
+      }
+      break;
+    case 'clarification':
+      lines.push('- The user is asking a clarifying question about the previous reply.');
+      break;
+    case 'iteration':
+      lines.push('- The user wants a different take on the previous reply.');
+      break;
+    default:
+      break;
+  }
+
+  if (summary.recentExcerpts.length > 0) {
+    lines.push('');
+    lines.push('#### Recent turns');
+    for (const excerpt of summary.recentExcerpts) {
+      lines.push(`- **${excerpt.role}:** ${excerpt.content}`);
+    }
+  }
+
+  if (summary.refinementOps.length > 0) {
+    lines.push('');
+    lines.push('#### Detected schema edits');
+    for (const op of summary.refinementOps) {
+      lines.push(`- ${describeOp(op)}`);
+    }
+  }
+
+  return lines.join('\n');
+}
+
+function describeOp(op: ChatRefinementOp): string {
+  switch (op.kind) {
+    case 'add-property':
+      return op.type
+        ? `Add property \`${op.name}\` of type \`${op.type}\`.`
+        : `Add property \`${op.name}\`.`;
+    case 'remove-property':
+      return `Remove property \`${op.name}\`.`;
+    case 'require-property':
+      return `Mark property \`${op.name}\` as required.`;
+    case 'rename-property':
+      return `Rename property \`${op.from}\` to \`${op.to}\`.`;
+  }
+}
+
+interface SchemaShape {
+  type?: string;
+  description?: string;
+  properties?: Record<string, Record<string, unknown>>;
+  required?: string[];
+  [key: string]: unknown;
+}
+
+/**
+ * Apply a sequence of refinement ops to the FIRST schema declared under
+ * `components.schemas` in `spec`. Returns a deep clone — never mutates the
+ * caller's object. If the spec has no schemas, the clone is returned
+ * untouched.
+ */
+export function applyRefinementsToSpec(
+  spec: Record<string, unknown>,
+  ops: ChatRefinementOp[],
+): Record<string, unknown> {
+  const clone = deepClone(spec);
+  if (ops.length === 0) return clone;
+  const schema = getFirstSchema(clone);
+  if (!schema) return clone;
+  schema.properties = schema.properties ?? {};
+  schema.required = Array.isArray(schema.required) ? [...schema.required] : [];
+
+  for (const op of ops) {
+    applyOpToSchema(schema, op);
+  }
+  pruneRequired(schema);
+  return clone;
+}
+
+function applyOpToSchema(schema: SchemaShape, op: ChatRefinementOp): void {
+  const props = schema.properties!;
+  switch (op.kind) {
+    case 'add-property': {
+      if (props[op.name]) {
+        // Property already exists — only update its type if a new one was provided.
+        if (op.type) props[op.name].type = op.type;
+      } else {
+        props[op.name] = {
+          type: op.type ?? 'string',
+          description: `Added in follow-up: ${op.name}.`,
+        };
+      }
+      return;
+    }
+    case 'remove-property': {
+      delete props[op.name];
+      schema.required = schema.required!.filter((n) => n !== op.name);
+      return;
+    }
+    case 'require-property': {
+      if (!props[op.name]) {
+        props[op.name] = {
+          type: 'string',
+          description: `Added (required) in follow-up: ${op.name}.`,
+        };
+      }
+      if (!schema.required!.includes(op.name)) schema.required!.push(op.name);
+      return;
+    }
+    case 'rename-property': {
+      const existing = props[op.from];
+      if (!existing) return;
+      delete props[op.from];
+      props[op.to] = existing;
+      schema.required = schema.required!.map((n) => (n === op.from ? op.to : n));
+      return;
+    }
+  }
+}
+
+function pruneRequired(schema: SchemaShape): void {
+  if (!schema.required) return;
+  const propNames = new Set(Object.keys(schema.properties ?? {}));
+  schema.required = schema.required.filter((n) => propNames.has(n));
+  if (schema.required.length === 0) delete schema.required;
+}
+
+function getFirstSchema(spec: Record<string, unknown>): SchemaShape | null {
+  const components = spec.components as Record<string, unknown> | undefined;
+  const schemas = components?.schemas as Record<string, SchemaShape> | undefined;
+  if (!schemas) return null;
+  const names = Object.keys(schemas);
+  if (names.length === 0) return null;
+  return schemas[names[0]];
+}
+
+function deepClone<T>(value: T): T {
+  if (typeof structuredClone === 'function') {
+    return structuredClone(value);
+  }
+  return JSON.parse(JSON.stringify(value)) as T;
+}

--- a/objectified-ui/src/app/ade/studio/components/chatbot/conversation-history.ts
+++ b/objectified-ui/src/app/ade/studio/components/chatbot/conversation-history.ts
@@ -89,20 +89,28 @@ const CLARIFICATION_LEADERS = [
 ];
 
 /**
- * Build a {@link ChatHistorySummary} from prior transcript + the new prompt.
+ * Build a {@link ChatHistorySummary} from the full transcript plus the new
+ * prompt text.
  *
- * `priorMessages` is the transcript BEFORE the user's just-sent message —
- * matching the shape the {@link ChatSendContext.messages} field carries when
- * the chat shell invokes the responder.
+ * `messages` is the transcript INCLUDING the user's just-sent message, which
+ * is typically the final entry in the array when the chat shell invokes the
+ * responder.
  */
 export function summarizeConversationHistory(
-  priorMessages: ChatMessage[],
+  messages: ChatMessage[],
   prompt: string,
 ): ChatHistorySummary {
   const trimmedPrompt = prompt.trim();
   const lower = trimmedPrompt.toLowerCase();
+  const lastMessage = messages[messages.length - 1];
+  const priorMessages =
+    lastMessage &&
+    lastMessage.role === 'user' &&
+    lastMessage.content.trim() === trimmedPrompt
+      ? messages.slice(0, -1)
+      : messages;
 
-  const userTurns = priorMessages.filter((m) => m.role === 'user').length + 1;
+  const userTurns = messages.filter((m) => m.role === 'user').length;
   const assistantTurns = priorMessages.filter(
     (m) => m.role === 'assistant' && !m.pending && m.content.trim().length > 0,
   ).length;
@@ -255,7 +263,7 @@ function isJsonSchemaType(value: string): boolean {
 }
 
 function extractRefinementOps(prompt: string): ChatRefinementOp[] {
-  const ops: ChatRefinementOp[] = [];
+  const indexed: Array<{ index: number; op: ChatRefinementOp }> = [];
   const seen = new Set<string>();
   for (const { regex, build } of REFINE_PATTERNS) {
     regex.lastIndex = 0;
@@ -266,10 +274,11 @@ function extractRefinementOps(prompt: string): ChatRefinementOp[] {
       const key = opKey(op);
       if (seen.has(key)) continue;
       seen.add(key);
-      ops.push(op);
+      indexed.push({ index: match.index, op });
     }
   }
-  return ops;
+  indexed.sort((a, b) => a.index - b.index);
+  return indexed.map(({ op }) => op);
 }
 
 function opKey(op: ChatRefinementOp): string {

--- a/objectified-ui/src/app/ade/studio/components/chatbot/demo-responder.ts
+++ b/objectified-ui/src/app/ade/studio/components/chatbot/demo-responder.ts
@@ -13,31 +13,72 @@
  * As of #259 the responder is also context-aware: when the chat shell hands
  * us a `studioContext` snapshot we mention the user's project / version,
  * acknowledge canvas selection, and reuse existing class / property names
- * inside the demo OpenAPI spec. The intent is to give reviewers a faithful
- * preview of how a real backend will ground its replies in the workspace.
+ * inside the demo OpenAPI spec.
+ *
+ * #260 layers in multi-turn awareness. Each call asks
+ * `summarizeConversationHistory` to classify the prompt against the prior
+ * transcript and we branch on the result:
+ *   - `refine-spec`: take the last spec we shipped, apply the requested
+ *     edits via `applyRefinementsToSpec`, and reship it so the Import
+ *     button keeps working.
+ *   - `comparison`: acknowledge the "more like X" subject inside the reply
+ *     and the regenerated spec.
+ *   - `clarification`: answer the question without re-shipping a schema.
+ *   - `iteration`: rebuild the spec from scratch but flag it as a redo.
+ *   - `standalone` / `first-turn`: behave as before.
  */
 
 import type { ChatStudioContext, ChatStudioProperty } from './chat-context';
 import { getSelectedClasses, isChatStudioContextEmpty } from './chat-context';
+import {
+  applyRefinementsToSpec,
+  summarizeConversationHistory,
+  type ChatHistorySummary,
+  type ChatRefinementOp,
+} from './conversation-history';
 import type { ChatSendFn } from './types';
 
 const SPEC_DEMO_PROMPTS = ['openapi', 'spec', 'schema', 'api'];
 
 export const createDemoChatResponder = (): ChatSendFn => async ({
+  messages,
   prompt,
   isRegenerate,
   studioContext,
 }) => {
+  const history = summarizeConversationHistory(messages, prompt);
   const lower = prompt.toLowerCase();
-  const wantsSpec = SPEC_DEMO_PROMPTS.some((needle) => lower.includes(needle));
   const variation = isRegenerate ? '\n\n_Regenerated with a slightly different angle._' : '';
   const groundingLine = describeGrounding(studioContext);
+  const continuityLine = describeContinuity(history);
+
+  if (history.intent === 'clarification') {
+    return buildClarificationReply({ history, groundingLine, continuityLine, variation });
+  }
+
+  if (history.intent === 'refine-spec' && history.lastAssistantSpec) {
+    return buildRefinementReply({
+      history,
+      groundingLine,
+      continuityLine,
+      variation,
+    });
+  }
+
+  const wantsSpec =
+    history.intent === 'comparison' ||
+    SPEC_DEMO_PROMPTS.some((needle) => lower.includes(needle));
 
   if (wantsSpec) {
-    const spec = buildSampleSpec(studioContext);
+    const spec = buildSampleSpec(studioContext, history);
+    const intro =
+      history.intent === 'comparison' && history.comparisonSubject
+        ? `Reworked the sketch to lean more like **${history.comparisonSubject}**${groundingLine ? ` ${groundingLine}` : ''} — review the JSON below and click **Import OpenAPI spec** to load it into Studio.`
+        : `Here's a small OpenAPI 3.1 sketch for what you described${groundingLine ? ` ${groundingLine}` : ''} — review the JSON below and click **Import OpenAPI spec** to load it into Studio.`;
     const suggestions = buildContextAwareSuggestions(studioContext);
-    return [
-      `Here's a small OpenAPI 3.1 sketch for what you described${groundingLine ? ` ${groundingLine}` : ''} — review the JSON below and click **Import OpenAPI spec** to load it into Studio.`,
+    const lines: string[] = [intro];
+    if (continuityLine) lines.push('', continuityLine);
+    lines.push(
       '',
       '```json',
       JSON.stringify(spec, null, 2),
@@ -45,11 +86,15 @@ export const createDemoChatResponder = (): ChatSendFn => async ({
       '',
       'A few things to consider next:',
       ...suggestions,
-    ].join('\n') + variation;
+    );
+    return lines.join('\n') + variation;
   }
 
-  return [
+  const lines: string[] = [
     `I'm the offline preview of the Studio AI assistant${groundingLine ? ` ${groundingLine}` : ''} — the live model lands in a follow-up ticket. Until then, here's what the chat surface supports today:`,
+  ];
+  if (continuityLine) lines.push('', continuityLine);
+  lines.push(
     '',
     '- **Markdown** rendering with headings, lists, and inline `code`',
     '- Code blocks with copy + syntax highlighting:',
@@ -61,8 +106,107 @@ export const createDemoChatResponder = (): ChatSendFn => async ({
     '```',
     '',
     'Try asking for an "OpenAPI spec" to see the import affordance.',
-  ].join('\n') + variation;
+  );
+  return lines.join('\n') + variation;
 };
+
+interface ReplyBuilderInput {
+  history: ChatHistorySummary;
+  groundingLine: string | null;
+  continuityLine: string | null;
+  variation: string;
+}
+
+function buildClarificationReply({
+  history,
+  groundingLine,
+  continuityLine,
+  variation,
+}: ReplyBuilderInput): string {
+  const turnLabel = `turn ${history.userTurnCount}`;
+  const lines: string[] = [
+    `Happy to clarify (${turnLabel})${groundingLine ? ` ${groundingLine}` : ''}.`,
+  ];
+  if (continuityLine) lines.push('', continuityLine);
+  lines.push(
+    '',
+    'In the previous reply I sketched a small OpenAPI fragment. The most common follow-up questions look like:',
+    '',
+    '- _What does field X mean?_ — describe its role in the schema',
+    '- _Why is field Y required?_ — explain the constraint',
+    '- _How would I change Z?_ — suggest a refinement you can ask for next',
+    '',
+    'Drop a follow-up like "make `name` required" or "remove `priceCents`" and I\'ll re-ship the same schema with the edit applied.',
+  );
+  return lines.join('\n') + variation;
+}
+
+function buildRefinementReply({
+  history,
+  groundingLine,
+  continuityLine,
+  variation,
+}: ReplyBuilderInput): string {
+  const lastSpec = history.lastAssistantSpec!;
+  const refined = applyRefinementsToSpec(lastSpec.spec, history.refinementOps);
+  const opSummary = summarizeOps(history.refinementOps);
+  const introBits: string[] = [
+    `Updated the previous schema${groundingLine ? ` ${groundingLine}` : ''}.`,
+  ];
+  if (opSummary) introBits.push(opSummary);
+  introBits.push('Click **Import OpenAPI spec** to apply the refined version.');
+
+  const lines: string[] = [introBits.join(' ')];
+  if (continuityLine) lines.push('', continuityLine);
+  lines.push(
+    '',
+    '```json',
+    JSON.stringify(refined, null, 2),
+    '```',
+    '',
+    'Need another change? Ask me to add, remove, rename, or require a property and I\'ll keep iterating.',
+  );
+  return lines.join('\n') + variation;
+}
+
+function describeContinuity(history: ChatHistorySummary): string | null {
+  if (history.assistantTurnCount === 0) return null;
+  switch (history.intent) {
+    case 'refine-spec':
+      return `_Building on turn ${history.userTurnCount - 1} — applying ${history.refinementOps.length === 1 ? '1 edit' : `${history.refinementOps.length} edits`} to the previous spec._`;
+    case 'comparison':
+      return history.comparisonSubject
+        ? `_Reframing the previous answer to look more like **${history.comparisonSubject}**._`
+        : '_Reframing the previous answer with a new reference point._';
+    case 'iteration':
+      return `_Trying a different angle on turn ${history.userTurnCount - 1}._`;
+    case 'standalone':
+      return `_Continuing the thread — turn ${history.userTurnCount} of ${history.userTurnCount}._`;
+    default:
+      return null;
+  }
+}
+
+function summarizeOps(ops: ChatRefinementOp[]): string | null {
+  if (ops.length === 0) return null;
+  const verbs = ops.map(opToVerb);
+  if (verbs.length === 1) return `Applied: ${verbs[0]}.`;
+  if (verbs.length === 2) return `Applied: ${verbs[0]} and ${verbs[1]}.`;
+  return `Applied: ${verbs.slice(0, -1).join(', ')}, and ${verbs[verbs.length - 1]}.`;
+}
+
+function opToVerb(op: ChatRefinementOp): string {
+  switch (op.kind) {
+    case 'add-property':
+      return op.type ? `added \`${op.name}\` (${op.type})` : `added \`${op.name}\``;
+    case 'remove-property':
+      return `removed \`${op.name}\``;
+    case 'require-property':
+      return `marked \`${op.name}\` required`;
+    case 'rename-property':
+      return `renamed \`${op.from}\` → \`${op.to}\``;
+  }
+}
 
 function describeGrounding(ctx: ChatStudioContext | undefined): string | null {
   if (!ctx || isChatStudioContextEmpty(ctx)) return null;
@@ -122,20 +266,33 @@ interface SampleSpec {
   };
 }
 
-function buildSampleSpec(ctx: ChatStudioContext | undefined): SampleSpec {
-  const title = ctx?.project?.name ? `${ctx.project.name} (Studio AI sketch)` : 'Sample Catalog API';
+function buildSampleSpec(
+  ctx: ChatStudioContext | undefined,
+  history: ChatHistorySummary,
+): SampleSpec {
+  const titleBase = ctx?.project?.name ? `${ctx.project.name} (Studio AI sketch)` : 'Sample Catalog API';
+  const title =
+    history.intent === 'comparison' && history.comparisonSubject
+      ? `${titleBase} — inspired by ${history.comparisonSubject}`
+      : titleBase;
   const version = ctx?.version?.label ?? '0.1.0';
   const className = pickReferenceClassName(ctx) ?? 'Product';
   const properties = buildSpecProperties(ctx);
+
+  const description = ctx?.project?.name
+    ? `Sketch generated by the Studio AI demo responder, grounded in ${ctx.project.name}.`
+    : 'Tiny catalog API generated by the Studio AI demo responder.';
+  const finalDescription =
+    history.intent === 'comparison' && history.comparisonSubject
+      ? `${description} Adjusted to look more like ${history.comparisonSubject}.`
+      : description;
 
   return {
     openapi: '3.1.0',
     info: {
       title,
       version,
-      description: ctx?.project?.name
-        ? `Sketch generated by the Studio AI demo responder, grounded in ${ctx.project.name}.`
-        : 'Tiny catalog API generated by the Studio AI demo responder.',
+      description: finalDescription,
     },
     components: {
       schemas: {

--- a/objectified-ui/src/app/ade/studio/components/chatbot/index.ts
+++ b/objectified-ui/src/app/ade/studio/components/chatbot/index.ts
@@ -37,4 +37,17 @@ export {
   hasOpenApiSpec,
 } from './openapi-detection';
 export type { DetectedOpenApiSpec } from './openapi-detection';
+export {
+  applyRefinementsToSpec,
+  buildConversationHistoryPreamble,
+  CHAT_HISTORY_EXCERPT_CHAR_CAP,
+  CHAT_HISTORY_TURN_CAP,
+  summarizeConversationHistory,
+} from './conversation-history';
+export type {
+  ChatFollowUpIntent,
+  ChatHistoryExcerpt,
+  ChatHistorySummary,
+  ChatRefinementOp,
+} from './conversation-history';
 export type { ChatFeedback, ChatMessage, ChatRole, ChatSendContext, ChatSendFn } from './types';

--- a/objectified-ui/tests/chatbot/ChatConversation.test.tsx
+++ b/objectified-ui/tests/chatbot/ChatConversation.test.tsx
@@ -1,5 +1,5 @@
 /**
- * Tests for the chat conversation orchestrator (#258).
+ * Tests for the chat conversation orchestrator (#258, #259, #260).
  *
  * Covers the end-to-end flow exercised by the StudioAiChatbot panel:
  *   - Empty-state suggestions seed the conversation
@@ -8,6 +8,9 @@
  *   - Regenerate re-uses the last user prompt and replaces the prior reply
  *   - Thumbs up/down feedback toggles
  *   - Composer is disabled while the assistant is working
+ *   - The studio context snapshot rides on every send (#259)
+ *   - Multi-turn follow-ups carry the full transcript and refine prior
+ *     specs through the chat surface (#260)
  */
 
 import React from 'react';
@@ -16,7 +19,7 @@ import '@testing-library/jest-dom';
 
 import { ChatConversation } from '../../src/app/ade/studio/components/chatbot/ChatConversation';
 import type { ChatStudioContext } from '../../src/app/ade/studio/components/chatbot/chat-context';
-import type { ChatSendFn } from '../../src/app/ade/studio/components/chatbot/types';
+import type { ChatMessage, ChatSendFn } from '../../src/app/ade/studio/components/chatbot/types';
 
 type ResponderCall = {
   prompt: string;
@@ -230,6 +233,65 @@ describe('ChatConversation', () => {
     await act(async () => {
       resolveWith('ok');
     });
+  });
+
+  it('passes the full prior transcript to the responder on follow-up turns (#260)', async () => {
+    const calls: ResponderCall[] = [];
+    const transcripts: ChatMessage[][] = [];
+    const responder: ChatSendFn = ({ messages, prompt, isRegenerate, studioContext }) => {
+      calls.push({ prompt, isRegenerate, studioContext });
+      transcripts.push(messages);
+      return Promise.resolve(`echo: ${prompt}`);
+    };
+    render(<ChatConversation onSendMessage={responder} />);
+
+    fireEvent.change(screen.getByTestId('studio-ai-chat-input'), { target: { value: 'first ask' } });
+    fireEvent.click(screen.getByTestId('studio-ai-chat-send'));
+    await waitFor(() => expect(calls).toHaveLength(1));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('studio-ai-chat-input')).not.toBeDisabled();
+    });
+
+    fireEvent.change(screen.getByTestId('studio-ai-chat-input'), { target: { value: 'follow up' } });
+    fireEvent.click(screen.getByTestId('studio-ai-chat-send'));
+    await waitFor(() => expect(calls).toHaveLength(2));
+
+    // First call only sees the just-sent user turn.
+    expect(transcripts[0]).toHaveLength(1);
+    expect(transcripts[0][0]).toMatchObject({ role: 'user', content: 'first ask' });
+
+    // Second call sees the full prior transcript: user + assistant + new user.
+    expect(transcripts[1]).toHaveLength(3);
+    expect(transcripts[1].map((m) => m.role)).toEqual(['user', 'assistant', 'user']);
+    expect(transcripts[1][1].content).toBe('echo: first ask');
+    expect(transcripts[1][2].content).toBe('follow up');
+  });
+
+  it('lets the user iteratively refine a previously imported spec (#260)', async () => {
+    // Drives the actual demo responder through the chat shell so the
+    // multi-turn refinement path is exercised end-to-end.
+    const { createDemoChatResponder } = await import('../../src/app/ade/studio/components/chatbot/demo-responder');
+    const responder = createDemoChatResponder();
+    const onImportSpec = jest.fn();
+    render(<ChatConversation onSendMessage={responder} onImportSpec={onImportSpec} />);
+
+    fireEvent.change(screen.getByTestId('studio-ai-chat-input'), { target: { value: 'sketch a schema' } });
+    fireEvent.click(screen.getByTestId('studio-ai-chat-send'));
+    await waitFor(() => expect(screen.getByTestId('studio-ai-chat-import-spec-0')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByTestId('studio-ai-chat-input')).not.toBeDisabled());
+
+    fireEvent.change(screen.getByTestId('studio-ai-chat-input'), { target: { value: 'add a phone field' } });
+    fireEvent.click(screen.getByTestId('studio-ai-chat-send'));
+    // The refinement reply re-ships an importable spec — wait on the second
+    // import button so we know both turns made it through the responder.
+    await waitFor(() => expect(screen.getAllByTestId(/studio-ai-chat-import-spec-/)).toHaveLength(1));
+    const bubbles = screen.getAllByTestId('studio-ai-chat-bubble');
+    const assistantBubbles = bubbles.filter((b) => b.getAttribute('data-role') === 'assistant');
+    expect(assistantBubbles).toHaveLength(2);
+    // The second assistant reply is the refinement: it must include the
+    // refined spec containing a `phone` property as JSON text.
+    expect(assistantBubbles[1].textContent ?? '').toMatch(/"phone"/);
   });
 
   it('forwards the import callback when the assistant returns an OpenAPI spec', async () => {

--- a/objectified-ui/tests/chatbot/conversation-history.test.ts
+++ b/objectified-ui/tests/chatbot/conversation-history.test.ts
@@ -1,0 +1,273 @@
+/**
+ * Tests for the multi-turn conversation history helpers (#260).
+ *
+ * Pins the intent classifier, refinement-op extraction, prompt-injection
+ * preamble, and the spec mutation pipeline so regressions show up loudly
+ * before they reach the chat surface.
+ */
+
+import {
+  applyRefinementsToSpec,
+  buildConversationHistoryPreamble,
+  CHAT_HISTORY_EXCERPT_CHAR_CAP,
+  CHAT_HISTORY_TURN_CAP,
+  summarizeConversationHistory,
+  type ChatRefinementOp,
+} from '../../src/app/ade/studio/components/chatbot/conversation-history';
+import type { ChatMessage } from '../../src/app/ade/studio/components/chatbot/types';
+
+function user(content: string, id = `u-${content.slice(0, 8)}`): ChatMessage {
+  return { id, role: 'user', content };
+}
+
+function assistant(content: string, id = `a-${content.slice(0, 8)}`): ChatMessage {
+  return { id, role: 'assistant', content };
+}
+
+const SAMPLE_SPEC_REPLY = [
+  'Here is the spec:',
+  '',
+  '```json',
+  JSON.stringify({
+    openapi: '3.1.0',
+    info: { title: 'Catalog', version: '0.1.0' },
+    components: {
+      schemas: {
+        Product: {
+          type: 'object',
+          properties: {
+            id: { type: 'string', format: 'uuid' },
+            name: { type: 'string' },
+            priceCents: { type: 'integer' },
+          },
+          required: ['id'],
+        },
+      },
+    },
+  }),
+  '```',
+].join('\n');
+
+describe('summarizeConversationHistory', () => {
+  it('classifies the first turn when there is no prior assistant reply', () => {
+    const summary = summarizeConversationHistory([], 'Sketch a User class');
+    expect(summary.intent).toBe('first-turn');
+    expect(summary.userTurnCount).toBe(1);
+    expect(summary.assistantTurnCount).toBe(0);
+    expect(summary.lastAssistantSpec).toBeNull();
+    expect(summary.refinementOps).toEqual([]);
+  });
+
+  it('treats unrelated follow-ups as standalone when no other pattern matches', () => {
+    const messages: ChatMessage[] = [user('hi'), assistant('hello there')];
+    const summary = summarizeConversationHistory(messages, 'sketch a wholly new schema');
+    expect(summary.intent).toBe('standalone');
+    expect(summary.userTurnCount).toBe(2);
+    expect(summary.assistantTurnCount).toBe(1);
+  });
+
+  it('skips pending and empty assistant messages when counting prior replies', () => {
+    const messages: ChatMessage[] = [
+      user('first'),
+      { id: 'pending', role: 'assistant', content: '', pending: true },
+    ];
+    const summary = summarizeConversationHistory(messages, 'follow up');
+    expect(summary.assistantTurnCount).toBe(0);
+    expect(summary.intent).toBe('first-turn');
+  });
+
+  it('detects clarification questions about the previous reply', () => {
+    const messages: ChatMessage[] = [user('q'), assistant('a long answer')];
+    const summary = summarizeConversationHistory(messages, 'What does that mean?');
+    expect(summary.intent).toBe('clarification');
+  });
+
+  it('detects iteration intent for "actually" / "instead" prompts', () => {
+    const messages: ChatMessage[] = [user('q'), assistant('first try')];
+    const summary = summarizeConversationHistory(messages, 'actually, try again with fewer fields');
+    expect(summary.intent).toBe('iteration');
+  });
+
+  it('detects "more like X" comparison prompts and captures the subject', () => {
+    const messages: ChatMessage[] = [user('q'), assistant(SAMPLE_SPEC_REPLY)];
+    const summary = summarizeConversationHistory(
+      messages,
+      'Make it more like Stripe Charges',
+    );
+    expect(summary.intent).toBe('comparison');
+    expect(summary.comparisonSubject).toBe('Stripe Charges');
+  });
+
+  it('detects refine-spec intent when a prior spec exists and refinement words appear', () => {
+    const messages: ChatMessage[] = [user('q'), assistant(SAMPLE_SPEC_REPLY)];
+    const summary = summarizeConversationHistory(messages, 'refine that please');
+    expect(summary.intent).toBe('refine-spec');
+    expect(summary.lastAssistantSpec).not.toBeNull();
+  });
+
+  it('returns standalone (not refine-spec) when refinement words appear but no spec is present', () => {
+    const messages: ChatMessage[] = [user('q'), assistant('plain text reply')];
+    const summary = summarizeConversationHistory(messages, 'refine that please');
+    expect(summary.intent).toBe('standalone');
+    expect(summary.lastAssistantSpec).toBeNull();
+  });
+
+  it('extracts add / remove / require / rename ops from the prompt', () => {
+    const messages: ChatMessage[] = [user('q'), assistant(SAMPLE_SPEC_REPLY)];
+    const summary = summarizeConversationHistory(
+      messages,
+      'add a phone field of type string, remove priceCents, make name required, rename id to productId',
+    );
+    expect(summary.intent).toBe('refine-spec');
+    expect(summary.refinementOps).toEqual<ChatRefinementOp[]>([
+      { kind: 'rename-property', from: 'id', to: 'productId' },
+      { kind: 'remove-property', name: 'priceCents' },
+      { kind: 'require-property', name: 'name' },
+      { kind: 'add-property', name: 'phone', type: 'string' },
+    ]);
+  });
+
+  it('parses concise add-property phrasing like "add timestamps integer"', () => {
+    const messages: ChatMessage[] = [user('q'), assistant(SAMPLE_SPEC_REPLY)];
+    const summary = summarizeConversationHistory(messages, 'add createdAt integer');
+    expect(summary.refinementOps).toContainEqual({
+      kind: 'add-property',
+      name: 'createdAt',
+      type: 'integer',
+    });
+  });
+
+  it('builds excerpts capped to the most recent turns and trims long text', () => {
+    const long = 'word '.repeat(120);
+    const messages: ChatMessage[] = [];
+    for (let i = 0; i < CHAT_HISTORY_TURN_CAP + 4; i += 1) {
+      messages.push(user(`u-${i}`, `u-${i}`));
+      messages.push(assistant(`a-${i}-${long}`, `a-${i}`));
+    }
+    const summary = summarizeConversationHistory(messages, 'next');
+    expect(summary.recentExcerpts.length).toBeLessThanOrEqual(CHAT_HISTORY_TURN_CAP);
+    for (const e of summary.recentExcerpts) {
+      expect(e.content.length).toBeLessThanOrEqual(CHAT_HISTORY_EXCERPT_CHAR_CAP);
+    }
+  });
+
+  it('replaces fenced code blocks in excerpts with a placeholder', () => {
+    const messages: ChatMessage[] = [user('q'), assistant(SAMPLE_SPEC_REPLY)];
+    const summary = summarizeConversationHistory(messages, 'next');
+    const last = summary.recentExcerpts[summary.recentExcerpts.length - 1];
+    expect(last.content).toContain('[code block omitted]');
+    expect(last.content).not.toContain('```');
+  });
+});
+
+describe('buildConversationHistoryPreamble', () => {
+  it('returns an empty string for the first turn', () => {
+    const summary = summarizeConversationHistory([], 'hello');
+    expect(buildConversationHistoryPreamble(summary)).toBe('');
+  });
+
+  it('mentions turn counters and intent when refining a spec', () => {
+    const messages: ChatMessage[] = [user('q'), assistant(SAMPLE_SPEC_REPLY)];
+    const summary = summarizeConversationHistory(messages, 'add a phone field');
+    const preamble = buildConversationHistoryPreamble(summary);
+    expect(preamble).toMatch(/Turn 2 of an ongoing thread/);
+    expect(preamble).toMatch(/refinement of the last generated schema/i);
+    expect(preamble).toMatch(/Add property `phone`/);
+  });
+
+  it('mentions the comparison subject when present', () => {
+    const messages: ChatMessage[] = [user('q'), assistant(SAMPLE_SPEC_REPLY)];
+    const summary = summarizeConversationHistory(messages, 'Make it more like FHIR Patient');
+    const preamble = buildConversationHistoryPreamble(summary);
+    expect(preamble).toMatch(/look more like: FHIR Patient/);
+  });
+
+  it('describes clarification intent without inventing schema edits', () => {
+    const messages: ChatMessage[] = [user('q'), assistant(SAMPLE_SPEC_REPLY)];
+    const summary = summarizeConversationHistory(messages, 'What does priceCents mean?');
+    const preamble = buildConversationHistoryPreamble(summary);
+    expect(preamble).toMatch(/clarifying question/);
+    expect(preamble).not.toMatch(/Detected schema edits/);
+  });
+});
+
+describe('applyRefinementsToSpec', () => {
+  const baseSpec = (): Record<string, unknown> => ({
+    openapi: '3.1.0',
+    info: { title: 'Catalog', version: '0.1.0' },
+    components: {
+      schemas: {
+        Product: {
+          type: 'object',
+          properties: {
+            id: { type: 'string' },
+            name: { type: 'string' },
+            priceCents: { type: 'integer' },
+          },
+          required: ['id'],
+        },
+      },
+    },
+  });
+
+  it('returns a clone — never mutates the input spec', () => {
+    const input = baseSpec();
+    const before = JSON.stringify(input);
+    applyRefinementsToSpec(input, [{ kind: 'remove-property', name: 'name' }]);
+    expect(JSON.stringify(input)).toBe(before);
+  });
+
+  it('adds a property with the requested type', () => {
+    const out = applyRefinementsToSpec(baseSpec(), [
+      { kind: 'add-property', name: 'phone', type: 'string' },
+    ]) as { components: { schemas: { Product: { properties: Record<string, { type: string }> } } } };
+    expect(out.components.schemas.Product.properties.phone.type).toBe('string');
+  });
+
+  it('updates the type of an existing property when add is requested with a type', () => {
+    const out = applyRefinementsToSpec(baseSpec(), [
+      { kind: 'add-property', name: 'priceCents', type: 'number' },
+    ]) as { components: { schemas: { Product: { properties: Record<string, { type: string }> } } } };
+    expect(out.components.schemas.Product.properties.priceCents.type).toBe('number');
+  });
+
+  it('removes a property and prunes required entries', () => {
+    const out = applyRefinementsToSpec(baseSpec(), [
+      { kind: 'remove-property', name: 'id' },
+    ]) as { components: { schemas: { Product: { properties: Record<string, unknown>; required?: string[] } } } };
+    expect(out.components.schemas.Product.properties.id).toBeUndefined();
+    expect(out.components.schemas.Product.required).toBeUndefined();
+  });
+
+  it('marks an existing property as required without duplicating it', () => {
+    const out = applyRefinementsToSpec(baseSpec(), [
+      { kind: 'require-property', name: 'name' },
+      { kind: 'require-property', name: 'name' },
+    ]) as { components: { schemas: { Product: { required: string[] } } } };
+    expect(out.components.schemas.Product.required).toEqual(['id', 'name']);
+  });
+
+  it('creates a placeholder property when require is asked for an unknown name', () => {
+    const out = applyRefinementsToSpec(baseSpec(), [
+      { kind: 'require-property', name: 'tenantId' },
+    ]) as { components: { schemas: { Product: { properties: Record<string, { type: string }>; required: string[] } } } };
+    expect(out.components.schemas.Product.properties.tenantId.type).toBe('string');
+    expect(out.components.schemas.Product.required).toContain('tenantId');
+  });
+
+  it('renames a property and updates the required list', () => {
+    const out = applyRefinementsToSpec(baseSpec(), [
+      { kind: 'rename-property', from: 'id', to: 'productId' },
+    ]) as { components: { schemas: { Product: { properties: Record<string, unknown>; required: string[] } } } };
+    expect(out.components.schemas.Product.properties.productId).toBeDefined();
+    expect(out.components.schemas.Product.properties.id).toBeUndefined();
+    expect(out.components.schemas.Product.required).toContain('productId');
+  });
+
+  it('returns the clone untouched when the spec has no schemas', () => {
+    const spec = { openapi: '3.1.0', info: { title: 'x', version: '0.1.0' } };
+    const out = applyRefinementsToSpec(spec, [{ kind: 'remove-property', name: 'x' }]);
+    expect(out).toEqual(spec);
+    expect(out).not.toBe(spec);
+  });
+});

--- a/objectified-ui/tests/chatbot/conversation-history.test.ts
+++ b/objectified-ui/tests/chatbot/conversation-history.test.ts
@@ -50,7 +50,7 @@ const SAMPLE_SPEC_REPLY = [
 
 describe('summarizeConversationHistory', () => {
   it('classifies the first turn when there is no prior assistant reply', () => {
-    const summary = summarizeConversationHistory([], 'Sketch a User class');
+    const summary = summarizeConversationHistory([user('Sketch a User class')], 'Sketch a User class');
     expect(summary.intent).toBe('first-turn');
     expect(summary.userTurnCount).toBe(1);
     expect(summary.assistantTurnCount).toBe(0);
@@ -59,7 +59,7 @@ describe('summarizeConversationHistory', () => {
   });
 
   it('treats unrelated follow-ups as standalone when no other pattern matches', () => {
-    const messages: ChatMessage[] = [user('hi'), assistant('hello there')];
+    const messages: ChatMessage[] = [user('hi'), assistant('hello there'), user('sketch a wholly new schema')];
     const summary = summarizeConversationHistory(messages, 'sketch a wholly new schema');
     expect(summary.intent).toBe('standalone');
     expect(summary.userTurnCount).toBe(2);
@@ -70,6 +70,7 @@ describe('summarizeConversationHistory', () => {
     const messages: ChatMessage[] = [
       user('first'),
       { id: 'pending', role: 'assistant', content: '', pending: true },
+      user('follow up'),
     ];
     const summary = summarizeConversationHistory(messages, 'follow up');
     expect(summary.assistantTurnCount).toBe(0);
@@ -77,19 +78,19 @@ describe('summarizeConversationHistory', () => {
   });
 
   it('detects clarification questions about the previous reply', () => {
-    const messages: ChatMessage[] = [user('q'), assistant('a long answer')];
+    const messages: ChatMessage[] = [user('q'), assistant('a long answer'), user('What does that mean?')];
     const summary = summarizeConversationHistory(messages, 'What does that mean?');
     expect(summary.intent).toBe('clarification');
   });
 
   it('detects iteration intent for "actually" / "instead" prompts', () => {
-    const messages: ChatMessage[] = [user('q'), assistant('first try')];
+    const messages: ChatMessage[] = [user('q'), assistant('first try'), user('actually, try again with fewer fields')];
     const summary = summarizeConversationHistory(messages, 'actually, try again with fewer fields');
     expect(summary.intent).toBe('iteration');
   });
 
   it('detects "more like X" comparison prompts and captures the subject', () => {
-    const messages: ChatMessage[] = [user('q'), assistant(SAMPLE_SPEC_REPLY)];
+    const messages: ChatMessage[] = [user('q'), assistant(SAMPLE_SPEC_REPLY), user('Make it more like Stripe Charges')];
     const summary = summarizeConversationHistory(
       messages,
       'Make it more like Stripe Charges',
@@ -99,36 +100,37 @@ describe('summarizeConversationHistory', () => {
   });
 
   it('detects refine-spec intent when a prior spec exists and refinement words appear', () => {
-    const messages: ChatMessage[] = [user('q'), assistant(SAMPLE_SPEC_REPLY)];
+    const messages: ChatMessage[] = [user('q'), assistant(SAMPLE_SPEC_REPLY), user('refine that please')];
     const summary = summarizeConversationHistory(messages, 'refine that please');
     expect(summary.intent).toBe('refine-spec');
     expect(summary.lastAssistantSpec).not.toBeNull();
   });
 
   it('returns standalone (not refine-spec) when refinement words appear but no spec is present', () => {
-    const messages: ChatMessage[] = [user('q'), assistant('plain text reply')];
+    const messages: ChatMessage[] = [user('q'), assistant('plain text reply'), user('refine that please')];
     const summary = summarizeConversationHistory(messages, 'refine that please');
     expect(summary.intent).toBe('standalone');
     expect(summary.lastAssistantSpec).toBeNull();
   });
 
   it('extracts add / remove / require / rename ops from the prompt', () => {
-    const messages: ChatMessage[] = [user('q'), assistant(SAMPLE_SPEC_REPLY)];
+    const prompt = 'add a phone field of type string, remove priceCents, make name required, rename id to productId';
+    const messages: ChatMessage[] = [user('q'), assistant(SAMPLE_SPEC_REPLY), user(prompt)];
     const summary = summarizeConversationHistory(
       messages,
-      'add a phone field of type string, remove priceCents, make name required, rename id to productId',
+      prompt,
     );
     expect(summary.intent).toBe('refine-spec');
     expect(summary.refinementOps).toEqual<ChatRefinementOp[]>([
-      { kind: 'rename-property', from: 'id', to: 'productId' },
+      { kind: 'add-property', name: 'phone', type: 'string' },
       { kind: 'remove-property', name: 'priceCents' },
       { kind: 'require-property', name: 'name' },
-      { kind: 'add-property', name: 'phone', type: 'string' },
+      { kind: 'rename-property', from: 'id', to: 'productId' },
     ]);
   });
 
   it('parses concise add-property phrasing like "add timestamps integer"', () => {
-    const messages: ChatMessage[] = [user('q'), assistant(SAMPLE_SPEC_REPLY)];
+    const messages: ChatMessage[] = [user('q'), assistant(SAMPLE_SPEC_REPLY), user('add createdAt integer')];
     const summary = summarizeConversationHistory(messages, 'add createdAt integer');
     expect(summary.refinementOps).toContainEqual({
       kind: 'add-property',
@@ -144,6 +146,7 @@ describe('summarizeConversationHistory', () => {
       messages.push(user(`u-${i}`, `u-${i}`));
       messages.push(assistant(`a-${i}-${long}`, `a-${i}`));
     }
+    messages.push(user('next')); // mirror production: include the current user turn.
     const summary = summarizeConversationHistory(messages, 'next');
     expect(summary.recentExcerpts.length).toBeLessThanOrEqual(CHAT_HISTORY_TURN_CAP);
     for (const e of summary.recentExcerpts) {
@@ -152,7 +155,7 @@ describe('summarizeConversationHistory', () => {
   });
 
   it('replaces fenced code blocks in excerpts with a placeholder', () => {
-    const messages: ChatMessage[] = [user('q'), assistant(SAMPLE_SPEC_REPLY)];
+    const messages: ChatMessage[] = [user('q'), assistant(SAMPLE_SPEC_REPLY), user('next')];
     const summary = summarizeConversationHistory(messages, 'next');
     const last = summary.recentExcerpts[summary.recentExcerpts.length - 1];
     expect(last.content).toContain('[code block omitted]');
@@ -162,12 +165,12 @@ describe('summarizeConversationHistory', () => {
 
 describe('buildConversationHistoryPreamble', () => {
   it('returns an empty string for the first turn', () => {
-    const summary = summarizeConversationHistory([], 'hello');
+    const summary = summarizeConversationHistory([user('hello')], 'hello');
     expect(buildConversationHistoryPreamble(summary)).toBe('');
   });
 
   it('mentions turn counters and intent when refining a spec', () => {
-    const messages: ChatMessage[] = [user('q'), assistant(SAMPLE_SPEC_REPLY)];
+    const messages: ChatMessage[] = [user('q'), assistant(SAMPLE_SPEC_REPLY), user('add a phone field')];
     const summary = summarizeConversationHistory(messages, 'add a phone field');
     const preamble = buildConversationHistoryPreamble(summary);
     expect(preamble).toMatch(/Turn 2 of an ongoing thread/);
@@ -176,14 +179,14 @@ describe('buildConversationHistoryPreamble', () => {
   });
 
   it('mentions the comparison subject when present', () => {
-    const messages: ChatMessage[] = [user('q'), assistant(SAMPLE_SPEC_REPLY)];
+    const messages: ChatMessage[] = [user('q'), assistant(SAMPLE_SPEC_REPLY), user('Make it more like FHIR Patient')];
     const summary = summarizeConversationHistory(messages, 'Make it more like FHIR Patient');
     const preamble = buildConversationHistoryPreamble(summary);
     expect(preamble).toMatch(/look more like: FHIR Patient/);
   });
 
   it('describes clarification intent without inventing schema edits', () => {
-    const messages: ChatMessage[] = [user('q'), assistant(SAMPLE_SPEC_REPLY)];
+    const messages: ChatMessage[] = [user('q'), assistant(SAMPLE_SPEC_REPLY), user('What does priceCents mean?')];
     const summary = summarizeConversationHistory(messages, 'What does priceCents mean?');
     const preamble = buildConversationHistoryPreamble(summary);
     expect(preamble).toMatch(/clarifying question/);

--- a/objectified-ui/tests/chatbot/demo-responder.test.ts
+++ b/objectified-ui/tests/chatbot/demo-responder.test.ts
@@ -1,10 +1,15 @@
 /**
- * Tests for the offline demo responder used by the Studio chatbot (#258, #259).
+ * Tests for the offline demo responder used by the Studio chatbot
+ * (#258, #259, #260).
  *
- * Covers both the "no context" baseline behaviour designers see in isolated
- * previews and the context-aware grounding wired up in #259 — project /
- * version mention, canvas selection acknowledgement, and reuse of existing
- * class / property names inside the sample OpenAPI spec.
+ * Covers:
+ *   - The "no context" baseline behaviour designers see in isolated previews
+ *   - The context-aware grounding wired up in #259 — project / version
+ *     mention, canvas selection acknowledgement, and reuse of existing
+ *     class / property names inside the sample OpenAPI spec
+ *   - The multi-turn behaviour wired up in #260 — refining the previous
+ *     spec, handling clarification questions, "make it more like X"
+ *     comparisons, and re-rolls
  */
 
 import { createDemoChatResponder } from '../../src/app/ade/studio/components/chatbot/demo-responder';
@@ -13,6 +18,7 @@ import {
   EMPTY_CHAT_STUDIO_CONTEXT,
   type ChatStudioContext,
 } from '../../src/app/ade/studio/components/chatbot/chat-context';
+import type { ChatMessage } from '../../src/app/ade/studio/components/chatbot/types';
 
 const richContext: ChatStudioContext = {
   project: { id: 'proj-1', name: 'Acme Catalog' },
@@ -120,5 +126,118 @@ describe('createDemoChatResponder', () => {
     };
     expect(spec.info.title).toBe('Sample Catalog API');
     expect(Object.keys(spec.components.schemas)).toContain('Product');
+  });
+
+  describe('multi-turn behaviour (#260)', () => {
+    async function getInitialSpecReply(): Promise<string> {
+      return responder({
+        messages: [],
+        prompt: 'Generate an OpenAPI spec for me',
+        isRegenerate: false,
+      });
+    }
+
+    function turnsAfter(initialReply: string, prompt: string): ChatMessage[] {
+      return [
+        { id: 'u1', role: 'user', content: 'Generate an OpenAPI spec for me' },
+        { id: 'a1', role: 'assistant', content: initialReply },
+        { id: 'u2', role: 'user', content: prompt },
+      ].slice(0, 2); // pass only the prior turns; prompt is supplied separately.
+    }
+
+    it('refines the previously-generated spec when the user asks to add a property', async () => {
+      const initial = await getInitialSpecReply();
+      const initialSpecs = detectOpenApiSpecs(initial);
+      const initialSchemaName = Object.keys(
+        (initialSpecs[0].spec as { components: { schemas: Record<string, unknown> } })
+          .components.schemas,
+      )[0];
+
+      const refinement = await responder({
+        messages: turnsAfter(initial, 'add a phone field of type string'),
+        prompt: 'add a phone field of type string',
+        isRegenerate: false,
+      });
+      expect(refinement).toMatch(/Updated the previous schema/);
+      expect(refinement).toMatch(/added `phone`/);
+      const refinedSpecs = detectOpenApiSpecs(refinement);
+      expect(refinedSpecs).toHaveLength(1);
+      const refinedSchema = (refinedSpecs[0].spec as {
+        components: { schemas: Record<string, { properties: Record<string, { type: string }> }> };
+      }).components.schemas[initialSchemaName];
+      expect(refinedSchema.properties.phone).toEqual({
+        type: 'string',
+        description: 'Added in follow-up: phone.',
+      });
+      // The original properties are preserved by the deep clone.
+      expect(refinedSchema.properties.id).toBeDefined();
+      expect(refinedSchema.properties.name).toBeDefined();
+    });
+
+    it('removes a property and prunes the required list when asked', async () => {
+      const initial = await getInitialSpecReply();
+      const refinement = await responder({
+        messages: turnsAfter(initial, 'remove priceCents'),
+        prompt: 'remove priceCents',
+        isRegenerate: false,
+      });
+      expect(refinement).toMatch(/removed `priceCents`/);
+      const spec = detectOpenApiSpecs(refinement)[0].spec as {
+        components: { schemas: Record<string, { properties: Record<string, unknown> }> };
+      };
+      const schema = Object.values(spec.components.schemas)[0];
+      expect(schema.properties.priceCents).toBeUndefined();
+    });
+
+    it('marks a property required when the follow-up uses "make X required"', async () => {
+      const initial = await getInitialSpecReply();
+      const refinement = await responder({
+        messages: turnsAfter(initial, 'make name required'),
+        prompt: 'make name required',
+        isRegenerate: false,
+      });
+      const spec = detectOpenApiSpecs(refinement)[0].spec as {
+        components: { schemas: Record<string, { required: string[] }> };
+      };
+      const schema = Object.values(spec.components.schemas)[0];
+      expect(schema.required).toContain('name');
+    });
+
+    it('answers clarification questions without re-shipping a spec', async () => {
+      const initial = await getInitialSpecReply();
+      const reply = await responder({
+        messages: turnsAfter(initial, 'What does priceCents represent?'),
+        prompt: 'What does priceCents represent?',
+        isRegenerate: false,
+      });
+      expect(reply).toMatch(/Happy to clarify/);
+      expect(reply).toMatch(/turn 2/);
+      expect(detectOpenApiSpecs(reply)).toHaveLength(0);
+    });
+
+    it('reframes the spec when the user asks for "more like X"', async () => {
+      const initial = await getInitialSpecReply();
+      const reply = await responder({
+        messages: turnsAfter(initial, 'Make it more like Stripe Charges'),
+        prompt: 'Make it more like Stripe Charges',
+        isRegenerate: false,
+      });
+      expect(reply).toMatch(/lean more like \*\*Stripe Charges\*\*/);
+      const spec = detectOpenApiSpecs(reply)[0].spec as {
+        info: { title: string; description: string };
+      };
+      expect(spec.info.title).toMatch(/Stripe Charges/);
+      expect(spec.info.description).toMatch(/Stripe Charges/);
+    });
+
+    it('flags multi-turn standalone prompts with a continuation note', async () => {
+      const initial = await getInitialSpecReply();
+      const reply = await responder({
+        messages: turnsAfter(initial, 'tell me a joke'),
+        prompt: 'tell me a joke',
+        isRegenerate: false,
+      });
+      expect(reply).toMatch(/Continuing the thread — turn 2/);
+    });
   });
 });

--- a/objectified-ui/tests/chatbot/demo-responder.test.ts
+++ b/objectified-ui/tests/chatbot/demo-responder.test.ts
@@ -142,7 +142,7 @@ describe('createDemoChatResponder', () => {
         { id: 'u1', role: 'user', content: 'Generate an OpenAPI spec for me' },
         { id: 'a1', role: 'assistant', content: initialReply },
         { id: 'u2', role: 'user', content: prompt },
-      ].slice(0, 2); // pass only the prior turns; prompt is supplied separately.
+      ]; // mirror production: messages includes the latest user turn as well.
     }
 
     it('refines the previously-generated spec when the user asks to add a property', async () => {


### PR DESCRIPTION
## Summary

Implements [issue #260 (KenSuenobu/objectified)](https://github.com/KenSuenobu/objectified/issues/260) — multi-turn conversations with context history for the Studio AI chatbot.

The chat shell already passed the full transcript to the responder (#258); this ticket teaches the responder how to interpret it as an actual thread instead of independent one-shots.

### What changed

- **New module** `objectified-ui/src/app/ade/studio/components/chatbot/conversation-history.ts`:
  - `summarizeConversationHistory()` classifies each prompt against the prior transcript into one of: `first-turn`, `standalone`, `refine-spec`, `comparison`, `clarification`, `iteration`.
  - Detects the most recent assistant OpenAPI spec, parses `add` / `remove` / `require` / `rename` operations out of the prompt, and captures comparison subjects (`make it more like Stripe Charges`).
  - `applyRefinementsToSpec()` clones the prior spec and applies the parsed ops to its first schema (prunes `required`, generates placeholders for unknown property names when require-ing).
  - `buildConversationHistoryPreamble()` renders a compact prompt-injection preamble for the future Ollama transport (#265).
- **Demo responder** (`demo-responder.ts`) now branches on the detected intent:
  - `refine-spec` → re-ships the prior spec with edits applied (Import button stays alive).
  - `comparison` → reframes the spec, baking the subject into the title / description.
  - `clarification` → answers without re-shipping a schema.
  - Every multi-turn reply gets a continuity line so the user can see the thread context.
- **Roadmap** entry marked complete; **WHATS_NEW** updated; `objectified-ui` bumped to **0.10.17**.

### Acceptance criteria coverage

- [x] Follow-up questions with context — every send now carries the prior transcript and the responder labels turns.
- [x] Clarification requests — detected and answered without disrupting the previous spec.
- [x] Iterative refinement of schemas — add / remove / require / rename ops applied against the prior spec.
- [x] "Make it more like X" instructions — subject captured and reflected in the new spec.

## Test plan

- [x] `yarn test --testPathPatterns chatbot` — **120 / 120 pass** (32 new tests covering intent detection, op extraction, spec mutation, and end-to-end refinement through the chat shell).
- [x] `yarn build` — passes.
- [x] `yarn test` (full suite) — 2774 tests pass; the only failing suite (`tests/llm-streaming.test.ts`) is a pre-existing baseline failure unrelated to this PR (jest-circus `pretty-format` import issue, also fails on `main`).
- [ ] Manual: open the Studio AI chatbot, ask "sketch a schema", then chain "add a phone field", "make name required", "remove priceCents", "make it more like Stripe Charges", "what does priceCents mean?". Each follow-up should land a refined spec or a clarification, not a fresh schema.

## Risk / notes

- All new code lives behind the existing chatbot surface and the offline demo responder. Nothing else in the app calls into `conversation-history.ts` yet, so blast radius is limited to the AI chatbot panel.
- The pattern matchers are conservative (require explicit verbs and field names) so a casual user message like "the schema looks fine" stays in the `standalone` lane rather than getting interpreted as an edit.
- `applyRefinementsToSpec()` always returns a deep clone — never mutates the assistant's prior spec — so re-importing the original message remains safe.

Closes #260

Made with [Cursor](https://cursor.com)