### PR TITLE
Fix #2755 - add linked-account token resolver

### DIFF
--- a/objectified-ui/lib/repositories/providers/__tests__/resolve-repository-token.test.ts
+++ b/objectified-ui/lib/repositories/providers/__tests__/resolve-repository-token.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it, jest } from '@jest/globals';
+
+import {
+  createResolveRepositoryTokenResolver,
+  RepositoryTokenResolutionError,
+} from '../resolve-repository-token';
+
+type QueryResult = { rowCount: number; rows: Record<string, unknown>[] };
+
+function makeQueryStub(handlers: Array<(sql: string, params: unknown[]) => QueryResult>): jest.MockedFunction<
+  (sql: string, params: unknown[]) => Promise<QueryResult>
+> {
+  let index = 0;
+  return jest.fn(async (sql: string, params: unknown[]) => {
+    const handler = handlers[index];
+    if (!handler) {
+      throw new Error(`Unexpected query #${index + 1}: ${sql}`);
+    }
+    index += 1;
+    return handler(sql, params);
+  });
+}
+
+describe('resolveRepositoryToken', () => {
+  it('returns in-memory token for active linked account and writes success audit without token payload', async () => {
+    const query = makeQueryStub([
+      () => ({
+        rowCount: 1,
+        rows: [
+          {
+            linked_account_id: 'linked-1',
+            scopes: ['repo', 'read:org'],
+            project_id: 'project-1',
+            provider: 'github',
+            user_id: 'user-1',
+            access_token: 'access-live',
+            refresh_token: null,
+            token_expires_at: '2030-01-01T00:00:00.000Z',
+          },
+        ],
+      }),
+      (sql, params) => {
+        expect(sql).toContain('INSERT INTO odb.workflow_audit');
+        const detail = JSON.parse(String(params[5]));
+        expect(detail).toEqual({
+          repository_id: 'repo-1',
+          linked_account_id: 'linked-1',
+          provider: 'github',
+          result: 'success',
+        });
+        expect(JSON.stringify(detail)).not.toContain('access-live');
+        return { rowCount: 1, rows: [] };
+      },
+    ]);
+
+    const resolveRepositoryToken = createResolveRepositoryTokenResolver({
+      query,
+      now: () => new Date('2026-04-23T00:00:00.000Z'),
+      refreshers: {},
+    });
+
+    const resolved = await resolveRepositoryToken('repo-1', { tenantId: 'tenant-1', userId: 'user-1' }, ['repo']);
+
+    expect(resolved).toMatchObject({
+      repositoryId: 'repo-1',
+      linkedAccountId: 'linked-1',
+      provider: 'github',
+      accessToken: 'access-live',
+    });
+  });
+
+  it('refreshes expired token when provider refresher exists and persists new token values', async () => {
+    const query = makeQueryStub([
+      () => ({
+        rowCount: 1,
+        rows: [
+          {
+            linked_account_id: 'linked-2',
+            scopes: ['repo'],
+            project_id: null,
+            provider: 'custom',
+            user_id: 'user-2',
+            access_token: 'old-token',
+            refresh_token: 'refresh-2',
+            token_expires_at: '2025-01-01T00:00:00.000Z',
+          },
+        ],
+      }),
+      (sql, params) => {
+        expect(sql).toContain('UPDATE odb.external_auth_providers');
+        expect(params).toEqual([
+          'new-token',
+          'new-refresh',
+          new Date('2026-06-01T00:00:00.000Z'),
+          'linked-2',
+        ]);
+        return { rowCount: 1, rows: [] };
+      },
+      (sql, params) => {
+        expect(sql).toContain('INSERT INTO odb.workflow_audit');
+        const detail = JSON.parse(String(params[5]));
+        expect(detail.result).toBe('success');
+        expect(JSON.stringify(detail)).not.toContain('new-token');
+        return { rowCount: 1, rows: [] };
+      },
+    ]);
+
+    const resolveRepositoryToken = createResolveRepositoryTokenResolver({
+      query,
+      now: () => new Date('2026-04-23T00:00:00.000Z'),
+      refreshers: {
+        custom: async () => ({
+          accessToken: 'new-token',
+          refreshToken: 'new-refresh',
+          expiresAt: new Date('2026-06-01T00:00:00.000Z'),
+        }),
+      },
+    });
+
+    const resolved = await resolveRepositoryToken('repo-2', { tenantId: 'tenant-2', userId: 'user-2' });
+
+    expect(resolved.accessToken).toBe('new-token');
+    expect(resolved.expiresAt?.toISOString()).toBe('2026-06-01T00:00:00.000Z');
+  });
+
+  it('raises typed errors and writes failure audit without token payloads', async () => {
+    const query = makeQueryStub([
+      () => ({
+        rowCount: 1,
+        rows: [
+          {
+            linked_account_id: 'linked-3',
+            scopes: ['repo'],
+            project_id: 'project-3',
+            provider: 'github',
+            user_id: 'user-3',
+            access_token: 'expired-token',
+            refresh_token: null,
+            token_expires_at: '2020-01-01T00:00:00.000Z',
+          },
+        ],
+      }),
+      (sql, params) => {
+        expect(sql).toContain('INSERT INTO odb.workflow_audit');
+        const detail = JSON.parse(String(params[5]));
+        expect(detail).toEqual({
+          repository_id: 'repo-3',
+          linked_account_id: 'linked-3',
+          provider: 'github',
+          result: 'failure',
+        });
+        expect(JSON.stringify(detail)).not.toContain('expired-token');
+        return { rowCount: 1, rows: [] };
+      },
+    ]);
+
+    const resolveRepositoryToken = createResolveRepositoryTokenResolver({
+      query,
+      now: () => new Date('2026-04-23T00:00:00.000Z'),
+      refreshers: {},
+    });
+
+    await expect(
+      resolveRepositoryToken('repo-3', { tenantId: 'tenant-3', userId: 'user-3' })
+    ).rejects.toMatchObject<Partial<RepositoryTokenResolutionError>>({
+      code: 'TOKEN_EXPIRED_NO_REFRESH',
+    });
+  });
+});

