### PR TITLE
Fix #2757 - add per-repo branch and subpath controls

### DIFF
--- a/docs/PLANNED_FEATURE_ROADMAP_REPOSITORY.md
+++ b/docs/PLANNED_FEATURE_ROADMAP_REPOSITORY.md
@@ -3,6 +3,7 @@
 ## Completed
 
 - REPO-1.4 (#2756): Added repository registration UI flow and REST registration endpoint for GitHub repositories.
+- REPO-1.5 (#2757): Added per-repository branch management with per-branch subpath and polling settings, including default branch preselection and wildcard branch patterns.
 
 ## Open Issues
 

--- a/objectified-rest/pyproject.toml
+++ b/objectified-rest/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "objectified-rest"
-version = "1.0.52"
+version = "1.0.53"
 description = "REST API for serving OpenAPI specifications from the Objectified database"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/objectified-rest/src/app/repositories_routes.py
+++ b/objectified-rest/src/app/repositories_routes.py
@@ -35,6 +35,10 @@ class RepositoryRegisterRequest(BaseModel):
     manifest: str | None = None
 
 
+class RepositoryBranchesUpdateRequest(BaseModel):
+    branches: List[RepositoryBranchInput] = Field(min_length=1)
+
+
 class RepositoryScanTimelineEntry(BaseModel):
     id: str
     type: Literal["scan"]
@@ -86,11 +90,22 @@ def _validate_uuid(raw: str, field_name: str) -> None:
 
 
 def _normalize_branch(record: RepositoryBranchInput) -> RepositoryBranchRecord:
+    normalized_subpath = record.subpathGlob.strip() if record.subpathGlob else "**/*"
     return RepositoryBranchRecord(
         branch=record.branch.strip(),
-        subpathGlob=record.subpathGlob.strip() if record.subpathGlob else None,
+        subpathGlob=normalized_subpath,
         pollIntervalSec=record.pollIntervalSec,
     )
+
+
+def _normalize_branches(branches: List[RepositoryBranchInput]) -> List[RepositoryBranchRecord]:
+    normalized_branches = [_normalize_branch(branch) for branch in branches]
+    if any(not branch.branch for branch in normalized_branches):
+        raise HTTPException(status_code=400, detail="branches[].branch is required")
+    dedupe_key_count = len({branch.branch for branch in normalized_branches})
+    if dedupe_key_count != len(normalized_branches):
+        raise HTTPException(status_code=400, detail="branches[].branch must be unique")
+    return normalized_branches
 
 
 def _to_summary(repo: RepositoryRecord) -> Dict[str, Any]:
@@ -121,9 +136,7 @@ async def register_repository(
     if not owner or not name:
         raise HTTPException(status_code=400, detail="owner and name are required")
 
-    normalized_branches = [_normalize_branch(branch) for branch in request.branches]
-    if any(not b.branch for b in normalized_branches):
-        raise HTTPException(status_code=400, detail="branches[].branch is required")
+    normalized_branches = _normalize_branches(request.branches)
 
     now = _utc_now_iso()
     repository_id = str(uuid4())
@@ -185,3 +198,22 @@ async def get_repository(
     if repository is None:
         raise HTTPException(status_code=404, detail=f"Repository not found: {repository_id}")
     return repository
+
+
+@router.patch("/{tenant_slug}/{repository_id}/branches", response_model=RepositoryRecord)
+async def update_repository_branches(
+    tenant_slug: str,
+    repository_id: str,
+    request: RepositoryBranchesUpdateRequest,
+    auth_data: Dict[str, Any] = Depends(validate_authentication),
+) -> RepositoryRecord:
+    tenant_id = auth_data["tenant_id"]
+    normalized_branches = _normalize_branches(request.branches)
+
+    with _STORE_LOCK:
+        repository = _REPO_STORE.get(tenant_id, {}).get(repository_id)
+        if repository is None:
+            raise HTTPException(status_code=404, detail=f"Repository not found: {repository_id}")
+        repository.branches = normalized_branches
+        repository.updatedAt = _utc_now_iso()
+        return repository

--- a/objectified-rest/src/app/repositories_routes.py
+++ b/objectified-rest/src/app/repositories_routes.py
@@ -90,7 +90,8 @@ def _validate_uuid(raw: str, field_name: str) -> None:
 
 
 def _normalize_branch(record: RepositoryBranchInput) -> RepositoryBranchRecord:
-    normalized_subpath = record.subpathGlob.strip() if record.subpathGlob else "**/*"
+    stripped_subpath = record.subpathGlob.strip() if record.subpathGlob else ""
+    normalized_subpath = stripped_subpath if stripped_subpath else "**/*"
     return RepositoryBranchRecord(
         branch=record.branch.strip(),
         subpathGlob=normalized_subpath,

--- a/objectified-rest/tests/test_repositories_routes.py
+++ b/objectified-rest/tests/test_repositories_routes.py
@@ -127,3 +127,24 @@ def test_update_repository_branches_replaces_config_and_updates_timestamp():
         {"branch": "main", "subpathGlob": "**/*", "pollIntervalSec": 300},
     ]
     assert body["updatedAt"] >= original_updated_at
+
+
+def test_register_repository_normalizes_whitespace_only_subpath_glob():
+    app.dependency_overrides[validate_authentication] = _override_auth
+    try:
+        response = client.post(
+            f"/v1/repositories/{_TENANT_SLUG}",
+            json={
+                "linkedAccountId": "aaaaaaaa-bbbb-cccc-dddd-000000000005",
+                "provider": "github",
+                "owner": "acme",
+                "name": "whitespace-subpath-test",
+                "branches": [{"branch": "main", "subpathGlob": "   "}],
+            },
+        )
+    finally:
+        app.dependency_overrides.pop(validate_authentication, None)
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["repository"]["branches"] == [{"branch": "main", "subpathGlob": "**/*", "pollIntervalSec": None}]

--- a/objectified-rest/tests/test_repositories_routes.py
+++ b/objectified-rest/tests/test_repositories_routes.py
@@ -42,6 +42,7 @@ def test_register_repository_returns_scan_job_and_timeline_entry():
     assert body["repository"]["fullName"] == "acme/api-platform"
     assert body["repository"]["status"] == "scan_in_progress"
     assert body["repository"]["timeline"][0]["message"] == "Scan in progress..."
+    assert body["repository"]["branches"] == [{"branch": "main", "subpathGlob": "specs/**", "pollIntervalSec": None}]
 
 
 def test_repository_list_and_detail_are_tenant_scoped():
@@ -68,3 +69,61 @@ def test_repository_list_and_detail_are_tenant_scoped():
     assert detail_response.status_code == 200
     assert any(item["id"] == repository_id for item in list_response.json()["repositories"])
     assert detail_response.json()["id"] == repository_id
+
+
+def test_register_repository_defaults_subpath_and_accepts_wildcard_branch():
+    app.dependency_overrides[validate_authentication] = _override_auth
+    try:
+        response = client.post(
+            f"/v1/repositories/{_TENANT_SLUG}",
+            json={
+                "linkedAccountId": "aaaaaaaa-bbbb-cccc-dddd-000000000003",
+                "provider": "github",
+                "owner": "acme",
+                "name": "api-platform",
+                "branches": [{"branch": "release/*"}],
+            },
+        )
+    finally:
+        app.dependency_overrides.pop(validate_authentication, None)
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["repository"]["branches"] == [{"branch": "release/*", "subpathGlob": "**/*", "pollIntervalSec": None}]
+
+
+def test_update_repository_branches_replaces_config_and_updates_timestamp():
+    app.dependency_overrides[validate_authentication] = _override_auth
+    try:
+        create_response = client.post(
+            f"/v1/repositories/{_TENANT_SLUG}",
+            json={
+                "linkedAccountId": "aaaaaaaa-bbbb-cccc-dddd-000000000004",
+                "provider": "github",
+                "owner": "widgets-co",
+                "name": "orders",
+                "branches": [{"branch": "main"}],
+            },
+        )
+        repository_id = create_response.json()["repository"]["id"]
+        original_updated_at = create_response.json()["repository"]["updatedAt"]
+        patch_response = client.patch(
+            f"/v1/repositories/{_TENANT_SLUG}/{repository_id}/branches",
+            json={
+                "branches": [
+                    {"branch": "release/*", "subpathGlob": "services/**", "pollIntervalSec": 120},
+                    {"branch": "main", "pollIntervalSec": 300},
+                ]
+            },
+        )
+    finally:
+        app.dependency_overrides.pop(validate_authentication, None)
+
+    assert create_response.status_code == 201
+    assert patch_response.status_code == 200
+    body = patch_response.json()
+    assert body["branches"] == [
+        {"branch": "release/*", "subpathGlob": "services/**", "pollIntervalSec": 120},
+        {"branch": "main", "subpathGlob": "**/*", "pollIntervalSec": 300},
+    ]
+    assert body["updatedAt"] >= original_updated_at

--- a/objectified-ui/e2e/repositories-register.spec.ts
+++ b/objectified-ui/e2e/repositories-register.spec.ts
@@ -13,6 +13,11 @@ test.describe('Repositories registration', () => {
         return;
       }
 
+      const payload = route.request().postDataJSON() as {
+        branches?: Array<{ branch: string; subpathGlob?: string; pollIntervalSec?: number }>;
+      };
+      expect(payload.branches).toEqual([{ branch: 'main', subpathGlob: '**/*' }]);
+
       await route.fulfill({
         status: 201,
         contentType: 'application/json',
@@ -88,6 +93,7 @@ test.describe('Repositories registration', () => {
               name: 'api-platform',
               full_name: 'acme/api-platform',
               description: 'Core API repo',
+              default_branch: 'main',
             },
           ],
         }),
@@ -100,6 +106,7 @@ test.describe('Repositories registration', () => {
         contentType: 'application/json',
         body: JSON.stringify({
           branches: ['main', 'release/2026.04'],
+          defaultBranch: 'main',
         }),
       });
     });
@@ -124,7 +131,6 @@ test.describe('Repositories registration', () => {
     await wizard.getByRole('button', { name: 'acme/api-platform Core API repo' }).click();
     await wizard.getByRole('button', { name: 'Next', exact: true }).click();
 
-    await wizard.getByRole('checkbox').first().check();
     await wizard.getByRole('button', { name: 'Next', exact: true }).click();
 
     await wizard.locator('textarea').fill('scan:\n  enabled: true\n');

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.10.21",
+  "version": "0.10.22",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -8,6 +8,7 @@ We continue to improve the platform based on your feedback with improvements and
 - Added a provider abstraction layer for repository connectors with a GitHub adapter, shared provider error taxonomy, and cross-provider contract tests.
 - Added a server-only `resolveRepositoryToken` helper that resolves linked-account repository credentials, refreshes supported expired tokens, emits typed resolver errors, and writes token-safe workflow audit rows.
 - Added a new ADE Repositories page with a four-step GitHub registration wizard and initial scan timeline flow.
+- Added per-repository branch management so tracked branches can be added/removed with per-branch subpath glob and polling settings, defaulting to the provider default branch and supporting wildcard branch patterns.
 
 ## UI
 - Branch workflow is its own button in the canvas now, and compacted to fit most functionality that's in Versions now.

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -4,6 +4,7 @@ We continue to improve the platform based on your feedback with improvements and
 
 ---
 
+## Repositories
 - Added repository connector MVP database tables for repository registration, branch tracking, and linked-account credential references.
 - Added a provider abstraction layer for repository connectors with a GitHub adapter, shared provider error taxonomy, and cross-provider contract tests.
 - Added a server-only `resolveRepositoryToken` helper that resolves linked-account repository credentials, refreshes supported expired tokens, emits typed resolver errors, and writes token-safe workflow audit rows.

--- a/objectified-ui/src/app/ade/dashboard/repositories/[id]/page.tsx
+++ b/objectified-ui/src/app/ade/dashboard/repositories/[id]/page.tsx
@@ -5,6 +5,7 @@ import { useParams, useRouter } from 'next/navigation';
 import { ArrowLeft, GitBranchPlus, Loader2 } from 'lucide-react';
 import { Button } from '@/app/components/ui/Button';
 import { Alert } from '@/app/components/ui/Alert';
+import { Input } from '@/app/components/ui/Input';
 import { dashboardContentStackClass, dashboardMainClass, dashboardPanelClass } from '@/app/components/ade/dashboard/dashboardScreenClasses';
 import { getRepositoriesI18nBundle } from '../i18n';
 
@@ -18,13 +19,20 @@ interface RepositoryTimelineItem {
 
 interface RepositoryDetail {
   id: string;
+  linkedAccountId: string;
   provider: string;
   owner: string;
   name: string;
   fullName: string;
   status: string;
-  branches: Array<{ branch: string; subpathGlob?: string }>;
+  branches: Array<{ branch: string; subpathGlob?: string; pollIntervalSec?: number }>;
   timeline: RepositoryTimelineItem[];
+}
+
+interface BranchRow {
+  branch: string;
+  subpathGlob: string;
+  pollIntervalSec?: number;
 }
 
 export default function RepositoryDetailPage() {
@@ -32,8 +40,87 @@ export default function RepositoryDetailPage() {
   const router = useRouter();
   const copy = getRepositoriesI18nBundle('en');
   const [repository, setRepository] = useState<RepositoryDetail | null>(null);
+  const [branchRows, setBranchRows] = useState<BranchRow[]>([]);
+  const [availableBranches, setAvailableBranches] = useState<string[]>([]);
+  const [customBranchPattern, setCustomBranchPattern] = useState('');
   const [errorMessage, setErrorMessage] = useState('');
+  const [successMessage, setSuccessMessage] = useState('');
   const [isLoading, setIsLoading] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
+
+  const updateSubpath = (branchName: string, next: string) => {
+    setBranchRows((prev) =>
+      prev.map((row) => (row.branch === branchName ? { ...row, subpathGlob: next } : row))
+    );
+  };
+
+  const updatePollInterval = (branchName: string, next: string) => {
+    const normalized = Number.parseInt(next, 10);
+    setBranchRows((prev) =>
+      prev.map((row) =>
+        row.branch === branchName
+          ? { ...row, pollIntervalSec: Number.isFinite(normalized) ? normalized : undefined }
+          : row
+      )
+    );
+  };
+
+  const removeBranch = (branchName: string) => {
+    setBranchRows((prev) => prev.filter((row) => row.branch !== branchName));
+  };
+
+  const addBranch = (branchName: string) => {
+    const normalized = branchName.trim();
+    if (!normalized) return;
+    setBranchRows((prev) => {
+      if (prev.some((row) => row.branch === normalized)) {
+        return prev;
+      }
+      return [...prev, { branch: normalized, subpathGlob: '**/*' }];
+    });
+  };
+
+  const saveBranches = async () => {
+    if (!repository || branchRows.length === 0) {
+      setErrorMessage(copy.branchesRequired);
+      return;
+    }
+    setIsSaving(true);
+    setErrorMessage('');
+    setSuccessMessage('');
+    try {
+      const response = await fetch(`/api/repositories/${repository.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          branches: branchRows.map((row) => ({
+            branch: row.branch.trim(),
+            subpathGlob: row.subpathGlob.trim() || undefined,
+            pollIntervalSec: row.pollIntervalSec,
+          })),
+        }),
+      });
+      const data = await response.json();
+      if (!response.ok || !data.success) {
+        throw new Error(data.error || 'Failed to update branches');
+      }
+      const updatedRepository = data.repository as RepositoryDetail;
+      setRepository(updatedRepository);
+      setBranchRows(
+        (updatedRepository.branches || []).map((branch) => ({
+          branch: branch.branch,
+          subpathGlob: branch.subpathGlob || '**/*',
+          pollIntervalSec: branch.pollIntervalSec,
+        }))
+      );
+      setSuccessMessage('Repository branches updated.');
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to update branches';
+      setErrorMessage(message);
+    } finally {
+      setIsSaving(false);
+    }
+  };
 
   useEffect(() => {
     const loadRepository = async () => {
@@ -45,7 +132,28 @@ export default function RepositoryDetailPage() {
         if (!response.ok || !data.success) {
           throw new Error(data.error || 'Failed to load repository');
         }
-        setRepository(data.repository);
+        const loadedRepository = data.repository as RepositoryDetail;
+        setRepository(loadedRepository);
+        setBranchRows(
+          (loadedRepository.branches || []).map((branch) => ({
+            branch: branch.branch,
+            subpathGlob: branch.subpathGlob || '**/*',
+            pollIntervalSec: branch.pollIntervalSec,
+          }))
+        );
+        if (loadedRepository.linkedAccountId && loadedRepository.fullName) {
+          const branchesResponse = await fetch(
+            `/api/sso/github/branches?accountId=${encodeURIComponent(loadedRepository.linkedAccountId)}&repo=${encodeURIComponent(loadedRepository.fullName)}`
+          );
+          const branchesData = await branchesResponse.json();
+          if (branchesResponse.ok && Array.isArray(branchesData.branches)) {
+            setAvailableBranches(branchesData.branches);
+          } else {
+            setAvailableBranches([]);
+          }
+        } else {
+          setAvailableBranches([]);
+        }
       } catch (error) {
         const message = error instanceof Error ? error.message : 'Failed to load repository';
         setErrorMessage(message);
@@ -79,6 +187,7 @@ export default function RepositoryDetailPage() {
       <main className={dashboardMainClass}>
         <div className={dashboardContentStackClass}>
           {errorMessage ? <Alert variant="error">{errorMessage}</Alert> : null}
+          {successMessage ? <Alert variant="success">{successMessage}</Alert> : null}
           {isLoading ? (
             <div className="flex items-center justify-center py-10 text-sm text-gray-500 dark:text-gray-400">
               <Loader2 className="h-5 w-5 animate-spin mr-2" />
@@ -105,9 +214,86 @@ export default function RepositoryDetailPage() {
                       <li key={branch.branch}>
                         <span className="font-medium">{branch.branch}</span>
                         {branch.subpathGlob ? ` (${branch.subpathGlob})` : ''}
+                        {branch.pollIntervalSec ? ` · ${branch.pollIntervalSec}s` : ''}
                       </li>
                     ))}
                   </ul>
+                </div>
+              </section>
+
+              <section className={`${dashboardPanelClass} p-5 space-y-3`}>
+                <h3 className="font-semibold text-gray-900 dark:text-gray-100">{copy.stepBranchesTitle}</h3>
+                {availableBranches.length > 0 ? (
+                  <div className="flex flex-wrap gap-2">
+                    {availableBranches.map((branchName) => (
+                      <Button
+                        key={branchName}
+                        type="button"
+                        size="sm"
+                        variant={branchRows.some((row) => row.branch === branchName) ? 'secondary' : 'outline'}
+                        onClick={() =>
+                          branchRows.some((row) => row.branch === branchName)
+                            ? removeBranch(branchName)
+                            : addBranch(branchName)
+                        }
+                      >
+                        {branchName}
+                      </Button>
+                    ))}
+                  </div>
+                ) : null}
+
+                <div className="rounded-lg border border-gray-200 dark:border-gray-700 p-3 space-y-2">
+                  <p className="text-sm font-medium">{copy.addBranchPatternLabel}</p>
+                  <div className="flex items-center gap-2">
+                    <Input
+                      value={customBranchPattern}
+                      onChange={(event) => setCustomBranchPattern(event.target.value)}
+                      placeholder={copy.branchPatternPlaceholder}
+                    />
+                    <Button
+                      type="button"
+                      variant="outline"
+                      onClick={() => {
+                        addBranch(customBranchPattern);
+                        setCustomBranchPattern('');
+                      }}
+                    >
+                      {copy.addPatternButton}
+                    </Button>
+                  </div>
+                </div>
+
+                <div className="space-y-2">
+                  {branchRows.map((branch) => (
+                    <div key={branch.branch} className="rounded-lg border border-gray-200 dark:border-gray-700 p-3 space-y-2">
+                      <div className="flex items-center justify-between gap-2">
+                        <span className="text-sm font-medium">{branch.branch}</span>
+                        <Button type="button" size="sm" variant="outline" onClick={() => removeBranch(branch.branch)}>
+                          {copy.removeButton}
+                        </Button>
+                      </div>
+                      <Input
+                        value={branch.subpathGlob}
+                        placeholder={copy.branchSubpathPlaceholder}
+                        onChange={(event) => updateSubpath(branch.branch, event.target.value)}
+                      />
+                      <Input
+                        type="number"
+                        min={15}
+                        max={86400}
+                        value={branch.pollIntervalSec ?? ''}
+                        placeholder={copy.pollIntervalPlaceholder}
+                        onChange={(event) => updatePollInterval(branch.branch, event.target.value)}
+                      />
+                    </div>
+                  ))}
+                </div>
+
+                <div className="flex justify-end">
+                  <Button onClick={() => void saveBranches()} disabled={isSaving || branchRows.length === 0}>
+                    {isSaving ? copy.savingButton : copy.saveBranchesButton}
+                  </Button>
                 </div>
               </section>
 

--- a/objectified-ui/src/app/ade/dashboard/repositories/[id]/page.tsx
+++ b/objectified-ui/src/app/ade/dashboard/repositories/[id]/page.tsx
@@ -113,7 +113,7 @@ export default function RepositoryDetailPage() {
           pollIntervalSec: branch.pollIntervalSec,
         }))
       );
-      setSuccessMessage('Repository branches updated.');
+      setSuccessMessage(copy.branchesUpdatedMessage);
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Failed to update branches';
       setErrorMessage(message);

--- a/objectified-ui/src/app/ade/dashboard/repositories/i18n.ts
+++ b/objectified-ui/src/app/ade/dashboard/repositories/i18n.ts
@@ -36,6 +36,7 @@ export interface RepositoriesI18nBundle {
   repoRequired: string;
   branchesRequired: string;
   successMessage: string;
+  branchesUpdatedMessage: string;
   scanTimelineMessage: string;
   loadingRepositories: string;
   loadingRepository: string;
@@ -89,6 +90,7 @@ export const repositoriesI18n: Record<RepositoriesLocale, RepositoriesI18nBundle
     repoRequired: 'Select a repository before continuing.',
     branchesRequired: 'Select at least one branch.',
     successMessage: 'Repository registered. Initial scan started.',
+    branchesUpdatedMessage: 'Repository branches updated.',
     scanTimelineMessage: 'Scan in progress...',
     loadingRepositories: 'Loading repositories...',
     loadingRepository: 'Loading repository...',

--- a/objectified-ui/src/app/ade/dashboard/repositories/i18n.ts
+++ b/objectified-ui/src/app/ade/dashboard/repositories/i18n.ts
@@ -23,6 +23,15 @@ export interface RepositoriesI18nBundle {
   stepRepoTitle: string;
   stepBranchesTitle: string;
   stepManifestTitle: string;
+  defaultBranchLabel: string;
+  addBranchPatternLabel: string;
+  addPatternButton: string;
+  branchPatternPlaceholder: string;
+  pollIntervalPlaceholder: string;
+  removeButton: string;
+  availableBranchesLabel: string;
+  saveBranchesButton: string;
+  savingButton: string;
   accountRequired: string;
   repoRequired: string;
   branchesRequired: string;
@@ -67,6 +76,15 @@ export const repositoriesI18n: Record<RepositoriesLocale, RepositoriesI18nBundle
     stepRepoTitle: 'Step 2: Search and pick repository',
     stepBranchesTitle: 'Step 3: Select branches and subpath',
     stepManifestTitle: 'Step 4: Optional manifest upload',
+    defaultBranchLabel: 'Default branch',
+    addBranchPatternLabel: 'Track branch pattern',
+    addPatternButton: 'Add pattern',
+    branchPatternPlaceholder: 'release/*',
+    pollIntervalPlaceholder: 'Poll interval seconds (optional)',
+    removeButton: 'Remove',
+    availableBranchesLabel: 'Available branches',
+    saveBranchesButton: 'Save branches',
+    savingButton: 'Saving...',
     accountRequired: 'Select a linked account before continuing.',
     repoRequired: 'Select a repository before continuing.',
     branchesRequired: 'Select at least one branch.',

--- a/objectified-ui/src/app/ade/dashboard/repositories/page.tsx
+++ b/objectified-ui/src/app/ade/dashboard/repositories/page.tsx
@@ -41,11 +41,13 @@ interface RepoSummary {
   name: string;
   full_name: string;
   description?: string | null;
+  default_branch?: string;
 }
 
 interface BranchItem {
   branch: string;
-  subpathGlob?: string;
+  subpathGlob: string;
+  pollIntervalSec?: number;
 }
 
 interface RegisteredRepository {
@@ -77,6 +79,7 @@ const RepositoriesPage = () => {
   const [selectedRepo, setSelectedRepo] = useState<RepoSummary | null>(null);
   const [branches, setBranches] = useState<string[]>([]);
   const [selectedBranches, setSelectedBranches] = useState<BranchItem[]>([]);
+  const [customBranchPattern, setCustomBranchPattern] = useState('');
   const [manifest, setManifest] = useState('');
   const [isWizardBusy, setIsWizardBusy] = useState(false);
 
@@ -108,6 +111,7 @@ const RepositoriesPage = () => {
     setGithubRepos([]);
     setBranches([]);
     setSelectedBranches([]);
+    setCustomBranchPattern('');
     setManifest('');
     setRepoSearch('');
     setErrorMessage('');
@@ -128,6 +132,7 @@ const RepositoriesPage = () => {
     setSelectedRepo(null);
     setBranches([]);
     setSelectedBranches([]);
+    setCustomBranchPattern('');
     setIsWizardBusy(true);
     try {
       const response = await fetch(`/api/sso/github/repos?accountId=${encodeURIComponent(account.id)}`);
@@ -156,8 +161,15 @@ const RepositoriesPage = () => {
       if (!response.ok) {
         throw new Error(data.error || 'Failed to load branches');
       }
-      setBranches(data.branches || []);
-      setSelectedBranches([]);
+      const availableBranches = Array.isArray(data.branches) ? data.branches : [];
+      const defaultBranchName =
+        (typeof data.defaultBranch === 'string' && data.defaultBranch) || repo.default_branch || null;
+      const defaultBranch =
+        defaultBranchName && availableBranches.includes(defaultBranchName)
+          ? [{ branch: defaultBranchName, subpathGlob: '**/*' }]
+          : [];
+      setBranches(availableBranches);
+      setSelectedBranches(defaultBranch);
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Failed to load branches';
       setErrorMessage(message);
@@ -187,7 +199,7 @@ const RepositoriesPage = () => {
       if (exists) {
         return prev.filter((entry) => entry.branch !== branchName);
       }
-      return [...prev, { branch: branchName }];
+      return [...prev, { branch: branchName, subpathGlob: '**/*' }];
     });
   };
 
@@ -195,10 +207,33 @@ const RepositoriesPage = () => {
     setSelectedBranches((prev) =>
       prev.map((entry) =>
         entry.branch === branchName
-          ? { ...entry, subpathGlob: value.trim() || undefined }
+          ? { ...entry, subpathGlob: value }
           : entry
       )
     );
+  };
+
+  const updatePollInterval = (branchName: string, value: string) => {
+    const next = Number.parseInt(value, 10);
+    setSelectedBranches((prev) =>
+      prev.map((entry) =>
+        entry.branch === branchName
+          ? { ...entry, pollIntervalSec: Number.isFinite(next) ? next : undefined }
+          : entry
+      )
+    );
+  };
+
+  const addCustomBranch = () => {
+    const branchPattern = customBranchPattern.trim();
+    if (!branchPattern) return;
+    setSelectedBranches((prev) => {
+      if (prev.some((entry) => entry.branch === branchPattern)) {
+        return prev;
+      }
+      return [...prev, { branch: branchPattern, subpathGlob: '**/*' }];
+    });
+    setCustomBranchPattern('');
   };
 
   const goNext = () => {
@@ -232,7 +267,11 @@ const RepositoriesPage = () => {
           provider: 'github',
           owner,
           name,
-          branches: selectedBranches,
+          branches: selectedBranches.map((branch) => ({
+            branch: branch.branch.trim(),
+            subpathGlob: branch.subpathGlob.trim() || undefined,
+            pollIntervalSec: branch.pollIntervalSec,
+          })),
           manifest: manifest.trim() ? manifest : undefined,
         }),
       });
@@ -263,6 +302,9 @@ const RepositoriesPage = () => {
   };
 
   const showNoLinkedAccountsPrompt = wizardStep === 0 && linkedAccounts.length === 0;
+  const selectedCustomBranches = selectedBranches.filter(
+    (entry) => !branches.includes(entry.branch)
+  );
 
   return (
     <>
@@ -451,12 +493,18 @@ const RepositoriesPage = () => {
                     </button>
                   ))}
                 </div>
+                {selectedRepo?.default_branch ? (
+                  <p className="text-xs text-gray-500 dark:text-gray-400">
+                    {copy.defaultBranchLabel}: <span className="font-medium">{selectedRepo.default_branch}</span>
+                  </p>
+                ) : null}
               </div>
             )}
 
             {wizardStep === 2 && (
               <div className="space-y-3">
                 <p className="text-sm font-medium">{copy.stepBranchesTitle}</p>
+                <p className="text-xs text-gray-500 dark:text-gray-400">{copy.availableBranchesLabel}</p>
                 <div className="max-h-52 overflow-auto space-y-2">
                   {branches.map((branchName) => {
                     const selected = selectedBranches.find((entry) => entry.branch === branchName);
@@ -471,17 +519,71 @@ const RepositoriesPage = () => {
                           {branchName}
                         </label>
                         {selected ? (
-                          <Input
-                            className="mt-2"
-                            placeholder={copy.branchSubpathPlaceholder}
-                            value={selected.subpathGlob || ''}
-                            onChange={(event) => updateSubpath(branchName, event.target.value)}
-                          />
+                          <div className="space-y-2 mt-2">
+                            <Input
+                              placeholder={copy.branchSubpathPlaceholder}
+                              value={selected.subpathGlob}
+                              onChange={(event) => updateSubpath(branchName, event.target.value)}
+                            />
+                            <Input
+                              type="number"
+                              min={15}
+                              max={86400}
+                              placeholder={copy.pollIntervalPlaceholder}
+                              value={selected.pollIntervalSec ?? ''}
+                              onChange={(event) => updatePollInterval(branchName, event.target.value)}
+                            />
+                          </div>
                         ) : null}
                       </div>
                     );
                   })}
                 </div>
+                <div className="rounded-lg border border-gray-200 dark:border-gray-700 p-3 space-y-2">
+                  <p className="text-sm font-medium">{copy.addBranchPatternLabel}</p>
+                  <div className="flex items-center gap-2">
+                    <Input
+                      value={customBranchPattern}
+                      onChange={(event) => setCustomBranchPattern(event.target.value)}
+                      placeholder={copy.branchPatternPlaceholder}
+                    />
+                    <Button type="button" variant="outline" onClick={addCustomBranch}>
+                      {copy.addPatternButton}
+                    </Button>
+                  </div>
+                </div>
+                {selectedCustomBranches.length > 0 ? (
+                  <div className="space-y-2">
+                    {selectedCustomBranches.map((branch) => (
+                      <div key={branch.branch} className="rounded-lg border border-gray-200 dark:border-gray-700 p-3 space-y-2">
+                        <div className="flex items-center justify-between gap-2">
+                          <span className="text-sm font-medium">{branch.branch}</span>
+                          <Button
+                            type="button"
+                            variant="outline"
+                            size="sm"
+                            onClick={() => toggleBranch(branch.branch)}
+                          >
+                            {copy.removeButton}
+                          </Button>
+                        </div>
+                        <Input
+                          placeholder={copy.branchSubpathPlaceholder}
+                          value={branch.subpathGlob}
+                          onChange={(event) => updateSubpath(branch.branch, event.target.value)}
+                        />
+                        <Input
+                          type="number"
+                          min={15}
+                          max={86400}
+                          placeholder={copy.pollIntervalPlaceholder}
+                          value={branch.pollIntervalSec ?? ''}
+                          onChange={(event) => updatePollInterval(branch.branch, event.target.value)}
+                        />
+                      </div>
+                    ))}
+                  </div>
+                ) : null}
               </div>
             )}
 

--- a/objectified-ui/src/app/api/repositories/[id]/route.ts
+++ b/objectified-ui/src/app/api/repositories/[id]/route.ts
@@ -13,35 +13,71 @@ type SessionUser = {
   current_tenant_id?: string;
 };
 
+async function resolveAuthContext() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user) {
+    return { error: NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 }) };
+  }
+  const user = session.user as SessionUser;
+  if (!user.current_tenant_id) {
+    return { error: NextResponse.json({ success: false, error: 'No tenant selected' }, { status: 400 }) };
+  }
+  const tenant = await getTenantById(user.current_tenant_id);
+  if (!tenant?.slug) {
+    return { error: NextResponse.json({ success: false, error: 'Tenant slug not found' }, { status: 400 }) };
+  }
+  return { sessionUser: user, tenantSlug: tenant.slug };
+}
+
 export async function GET(
   _request: Request,
   context: { params: Promise<{ id: string }> }
 ) {
   try {
-    const session = await getServerSession(authOptions);
-    if (!session?.user) {
-      return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
-    }
-    const user = session.user as SessionUser;
-    if (!user.current_tenant_id) {
-      return NextResponse.json({ success: false, error: 'No tenant selected' }, { status: 400 });
-    }
-    const tenant = await getTenantById(user.current_tenant_id);
-    if (!tenant?.slug) {
-      return NextResponse.json({ success: false, error: 'Tenant slug not found' }, { status: 400 });
-    }
+    const auth = await resolveAuthContext();
+    if ('error' in auth) return auth.error;
 
     const params = await context.params;
     const response = await fetch(
-      `${REST_API_BASE_URL}/repositories/${encodeURIComponent(tenant.slug)}/${encodeURIComponent(params.id)}`,
+      `${REST_API_BASE_URL}/repositories/${encodeURIComponent(auth.tenantSlug)}/${encodeURIComponent(params.id)}`,
       {
         method: 'GET',
-        headers: createRestAuthHeaders(user),
+        headers: createRestAuthHeaders(auth.sessionUser),
       }
     );
     const data = await response.json().catch(() => ({}));
     if (!response.ok) {
       const detail = typeof data.detail === 'string' ? data.detail : 'Failed to load repository';
+      return NextResponse.json({ success: false, error: detail }, { status: response.status });
+    }
+    return NextResponse.json({ success: true, repository: data });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Internal server error';
+    return NextResponse.json({ success: false, error: message }, { status: 500 });
+  }
+}
+
+export async function PATCH(
+  request: Request,
+  context: { params: Promise<{ id: string }> }
+) {
+  try {
+    const auth = await resolveAuthContext();
+    if ('error' in auth) return auth.error;
+
+    const params = await context.params;
+    const body = await request.json();
+    const response = await fetch(
+      `${REST_API_BASE_URL}/repositories/${encodeURIComponent(auth.tenantSlug)}/${encodeURIComponent(params.id)}/branches`,
+      {
+        method: 'PATCH',
+        headers: createRestAuthHeaders(auth.sessionUser),
+        body: JSON.stringify(body),
+      }
+    );
+    const data = await response.json().catch(() => ({}));
+    if (!response.ok) {
+      const detail = typeof data.detail === 'string' ? data.detail : 'Failed to update repository branches';
       return NextResponse.json({ success: false, error: detail }, { status: response.status });
     }
     return NextResponse.json({ success: true, repository: data });

--- a/objectified-ui/src/app/api/sso/github/branches/route.ts
+++ b/objectified-ui/src/app/api/sso/github/branches/route.ts
@@ -45,21 +45,24 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: 'No access token found for this account' }, { status: 401 });
     }
 
-    const url = `https://api.github.com/repos/${encodeURIComponent(repoOwner)}/${encodeURIComponent(repoName)}/branches?per_page=100`;
+    const commonHeaders = {
+      Authorization: `Bearer ${account.access_token}`,
+      Accept: 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+    };
+    const branchesUrl = `https://api.github.com/repos/${encodeURIComponent(repoOwner)}/${encodeURIComponent(repoName)}/branches?per_page=100`;
+    const repositoryUrl = `https://api.github.com/repos/${encodeURIComponent(repoOwner)}/${encodeURIComponent(repoName)}`;
 
-    const githubResponse = await fetch(url, {
-      headers: {
-        Authorization: `Bearer ${account.access_token}`,
-        Accept: 'application/vnd.github+json',
-        'X-GitHub-Api-Version': '2022-11-28',
-      },
-    });
+    const [githubBranchesResponse, githubRepositoryResponse] = await Promise.all([
+      fetch(branchesUrl, { headers: commonHeaders }),
+      fetch(repositoryUrl, { headers: commonHeaders }),
+    ]);
 
-    if (!githubResponse.ok) {
-      const errorText = await githubResponse.text();
-      console.error('GitHub API error:', githubResponse.status, errorText);
+    if (!githubBranchesResponse.ok) {
+      const errorText = await githubBranchesResponse.text();
+      console.error('GitHub API error:', githubBranchesResponse.status, errorText);
 
-      if (githubResponse.status === 401) {
+      if (githubBranchesResponse.status === 401) {
         return NextResponse.json(
           { error: 'GitHub access token is invalid or expired. Please re-link your account.' },
           { status: 401 }
@@ -67,19 +70,27 @@ export async function GET(request: NextRequest) {
       }
 
       return NextResponse.json(
-        { error: `GitHub API error: ${githubResponse.statusText}` },
-        { status: githubResponse.status }
+        { error: `GitHub API error: ${githubBranchesResponse.statusText}` },
+        { status: githubBranchesResponse.status }
       );
     }
 
-    const branches: unknown = await githubResponse.json();
+    const branches: unknown = await githubBranchesResponse.json();
     const names = Array.isArray(branches)
       ? branches
           .map((b) => (typeof b === 'object' && b !== null && 'name' in b ? String((b as { name: string }).name) : ''))
           .filter(Boolean)
       : [];
+    const repositoryPayload: unknown = githubRepositoryResponse.ok ? await githubRepositoryResponse.json() : null;
+    const defaultBranch =
+      typeof repositoryPayload === 'object' &&
+      repositoryPayload !== null &&
+      'default_branch' in repositoryPayload &&
+      typeof (repositoryPayload as { default_branch?: unknown }).default_branch === 'string'
+        ? String((repositoryPayload as { default_branch: string }).default_branch)
+        : null;
 
-    return NextResponse.json({ branches: names });
+    return NextResponse.json({ branches: names, defaultBranch });
   } catch (error: unknown) {
     console.error('Error fetching GitHub branches:', error);
     const message = error instanceof Error ? error.message : 'Failed to fetch branches';


### PR DESCRIPTION
## Summary
- add repository branch configuration updates via a new REST PATCH endpoint and UI API proxy for tracked branch rows
- update registration and repository detail flows to manage per-branch `subpathGlob` + `pollIntervalSec`, including wildcard branch patterns like `release/*`
- auto-select the provider default branch on registration, default missing subpath globs to `**/*`, and add roadmap/version-note/version bumps

## Test plan
- [x] `yarn workspace objectified-ui lint "src/app/ade/dashboard/repositories/page.tsx" "src/app/ade/dashboard/repositories/[id]/page.tsx" "src/app/api/repositories/[id]/route.ts" "src/app/api/sso/github/branches/route.ts"`
- [x] `yarn workspace objectified-ui test:e2e e2e/repositories-register.spec.ts`
- [ ] `yarn build` *(currently fails from pre-existing type error in `objectified-ui/lib/repositories/providers/resolve-repository-token.ts`)*
- [ ] `yarn test` *(currently fails from pre-existing `tests/llm-streaming.test.ts` pretty-format issue)*
- [ ] `uv run pytest tests/test_repositories_routes.py` *(blocked: `uv` not available in this environment)*

## Risk / Notes
- Branch updates now fully replace tracked branch rows for a repository; clients should send the full desired branch list on save.
- Default branch resolution comes from GitHub repo metadata returned by `/api/sso/github/branches`.

Closes #2757

Made with [Cursor](https://cursor.com)