### PR TITLE
Fix #2754 - add repository provider abstraction layer

### DIFF
--- a/objectified-rest/pyproject.toml
+++ b/objectified-rest/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "objectified-rest"
-version = "1.0.50"
+version = "1.0.51"
 description = "REST API for serving OpenAPI specifications from the Objectified database"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/objectified-rest/src/app/repositories/__init__.py
+++ b/objectified-rest/src/app/repositories/__init__.py
@@ -1,0 +1,1 @@
+"""Repository provider abstractions and adapters."""

--- a/objectified-rest/src/app/repositories/providers/__init__.py
+++ b/objectified-rest/src/app/repositories/providers/__init__.py
@@ -1,0 +1,31 @@
+from .base import (
+    BranchInfo,
+    ListReposOpts,
+    ReadFileResult,
+    RepoDetail,
+    RepoRef,
+    RepositoryProvider,
+    RepositoryProviderError,
+    RepositoryProviderErrorCode,
+    RepositoryProviderId,
+    RepoSummary,
+    TreeEntry,
+    WebhookTarget,
+)
+from .github_provider import GithubRepositoryProvider
+
+__all__ = [
+    "BranchInfo",
+    "GithubRepositoryProvider",
+    "ListReposOpts",
+    "ReadFileResult",
+    "RepoDetail",
+    "RepoRef",
+    "RepositoryProvider",
+    "RepositoryProviderError",
+    "RepositoryProviderErrorCode",
+    "RepositoryProviderId",
+    "RepoSummary",
+    "TreeEntry",
+    "WebhookTarget",
+]

--- a/objectified-rest/src/app/repositories/providers/base.py
+++ b/objectified-rest/src/app/repositories/providers/base.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from enum import Enum
+from typing import AsyncIterator
+
+
+class RepositoryProviderId(str, Enum):
+    GITHUB = "github"
+    GITLAB = "gitlab"
+    BITBUCKET = "bitbucket"
+    AZURE_DEVOPS = "azure_devops"
+
+
+class RepositoryProviderErrorCode(str, Enum):
+    RATE_LIMITED = "RATE_LIMITED"
+    UNAUTHORIZED = "UNAUTHORIZED"
+    NOT_FOUND = "NOT_FOUND"
+    NETWORK = "NETWORK"
+    UNKNOWN = "UNKNOWN"
+
+
+class RepositoryProviderError(RuntimeError):
+    def __init__(self, code: RepositoryProviderErrorCode, message: str, status: int | None = None) -> None:
+        super().__init__(message)
+        self.code = code
+        self.status = status
+
+
+@dataclass(frozen=True)
+class ListReposOpts:
+    per_page: int = 100
+    page: int = 1
+    sort: str = "updated"
+    visibility: str = "all"
+
+
+@dataclass(frozen=True)
+class RepoRef:
+    owner: str
+    name: str
+
+
+@dataclass(frozen=True)
+class RepoSummary:
+    id: str
+    name: str
+    full_name: str
+    description: str | None
+    is_private: bool
+    default_branch: str
+    html_url: str
+    updated_at: str | None
+
+
+@dataclass(frozen=True)
+class RepoDetail(RepoSummary):
+    pass
+
+
+@dataclass(frozen=True)
+class BranchInfo:
+    name: str
+    commit_sha: str
+    is_protected: bool
+
+
+@dataclass(frozen=True)
+class TreeEntry:
+    path: str
+    type: str
+    sha: str
+    size_bytes: int
+
+
+@dataclass(frozen=True)
+class WebhookTarget:
+    url: str
+    events: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ReadFileResult:
+    content_base64: str
+    sha: str
+    size_bytes: int
+
+
+class RepositoryProvider(ABC):
+    id: RepositoryProviderId
+
+    @abstractmethod
+    async def list_repositories(self, token: str, opts: ListReposOpts | None = None) -> AsyncIterator[RepoSummary]:
+        raise NotImplementedError
+
+    @abstractmethod
+    async def get_repository(self, token: str, owner: str, name: str) -> RepoDetail:
+        raise NotImplementedError
+
+    @abstractmethod
+    async def list_branches(self, token: str, repo: RepoRef) -> AsyncIterator[BranchInfo]:
+        raise NotImplementedError
+
+    @abstractmethod
+    async def get_commit_sha(self, token: str, repo: RepoRef, branch: str) -> str:
+        raise NotImplementedError
+
+    @abstractmethod
+    async def walk_tree(
+        self, token: str, repo: RepoRef, branch: str, subpath: str | None = None
+    ) -> AsyncIterator[TreeEntry]:
+        raise NotImplementedError
+
+    @abstractmethod
+    async def read_file(self, token: str, repo: RepoRef, branch: str, path: str) -> ReadFileResult:
+        raise NotImplementedError

--- a/objectified-rest/src/app/repositories/providers/github_provider.py
+++ b/objectified-rest/src/app/repositories/providers/github_provider.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import Any, AsyncIterator
+from urllib.parse import quote
 
 import httpx
 
@@ -23,15 +24,35 @@ class GithubRepositoryProvider(RepositoryProvider):
     id = RepositoryProviderId.GITHUB
 
     def __init__(self, client: httpx.AsyncClient | None = None) -> None:
-        self._client = client
+        self._external_client = client
+        self._owned_client: httpx.AsyncClient | None = None
+
+    def _get_or_create_client(self) -> httpx.AsyncClient:
+        if self._external_client is not None:
+            return self._external_client
+        if self._owned_client is None:
+            self._owned_client = httpx.AsyncClient(base_url="https://api.github.com", timeout=20)
+        return self._owned_client
+
+    async def aclose(self) -> None:
+        if self._owned_client is not None:
+            await self._owned_client.aclose()
+            self._owned_client = None
+
+    async def __aenter__(self) -> "GithubRepositoryProvider":
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        await self.aclose()
 
     async def list_repositories(self, token: str, opts: ListReposOpts | None = None) -> AsyncIterator[RepoSummary]:
         current = opts or ListReposOpts()
         page = current.page