--- a/objectified-ui/lib/repositories/providers/index.ts
+++ b/objectified-ui/lib/repositories/providers/index.ts
@@ -1,5 +1,11 @@
 export { GithubRepositoryProvider } from './github-provider';
 export { RepositoryProviderError, type RepositoryProvider } from './repository-provider';
+export {
+  createResolveRepositoryTokenResolver,
+  RepositoryTokenResolutionError,
+  resolveRepositoryToken,
+  type ScopedRepositoryToken,
+} from './resolve-repository-token';
 export type {
   BranchInfo,
   ListReposOpts,

--- a/objectified-ui/lib/repositories/providers/resolve-repository-token.ts
+++ b/objectified-ui/lib/repositories/providers/resolve-repository-token.ts
@@ -1,0 +1,299 @@
+'use server';
+
+const connectionPool = require('../../db/db');
+
+type RepositoryTokenErrorCode =
+  | 'TOKEN_REVOKED'
+  | 'TOKEN_EXPIRED_NO_REFRESH'
+  | 'LINKED_ACCOUNT_REMOVED'
+  | 'INSUFFICIENT_SCOPE';
+
+interface UserContext {
+  tenantId: string;
+  userId: string;
+}
+
+interface LinkedAccountTokenRow {
+  linked_account_id: string;
+  scopes: string[] | null;
+  project_id: string | null;
+  provider: string;
+  user_id: string;
+  access_token: string | null;
+  refresh_token: string | null;
+  token_expires_at: Date | string | null;
+}
+
+interface RefreshedTokenBundle {
+  accessToken: string;
+  refreshToken?: string | null;
+  expiresAt: Date | null;
+}
+
+interface TokenRefresherInput {
+  refreshToken: string;
+  provider: string;
+  linkedAccountId: string;
+  userContext: UserContext;
+}
+
+type TokenRefresher = (input: TokenRefresherInput) => Promise<RefreshedTokenBundle>;
+
+interface ResolveRepositoryTokenDeps {
+  query: (sql: string, params: unknown[]) => Promise<{ rowCount: number | null; rows: Record<string, unknown>[] }>;
+  now: () => Date;
+  refreshers: Partial<Record<string, TokenRefresher>>;
+}
+
+export interface ScopedRepositoryToken {
+  repositoryId: string;
+  linkedAccountId: string;
+  provider: string;
+  accessToken: string;
+  expiresAt: Date | null;
+}
+
+export class RepositoryTokenResolutionError extends Error {
+  readonly code: RepositoryTokenErrorCode;
+
+  constructor(code: RepositoryTokenErrorCode, message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'RepositoryTokenResolutionError';
+    this.code = code;
+  }
+}
+
+function parseTimestamp(value: Date | string | null): Date | null {
+  if (value === null) {
+    return null;
+  }
+  if (value instanceof Date) {
+    return value;
+  }
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function toLinkedAccountTokenRow(value: Record<string, unknown> | null): LinkedAccountTokenRow | null {
+  if (!value) {
+    return null;
+  }
+  const scopes = Array.isArray(value.scopes)
+    ? value.scopes.filter((scope): scope is string => typeof scope === 'string')
+    : null;
+  return {
+    linked_account_id: typeof value.linked_account_id === 'string' ? value.linked_account_id : '',
+    scopes,
+    project_id: typeof value.project_id === 'string' ? value.project_id : null,
+    provider: typeof value.provider === 'string' ? value.provider : '',
+    user_id: typeof value.user_id === 'string' ? value.user_id : '',
+    access_token: typeof value.access_token === 'string' ? value.access_token : null,
+    refresh_token: typeof value.refresh_token === 'string' ? value.refresh_token : null,
+    token_expires_at:
+      value.token_expires_at instanceof Date || typeof value.token_expires_at === 'string'
+        ? value.token_expires_at
+        : null,
+  };
+}
+
+function hasAllScopes(requiredScopes: string[], grantedScopes: string[] | null): boolean {
+  if (requiredScopes.length === 0) {
+    return true;
+  }
+  if (!Array.isArray(grantedScopes)) {
+    return false;
+  }
+  const granted = new Set(grantedScopes);
+  return requiredScopes.every((scope) => granted.has(scope));
+}
+
+async function insertTokenAudit(
+  deps: ResolveRepositoryTokenDeps,
+  args: {
+    tenantId: string;
+    projectId: string | null;
+    actorId: string;
+    repositoryId: string;
+    linkedAccountId: string | null;
+    provider: string | null;
+    result: 'success' | 'failure';
+  }
+): Promise<void> {
+  const detail = {
+    repository_id: args.repositoryId,
+    linked_account_id: args.linkedAccountId,
+    provider: args.provider,
+    result: args.result,
+  };
+
+  await deps.query(
+    `INSERT INTO odb.workflow_audit (
+      tenant_id, project_id, version_id, action, outcome, actor_id, detail
+    ) VALUES ($1, $2, NULL, $3, $4, $5, $6::jsonb)`,
+    [args.tenantId, args.projectId, 'repository.token_resolved', args.result, args.actorId, JSON.stringify(detail)]
+  );
+}
+
+export function createResolveRepositoryTokenResolver(partialDeps?: Partial<ResolveRepositoryTokenDeps>) {
+  const deps: ResolveRepositoryTokenDeps = {
+    query: partialDeps?.query ?? ((sql: string, params: unknown[]) => connectionPool.query(sql, params)),
+    now: partialDeps?.now ?? (() => new Date()),
+    refreshers: partialDeps?.refreshers ?? {},
+  };
+
+  return async function resolveRepositoryToken(
+    repositoryId: string,
+    userContext: UserContext,
+    requiredScopes: string[] = []
+  ): Promise<ScopedRepositoryToken> {
+    let linkedAccountId: string | null = null;
+    let provider: string | null = null;
+    let projectId: string | null = null;
+
+    try {
+      const linkedAccountResult = await deps.query(
+        `SELECT rcr.linked_account_id, rcr.scopes, r.project_id,
+                eap.provider, eap.user_id, eap.access_token, eap.refresh_token, eap.token_expires_at
+         FROM odb.repository_credential_ref rcr
+         JOIN odb.repository r ON r.id = rcr.repository_id
+         LEFT JOIN odb.external_auth_providers eap ON eap.id = rcr.linked_account_id
+         WHERE rcr.repository_id = $1
+           AND r.tenant_id = $2
+         LIMIT 1`,
+        [repositoryId, userContext.tenantId]
+      );
+
+      const row = toLinkedAccountTokenRow(linkedAccountResult.rows[0] ?? null);
+      if (!row || !row.linked_account_id || !row.provider) {
+        throw new RepositoryTokenResolutionError(
+          'LINKED_ACCOUNT_REMOVED',
+          'Repository linked account reference was removed.'
+        );
+      }
+
+      linkedAccountId = row.linked_account_id;
+      provider = row.provider;
+      projectId = row.project_id;
+
+      if (row.user_id !== userContext.userId) {
+        throw new RepositoryTokenResolutionError(
+          'LINKED_ACCOUNT_REMOVED',
+          'Linked account no longer belongs to the active user.'
+        );
+      }
+
+      if (!hasAllScopes(requiredScopes, row.scopes)) {
+        throw new RepositoryTokenResolutionError(
+          'INSUFFICIENT_SCOPE',
+          'Linked account token does not include required repository scopes.'
+        );
+      }
+
+      const expiresAt = parseTimestamp(row.token_expires_at);
+      const now = deps.now();
+      const isExpired = expiresAt !== null && expiresAt.getTime() <= now.getTime();
+
+      let accessToken = row.access_token;
+      let nextExpiresAt = expiresAt;
+
+      if (isExpired) {
+        if (!row.refresh_token) {
+          throw new RepositoryTokenResolutionError(
+            'TOKEN_EXPIRED_NO_REFRESH',
+            'Linked account token expired and no refresh token is available.'
+          );
+        }
+
+        const refresher = deps.refreshers[row.provider];
+        if (!refresher) {
+          throw new RepositoryTokenResolutionError(
+            'TOKEN_EXPIRED_NO_REFRESH',
+            `Provider "${row.provider}" does not support token refresh in this environment.`
+          );
+        }
+
+        let refreshed: RefreshedTokenBundle;
+        try {
+          refreshed = await refresher({
+            refreshToken: row.refresh_token,
+            provider: row.provider,
+            linkedAccountId: row.linked_account_id,
+            userContext,
+          });
+        } catch (error) {
+          throw new RepositoryTokenResolutionError(
+            'TOKEN_REVOKED',
+            'Linked account refresh token was rejected by the provider.',
+            { cause: error }
+          );
+        }
+
+        accessToken = refreshed.accessToken;
+        nextExpiresAt = refreshed.expiresAt;
+        const refreshToken = refreshed.refreshToken ?? row.refresh_token;
+
+        const updateResult = await deps.query(
+          `UPDATE odb.external_auth_providers
+           SET access_token = $1,
+               refresh_token = $2,
+               token_expires_at = $3,
+               updated_at = CURRENT_TIMESTAMP
+           WHERE id = $4`,
+          [accessToken, refreshToken, nextExpiresAt, row.linked_account_id]
+        );
+        if ((updateResult.rowCount ?? 0) === 0) {
+          throw new RepositoryTokenResolutionError(
+            'LINKED_ACCOUNT_REMOVED',
+            'Linked account was removed while refreshing token.'
+          );
+        }
+      }
+
+      if (!accessToken) {
+        throw new RepositoryTokenResolutionError(
+          'TOKEN_REVOKED',
+          'Linked account token is missing or was revoked.'
+        );
+      }
+
+      await insertTokenAudit(deps, {
+        tenantId: userContext.tenantId,
+        projectId,
+        actorId: userContext.userId,
+        repositoryId,
+        linkedAccountId,
+        provider,
+        result: 'success',
+      });
+
+      return {
+        repositoryId,
+        linkedAccountId,
+        provider: row.provider,
+        accessToken,
+        expiresAt: nextExpiresAt,
+      };
+    } catch (error) {
+      await insertTokenAudit(deps, {
+        tenantId: userContext.tenantId,
+        projectId,
+        actorId: userContext.userId,
+        repositoryId,
+        linkedAccountId,
+        provider,
+        result: 'failure',
+      }).catch(() => undefined);
+
+      if (error instanceof RepositoryTokenResolutionError) {
+        throw error;
+      }
+      throw new RepositoryTokenResolutionError(
+        'TOKEN_REVOKED',
+        'Token resolution failed due to an unexpected repository credential error.',
+        { cause: error }
+      );
+    }
+  };
+}
+
+export const resolveRepositoryToken = createResolveRepositoryTokenResolver();

--- a/objectified-ui/lib/repositories/providers/resolve-repository-token.ts
+++ b/objectified-ui/lib/repositories/providers/resolve-repository-token.ts
@@ -159,11 +159,15 @@ export function createResolveRepositoryTokenResolver(partialDeps?: Partial<Resol
          LEFT JOIN odb.external_auth_providers eap ON eap.id = rcr.linked_account_id
          WHERE rcr.repository_id = $1
            AND r.tenant_id = $2
+           AND eap.user_id = $3
+         ORDER BY rcr.linked_account_id
          LIMIT 1`,
-        [repositoryId, userContext.tenantId]
+        [repositoryId, userContext.tenantId, userContext.userId]
       );
 
       const row = toLinkedAccountTokenRow(linkedAccountResult.rows[0] ?? null);
+      linkedAccountId = row?.linked_account_id ?? null;
+
       if (!row || !row.linked_account_id || !row.provider) {
         throw new RepositoryTokenResolutionError(
           'LINKED_ACCOUNT_REMOVED',
@@ -171,7 +175,6 @@ export function createResolveRepositoryTokenResolver(partialDeps?: Partial<Resol
         );
       }
 
-      linkedAccountId = row.linked_account_id;
       provider = row.provider;
       projectId = row.project_id;
 
@@ -236,8 +239,7 @@ export function createResolveRepositoryTokenResolver(partialDeps?: Partial<Resol
           `UPDATE odb.external_auth_providers
            SET access_token = $1,
                refresh_token = $2,
-               token_expires_at = $3,
-               updated_at = CURRENT_TIMESTAMP
+               token_expires_at = $3
            WHERE id = $4`,
           [accessToken, refreshToken, nextExpiresAt, row.linked_account_id]
         );

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.10.19",
+  "version": "0.10.20",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -6,6 +6,7 @@ We continue to improve the platform based on your feedback with improvements and
 
 - Added repository connector MVP database tables for repository registration, branch tracking, and linked-account credential references.
 - Added a provider abstraction layer for repository connectors with a GitHub adapter, shared provider error taxonomy, and cross-provider contract tests.
+- Added a server-only `resolveRepositoryToken` helper that resolves linked-account repository credentials, refreshes supported expired tokens, emits typed resolver errors, and writes token-safe workflow audit rows.
 
 ## UI
 - Branch workflow is its own button in the canvas now, and compacted to fit most functionality that's in Versions now.


### PR DESCRIPTION
## Summary
- Add a server-only `resolveRepositoryToken` helper in `objectified-ui` that resolves the linked account credential for a repository at request time and keeps token handling in-memory.
- Enforce typed resolver failures (`TOKEN_REVOKED`, `TOKEN_EXPIRED_NO_REFRESH`, `LINKED_ACCOUNT_REMOVED`, `INSUFFICIENT_SCOPE`) and scope checks before provider access.
- Refresh expired tokens through provider refresh handlers when available, persist refreshed credentials to `odb.external_auth_providers`, and write token-safe `repository.token_resolved` rows to `odb.workflow_audit`.
- Add focused unit tests for success, refresh persistence, and failure/audit paths; export the resolver from the repository providers index.
- Update `objectified-ui` patch version and add a `WHATS_NEW` release note line.

## Test plan
- [x] `yarn build` (repo root)
- [x] `yarn test lib/repositories/providers/__tests__/contract.test.ts lib/repositories/providers/__tests__/resolve-repository-token.test.ts --verbose` (objectified-ui)
- [x] `yarn test resolve-repository-token --verbose` (objectified-ui)
- [ ] `yarn test` (repo root) *(currently fails on pre-existing `tests/llm-streaming.test.ts` with `TypeError: (0 , _prettyFormat.format) is not a function`)*

## Risk / notes
- No repository tokens are written to workflow audit payloads or logs in the resolver flow.
- Refresh support is provider-injected; providers without a configured refresher return `TOKEN_EXPIRED_NO_REFRESH`.

Closes #2755

Made with [Cursor](https://cursor.com)