### PR TITLE
Fix #2760 - implement Bitbucket Cloud repository provider

### DIFF
--- a/docs/PLANNED_FEATURE_ROADMAP_REPOSITORY.md
+++ b/docs/PLANNED_FEATURE_ROADMAP_REPOSITORY.md
@@ -2,6 +2,7 @@
 
 ## Completed
 
+- REPO-1.8 (#2760): Implemented a Bitbucket Cloud repository provider adapter for REST API 2.0 with shared contract coverage, UUID-based webhook verification, and linked-account availability for Bitbucket linking.
 - REPO-1.7 (#2759): Implemented the GitLab repository provider adapter with full contract coverage, keyset pagination for repository listing, and GitLab webhook registration/signature verification.
 - REPO-1.4 (#2756): Added repository registration UI flow and REST registration endpoint for GitHub repositories.
 - REPO-1.5 (#2757): Added per-repository branch management with per-branch subpath and polling settings, including default branch preselection and wildcard branch patterns.

--- a/objectified-ui/lib/repositories/providers/__tests__/contract.test.ts
+++ b/objectified-ui/lib/repositories/providers/__tests__/contract.test.ts
@@ -41,6 +41,10 @@ function textResponse(
     } as Headers,
     json: async () => JSON.parse(body),
     text: async () => body,
+    arrayBuffer: async () => {
+      const buf = Buffer.from(body, 'utf8');
+      return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength) as ArrayBuffer;
+    },
   } as Response;
 }
 

--- a/objectified-ui/lib/repositories/providers/__tests__/contract.test.ts
+++ b/objectified-ui/lib/repositories/providers/__tests__/contract.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, jest } from '@jest/globals';
+import { BitbucketRepositoryProvider } from '../bitbucket-provider';
 import { GithubRepositoryProvider } from '../github-provider';
 import { GitlabRepositoryProvider } from '../gitlab-provider';
 import { RepositoryProviderError } from '../repository-provider';
@@ -20,6 +21,26 @@ function jsonResponse(
     } as Headers,
     json: async () => body,
     text: async () => JSON.stringify(body),
+  } as Response;
+}
+
+function textResponse(
+  body: string,
+  init?: { status?: number; headers?: Record<string, string> }
+): Response {
+  const status = init?.status ?? 200;
+  const headersMap = new Map<string, string>(
+    Object.entries(init?.headers ?? {}).map(([key, value]) => [key.toLowerCase(), value])
+  );
+
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: {
+      get: (name: string) => headersMap.get(name.toLowerCase()) ?? null,
+    } as Headers,
+    json: async () => JSON.parse(body),
+    text: async () => body,
   } as Response;
 }
 