+        per_page = min(current.per_page, 100)
 
         while True:
             repositories = await self._request_json(
-                f"/user/repos?sort={current.sort}&per_page={current.per_page}&page={page}&visibility={current.visibility}",
+                f"/user/repos?sort={current.sort}&per_page={per_page}&page={page}&visibility={current.visibility}",
                 token,
             )
             if not isinstance(repositories, list) or len(repositories) == 0:
@@ -51,7 +72,7 @@ class GithubRepositoryProvider(RepositoryProvider):
                     updated_at=repo.get("updated_at"),
                 )
 
-            if len(repositories) < current.per_page:
+            if len(repositories) < per_page:
                 return
             page += 1
 
@@ -100,7 +121,7 @@ class GithubRepositoryProvider(RepositoryProvider):
             page += 1
 
     async def get_commit_sha(self, token: str, repo: RepoRef, branch: str) -> str:
-        commit = await self._request_json(f"/repos/{repo.owner}/{repo.name}/commits/{branch}", token)
+        commit = await self._request_json(f"/repos/{repo.owner}/{repo.name}/commits/{quote(branch, safe='')}", token)
         if not isinstance(commit, dict):
             raise RepositoryProviderError(RepositoryProviderErrorCode.UNKNOWN, "Malformed GitHub response")
         return str(commit.get("sha", ""))
@@ -108,7 +129,7 @@ class GithubRepositoryProvider(RepositoryProvider):
     async def walk_tree(
         self, token: str, repo: RepoRef, branch: str, subpath: str | None = None
     ) -> AsyncIterator[TreeEntry]:
-        tree_response = await self._request_json(f"/repos/{repo.owner}/{repo.name}/git/trees/{branch}?recursive=1", token)
+        tree_response = await self._request_json(f"/repos/{repo.owner}/{repo.name}/git/trees/{quote(branch, safe='')}?recursive=1", token)
         if not isinstance(tree_response, dict):
             raise RepositoryProviderError(RepositoryProviderErrorCode.UNKNOWN, "Malformed GitHub response")
 
@@ -139,9 +160,9 @@ class GithubRepositoryProvider(RepositoryProvider):
             )
 
     async def read_file(self, token: str, repo: RepoRef, branch: str, path: str) -> ReadFileResult:
-        encoded_path = "/".join(httpx.QueryParams({"p": part})["p"] for part in path.split("/"))
+        encoded_path = "/".join(quote(part, safe="") for part in path.strip("/").split("/") if part)
         file_response = await self._request_json(
-            f"/repos/{repo.owner}/{repo.name}/contents/{encoded_path}?ref={branch}",
+            f"/repos/{repo.owner}/{repo.name}/contents/{encoded_path}?ref={quote(branch, safe='')}",
             token,
         )
         if not isinstance(file_response, dict):
@@ -161,11 +182,8 @@ class GithubRepositoryProvider(RepositoryProvider):
             "X-GitHub-Api-Version": "2022-11-28",
         }
 
-        if self._client is not None:
-            return await _request_with_client(self._client, path_with_query, headers)
-
-        async with httpx.AsyncClient(base_url="https://api.github.com", timeout=20) as client:
-            return await _request_with_client(client, path_with_query, headers)
+        client = self._get_or_create_client()
+        return await _request_with_client(client, path_with_query, headers)
 
 
 async def _request_with_client(client: httpx.AsyncClient, path_with_query: str, headers: dict[str, str]) -> Any:
