### PR TITLE
Fix #2762 - repository tree walker

### DIFF
--- a/docs/PLANNED_FEATURE_ROADMAP_REPOSITORY.md
+++ b/docs/PLANNED_FEATURE_ROADMAP_REPOSITORY.md
@@ -2,6 +2,7 @@
 
 ## Completed
 
+- REPO-2.1 (#2762): Added a streaming repository tree walker that iterates files at a commit SHA, enforces typed scan limits (`SCAN_LIMIT_EXCEEDED`), applies subpath glob filtering at the walker boundary, and emits `repository.scan.walked` workflow audit events.
 - REPO-1.8 (#2760): Implemented a Bitbucket Cloud repository provider adapter for REST API 2.0 with shared contract coverage, UUID-based webhook verification, and linked-account availability for Bitbucket linking.
 - REPO-1.7 (#2759): Implemented the GitLab repository provider adapter with full contract coverage, keyset pagination for repository listing, and GitLab webhook registration/signature verification.
 - REPO-1.4 (#2756): Added repository registration UI flow and REST registration endpoint for GitHub repositories.

--- a/objectified-rest/pyproject.toml
+++ b/objectified-rest/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "objectified-rest"
-version = "1.0.54"
+version = "1.0.55"
 description = "REST API for serving OpenAPI specifications from the Objectified database"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/objectified-rest/src/app/repositories/providers/base.py
+++ b/objectified-rest/src/app/repositories/providers/base.py
@@ -18,6 +18,7 @@ class RepositoryProviderErrorCode(str, Enum):
     UNAUTHORIZED = "UNAUTHORIZED"
     NOT_FOUND = "NOT_FOUND"
     NETWORK = "NETWORK"
+    SCAN_LIMIT_EXCEEDED = "SCAN_LIMIT_EXCEEDED"
     UNKNOWN = "UNKNOWN"
 
 
@@ -72,6 +73,7 @@ class TreeEntry:
     type: str
     sha: str
     size_bytes: int
+    mode: str = ""
 
 
 @dataclass(frozen=True)

--- a/objectified-rest/src/app/repositories/providers/github_provider.py
+++ b/objectified-rest/src/app/repositories/providers/github_provider.py
@@ -157,6 +157,7 @@ class GithubRepositoryProvider(RepositoryProvider):
                 type=entry_type,
                 sha=str(entry.get("sha", "")),
                 size_bytes=int(entry.get("size", 0)),
+                mode=str(entry.get("mode", "")),
             )
 
     async def read_file(self, token: str, repo: RepoRef, branch: str, path: str) -> ReadFileResult:

--- a/objectified-rest/src/app/repositories/tree_walker.py
+++ b/objectified-rest/src/app/repositories/tree_walker.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from fnmatch import fnmatchcase
+from inspect import isawaitable
+from typing import Any, AsyncIterator, Callable, Sequence
+
+from .providers import RepoRef, RepositoryProvider, RepositoryProviderError, RepositoryProviderErrorCode, TreeEntry
+
+WorkflowAuditEmitter = Callable[[str, dict[str, Any]], Any]
+
+
+@dataclass(frozen=True)
+class RepositoryWalkStats:
+    files: int
+    bytes: int
+
+
+@dataclass(frozen=True)
+class ScanLimit:
+    max_files: int | None = None
+    max_bytes: int | None = None
+
+    def __post_init__(self) -> None:
+        if self.max_files is not None and self.max_files < 1:
+            raise ValueError("max_files must be >= 1 when provided")
+        if self.max_bytes is not None and self.max_bytes < 1:
+            raise ValueError("max_bytes must be >= 1 when provided")
+
+
+async def walk_repository_tree(
+    provider: RepositoryProvider,
+    *,
+    token: str,
+    repo: RepoRef,
+    commit_sha: str,
+    subpath_glob: str | None,
+    limits: ScanLimit | None = None,
+    audit_emitter: WorkflowAuditEmitter | None = None,
+) -> AsyncIterator[TreeEntry]:
+    """Yield repository file entries for a specific commit SHA with scan limits."""
+    stats = RepositoryWalkStats(files=0, bytes=0)
+    effective_limits = limits or ScanLimit()
+
+    async for entry in provider.walk_tree(token=token, repo=repo, branch=commit_sha):
+        if entry.type != "file":
+            continue
+        if not _glob_match(entry.path, subpath_glob):
+            continue
+
+        next_files = stats.files + 1
+        next_bytes = stats.bytes + max(0, entry.size_bytes)
+        _ensure_scan_limits(
+            limits=effective_limits,
+            files=next_files,
+            bytes_scanned=next_bytes,
+            path=entry.path,
+        )
+        stats = RepositoryWalkStats(files=next_files, bytes=next_bytes)
+        yield entry
+
+    if audit_emitter is not None:
+        maybe_awaitable = audit_emitter(
+            "repository.scan.walked",
+            {
+                "owner": repo.owner,
+                "name": repo.name,
+                "commitSha": commit_sha,
+                "subpathGlob": subpath_glob,
+                "files": stats.files,
+                "bytes": stats.bytes,
+            },
+        )
+        if isawaitable(maybe_awaitable):
+            await maybe_awaitable
+
+
+def _ensure_scan_limits(*, limits: ScanLimit, files: int, bytes_scanned: int, path: str) -> None:
+    if limits.max_files is not None and files > limits.max_files:
+        raise RepositoryProviderError(
+            RepositoryProviderErrorCode.SCAN_LIMIT_EXCEEDED,
+            f"scan file limit exceeded at '{path}': {files} > {limits.max_files}",
+        )
+    if limits.max_bytes is not None and bytes_scanned > limits.max_bytes:
+        raise RepositoryProviderError(
+            RepositoryProviderErrorCode.SCAN_LIMIT_EXCEEDED,
+            f"scan byte limit exceeded at '{path}': {bytes_scanned} > {limits.max_bytes}",
+        )
+
+
+def _glob_match(path: str, pattern: str | None) -> bool:
+    if not pattern:
+        return True
+
+    normalized_pattern = pattern.strip()
+    if not normalized_pattern or normalized_pattern in {"**", "**/*"}:
+        return True
+
+    path_parts = tuple(part for part in path.strip("/").split("/") if part)
+    pattern_parts = tuple(part for part in normalized_pattern.strip("/").split("/") if part)
+    if not path_parts:
+        return False
+    if not pattern_parts:
+        return True
+    return _match_parts(path_parts, pattern_parts)
+
+
+def _match_parts(path_parts: Sequence[str], pattern_parts: Sequence[str]) -> bool:
+    if not pattern_parts:
+        return len(path_parts) == 0
+
+    pattern_head = pattern_parts[0]
+    if pattern_head == "**":
+        return _match_parts(path_parts, pattern_parts[1:]) or (
+            len(path_parts) > 0 and _match_parts(path_parts[1:], pattern_parts)
+        )
+
+    if not path_parts:
+        return False
+    if not fnmatchcase(path_parts[0], pattern_head):
+        return False
+    return _match_parts(path_parts[1:], pattern_parts[1:])

--- a/objectified-rest/tests/repositories/providers/test_github_repository_provider.py
+++ b/objectified-rest/tests/repositories/providers/test_github_repository_provider.py
@@ -63,8 +63,8 @@ async def test_github_provider_contract_methods() -> None:
                 200,
                 {
                     "tree": [
-                        {"path": "docs/readme.md", "type": "blob", "sha": "s1", "size": 10},
-                        {"path": "src/index.ts", "type": "blob", "sha": "s2", "size": 11},
+                        {"path": "docs/readme.md", "type": "blob", "sha": "s1", "size": 10, "mode": "100644"},
+                        {"path": "src/index.ts", "type": "blob", "sha": "s2", "size": 11, "mode": "100644"},
                     ]
                 },
             )
@@ -89,6 +89,7 @@ async def test_github_provider_contract_methods() -> None:
     assert [branch.name for branch in branches] == ["main"]
     assert sha == "abc123"
     assert [entry.path for entry in tree] == ["docs/readme.md"]
+    assert tree[0].mode == "100644"
     assert read_file.content_base64 == "YQ=="
 
 

--- a/objectified-rest/tests/repositories/test_tree_walker.py
+++ b/objectified-rest/tests/repositories/test_tree_walker.py
@@ -1,0 +1,147 @@
+import pytest
+
+from app.repositories.providers import RepoRef, RepositoryProviderError, RepositoryProviderErrorCode, TreeEntry
+from app.repositories.providers.base import ListReposOpts, ReadFileResult, RepoDetail
+from app.repositories.tree_walker import ScanLimit, walk_repository_tree
+
+
+class _StubProvider:
+    def __init__(self, entries: list[TreeEntry]) -> None:
+        self._entries = entries
+        self.walk_tree_calls: list[tuple[str, RepoRef, str, str | None]] = []
+        self.walk_tree_yields = 0
+
+    async def list_repositories(self, token: str, opts: ListReposOpts | None = None):  # pragma: no cover
+        raise NotImplementedError
+
+    async def get_repository(self, token: str, owner: str, name: str) -> RepoDetail:  # pragma: no cover
+        raise NotImplementedError
+
+    async def list_branches(self, token: str, repo: RepoRef):  # pragma: no cover
+        raise NotImplementedError
+
+    async def get_commit_sha(self, token: str, repo: RepoRef, branch: str) -> str:  # pragma: no cover
+        raise NotImplementedError
+
+    async def walk_tree(self, token: str, repo: RepoRef, branch: str, subpath: str | None = None):
+        self.walk_tree_calls.append((token, repo, branch, subpath))
+        for entry in self._entries:
+            self.walk_tree_yields += 1
+            yield entry
+
+    async def read_file(self, token: str, repo: RepoRef, branch: str, path: str) -> ReadFileResult:  # pragma: no cover
+        raise NotImplementedError
+
+
+@pytest.mark.asyncio
+async def test_walk_repository_tree_is_streaming_and_passes_commit_sha() -> None:
+    provider = _StubProvider(
+        [
+            TreeEntry(path="README.md", type="file", sha="a1", size_bytes=4, mode="100644"),
+            TreeEntry(path="src/main.py", type="file", sha="a2", size_bytes=8, mode="100644"),
+        ]
+    )
+
+    collected: list[TreeEntry] = []
+    async for entry in walk_repository_tree(
+        provider=provider,
+        token="token-a",
+        repo=RepoRef(owner="acme", name="repo-a"),
+        commit_sha="commit-sha-1",
+        subpath_glob="**/*",
+    ):
+        collected.append(entry)
+        break
+
+    assert len(collected) == 1
+    assert collected[0].path == "README.md"
+    assert provider.walk_tree_yields == 1
+    assert provider.walk_tree_calls == [("token-a", RepoRef(owner="acme", name="repo-a"), "commit-sha-1", None)]
+
+
+@pytest.mark.asyncio
+async def test_walk_repository_tree_filters_on_subpath_glob_boundary() -> None:
+    provider = _StubProvider(
+        [
+            TreeEntry(path="docs/readme.md", type="file", sha="a1", size_bytes=10, mode="100644"),
+            TreeEntry(path="src/main.py", type="file", sha="a2", size_bytes=12, mode="100644"),
+            TreeEntry(path="src/utils/helpers.py", type="file", sha="a3", size_bytes=15, mode="100644"),
+            TreeEntry(path="src/generated", type="dir", sha="a4", size_bytes=0, mode="040000"),
+        ]
+    )
+
+    result = [
+        entry
+        async for entry in walk_repository_tree(
+            provider=provider,
+            token="token-a",
+            repo=RepoRef(owner="acme", name="repo-a"),
+            commit_sha="commit-sha-1",
+            subpath_glob="src/**/*.py",
+        )
+    ]
+
+    assert [entry.path for entry in result] == ["src/main.py", "src/utils/helpers.py"]
+
+
+@pytest.mark.asyncio
+async def test_walk_repository_tree_raises_typed_error_when_scan_limits_exceeded() -> None:
+    provider = _StubProvider(
+        [
+            TreeEntry(path="src/main.py", type="file", sha="a1", size_bytes=10, mode="100644"),
+            TreeEntry(path="src/helpers.py", type="file", sha="a2", size_bytes=10, mode="100644"),
+        ]
+    )
+
+    with pytest.raises(RepositoryProviderError) as exc:
+        [
+            entry
+            async for entry in walk_repository_tree(
+                provider=provider,
+                token="token-a",
+                repo=RepoRef(owner="acme", name="repo-a"),
+                commit_sha="commit-sha-1",
+                subpath_glob="src/**/*.py",
+                limits=ScanLimit(max_files=1, max_bytes=100),
+            )
+        ]
+
+    assert exc.value.code == RepositoryProviderErrorCode.SCAN_LIMIT_EXCEEDED
+    assert "scan file limit exceeded" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_walk_repository_tree_emits_repository_scan_walked_audit() -> None:
+    provider = _StubProvider(
+        [
+            TreeEntry(path="README.md", type="file", sha="a1", size_bytes=4, mode="100644"),
+            TreeEntry(path="docs/guide.md", type="file", sha="a2", size_bytes=11, mode="100644"),
+        ]
+    )
+    audits: list[tuple[str, dict[str, object]]] = []
+
+    [
+        entry
+        async for entry in walk_repository_tree(
+            provider=provider,
+            token="token-a",
+            repo=RepoRef(owner="acme", name="repo-a"),
+            commit_sha="commit-sha-1",
+            subpath_glob="**/*",
+            audit_emitter=lambda event_type, detail: audits.append((event_type, detail)),
+        )
+    ]
+
+    assert audits == [
+        (
+            "repository.scan.walked",
+            {
+                "owner": "acme",
+                "name": "repo-a",
+                "commitSha": "commit-sha-1",
+                "subpathGlob": "**/*",
+                "files": 2,
+                "bytes": 15,
+            },
+        )
+    ]

--- a/objectified-ui/lib/repositories/providers/types.ts
+++ b/objectified-ui/lib/repositories/providers/types.ts
@@ -36,6 +36,7 @@ export interface TreeEntry {
   type: 'file' | 'dir' | 'symlink' | 'submodule';
   sha: string;
   sizeBytes: number;
+  mode?: string;
 }
 
 export interface WebhookTarget {
@@ -48,4 +49,5 @@ export type RepositoryProviderErrorCode =
   | 'UNAUTHORIZED'
   | 'NOT_FOUND'
   | 'NETWORK'
+  | 'SCAN_LIMIT_EXCEEDED'
   | 'UNKNOWN';

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.10.25",
+  "version": "0.10.26",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -5,6 +5,7 @@ We continue to improve the platform based on your feedback with improvements and
 ---
 
 ## Repositories
+- Added a streaming repository tree walker for connector scans with commit-SHA traversal, boundary glob filtering, typed scan-limit errors, and `repository.scan.walked` workflow audit emission.
 - Added repository connector MVP database tables for repository registration, branch tracking, and linked-account credential references.
 - Added a provider abstraction layer for repository connectors with a GitHub adapter, shared provider error taxonomy, and cross-provider contract tests.
 - Added a GitLab repository provider (`@gitbeaker/rest`) with full contract support, keyset repository pagination, and GitLab webhook secret verification.


### PR DESCRIPTION
## What was done and why
- Added `walk_repository_tree` in `objectified-rest` to stream file `TreeEntry` records from `RepositoryProvider.walk_tree` at a specific commit SHA.
- Applied subpath glob filtering at the walker boundary so providers can stay broad while scan scope remains precise.
- Enforced per-scan `maxFiles` / `maxBytes` limits with typed `SCAN_LIMIT_EXCEEDED` errors and emitted `repository.scan.walked` audit detail when the walk completes.
- Extended provider tree entry shape to include `mode`, plus tests for provider mode mapping and walker behavior.
- Updated roadmap/changelog and bumped `objectified-rest` and `objectified-ui` patch versions per workspace workflow.

## How to test
- Run `yarn build` from repo root.
- Run `yarn test` from repo root.
- (If Python tooling is available) run `pytest tests/repositories/providers/test_github_repository_provider.py tests/repositories/test_tree_walker.py` inside `objectified-rest`.

## Risk / notes
- Walker currently filters by `entry.type == "file"` before limit accounting to match scan semantics.
- Python `pip/pytest` are unavailable in this environment, so Python tests could not be executed here.

Closes #2762

Made with [Cursor](https://cursor.com)