@@ -348,6 +369,162 @@ describe('GitLab RepositoryProvider contract', () => {
     await expect(
       new GitlabRepositoryProvider(() => unknownApi).getRepository('t', 'a', 'b')
     ).rejects.toMatchObject<Partial<RepositoryProviderError>>({
+      code: 'UNKNOWN',
+    });
+  });
+});
+
+describe('Bitbucket RepositoryProvider contract', () => {
+  it('implements every contract method for Bitbucket, including webhooks', async () => {
+    const fetchMock = jest
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        jsonResponse({
+          values: [
+            {
+              uuid: '{repo-1}',
+              name: 'repo-a',
+              full_name: 'acme/repo-a',
+              description: 'A',
+              is_private: false,
+              mainbranch: { name: 'main' },
+              links: { html: { href: 'https://bitbucket.org/acme/repo-a' } },
+              updated_on: '2026-01-01T00:00:00+00:00',
+            },
+          ],
+        })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          uuid: '{repo-1}',
+          name: 'repo-a',
+          full_name: 'acme/repo-a',
+          description: 'A',
+          is_private: false,
+          mainbranch: { name: 'main' },
+          links: { html: { href: 'https://bitbucket.org/acme/repo-a' } },
+          updated_on: '2026-01-01T00:00:00+00:00',
+        })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          values: [
+            { name: 'main', target: { hash: 'abc123' } },
+            { name: 'dev', target: { hash: 'def456' } },
+          ],
+        })
+      )
+      .mockResolvedValueOnce(jsonResponse({ name: 'main', target: { hash: 'abc123' } }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          values: [
+            { path: 'docs/readme.md', type: 'commit_file', commit: { hash: 's1' }, size: 4 },
+            { path: 'docs', type: 'commit_directory', commit: { hash: 's2' }, size: 0 },
+          ],
+        })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          size: 7,
+          commit: { hash: 'f1' },
+        })
+      )
+      .mockResolvedValueOnce(textResponse('content'))
+      .mockResolvedValueOnce(jsonResponse({ uuid: '{hook-123}' }))
+      .mockResolvedValueOnce(jsonResponse({}, { status: 204 }));
+
+    const provider = new BitbucketRepositoryProvider(fetchMock);
+
+    const repos = await collect(provider.listRepositories('token-1', { perPage: 10 }));
+    const repo = await provider.getRepository('token-1', 'acme', 'repo-a');
+    const branches = await collect(provider.listBranches('token-1', { owner: 'acme', name: 'repo-a' }));
+    const sha = await provider.getCommitSha('token-1', { owner: 'acme', name: 'repo-a' }, 'main');
+    const tree = await collect(provider.walkTree('token-1', { owner: 'acme', name: 'repo-a' }, 'main', 'docs'));
+    const file = await provider.readFile('token-1', { owner: 'acme', name: 'repo-a' }, 'main', 'docs/readme.md');
+    const webhook = await provider.registerWebhook('token-1', { owner: 'acme', name: 'repo-a' }, {
+      url: 'https://example.com/hooks/bitbucket',
+      events: ['repo:push'],
+    });
+    await provider.removeWebhook('token-1', { owner: 'acme', name: 'repo-a' }, webhook.id);
+
+    const validHeaders = new Headers({ 'x-hook-uuid': '{hook-123}' });
+    const invalidHeaders = new Headers({ 'x-hook-uuid': '{hook-999}' });
+
+    expect(repos.map((item) => item.fullName)).toEqual(['acme/repo-a']);
+    expect(repo.fullName).toBe('acme/repo-a');
+    expect(branches.map((b) => b.name)).toEqual(['main', 'dev']);
+    expect(sha).toBe('abc123');
+    expect(tree.map((entry) => entry.path)).toEqual(['docs/readme.md', 'docs']);
+    expect(file).toEqual({ contentBase64: 'Y29udGVudA==', sha: 'f1', sizeBytes: 7 });
+    expect(webhook).toEqual({ id: 'hook-123', secret: 'hook-123' });
+    expect(provider.verifyWebhookSignature?.(webhook.secret, validHeaders, '')).toBe(true);
+    expect(provider.verifyWebhookSignature?.(webhook.secret, invalidHeaders, '')).toBe(false);
+  });
+
+  it('never caches token and forwards it per call', async () => {
+    const fetchMock = jest
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(jsonResponse({ values: [] }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          uuid: '{repo-1}',
+          name: 'repo-a',
+          full_name: 'acme/repo-a',
+          is_private: false,
+          mainbranch: { name: 'main' },
+          links: { html: { href: 'https://bitbucket.org/acme/repo-a' } },
+          updated_on: null,
+        })
+      );
+    const provider = new BitbucketRepositoryProvider(fetchMock);
+
+    await collect(provider.listRepositories('token-A'));
+    await provider.getRepository('token-B', 'acme', 'repo-a');
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[0]?.[1]).toMatchObject({
+      headers: expect.objectContaining({ Authorization: 'Bearer token-A' }),
+    });
+    expect(fetchMock.mock.calls[1]?.[1]).toMatchObject({
+      headers: expect.objectContaining({ Authorization: 'Bearer token-B' }),
+    });
+  });
+
+  it('normalizes provider errors to the shared taxonomy', async () => {
+    const unauthorized = new BitbucketRepositoryProvider(
+      jest.fn<typeof fetch>().mockResolvedValueOnce(jsonResponse({ message: 'bad token' }, { status: 401 }))
+    );
+    const notFound = new BitbucketRepositoryProvider(
+      jest.fn<typeof fetch>().mockResolvedValueOnce(jsonResponse({ message: 'missing' }, { status: 404 }))
+    );
+    const rateLimited = new BitbucketRepositoryProvider(
+      jest.fn<typeof fetch>().mockResolvedValueOnce(
+        jsonResponse(
+          { message: 'rate limit exceeded' },
+          { status: 403, headers: { 'x-ratelimit-remaining': '0' } }
+        )
+      )
+    );
+    const network = new BitbucketRepositoryProvider(
+      jest.fn<typeof fetch>().mockRejectedValueOnce(new TypeError('network down'))
+    );
+    const unknown = new BitbucketRepositoryProvider(
+      jest.fn<typeof fetch>().mockResolvedValueOnce(jsonResponse({ message: 'boom' }, { status: 500 }))
+    );
+
+    await expect(unauthorized.getRepository('t', 'a', 'b')).rejects.toMatchObject<Partial<RepositoryProviderError>>({
+      code: 'UNAUTHORIZED',
+    });
+    await expect(notFound.getRepository('t', 'a', 'b')).rejects.toMatchObject<Partial<RepositoryProviderError>>({
+      code: 'NOT_FOUND',
+    });
+    await expect(rateLimited.getRepository('t', 'a', 'b')).rejects.toMatchObject<Partial<RepositoryProviderError>>({
+      code: 'RATE_LIMITED',
+    });
+    await expect(network.getRepository('t', 'a', 'b')).rejects.toMatchObject<Partial<RepositoryProviderError>>({
+      code: 'NETWORK',
+    });
+    await expect(unknown.getRepository('t', 'a', 'b')).rejects.toMatchObject<Partial<RepositoryProviderError>>({
       code: 'UNKNOWN',
     });
   });