@@ -183,7 +201,7 @@ async def _request_with_client(client: httpx.AsyncClient, path_with_query: str, 
     if response.status_code == 404:
         raise RepositoryProviderError(RepositoryProviderErrorCode.NOT_FOUND, "GitHub resource not found", 404)
     if response.status_code == 429 or _is_rate_limited(response.status_code, body, response.headers):
-        raise RepositoryProviderError(RepositoryProviderErrorCode.RATE_LIMITED, "GitHub API rate limit exceeded", 429)
+        raise RepositoryProviderError(RepositoryProviderErrorCode.RATE_LIMITED, "GitHub API rate limit exceeded", response.status_code)
     raise RepositoryProviderError(
         RepositoryProviderErrorCode.UNKNOWN,
         f"Unexpected GitHub API error: {response.status_code}",

--- a/objectified-rest/src/app/repositories/providers/github_provider.py
+++ b/objectified-rest/src/app/repositories/providers/github_provider.py
@@ -161,8 +161,9 @@ class GithubRepositoryProvider(RepositoryProvider):
 
     async def read_file(self, token: str, repo: RepoRef, branch: str, path: str) -> ReadFileResult:
         encoded_path = "/".join(quote(part, safe="") for part in path.strip("/").split("/") if part)
+        contents_path = f"/repos/{repo.owner}/{repo.name}/contents" + (f"/{encoded_path}" if encoded_path else "")
         file_response = await self._request_json(
-            f"/repos/{repo.owner}/{repo.name}/contents/{encoded_path}?ref={quote(branch, safe='')}",
+            f"{contents_path}?ref={quote(branch, safe='')}",
             token,
         )
         if not isinstance(file_response, dict):

--- a/objectified-rest/src/app/repositories/providers/github_provider.py
+++ b/objectified-rest/src/app/repositories/providers/github_provider.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+from typing import Any, AsyncIterator
+
+import httpx
+
+from .base import (
+    BranchInfo,
+    ListReposOpts,
+    ReadFileResult,
+    RepoDetail,
+    RepoRef,
+    RepositoryProvider,
+    RepositoryProviderError,
+    RepositoryProviderErrorCode,
+    RepositoryProviderId,
+    RepoSummary,
+    TreeEntry,
+)
+
+
+class GithubRepositoryProvider(RepositoryProvider):
+    id = RepositoryProviderId.GITHUB
+
+    def __init__(self, client: httpx.AsyncClient | None = None) -> None:
+        self._client = client
+
+    async def list_repositories(self, token: str, opts: ListReposOpts | None = None) -> AsyncIterator[RepoSummary]:
+        current = opts or ListReposOpts()
+        page = current.page
+
+        while True:
+            repositories = await self._request_json(
+                f"/user/repos?sort={current.sort}&per_page={current.per_page}&page={page}&visibility={current.visibility}",
+                token,
+            )
+            if not isinstance(repositories, list) or len(repositories) == 0:
+                return
+
+            for repo in repositories:
+                if not isinstance(repo, dict):
+                    continue
+                yield RepoSummary(
+                    id=str(repo.get("id", "")),
+                    name=str(repo.get("name", "")),
+                    full_name=str(repo.get("full_name", "")),
+                    description=repo.get("description"),
+                    is_private=bool(repo.get("private", False)),
+                    default_branch=str(repo.get("default_branch", "main")),
+                    html_url=str(repo.get("html_url", "")),
+                    updated_at=repo.get("updated_at"),
+                )
+
+            if len(repositories) < current.per_page:
+                return
+            page += 1
+
+    async def get_repository(self, token: str, owner: str, name: str) -> RepoDetail:
+        repo = await self._request_json(f"/repos/{owner}/{name}", token)
+        if not isinstance(repo, dict):
+            raise RepositoryProviderError(RepositoryProviderErrorCode.UNKNOWN, "Malformed GitHub response")
+
+        return RepoDetail(
+            id=str(repo.get("id", "")),
+            name=str(repo.get("name", "")),
+            full_name=str(repo.get("full_name", f"{owner}/{name}")),
+            description=repo.get("description"),
+            is_private=bool(repo.get("private", False)),
+            default_branch=str(repo.get("default_branch", "main")),
+            html_url=str(repo.get("html_url", "")),
+            updated_at=repo.get("updated_at"),
+        )
+
+    async def list_branches(self, token: str, repo: RepoRef) -> AsyncIterator[BranchInfo]:
+        page = 1
+        per_page = 100
+
+        while True:
+            branches = await self._request_json(
+                f"/repos/{repo.owner}/{repo.name}/branches?per_page={per_page}&page={page}",
+                token,
+            )
+            if not isinstance(branches, list) or len(branches) == 0:
+                return
+
+            for branch in branches:
+                if not isinstance(branch, dict):
+                    continue
+                commit = branch.get("commit", {})
+                if not isinstance(commit, dict):
+                    commit = {}
+                yield BranchInfo(
+                    name=str(branch.get("name", "")),
+                    commit_sha=str(commit.get("sha", "")),
+                    is_protected=bool(branch.get("protected", False)),
+                )
+
+            if len(branches) < per_page:
+                return
+            page += 1
+
+    async def get_commit_sha(self, token: str, repo: RepoRef, branch: str) -> str:
+        commit = await self._request_json(f"/repos/{repo.owner}/{repo.name}/commits/{branch}", token)
+        if not isinstance(commit, dict):
+            raise RepositoryProviderError(RepositoryProviderErrorCode.UNKNOWN, "Malformed GitHub response")
+        return str(commit.get("sha", ""))
+
+    async def walk_tree(
+        self, token: str, repo: RepoRef, branch: str, subpath: str | None = None
+    ) -> AsyncIterator[TreeEntry]:
+        tree_response = await self._request_json(f"/repos/{repo.owner}/{repo.name}/git/trees/{branch}?recursive=1", token)
+        if not isinstance(tree_response, dict):
+            raise RepositoryProviderError(RepositoryProviderErrorCode.UNKNOWN, "Malformed GitHub response")
+
+        tree = tree_response.get("tree", [])
+        if not isinstance(tree, list):
+            return
+
+        prefix = _normalize_subpath(subpath)
+        for entry in tree:
+            if not isinstance(entry, dict):
+                continue
+
+            path = str(entry.get("path", ""))
+            if not path:
+                continue
+            if prefix and not path.startswith(prefix):
+                continue
+
+            entry_type = _map_tree_type(str(entry.get("type", "")))
+            if not entry_type:
+                continue
+
+            yield TreeEntry(
+                path=path,
+                type=entry_type,
+                sha=str(entry.get("sha", "")),
+                size_bytes=int(entry.get("size", 0)),
+            )
+
+    async def read_file(self, token: str, repo: RepoRef, branch: str, path: str) -> ReadFileResult:
+        encoded_path = "/".join(httpx.QueryParams({"p": part})["p"] for part in path.split("/"))
+        file_response = await self._request_json(
+            f"/repos/{repo.owner}/{repo.name}/contents/{encoded_path}?ref={branch}",
+            token,
+        )
+        if not isinstance(file_response, dict):
+            raise RepositoryProviderError(RepositoryProviderErrorCode.UNKNOWN, "Malformed GitHub response")
+
+        content = str(file_response.get("content", "")).replace("\n", "")
+        return ReadFileResult(
+            content_base64=content,
+            sha=str(file_response.get("sha", "")),
+            size_bytes=int(file_response.get("size", 0)),
+        )
+
+    async def _request_json(self, path_with_query: str, token: str) -> Any:
+        headers = {
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        }
+
+        if self._client is not None:
+            return await _request_with_client(self._client, path_with_query, headers)
+
+        async with httpx.AsyncClient(base_url="https://api.github.com", timeout=20) as client:
+            return await _request_with_client(client, path_with_query, headers)
+
+
+async def _request_with_client(client: httpx.AsyncClient, path_with_query: str, headers: dict[str, str]) -> Any:
+    try:
+        response = await client.get(path_with_query, headers=headers)
+    except httpx.HTTPError as exc:
+        raise RepositoryProviderError(RepositoryProviderErrorCode.NETWORK, "Failed to reach GitHub API") from exc
+
+    if response.is_success:
+        return response.json()
+
+    body = response.text
+    if response.status_code == 401:
+        raise RepositoryProviderError(RepositoryProviderErrorCode.UNAUTHORIZED, "Unauthorized GitHub token", 401)
+    if response.status_code == 404:
+        raise RepositoryProviderError(RepositoryProviderErrorCode.NOT_FOUND, "GitHub resource not found", 404)
+    if response.status_code == 429 or _is_rate_limited(response.status_code, body, response.headers):
+        raise RepositoryProviderError(RepositoryProviderErrorCode.RATE_LIMITED, "GitHub API rate limit exceeded", 429)
+    raise RepositoryProviderError(
+        RepositoryProviderErrorCode.UNKNOWN,
+        f"Unexpected GitHub API error: {response.status_code}",
+        response.status_code,
+    )
+
+
+def _is_rate_limited(status_code: int, body: str, headers: httpx.Headers) -> bool:
+    if status_code != 403:
+        return False
+    if headers.get("x-ratelimit-remaining") == "0":
+        return True
+    return "rate limit" in body.lower()
+
+
+def _normalize_subpath(subpath: str | None) -> str:
+    if not subpath:
+        return ""
+    trimmed = subpath.strip("/")
+    if not trimmed:
+        return ""
+    return f"{trimmed}/"
+
+
+def _map_tree_type(raw: str) -> str | None:
+    if raw == "blob":
+        return "file"
+    if raw == "tree":
+        return "dir"
+    if raw == "symlink":
+        return "symlink"
+    if raw == "commit":
+        return "submodule"
+    return None

--- a/objectified-rest/tests/repositories/providers/test_github_repository_provider.py
+++ b/objectified-rest/tests/repositories/providers/test_github_repository_provider.py
@@ -1,0 +1,106 @@
+import json
+
+import httpx
+import pytest
+
+from app.repositories.providers import (
+    GithubRepositoryProvider,
+    RepoRef,
+    RepositoryProviderError,
+    RepositoryProviderErrorCode,
+)
+
+
+def _json_response(status: int, payload: object, headers: dict[str, str] | None = None) -> httpx.Response:
+    return httpx.Response(status, headers=headers, content=json.dumps(payload).encode("utf-8"))
+
+
+@pytest.mark.asyncio
+async def test_github_provider_contract_methods() -> None:
+    call_index = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal call_index
+        call_index += 1
+
+        if call_index == 1:
+            assert request.headers["Authorization"] == "Bearer token-a"
+            return _json_response(
+                200,
+                [
+                    {
+                        "id": 1,
+                        "name": "repo-a",
+                        "full_name": "acme/repo-a",
+                        "description": "demo",
+                        "private": False,
+                        "default_branch": "main",
+                        "html_url": "https://github.com/acme/repo-a",
+                        "updated_at": "2026-01-01T00:00:00Z",
+                    }
+                ],
+            )
+        if call_index == 2:
+            return _json_response(
+                200,
+                {
+                    "id": 1,
+                    "name": "repo-a",
+                    "full_name": "acme/repo-a",
+                    "description": "demo",
+                    "private": False,
+                    "default_branch": "main",
+                    "html_url": "https://github.com/acme/repo-a",
+                    "updated_at": "2026-01-01T00:00:00Z",
+                },
+            )
+        if call_index == 3:
+            return _json_response(200, [{"name": "main", "protected": True, "commit": {"sha": "abc123"}}])
+        if call_index == 4:
+            return _json_response(200, {"sha": "abc123"})
+        if call_index == 5:
+            return _json_response(
+                200,
+                {
+                    "tree": [
+                        {"path": "docs/readme.md", "type": "blob", "sha": "s1", "size": 10},
+                        {"path": "src/index.ts", "type": "blob", "sha": "s2", "size": 11},
+                    ]
+                },
+            )
+        return _json_response(200, {"content": "YQ==", "sha": "f1", "size": 1})
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(base_url="https://api.github.com", transport=transport) as client:
+        provider = GithubRepositoryProvider(client)
+
+        repos = [repo async for repo in provider.list_repositories("token-a")]
+        repo = await provider.get_repository("token-a", "acme", "repo-a")
+        branches = [branch async for branch in provider.list_branches("token-a", RepoRef(owner="acme", name="repo-a"))]
+        sha = await provider.get_commit_sha("token-a", RepoRef(owner="acme", name="repo-a"), "main")
+        tree = [
+            item
+            async for item in provider.walk_tree("token-a", RepoRef(owner="acme", name="repo-a"), "main", subpath="docs")
+        ]
+        read_file = await provider.read_file("token-a", RepoRef(owner="acme", name="repo-a"), "main", "docs/readme.md")
+
+    assert len(repos) == 1
+    assert repo.full_name == "acme/repo-a"
+    assert [branch.name for branch in branches] == ["main"]
+    assert sha == "abc123"
+    assert [entry.path for entry in tree] == ["docs/readme.md"]
+    assert read_file.content_base64 == "YQ=="
+
+
+@pytest.mark.asyncio
+async def test_github_provider_normalizes_errors() -> None:
+    def rate_limit_handler(request: httpx.Request) -> httpx.Response:
+        return _json_response(403, {"message": "API rate limit exceeded"}, headers={"x-ratelimit-remaining": "0"})
+
+    transport = httpx.MockTransport(rate_limit_handler)
+    async with httpx.AsyncClient(base_url="https://api.github.com", transport=transport) as client:
+        provider = GithubRepositoryProvider(client)
+        with pytest.raises(RepositoryProviderError) as exc:
+            await provider.get_repository("token-z", "acme", "repo-a")
+
+    assert exc.value.code == RepositoryProviderErrorCode.RATE_LIMITED

--- a/objectified-ui/jest.config.ts
+++ b/objectified-ui/jest.config.ts
@@ -3,7 +3,7 @@ import type { Config } from 'jest';
 const config: Config = {
   preset: 'ts-jest',
   testEnvironment: 'jsdom', // Changed from 'node' to support React components
-  roots: ['<rootDir>/tests'],
+  roots: ['<rootDir>/tests', '<rootDir>/lib/repositories/providers/__tests__'],
   testMatch: ['**/*.test.ts', '**/*.test.tsx'], // Added tsx
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
   collectCoverageFrom: [

--- a/objectified-ui/lib/repositories/providers/__tests__/contract.test.ts
+++ b/objectified-ui/lib/repositories/providers/__tests__/contract.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { GithubRepositoryProvider } from '../github-provider';
+import { RepositoryProviderError } from '../repository-provider';
+
+function jsonResponse(
+  body: unknown,
+  init?: { status?: number; headers?: Record<string, string> }
+): Response {
+  const status = init?.status ?? 200;
+  const headersMap = new Map<string, string>(
+    Object.entries(init?.headers ?? {}).map(([key, value]) => [key.toLowerCase(), value])
+  );
+
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: {
+      get: (name: string) => headersMap.get(name.toLowerCase()) ?? null,
+    } as Headers,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as Response;
+}
+
+async function collect<T>(iterable: AsyncIterable<T>): Promise<T[]> {
+  const list: T[] = [];
+  for await (const item of iterable) {
+    list.push(item);
+  }
+  return list;
+}
+
+describe('RepositoryProvider contract', () => {
+  it('implements every contract method for GitHub', async () => {
+    const fetchMock = jest
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        jsonResponse([
+          {
+            id: 1,
+            name: 'repo-a',
+            full_name: 'acme/repo-a',
+            description: 'A',
+            private: false,
+            default_branch: 'main',
+            html_url: 'https://github.com/acme/repo-a',
+            updated_at: '2026-01-01T00:00:00Z',
+          },
+        ])
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          id: 1,
+          name: 'repo-a',
+          full_name: 'acme/repo-a',
+          description: 'A',
+          private: false,
+          default_branch: 'main',
+          html_url: 'https://github.com/acme/repo-a',
+          updated_at: '2026-01-01T00:00:00Z',
+        })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse([
+          { name: 'main', protected: true, commit: { sha: 'abc123' } },
+          { name: 'dev', protected: false, commit: { sha: 'def456' } },
+        ])
+      )
+      .mockResolvedValueOnce(jsonResponse({ sha: 'abc123' }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          tree: [
+            { path: 'docs/readme.md', type: 'blob', sha: 's1', size: 4 },
+            { path: 'docs', type: 'tree', sha: 's2', size: 0 },
+            { path: 'src/index.ts', type: 'blob', sha: 's3', size: 10 },
+          ],
+        })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          content: 'Y29udGVudA==',
+          sha: 'f1',
+          size: 7,
+        })
+      );
+
+    const provider = new GithubRepositoryProvider(fetchMock);
+
+    const repos = await collect(provider.listRepositories('token-1'));
+    const repo = await provider.getRepository('token-1', 'acme', 'repo-a');
+    const branches = await collect(provider.listBranches('token-1', { owner: 'acme', name: 'repo-a' }));
+    const sha = await provider.getCommitSha('token-1', { owner: 'acme', name: 'repo-a' }, 'main');
+    const tree = await collect(provider.walkTree('token-1', { owner: 'acme', name: 'repo-a' }, 'main', 'docs'));
+    const file = await provider.readFile('token-1', { owner: 'acme', name: 'repo-a' }, 'main', 'docs/readme.md');
+
+    expect(repos).toHaveLength(1);
+    expect(repo.fullName).toBe('acme/repo-a');
+    expect(branches.map((b) => b.name)).toEqual(['main', 'dev']);
+    expect(sha).toBe('abc123');
+    expect(tree.map((entry) => entry.path)).toEqual(['docs/readme.md']);
+    expect(file).toEqual({ contentBase64: 'Y29udGVudA==', sha: 'f1', sizeBytes: 7 });
+  });
+
+  it('never caches token and forwards it per call', async () => {
+    const fetchMock = jest
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(jsonResponse([]))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          id: 1,
+          name: 'repo-a',
+          full_name: 'acme/repo-a',
+          description: null,
+          private: false,
+          default_branch: 'main',
+          html_url: 'https://github.com/acme/repo-a',
+          updated_at: null,
+        })
+      );
+    const provider = new GithubRepositoryProvider(fetchMock);
+
+    await collect(provider.listRepositories('token-A'));
+    await provider.getRepository('token-B', 'acme', 'repo-a');
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[0]?.[1]).toMatchObject({
+      headers: expect.objectContaining({ Authorization: 'Bearer token-A' }),
+    });
+    expect(fetchMock.mock.calls[1]?.[1]).toMatchObject({
+      headers: expect.objectContaining({ Authorization: 'Bearer token-B' }),
+    });
+  });
+
+  it('normalizes provider errors to the shared taxonomy', async () => {
+    const unauthorized = new GithubRepositoryProvider(
+      jest.fn<typeof fetch>().mockResolvedValueOnce(jsonResponse({ message: 'bad token' }, { status: 401 }))
+    );
+    const notFound = new GithubRepositoryProvider(
+      jest.fn<typeof fetch>().mockResolvedValueOnce(jsonResponse({ message: 'missing' }, { status: 404 }))
+    );
+    const rateLimited = new GithubRepositoryProvider(
+      jest.fn<typeof fetch>().mockResolvedValueOnce(
+        jsonResponse(
+          { message: 'API rate limit exceeded' },
+          { status: 403, headers: { 'x-ratelimit-remaining': '0' } }
+        )
+      )
+    );
+    const network = new GithubRepositoryProvider(
+      jest.fn<typeof fetch>().mockRejectedValueOnce(new TypeError('network down'))
+    );
+    const unknown = new GithubRepositoryProvider(
+      jest.fn<typeof fetch>().mockResolvedValueOnce(jsonResponse({ message: 'boom' }, { status: 500 }))
+    );
+
+    await expect(unauthorized.getRepository('t', 'a', 'b')).rejects.toMatchObject<Partial<RepositoryProviderError>>({
+      code: 'UNAUTHORIZED',
+    });
+    await expect(notFound.getRepository('t', 'a', 'b')).rejects.toMatchObject<Partial<RepositoryProviderError>>({
+      code: 'NOT_FOUND',
+    });
+    await expect(rateLimited.getRepository('t', 'a', 'b')).rejects.toMatchObject<Partial<RepositoryProviderError>>({
+      code: 'RATE_LIMITED',
+    });
+    await expect(network.getRepository('t', 'a', 'b')).rejects.toMatchObject<Partial<RepositoryProviderError>>({
+      code: 'NETWORK',
+    });
+    await expect(unknown.getRepository('t', 'a', 'b')).rejects.toMatchObject<Partial<RepositoryProviderError>>({
+      code: 'UNKNOWN',
+    });
+  });
+});

