### PR TITLE
Fix #261 - AI conversation history actions

### DIFF
--- a/docs/PLANNED_FEATURE_ROADMAP_AI.md
+++ b/docs/PLANNED_FEATURE_ROADMAP_AI.md
@@ -24,12 +24,12 @@ This outlines the planned features for integrating AI capabilities into Objectif
 ### Studio AI Chatbot
 
 **Conversation Features** 📋 PLANNED
-- 📋 **Conversation History**:
-    - 📋 Persist conversations per project/version
-    - 📋 Browse past conversations
-    - 📋 Search conversation history
-    - 📋 Export conversations as markdown
-    - 📋 Clear conversation option
+- ✅ **Conversation History** (#261):
+    - ✅ Persist conversations per project/version
+    - ✅ Browse past conversations
+    - ✅ Search conversation history
+    - ✅ Export conversations as markdown
+    - ✅ Clear conversation option
 - ✅ **Context Awareness** (#259):
     - ✅ AI knows current project, version, classes
     - ✅ AI can reference existing schemas in responses
@@ -46,7 +46,6 @@ This outlines the planned features for integrating AI capabilities into Objectif
 
 | Ticket | Feature Description                                |
 |--------|----------------------------------------------------|
-| #261   | AI Conversation history actions                    |
 | #262   | Install guardrails.ai server                       |
 | #263   | Add guardrails to prevent sensitive data exposure  |
 | #264   | Add guardrails to prevent further sensitive issues |

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.10.17",
+  "version": "0.10.18",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -25,6 +25,7 @@ We continue to improve the platform based on your feedback with improvements and
 - Filled out the Studio AI chat surface to the design guidelines: distinct user/assistant bubbles, typing indicator, markdown rendering, syntax-highlighted code blocks with a copy button, regenerate / thumbs up / thumbs down message actions, and a one-click import button when an assistant reply contains an OpenAPI spec in a ```json``` block.
 - The Studio AI chatbot is now context-aware: each message you send carries a snapshot of your current project, version, classes, reusable properties, and canvas selection, and a "Sharing context" chip in the panel lets you inspect exactly what the assistant can see.
 - The Studio AI chatbot now handles multi-turn conversations: follow-up prompts like "add a phone field", "remove priceCents", "make name required", "rename id to productId", "make it more like Stripe Charges", or simple clarification questions are recognized as edits to the previous reply, and the refined OpenAPI spec is re-shipped so you can keep iterating without restarting the thread.
+- The Studio AI chatbot now persists conversations per project and version: a new toolbar above the chat surfaces "New", "History", "Export", and "Clear" actions, the history view lets you browse and search every saved thread, exporting downloads the active conversation as a markdown file, and the chat automatically restores your most recent thread when you reopen the panel.
 
 ---
 

--- a/objectified-ui/src/app/ade/studio/components/chatbot/ChatConversation.tsx
+++ b/objectified-ui/src/app/ade/studio/components/chatbot/ChatConversation.tsx
@@ -121,6 +121,11 @@ export function ChatConversation({
   const requestIdRef = React.useRef(0);
   const studioContextRef = React.useRef<ChatStudioContext | undefined>(studioContext);
   const lastRestoreScopeRef = React.useRef<string | null>(null);
+  // Set to true only by user-originated transcript changes (send / regenerate).
+  // Cleared by the persist effect after saving, and reset to false whenever
+  // messages are loaded from the store (restore / open-from-history) so we
+  // never re-persist a conversation that already matches what is stored.
+  const pendingPersistRef = React.useRef(false);
   React.useEffect(() => {
     studioContextRef.current = studioContext;
   }, [studioContext]);
@@ -134,6 +139,10 @@ export function ChatConversation({
     const key = scopeKey(scope);
     if (lastRestoreScopeRef.current === key) return;
     lastRestoreScopeRef.current = key;
+    // Any pending persist from the previous scope is no longer valid — the
+    // messages it refers to belong to the old scope and must not be saved
+    // under the new one.
+    pendingPersistRef.current = false;
     const latest = store.list(scope)[0];
     if (latest) {
       setMessages(latest.messages);
@@ -151,10 +160,16 @@ export function ChatConversation({
   }, [messages]);
 
   // Auto-persist whenever the transcript settles (no pending turns).
+  // Guard: only run when the change was user-originated (send / regenerate),
+  // not when messages were loaded from the store (restore / open-from-history).
+  // This prevents unnecessary `updatedAt` rewrites that would reorder history
+  // and avoids writing the old transcript under a newly-switched scope.
   React.useEffect(() => {
+    if (!pendingPersistRef.current) return;
     if (messages.length === 0) return;
     if (messages.some((m) => m.pending)) return;
     if (!messages.some((m) => m.role === 'user')) return;
+    pendingPersistRef.current = false;
     const conversation = buildStoredConversation({
       id: activeId ?? undefined,
       scope,
@@ -220,6 +235,7 @@ export function ChatConversation({
     (text: string) => {
       const userMessage: ChatMessage = { id: createId(), role: 'user', content: text };
       const nextTranscript = [...messages, userMessage];
+      pendingPersistRef.current = true;
       setMessages(nextTranscript);
       void runAssistantTurn(nextTranscript, text, false);
     },
@@ -238,6 +254,7 @@ export function ChatConversation({
     if (lastUserIndex === -1) return;
     const trimmedTranscript = messages.slice(0, lastUserIndex + 1);
     const prompt = messages[lastUserIndex].content;
+    pendingPersistRef.current = true;
     setMessages(trimmedTranscript);
     void runAssistantTurn(trimmedTranscript, prompt, true);
   }, [isBusy, messages, runAssistantTurn]);
@@ -274,6 +291,9 @@ export function ChatConversation({
   }, []);
 
   const handleNewConversation = React.useCallback(() => {
+    requestIdRef.current += 1;
+    setIsBusy(false);
+    pendingPersistRef.current = false;
     resetActive();
     setView('chat');
   }, [resetActive]);
@@ -281,6 +301,9 @@ export function ChatConversation({
   const handleClearCurrent = React.useCallback(() => {
     if (messages.length === 0) return;
     if (!askConfirm('Clear the current conversation? It will be removed from your history.')) return;
+    requestIdRef.current += 1;
+    setIsBusy(false);
+    pendingPersistRef.current = false;
     if (activeId) store.remove(activeId);
     resetActive();
     bumpHistoryVersion();
@@ -315,6 +338,8 @@ export function ChatConversation({
     (id: string) => {
       const conversation = store.get(id);
       if (!conversation) return;
+      // Loading from store — do not trigger an auto-persist for this change.
+      pendingPersistRef.current = false;
       setMessages(conversation.messages);
       setActiveId(conversation.id);
       setActiveCreatedAt(conversation.createdAt);
@@ -325,13 +350,14 @@ export function ChatConversation({
 
   const handleDeleteStored = React.useCallback(
     (id: string) => {
+      if (!askConfirm('Delete this conversation? This cannot be undone.')) return;
       store.remove(id);
       if (activeId === id) {
         resetActive();
       }
       bumpHistoryVersion();
     },
-    [store, activeId, resetActive],
+    [store, activeId, resetActive, askConfirm],
   );
 
   const handleClearAllStored = React.useCallback(() => {

--- a/objectified-ui/src/app/ade/studio/components/chatbot/ChatConversation.tsx
+++ b/objectified-ui/src/app/ade/studio/components/chatbot/ChatConversation.tsx
@@ -1,19 +1,29 @@
 'use client';
 
 import * as React from 'react';
-import { Sparkles } from 'lucide-react';
+import { Download, History, Plus, Sparkles, Trash2 } from 'lucide-react';
 
 import { ChatBubble } from './ChatBubble';
 import { ChatComposer } from './ChatComposer';
 import { ChatContextChip } from './ChatContextChip';
 import type { ChatStudioContext } from './chat-context';
 import { isChatStudioContextEmpty } from './chat-context';
+import { ConversationHistoryPanel } from './ConversationHistoryPanel';
+import {
+  buildStoredConversation,
+  createConversationStore,
+  createLocalStorageConversationStorage,
+  exportConversationToMarkdown,
+  type ConversationStore,
+  type StoredConversation,
+  type StoredConversationScope,
+} from './conversation-store';
 import { createDemoChatResponder } from './demo-responder';
 import type { DetectedOpenApiSpec } from './openapi-detection';
 import type { ChatFeedback, ChatMessage, ChatSendFn } from './types';
 
 /**
- * Studio AI chat conversation surface (#258, #259).
+ * Studio AI chat conversation surface (#258, #259, #260, #261).
  *
  * Owns the message transcript, scroll behaviour, and request lifecycle for
  * the chatbot panel. Stateless from the caller's perspective: pass an
@@ -26,6 +36,9 @@ import type { ChatFeedback, ChatMessage, ChatSendFn } from './types';
  *   - When a `studioContext` snapshot is provided (#259), each send captures
  *     the snapshot at that moment and forwards it to the responder, and a
  *     small "Sharing context" chip lets the user inspect what is being sent
+ *   - Conversations are auto-persisted per project / version (#261), with a
+ *     toolbar for new / history / export / clear and a browse + search
+ *     surface tucked behind the history button
  */
 export interface ChatConversationProps {
   /** Adapter invoked to produce assistant replies. Defaults to the demo responder. */
@@ -43,6 +56,28 @@ export interface ChatConversationProps {
    * and current canvas selection.
    */
   studioContext?: ChatStudioContext;
+  /**
+   * Optional persistence backend (#261). Defaults to a localStorage-backed
+   * store. Tests inject a memory-backed store to assert persistence
+   * behaviour without touching the DOM.
+   */
+  conversationStore?: ConversationStore;
+  /**
+   * Restore the most recent persisted conversation in the active scope on
+   * mount. Defaults to `true`. Tests opt out for deterministic empty-state
+   * runs.
+   */
+  restoreLastConversation?: boolean;
+  /**
+   * Confirmation hook for destructive actions (clear, clear-all). Defaults
+   * to `window.confirm` when available. Returning `false` aborts the action.
+   */
+  confirmAction?: (message: string) => boolean;
+  /**
+   * Override how exported markdown is delivered. Defaults to triggering a
+   * browser download. Tests inject a spy to assert the markdown content.
+   */
+  onExportConversation?: (input: { filename: string; markdown: string }) => void;
 }
 
 const PROMPT_SUGGESTIONS: readonly string[] = [
@@ -57,25 +92,82 @@ export function ChatConversation({
   initialMessages,
   emptyStateMessage,
   studioContext,
+  conversationStore,
+  restoreLastConversation = true,
+  confirmAction,
+  onExportConversation,
 }: ChatConversationProps) {
   const responder = React.useMemo(() => onSendMessage ?? createDemoChatResponder(), [onSendMessage]);
+  const store = React.useMemo<ConversationStore>(
+    () => conversationStore ?? createConversationStore(createLocalStorageConversationStorage()),
+    [conversationStore],
+  );
+  const scope = React.useMemo<StoredConversationScope>(
+    () => ({
+      projectId: studioContext?.project?.id ?? null,
+      versionId: studioContext?.version?.id ?? null,
+    }),
+    [studioContext?.project?.id, studioContext?.version?.id],
+  );
+
   const [messages, setMessages] = React.useState<ChatMessage[]>(() => initialMessages ?? []);
   const [isBusy, setIsBusy] = React.useState(false);
+  const [view, setView] = React.useState<'chat' | 'history'>('chat');
+  const [activeId, setActiveId] = React.useState<string | null>(null);
+  const [activeCreatedAt, setActiveCreatedAt] = React.useState<number | null>(null);
+  const [historyVersion, bumpHistoryVersion] = React.useReducer((n: number) => n + 1, 0);
+
   const messagesEndRef = React.useRef<HTMLDivElement>(null);
   const requestIdRef = React.useRef(0);
-  // Hold the current snapshot in a ref so each send captures the latest state
-  // without re-creating the send callback on every studio change (which would
-  // thrash effects in the composer / message list).
   const studioContextRef = React.useRef<ChatStudioContext | undefined>(studioContext);
+  const lastRestoreScopeRef = React.useRef<string | null>(null);
   React.useEffect(() => {
     studioContextRef.current = studioContext;
   }, [studioContext]);
 
   const hasStudioContext = !!studioContext && !isChatStudioContextEmpty(studioContext);
 
+  // Restore the most recent conversation when the scope changes.
+  React.useEffect(() => {
+    if (!restoreLastConversation) return;
+    if (initialMessages && initialMessages.length > 0) return;
+    const key = scopeKey(scope);
+    if (lastRestoreScopeRef.current === key) return;
+    lastRestoreScopeRef.current = key;
+    const latest = store.list(scope)[0];
+    if (latest) {
+      setMessages(latest.messages);
+      setActiveId(latest.id);
+      setActiveCreatedAt(latest.createdAt);
+    } else {
+      setMessages([]);
+      setActiveId(null);
+      setActiveCreatedAt(null);
+    }
+  }, [restoreLastConversation, initialMessages, scope, store]);
+
   React.useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth', block: 'end' });
   }, [messages]);
+
+  // Auto-persist whenever the transcript settles (no pending turns).
+  React.useEffect(() => {
+    if (messages.length === 0) return;
+    if (messages.some((m) => m.pending)) return;
+    if (!messages.some((m) => m.role === 'user')) return;
+    const conversation = buildStoredConversation({
+      id: activeId ?? undefined,
+      scope,
+      messages,
+      createdAt: activeCreatedAt ?? undefined,
+    });
+    store.save(conversation);
+    if (!activeId) {
+      setActiveId(conversation.id);
+      setActiveCreatedAt(conversation.createdAt);
+    }
+    bumpHistoryVersion();
+  }, [messages, scope, store, activeId, activeCreatedAt]);
 
   const lastAssistantId = React.useMemo(() => {
     for (let i = messages.length - 1; i >= 0; i -= 1) {
@@ -112,7 +204,6 @@ export function ChatConversation({
         reply = 'Sorry — the assistant could not respond. Please try again.';
       }
 
-      // Drop the response if a newer turn started while we were waiting.
       if (requestIdRef.current !== requestId) return;
 
       setMessages((current) =>
@@ -137,7 +228,6 @@ export function ChatConversation({
 
   const handleRegenerate = React.useCallback(() => {
     if (isBusy) return;
-    // Find the last user prompt and the assistant reply that followed it.
     let lastUserIndex = -1;
     for (let i = messages.length - 1; i >= 0; i -= 1) {
       if (messages[i].role === 'user') {
@@ -165,42 +255,266 @@ export function ChatConversation({
     []
   );
 
+  const askConfirm = React.useCallback(
+    (message: string) => {
+      const fn = confirmAction ?? defaultConfirm;
+      try {
+        return fn(message);
+      } catch {
+        return true;
+      }
+    },
+    [confirmAction],
+  );
+
+  const resetActive = React.useCallback(() => {
+    setMessages([]);
+    setActiveId(null);
+    setActiveCreatedAt(null);
+  }, []);
+
+  const handleNewConversation = React.useCallback(() => {
+    resetActive();
+    setView('chat');
+  }, [resetActive]);
+
+  const handleClearCurrent = React.useCallback(() => {
+    if (messages.length === 0) return;
+    if (!askConfirm('Clear the current conversation? It will be removed from your history.')) return;
+    if (activeId) store.remove(activeId);
+    resetActive();
+    bumpHistoryVersion();
+    setView('chat');
+  }, [messages.length, askConfirm, activeId, store, resetActive]);
+
+  const handleExportCurrent = React.useCallback(() => {
+    if (messages.length === 0) return;
+    const conversation = buildStoredConversation({
+      id: activeId ?? undefined,
+      scope,
+      messages,
+      createdAt: activeCreatedAt ?? undefined,
+    });
+    const markdown = exportConversationToMarkdown(conversation);
+    const filename = buildExportFilename(conversation);
+    if (onExportConversation) {
+      onExportConversation({ filename, markdown });
+      return;
+    }
+    triggerMarkdownDownload(filename, markdown);
+  }, [messages, activeId, scope, activeCreatedAt, onExportConversation]);
+
+  const handleOpenHistory = React.useCallback(() => {
+    setView('history');
+  }, []);
+  const handleCloseHistory = React.useCallback(() => {
+    setView('chat');
+  }, []);
+
+  const handleOpenStored = React.useCallback(
+    (id: string) => {
+      const conversation = store.get(id);
+      if (!conversation) return;
+      setMessages(conversation.messages);
+      setActiveId(conversation.id);
+      setActiveCreatedAt(conversation.createdAt);
+      setView('chat');
+    },
+    [store],
+  );
+
+  const handleDeleteStored = React.useCallback(
+    (id: string) => {
+      store.remove(id);
+      if (activeId === id) {
+        resetActive();
+      }
+      bumpHistoryVersion();
+    },
+    [store, activeId, resetActive],
+  );
+
+  const handleClearAllStored = React.useCallback(() => {
+    if (!askConfirm('Clear every saved conversation in this scope? This cannot be undone.')) return;
+    store.clear(scope);
+    resetActive();
+    bumpHistoryVersion();
+  }, [askConfirm, store, scope, resetActive]);
+
+  const storedConversations = React.useMemo(
+    () => store.list(scope),
+    // historyVersion lets us re-derive after save / remove / clear without
+    // relying on the store being a referentially-stable object across runs.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [store, scope, historyVersion],
+  );
+
   const showEmptyState = messages.length === 0;
+  const hasMessages = messages.length > 0;
 
   return (
     <div className="flex h-full min-h-0 flex-col" data-testid="studio-ai-chat-conversation">
-      <div className="flex-1 overflow-y-auto px-4 py-3" data-testid="studio-ai-chat-messages">
-        {showEmptyState ? (
-          <EmptyState
-            message={emptyStateMessage}
-            suggestions={PROMPT_SUGGESTIONS}
-            onSelect={handleSend}
-          />
-        ) : (
-          <div className="space-y-4">
-            {messages.map((message) => (
-              <ChatBubble
-                key={message.id}
-                message={message}
-                isLatestAssistant={message.id === lastAssistantId}
-                onRegenerate={message.id === lastAssistantId ? handleRegenerate : undefined}
-                onFeedback={(feedback) => handleFeedback(message.id, feedback)}
-                onImportSpec={onImportSpec}
+      <ChatToolbar
+        onNew={handleNewConversation}
+        onHistory={handleOpenHistory}
+        onExport={handleExportCurrent}
+        onClear={handleClearCurrent}
+        canExport={hasMessages}
+        canClear={hasMessages}
+        historyCount={storedConversations.length}
+      />
+
+      {view === 'history' ? (
+        <ConversationHistoryPanel
+          conversations={storedConversations}
+          activeId={activeId}
+          onOpen={handleOpenStored}
+          onDelete={handleDeleteStored}
+          onClearAll={handleClearAllStored}
+          onClose={handleCloseHistory}
+        />
+      ) : (
+        <>
+          <div className="flex-1 overflow-y-auto px-4 py-3" data-testid="studio-ai-chat-messages">
+            {showEmptyState ? (
+              <EmptyState
+                message={emptyStateMessage}
+                suggestions={PROMPT_SUGGESTIONS}
+                onSelect={handleSend}
               />
-            ))}
-            <div ref={messagesEndRef} aria-hidden />
+            ) : (
+              <div className="space-y-4">
+                {messages.map((message) => (
+                  <ChatBubble
+                    key={message.id}
+                    message={message}
+                    isLatestAssistant={message.id === lastAssistantId}
+                    onRegenerate={message.id === lastAssistantId ? handleRegenerate : undefined}
+                    onFeedback={(feedback) => handleFeedback(message.id, feedback)}
+                    onImportSpec={onImportSpec}
+                  />
+                ))}
+                <div ref={messagesEndRef} aria-hidden />
+              </div>
+            )}
           </div>
-        )}
-      </div>
 
-      {hasStudioContext && (
-        <div className="border-t border-gray-200 bg-white px-3 py-2 dark:border-gray-700 dark:bg-gray-900">
-          <ChatContextChip studioContext={studioContext!} />
-        </div>
+          {hasStudioContext && (
+            <div className="border-t border-gray-200 bg-white px-3 py-2 dark:border-gray-700 dark:bg-gray-900">
+              <ChatContextChip studioContext={studioContext!} />
+            </div>
+          )}
+
+          <ChatComposer onSend={handleSend} isBusy={isBusy} />
+        </>
       )}
-
-      <ChatComposer onSend={handleSend} isBusy={isBusy} />
     </div>
+  );
+}
+
+interface ChatToolbarProps {
+  onNew: () => void;
+  onHistory: () => void;
+  onExport: () => void;
+  onClear: () => void;
+  canExport: boolean;
+  canClear: boolean;
+  historyCount: number;
+}
+
+function ChatToolbar({
+  onNew,
+  onHistory,
+  onExport,
+  onClear,
+  canExport,
+  canClear,
+  historyCount,
+}: ChatToolbarProps) {
+  return (
+    <div
+      className="flex items-center justify-between gap-1 border-b border-gray-200 bg-gray-50 px-2 py-1 dark:border-gray-700 dark:bg-gray-900/60"
+      data-testid="studio-ai-chat-toolbar"
+    >
+      <div className="flex items-center gap-1">
+        <ToolbarButton
+          onClick={onNew}
+          icon={<Plus className="h-3.5 w-3.5" />}
+          label="Start a new conversation"
+          testId="studio-ai-chat-new"
+        >
+          New
+        </ToolbarButton>
+        <ToolbarButton
+          onClick={onHistory}
+          icon={<History className="h-3.5 w-3.5" />}
+          label={`Browse past conversations (${historyCount})`}
+          testId="studio-ai-chat-history"
+        >
+          History {historyCount > 0 ? `(${historyCount})` : ''}
+        </ToolbarButton>
+      </div>
+      <div className="flex items-center gap-1">
+        <ToolbarButton
+          onClick={onExport}
+          icon={<Download className="h-3.5 w-3.5" />}
+          label="Export current conversation as markdown"
+          testId="studio-ai-chat-export"
+          disabled={!canExport}
+        >
+          Export
+        </ToolbarButton>
+        <ToolbarButton
+          onClick={onClear}
+          icon={<Trash2 className="h-3.5 w-3.5" />}
+          label="Clear current conversation"
+          testId="studio-ai-chat-clear"
+          disabled={!canClear}
+          tone="danger"
+        >
+          Clear
+        </ToolbarButton>
+      </div>
+    </div>
+  );
+}
+
+interface ToolbarButtonProps {
+  onClick: () => void;
+  icon: React.ReactNode;
+  label: string;
+  testId: string;
+  disabled?: boolean;
+  tone?: 'default' | 'danger';
+  children: React.ReactNode;
+}
+
+function ToolbarButton({
+  onClick,
+  icon,
+  label,
+  testId,
+  disabled,
+  tone = 'default',
+  children,
+}: ToolbarButtonProps) {
+  const toneClasses =
+    tone === 'danger'
+      ? 'text-red-600 hover:bg-red-50 hover:text-red-700 dark:text-red-300 dark:hover:bg-red-950/40'
+      : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-gray-100';
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      aria-label={label}
+      title={label}
+      data-testid={testId}
+      className={`inline-flex h-7 items-center gap-1 rounded-md px-2 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 disabled:cursor-not-allowed disabled:opacity-50 ${toneClasses}`}
+    >
+      {icon}
+      <span>{children}</span>
+    </button>
   );
 }
 
@@ -245,4 +559,46 @@ let counter = 0;
 function createId(): string {
   counter += 1;
   return `chat-${Date.now().toString(36)}-${counter.toString(36)}`;
+}
+
+function scopeKey(scope: StoredConversationScope): string {
+  return `${scope.projectId ?? '∅'}::${scope.versionId ?? '∅'}`;
+}
+
+function defaultConfirm(message: string): boolean {
+  if (typeof window === 'undefined') return true;
+  try {
+    return window.confirm(message);
+  } catch {
+    return true;
+  }
+}
+
+function buildExportFilename(conversation: StoredConversation): string {
+  const slug = conversation.title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 60);
+  const stamp = new Date(conversation.updatedAt).toISOString().slice(0, 10);
+  const base = slug.length > 0 ? slug : 'conversation';
+  return `studio-ai-${base}-${stamp}.md`;
+}
+
+function triggerMarkdownDownload(filename: string, markdown: string): void {
+  if (typeof document === 'undefined' || typeof window === 'undefined') return;
+  try {
+    const blob = new Blob([markdown], { type: 'text/markdown;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = filename;
+    anchor.style.display = 'none';
+    document.body.appendChild(anchor);
+    anchor.click();
+    anchor.remove();
+    setTimeout(() => URL.revokeObjectURL(url), 0);
+  } catch (error) {
+    console.error('Failed to trigger conversation export download', error);
+  }
 }

--- a/objectified-ui/src/app/ade/studio/components/chatbot/ConversationHistoryPanel.tsx
+++ b/objectified-ui/src/app/ade/studio/components/chatbot/ConversationHistoryPanel.tsx
@@ -1,0 +1,217 @@
+'use client';
+
+import * as React from 'react';
+import { ArrowLeft, MessageSquare, Search, Trash2 } from 'lucide-react';
+
+import type { StoredConversation } from './conversation-store';
+
+/**
+ * Browse / search past conversations (#261).
+ *
+ * Mounted inside the chatbot panel when the user opens "history". The
+ * surface is intentionally read-only-ish: opening a conversation hands the
+ * id back to the chat shell which swaps it into the active transcript, and
+ * the destructive actions (delete one, clear all) are confirmed by the
+ * shell before they fire.
+ */
+export interface ConversationHistoryPanelProps {
+  conversations: StoredConversation[];
+  /** Marks the currently-open conversation in the list, if any. */
+  activeId?: string | null;
+  onOpen: (id: string) => void;
+  onDelete: (id: string) => void;
+  onClearAll: () => void;
+  onClose: () => void;
+}
+
+export function ConversationHistoryPanel({
+  conversations,
+  activeId,
+  onOpen,
+  onDelete,
+  onClearAll,
+  onClose,
+}: ConversationHistoryPanelProps) {
+  const [query, setQuery] = React.useState('');
+  const trimmed = query.trim().toLowerCase();
+  const filtered = React.useMemo(() => {
+    if (trimmed.length === 0) return conversations;
+    return conversations.filter((conv) => matchesQuery(conv, trimmed));
+  }, [conversations, trimmed]);
+
+  return (
+    <div
+      className="flex h-full min-h-0 flex-col"
+      data-testid="studio-ai-chat-history-panel"
+    >
+      <div className="flex items-center justify-between gap-2 border-b border-gray-200 px-3 py-2 dark:border-gray-700">
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Back to conversation"
+            data-testid="studio-ai-chat-history-back"
+            className="inline-flex h-7 w-7 items-center justify-center rounded-md text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-100"
+          >
+            <ArrowLeft className="h-4 w-4" />
+          </button>
+          <p className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+            Past conversations
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={onClearAll}
+          disabled={conversations.length === 0}
+          data-testid="studio-ai-chat-history-clear-all"
+          className="inline-flex items-center gap-1.5 rounded-md border border-red-200 bg-white px-2 py-1 text-xs font-medium text-red-700 transition-colors hover:bg-red-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-300 disabled:cursor-not-allowed disabled:opacity-50 dark:border-red-700/60 dark:bg-gray-900 dark:text-red-300 dark:hover:bg-red-950/40"
+        >
+          <Trash2 className="h-3.5 w-3.5" />
+          Clear all
+        </button>
+      </div>
+
+      <div className="border-b border-gray-200 px-3 py-2 dark:border-gray-700">
+        <label className="relative block">
+          <span className="sr-only">Search conversations</span>
+          <Search
+            aria-hidden
+            className="pointer-events-none absolute left-2 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400"
+          />
+          <input
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search conversations…"
+            data-testid="studio-ai-chat-history-search"
+            className="w-full rounded-md border border-gray-300 bg-white py-1.5 pl-8 pr-2 text-sm text-gray-900 placeholder:text-gray-400 focus-visible:border-indigo-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-200 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100 dark:placeholder:text-gray-500"
+          />
+        </label>
+      </div>
+
+      <div
+        className="flex-1 overflow-y-auto"
+        data-testid="studio-ai-chat-history-list"
+      >
+        {conversations.length === 0 ? (
+          <EmptyHistoryState />
+        ) : filtered.length === 0 ? (
+          <NoMatchesState query={query} />
+        ) : (
+          <ul className="divide-y divide-gray-100 dark:divide-gray-800">
+            {filtered.map((conversation) => (
+              <HistoryRow
+                key={conversation.id}
+                conversation={conversation}
+                isActive={conversation.id === activeId}
+                onOpen={() => onOpen(conversation.id)}
+                onDelete={() => onDelete(conversation.id)}
+              />
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}
+
+interface HistoryRowProps {
+  conversation: StoredConversation;
+  isActive: boolean;
+  onOpen: () => void;
+  onDelete: () => void;
+}
+
+function HistoryRow({ conversation, isActive, onOpen, onDelete }: HistoryRowProps) {
+  const messageCount = conversation.messages.filter((m) => !m.pending).length;
+  const updated = formatRelativeTime(conversation.updatedAt);
+
+  return (
+    <li
+      data-testid="studio-ai-chat-history-row"
+      data-conversation-id={conversation.id}
+      data-active={isActive ? 'true' : 'false'}
+      className={`group flex items-start gap-2 px-3 py-2 transition-colors ${
+        isActive
+          ? 'bg-indigo-50 dark:bg-indigo-900/30'
+          : 'hover:bg-gray-50 dark:hover:bg-gray-800/60'
+      }`}
+    >
+      <button
+        type="button"
+        onClick={onOpen}
+        data-testid="studio-ai-chat-history-open"
+        className="flex flex-1 items-start gap-2 text-left focus-visible:outline-none"
+      >
+        <MessageSquare className="mt-0.5 h-4 w-4 shrink-0 text-gray-400 group-hover:text-indigo-500 dark:text-gray-500" />
+        <span className="flex min-w-0 flex-1 flex-col">
+          <span className="truncate text-sm font-medium text-gray-900 dark:text-gray-100">
+            {conversation.title}
+          </span>
+          <span className="truncate text-xs text-gray-500 dark:text-gray-400">
+            {messageCount} {messageCount === 1 ? 'message' : 'messages'} · {updated}
+          </span>
+        </span>
+      </button>
+      <button
+        type="button"
+        onClick={onDelete}
+        aria-label={`Delete conversation: ${conversation.title}`}
+        data-testid="studio-ai-chat-history-delete"
+        className="inline-flex h-7 w-7 items-center justify-center rounded-md text-gray-400 opacity-0 transition-all hover:bg-red-50 hover:text-red-600 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-300 group-hover:opacity-100 dark:hover:bg-red-950/40 dark:hover:text-red-300"
+      >
+        <Trash2 className="h-3.5 w-3.5" />
+      </button>
+    </li>
+  );
+}
+
+function EmptyHistoryState() {
+  return (
+    <div
+      className="flex h-full flex-col items-center justify-center px-4 py-8 text-center text-sm text-gray-500 dark:text-gray-400"
+      data-testid="studio-ai-chat-history-empty"
+    >
+      <MessageSquare className="mb-2 h-6 w-6 text-gray-300 dark:text-gray-600" />
+      <p className="font-medium text-gray-700 dark:text-gray-300">No conversations yet</p>
+      <p className="mt-1 max-w-xs text-xs">
+        Start a new chat and your conversations will be saved here so you can revisit them
+        later.
+      </p>
+    </div>
+  );
+}
+
+function NoMatchesState({ query }: { query: string }) {
+  return (
+    <div
+      className="flex h-full flex-col items-center justify-center px-4 py-8 text-center text-sm text-gray-500 dark:text-gray-400"
+      data-testid="studio-ai-chat-history-no-matches"
+    >
+      <Search className="mb-2 h-6 w-6 text-gray-300 dark:text-gray-600" />
+      <p className="font-medium text-gray-700 dark:text-gray-300">No matches</p>
+      <p className="mt-1 max-w-xs text-xs">
+        Nothing in your history matches &ldquo;{query}&rdquo;. Try a different search term.
+      </p>
+    </div>
+  );
+}
+
+function matchesQuery(conversation: StoredConversation, lowered: string): boolean {
+  if (conversation.title.toLowerCase().includes(lowered)) return true;
+  return conversation.messages.some((m) =>
+    m.content.toLowerCase().includes(lowered),
+  );
+}
+
+function formatRelativeTime(timestamp: number, now: number = Date.now()): string {
+  const diff = Math.max(0, now - timestamp);
+  const minutes = Math.floor(diff / 60_000);
+  if (minutes < 1) return 'just now';
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days}d ago`;
+  return new Date(timestamp).toLocaleDateString();
+}

--- a/objectified-ui/src/app/ade/studio/components/chatbot/conversation-store.ts
+++ b/objectified-ui/src/app/ade/studio/components/chatbot/conversation-store.ts
@@ -1,0 +1,328 @@
+/**
+ * Conversation persistence for the Studio AI chatbot (#261).
+ *
+ * The chat surface keeps a working transcript in component state, but users
+ * also expect their conversations to survive a panel close, a tab reload, or
+ * a switch to another canvas. This module owns the small, UI-agnostic data
+ * model that the chatbot persists to (today) `localStorage` and the helpers
+ * the UI uses to:
+ *
+ *   - List, search, and export past conversations
+ *   - Save / replace the active conversation as new turns arrive
+ *   - Scope conversations to the current project / version so unrelated
+ *     workspaces stay separate
+ *   - Clear a single conversation or every conversation in a scope
+ *
+ * The storage backend is pluggable: the production UI uses
+ * {@link createLocalStorageConversationStorage}, while tests use
+ * {@link createMemoryConversationStorage} for deterministic, DOM-free runs.
+ *
+ * The Ollama transport (#265) and any future server-side history can replace
+ * the storage adapter without touching the chat shell.
+ */
+
+import type { ChatMessage } from './types';
+
+/** Local-storage key used by the default browser adapter. */
+export const CHAT_HISTORY_STORAGE_KEY = 'objectified.studio.chatbot.conversations.v1';
+/** Per-conversation title cap — keeps the history list scannable. */
+export const CHAT_HISTORY_TITLE_CHAR_CAP = 80;
+/** Hard cap on persisted conversations per scope; oldest are pruned first. */
+export const CHAT_HISTORY_MAX_CONVERSATIONS = 50;
+
+export interface StoredConversationScope {
+  /** Project the conversation belongs to. `null` means "no project context". */
+  projectId: string | null;
+  /** Version inside the project. `null` means "no version selected". */
+  versionId: string | null;
+}
+
+export interface StoredConversation extends StoredConversationScope {
+  id: string;
+  title: string;
+  /** Epoch ms — when the conversation was first created. */
+  createdAt: number;
+  /** Epoch ms — when the conversation was last edited. */
+  updatedAt: number;
+  messages: ChatMessage[];
+}
+
+export interface ConversationStorage {
+  /** Returns every persisted conversation. Errors must be swallowed. */
+  read(): StoredConversation[];
+  /** Persists the full list, replacing any prior contents. */
+  write(conversations: StoredConversation[]): void;
+}
+
+export interface ConversationStore {
+  /** Newest-first list of conversations matching `scope`, or all when omitted. */
+  list(scope?: Partial<StoredConversationScope>): StoredConversation[];
+  get(id: string): StoredConversation | null;
+  /** Inserts or replaces by id. Returns the saved conversation. */
+  save(conversation: StoredConversation): StoredConversation;
+  remove(id: string): void;
+  /** Removes every conversation in `scope`, or every conversation when omitted. */
+  clear(scope?: Partial<StoredConversationScope>): void;
+  /**
+   * Case-insensitive substring search across title + message content within
+   * the optional `scope`. Empty queries return the full scoped list.
+   */
+  search(query: string, scope?: Partial<StoredConversationScope>): StoredConversation[];
+}
+
+/**
+ * Create a store backed by an arbitrary {@link ConversationStorage}. The
+ * store handles ordering, capping, and scope filtering so adapters stay
+ * trivial.
+ */
+export function createConversationStore(storage: ConversationStorage): ConversationStore {
+  function readSorted(): StoredConversation[] {
+    const all = storage.read();
+    return [...all].sort((a, b) => b.updatedAt - a.updatedAt);
+  }
+
+  return {
+    list(scope) {
+      const all = readSorted();
+      return scope ? all.filter((c) => matchesScope(c, scope)) : all;
+    },
+    get(id) {
+      return storage.read().find((c) => c.id === id) ?? null;
+    },
+    save(conversation) {
+      const current = storage.read();
+      const next = current.filter((c) => c.id !== conversation.id);
+      next.push(conversation);
+      next.sort((a, b) => b.updatedAt - a.updatedAt);
+      storage.write(pruneToCap(next));
+      return conversation;
+    },
+    remove(id) {
+      const current = storage.read();
+      const next = current.filter((c) => c.id !== id);
+      if (next.length !== current.length) storage.write(next);
+    },
+    clear(scope) {
+      const current = storage.read();
+      const next = scope ? current.filter((c) => !matchesScope(c, scope)) : [];
+      storage.write(next);
+    },
+    search(query, scope) {
+      const all = readSorted();
+      const scoped = scope ? all.filter((c) => matchesScope(c, scope)) : all;
+      const q = query.trim().toLowerCase();
+      if (q.length === 0) return scoped;
+      return scoped.filter((c) => conversationMatchesQuery(c, q));
+    },
+  };
+}
+
+function matchesScope(
+  conversation: StoredConversation,
+  scope: Partial<StoredConversationScope>,
+): boolean {
+  if (Object.prototype.hasOwnProperty.call(scope, 'projectId')) {
+    if ((scope.projectId ?? null) !== conversation.projectId) return false;
+  }
+  if (Object.prototype.hasOwnProperty.call(scope, 'versionId')) {
+    if ((scope.versionId ?? null) !== conversation.versionId) return false;
+  }
+  return true;
+}
+
+function conversationMatchesQuery(
+  conversation: StoredConversation,
+  loweredQuery: string,
+): boolean {
+  if (conversation.title.toLowerCase().includes(loweredQuery)) return true;
+  return conversation.messages.some((m) =>
+    m.content.toLowerCase().includes(loweredQuery),
+  );
+}
+
+function pruneToCap(conversations: StoredConversation[]): StoredConversation[] {
+  if (conversations.length <= CHAT_HISTORY_MAX_CONVERSATIONS) return conversations;
+  const byScope = new Map<string, StoredConversation[]>();
+  for (const conv of conversations) {
+    const key = scopeKey(conv);
+    const bucket = byScope.get(key);
+    if (bucket) bucket.push(conv);
+    else byScope.set(key, [conv]);
+  }
+  const kept: StoredConversation[] = [];
+  for (const bucket of byScope.values()) {
+    bucket.sort((a, b) => b.updatedAt - a.updatedAt);
+    kept.push(...bucket.slice(0, CHAT_HISTORY_MAX_CONVERSATIONS));
+  }
+  kept.sort((a, b) => b.updatedAt - a.updatedAt);
+  return kept;
+}
+
+function scopeKey(conversation: StoredConversationScope): string {
+  return `${conversation.projectId ?? '∅'}::${conversation.versionId ?? '∅'}`;
+}
+
+/**
+ * In-memory adapter — used by tests and any caller that doesn't want to
+ * touch the browser. Mutating `initial` does not affect the adapter; the
+ * adapter takes a defensive copy.
+ */
+export function createMemoryConversationStorage(
+  initial: StoredConversation[] = [],
+): ConversationStorage {
+  let state = cloneList(initial);
+  return {
+    read: () => cloneList(state),
+    write: (next) => {
+      state = cloneList(next);
+    },
+  };
+}
+
+/**
+ * Browser adapter — wraps `localStorage` with parse / stringify, defends
+ * against quota errors, and degrades to a no-op when storage is unavailable
+ * (e.g. SSR, private mode).
+ */
+export function createLocalStorageConversationStorage(
+  storageKey: string = CHAT_HISTORY_STORAGE_KEY,
+  storageFactory: () => Storage | null = defaultStorageFactory,
+): ConversationStorage {
+  return {
+    read() {
+      const storage = safeStorage(storageFactory);
+      if (!storage) return [];
+      try {
+        const raw = storage.getItem(storageKey);
+        if (!raw) return [];
+        const parsed = JSON.parse(raw);
+        if (!Array.isArray(parsed)) return [];
+        return parsed.filter(isStoredConversation);
+      } catch {
+        return [];
+      }
+    },
+    write(conversations) {
+      const storage = safeStorage(storageFactory);
+      if (!storage) return;
+      try {
+        storage.setItem(storageKey, JSON.stringify(conversations));
+      } catch {
+        // Quota or serialization errors are intentionally swallowed —
+        // history persistence is a best-effort enhancement.
+      }
+    },
+  };
+}
+
+function defaultStorageFactory(): Storage | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+function safeStorage(factory: () => Storage | null): Storage | null {
+  try {
+    return factory();
+  } catch {
+    return null;
+  }
+}
+
+function isStoredConversation(value: unknown): value is StoredConversation {
+  if (!value || typeof value !== 'object') return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.id === 'string' &&
+    typeof v.title === 'string' &&
+    typeof v.createdAt === 'number' &&
+    typeof v.updatedAt === 'number' &&
+    Array.isArray(v.messages) &&
+    (v.projectId === null || typeof v.projectId === 'string') &&
+    (v.versionId === null || typeof v.versionId === 'string')
+  );
+}
+
+function cloneList(conversations: StoredConversation[]): StoredConversation[] {
+  return conversations.map((c) => ({ ...c, messages: c.messages.map((m) => ({ ...m })) }));
+}
+
+/**
+ * Pull a short, human-friendly title out of a transcript. Prefers the first
+ * user prompt; falls back to the first assistant reply; returns
+ * `'Untitled conversation'` when the transcript is empty.
+ */
+export function deriveConversationTitle(messages: ChatMessage[]): string {
+  const firstUser = messages.find((m) => m.role === 'user' && m.content.trim().length > 0);
+  const seed = firstUser ?? messages.find((m) => m.content.trim().length > 0);
+  if (!seed) return 'Untitled conversation';
+  const compact = seed.content.replace(/\s+/g, ' ').trim();
+  if (compact.length <= CHAT_HISTORY_TITLE_CHAR_CAP) return compact;
+  return `${compact.slice(0, CHAT_HISTORY_TITLE_CHAR_CAP - 1).trimEnd()}…`;
+}
+
+/** Render a single conversation as standalone markdown. */
+export function exportConversationToMarkdown(conversation: StoredConversation): string {
+  const lines: string[] = [`# ${conversation.title}`];
+  const meta: string[] = [];
+  meta.push(`Created: ${new Date(conversation.createdAt).toISOString()}`);
+  meta.push(`Updated: ${new Date(conversation.updatedAt).toISOString()}`);
+  if (conversation.projectId) meta.push(`Project: ${conversation.projectId}`);
+  if (conversation.versionId) meta.push(`Version: ${conversation.versionId}`);
+  lines.push('', meta.map((m) => `- ${m}`).join('\n'));
+
+  for (const message of conversation.messages) {
+    if (message.pending) continue;
+    const heading = message.role === 'user' ? '## User' : '## Assistant';
+    lines.push('', heading, '', message.content.trim().length > 0 ? message.content : '_(empty)_');
+  }
+
+  return `${lines.join('\n').trim()}\n`;
+}
+
+/**
+ * Render multiple conversations as a single markdown document with `---`
+ * dividers. Useful for "export all" affordances on the history panel.
+ */
+export function exportConversationsToMarkdown(conversations: StoredConversation[]): string {
+  if (conversations.length === 0) return '';
+  return conversations
+    .map((conversation) => exportConversationToMarkdown(conversation).trimEnd())
+    .join('\n\n---\n\n')
+    .concat('\n');
+}
+
+/**
+ * Convenience: build a {@link StoredConversation} from the running chat
+ * state. Generates a stable id when one isn't provided so callers can keep
+ * upserting through the chat lifecycle.
+ */
+export function buildStoredConversation(input: {
+  id?: string;
+  scope: StoredConversationScope;
+  messages: ChatMessage[];
+  createdAt?: number;
+  updatedAt?: number;
+  now?: () => number;
+}): StoredConversation {
+  const now = input.now ?? Date.now;
+  const created = input.createdAt ?? now();
+  return {
+    id: input.id ?? generateConversationId(now),
+    projectId: input.scope.projectId,
+    versionId: input.scope.versionId,
+    title: deriveConversationTitle(input.messages),
+    createdAt: created,
+    updatedAt: input.updatedAt ?? now(),
+    messages: input.messages.map((m) => ({ ...m })),
+  };
+}
+
+let conversationCounter = 0;
+function generateConversationId(now: () => number): string {
+  conversationCounter += 1;
+  return `chat-conv-${now().toString(36)}-${conversationCounter.toString(36)}`;
+}

--- a/objectified-ui/src/app/ade/studio/components/chatbot/conversation-store.ts
+++ b/objectified-ui/src/app/ade/studio/components/chatbot/conversation-store.ts
@@ -241,8 +241,19 @@ function isStoredConversation(value: unknown): value is StoredConversation {
     typeof v.createdAt === 'number' &&
     typeof v.updatedAt === 'number' &&
     Array.isArray(v.messages) &&
+    v.messages.every(isChatMessage) &&
     (v.projectId === null || typeof v.projectId === 'string') &&
     (v.versionId === null || typeof v.versionId === 'string')
+  );
+}
+
+function isChatMessage(value: unknown): boolean {
+  if (!value || typeof value !== 'object') return false;
+  const m = value as Record<string, unknown>;
+  return (
+    typeof m.id === 'string' &&
+    (m.role === 'user' || m.role === 'assistant' || m.role === 'system') &&
+    typeof m.content === 'string'
   );
 }
 

--- a/objectified-ui/src/app/ade/studio/components/chatbot/index.ts
+++ b/objectified-ui/src/app/ade/studio/components/chatbot/index.ts
@@ -31,6 +31,8 @@ export type {
   ChatStudioProperty,
   ChatStudioVersion,
 } from './chat-context';
+export { ConversationHistoryPanel } from './ConversationHistoryPanel';
+export type { ConversationHistoryPanelProps } from './ConversationHistoryPanel';
 export { createDemoChatResponder } from './demo-responder';
 export {
   detectOpenApiSpecs,
@@ -50,4 +52,22 @@ export type {
   ChatHistorySummary,
   ChatRefinementOp,
 } from './conversation-history';
+export {
+  buildStoredConversation,
+  CHAT_HISTORY_MAX_CONVERSATIONS,
+  CHAT_HISTORY_STORAGE_KEY,
+  CHAT_HISTORY_TITLE_CHAR_CAP,
+  createConversationStore,
+  createLocalStorageConversationStorage,
+  createMemoryConversationStorage,
+  deriveConversationTitle,
+  exportConversationToMarkdown,
+  exportConversationsToMarkdown,
+} from './conversation-store';
+export type {
+  ConversationStorage,
+  ConversationStore,
+  StoredConversation,
+  StoredConversationScope,
+} from './conversation-store';
 export type { ChatFeedback, ChatMessage, ChatRole, ChatSendContext, ChatSendFn } from './types';

--- a/objectified-ui/tests/chatbot/ChatConversation.test.tsx
+++ b/objectified-ui/tests/chatbot/ChatConversation.test.tsx
@@ -1,5 +1,5 @@
 /**
- * Tests for the chat conversation orchestrator (#258, #259, #260).
+ * Tests for the chat conversation orchestrator (#258, #259, #260, #261).
  *
  * Covers the end-to-end flow exercised by the StudioAiChatbot panel:
  *   - Empty-state suggestions seed the conversation
@@ -11,6 +11,8 @@
  *   - The studio context snapshot rides on every send (#259)
  *   - Multi-turn follow-ups carry the full transcript and refine prior
  *     specs through the chat surface (#260)
+ *   - Conversation history actions: persist per scope, browse, search,
+ *     export markdown, clear current, clear all (#261)
  */
 
 import React from 'react';
@@ -19,7 +21,24 @@ import '@testing-library/jest-dom';
 
 import { ChatConversation } from '../../src/app/ade/studio/components/chatbot/ChatConversation';
 import type { ChatStudioContext } from '../../src/app/ade/studio/components/chatbot/chat-context';
+import {
+  createConversationStore,
+  createMemoryConversationStorage,
+  type ConversationStore,
+  type StoredConversation,
+} from '../../src/app/ade/studio/components/chatbot/conversation-store';
 import type { ChatMessage, ChatSendFn } from '../../src/app/ade/studio/components/chatbot/types';
+
+function makeMemoryStore(initial: StoredConversation[] = []): ConversationStore {
+  return createConversationStore(createMemoryConversationStorage(initial));
+}
+
+function neverConfirm(): boolean {
+  return false;
+}
+function alwaysConfirm(): boolean {
+  return true;
+}
 
 type ResponderCall = {
   prompt: string;
@@ -53,6 +72,12 @@ function createDeferredResponder(): {
 
 beforeEach(() => {
   Element.prototype.scrollIntoView = jest.fn();
+  // Conversations auto-persist to localStorage in production; reset between
+  // tests so each run starts from a clean slate without restoring stale
+  // history into the chat surface.
+  if (typeof window !== 'undefined' && window.localStorage) {
+    window.localStorage.clear();
+  }
 });
 
 describe('ChatConversation', () => {
@@ -292,6 +317,338 @@ describe('ChatConversation', () => {
     // The second assistant reply is the refinement: it must include the
     // refined spec containing a `phone` property as JSON text.
     expect(assistantBubbles[1].textContent ?? '').toMatch(/"phone"/);
+  });
+
+  describe('conversation history actions (#261)', () => {
+    it('renders the toolbar with new / history / export / clear actions', () => {
+      render(
+        <ChatConversation
+          conversationStore={makeMemoryStore()}
+          restoreLastConversation={false}
+        />,
+      );
+      expect(screen.getByTestId('studio-ai-chat-toolbar')).toBeInTheDocument();
+      expect(screen.getByTestId('studio-ai-chat-new')).toBeInTheDocument();
+      expect(screen.getByTestId('studio-ai-chat-history')).toBeInTheDocument();
+      expect(screen.getByTestId('studio-ai-chat-export')).toBeDisabled();
+      expect(screen.getByTestId('studio-ai-chat-clear')).toBeDisabled();
+    });
+
+    it('persists each conversation under the current scope as turns settle', async () => {
+      const store = makeMemoryStore();
+      const studioContext: ChatStudioContext = {
+        project: { id: 'proj-1', name: 'Acme' },
+        version: { id: 'ver-1', label: 'v1' },
+        classes: [],
+        properties: [],
+        selectedClassIds: [],
+      };
+      const responder: ChatSendFn = ({ prompt }) => Promise.resolve(`reply: ${prompt}`);
+      render(
+        <ChatConversation
+          onSendMessage={responder}
+          studioContext={studioContext}
+          conversationStore={store}
+          restoreLastConversation={false}
+        />,
+      );
+
+      fireEvent.change(screen.getByTestId('studio-ai-chat-input'), { target: { value: 'design a cart' } });
+      fireEvent.click(screen.getByTestId('studio-ai-chat-send'));
+
+      await waitFor(() => expect(store.list()).toHaveLength(1));
+      const stored = store.list()[0];
+      expect(stored.projectId).toBe('proj-1');
+      expect(stored.versionId).toBe('ver-1');
+      expect(stored.title).toBe('design a cart');
+      expect(stored.messages.map((m) => m.role)).toEqual(['user', 'assistant']);
+    });
+
+    it('restores the most recent persisted conversation in the active scope on mount', async () => {
+      const studioContext: ChatStudioContext = {
+        project: { id: 'proj-1', name: 'Acme' },
+        version: null,
+        classes: [],
+        properties: [],
+        selectedClassIds: [],
+      };
+      const store = makeMemoryStore([
+        {
+          id: 'conv-keep',
+          projectId: 'proj-1',
+          versionId: null,
+          title: 'Keep me',
+          createdAt: 100,
+          updatedAt: 200,
+          messages: [
+            { id: 'u1', role: 'user', content: 'remembered prompt' },
+            { id: 'a1', role: 'assistant', content: 'remembered reply' },
+          ],
+        },
+      ]);
+      render(
+        <ChatConversation
+          studioContext={studioContext}
+          conversationStore={store}
+        />,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('remembered prompt')).toBeInTheDocument();
+      });
+      expect(screen.getByText('remembered reply')).toBeInTheDocument();
+    });
+
+    it('opens the history surface, lists prior conversations, and switches active when one is opened', async () => {
+      const store = makeMemoryStore([
+        {
+          id: 'conv-old',
+          projectId: null,
+          versionId: null,
+          title: 'older convo',
+          createdAt: 100,
+          updatedAt: 100,
+          messages: [
+            { id: 'u', role: 'user', content: 'older prompt' },
+            { id: 'a', role: 'assistant', content: 'older reply' },
+          ],
+        },
+        {
+          id: 'conv-new',
+          projectId: null,
+          versionId: null,
+          title: 'newer convo',
+          createdAt: 200,
+          updatedAt: 200,
+          messages: [
+            { id: 'u', role: 'user', content: 'newer prompt' },
+            { id: 'a', role: 'assistant', content: 'newer reply' },
+          ],
+        },
+      ]);
+      render(
+        <ChatConversation
+          conversationStore={store}
+          restoreLastConversation={false}
+        />,
+      );
+
+      fireEvent.click(screen.getByTestId('studio-ai-chat-history'));
+      const rows = screen.getAllByTestId('studio-ai-chat-history-row');
+      expect(rows).toHaveLength(2);
+      expect(within(rows[0]).getByText('newer convo')).toBeInTheDocument();
+      expect(within(rows[1]).getByText('older convo')).toBeInTheDocument();
+
+      fireEvent.click(within(rows[1]).getByTestId('studio-ai-chat-history-open'));
+
+      await waitFor(() => {
+        expect(screen.getByText('older prompt')).toBeInTheDocument();
+      });
+      expect(screen.getByText('older reply')).toBeInTheDocument();
+    });
+
+    it('filters the history list with the search box', () => {
+      const store = makeMemoryStore([
+        {
+          id: 'a',
+          projectId: null,
+          versionId: null,
+          title: 'Cart schema',
+          createdAt: 1,
+          updatedAt: 2,
+          messages: [{ id: 'u', role: 'user', content: 'design cart' }],
+        },
+        {
+          id: 'b',
+          projectId: null,
+          versionId: null,
+          title: 'Auth design',
+          createdAt: 1,
+          updatedAt: 3,
+          messages: [{ id: 'u', role: 'user', content: 'login flow' }],
+        },
+      ]);
+      render(
+        <ChatConversation
+          conversationStore={store}
+          restoreLastConversation={false}
+        />,
+      );
+
+      fireEvent.click(screen.getByTestId('studio-ai-chat-history'));
+      fireEvent.change(screen.getByTestId('studio-ai-chat-history-search'), {
+        target: { value: 'cart' },
+      });
+      const rows = screen.getAllByTestId('studio-ai-chat-history-row');
+      expect(rows).toHaveLength(1);
+      expect(within(rows[0]).getByText('Cart schema')).toBeInTheDocument();
+    });
+
+    it('exports the active conversation as markdown via the supplied handler', async () => {
+      const responder: ChatSendFn = ({ prompt }) => Promise.resolve(`reply: ${prompt}`);
+      const store = makeMemoryStore();
+      const onExportConversation = jest.fn();
+      render(
+        <ChatConversation
+          onSendMessage={responder}
+          conversationStore={store}
+          restoreLastConversation={false}
+          onExportConversation={onExportConversation}
+        />,
+      );
+
+      fireEvent.change(screen.getByTestId('studio-ai-chat-input'), { target: { value: 'design a cart' } });
+      fireEvent.click(screen.getByTestId('studio-ai-chat-send'));
+      await waitFor(() => expect(screen.getByTestId('studio-ai-chat-export')).not.toBeDisabled());
+
+      fireEvent.click(screen.getByTestId('studio-ai-chat-export'));
+      expect(onExportConversation).toHaveBeenCalledTimes(1);
+      const arg = onExportConversation.mock.calls[0][0] as { filename: string; markdown: string };
+      expect(arg.filename).toMatch(/^studio-ai-design-a-cart-\d{4}-\d{2}-\d{2}\.md$/);
+      expect(arg.markdown).toMatch(/^# design a cart/);
+      expect(arg.markdown).toMatch(/## User/);
+      expect(arg.markdown).toMatch(/design a cart/);
+      expect(arg.markdown).toMatch(/reply: design a cart/);
+    });
+
+    it('clears the active conversation, removes it from history, and resets the view', async () => {
+      const responder: ChatSendFn = ({ prompt }) => Promise.resolve(`reply: ${prompt}`);
+      const store = makeMemoryStore();
+      render(
+        <ChatConversation
+          onSendMessage={responder}
+          conversationStore={store}
+          restoreLastConversation={false}
+          confirmAction={alwaysConfirm}
+        />,
+      );
+
+      fireEvent.change(screen.getByTestId('studio-ai-chat-input'), { target: { value: 'something to clear' } });
+      fireEvent.click(screen.getByTestId('studio-ai-chat-send'));
+      await waitFor(() => expect(store.list()).toHaveLength(1));
+
+      fireEvent.click(screen.getByTestId('studio-ai-chat-clear'));
+
+      expect(store.list()).toHaveLength(0);
+      expect(screen.queryByText('something to clear')).not.toBeInTheDocument();
+      expect(screen.getAllByTestId('studio-ai-chat-suggestion').length).toBeGreaterThan(0);
+    });
+
+    it('does not clear when the confirmation is declined', async () => {
+      const responder: ChatSendFn = ({ prompt }) => Promise.resolve(`reply: ${prompt}`);
+      const store = makeMemoryStore();
+      render(
+        <ChatConversation
+          onSendMessage={responder}
+          conversationStore={store}
+          restoreLastConversation={false}
+          confirmAction={neverConfirm}
+        />,
+      );
+
+      fireEvent.change(screen.getByTestId('studio-ai-chat-input'), { target: { value: 'keep me' } });
+      fireEvent.click(screen.getByTestId('studio-ai-chat-send'));
+      await waitFor(() => expect(store.list()).toHaveLength(1));
+
+      fireEvent.click(screen.getByTestId('studio-ai-chat-clear'));
+
+      expect(store.list()).toHaveLength(1);
+      expect(screen.getByText('keep me')).toBeInTheDocument();
+    });
+
+    it('clear-all from the history surface wipes every conversation in scope', async () => {
+      const studioContext: ChatStudioContext = {
+        project: { id: 'proj-1', name: 'Acme' },
+        version: null,
+        classes: [],
+        properties: [],
+        selectedClassIds: [],
+      };
+      const store = makeMemoryStore([
+        {
+          id: 'in-scope',
+          projectId: 'proj-1',
+          versionId: null,
+          title: 'in scope',
+          createdAt: 1,
+          updatedAt: 1,
+          messages: [{ id: 'u', role: 'user', content: 'in scope prompt' }],
+        },
+        {
+          id: 'other-scope',
+          projectId: 'proj-2',
+          versionId: null,
+          title: 'other scope',
+          createdAt: 1,
+          updatedAt: 1,
+          messages: [{ id: 'u', role: 'user', content: 'other scope prompt' }],
+        },
+      ]);
+      render(
+        <ChatConversation
+          studioContext={studioContext}
+          conversationStore={store}
+          confirmAction={alwaysConfirm}
+        />,
+      );
+
+      fireEvent.click(screen.getByTestId('studio-ai-chat-history'));
+      fireEvent.click(screen.getByTestId('studio-ai-chat-history-clear-all'));
+
+      expect(store.list({ projectId: 'proj-1', versionId: null })).toHaveLength(0);
+      expect(store.list({ projectId: 'proj-2', versionId: null })).toHaveLength(1);
+    });
+
+    it('starting a New conversation hides previous bubbles but keeps the prior entry in history', async () => {
+      const responder: ChatSendFn = ({ prompt }) => Promise.resolve(`reply: ${prompt}`);
+      const store = makeMemoryStore();
+      render(
+        <ChatConversation
+          onSendMessage={responder}
+          conversationStore={store}
+          restoreLastConversation={false}
+        />,
+      );
+
+      fireEvent.change(screen.getByTestId('studio-ai-chat-input'), { target: { value: 'first thread' } });
+      fireEvent.click(screen.getByTestId('studio-ai-chat-send'));
+      await waitFor(() => expect(store.list()).toHaveLength(1));
+
+      fireEvent.click(screen.getByTestId('studio-ai-chat-new'));
+
+      expect(screen.queryByText('first thread')).not.toBeInTheDocument();
+      expect(screen.getAllByTestId('studio-ai-chat-suggestion').length).toBeGreaterThan(0);
+      expect(store.list()).toHaveLength(1);
+    });
+
+    it('deleting a conversation from history removes it and wipes the active view if it was open', async () => {
+      const store = makeMemoryStore([
+        {
+          id: 'conv-1',
+          projectId: null,
+          versionId: null,
+          title: 'doomed',
+          createdAt: 1,
+          updatedAt: 1,
+          messages: [{ id: 'u', role: 'user', content: 'doomed prompt' }],
+        },
+      ]);
+      render(<ChatConversation conversationStore={store} />);
+
+      await waitFor(() => {
+        expect(screen.getByText('doomed prompt')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByTestId('studio-ai-chat-history'));
+      fireEvent.click(screen.getByTestId('studio-ai-chat-history-delete'));
+
+      expect(store.list()).toHaveLength(0);
+      // After deletion the history surface shows the empty state and the
+      // chat returns to the empty-conversation state.
+      expect(screen.getByTestId('studio-ai-chat-history-empty')).toBeInTheDocument();
+      fireEvent.click(screen.getByTestId('studio-ai-chat-history-back'));
+      expect(screen.getAllByTestId('studio-ai-chat-suggestion').length).toBeGreaterThan(0);
+    });
   });
 
   it('forwards the import callback when the assistant returns an OpenAPI spec', async () => {

--- a/objectified-ui/tests/chatbot/ChatConversation.test.tsx
+++ b/objectified-ui/tests/chatbot/ChatConversation.test.tsx
@@ -633,7 +633,7 @@ describe('ChatConversation', () => {
           messages: [{ id: 'u', role: 'user', content: 'doomed prompt' }],
         },
       ]);
-      render(<ChatConversation conversationStore={store} />);
+      render(<ChatConversation conversationStore={store} confirmAction={alwaysConfirm} />);
 
       await waitFor(() => {
         expect(screen.getByText('doomed prompt')).toBeInTheDocument();

--- a/objectified-ui/tests/chatbot/ConversationHistoryPanel.test.tsx
+++ b/objectified-ui/tests/chatbot/ConversationHistoryPanel.test.tsx
@@ -1,0 +1,205 @@
+/**
+ * Tests for the conversation history browse / search surface (#261).
+ *
+ * Pins the row rendering, scope-agnostic substring search, and the wiring
+ * for the open / delete / clear-all callbacks the chat shell hands in.
+ */
+
+import React from 'react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import { ConversationHistoryPanel } from '../../src/app/ade/studio/components/chatbot/ConversationHistoryPanel';
+import type { StoredConversation } from '../../src/app/ade/studio/components/chatbot/conversation-store';
+import type { ChatMessage } from '../../src/app/ade/studio/components/chatbot/types';
+
+function user(content: string, id = `u-${content.slice(0, 8)}`): ChatMessage {
+  return { id, role: 'user', content };
+}
+
+function assistant(content: string, id = `a-${content.slice(0, 8)}`): ChatMessage {
+  return { id, role: 'assistant', content };
+}
+
+function makeConversation(overrides: Partial<StoredConversation> = {}): StoredConversation {
+  return {
+    id: overrides.id ?? 'c-1',
+    projectId: overrides.projectId ?? null,
+    versionId: overrides.versionId ?? null,
+    title: overrides.title ?? 'Sample',
+    createdAt: overrides.createdAt ?? Date.now(),
+    updatedAt: overrides.updatedAt ?? Date.now(),
+    messages: overrides.messages ?? [user('hi'), assistant('hello')],
+  };
+}
+
+describe('ConversationHistoryPanel', () => {
+  it('renders the empty state when no conversations are persisted', () => {
+    render(
+      <ConversationHistoryPanel
+        conversations={[]}
+        onOpen={jest.fn()}
+        onDelete={jest.fn()}
+        onClearAll={jest.fn()}
+        onClose={jest.fn()}
+      />,
+    );
+    expect(screen.getByTestId('studio-ai-chat-history-empty')).toBeInTheDocument();
+    expect(screen.getByTestId('studio-ai-chat-history-clear-all')).toBeDisabled();
+  });
+
+  it('lists each conversation with its title and message count', () => {
+    const conversations = [
+      makeConversation({ id: 'a', title: 'Cart schema', messages: [user('hi'), assistant('there')] }),
+      makeConversation({ id: 'b', title: 'Auth design', messages: [user('login'), assistant('ok'), user('next')] }),
+    ];
+    render(
+      <ConversationHistoryPanel
+        conversations={conversations}
+        onOpen={jest.fn()}
+        onDelete={jest.fn()}
+        onClearAll={jest.fn()}
+        onClose={jest.fn()}
+      />,
+    );
+    const rows = screen.getAllByTestId('studio-ai-chat-history-row');
+    expect(rows).toHaveLength(2);
+    expect(within(rows[0]).getByText('Cart schema')).toBeInTheDocument();
+    expect(within(rows[0]).getByText(/2 messages/)).toBeInTheDocument();
+    expect(within(rows[1]).getByText('Auth design')).toBeInTheDocument();
+    expect(within(rows[1]).getByText(/3 messages/)).toBeInTheDocument();
+  });
+
+  it('marks the active conversation visually', () => {
+    const conversations = [
+      makeConversation({ id: 'a', title: 'first' }),
+      makeConversation({ id: 'b', title: 'second' }),
+    ];
+    render(
+      <ConversationHistoryPanel
+        conversations={conversations}
+        activeId="b"
+        onOpen={jest.fn()}
+        onDelete={jest.fn()}
+        onClearAll={jest.fn()}
+        onClose={jest.fn()}
+      />,
+    );
+    const rows = screen.getAllByTestId('studio-ai-chat-history-row');
+    expect(rows[0]).toHaveAttribute('data-active', 'false');
+    expect(rows[1]).toHaveAttribute('data-active', 'true');
+  });
+
+  it('filters conversations by title and message content as the user types', () => {
+    const conversations = [
+      makeConversation({
+        id: 'a',
+        title: 'Cart schema',
+        messages: [user('design cart'), assistant('done')],
+      }),
+      makeConversation({
+        id: 'b',
+        title: 'Auth design',
+        messages: [user('login flow'), assistant('use OAuth')],
+      }),
+      makeConversation({
+        id: 'c',
+        title: 'Catalog',
+        messages: [user('list products'), assistant('SKU map')],
+      }),
+    ];
+    render(
+      <ConversationHistoryPanel
+        conversations={conversations}
+        onOpen={jest.fn()}
+        onDelete={jest.fn()}
+        onClearAll={jest.fn()}
+        onClose={jest.fn()}
+      />,
+    );
+
+    const search = screen.getByTestId('studio-ai-chat-history-search');
+    fireEvent.change(search, { target: { value: 'oauth' } });
+    const rows = screen.getAllByTestId('studio-ai-chat-history-row');
+    expect(rows).toHaveLength(1);
+    expect(within(rows[0]).getByText('Auth design')).toBeInTheDocument();
+  });
+
+  it('shows a no-match state when the search term has no hits', () => {
+    render(
+      <ConversationHistoryPanel
+        conversations={[makeConversation({ id: 'a', title: 'Cart' })]}
+        onOpen={jest.fn()}
+        onDelete={jest.fn()}
+        onClearAll={jest.fn()}
+        onClose={jest.fn()}
+      />,
+    );
+    fireEvent.change(screen.getByTestId('studio-ai-chat-history-search'), {
+      target: { value: 'zzz' },
+    });
+    expect(screen.getByTestId('studio-ai-chat-history-no-matches')).toBeInTheDocument();
+  });
+
+  it('invokes onOpen with the conversation id when a row is clicked', () => {
+    const onOpen = jest.fn();
+    const conversations = [makeConversation({ id: 'pick-me', title: 'pick me' })];
+    render(
+      <ConversationHistoryPanel
+        conversations={conversations}
+        onOpen={onOpen}
+        onDelete={jest.fn()}
+        onClearAll={jest.fn()}
+        onClose={jest.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('studio-ai-chat-history-open'));
+    expect(onOpen).toHaveBeenCalledWith('pick-me');
+  });
+
+  it('invokes onDelete with the conversation id when the row delete button is clicked', () => {
+    const onDelete = jest.fn();
+    const conversations = [makeConversation({ id: 'doomed', title: 'doomed' })];
+    render(
+      <ConversationHistoryPanel
+        conversations={conversations}
+        onOpen={jest.fn()}
+        onDelete={onDelete}
+        onClearAll={jest.fn()}
+        onClose={jest.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('studio-ai-chat-history-delete'));
+    expect(onDelete).toHaveBeenCalledWith('doomed');
+  });
+
+  it('invokes onClearAll when the clear-all button is pressed', () => {
+    const onClearAll = jest.fn();
+    render(
+      <ConversationHistoryPanel
+        conversations={[makeConversation({ id: 'x' })]}
+        onOpen={jest.fn()}
+        onDelete={jest.fn()}
+        onClearAll={onClearAll}
+        onClose={jest.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('studio-ai-chat-history-clear-all'));
+    expect(onClearAll).toHaveBeenCalledTimes(1);
+  });
+
+  it('invokes onClose when the back button is pressed', () => {
+    const onClose = jest.fn();
+    render(
+      <ConversationHistoryPanel
+        conversations={[]}
+        onOpen={jest.fn()}
+        onDelete={jest.fn()}
+        onClearAll={jest.fn()}
+        onClose={onClose}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('studio-ai-chat-history-back'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/objectified-ui/tests/chatbot/conversation-store.test.ts
+++ b/objectified-ui/tests/chatbot/conversation-store.test.ts
@@ -1,0 +1,370 @@
+/**
+ * Tests for the conversation persistence layer (#261).
+ *
+ * Pins the storage adapter contract, scope filtering, search, export, and
+ * the safety net around quota / SSR conditions so the chat surface can rely
+ * on the store without defensive boilerplate.
+ */
+
+import {
+  CHAT_HISTORY_MAX_CONVERSATIONS,
+  CHAT_HISTORY_TITLE_CHAR_CAP,
+  buildStoredConversation,
+  createConversationStore,
+  createLocalStorageConversationStorage,
+  createMemoryConversationStorage,
+  deriveConversationTitle,
+  exportConversationToMarkdown,
+  exportConversationsToMarkdown,
+  type StoredConversation,
+} from '../../src/app/ade/studio/components/chatbot/conversation-store';
+import type { ChatMessage } from '../../src/app/ade/studio/components/chatbot/types';
+
+function user(content: string, id = `u-${content.slice(0, 8)}`): ChatMessage {
+  return { id, role: 'user', content };
+}
+
+function assistant(content: string, id = `a-${content.slice(0, 8)}`): ChatMessage {
+  return { id, role: 'assistant', content };
+}
+
+function makeConversation(overrides: Partial<StoredConversation> = {}): StoredConversation {
+  return {
+    id: overrides.id ?? 'c-1',
+    projectId: overrides.projectId ?? null,
+    versionId: overrides.versionId ?? null,
+    title: overrides.title ?? 'Sample',
+    createdAt: overrides.createdAt ?? 100,
+    updatedAt: overrides.updatedAt ?? 200,
+    messages: overrides.messages ?? [user('hi'), assistant('hello')],
+  };
+}
+
+describe('deriveConversationTitle', () => {
+  it('falls back to a sentinel when the transcript is empty', () => {
+    expect(deriveConversationTitle([])).toBe('Untitled conversation');
+  });
+
+  it('uses the first user prompt as the title and collapses whitespace', () => {
+    const messages: ChatMessage[] = [
+      user('  Sketch a   schema\nfor users  '),
+      assistant('done'),
+    ];
+    expect(deriveConversationTitle(messages)).toBe('Sketch a schema for users');
+  });
+
+  it('skips pending or empty messages when picking the title seed', () => {
+    const messages: ChatMessage[] = [
+      { id: 'p', role: 'user', content: '   ' },
+      assistant('hello'),
+    ];
+    expect(deriveConversationTitle(messages)).toBe('hello');
+  });
+
+  it('caps long titles at the configured character budget', () => {
+    const long = 'word '.repeat(40).trim();
+    const title = deriveConversationTitle([user(long)]);
+    expect(title.length).toBeLessThanOrEqual(CHAT_HISTORY_TITLE_CHAR_CAP);
+    expect(title.endsWith('…')).toBe(true);
+  });
+});
+
+describe('createConversationStore (memory adapter)', () => {
+  it('lists conversations newest-first', () => {
+    const store = createConversationStore(createMemoryConversationStorage());
+    store.save(makeConversation({ id: 'a', updatedAt: 1 }));
+    store.save(makeConversation({ id: 'b', updatedAt: 3 }));
+    store.save(makeConversation({ id: 'c', updatedAt: 2 }));
+    expect(store.list().map((c) => c.id)).toEqual(['b', 'c', 'a']);
+  });
+
+  it('upserts by id rather than appending duplicates', () => {
+    const store = createConversationStore(createMemoryConversationStorage());
+    store.save(makeConversation({ id: 'a', title: 'first', updatedAt: 1 }));
+    store.save(makeConversation({ id: 'a', title: 'second', updatedAt: 5 }));
+    const list = store.list();
+    expect(list).toHaveLength(1);
+    expect(list[0].title).toBe('second');
+  });
+
+  it('filters by scope using project + version null-safe equality', () => {
+    const store = createConversationStore(createMemoryConversationStorage());
+    store.save(makeConversation({ id: 'global' }));
+    store.save(makeConversation({ id: 'p1-only', projectId: 'p1' }));
+    store.save(makeConversation({ id: 'p1-v1', projectId: 'p1', versionId: 'v1' }));
+    store.save(makeConversation({ id: 'p2-v1', projectId: 'p2', versionId: 'v1' }));
+
+    expect(store.list({ projectId: 'p1', versionId: 'v1' }).map((c) => c.id)).toEqual(['p1-v1']);
+    expect(store.list({ projectId: 'p1' }).map((c) => c.id).sort()).toEqual(['p1-only', 'p1-v1']);
+    expect(store.list({ projectId: null, versionId: null }).map((c) => c.id)).toEqual(['global']);
+  });
+
+  it('removes a single conversation by id without touching others', () => {
+    const store = createConversationStore(createMemoryConversationStorage());
+    store.save(makeConversation({ id: 'a', updatedAt: 1 }));
+    store.save(makeConversation({ id: 'b', updatedAt: 2 }));
+    store.remove('a');
+    expect(store.list().map((c) => c.id)).toEqual(['b']);
+    // Removing an unknown id is a no-op.
+    expect(() => store.remove('missing')).not.toThrow();
+  });
+
+  it('clears every conversation in a scope', () => {
+    const store = createConversationStore(createMemoryConversationStorage());
+    store.save(makeConversation({ id: 'p1-a', projectId: 'p1', versionId: 'v1' }));
+    store.save(makeConversation({ id: 'p1-b', projectId: 'p1', versionId: 'v1' }));
+    store.save(makeConversation({ id: 'p2-a', projectId: 'p2', versionId: 'v1' }));
+    store.clear({ projectId: 'p1', versionId: 'v1' });
+    expect(store.list().map((c) => c.id)).toEqual(['p2-a']);
+  });
+
+  it('clears every conversation when no scope is provided', () => {
+    const store = createConversationStore(createMemoryConversationStorage());
+    store.save(makeConversation({ id: 'a' }));
+    store.save(makeConversation({ id: 'b', projectId: 'p1' }));
+    store.clear();
+    expect(store.list()).toEqual([]);
+  });
+
+  it('searches across titles and message content case-insensitively', () => {
+    const store = createConversationStore(createMemoryConversationStorage());
+    store.save(
+      makeConversation({
+        id: 'a',
+        title: 'Cart schema',
+        messages: [user('design cart')],
+        updatedAt: 1,
+      }),
+    );
+    store.save(
+      makeConversation({
+        id: 'b',
+        title: 'Catalog',
+        messages: [user('product catalog'), assistant('here is a SKU map')],
+        updatedAt: 2,
+      }),
+    );
+    store.save(
+      makeConversation({
+        id: 'c',
+        title: 'Auth',
+        messages: [user('login flow')],
+        updatedAt: 3,
+      }),
+    );
+    expect(store.search('cart').map((c) => c.id)).toEqual(['a']);
+    expect(store.search('SKU').map((c) => c.id)).toEqual(['b']);
+    expect(store.search('').map((c) => c.id)).toEqual(['c', 'b', 'a']);
+  });
+
+  it('search respects the optional scope', () => {
+    const store = createConversationStore(createMemoryConversationStorage());
+    store.save(makeConversation({ id: 'p1', projectId: 'p1', title: 'cart', updatedAt: 2 }));
+    store.save(makeConversation({ id: 'p2', projectId: 'p2', title: 'cart', updatedAt: 1 }));
+    expect(store.search('cart', { projectId: 'p1' }).map((c) => c.id)).toEqual(['p1']);
+  });
+
+  it('prunes stored conversations per scope when the cap is exceeded', () => {
+    const adapter = createMemoryConversationStorage();
+    const store = createConversationStore(adapter);
+    for (let i = 0; i < CHAT_HISTORY_MAX_CONVERSATIONS + 5; i += 1) {
+      store.save(
+        makeConversation({
+          id: `p1-${i}`,
+          projectId: 'p1',
+          versionId: 'v1',
+          updatedAt: 1000 + i,
+        }),
+      );
+    }
+    const all = adapter.read();
+    expect(all.filter((c) => c.projectId === 'p1')).toHaveLength(CHAT_HISTORY_MAX_CONVERSATIONS);
+    // Newest survive — the very latest must still be present.
+    const ids = all.map((c) => c.id);
+    expect(ids).toContain(`p1-${CHAT_HISTORY_MAX_CONVERSATIONS + 4}`);
+    expect(ids).not.toContain('p1-0');
+  });
+
+  it('caps separately per scope so unrelated projects do not evict each other', () => {
+    const adapter = createMemoryConversationStorage();
+    const store = createConversationStore(adapter);
+    store.save(makeConversation({ id: 'p1-only', projectId: 'p1', updatedAt: 1 }));
+    for (let i = 0; i < CHAT_HISTORY_MAX_CONVERSATIONS + 3; i += 1) {
+      store.save(makeConversation({ id: `p2-${i}`, projectId: 'p2', updatedAt: 100 + i }));
+    }
+    expect(adapter.read().some((c) => c.id === 'p1-only')).toBe(true);
+  });
+});
+
+describe('createLocalStorageConversationStorage', () => {
+  it('round-trips conversations through a real storage instance', () => {
+    const memory = new Map<string, string>();
+    const storage: Storage = {
+      get length() {
+        return memory.size;
+      },
+      clear: () => memory.clear(),
+      getItem: (key) => memory.get(key) ?? null,
+      key: (i) => Array.from(memory.keys())[i] ?? null,
+      removeItem: (key) => {
+        memory.delete(key);
+      },
+      setItem: (key, value) => {
+        memory.set(key, value);
+      },
+    };
+    const adapter = createLocalStorageConversationStorage('test-key', () => storage);
+    adapter.write([makeConversation({ id: 'a', updatedAt: 1 })]);
+    expect(adapter.read()).toEqual([makeConversation({ id: 'a', updatedAt: 1 })]);
+  });
+
+  it('returns an empty list when storage is unavailable (SSR / private mode)', () => {
+    const adapter = createLocalStorageConversationStorage('test-key', () => null);
+    expect(adapter.read()).toEqual([]);
+    expect(() => adapter.write([makeConversation()])).not.toThrow();
+  });
+
+  it('swallows JSON parse errors and returns an empty list', () => {
+    const memory = new Map<string, string>([['test-key', 'not-json']]);
+    const storage: Storage = {
+      get length() {
+        return memory.size;
+      },
+      clear: () => memory.clear(),
+      getItem: (key) => memory.get(key) ?? null,
+      key: (i) => Array.from(memory.keys())[i] ?? null,
+      removeItem: (key) => {
+        memory.delete(key);
+      },
+      setItem: (key, value) => {
+        memory.set(key, value);
+      },
+    };
+    const adapter = createLocalStorageConversationStorage('test-key', () => storage);
+    expect(adapter.read()).toEqual([]);
+  });
+
+  it('drops malformed entries when reading', () => {
+    const payload = JSON.stringify([
+      makeConversation({ id: 'good' }),
+      { id: 'bad', random: true },
+    ]);
+    const memory = new Map<string, string>([['test-key', payload]]);
+    const storage: Storage = {
+      get length() {
+        return memory.size;
+      },
+      clear: () => memory.clear(),
+      getItem: (key) => memory.get(key) ?? null,
+      key: (i) => Array.from(memory.keys())[i] ?? null,
+      removeItem: (key) => {
+        memory.delete(key);
+      },
+      setItem: (key, value) => {
+        memory.set(key, value);
+      },
+    };
+    const adapter = createLocalStorageConversationStorage('test-key', () => storage);
+    expect(adapter.read().map((c) => c.id)).toEqual(['good']);
+  });
+
+  it('swallows quota errors during write', () => {
+    const storage: Storage = {
+      length: 0,
+      clear: () => {},
+      getItem: () => null,
+      key: () => null,
+      removeItem: () => {},
+      setItem: () => {
+        throw new DOMException('Quota exceeded', 'QuotaExceededError');
+      },
+    };
+    const adapter = createLocalStorageConversationStorage('test-key', () => storage);
+    expect(() => adapter.write([makeConversation()])).not.toThrow();
+  });
+});
+
+describe('exportConversationToMarkdown', () => {
+  it('renders a heading, metadata bullets, and role sections', () => {
+    const conversation = makeConversation({
+      id: 'export-1',
+      title: 'Cart schema',
+      projectId: 'proj-1',
+      versionId: 'ver-1',
+      createdAt: Date.UTC(2026, 3, 1),
+      updatedAt: Date.UTC(2026, 3, 2),
+      messages: [user('design a cart'), assistant('here you go')],
+    });
+    const md = exportConversationToMarkdown(conversation);
+    expect(md.startsWith('# Cart schema')).toBe(true);
+    expect(md).toMatch(/Project: proj-1/);
+    expect(md).toMatch(/Version: ver-1/);
+    expect(md).toMatch(/## User/);
+    expect(md).toMatch(/design a cart/);
+    expect(md).toMatch(/## Assistant/);
+    expect(md).toMatch(/here you go/);
+  });
+
+  it('omits pending messages from the export', () => {
+    const conversation = makeConversation({
+      messages: [user('hi'), { id: 'p', role: 'assistant', content: '', pending: true }],
+    });
+    const md = exportConversationToMarkdown(conversation);
+    expect(md).not.toMatch(/_\(empty\)_/);
+    expect(md).not.toMatch(/## Assistant/);
+  });
+
+  it('joins multiple conversations with horizontal-rule dividers', () => {
+    const md = exportConversationsToMarkdown([
+      makeConversation({ id: 'a', title: 'first' }),
+      makeConversation({ id: 'b', title: 'second' }),
+    ]);
+    expect(md).toMatch(/# first[\s\S]*---[\s\S]*# second/);
+  });
+
+  it('returns an empty string for an empty list', () => {
+    expect(exportConversationsToMarkdown([])).toBe('');
+  });
+});
+
+describe('buildStoredConversation', () => {
+  it('seeds id, title, and timestamps from the running transcript', () => {
+    const now = jest.fn(() => 12345);
+    const stored = buildStoredConversation({
+      scope: { projectId: 'p1', versionId: 'v1' },
+      messages: [user('Design a billing schema')],
+      now,
+    });
+    expect(stored.projectId).toBe('p1');
+    expect(stored.versionId).toBe('v1');
+    expect(stored.title).toBe('Design a billing schema');
+    expect(stored.createdAt).toBe(12345);
+    expect(stored.updatedAt).toBe(12345);
+    expect(stored.id).toMatch(/^chat-conv-/);
+  });
+
+  it('preserves the supplied id and createdAt while bumping updatedAt to "now"', () => {
+    let count = 0;
+    const now = () => 1000 + count++ * 10;
+    const stored = buildStoredConversation({
+      id: 'conv-existing',
+      scope: { projectId: null, versionId: null },
+      messages: [user('q')],
+      createdAt: 50,
+      now,
+    });
+    expect(stored.id).toBe('conv-existing');
+    expect(stored.createdAt).toBe(50);
+    expect(stored.updatedAt).toBeGreaterThanOrEqual(1000);
+  });
+
+  it('clones messages so mutating the returned object does not leak back', () => {
+    const messages: ChatMessage[] = [user('q')];
+    const stored = buildStoredConversation({
+      scope: { projectId: null, versionId: null },
+      messages,
+    });
+    stored.messages[0].content = 'mutated';
+    expect(messages[0].content).toBe('q');
+  });
+});

--- a/objectified-ui/tests/chatbot/conversation-store.test.ts
+++ b/objectified-ui/tests/chatbot/conversation-store.test.ts
@@ -268,6 +268,41 @@ describe('createLocalStorageConversationStorage', () => {
     expect(adapter.read().map((c) => c.id)).toEqual(['good']);
   });
 
+  it('drops conversations whose messages array contains malformed entries', () => {
+    const badMessages = JSON.stringify([
+      makeConversation({ id: 'good' }),
+      {
+        id: 'bad-msgs',
+        title: 'Looks fine',
+        createdAt: 1,
+        updatedAt: 2,
+        projectId: null,
+        versionId: null,
+        // messages entries lack the required id/role/content shape
+        messages: ['string', null, { notAMessage: true }],
+      },
+    ]);
+    const memory = new Map<string, string>([['test-key', badMessages]]);
+    const storage: Storage = {
+      get length() {
+        return memory.size;
+      },
+      clear: () => memory.clear(),
+      getItem: (key) => memory.get(key) ?? null,
+      key: (i) => Array.from(memory.keys())[i] ?? null,
+      removeItem: (key) => {
+        memory.delete(key);
+      },
+      setItem: (key, value) => {
+        memory.set(key, value);
+      },
+    };
+    const adapter = createLocalStorageConversationStorage('test-key', () => storage);
+    // The conversation with malformed messages must be silently dropped so
+    // downstream code cannot call m.content.toLowerCase() on a non-string.
+    expect(adapter.read().map((c) => c.id)).toEqual(['good']);
+  });
+
   it('swallows quota errors during write', () => {
     const storage: Storage = {
       length: 0,


### PR DESCRIPTION
## Summary

Closes #261. Adds the conversation history capabilities the issue called for to the Studio AI chatbot:

- **Persist conversations per project / version** — every settled turn auto-saves to a pluggable store (`localStorage` in production, in-memory for tests) keyed by the active project + version snapshot.
- **Browse past conversations** — a new toolbar above the chat exposes a "History" view that lists prior threads, marks the active one, and supports per-row open / delete plus a "Clear all" affordance.
- **Search conversation history** — the history panel ships with a substring search across titles and message content; the store exposes the same search for non-UI callers.
- **Export conversations as markdown** — the toolbar's "Export" button renders the active thread as markdown (heading, metadata bullets, role sections) and downloads it; tests inject an override hook to capture the markdown.
- **Clear conversation option** — the toolbar's "Clear" button confirms and removes the active conversation from both the in-memory transcript and the store.

The chat surface restores the most recent in-scope conversation when the panel reopens, so users land back in their last thread automatically.

### Implementation notes

- New `conversation-store.ts` owns the data model, scope filtering, search, per-scope cap, export-to-markdown helpers, and adapter factories. The local-storage adapter handles SSR (returns empty), JSON parse failures (swallowed), and quota errors (swallowed).
- New `ConversationHistoryPanel.tsx` is presentational — the chat shell hands it the conversation list and callbacks; the panel does its own live filtering for snappy typing feedback.
- `ChatConversation.tsx` gained four optional props (`conversationStore`, `restoreLastConversation`, `confirmAction`, `onExportConversation`) to keep the surface fully testable without leaning on jsdom's `window.confirm` or the download flow.
- All new code is exported from the chatbot barrel (`chatbot/index.ts`) so the Ollama transport (#265) can swap the storage adapter without touching the chat shell.

### Roadmap / docs

- Marked the "Conversation History" bullets ✅ in `docs/PLANNED_FEATURE_ROADMAP_AI.md` and removed #261 from the open issues table.
- Added a one-line summary of the feature to `objectified-ui/public/WHATS_NEW.md`.
- Bumped `objectified-ui` to `0.10.18`.

## Test plan

- [x] `yarn jest conversation-store.test.ts` — 26 specs covering title derivation, scoped list / save / remove / clear / search, per-scope capping, export-to-markdown, the local-storage adapter (round-trip, SSR, parse errors, malformed entries, quota errors), and `buildStoredConversation`.
- [x] `yarn jest ConversationHistoryPanel.test.tsx` — 9 specs covering empty state, row rendering, active row highlight, live search, no-match state, and open / delete / clear-all / close callbacks.
- [x] `yarn jest ChatConversation.test.tsx` — extended with 11 new `#261` specs covering toolbar visibility, scoped persistence, scope-aware restoration, history navigation, search, export-to-markdown, clear with and without confirm, scoped clear-all, "New" preserving prior history, and delete-from-history clearing the active view; pre-existing `#258` / `#259` / `#260` specs continue to pass.
- [x] `yarn jest StudioAiChatbot.test.tsx` — full integration tests still green.
- [x] `yarn build` — production build succeeds.
- [x] Manual smoke (recommended): open the chatbot on a canvas page, send a turn, verify the toolbar lights up, switch to History, search, export, clear, then reopen the panel and confirm the latest in-scope conversation reappears.

### Risk / notes

- Persistence today is `localStorage` only. The store interface is intentionally adapter-shaped so the eventual server-side history (post-Ollama) can drop in without touching the chat surface.
- The conversation cap (50 per scope) keeps `localStorage` usage bounded and is exposed as `CHAT_HISTORY_MAX_CONVERSATIONS` for tuning.
- `window.confirm` is only used as a fallback when no `confirmAction` prop is supplied; jsdom's missing implementation is caught and treated as "yes" in tests.

Closes #261

Made with [Cursor](https://cursor.com)