--- a/objectified-ui/lib/repositories/providers/bitbucket-provider.ts
+++ b/objectified-ui/lib/repositories/providers/bitbucket-provider.ts
@@ -1,0 +1,412 @@
+import { timingSafeEqual } from 'node:crypto';
+
+import { RepositoryProviderError, type RepositoryProvider } from './repository-provider';
+import type {
+  BranchInfo,
+  ListReposOpts,
+  RepoDetail,
+  RepoRef,
+  RepoSummary,
+  TreeEntry,
+  WebhookTarget,
+} from './types';
+
+type FetchFn = typeof fetch;
+
+interface RequestOptions {
+  pathOrUrl: string;
+  token: string;
+  query?: Record<string, string | number | undefined>;
+  method?: 'GET' | 'POST' | 'DELETE';
+  body?: unknown;
+}
+
+const BITBUCKET_API_BASE = 'https://api.bitbucket.org/2.0';
+const BITBUCKET_MAX_PAGE = 100;
+
+export class BitbucketRepositoryProvider implements RepositoryProvider {
+  readonly id = 'bitbucket' as const;
+  private readonly fetchFn: FetchFn;
+
+  constructor(fetchFn?: FetchFn) {
+    this.fetchFn = fetchFn ?? fetch;
+  }
+
+  async *listRepositories(token: string, opts?: ListReposOpts): AsyncIterable<RepoSummary> {
+    const perPage = Math.min(opts?.perPage ?? BITBUCKET_MAX_PAGE, BITBUCKET_MAX_PAGE);
+    let nextPathOrUrl: string | null = '/repositories';
+    let query: Record<string, string | number | undefined> | undefined = {
+      role: 'member',
+      pagelen: perPage,
+      page: opts?.page ?? 1,
+      sort: mapBitbucketSort(opts?.sort),
+    };
+
+    while (nextPathOrUrl) {
+      const payload: Record<string, unknown> = await this.requestJson({
+        pathOrUrl: nextPathOrUrl,
+        token,
+        query,
+      });
+
+      const repositories = Array.isArray(payload.values) ? payload.values : [];
+      for (const repository of repositories) {
+        const summary = toRepoSummary(repository);
+        if (summary) {
+          yield summary;
+        }
+      }
+
+      nextPathOrUrl = typeof payload.next === 'string' ? payload.next : null;
+      query = undefined;
+    }
+  }
+
+  async getRepository(token: string, owner: string, name: string): Promise<RepoDetail> {
+    const repository = await this.requestJson<unknown>({
+      pathOrUrl: `/repositories/${encodeURIComponent(owner)}/${encodeURIComponent(name)}`,
+      token,
+    });
+    const summary = toRepoSummary(repository);
+    if (summary) {
+      return summary;
+    }
+
+    return {
+      id: '',
+      name,
+      fullName: `${owner}/${name}`,
+      description: null,
+      isPrivate: true,
+      defaultBranch: 'main',
+      htmlUrl: '',
+      updatedAt: null,
+    };
+  }
+
+  async *listBranches(token: string, repo: RepoRef): AsyncIterable<BranchInfo> {
+    let nextPathOrUrl: string | null =
+      `/repositories/${encodeURIComponent(repo.owner)}/${encodeURIComponent(repo.name)}/refs/branches`;
+    let query: Record<string, string | number | undefined> | undefined = { pagelen: BITBUCKET_MAX_PAGE };
+
+    while (nextPathOrUrl) {
+      const payload: Record<string, unknown> = await this.requestJson({
+        pathOrUrl: nextPathOrUrl,
+        token,
+        query,
+      });
+      const branches = Array.isArray(payload.values) ? payload.values : [];
+
+      for (const branch of branches) {
+        const record = toRecord(branch);
+        if (!record) {
+          continue;
+        }
+        const target = toRecord(record.target);
+        yield {
+          name: String(record.name ?? ''),
+          commitSha: String(target?.hash ?? ''),
+          isProtected: false,
+        };
+      }
+
+      nextPathOrUrl = typeof payload.next === 'string' ? payload.next : null;
+      query = undefined;
+    }
+  }
+
+  async getCommitSha(token: string, repo: RepoRef, branch: string): Promise<string> {
+    const payload: unknown = await this.requestJson({
+      pathOrUrl:
+        `/repositories/${encodeURIComponent(repo.owner)}/${encodeURIComponent(repo.name)}/refs/branches/` +
+        encodeURIComponent(branch),
+      token,
+    });
+    const record = toRecord(payload);
+    const target = toRecord(record?.target);
+    return String(target?.hash ?? '');
+  }
+
+  async *walkTree(token: string, repo: RepoRef, branch: string, subpath?: string): AsyncIterable<TreeEntry> {
+    const normalizedSubpath = normalizePath(subpath ?? '');
+    const queue: string[] = [normalizedSubpath];
+    const visited = new Set<string>(queue);
+
+    while (queue.length > 0) {
+      const directory = queue.shift() ?? '';
+      let nextPathOrUrl: string | null = buildSrcPath(repo, branch, directory);
+      let query: Record<string, string | number | undefined> | undefined = { pagelen: BITBUCKET_MAX_PAGE };
+
+      while (nextPathOrUrl) {
+        const payload: Record<string, unknown> = await this.requestJson({
+          pathOrUrl: nextPathOrUrl,
+          token,
+          query,
+        });
+
+        const entries = Array.isArray(payload.values) ? payload.values : [];
+        for (const entry of entries) {
+          const normalized = toTreeEntry(entry);
+          if (!normalized) {
+            continue;
+          }
+
+          if (normalized.type === 'dir' && !visited.has(normalized.path)) {
+            visited.add(normalized.path);
+            queue.push(normalized.path);
+          }
+
+          yield normalized;
+        }
+
+        nextPathOrUrl = typeof payload.next === 'string' ? payload.next : null;
+        query = undefined;
+      }
+    }
+  }
+
+  async readFile(
+    token: string,
+    repo: RepoRef,
+    branch: string,
+    path: string
+  ): Promise<{ contentBase64: string; sha: string; sizeBytes: number }> {
+    const normalizedPath = normalizePath(path);
+    const pathOrUrl = buildSrcPath(repo, branch, normalizedPath);
+    const metadata: unknown = await this.requestJson({
+      pathOrUrl,
+      token,
+      query: { format: 'meta' },
+    });
+    const content = await this.requestText({ pathOrUrl, token });
+    const metadataRecord = toRecord(metadata);
+    const commit = toRecord(metadataRecord?.commit);
+    return {
+      contentBase64: Buffer.from(content, 'utf8').toString('base64'),
+      sha: String(commit?.hash ?? ''),
+      sizeBytes: Number(metadataRecord?.size ?? Buffer.byteLength(content)),
+    };
+  }
+
+  async registerWebhook(token: string, repo: RepoRef, target: WebhookTarget): Promise<{ id: string; secret: string }> {
+    const payload: unknown = await this.requestJson({
+      pathOrUrl: `/repositories/${encodeURIComponent(repo.owner)}/${encodeURIComponent(repo.name)}/hooks`,
+      token,
+      method: 'POST',
+      body: {
+        description: 'Objectified repository webhook',
+        url: target.url,
+        active: true,
+        events: normalizeBitbucketEvents(target.events),
+      },
+    });
+    const record = toRecord(payload);
+    const uuid = normalizeHookUuid(String(record?.uuid ?? ''));
+    return {
+      id: uuid,
+      secret: uuid,
+    };
+  }
+
+  async removeWebhook(token: string, repo: RepoRef, id: string): Promise<void> {
+    const normalizedId = normalizeHookUuid(id);
+    if (!normalizedId) {
+      throw new RepositoryProviderError('UNKNOWN', 'Bitbucket webhook id is invalid');
+    }
+    await this.request({
+      pathOrUrl: `/repositories/${encodeURIComponent(repo.owner)}/${encodeURIComponent(repo.name)}/hooks/${encodeURIComponent(normalizedId)}`,
+      token,
+      method: 'DELETE',
+    });
+  }
+
+  verifyWebhookSignature(secret: string, headers: Headers): boolean {
+    const expected = normalizeHookUuid(secret);
+    const provided = normalizeHookUuid(headers.get('x-hook-uuid') ?? '');
+    if (!expected || !provided) {
+      return false;
+    }
+
+    const expectedBuffer = Buffer.from(expected);
+    const providedBuffer = Buffer.from(provided);
+    if (expectedBuffer.length !== providedBuffer.length) {
+      return false;
+    }
+    return timingSafeEqual(expectedBuffer, providedBuffer);
+  }
+
+  private async requestJson<T>(options: RequestOptions): Promise<T> {
+    const response = await this.request(options);
+    return (await response.json()) as T;
+  }
+
+  private async requestText(options: RequestOptions): Promise<string> {
+    const response = await this.request(options);
+    return await response.text();
+  }
+
+  private async request({ pathOrUrl, token, query, method = 'GET', body }: RequestOptions): Promise<Response> {
+    const url = buildUrl(pathOrUrl, query);
+
+    let response: Response;
+    try {
+      response = await this.fetchFn(url, {
+        method,
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: 'application/json',
+          ...(body !== undefined ? { 'Content-Type': 'application/json' } : {}),
+        },
+        ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+      });
+    } catch (error) {
+      throw new RepositoryProviderError('NETWORK', 'Failed to reach Bitbucket API', undefined, { cause: error });
+    }
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw normalizeBitbucketError(response.status, text, response.headers);
+    }
+
+    return response;
+  }
+}
+
+function buildUrl(pathOrUrl: string, query?: Record<string, string | number | undefined>): string {
+  const url = new URL(pathOrUrl, BITBUCKET_API_BASE);
+  for (const [key, value] of Object.entries(query ?? {})) {
+    if (value !== undefined) {
+      url.searchParams.set(key, String(value));
+    }
+  }
+  return url.toString();
+}
+
+function buildSrcPath(repo: RepoRef, branch: string, path: string): string {
+  const encodedRepo = `${encodeURIComponent(repo.owner)}/${encodeURIComponent(repo.name)}`;
+  const encodedBranch = encodeURIComponent(branch);
+  const normalizedPath = normalizePath(path);
+  if (!normalizedPath) {
+    return `/repositories/${encodedRepo}/src/${encodedBranch}`;
+  }
+  const encodedPath = normalizedPath
+    .split('/')
+    .filter((segment) => segment.length > 0)
+    .map((segment) => encodeURIComponent(segment))
+    .join('/');
+  return `/repositories/${encodedRepo}/src/${encodedBranch}/${encodedPath}`;
+}
+
+function toRepoSummary(value: unknown): RepoSummary | null {
+  const record = toRecord(value);
+  if (!record) {
+    return null;
+  }
+  const fullName = String(record.full_name ?? '');
+  const slug = toRecord(record.slug);
+  const mainbranch = toRecord(record.mainbranch);
+  const links = toRecord(record.links);
+  const htmlLink = toRecord(links?.html);
+  return {
+    id: String(record.uuid ?? record.id ?? ''),
+    name: String(record.name ?? slug?.name ?? ''),
+    fullName,
+    description: typeof record.description === 'string' ? record.description : null,
+    isPrivate: Boolean(record.is_private),
+    defaultBranch: typeof mainbranch?.name === 'string' ? mainbranch.name : 'main',
+    htmlUrl: String(htmlLink?.href ?? ''),
+    updatedAt: typeof record.updated_on === 'string' ? record.updated_on : null,
+  };
+}
+
+function toTreeEntry(value: unknown): TreeEntry | null {
+  const record = toRecord(value);
+  if (!record || typeof record.path !== 'string' || record.path.length === 0) {
+    return null;
+  }
+  const type = mapTreeType(record.type);
+  if (!type) {
+    return null;
+  }
+  const commit = toRecord(record.commit);
+  return {
+    path: normalizePath(record.path),
+    type,
+    sha: String(commit?.hash ?? ''),
+    sizeBytes: Number(record.size ?? 0),
+  };
+}
+
+function mapTreeType(value: unknown): TreeEntry['type'] | null {
+  switch (value) {
+    case 'commit_file':
+      return 'file';
+    case 'commit_directory':
+      return 'dir';
+    case 'commit_link':
+      return 'symlink';
+    case 'commit_subrepository':
+      return 'submodule';
+    default:
+      return null;
+  }
+}
+
+function toRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
+
+function mapBitbucketSort(sort?: ListReposOpts['sort']): string {
+  switch (sort) {
+    case 'created':
+      return '-created_on';
+    case 'pushed':
+      return '-updated_on';
+    case 'full_name':
+      return 'full_name';
+    case 'updated':
+    default:
+      return '-updated_on';
+  }
+}
+
+function normalizeBitbucketEvents(events: string[]): string[] {
+  if (events.length === 0) {
+    return ['repo:push'];
+  }
+  return events.map((event) => event.trim()).filter((event) => event.length > 0);
+}
+
+function normalizeBitbucketError(status: number, body: string, headers: Headers): RepositoryProviderError {
+  if (status === 401) {
+    return new RepositoryProviderError('UNAUTHORIZED', 'Unauthorized Bitbucket token', status);
+  }
+  if (status === 404) {
+    return new RepositoryProviderError('NOT_FOUND', 'Bitbucket resource not found', status);
+  }
+  if (status === 429 || isBitbucketRateLimited(status, body, headers)) {
+    return new RepositoryProviderError('RATE_LIMITED', 'Bitbucket API rate limit exceeded', status);
+  }
+  return new RepositoryProviderError('UNKNOWN', 'Unexpected Bitbucket API error', status);
+}
+
+function isBitbucketRateLimited(status: number, body: string, headers: Headers): boolean {
+  if (status !== 403) {
+    return false;
+  }
+  if (headers.get('x-ratelimit-remaining') === '0') {
+    return true;
+  }
+  return body.toLowerCase().includes('rate limit');
+}
+
+function normalizePath(value: string): string {
+  return value.replace(/^\/+|\/+$/g, '');
+}
+
+function normalizeHookUuid(uuid: string): string {
+  return uuid.replace(/[{}]/g, '').trim().toLowerCase();
+}