--- a/objectified-ui/lib/repositories/providers/github-provider.ts
+++ b/objectified-ui/lib/repositories/providers/github-provider.ts
@@ -18,7 +18,7 @@ export class GithubRepositoryProvider implements RepositoryProvider {
   }
 
   async *listRepositories(token: string, opts?: ListReposOpts): AsyncIterable<RepoSummary> {
-    const perPage = opts?.perPage ?? 100;
+    const perPage = Math.min(opts?.perPage ?? 100, 100);
     let page = opts?.page ?? 1;
     const sort = opts?.sort ?? 'updated';
 
@@ -169,17 +169,24 @@ export class GithubRepositoryProvider implements RepositoryProvider {
     }
   }
 
+  private encodeContentPath(path: string): string {
+    return path
+      .replace(/^\/+|\/+$/g, '')
+      .split('/')
+      .filter((segment) => segment.length > 0)
+      .map((segment) => encodeURIComponent(segment))
+      .join('/');
+  }
+
   async readFile(
     token: string,
     repo: RepoRef,
     branch: string,
     path: string
   ): Promise<{ contentBase64: string; sha: string; sizeBytes: number }> {
+    const encodedPath = this.encodeContentPath(path);
     const content = await this.requestJson<Record<string, unknown>>({
-      path: `/repos/${encodeURIComponent(repo.owner)}/${encodeURIComponent(repo.name)}/contents/${path
-        .split('/')
-        .map((segment) => encodeURIComponent(segment))
-        .join('/')}`,
+      path: `/repos/${encodeURIComponent(repo.owner)}/${encodeURIComponent(repo.name)}/contents${encodedPath ? `/${encodedPath}` : ''}`,
       token,
       query: { ref: branch },
     });

--- a/objectified-ui/lib/repositories/providers/github-provider.ts
+++ b/objectified-ui/lib/repositories/providers/github-provider.ts
@@ -1,0 +1,277 @@
+import { RepositoryProviderError, type RepositoryProvider } from './repository-provider';
+import type { BranchInfo, ListReposOpts, RepoDetail, RepoRef, RepoSummary, TreeEntry } from './types';
+
+type FetchFn = typeof fetch;
+
+interface RequestJsonOptions {
+  path: string;
+  token: string;
+  query?: Record<string, string | number | undefined>;
+}
+
+export class GithubRepositoryProvider implements RepositoryProvider {
+  readonly id = 'github' as const;
+  private readonly fetchFn: FetchFn;
+
+  constructor(fetchFn?: FetchFn) {
+    this.fetchFn = fetchFn ?? fetch;
+  }
+
+  async *listRepositories(token: string, opts?: ListReposOpts): AsyncIterable<RepoSummary> {
+    const perPage = opts?.perPage ?? 100;
+    let page = opts?.page ?? 1;
+    const sort = opts?.sort ?? 'updated';
+
+    while (true) {
+      const repositories = await this.requestJson<unknown[]>({
+        path: '/user/repos',
+        token,
+        query: {
+          per_page: perPage,
+          page,
+          sort,
+          visibility: opts?.visibility,
+        },
+      });
+
+      if (!Array.isArray(repositories) || repositories.length === 0) {
+        return;
+      }
+
+      for (const entry of repositories) {
+        if (!entry || typeof entry !== 'object') {
+          continue;
+        }
+
+        const repo = entry as Record<string, unknown>;
+        yield {
+          id: String(repo.id ?? ''),
+          name: String(repo.name ?? ''),
+          fullName: String(repo.full_name ?? ''),
+          description: typeof repo.description === 'string' ? repo.description : null,
+          isPrivate: Boolean(repo.private),
+          defaultBranch: typeof repo.default_branch === 'string' ? repo.default_branch : 'main',
+          htmlUrl: String(repo.html_url ?? ''),
+          updatedAt: typeof repo.updated_at === 'string' ? repo.updated_at : null,
+        };
+      }
+
+      if (repositories.length < perPage) {
+        return;
+      }
+
+      page += 1;
+    }
+  }
+
+  async getRepository(token: string, owner: string, name: string): Promise<RepoDetail> {
+    const repo = await this.requestJson<Record<string, unknown>>({
+      path: `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(name)}`,
+      token,
+    });
+
+    return {
+      id: String(repo.id ?? ''),
+      name: String(repo.name ?? ''),
+      fullName: String(repo.full_name ?? `${owner}/${name}`),
+      description: typeof repo.description === 'string' ? repo.description : null,
+      isPrivate: Boolean(repo.private),
+      defaultBranch: typeof repo.default_branch === 'string' ? repo.default_branch : 'main',
+      htmlUrl: String(repo.html_url ?? ''),
+      updatedAt: typeof repo.updated_at === 'string' ? repo.updated_at : null,
+    };
+  }
+
+  async *listBranches(token: string, repo: RepoRef): AsyncIterable<BranchInfo> {
+    let page = 1;
+    const perPage = 100;
+
+    while (true) {
+      const response = await this.requestJson<unknown[]>({
+        path: `/repos/${encodeURIComponent(repo.owner)}/${encodeURIComponent(repo.name)}/branches`,
+        token,
+        query: { per_page: perPage, page },
+      });
+
+      if (!Array.isArray(response) || response.length === 0) {
+        return;
+      }
+
+      for (const branch of response) {
+        if (!branch || typeof branch !== 'object') {
+          continue;
+        }
+
+        const raw = branch as Record<string, unknown>;
+        const commit = (raw.commit as Record<string, unknown> | undefined) ?? {};
+        yield {
+          name: String(raw.name ?? ''),
+          commitSha: String(commit.sha ?? ''),
+          isProtected: Boolean(raw.protected),
+        };
+      }
+
+      if (response.length < perPage) {
+        return;
+      }
+
+      page += 1;
+    }
+  }
+
+  async getCommitSha(token: string, repo: RepoRef, branch: string): Promise<string> {
+    const commit = await this.requestJson<Record<string, unknown>>({
+      path: `/repos/${encodeURIComponent(repo.owner)}/${encodeURIComponent(repo.name)}/commits/${encodeURIComponent(branch)}`,
+      token,
+    });
+    return String(commit.sha ?? '');
+  }
+
+  async *walkTree(token: string, repo: RepoRef, branch: string, subpath?: string): AsyncIterable<TreeEntry> {
+    const normalizedSubpath = normalizeSubpath(subpath);
+    const response = await this.requestJson<Record<string, unknown>>({
+      path: `/repos/${encodeURIComponent(repo.owner)}/${encodeURIComponent(repo.name)}/git/trees/${encodeURIComponent(branch)}`,
+      token,
+      query: { recursive: 1 },
+    });
+    const tree = response.tree;
+
+    if (!Array.isArray(tree)) {
+      return;
+    }
+
+    for (const item of tree) {
+      if (!item || typeof item !== 'object') {
+        continue;
+      }
+
+      const raw = item as Record<string, unknown>;
+      const rawPath = String(raw.path ?? '');
+      if (!rawPath) {
+        continue;
+      }
+
+      if (normalizedSubpath && !rawPath.startsWith(normalizedSubpath)) {
+        continue;
+      }
+
+      const type = mapTreeType(raw.type);
+      if (!type) {
+        continue;
+      }
+
+      yield {
+        path: rawPath,
+        type,
+        sha: String(raw.sha ?? ''),
+        sizeBytes: Number(raw.size ?? 0),
+      };
+    }
+  }
+
+  async readFile(
+    token: string,
+    repo: RepoRef,
+    branch: string,
+    path: string
+  ): Promise<{ contentBase64: string; sha: string; sizeBytes: number }> {
+    const content = await this.requestJson<Record<string, unknown>>({
+      path: `/repos/${encodeURIComponent(repo.owner)}/${encodeURIComponent(repo.name)}/contents/${path
+        .split('/')
+        .map((segment) => encodeURIComponent(segment))
+        .join('/')}`,
+      token,
+      query: { ref: branch },
+    });
+
+    const rawContent = typeof content.content === 'string' ? content.content : '';
+    return {
+      contentBase64: rawContent.replace(/\n/g, ''),
+      sha: String(content.sha ?? ''),
+      sizeBytes: Number(content.size ?? 0),
+    };
+  }
+
+  private async requestJson<T>({ path, token, query }: RequestJsonOptions): Promise<T> {
+    const searchParams = new URLSearchParams();
+    for (const [key, value] of Object.entries(query ?? {})) {
+      if (value !== undefined) {
+        searchParams.set(key, String(value));
+      }
+    }
+    const suffix = searchParams.size > 0 ? `?${searchParams.toString()}` : '';
+    const url = `https://api.github.com${path}${suffix}`;
+
+    let response: Response;
+    try {
+      response = await this.fetchFn(url, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: 'application/vnd.github+json',
+          'X-GitHub-Api-Version': '2022-11-28',
+        },
+      });
+    } catch (error) {
+      throw new RepositoryProviderError('NETWORK', 'Failed to reach GitHub API', undefined, { cause: error });
+    }
+
+    if (!response.ok) {
+      const body = await response.text();
+      throw normalizeError(response.status, body, response.headers);
+    }
+
+    return (await response.json()) as T;
+  }
+}
+
+function normalizeSubpath(subpath?: string): string {
+  if (!subpath) {
+    return '';
+  }
+  const trimmed = subpath.replace(/^\/+/, '').replace(/\/+$/, '');
+  if (!trimmed) {
+    return '';
+  }
+  return `${trimmed}/`;
+}
+
+function mapTreeType(value: unknown): TreeEntry['type'] | null {
+  switch (value) {
+    case 'blob':
+      return 'file';
+    case 'tree':
+      return 'dir';
+    case 'symlink':
+      return 'symlink';
+    case 'commit':
+      return 'submodule';
+    default:
+      return null;
+  }
+}
+
+function normalizeError(status: number, body: string, headers: Headers): RepositoryProviderError {
+  if (status === 401) {
+    return new RepositoryProviderError('UNAUTHORIZED', 'Unauthorized GitHub token', status);
+  }
+  if (status === 404) {
+    return new RepositoryProviderError('NOT_FOUND', 'GitHub resource not found', status);
+  }
+  if (status === 429 || isRateLimited(status, body, headers)) {
+    return new RepositoryProviderError('RATE_LIMITED', 'GitHub API rate limit exceeded', status);
+  }
+  return new RepositoryProviderError('UNKNOWN', 'Unexpected GitHub API error', status);
+}
+
+function isRateLimited(status: number, body: string, headers: Headers): boolean {
+  if (status !== 403) {
+    return false;
+  }
+
+  const remaining = headers.get('x-ratelimit-remaining');
+  if (remaining === '0') {
+    return true;
+  }
+
+  return body.toLowerCase().includes('rate limit');
+}

