### PR TITLE
Fix #2759 - implement GitLab repository provider

### DIFF
--- a/docs/PLANNED_FEATURE_ROADMAP_REPOSITORY.md
+++ b/docs/PLANNED_FEATURE_ROADMAP_REPOSITORY.md
@@ -2,6 +2,7 @@
 
 ## Completed
 
+- REPO-1.7 (#2759): Implemented the GitLab repository provider adapter with full contract coverage, keyset pagination for repository listing, and GitLab webhook registration/signature verification.
 - REPO-1.4 (#2756): Added repository registration UI flow and REST registration endpoint for GitHub repositories.
 - REPO-1.5 (#2757): Added per-repository branch management with per-branch subpath and polling settings, including default branch preselection and wildcard branch patterns.
 - REPO-1.6 (#2758): Added repository settings edit/archive/unarchive/delete flows with typed delete confirmation, archival audit events, and deletion cascades for repository relations.

--- a/objectified-ui/lib/repositories/providers/__tests__/contract.test.ts
+++ b/objectified-ui/lib/repositories/providers/__tests__/contract.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, jest } from '@jest/globals';
 import { GithubRepositoryProvider } from '../github-provider';
+import { GitlabRepositoryProvider } from '../gitlab-provider';
 import { RepositoryProviderError } from '../repository-provider';
 
 function jsonResponse(
@@ -28,6 +29,29 @@ async function collect<T>(iterable: AsyncIterable<T>): Promise<T[]> {
     list.push(item);
   }
   return list;
+}
+
+function makeGitlabApiMock() {
+  return {
+    Projects: {
+      all: jest.fn(),
+      show: jest.fn(),
+    },
+    Branches: {
+      all: jest.fn(),
+      show: jest.fn(),
+    },
+    Repositories: {
+      allRepositoryTrees: jest.fn(),
+    },
+    RepositoryFiles: {
+      show: jest.fn(),
+    },
+    ProjectHooks: {
+      add: jest.fn(),
+      remove: jest.fn(),
+    },
+  };
 }
 
 describe('RepositoryProvider contract', () => {
@@ -166,6 +190,164 @@ describe('RepositoryProvider contract', () => {
       code: 'NETWORK',
     });
     await expect(unknown.getRepository('t', 'a', 'b')).rejects.toMatchObject<Partial<RepositoryProviderError>>({
+      code: 'UNKNOWN',
+    });
+  });
+});
+
+describe('GitLab RepositoryProvider contract', () => {
+  it('implements every contract method for GitLab, including webhooks', async () => {
+    const api = makeGitlabApiMock();
+    api.Projects.all
+      .mockResolvedValueOnce([
+        {
+          id: 1,
+          path: 'repo-a',
+          path_with_namespace: 'acme/repo-a',
+          description: 'A',
+          visibility: 'public',
+          default_branch: 'main',
+          web_url: 'https://gitlab.com/acme/repo-a',
+          last_activity_at: '2026-01-01T00:00:00Z',
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          id: 2,
+          path: 'repo-b',
+          path_with_namespace: 'acme/repo-b',
+          description: null,
+          visibility: 'private',
+          default_branch: 'main',
+          web_url: 'https://gitlab.com/acme/repo-b',
+          last_activity_at: '2026-01-02T00:00:00Z',
+        },
+      ])
+      .mockResolvedValueOnce([]);
+    api.Projects.show.mockResolvedValueOnce({
+      id: 1,
+      path: 'repo-a',
+      path_with_namespace: 'acme/repo-a',
+      description: 'A',
+      visibility: 'public',
+      default_branch: 'main',
+      web_url: 'https://gitlab.com/acme/repo-a',
+      last_activity_at: '2026-01-01T00:00:00Z',
+    });
+    api.Branches.all.mockResolvedValueOnce([
+      { name: 'main', protected: true, commit: { id: 'abc123' } },
+      { name: 'dev', protected: false, commit: { id: 'def456' } },
+    ]);
+    api.Branches.show.mockResolvedValueOnce({ name: 'main', commit: { id: 'abc123' } });
+    api.Repositories.allRepositoryTrees.mockResolvedValueOnce([
+      { path: 'docs/readme.md', type: 'blob', id: 's1', size: 4 },
+      { path: 'docs', type: 'tree', id: 's2', size: 0 },
+      { path: 'src/index.ts', type: 'blob', id: 's3', size: 10 },
+    ]);
+    api.RepositoryFiles.show.mockResolvedValueOnce({
+      content: 'Y29udGVudA==',
+      blob_id: 'f1',
+      size: 7,
+    });
+    api.ProjectHooks.add.mockResolvedValueOnce({ id: 42 });
+    api.ProjectHooks.remove.mockResolvedValueOnce(undefined);
+
+    const provider = new GitlabRepositoryProvider(() => api, () => 'fixed-secret');
+
+    const repos = await collect(provider.listRepositories('token-1', { perPage: 1 }));
+    const repo = await provider.getRepository('token-1', 'acme', 'repo-a');
+    const branches = await collect(provider.listBranches('token-1', { owner: 'acme', name: 'repo-a' }));
+    const sha = await provider.getCommitSha('token-1', { owner: 'acme', name: 'repo-a' }, 'main');
+    const tree = await collect(provider.walkTree('token-1', { owner: 'acme', name: 'repo-a' }, 'main', 'docs'));
+    const file = await provider.readFile('token-1', { owner: 'acme', name: 'repo-a' }, 'main', 'docs/readme.md');
+    const webhook = await provider.registerWebhook('token-1', { owner: 'acme', name: 'repo-a' }, {
+      url: 'https://example.com/hooks/gitlab',
+      events: ['push'],
+    });
+    await provider.removeWebhook('token-1', { owner: 'acme', name: 'repo-a' }, '42');
+
+    const validHeaders = new Headers({ 'x-gitlab-token': 'fixed-secret' });
+    const invalidHeaders = new Headers({ 'x-gitlab-token': 'wrong-secret' });
+
+    expect(repos.map((item) => item.fullName)).toEqual(['acme/repo-a', 'acme/repo-b']);
+    expect(repo.fullName).toBe('acme/repo-a');
+    expect(branches.map((b) => b.name)).toEqual(['main', 'dev']);
+    expect(sha).toBe('abc123');
+    expect(tree.map((entry) => entry.path)).toEqual(['docs/readme.md']);
+    expect(file).toEqual({ contentBase64: 'Y29udGVudA==', sha: 'f1', sizeBytes: 7 });
+    expect(webhook).toEqual({ id: '42', secret: 'fixed-secret' });
+    expect(provider.verifyWebhookSignature?.('fixed-secret', validHeaders, '')).toBe(true);
+    expect(provider.verifyWebhookSignature?.('fixed-secret', invalidHeaders, '')).toBe(false);
+
+    expect(api.Projects.all.mock.calls[0]?.[0]).toMatchObject({
+      pagination: 'keyset',
+      orderBy: 'id',
+      sort: 'asc',
+      perPage: 1,
+    });
+    expect(api.Projects.all.mock.calls[1]?.[0]).toMatchObject({
+      idAfter: 1,
+    });
+  });
+
+  it('never caches token and forwards it per call', async () => {
+    const api = makeGitlabApiMock();
+    api.Projects.all.mockResolvedValueOnce([]);
+    api.Projects.show.mockResolvedValueOnce({
+      id: 1,
+      path: 'repo-a',
+      path_with_namespace: 'acme/repo-a',
+      visibility: 'public',
+      default_branch: 'main',
+      web_url: 'https://gitlab.com/acme/repo-a',
+      last_activity_at: null,
+    });
+    const apiFactory = jest.fn().mockReturnValue(api);
+
+    const provider = new GitlabRepositoryProvider(apiFactory);
+    await collect(provider.listRepositories('token-A'));
+    await provider.getRepository('token-B', 'acme', 'repo-a');
+
+    expect(apiFactory).toHaveBeenCalledTimes(2);
+    expect(apiFactory).toHaveBeenNthCalledWith(1, 'token-A');
+    expect(apiFactory).toHaveBeenNthCalledWith(2, 'token-B');
+  });
+
+  it('normalizes provider errors to the shared taxonomy', async () => {
+    const unauthorizedApi = makeGitlabApiMock();
+    unauthorizedApi.Projects.show.mockRejectedValueOnce({ response: { status: 401 } });
+    const notFoundApi = makeGitlabApiMock();
+    notFoundApi.Projects.show.mockRejectedValueOnce({ response: { status: 404 } });
+    const rateLimitedApi = makeGitlabApiMock();
+    rateLimitedApi.Projects.show.mockRejectedValueOnce({ response: { status: 429 } });
+    const networkApi = makeGitlabApiMock();
+    networkApi.Projects.show.mockRejectedValueOnce(new TypeError('network down'));
+    const unknownApi = makeGitlabApiMock();
+    unknownApi.Projects.show.mockRejectedValueOnce({ response: { status: 500 } });
+
+    await expect(
+      new GitlabRepositoryProvider(() => unauthorizedApi).getRepository('t', 'a', 'b')
+    ).rejects.toMatchObject<Partial<RepositoryProviderError>>({
+      code: 'UNAUTHORIZED',
+    });
+    await expect(
+      new GitlabRepositoryProvider(() => notFoundApi).getRepository('t', 'a', 'b')
+    ).rejects.toMatchObject<Partial<RepositoryProviderError>>({
+      code: 'NOT_FOUND',
+    });
+    await expect(
+      new GitlabRepositoryProvider(() => rateLimitedApi).getRepository('t', 'a', 'b')
+    ).rejects.toMatchObject<Partial<RepositoryProviderError>>({
+      code: 'RATE_LIMITED',
+    });
+    await expect(
+      new GitlabRepositoryProvider(() => networkApi).getRepository('t', 'a', 'b')
+    ).rejects.toMatchObject<Partial<RepositoryProviderError>>({
+      code: 'NETWORK',
+    });
+    await expect(
+      new GitlabRepositoryProvider(() => unknownApi).getRepository('t', 'a', 'b')
+    ).rejects.toMatchObject<Partial<RepositoryProviderError>>({
       code: 'UNKNOWN',
     });
   });

--- a/objectified-ui/lib/repositories/providers/gitlab-provider.ts
+++ b/objectified-ui/lib/repositories/providers/gitlab-provider.ts
@@ -55,6 +55,8 @@ export class GitlabRepositoryProvider implements RepositoryProvider {
     const perPage = Math.min(opts?.perPage ?? GITLAB_MAX_PER_PAGE, GITLAB_MAX_PER_PAGE);
     const page = opts?.page ?? 1;
 
+    const visibilityFilter = mapGitlabVisibility(opts?.visibility);
+
     if (page > 1) {
       const repositories = await this.request<unknown[]>(() =>
         api.Projects.all({
@@ -63,6 +65,7 @@ export class GitlabRepositoryProvider implements RepositoryProvider {
           sort: 'desc',
           perPage,
           page,
+          ...(visibilityFilter !== undefined && { visibility: visibilityFilter }),
         })
       );
       for (const repo of repositories) {
@@ -84,6 +87,7 @@ export class GitlabRepositoryProvider implements RepositoryProvider {
           sort: 'asc',
           perPage,
           idAfter,
+          ...(visibilityFilter !== undefined && { visibility: visibilityFilter }),
         })
       );
 
@@ -223,7 +227,7 @@ export class GitlabRepositoryProvider implements RepositoryProvider {
       api.RepositoryFiles.show(projectPath(repo.owner, repo.name), normalizeFilePath(path), branch)
     );
     const record = toRecord(file);
-    const content = typeof record?.content === 'string' ? record.content : '';
+    const content = typeof record?.content === 'string' ? record.content.replace(/\n/g, '') : '';
     return {
       contentBase64: content,
       sha: String(record?.blob_id ?? ''),
@@ -246,7 +250,7 @@ export class GitlabRepositoryProvider implements RepositoryProvider {
     const api = this.apiFactory(token);
     const hookId = Number(id);
     if (!Number.isFinite(hookId)) {
-      throw new RepositoryProviderError('NOT_FOUND', 'GitLab webhook id is invalid');
+      throw new RepositoryProviderError('UNKNOWN', 'GitLab webhook id is invalid');
     }
     await this.request(() => api.ProjectHooks.remove(projectPath(repo.owner, repo.name), hookId));
   }
@@ -289,11 +293,12 @@ function toRepoSummary(value: unknown): RepoSummary | null {
     return null;
   }
   const namespacePath = String(record.path_with_namespace ?? '');
-  const [, ...segments] = namespacePath.split('/');
-  const name = String(record.path ?? segments.join('/') ?? '');
+  const segments = namespacePath.split('/').filter((segment) => segment.length > 0);
+  const fallbackName = segments[segments.length - 1] ?? '';
+  const name = String(record.path ?? fallbackName);
   return {
     id: String(record.id ?? ''),
-    name: String(record.path ?? name),
+    name,
     fullName: namespacePath,
     description: typeof record.description === 'string' ? record.description : null,
     isPrivate: String(record.visibility ?? 'private') !== 'public',
@@ -364,6 +369,16 @@ function normalizeFilePath(path: string): string {
   return path.replace(/^\/+|\/+$/g, '');
 }
 
+function mapGitlabVisibility(visibility?: ListReposOpts['visibility']): string | undefined {
+  if (visibility === 'public') {
+    return 'public';
+  }
+  if (visibility === 'private') {
+    return 'private';
+  }
+  return undefined;
+}
+
 function mapGitlabSort(sort?: ListReposOpts['sort']): string {
   if (sort === 'created') {
     return 'created_at';
@@ -399,7 +414,7 @@ function normalizeGitlabError(error: unknown): RepositoryProviderError {
   if (status === 404) {
     return new RepositoryProviderError('NOT_FOUND', 'GitLab resource not found', status, { cause: error });
   }
-  if (status === 429 || status === 403) {
+  if (status === 429) {
     return new RepositoryProviderError('RATE_LIMITED', 'GitLab API rate limit exceeded', status, { cause: error });
   }
   if (status !== undefined) {

--- a/objectified-ui/lib/repositories/providers/gitlab-provider.ts
+++ b/objectified-ui/lib/repositories/providers/gitlab-provider.ts
@@ -1,0 +1,428 @@
+import { randomBytes, timingSafeEqual } from 'node:crypto';
+
+import { Gitlab } from '@gitbeaker/rest';
+
+import { RepositoryProviderError, type RepositoryProvider } from './repository-provider';
+import type {
+  BranchInfo,
+  ListReposOpts,
+  RepoDetail,
+  RepoRef,
+  RepoSummary,
+  TreeEntry,
+  WebhookTarget,
+} from './types';
+
+const GITLAB_MAX_PER_PAGE = 100;
+
+type GitlabApiFactory = (token: string) => GitlabApi;
+type SecretGenerator = () => string;
+
+interface GitlabApi {
+  Projects: {
+    all(options: Record<string, unknown>): Promise<unknown[]>;
+    show(projectId: string): Promise<unknown>;
+  };
+  Branches: {
+    all(projectId: string, options: Record<string, unknown>): Promise<unknown[]>;
+    show(projectId: string, branch: string): Promise<unknown>;
+  };
+  Repositories: {
+    allRepositoryTrees(projectId: string, options: Record<string, unknown>): Promise<unknown[]>;
+  };
+  RepositoryFiles: {
+    show(projectId: string, filePath: string, ref: string): Promise<unknown>;
+  };
+  ProjectHooks: {
+    add(projectId: string, url: string, options: Record<string, unknown>): Promise<unknown>;
+    remove(projectId: string, hookId: number): Promise<void>;
+  };
+}
+
+export class GitlabRepositoryProvider implements RepositoryProvider {
+  readonly id = 'gitlab' as const;
+
+  private readonly apiFactory: GitlabApiFactory;
+  private readonly secretGenerator: SecretGenerator;
+
+  constructor(apiFactory?: GitlabApiFactory, secretGenerator?: SecretGenerator) {
+    this.apiFactory = apiFactory ?? createDefaultApi;
+    this.secretGenerator = secretGenerator ?? createWebhookSecret;
+  }
+
+  async *listRepositories(token: string, opts?: ListReposOpts): AsyncIterable<RepoSummary> {
+    const api = this.apiFactory(token);
+    const perPage = Math.min(opts?.perPage ?? GITLAB_MAX_PER_PAGE, GITLAB_MAX_PER_PAGE);
+    const page = opts?.page ?? 1;
+
+    if (page > 1) {
+      const repositories = await this.request<unknown[]>(() =>
+        api.Projects.all({
+          simple: true,
+          orderBy: mapGitlabSort(opts?.sort),
+          sort: 'desc',
+          perPage,
+          page,
+        })
+      );
+      for (const repo of repositories) {
+        const summary = toRepoSummary(repo);
+        if (summary) {
+          yield summary;
+        }
+      }
+      return;
+    }
+
+    let idAfter: number | undefined;
+    while (true) {
+      const repositories = await this.request<unknown[]>(() =>
+        api.Projects.all({
+          simple: true,
+          pagination: 'keyset',
+          orderBy: 'id',
+          sort: 'asc',
+          perPage,
+          idAfter,
+        })
+      );
+
+      if (!Array.isArray(repositories) || repositories.length === 0) {
+        return;
+      }
+
+      for (const repo of repositories) {
+        const summary = toRepoSummary(repo);
+        if (!summary) {
+          continue;
+        }
+        yield summary;
+      }
+
+      if (repositories.length < perPage) {
+        return;
+      }
+
+      const lastId = toNumericId(repositories[repositories.length - 1]);
+      if (lastId === null) {
+        return;
+      }
+      idAfter = lastId;
+    }
+  }
+
+  async getRepository(token: string, owner: string, name: string): Promise<RepoDetail> {
+    const api = this.apiFactory(token);
+    const repository = await this.request<unknown>(() => api.Projects.show(projectPath(owner, name)));
+    const summary = toRepoSummary(repository);
+    if (summary) {
+      return summary;
+    }
+
+    return {
+      id: '',
+      name,
+      fullName: `${owner}/${name}`,
+      description: null,
+      isPrivate: true,
+      defaultBranch: 'main',
+      htmlUrl: '',
+      updatedAt: null,
+    };
+  }
+
+  async *listBranches(token: string, repo: RepoRef): AsyncIterable<BranchInfo> {
+    const api = this.apiFactory(token);
+    const perPage = GITLAB_MAX_PER_PAGE;
+    let page = 1;
+
+    while (true) {
+      const branches = await this.request<unknown[]>(() =>
+        api.Branches.all(projectPath(repo.owner, repo.name), { perPage, page })
+      );
+      if (!Array.isArray(branches) || branches.length === 0) {
+        return;
+      }
+
+      for (const branch of branches) {
+        if (!branch || typeof branch !== 'object') {
+          continue;
+        }
+        const raw = branch as Record<string, unknown>;
+        const commit = toRecord(raw.commit);
+        yield {
+          name: String(raw.name ?? ''),
+          commitSha: String(commit?.id ?? ''),
+          isProtected: Boolean(raw.protected),
+        };
+      }
+
+      if (branches.length < perPage) {
+        return;
+      }
+      page += 1;
+    }
+  }
+
+  async getCommitSha(token: string, repo: RepoRef, branch: string): Promise<string> {
+    const api = this.apiFactory(token);
+    const branchData = await this.request<unknown>(() =>
+      api.Branches.show(projectPath(repo.owner, repo.name), branch)
+    );
+    const record = toRecord(branchData);
+    const commit = toRecord(record?.commit);
+    return String(commit?.id ?? '');
+  }
+
+  async *walkTree(token: string, repo: RepoRef, branch: string, subpath?: string): AsyncIterable<TreeEntry> {
+    const api = this.apiFactory(token);
+    const normalizedSubpath = normalizeSubpath(subpath);
+    const perPage = GITLAB_MAX_PER_PAGE;
+    let page = 1;
+
+    while (true) {
+      const tree = await this.request<unknown[]>(() =>
+        api.Repositories.allRepositoryTrees(projectPath(repo.owner, repo.name), {
+          ref: branch,
+          recursive: true,
+          path: normalizedSubpath || undefined,
+          perPage,
+          page,
+        })
+      );
+      if (!Array.isArray(tree) || tree.length === 0) {
+        return;
+      }
+
+      for (const node of tree) {
+        const entry = toTreeEntry(node);
+        if (!entry) {
+          continue;
+        }
+        if (normalizedSubpath && !entry.path.startsWith(`${normalizedSubpath}/`)) {
+          continue;
+        }
+        yield entry;
+      }
+
+      if (tree.length < perPage) {
+        return;
+      }
+      page += 1;
+    }
+  }
+
+  async readFile(
+    token: string,
+    repo: RepoRef,
+    branch: string,
+    path: string
+  ): Promise<{ contentBase64: string; sha: string; sizeBytes: number }> {
+    const api = this.apiFactory(token);
+    const file = await this.request<unknown>(() =>
+      api.RepositoryFiles.show(projectPath(repo.owner, repo.name), normalizeFilePath(path), branch)
+    );
+    const record = toRecord(file);
+    const content = typeof record?.content === 'string' ? record.content : '';
+    return {
+      contentBase64: content,
+      sha: String(record?.blob_id ?? ''),
+      sizeBytes: Number(record?.size ?? 0),
+    };
+  }
+
+  async registerWebhook(token: string, repo: RepoRef, target: WebhookTarget): Promise<{ id: string; secret: string }> {
+    const api = this.apiFactory(token);
+    const secret = this.secretGenerator();
+    const options = toHookOptions(target.events, secret);
+    const hook = await this.request<unknown>(() =>
+      api.ProjectHooks.add(projectPath(repo.owner, repo.name), target.url, options)
+    );
+    const record = toRecord(hook);
+    return { id: String(record?.id ?? ''), secret };
+  }
+
+  async removeWebhook(token: string, repo: RepoRef, id: string): Promise<void> {
+    const api = this.apiFactory(token);
+    const hookId = Number(id);
+    if (!Number.isFinite(hookId)) {
+      throw new RepositoryProviderError('NOT_FOUND', 'GitLab webhook id is invalid');
+    }
+    await this.request(() => api.ProjectHooks.remove(projectPath(repo.owner, repo.name), hookId));
+  }
+
+  verifyWebhookSignature(secret: string, headers: Headers): boolean {
+    const provided = headers.get('x-gitlab-token');
+    if (!provided) {
+      return false;
+    }
+
+    const expectedBuffer = Buffer.from(secret);
+    const providedBuffer = Buffer.from(provided);
+    if (expectedBuffer.length !== providedBuffer.length) {
+      return false;
+    }
+
+    return timingSafeEqual(expectedBuffer, providedBuffer);
+  }
+
+  private async request<T>(fn: () => Promise<T>): Promise<T> {
+    try {
+      return await fn();
+    } catch (error) {
+      throw normalizeGitlabError(error);
+    }
+  }
+}
+
+function createDefaultApi(token: string): GitlabApi {
+  return new Gitlab({ token }) as unknown as GitlabApi;
+}
+
+function createWebhookSecret(): string {
+  return randomBytes(24).toString('hex');
+}
+
+function toRepoSummary(value: unknown): RepoSummary | null {
+  const record = toRecord(value);
+  if (!record) {
+    return null;
+  }
+  const namespacePath = String(record.path_with_namespace ?? '');
+  const [, ...segments] = namespacePath.split('/');
+  const name = String(record.path ?? segments.join('/') ?? '');
+  return {
+    id: String(record.id ?? ''),
+    name: String(record.path ?? name),
+    fullName: namespacePath,
+    description: typeof record.description === 'string' ? record.description : null,
+    isPrivate: String(record.visibility ?? 'private') !== 'public',
+    defaultBranch: typeof record.default_branch === 'string' ? record.default_branch : 'main',
+    htmlUrl: String(record.web_url ?? ''),
+    updatedAt: typeof record.last_activity_at === 'string' ? record.last_activity_at : null,
+  };
+}
+
+function toTreeEntry(value: unknown): TreeEntry | null {
+  const record = toRecord(value);
+  if (!record || typeof record.path !== 'string' || record.path.length === 0) {
+    return null;
+  }
+  const type = mapTreeType(record.type);
+  if (!type) {
+    return null;
+  }
+  return {
+    path: record.path,
+    type,
+    sha: String(record.id ?? ''),
+    sizeBytes: Number(record.size ?? 0),
+  };
+}
+
+function mapTreeType(value: unknown): TreeEntry['type'] | null {
+  switch (value) {
+    case 'blob':
+      return 'file';
+    case 'tree':
+      return 'dir';
+    case 'commit':
+      return 'submodule';
+    default:
+      return null;
+  }
+}
+
+function toRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
+
+function toNumericId(value: unknown): number | null {
+  const record = toRecord(value);
+  if (!record) {
+    return null;
+  }
+  const parsed = Number(record.id);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function projectPath(owner: string, name: string): string {
+  return encodeURIComponent(`${owner}/${name}`);
+}
+
+function normalizeSubpath(subpath?: string): string {
+  if (!subpath) {
+    return '';
+  }
+  return subpath.replace(/^\/+|\/+$/g, '');
+}
+
+function normalizeFilePath(path: string): string {
+  return path.replace(/^\/+|\/+$/g, '');
+}
+
+function mapGitlabSort(sort?: ListReposOpts['sort']): string {
+  if (sort === 'created') {
+    return 'created_at';
+  }
+  if (sort === 'updated') {
+    return 'last_activity_at';
+  }
+  if (sort === 'full_name') {
+    return 'name';
+  }
+  return 'last_activity_at';
+}
+
+function toHookOptions(events: string[], secret: string): Record<string, unknown> {
+  const options: Record<string, unknown> = { token: secret, enableSslVerification: true };
+  if (events.length === 0) {
+    options.push_events = true;
+    return options;
+  }
+
+  for (const event of events) {
+    const normalized = `${event.toLowerCase().replace(/[^a-z0-9]+/g, '_')}_events`;
+    options[normalized] = true;
+  }
+  return options;
+}
+
+function normalizeGitlabError(error: unknown): RepositoryProviderError {
+  const status = extractStatus(error);
+  if (status === 401) {
+    return new RepositoryProviderError('UNAUTHORIZED', 'Unauthorized GitLab token', status, { cause: error });
+  }
+  if (status === 404) {
+    return new RepositoryProviderError('NOT_FOUND', 'GitLab resource not found', status, { cause: error });
+  }
+  if (status === 429 || status === 403) {
+    return new RepositoryProviderError('RATE_LIMITED', 'GitLab API rate limit exceeded', status, { cause: error });
+  }
+  if (status !== undefined) {
+    return new RepositoryProviderError('UNKNOWN', 'Unexpected GitLab API error', status, { cause: error });
+  }
+  return new RepositoryProviderError('NETWORK', 'Failed to reach GitLab API', undefined, { cause: error });
+}
+
+function extractStatus(error: unknown): number | undefined {
+  const first = toRecord(error);
+  if (typeof first?.status === 'number') {
+    return first.status;
+  }
+
+  const response = toRecord(first?.response);
+  if (typeof response?.status === 'number') {
+    return response.status;
+  }
+
+  const cause = toRecord(first?.cause);
+  if (typeof cause?.status === 'number') {
+    return cause.status;
+  }
+
+  return undefined;
+}

--- a/objectified-ui/lib/repositories/providers/gitlab-provider.ts
+++ b/objectified-ui/lib/repositories/providers/gitlab-provider.ts
@@ -227,7 +227,7 @@ export class GitlabRepositoryProvider implements RepositoryProvider {
       api.RepositoryFiles.show(projectPath(repo.owner, repo.name), normalizeFilePath(path), branch)
     );
     const record = toRecord(file);
-    const content = typeof record?.content === 'string' ? record.content.replace(/\n/g, '') : '';
+    const content = typeof record?.content === 'string' ? record.content.replaceAll('\n', '') : '';
     return {
       contentBase64: content,
       sha: String(record?.blob_id ?? ''),

--- a/objectified-ui/lib/repositories/providers/index.ts
+++ b/objectified-ui/lib/repositories/providers/index.ts
@@ -1,4 +1,5 @@
 export { GithubRepositoryProvider } from './github-provider';
+export { GitlabRepositoryProvider } from './gitlab-provider';
 export { RepositoryProviderError, type RepositoryProvider } from './repository-provider';
 export {
   createResolveRepositoryTokenResolver,

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.10.23",
+  "version": "0.10.24",
   "private": true,
   "scripts": {
     "dev": "next dev",
@@ -43,6 +43,7 @@
     "@dnd-kit/utilities": "^3.2.2",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
+    "@gitbeaker/rest": "^43.8.0",
     "@monaco-editor/react": "^4.7.0",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-alert-dialog": "^1.1.15",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -7,6 +7,7 @@ We continue to improve the platform based on your feedback with improvements and
 ## Repositories
 - Added repository connector MVP database tables for repository registration, branch tracking, and linked-account credential references.
 - Added a provider abstraction layer for repository connectors with a GitHub adapter, shared provider error taxonomy, and cross-provider contract tests.
+- Added a GitLab repository provider (`@gitbeaker/rest`) with full contract support, keyset repository pagination, and GitLab webhook secret verification.
 - Added a server-only `resolveRepositoryToken` helper that resolves linked-account repository credentials, refreshes supported expired tokens, emits typed resolver errors, and writes token-safe workflow audit rows.
 - Added a new ADE Repositories page with a four-step GitHub registration wizard and initial scan timeline flow.
 - Added per-repository branch management so tracked branches can be added/removed with per-branch subpath glob and polling settings, defaulting to the provider default branch and supporting wildcard branch patterns.

--- a/yarn.lock
+++ b/yarn.lock
@@ -906,6 +906,39 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@gitbeaker/core@npm:^43.8.0":
+  version: 43.8.0
+  resolution: "@gitbeaker/core@npm:43.8.0"
+  dependencies:
+    "@gitbeaker/requester-utils": "npm:^43.8.0"
+    qs: "npm:^6.14.0"
+    xcase: "npm:^2.0.1"
+  checksum: 10c0/5913aea8ae89b30f37693093fe68a94fbe4ab2737e661ba6795b3d22463ffa63806076b392b938d4c662d691c0114facc022bcdde29297e7b6617b146c449ff6
+  languageName: node
+  linkType: hard
+
+"@gitbeaker/requester-utils@npm:^43.8.0":
+  version: 43.8.0
+  resolution: "@gitbeaker/requester-utils@npm:43.8.0"
+  dependencies:
+    picomatch-browser: "npm:^2.2.6"
+    qs: "npm:^6.14.0"
+    rate-limiter-flexible: "npm:^8.0.1"
+    xcase: "npm:^2.0.1"
+  checksum: 10c0/07fd5af56fa3b577009bac6fc59a9b54b3e188a8b412c926b253b21528fb46f8ab02dbeba5c032a9a77d169a69208550147a099c71681d5b9193c87224db8d19
+  languageName: node
+  linkType: hard
+
+"@gitbeaker/rest@npm:^43.8.0":
+  version: 43.8.0
+  resolution: "@gitbeaker/rest@npm:43.8.0"
+  dependencies:
+    "@gitbeaker/core": "npm:^43.8.0"
+    "@gitbeaker/requester-utils": "npm:^43.8.0"
+  checksum: 10c0/f3b25c6a67c25f9d5aac4674bacd36321c06bedd55e4fe859cba569e6c0121ac00d41838094ca7e19dc3158f59e57f8bae7d565b2e7d308904a3bbe234152b8b
+  languageName: node
+  linkType: hard
+
 "@humanfs/core@npm:^0.19.1":
   version: 0.19.1
   resolution: "@humanfs/core@npm:0.19.1"
@@ -10238,6 +10271,7 @@ __metadata:
     "@dnd-kit/utilities": "npm:^3.2.2"
     "@emotion/react": "npm:^11.14.0"
     "@emotion/styled": "npm:^11.14.1"
+    "@gitbeaker/rest": "npm:^43.8.0"
     "@jest/globals": "npm:^30.3.0"
     "@monaco-editor/react": "npm:^4.7.0"
     "@playwright/test": "npm:^1.59.1"
@@ -10697,6 +10731,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"picomatch-browser@npm:^2.2.6":
+  version: 2.2.6
+  resolution: "picomatch-browser@npm:2.2.6"
+  checksum: 10c0/bf97d3e6f77dee776fe4cc7728037931b681c56e1fd964023ed797de341a0e32dcc1e90a5552cc74923cb97566464870a37be188b09e3db7279f9e9a9b12d977
+  languageName: node
+  linkType: hard
+
 "picomatch@npm:^2.0.4, picomatch@npm:^2.3.1":
   version: 2.3.1
   resolution: "picomatch@npm:2.3.1"
@@ -10938,6 +10979,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"qs@npm:^6.14.0":
+  version: 6.15.1
+  resolution: "qs@npm:6.15.1"
+  dependencies:
+    side-channel: "npm:^1.1.0"
+  checksum: 10c0/19ee504f0ebff72598503e38cd6d9bd7b52a8ab62ae18b1e6bee3d4db58469bd65871ef1893a881bafb0f80ef2f9ab586e1f255cf25cc8d816c0f5a704721d97
+  languageName: node
+  linkType: hard
+
 "queue-microtask@npm:^1.2.2":
   version: 1.2.3
   resolution: "queue-microtask@npm:1.2.3"
@@ -11024,6 +11074,13 @@ __metadata:
   dependencies:
     performance-now: "npm:^2.1.0"
   checksum: 10c0/337f0853c9e6a77647b0f499beedafea5d6facfb9f2d488a624f88b03df2be72b8a0e7f9118a3ff811377d534912039a3311815700d2b6d2313f82f736f9eb6e
+  languageName: node
+  linkType: hard
+
+"rate-limiter-flexible@npm:^8.0.1":
+  version: 8.3.0
+  resolution: "rate-limiter-flexible@npm:8.3.0"
+  checksum: 10c0/30b0aad1128b5a5cff44b289c6083be6ee782389015c1a93f854b1f07a682e539fcd48a3b983c828271b8f8ade3c930055edc2cf376915a3300a0d572d911244
   languageName: node
   linkType: hard
 
@@ -13070,6 +13127,13 @@ __metadata:
     utf-8-validate:
       optional: true
   checksum: 10c0/956ac5f11738c914089b65878b9223692ace77337ba55379ae68e1ecbeae9b47a0c6eb9403688f609999a58c80d83d99865fe0029b229d308b08c1ef93d4ea14
+  languageName: node
+  linkType: hard
+
+"xcase@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "xcase@npm:2.0.1"
+  checksum: 10c0/11b8ae8f6734b29d442a5acf1dff3a896cabbf49e7ffa01472ff6fa687a6e6f6a25889d06c10a41950e7a90fe89239fa78d95eab0c5eb654ca75f0ccd71ba8ed
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- implement `GitlabRepositoryProvider` using `@gitbeaker/rest` with full `RepositoryProvider` contract coverage
- add keyset pagination for GitLab repository listing and shared provider error normalization
- add GitLab webhook registration/removal and `X-Gitlab-Token` shared-secret signature verification
- expand provider contract tests to cover GitLab behavior (including token forwarding and error taxonomy)
- update roadmap/whats-new notes and bump `objectified-ui` patch version

## Test plan
- [x] `yarn workspace objectified-ui test lib/repositories/providers/__tests__/contract.test.ts --verbose`
- [x] `yarn build`
- [x] `yarn test`
- [x] `yarn workspace objectified-ui eslint lib/repositories/providers/gitlab-provider.ts lib/repositories/providers/__tests__/contract.test.ts lib/repositories/providers/index.ts`

## Risk / Notes
- provider uses GitLab keyset pagination for repository listing and page-based pagination for endpoints without keyset support
- monorepo-wide `objectified-ui` lint currently reports many pre-existing violations unrelated to this ticket; changed files lint clean

Closes #2759

Made with [Cursor](https://cursor.com)