### PR TITLE
Fix #2758 - repository edit/archive/delete lifecycle

### DIFF
--- a/docs/PLANNED_FEATURE_ROADMAP_REPOSITORY.md
+++ b/docs/PLANNED_FEATURE_ROADMAP_REPOSITORY.md
@@ -4,6 +4,7 @@
 
 - REPO-1.4 (#2756): Added repository registration UI flow and REST registration endpoint for GitHub repositories.
 - REPO-1.5 (#2757): Added per-repository branch management with per-branch subpath and polling settings, including default branch preselection and wildcard branch patterns.
+- REPO-1.6 (#2758): Added repository settings edit/archive/unarchive/delete flows with typed delete confirmation, archival audit events, and deletion cascades for repository relations.
 
 ## Open Issues
 

--- a/objectified-rest/pyproject.toml
+++ b/objectified-rest/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "objectified-rest"
-version = "1.0.53"
+version = "1.0.54"
 description = "REST API for serving OpenAPI specifications from the Objectified database"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/objectified-rest/src/app/repositories_routes.py
+++ b/objectified-rest/src/app/repositories_routes.py
@@ -12,7 +12,7 @@ from threading import Lock
 from typing import Any, Dict, List, Literal
 from uuid import UUID, uuid4
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Body, Depends, HTTPException, Response
 from pydantic import BaseModel, Field
 
 from .auth import validate_authentication
@@ -39,6 +39,16 @@ class RepositoryBranchesUpdateRequest(BaseModel):
     branches: List[RepositoryBranchInput] = Field(min_length=1)
 
 
+class RepositoryEditRequest(BaseModel):
+    owner: str | None = None
+    name: str | None = None
+    manifest: str | None = None
+
+
+class RepositoryDeleteRequest(BaseModel):
+    confirmFullName: str = Field(min_length=1)
+
+
 class RepositoryScanTimelineEntry(BaseModel):
     id: str
     type: Literal["scan"]
@@ -61,11 +71,12 @@ class RepositoryRecord(BaseModel):
     owner: str
     name: str
     fullName: str
-    status: Literal["healthy", "warnings", "error", "scan_in_progress"] = "scan_in_progress"
+    status: Literal["healthy", "warnings", "error", "scan_in_progress", "archived"] = "scan_in_progress"
     branches: List[RepositoryBranchRecord]
     manifest: str | None = None
     createdAt: str
     updatedAt: str
+    archivedAt: str | None = None
     timeline: List[RepositoryScanTimelineEntry]
 
 
@@ -75,6 +86,11 @@ class RegisterRepositoryResponse(BaseModel):
 
 
 _REPO_STORE: Dict[str, Dict[str, RepositoryRecord]] = {}
+_REPO_BRANCH_STORE: Dict[str, List[RepositoryBranchRecord]] = {}
+_REPO_SCAN_STORE: Dict[str, List[RepositoryScanTimelineEntry]] = {}
+_REPO_FILE_STORE: Dict[str, List[Dict[str, Any]]] = {}
+_REPO_CREDENTIAL_REF_STORE: Dict[str, List[Dict[str, Any]]] = {}
+_REPO_AUDIT_STORE: List[Dict[str, Any]] = []
 _STORE_LOCK = Lock()
 
 
@@ -123,6 +139,28 @@ def _to_summary(repo: RepositoryRecord) -> Dict[str, Any]:
     }
 
 
+def _write_audit_row(tenant_id: str, repository_id: str, event_type: Literal["repository.archived", "repository.unarchived", "repository.removed"]) -> None:
+    _REPO_AUDIT_STORE.append(
+        {
+            "id": str(uuid4()),
+            "tenantId": tenant_id,
+            "repositoryId": repository_id,
+            "eventType": event_type,
+            "createdAt": _utc_now_iso(),
+        }
+    )
+
+
+def _list_poll_targets_for_tenant(tenant_id: str) -> List[Dict[str, str]]:
+    poll_targets: List[Dict[str, str]] = []
+    for repository in _REPO_STORE.get(tenant_id, {}).values():
+        if repository.status == "archived":
+            continue
+        for branch in _REPO_BRANCH_STORE.get(repository.id, repository.branches):
+            poll_targets.append({"repositoryId": repository.id, "branch": branch.branch})
+    return poll_targets
+
+
 @router.post("/{tenant_slug}", status_code=201, response_model=RegisterRepositoryResponse)
 async def register_repository(
     tenant_slug: str,
@@ -167,6 +205,10 @@ async def register_repository(
 
     with _STORE_LOCK:
         tenant_repos = _REPO_STORE.setdefault(tenant_id, {})
+        _REPO_BRANCH_STORE[repository.id] = list(normalized_branches)
+        _REPO_SCAN_STORE[repository.id] = [timeline_entry]
+        _REPO_FILE_STORE[repository.id] = []
+        _REPO_CREDENTIAL_REF_STORE[repository.id] = [{"linkedAccountId": request.linkedAccountId}]
         tenant_repos[repository.id] = repository
 
     return RegisterRepositoryResponse(
@@ -215,6 +257,147 @@ async def update_repository_branches(
         repository = _REPO_STORE.get(tenant_id, {}).get(repository_id)
         if repository is None:
             raise HTTPException(status_code=404, detail=f"Repository not found: {repository_id}")
-        repository.branches = normalized_branches
+        _REPO_BRANCH_STORE[repository.id] = list(normalized_branches)
+        repository.branches = list(normalized_branches)
         repository.updatedAt = _utc_now_iso()
         return repository
+
+
+@router.patch("/{tenant_slug}/{repository_id}", response_model=RepositoryRecord)
+async def edit_repository(
+    tenant_slug: str,
+    repository_id: str,
+    request: RepositoryEditRequest,
+    auth_data: Dict[str, Any] = Depends(validate_authentication),
+) -> RepositoryRecord:
+    tenant_id = auth_data["tenant_id"]
+    if request.owner is None and request.name is None and request.manifest is None:
+        raise HTTPException(status_code=400, detail="At least one editable field is required")
+
+    with _STORE_LOCK:
+        repository = _REPO_STORE.get(tenant_id, {}).get(repository_id)
+        if repository is None:
+            raise HTTPException(status_code=404, detail=f"Repository not found: {repository_id}")
+
+        if request.owner is not None:
+            owner = request.owner.strip()
+            if not owner:
+                raise HTTPException(status_code=400, detail="owner must not be empty")
+            repository.owner = owner
+
+        if request.name is not None:
+            name = request.name.strip()
+            if not name:
+                raise HTTPException(status_code=400, detail="name must not be empty")
+            repository.name = name
+
+        if request.owner is not None or request.name is not None:
+            repository.fullName = f"{repository.owner}/{repository.name}"
+
+        if request.manifest is not None:
+            repository.manifest = request.manifest
+
+        repository.updatedAt = _utc_now_iso()
+        return repository
+
+
+@router.post("/{tenant_slug}/{repository_id}/archive", response_model=RepositoryRecord)
+async def archive_repository(
+    tenant_slug: str,
+    repository_id: str,
+    auth_data: Dict[str, Any] = Depends(validate_authentication),
+) -> RepositoryRecord:
+    tenant_id = auth_data["tenant_id"]
+    with _STORE_LOCK:
+        repository = _REPO_STORE.get(tenant_id, {}).get(repository_id)
+        if repository is None:
+            raise HTTPException(status_code=404, detail=f"Repository not found: {repository_id}")
+
+        now = _utc_now_iso()
+        repository.status = "archived"
+        repository.archivedAt = now
+        repository.updatedAt = now
+        _write_audit_row(tenant_id, repository_id, "repository.archived")
+        return repository
+
+
+@router.post("/{tenant_slug}/{repository_id}/unarchive", response_model=RepositoryRecord)
+async def unarchive_repository(
+    tenant_slug: str,
+    repository_id: str,
+    auth_data: Dict[str, Any] = Depends(validate_authentication),
+) -> RepositoryRecord:
+    tenant_id = auth_data["tenant_id"]
+    with _STORE_LOCK:
+        repository = _REPO_STORE.get(tenant_id, {}).get(repository_id)
+        if repository is None:
+            raise HTTPException(status_code=404, detail=f"Repository not found: {repository_id}")
+
+        repository.status = "healthy"
+        repository.archivedAt = None
+        repository.updatedAt = _utc_now_iso()
+        _write_audit_row(tenant_id, repository_id, "repository.unarchived")
+        return repository
+
+
+@router.delete("/{tenant_slug}/{repository_id}", status_code=204)
+async def delete_repository(
+    tenant_slug: str,
+    repository_id: str,
+    request: RepositoryDeleteRequest = Body(...),
+    auth_data: Dict[str, Any] = Depends(validate_authentication),
+) -> Response:
+    tenant_id = auth_data["tenant_id"]
+    with _STORE_LOCK:
+        tenant_repos = _REPO_STORE.get(tenant_id, {})
+        repository = tenant_repos.get(repository_id)
+        if repository is None:
+            raise HTTPException(status_code=404, detail=f"Repository not found: {repository_id}")
+        if request.confirmFullName.strip() != repository.fullName:
+            raise HTTPException(status_code=400, detail="confirmFullName must match repository fullName")
+
+        tenant_repos.pop(repository_id, None)
+        _REPO_BRANCH_STORE.pop(repository_id, None)
+        _REPO_SCAN_STORE.pop(repository_id, None)
+        _REPO_FILE_STORE.pop(repository_id, None)
+        _REPO_CREDENTIAL_REF_STORE.pop(repository_id, None)
+        _write_audit_row(tenant_id, repository_id, "repository.removed")
+
+    return Response(status_code=204)
+
+
+def _reset_repository_state_for_tests() -> None:
+    with _STORE_LOCK:
+        _REPO_STORE.clear()
+        _REPO_BRANCH_STORE.clear()
+        _REPO_SCAN_STORE.clear()
+        _REPO_FILE_STORE.clear()
+        _REPO_CREDENTIAL_REF_STORE.clear()
+        _REPO_AUDIT_STORE.clear()
+
+
+def _seed_repository_relations_for_tests(repository_id: str) -> None:
+    with _STORE_LOCK:
+        _REPO_SCAN_STORE[repository_id] = [RepositoryScanTimelineEntry(id=str(uuid4()), type="scan", status="completed", message="done", createdAt=_utc_now_iso())]
+        _REPO_FILE_STORE[repository_id] = [{"path": "README.md"}]
+        _REPO_CREDENTIAL_REF_STORE[repository_id] = [{"linkedAccountId": str(uuid4())}]
+
+
+def _get_repository_audit_rows_for_tests(repository_id: str) -> List[Dict[str, Any]]:
+    with _STORE_LOCK:
+        return [row for row in _REPO_AUDIT_STORE if row["repositoryId"] == repository_id]
+
+
+def _get_repository_relations_exist_for_tests(repository_id: str) -> Dict[str, bool]:
+    with _STORE_LOCK:
+        return {
+            "repository_branch": repository_id in _REPO_BRANCH_STORE,
+            "repository_scan": repository_id in _REPO_SCAN_STORE,
+            "repository_file": repository_id in _REPO_FILE_STORE,
+            "repository_credential_ref": repository_id in _REPO_CREDENTIAL_REF_STORE,
+        }
+
+
+def _list_poll_targets_for_tests(tenant_id: str) -> List[Dict[str, str]]:
+    with _STORE_LOCK:
+        return _list_poll_targets_for_tenant(tenant_id)

--- a/objectified-rest/tests/test_repositories_routes.py
+++ b/objectified-rest/tests/test_repositories_routes.py
@@ -1,7 +1,15 @@
+import pytest
 from fastapi.testclient import TestClient
 
 from app.auth import validate_authentication
 from app.main import app
+from app.repositories_routes import (
+    _get_repository_audit_rows_for_tests,
+    _get_repository_relations_exist_for_tests,
+    _list_poll_targets_for_tests,
+    _reset_repository_state_for_tests,
+    _seed_repository_relations_for_tests,
+)
 
 client = TestClient(app)
 
@@ -17,6 +25,13 @@ _TENANT_SLUG = "test-tenant"
 
 def _override_auth():
     return _MOCK_AUTH
+
+
+@pytest.fixture(autouse=True)
+def _clear_repository_state():
+    _reset_repository_state_for_tests()
+    yield
+    _reset_repository_state_for_tests()
 
 
 def test_register_repository_returns_scan_job_and_timeline_entry():
@@ -148,3 +163,110 @@ def test_register_repository_normalizes_whitespace_only_subpath_glob():
     assert response.status_code == 201
     body = response.json()
     assert body["repository"]["branches"] == [{"branch": "main", "subpathGlob": "**/*", "pollIntervalSec": None}]
+
+
+def test_patch_repository_updates_owner_name_and_manifest():
+    app.dependency_overrides[validate_authentication] = _override_auth
+    try:
+        create_response = client.post(
+            f"/v1/repositories/{_TENANT_SLUG}",
+            json={
+                "linkedAccountId": "aaaaaaaa-bbbb-cccc-dddd-000000000011",
+                "provider": "github",
+                "owner": "acme",
+                "name": "service-a",
+                "branches": [{"branch": "main"}],
+            },
+        )
+        repository_id = create_response.json()["repository"]["id"]
+        patch_response = client.patch(
+            f"/v1/repositories/{_TENANT_SLUG}/{repository_id}",
+            json={
+                "owner": "acme-inc",
+                "name": "service-core",
+                "manifest": "scan:\n  include:\n    - src/**\n",
+            },
+        )
+    finally:
+        app.dependency_overrides.pop(validate_authentication, None)
+
+    assert patch_response.status_code == 200
+    body = patch_response.json()
+    assert body["owner"] == "acme-inc"
+    assert body["name"] == "service-core"
+    assert body["fullName"] == "acme-inc/service-core"
+    assert body["manifest"] == "scan:\n  include:\n    - src/**\n"
+
+
+def test_archive_unarchive_writes_audit_and_scheduler_skips_archived():
+    app.dependency_overrides[validate_authentication] = _override_auth
+    try:
+        create_response = client.post(
+            f"/v1/repositories/{_TENANT_SLUG}",
+            json={
+                "linkedAccountId": "aaaaaaaa-bbbb-cccc-dddd-000000000012",
+                "provider": "github",
+                "owner": "acme",
+                "name": "service-b",
+                "branches": [{"branch": "main"}, {"branch": "release/*"}],
+            },
+        )
+        repository_id = create_response.json()["repository"]["id"]
+        archive_response = client.post(f"/v1/repositories/{_TENANT_SLUG}/{repository_id}/archive")
+        poll_targets_after_archive = _list_poll_targets_for_tests(_MOCK_AUTH["tenant_id"])
+        unarchive_response = client.post(f"/v1/repositories/{_TENANT_SLUG}/{repository_id}/unarchive")
+        poll_targets_after_unarchive = _list_poll_targets_for_tests(_MOCK_AUTH["tenant_id"])
+        audit_rows = _get_repository_audit_rows_for_tests(repository_id)
+    finally:
+        app.dependency_overrides.pop(validate_authentication, None)
+
+    assert archive_response.status_code == 200
+    assert archive_response.json()["status"] == "archived"
+    assert archive_response.json()["archivedAt"] is not None
+    assert poll_targets_after_archive == []
+
+    assert unarchive_response.status_code == 200
+    assert unarchive_response.json()["status"] == "healthy"
+    assert unarchive_response.json()["archivedAt"] is None
+    assert sorted(target["branch"] for target in poll_targets_after_unarchive) == ["main", "release/*"]
+
+    assert [row["eventType"] for row in audit_rows] == ["repository.archived", "repository.unarchived"]
+
+
+def test_delete_repository_requires_confirmation_and_cascades():
+    app.dependency_overrides[validate_authentication] = _override_auth
+    try:
+        create_response = client.post(
+            f"/v1/repositories/{_TENANT_SLUG}",
+            json={
+                "linkedAccountId": "aaaaaaaa-bbbb-cccc-dddd-000000000013",
+                "provider": "github",
+                "owner": "acme",
+                "name": "service-c",
+                "branches": [{"branch": "main"}],
+            },
+        )
+        repository = create_response.json()["repository"]
+        repository_id = repository["id"]
+        _seed_repository_relations_for_tests(repository_id)
+        wrong_confirmation = client.request(
+            method="DELETE",
+            url=f"/v1/repositories/{_TENANT_SLUG}/{repository_id}",
+            json={"confirmFullName": "acme/wrong-repo"},
+        )
+        delete_response = client.request(
+            method="DELETE",
+            url=f"/v1/repositories/{_TENANT_SLUG}/{repository_id}",
+            json={"confirmFullName": repository["fullName"]},
+        )
+        relations_exist = _get_repository_relations_exist_for_tests(repository_id)
+        detail_response = client.get(f"/v1/repositories/{_TENANT_SLUG}/{repository_id}")
+        audit_rows = _get_repository_audit_rows_for_tests(repository_id)
+    finally:
+        app.dependency_overrides.pop(validate_authentication, None)
+
+    assert wrong_confirmation.status_code == 400
+    assert delete_response.status_code == 204
+    assert all(not exists for exists in relations_exist.values())
+    assert detail_response.status_code == 404
+    assert [row["eventType"] for row in audit_rows] == ["repository.removed"]

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.10.22",
+  "version": "0.10.23",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -10,6 +10,7 @@ We continue to improve the platform based on your feedback with improvements and
 - Added a server-only `resolveRepositoryToken` helper that resolves linked-account repository credentials, refreshes supported expired tokens, emits typed resolver errors, and writes token-safe workflow audit rows.
 - Added a new ADE Repositories page with a four-step GitHub registration wizard and initial scan timeline flow.
 - Added per-repository branch management so tracked branches can be added/removed with per-branch subpath glob and polling settings, defaulting to the provider default branch and supporting wildcard branch patterns.
+- Added repository lifecycle management for edit/archive/unarchive/delete with typed delete confirmation, dashboard controls, and REST audit/cascade handling.
 
 ## UI
 - Branch workflow is its own button in the canvas now, and compacted to fit most functionality that's in Versions now.

--- a/objectified-ui/src/app/ade/dashboard/repositories/[id]/page.tsx
+++ b/objectified-ui/src/app/ade/dashboard/repositories/[id]/page.tsx
@@ -6,6 +6,14 @@ import { ArrowLeft, GitBranchPlus, Loader2 } from 'lucide-react';
 import { Button } from '@/app/components/ui/Button';
 import { Alert } from '@/app/components/ui/Alert';
 import { Input } from '@/app/components/ui/Input';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/app/components/ui/Dialog';
 import { dashboardContentStackClass, dashboardMainClass, dashboardPanelClass } from '@/app/components/ade/dashboard/dashboardScreenClasses';
 import { getRepositoriesI18nBundle } from '../i18n';
 
@@ -25,6 +33,8 @@ interface RepositoryDetail {
   name: string;
   fullName: string;
   status: string;
+  manifest?: string | null;
+  archivedAt?: string | null;
   branches: Array<{ branch: string; subpathGlob?: string; pollIntervalSec?: number }>;
   timeline: RepositoryTimelineItem[];
 }
@@ -46,7 +56,15 @@ export default function RepositoryDetailPage() {
   const [errorMessage, setErrorMessage] = useState('');
   const [successMessage, setSuccessMessage] = useState('');
   const [isLoading, setIsLoading] = useState(true);
-  const [isSaving, setIsSaving] = useState(false);
+  const [isSavingBranches, setIsSavingBranches] = useState(false);
+  const [isSavingDetails, setIsSavingDetails] = useState(false);
+  const [isMutatingLifecycle, setIsMutatingLifecycle] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [deleteConfirmation, setDeleteConfirmation] = useState('');
+  const [ownerInput, setOwnerInput] = useState('');
+  const [nameInput, setNameInput] = useState('');
+  const [manifestInput, setManifestInput] = useState('');
 
   const updateSubpath = (branchName: string, next: string) => {
     setBranchRows((prev) =>
@@ -85,7 +103,7 @@ export default function RepositoryDetailPage() {
       setErrorMessage(copy.branchesRequired);
       return;
     }
-    setIsSaving(true);
+    setIsSavingBranches(true);
     setErrorMessage('');
     setSuccessMessage('');
     try {
@@ -118,7 +136,91 @@ export default function RepositoryDetailPage() {
       const message = error instanceof Error ? error.message : 'Failed to update branches';
       setErrorMessage(message);
     } finally {
-      setIsSaving(false);
+      setIsSavingBranches(false);
+    }
+  };
+
+  const saveRepositoryDetails = async () => {
+    if (!repository) return;
+    const owner = ownerInput.trim();
+    const name = nameInput.trim();
+    if (!owner || !name) {
+      setErrorMessage('Owner and repository name are required.');
+      return;
+    }
+    setIsSavingDetails(true);
+    setErrorMessage('');
+    setSuccessMessage('');
+    try {
+      const response = await fetch(`/api/repositories/${repository.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          owner,
+          name,
+          manifest: manifestInput,
+        }),
+      });
+      const data = await response.json();
+      if (!response.ok || !data.success) {
+        throw new Error(data.error || 'Failed to update repository');
+      }
+      const updatedRepository = data.repository as RepositoryDetail;
+      setRepository(updatedRepository);
+      setOwnerInput(updatedRepository.owner);
+      setNameInput(updatedRepository.name);
+      setManifestInput(updatedRepository.manifest || '');
+      setSuccessMessage('Repository settings updated.');
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to update repository';
+      setErrorMessage(message);
+    } finally {
+      setIsSavingDetails(false);
+    }
+  };
+
+  const updateLifecycle = async (action: 'archive' | 'unarchive') => {
+    if (!repository) return;
+    setIsMutatingLifecycle(true);
+    setErrorMessage('');
+    setSuccessMessage('');
+    try {
+      const response = await fetch(`/api/repositories/${repository.id}/${action}`, { method: 'POST' });
+      const data = await response.json();
+      if (!response.ok || !data.success) {
+        throw new Error(data.error || `Failed to ${action} repository`);
+      }
+      const updatedRepository = data.repository as RepositoryDetail;
+      setRepository(updatedRepository);
+      setSuccessMessage(action === 'archive' ? 'Repository archived.' : 'Repository unarchived.');
+    } catch (error) {
+      const message = error instanceof Error ? error.message : `Failed to ${action} repository`;
+      setErrorMessage(message);
+    } finally {
+      setIsMutatingLifecycle(false);
+    }
+  };
+
+  const deleteRepository = async () => {
+    if (!repository) return;
+    setIsDeleting(true);
+    setErrorMessage('');
+    setSuccessMessage('');
+    try {
+      const response = await fetch(`/api/repositories/${repository.id}`, {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ confirmFullName: deleteConfirmation }),
+      });
+      if (response.status !== 204) {
+        const data = await response.json().catch(() => ({}));
+        throw new Error(data.error || 'Failed to delete repository');
+      }
+      router.push('/ade/dashboard/repositories');
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to delete repository';
+      setErrorMessage(message);
+      setIsDeleting(false);
     }
   };
 
@@ -134,6 +236,9 @@ export default function RepositoryDetailPage() {
         }
         const loadedRepository = data.repository as RepositoryDetail;
         setRepository(loadedRepository);
+        setOwnerInput(loadedRepository.owner);
+        setNameInput(loadedRepository.name);
+        setManifestInput(loadedRepository.manifest || '');
         setBranchRows(
           (loadedRepository.branches || []).map((branch) => ({
             branch: branch.branch,
@@ -205,6 +310,49 @@ export default function RepositoryDetailPage() {
                   <div>
                     <div className="text-gray-500 dark:text-gray-400">{copy.statusLabel}</div>
                     <div className="font-medium">{repository.status}</div>
+                  </div>
+                </div>
+                <div className="mt-4 grid grid-cols-1 gap-3">
+                  <Input
+                    value={ownerInput}
+                    onChange={(event) => setOwnerInput(event.target.value)}
+                    placeholder="Repository owner"
+                  />
+                  <Input
+                    value={nameInput}
+                    onChange={(event) => setNameInput(event.target.value)}
+                    placeholder="Repository name"
+                  />
+                  <textarea
+                    value={manifestInput}
+                    onChange={(event) => setManifestInput(event.target.value)}
+                    className="w-full min-h-28 rounded-lg border border-gray-200 dark:border-gray-700 p-3 text-sm bg-white dark:bg-gray-900"
+                    placeholder={copy.manifestPlaceholder}
+                  />
+                  <div className="flex flex-wrap items-center gap-2">
+                    <Button onClick={() => void saveRepositoryDetails()} disabled={isSavingDetails || isLoading}>
+                      {isSavingDetails ? copy.savingButton : 'Save repository settings'}
+                    </Button>
+                    {repository.status === 'archived' ? (
+                      <Button
+                        variant="outline"
+                        onClick={() => void updateLifecycle('unarchive')}
+                        disabled={isMutatingLifecycle}
+                      >
+                        Unarchive
+                      </Button>
+                    ) : (
+                      <Button
+                        variant="outline"
+                        onClick={() => void updateLifecycle('archive')}
+                        disabled={isMutatingLifecycle}
+                      >
+                        Archive
+                      </Button>
+                    )}
+                    <Button variant="destructive" onClick={() => setDeleteDialogOpen(true)} disabled={isDeleting}>
+                      Delete
+                    </Button>
                   </div>
                 </div>
                 <div className="mt-4">
@@ -291,8 +439,8 @@ export default function RepositoryDetailPage() {
                 </div>
 
                 <div className="flex justify-end">
-                  <Button onClick={() => void saveBranches()} disabled={isSaving || branchRows.length === 0}>
-                    {isSaving ? copy.savingButton : copy.saveBranchesButton}
+                  <Button onClick={() => void saveBranches()} disabled={isSavingBranches || branchRows.length === 0}>
+                    {isSavingBranches ? copy.savingButton : copy.saveBranchesButton}
                   </Button>
                 </div>
               </section>
@@ -314,6 +462,33 @@ export default function RepositoryDetailPage() {
           ) : null}
         </div>
       </main>
+      <Dialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete repository</DialogTitle>
+            <DialogDescription>
+              Type <span className="font-semibold">{repository?.fullName}</span> to confirm permanent deletion.
+            </DialogDescription>
+          </DialogHeader>
+          <Input
+            value={deleteConfirmation}
+            onChange={(event) => setDeleteConfirmation(event.target.value)}
+            placeholder={repository?.fullName || 'owner/name'}
+          />
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setDeleteDialogOpen(false)} disabled={isDeleting}>
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={() => void deleteRepository()}
+              disabled={isDeleting || !repository || deleteConfirmation.trim() !== repository.fullName}
+            >
+              {isDeleting ? copy.savingButton : 'Delete repository'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </>
   );
 }

--- a/objectified-ui/src/app/ade/dashboard/repositories/[id]/page.tsx
+++ b/objectified-ui/src/app/ade/dashboard/repositories/[id]/page.tsx
@@ -151,7 +151,7 @@ export default function RepositoryDetailPage() {
     const owner = ownerInput.trim();
     const name = nameInput.trim();
     if (!owner || !name) {
-      setErrorMessage('Owner and repository name are required.');
+      setErrorMessage(copy.ownerNameRequired);
       return;
     }
     setIsSavingDetails(true);
@@ -176,7 +176,7 @@ export default function RepositoryDetailPage() {
       setOwnerInput(updatedRepository.owner);
       setNameInput(updatedRepository.name);
       setManifestInput(updatedRepository.manifest || '');
-      setSuccessMessage('Repository settings updated.');
+      setSuccessMessage(copy.settingsUpdatedMessage);
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Failed to update repository';
       setErrorMessage(message);
@@ -198,7 +198,7 @@ export default function RepositoryDetailPage() {
       }
       const updatedRepository = data.repository as RepositoryDetail;
       setRepository(updatedRepository);
-      setSuccessMessage(action === 'archive' ? 'Repository disabled.' : 'Repository enabled.');
+      setSuccessMessage(action === 'archive' ? copy.repositoryDisabledMessage : copy.repositoryEnabledMessage);
     } catch (error) {
       const message =
         error instanceof Error
@@ -325,12 +325,12 @@ export default function RepositoryDetailPage() {
                   <Input
                     value={ownerInput}
                     onChange={(event) => setOwnerInput(event.target.value)}
-                    placeholder="Repository owner"
+                    placeholder={copy.ownerPlaceholder}
                   />
                   <Input
                     value={nameInput}
                     onChange={(event) => setNameInput(event.target.value)}
-                    placeholder="Repository name"
+                    placeholder={copy.namePlaceholder}
                   />
                   <textarea
                     value={manifestInput}
@@ -340,7 +340,7 @@ export default function RepositoryDetailPage() {
                   />
                   <div className="flex flex-wrap items-center gap-2">
                     <Button onClick={() => void saveRepositoryDetails()} disabled={isSavingDetails || isLoading}>
-                      {isSavingDetails ? copy.savingButton : 'Save repository settings'}
+                      {isSavingDetails ? copy.savingButton : copy.saveSettingsButton}
                     </Button>
                     {repository.status === 'archived' ? (
                       <Button
@@ -348,7 +348,7 @@ export default function RepositoryDetailPage() {
                         onClick={() => void updateLifecycle('unarchive')}
                         disabled={isMutatingLifecycle}
                       >
-                        Enable
+                        {copy.enableButton}
                       </Button>
                     ) : (
                       <Button
@@ -356,11 +356,11 @@ export default function RepositoryDetailPage() {
                         onClick={() => void updateLifecycle('archive')}
                         disabled={isMutatingLifecycle}
                       >
-                        Disable
+                        {copy.disableButton}
                       </Button>
                     )}
                     <Button variant="destructive" onClick={() => setDeleteDialogOpen(true)} disabled={isDeleting}>
-                      Delete
+                      {copy.deleteButton}
                     </Button>
                   </div>
                 </div>
@@ -474,26 +474,28 @@ export default function RepositoryDetailPage() {
       <Dialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>Delete repository</DialogTitle>
+            <DialogTitle>{copy.deleteDialogTitle}</DialogTitle>
             <DialogDescription>
-              Type <span className="font-semibold">{repository?.fullName}</span> to confirm permanent deletion.
+              {copy.deleteDialogDescriptionPrefix}{' '}
+              <span className="font-semibold">{repository?.fullName}</span>{' '}
+              {copy.deleteDialogDescriptionSuffix}
             </DialogDescription>
           </DialogHeader>
           <Input
             value={deleteConfirmation}
             onChange={(event) => setDeleteConfirmation(event.target.value)}
-            placeholder={repository?.fullName || 'owner/name'}
+            placeholder={repository?.fullName || copy.ownerNameFallbackPlaceholder}
           />
           <DialogFooter>
             <Button variant="outline" onClick={() => setDeleteDialogOpen(false)} disabled={isDeleting}>
-              Cancel
+              {copy.cancelButton}
             </Button>
             <Button
               variant="destructive"
               onClick={() => void deleteRepository()}
               disabled={isDeleting || !repository || deleteConfirmation.trim() !== repository.fullName}
             >
-              {isDeleting ? copy.savingButton : 'Delete repository'}
+              {isDeleting ? copy.savingButton : copy.deleteRepositoryButton}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/objectified-ui/src/app/ade/dashboard/repositories/[id]/page.tsx
+++ b/objectified-ui/src/app/ade/dashboard/repositories/[id]/page.tsx
@@ -45,6 +45,12 @@ interface BranchRow {
   pollIntervalSec?: number;
 }
 
+function formatRepositoryStatus(status: string): string {
+  if (status === 'archived') return 'Disabled';
+  if (status === 'scan_in_progress') return 'Scan in progress';
+  return status.replace(/_/g, ' ');
+}
+
 export default function RepositoryDetailPage() {
   const params = useParams<{ id: string }>();
   const router = useRouter();
@@ -188,13 +194,16 @@ export default function RepositoryDetailPage() {
       const response = await fetch(`/api/repositories/${repository.id}/${action}`, { method: 'POST' });
       const data = await response.json();
       if (!response.ok || !data.success) {
-        throw new Error(data.error || `Failed to ${action} repository`);
+        throw new Error(data.error || `Failed to ${action === 'archive' ? 'disable' : 'enable'} repository`);
       }
       const updatedRepository = data.repository as RepositoryDetail;
       setRepository(updatedRepository);
-      setSuccessMessage(action === 'archive' ? 'Repository archived.' : 'Repository unarchived.');
+      setSuccessMessage(action === 'archive' ? 'Repository disabled.' : 'Repository enabled.');
     } catch (error) {
-      const message = error instanceof Error ? error.message : `Failed to ${action} repository`;
+      const message =
+        error instanceof Error
+          ? error.message
+          : `Failed to ${action === 'archive' ? 'disable' : 'enable'} repository`;
       setErrorMessage(message);
     } finally {
       setIsMutatingLifecycle(false);
@@ -309,7 +318,7 @@ export default function RepositoryDetailPage() {
                   </div>
                   <div>
                     <div className="text-gray-500 dark:text-gray-400">{copy.statusLabel}</div>
-                    <div className="font-medium">{repository.status}</div>
+                    <div className="font-medium">{formatRepositoryStatus(repository.status)}</div>
                   </div>
                 </div>
                 <div className="mt-4 grid grid-cols-1 gap-3">
@@ -339,7 +348,7 @@ export default function RepositoryDetailPage() {
                         onClick={() => void updateLifecycle('unarchive')}
                         disabled={isMutatingLifecycle}
                       >
-                        Unarchive
+                        Enable
                       </Button>
                     ) : (
                       <Button
@@ -347,7 +356,7 @@ export default function RepositoryDetailPage() {
                         onClick={() => void updateLifecycle('archive')}
                         disabled={isMutatingLifecycle}
                       >
-                        Archive
+                        Disable
                       </Button>
                     )}
                     <Button variant="destructive" onClick={() => setDeleteDialogOpen(true)} disabled={isDeleting}>

--- a/objectified-ui/src/app/ade/dashboard/repositories/i18n.ts
+++ b/objectified-ui/src/app/ade/dashboard/repositories/i18n.ts
@@ -51,6 +51,22 @@ export interface RepositoriesI18nBundle {
   noLinkedAccountsQuestion: string;
   yesButton: string;
   noButton: string;
+  ownerPlaceholder: string;
+  namePlaceholder: string;
+  ownerNameRequired: string;
+  settingsUpdatedMessage: string;
+  repositoryDisabledMessage: string;
+  repositoryEnabledMessage: string;
+  saveSettingsButton: string;
+  enableButton: string;
+  disableButton: string;
+  deleteButton: string;
+  deleteDialogTitle: string;
+  deleteDialogDescriptionPrefix: string;
+  deleteDialogDescriptionSuffix: string;
+  cancelButton: string;
+  deleteRepositoryButton: string;
+  ownerNameFallbackPlaceholder: string;
 }
 
 export const repositoriesI18n: Record<RepositoriesLocale, RepositoriesI18nBundle> = {
@@ -106,6 +122,22 @@ export const repositoriesI18n: Record<RepositoriesLocale, RepositoriesI18nBundle
       'No linked accounts have been added yet. Would you like me to direct you to the linked accounts page?',
     yesButton: 'Yes',
     noButton: 'No',
+    ownerPlaceholder: 'Repository owner',
+    namePlaceholder: 'Repository name',
+    ownerNameRequired: 'Owner and repository name are required.',
+    settingsUpdatedMessage: 'Repository settings updated.',
+    repositoryDisabledMessage: 'Repository disabled.',
+    repositoryEnabledMessage: 'Repository enabled.',
+    saveSettingsButton: 'Save repository settings',
+    enableButton: 'Enable',
+    disableButton: 'Disable',
+    deleteButton: 'Delete',
+    deleteDialogTitle: 'Delete repository',
+    deleteDialogDescriptionPrefix: 'Type',
+    deleteDialogDescriptionSuffix: 'to confirm permanent deletion.',
+    cancelButton: 'Cancel',
+    deleteRepositoryButton: 'Delete repository',
+    ownerNameFallbackPlaceholder: 'owner/name',
   },
 };
 

--- a/objectified-ui/src/app/ade/dashboard/repositories/page.tsx
+++ b/objectified-ui/src/app/ade/dashboard/repositories/page.tsx
@@ -60,6 +60,12 @@ interface RegisteredRepository {
   branches: string[];
 }
 
+function formatRepositoryStatus(status: string): string {
+  if (status === 'archived') return 'Disabled';
+  if (status === 'scan_in_progress') return 'Scan in progress';
+  return status.replace(/_/g, ' ');
+}
+
 const RepositoriesPage = () => {
   const router = useRouter();
   const copy = getRepositoriesI18nBundle('en');
@@ -385,7 +391,7 @@ const RepositoriesPage = () => {
                           {(repo.branches || []).join(', ')}
                         </td>
                         <td className="px-6 py-4 text-sm text-gray-600 dark:text-gray-300">
-                          {repo.status}
+                          {formatRepositoryStatus(repo.status)}
                         </td>
                         <td className="px-6 py-4 text-right">
                           <Button

--- a/objectified-ui/src/app/api/repositories/[id]/archive/route.ts
+++ b/objectified-ui/src/app/api/repositories/[id]/archive/route.ts
@@ -1,0 +1,58 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/app/api/auth/[...nextauth]/route';
+import { getTenantById } from '@lib/db/helper';
+import { createRestAuthHeaders, REST_API_BASE_URL } from '@lib/rest-auth';
+
+export const dynamic = 'force-dynamic';
+
+type SessionUser = {
+  user_id?: string;
+  email?: string | null;
+  name?: string | null;
+  current_tenant_id?: string;
+};
+
+async function resolveAuthContext() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user) {
+    return { error: NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 }) };
+  }
+  const user = session.user as SessionUser;
+  if (!user.current_tenant_id) {
+    return { error: NextResponse.json({ success: false, error: 'No tenant selected' }, { status: 400 }) };
+  }
+  const tenant = await getTenantById(user.current_tenant_id);
+  if (!tenant?.slug) {
+    return { error: NextResponse.json({ success: false, error: 'Tenant slug not found' }, { status: 400 }) };
+  }
+  return { sessionUser: user, tenantSlug: tenant.slug };
+}
+
+export async function POST(
+  _request: Request,
+  context: { params: Promise<{ id: string }> }
+) {
+  try {
+    const auth = await resolveAuthContext();
+    if ('error' in auth) return auth.error;
+
+    const params = await context.params;
+    const response = await fetch(
+      `${REST_API_BASE_URL}/repositories/${encodeURIComponent(auth.tenantSlug)}/${encodeURIComponent(params.id)}/archive`,
+      {
+        method: 'POST',
+        headers: createRestAuthHeaders(auth.sessionUser),
+      }
+    );
+    const data = await response.json().catch(() => ({}));
+    if (!response.ok) {
+      const detail = typeof data.detail === 'string' ? data.detail : 'Failed to archive repository';
+      return NextResponse.json({ success: false, error: detail }, { status: response.status });
+    }
+    return NextResponse.json({ success: true, repository: data });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Internal server error';
+    return NextResponse.json({ success: false, error: message }, { status: 500 });
+  }
+}

--- a/objectified-ui/src/app/api/repositories/[id]/route.ts
+++ b/objectified-ui/src/app/api/repositories/[id]/route.ts
@@ -102,7 +102,25 @@ export async function DELETE(
     if ('error' in auth) return auth.error;
 
     const params = await context.params;
-    const body = await request.json();
+    const rawBody = await request.text();
+    if (!rawBody.trim()) {
+      return NextResponse.json(
+        { success: false, error: 'Request body is required' },
+        { status: 400 }
+      );
+    }
+
+    let body: unknown;
+    try {
+      body = JSON.parse(rawBody);
+    } catch {
+      return NextResponse.json({ success: false, error: 'Invalid JSON body' }, { status: 400 });
+    }
+
+    if (typeof body !== 'object' || body === null || typeof (body as Record<string, unknown>).confirmFullName !== 'string') {
+      return NextResponse.json({ success: false, error: 'confirmFullName is required' }, { status: 400 });
+    }
+
     const response = await fetch(
       `${REST_API_BASE_URL}/repositories/${encodeURIComponent(auth.tenantSlug)}/${encodeURIComponent(params.id)}`,
       {

--- a/objectified-ui/src/app/api/repositories/[id]/route.ts
+++ b/objectified-ui/src/app/api/repositories/[id]/route.ts
@@ -67,20 +67,59 @@ export async function PATCH(
 
     const params = await context.params;
     const body = await request.json();
+    const isBranchUpdate = Array.isArray(body?.branches);
+    const targetPath = isBranchUpdate
+      ? `${REST_API_BASE_URL}/repositories/${encodeURIComponent(auth.tenantSlug)}/${encodeURIComponent(params.id)}/branches`
+      : `${REST_API_BASE_URL}/repositories/${encodeURIComponent(auth.tenantSlug)}/${encodeURIComponent(params.id)}`;
+    const response = await fetch(targetPath, {
+      method: 'PATCH',
+      headers: createRestAuthHeaders(auth.sessionUser),
+      body: JSON.stringify(body),
+    });
+    const data = await response.json().catch(() => ({}));
+    if (!response.ok) {
+      const detail =
+        typeof data.detail === 'string'
+          ? data.detail
+          : isBranchUpdate
+            ? 'Failed to update repository branches'
+            : 'Failed to update repository';
+      return NextResponse.json({ success: false, error: detail }, { status: response.status });
+    }
+    return NextResponse.json({ success: true, repository: data });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Internal server error';
+    return NextResponse.json({ success: false, error: message }, { status: 500 });
+  }
+}
+
+export async function DELETE(
+  request: Request,
+  context: { params: Promise<{ id: string }> }
+) {
+  try {
+    const auth = await resolveAuthContext();
+    if ('error' in auth) return auth.error;
+
+    const params = await context.params;
+    const body = await request.json();
     const response = await fetch(
-      `${REST_API_BASE_URL}/repositories/${encodeURIComponent(auth.tenantSlug)}/${encodeURIComponent(params.id)}/branches`,
+      `${REST_API_BASE_URL}/repositories/${encodeURIComponent(auth.tenantSlug)}/${encodeURIComponent(params.id)}`,
       {
-        method: 'PATCH',
+        method: 'DELETE',
         headers: createRestAuthHeaders(auth.sessionUser),
         body: JSON.stringify(body),
       }
     );
+    if (response.status === 204) {
+      return new NextResponse(null, { status: 204 });
+    }
     const data = await response.json().catch(() => ({}));
     if (!response.ok) {
-      const detail = typeof data.detail === 'string' ? data.detail : 'Failed to update repository branches';
+      const detail = typeof data.detail === 'string' ? data.detail : 'Failed to delete repository';
       return NextResponse.json({ success: false, error: detail }, { status: response.status });
     }
-    return NextResponse.json({ success: true, repository: data });
+    return new NextResponse(null, { status: 204 });
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Internal server error';
     return NextResponse.json({ success: false, error: message }, { status: 500 });

--- a/objectified-ui/src/app/api/repositories/[id]/unarchive/route.ts
+++ b/objectified-ui/src/app/api/repositories/[id]/unarchive/route.ts
@@ -1,0 +1,58 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/app/api/auth/[...nextauth]/route';
+import { getTenantById } from '@lib/db/helper';
+import { createRestAuthHeaders, REST_API_BASE_URL } from '@lib/rest-auth';
+
+export const dynamic = 'force-dynamic';
+
+type SessionUser = {
+  user_id?: string;
+  email?: string | null;
+  name?: string | null;
+  current_tenant_id?: string;
+};
+
+async function resolveAuthContext() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user) {
+    return { error: NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 }) };
+  }
+  const user = session.user as SessionUser;
+  if (!user.current_tenant_id) {
+    return { error: NextResponse.json({ success: false, error: 'No tenant selected' }, { status: 400 }) };
+  }
+  const tenant = await getTenantById(user.current_tenant_id);
+  if (!tenant?.slug) {
+    return { error: NextResponse.json({ success: false, error: 'Tenant slug not found' }, { status: 400 }) };
+  }
+  return { sessionUser: user, tenantSlug: tenant.slug };
+}
+
+export async function POST(
+  _request: Request,
+  context: { params: Promise<{ id: string }> }
+) {
+  try {
+    const auth = await resolveAuthContext();
+    if ('error' in auth) return auth.error;
+
+    const params = await context.params;
+    const response = await fetch(
+      `${REST_API_BASE_URL}/repositories/${encodeURIComponent(auth.tenantSlug)}/${encodeURIComponent(params.id)}/unarchive`,
+      {
+        method: 'POST',
+        headers: createRestAuthHeaders(auth.sessionUser),
+      }
+    );
+    const data = await response.json().catch(() => ({}));
+    if (!response.ok) {
+      const detail = typeof data.detail === 'string' ? data.detail : 'Failed to unarchive repository';
+      return NextResponse.json({ success: false, error: detail }, { status: response.status });
+    }
+    return NextResponse.json({ success: true, repository: data });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Internal server error';
+    return NextResponse.json({ success: false, error: message }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Summary
- add REST repository lifecycle endpoints for metadata edits, archive/unarchive, and typed-confirmation delete
- enforce delete cascades across repository relation stores and write audit rows for archived/unarchived/removed operations
- add dashboard affordances and Next API proxy routes for edit, archive/unarchive, and delete flows
- add repository route tests plus roadmap/changelog/version updates for REPO-1.6

## Test plan
- [x] `yarn build`
- [x] `yarn test`
- [ ] `python3 -m pytest objectified-rest/tests/test_repositories_routes.py` (blocked locally: `No module named pytest`)

## Risk / notes
- Repository relation cascade and audit behavior is currently implemented against the in-memory repository route store used by this feature area.

Closes #2758

Made with [Cursor](https://cursor.com)