--- a/objectified-ui/lib/repositories/providers/github-provider.ts
+++ b/objectified-ui/lib/repositories/providers/github-provider.ts
@@ -9,6 +9,8 @@ interface RequestJsonOptions {
   query?: Record<string, string | number | undefined>;
 }
 
+const GITHUB_MAX_PER_PAGE = 100;
+
 export class GithubRepositoryProvider implements RepositoryProvider {
   readonly id = 'github' as const;
   private readonly fetchFn: FetchFn;
@@ -18,7 +20,7 @@ export class GithubRepositoryProvider implements RepositoryProvider {
   }
 
   async *listRepositories(token: string, opts?: ListReposOpts): AsyncIterable<RepoSummary> {
-    const perPage = Math.min(opts?.perPage ?? 100, 100);
+    const perPage = Math.min(opts?.perPage ?? GITHUB_MAX_PER_PAGE, GITHUB_MAX_PER_PAGE);
     let page = opts?.page ?? 1;
     const sort = opts?.sort ?? 'updated';
 
@@ -186,7 +188,7 @@ export class GithubRepositoryProvider implements RepositoryProvider {
   ): Promise<{ contentBase64: string; sha: string; sizeBytes: number }> {
     const encodedPath = this.encodeContentPath(path);
     const content = await this.requestJson<Record<string, unknown>>({
-      path: `/repos/${encodeURIComponent(repo.owner)}/${encodeURIComponent(repo.name)}/contents${encodedPath ? `/${encodedPath}` : ''}`,
+      path: `/repos/${encodeURIComponent(repo.owner)}/${encodeURIComponent(repo.name)}/contents/${encodedPath}`,
       token,
       query: { ref: branch },
     });

--- a/objectified-ui/lib/repositories/providers/index.ts
+++ b/objectified-ui/lib/repositories/providers/index.ts
@@ -1,0 +1,13 @@
+export { GithubRepositoryProvider } from './github-provider';
+export { RepositoryProviderError, type RepositoryProvider } from './repository-provider';
+export type {
+  BranchInfo,
+  ListReposOpts,
+  RepoDetail,
+  RepoRef,
+  RepoSummary,
+  RepositoryProviderErrorCode,
+  RepositoryProviderId,
+  TreeEntry,
+  WebhookTarget,
+} from './types';

--- a/objectified-ui/lib/repositories/providers/repository-provider.ts
+++ b/objectified-ui/lib/repositories/providers/repository-provider.ts
@@ -1,0 +1,43 @@
+import type {
+  BranchInfo,
+  ListReposOpts,
+  RepoDetail,
+  RepoRef,
+  RepoSummary,
+  RepositoryProviderErrorCode,
+  RepositoryProviderId,
+  TreeEntry,
+  WebhookTarget,
+} from './types';
+
+export class RepositoryProviderError extends Error {
+  readonly code: RepositoryProviderErrorCode;
+  readonly status?: number;
+
+  constructor(code: RepositoryProviderErrorCode, message: string, status?: number, options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'RepositoryProviderError';
+    this.code = code;
+    this.status = status;
+  }
+}
+
+export interface RepositoryProvider {
+  readonly id: RepositoryProviderId;
+
+  listRepositories(token: string, opts?: ListReposOpts): AsyncIterable<RepoSummary>;
+  getRepository(token: string, owner: string, name: string): Promise<RepoDetail>;
+  listBranches(token: string, repo: RepoRef): AsyncIterable<BranchInfo>;
+  getCommitSha(token: string, repo: RepoRef, branch: string): Promise<string>;
+  walkTree(token: string, repo: RepoRef, branch: string, subpath?: string): AsyncIterable<TreeEntry>;
+  readFile(
+    token: string,
+    repo: RepoRef,
+    branch: string,
+    path: string
+  ): Promise<{ contentBase64: string; sha: string; sizeBytes: number }>;
+
+  registerWebhook?(token: string, repo: RepoRef, target: WebhookTarget): Promise<{ id: string; secret: string }>;
+  removeWebhook?(token: string, repo: RepoRef, id: string): Promise<void>;
+  verifyWebhookSignature?(secret: string, headers: Headers, body: string): boolean;
+}

--- a/objectified-ui/lib/repositories/providers/types.ts
+++ b/objectified-ui/lib/repositories/providers/types.ts
@@ -1,0 +1,51 @@
+export type RepositoryProviderId = 'github' | 'gitlab' | 'bitbucket' | 'azure_devops';
+
+export interface ListReposOpts {
+  perPage?: number;
+  page?: number;
+  sort?: 'created' | 'updated' | 'pushed' | 'full_name';
+  visibility?: 'all' | 'public' | 'private';
+}
+
+export interface RepoRef {
+  owner: string;
+  name: string;
+}
+
+export interface RepoSummary {
+  id: string;
+  name: string;
+  fullName: string;
+  description: string | null;
+  isPrivate: boolean;
+  defaultBranch: string;
+  htmlUrl: string;
+  updatedAt: string | null;
+}
+
+export interface RepoDetail extends RepoSummary {}
+
+export interface BranchInfo {
+  name: string;
+  commitSha: string;
+  isProtected: boolean;
+}
+
+export interface TreeEntry {
+  path: string;
+  type: 'file' | 'dir' | 'symlink' | 'submodule';
+  sha: string;
+  sizeBytes: number;
+}
+
+export interface WebhookTarget {
+  url: string;
+  events: string[];
+}
+
+export type RepositoryProviderErrorCode =
+  | 'RATE_LIMITED'
+  | 'UNAUTHORIZED'
+  | 'NOT_FOUND'
+  | 'NETWORK'
+  | 'UNKNOWN';

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.10.18",
+  "version": "0.10.19",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -5,6 +5,7 @@ We continue to improve the platform based on your feedback with improvements and
 ---
 
 - Added repository connector MVP database tables for repository registration, branch tracking, and linked-account credential references.
+- Added a provider abstraction layer for repository connectors with a GitHub adapter, shared provider error taxonomy, and cross-provider contract tests.
 
 ## UI
 - Branch workflow is its own button in the canvas now, and compacted to fit most functionality that's in Versions now.
@@ -43,5 +44,5 @@ We'd love to hear your thoughts! Your feedback helps us make Objectified better.
 
 **Thank you for using Objectified!**
 
-*Last updated: April 22, 2026*
+*Last updated: April 23, 2026*
 


### PR DESCRIPTION
## Summary
- Adds a shared `RepositoryProvider` abstraction for repository connectors in `objectified-ui` and `objectified-rest`.
- Implements the first concrete adapter, `GithubRepositoryProvider`, with normalized `RepositoryProviderError` taxonomy (`RATE_LIMITED`, `UNAUTHORIZED`, `NOT_FOUND`, `NETWORK`, `UNKNOWN`) and token-passthrough semantics (no token caching).
- Introduces provider contract tests covering every interface method in `objectified-ui/lib/repositories/providers/__tests__/contract.test.ts` and mirrors Python adapter coverage in REST tests.

## How to test
- Run **`yarn workspace objectified-ui test contract.test.ts`** and verify the repository provider contract suite passes.
- Run **`yarn build`** from the monorepo root and verify all workspace builds succeed.
- Run **`yarn test`** from the monorepo root (currently blocked by pre-existing `tests/llm-streaming.test.ts` failure: `TypeError: (0 , _prettyFormat.format) is not a function`).
- Run **`pytest tests/repositories/providers/test_github_repository_provider.py`** inside `objectified-rest` once Python test tooling is installed.

## Risk / notes
- This change introduces new provider modules but does not switch existing API routes to the abstraction yet, minimizing immediate runtime risk.
- Python test execution is environment-dependent; the current machine lacks `pytest`/`uv`.

Fixes #2754

Made with [Cursor](https://cursor.com)