--- a/objectified-ui/lib/repositories/providers/bitbucket-provider.ts
+++ b/objectified-ui/lib/repositories/providers/bitbucket-provider.ts
@@ -72,16 +72,10 @@ export class BitbucketRepositoryProvider implements RepositoryProvider {
       return summary;
     }
 
-    return {
-      id: '',
-      name,
-      fullName: `${owner}/${name}`,
-      description: null,
-      isPrivate: true,
-      defaultBranch: 'main',
-      htmlUrl: '',
-      updatedAt: null,
-    };
+    throw new RepositoryProviderError(
+      'UNKNOWN',
+      `Bitbucket returned an unparseable repository payload for ${owner}/${name}`,
+    );
   }
 
   async *listBranches(token: string, repo: RepoRef): AsyncIterable<BranchInfo> {
@@ -178,13 +172,13 @@ export class BitbucketRepositoryProvider implements RepositoryProvider {
       token,
       query: { format: 'meta' },
     });
-    const content = await this.requestText({ pathOrUrl, token });
+    const contentBuffer = await this.requestBuffer({ pathOrUrl, token });
     const metadataRecord = toRecord(metadata);
     const commit = toRecord(metadataRecord?.commit);
     return {
-      contentBase64: Buffer.from(content, 'utf8').toString('base64'),
+      contentBase64: contentBuffer.toString('base64'),
       sha: String(commit?.hash ?? ''),
-      sizeBytes: Number(metadataRecord?.size ?? Buffer.byteLength(content)),
+      sizeBytes: Number(metadataRecord?.size ?? contentBuffer.length),
     };
   }
 
@@ -202,6 +196,9 @@ export class BitbucketRepositoryProvider implements RepositoryProvider {
     });
     const record = toRecord(payload);
     const uuid = normalizeHookUuid(String(record?.uuid ?? ''));
+    if (!uuid) {
+      throw new RepositoryProviderError('UNKNOWN', 'Bitbucket webhook registration did not return a valid uuid');
+    }
     return {
       id: uuid,
       secret: uuid,
@@ -220,7 +217,7 @@ export class BitbucketRepositoryProvider implements RepositoryProvider {
     });
   }
 
-  verifyWebhookSignature(secret: string, headers: Headers): boolean {
+  verifyWebhookSignature(secret: string, headers: Headers, _body: string): boolean {
     const expected = normalizeHookUuid(secret);
     const provided = normalizeHookUuid(headers.get('x-hook-uuid') ?? '');
     if (!expected || !provided) {
@@ -243,6 +240,11 @@ export class BitbucketRepositoryProvider implements RepositoryProvider {
   private async requestText(options: RequestOptions): Promise<string> {
     const response = await this.request(options);
     return await response.text();
+  }
+
+  private async requestBuffer(options: RequestOptions): Promise<Buffer> {
+    const response = await this.request(options);
+    return Buffer.from(await response.arrayBuffer());
   }
 
   private async request({ pathOrUrl, token, query, method = 'GET', body }: RequestOptions): Promise<Response> {
@@ -303,13 +305,13 @@ function toRepoSummary(value: unknown): RepoSummary | null {
     return null;
   }
   const fullName = String(record.full_name ?? '');
-  const slug = toRecord(record.slug);
+  const slug = String(record.slug ?? '');
   const mainbranch = toRecord(record.mainbranch);
   const links = toRecord(record.links);
   const htmlLink = toRecord(links?.html);
   return {
     id: String(record.uuid ?? record.id ?? ''),
-    name: String(record.name ?? slug?.name ?? ''),
+    name: String(record.name ?? slug),
     fullName,
     description: typeof record.description === 'string' ? record.description : null,
     isPrivate: Boolean(record.is_private),

--- a/objectified-ui/lib/repositories/providers/index.ts
+++ b/objectified-ui/lib/repositories/providers/index.ts
@@ -1,5 +1,6 @@
 export { GithubRepositoryProvider } from './github-provider';
 export { GitlabRepositoryProvider } from './gitlab-provider';
+export { BitbucketRepositoryProvider } from './bitbucket-provider';
 export { RepositoryProviderError, type RepositoryProvider } from './repository-provider';
 export {
   createResolveRepositoryTokenResolver,

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.10.24",
+  "version": "0.10.25",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -8,6 +8,7 @@ We continue to improve the platform based on your feedback with improvements and
 - Added repository connector MVP database tables for repository registration, branch tracking, and linked-account credential references.
 - Added a provider abstraction layer for repository connectors with a GitHub adapter, shared provider error taxonomy, and cross-provider contract tests.
 - Added a GitLab repository provider (`@gitbeaker/rest`) with full contract support, keyset repository pagination, and GitLab webhook secret verification.
+- Added a Bitbucket Cloud repository provider adapter with contract-test coverage, REST API 2.0 tree/file handling, and UUID-based webhook verification.
 - Added a server-only `resolveRepositoryToken` helper that resolves linked-account repository credentials, refreshes supported expired tokens, emits typed resolver errors, and writes token-safe workflow audit rows.
 - Added a new ADE Repositories page with a four-step GitHub registration wizard and initial scan timeline flow.
 - Added per-repository branch management so tracked branches can be added/removed with per-branch subpath glob and polling settings, defaulting to the provider default branch and supporting wildcard branch patterns.

--- a/objectified-ui/src/app/ade/dashboard/linked-accounts/page.tsx
+++ b/objectified-ui/src/app/ade/dashboard/linked-accounts/page.tsx
@@ -3,7 +3,7 @@
 import { useSession, signIn } from 'next-auth/react';
 import { useEffect, useState } from 'react';
 import { Plus, Trash2, Link as LinkIcon, Key } from 'lucide-react';
-import { SiGithub, SiGitlab, SiGoogle, SiAmazon } from 'react-icons/si';
+import { SiAmazon, SiBitbucket, SiGithub, SiGitlab, SiGoogle } from 'react-icons/si';
 import {
   Dialog,
   DialogContent,
@@ -58,6 +58,7 @@ interface ProviderConfig {
 const providerConfigs: Record<string, ProviderConfig> = {
   github: { name: 'github', displayName: 'GitHub', icon: SiGithub, color: '#24292e', available: true },
   gitlab: { name: 'gitlab', displayName: 'GitLab', icon: SiGitlab, color: '#fc6d26', available: true },
+  bitbucket: { name: 'bitbucket', displayName: 'Bitbucket', icon: SiBitbucket, color: '#0052cc', available: true },
   google: { name: 'google', displayName: 'Google / GCP', icon: SiGoogle, color: '#4285f4', available: false },
   aws: { name: 'aws', displayName: 'AWS', icon: SiAmazon, color: '#ff9900', available: false },
 };


### PR DESCRIPTION
## Summary
- add a new `BitbucketRepositoryProvider` implementing the shared repository provider contract against Bitbucket Cloud REST API 2.0
- cover Bitbucket behavior in contract tests, including repository/branch/tree/file operations, shared error normalization, token forwarding, and webhook registration/removal
- mark REPO-1.8 complete in the roadmap, add release notes, bump `objectified-ui` patch version, and enable Bitbucket as an available Linked Accounts provider

## Test plan
- [x] `yarn build`
- [x] `yarn test`

## Risk / notes
- Bitbucket webhook verification follows the UUID header model (`x-hook-uuid`) and compares against the stored hook UUID returned at registration.

Fixes #2760

Made with [Cursor](https://cursor.com)