### PR TITLE
Fix #2763 - add scanner include/exclude rules

### DIFF
--- a/docs/PLANNED_FEATURE_ROADMAP_REPOSITORY.md
+++ b/docs/PLANNED_FEATURE_ROADMAP_REPOSITORY.md
@@ -2,6 +2,7 @@
 
 ## Completed
 
+- REPO-2.2 (#2763): Added scanner include/exclude rule support with published default ignore patterns, manifest-level ignore merge behavior, ignore skip telemetry (`files_skipped_by_ignore`), and explicit `specs` precedence over ignores.
 - REPO-2.1 (#2762): Added a streaming repository tree walker that iterates files at a commit SHA, enforces typed scan limits (`SCAN_LIMIT_EXCEEDED`), applies subpath glob filtering at the walker boundary, and emits `repository.scan.walked` workflow audit events.
 - REPO-1.8 (#2760): Implemented a Bitbucket Cloud repository provider adapter for REST API 2.0 with shared contract coverage, UUID-based webhook verification, and linked-account availability for Bitbucket linking.
 - REPO-1.7 (#2759): Implemented the GitLab repository provider adapter with full contract coverage, keyset pagination for repository listing, and GitLab webhook registration/signature verification.

--- a/objectified-rest/pyproject.toml
+++ b/objectified-rest/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "objectified-rest"
-version = "1.0.55"
+version = "1.0.56"
 description = "REST API for serving OpenAPI specifications from the Objectified database"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/objectified-rest/src/app/repositories/tree_walker.py
+++ b/objectified-rest/src/app/repositories/tree_walker.py
@@ -10,12 +10,12 @@ from .providers import RepoRef, RepositoryProvider, RepositoryProviderError, Rep
 WorkflowAuditEmitter = Callable[[str, dict[str, Any]], Any]
 
 DEFAULT_SCAN_IGNORE_PATTERNS: tuple[str, ...] = (
-    ".git/**",
-    "node_modules/**",
-    "vendor/**",
-    "dist/**",
-    "build/**",
-    "coverage/**",
+    "**/.git/**",
+    "**/node_modules/**",
+    "**/vendor/**",
+    "**/dist/**",
+    "**/build/**",
+    "**/coverage/**",
     "**/__pycache__/**",
 )
 

--- a/objectified-rest/src/app/repositories/tree_walker.py
+++ b/objectified-rest/src/app/repositories/tree_walker.py
@@ -9,6 +9,16 @@ from .providers import RepoRef, RepositoryProvider, RepositoryProviderError, Rep
 
 WorkflowAuditEmitter = Callable[[str, dict[str, Any]], Any]
 
+DEFAULT_SCAN_IGNORE_PATTERNS: tuple[str, ...] = (
+    ".git/**",
+    "node_modules/**",
+    "vendor/**",
+    "dist/**",
+    "build/**",
+    "coverage/**",
+    "**/__pycache__/**",
+)
+
 
 @dataclass(frozen=True)
 class RepositoryWalkStats:
@@ -35,17 +45,29 @@ async def walk_repository_tree(
     repo: RepoRef,
     commit_sha: str,
     subpath_glob: str | None,
+    manifest_specs: Sequence[str] | None = None,
+    manifest_ignore: Sequence[str] | None = None,
     limits: ScanLimit | None = None,
     audit_emitter: WorkflowAuditEmitter | None = None,
 ) -> AsyncIterator[TreeEntry]:
     """Yield repository file entries for a specific commit SHA with scan limits."""
     stats = RepositoryWalkStats(files=0, bytes=0)
     effective_limits = limits or ScanLimit()
+    files_skipped_by_ignore = 0
+    explicit_specs = _normalize_patterns(manifest_specs)
+    merged_ignore_patterns = _merge_ignore_patterns(manifest_ignore)
 
     async for entry in provider.walk_tree(token=token, repo=repo, branch=commit_sha):
         if entry.type != "file":
             continue
         if not _glob_match(entry.path, subpath_glob):
+            continue
+        if _should_skip_for_ignore(
+            entry.path,
+            ignore_patterns=merged_ignore_patterns,
+            explicit_specs=explicit_specs,
+        ):
+            files_skipped_by_ignore += 1
             continue
 
         next_files = stats.files + 1
@@ -69,6 +91,7 @@ async def walk_repository_tree(
                 "subpathGlob": subpath_glob,
                 "files": stats.files,
                 "bytes": stats.bytes,
+                "files_skipped_by_ignore": files_skipped_by_ignore,
             },
         )
         if isawaitable(maybe_awaitable):
@@ -103,6 +126,30 @@ def _glob_match(path: str, pattern: str | None) -> bool:
     if not pattern_parts:
         return True
     return _match_parts(path_parts, pattern_parts)
+
+
+def _normalize_patterns(patterns: Sequence[str] | None) -> tuple[str, ...]:
+    if not patterns:
+        return ()
+    return tuple(pattern.strip() for pattern in patterns if pattern and pattern.strip())
+
+
+def _merge_ignore_patterns(manifest_ignore: Sequence[str] | None) -> tuple[str, ...]:
+    merged = list(DEFAULT_SCAN_IGNORE_PATTERNS)
+    for pattern in _normalize_patterns(manifest_ignore):
+        if pattern not in merged:
+            merged.append(pattern)
+    return tuple(merged)
+
+
+def _matches_any(path: str, patterns: Sequence[str]) -> bool:
+    return any(_glob_match(path, pattern) for pattern in patterns)
+
+
+def _should_skip_for_ignore(path: str, *, ignore_patterns: Sequence[str], explicit_specs: Sequence[str]) -> bool:
+    if _matches_any(path, explicit_specs):
+        return False
+    return _matches_any(path, ignore_patterns)
 
 
 def _match_parts(path_parts: Sequence[str], pattern_parts: Sequence[str]) -> bool:

--- a/objectified-rest/tests/repositories/test_tree_walker.py
+++ b/objectified-rest/tests/repositories/test_tree_walker.py
@@ -173,7 +173,32 @@ async def test_walk_repository_tree_applies_default_ignore_rules_and_reports_ski
 
     assert [entry.path for entry in result] == ["README.md", "src/main.py"]
     assert audits[0][1]["files_skipped_by_ignore"] == 1
-    assert "node_modules/**" in DEFAULT_SCAN_IGNORE_PATTERNS
+    assert "**/node_modules/**" in DEFAULT_SCAN_IGNORE_PATTERNS
+
+
+@pytest.mark.asyncio
+async def test_walk_repository_tree_ignores_nested_default_dirs() -> None:
+    provider = _StubProvider(
+        [
+            TreeEntry(path="packages/foo/node_modules/lodash/index.js", type="file", sha="b1", size_bytes=30, mode="100644"),
+            TreeEntry(path="packages/foo/src/index.ts", type="file", sha="b2", size_bytes=12, mode="100644"),
+            TreeEntry(path="packages/bar/dist/bundle.js", type="file", sha="b3", size_bytes=25, mode="100644"),
+            TreeEntry(path="packages/bar/src/index.ts", type="file", sha="b4", size_bytes=10, mode="100644"),
+        ]
+    )
+
+    result = [
+        entry
+        async for entry in walk_repository_tree(
+            provider=provider,
+            token="token-a",
+            repo=RepoRef(owner="acme", name="monorepo"),
+            commit_sha="commit-sha-2",
+            subpath_glob="**/*",
+        )
+    ]
+
+    assert [entry.path for entry in result] == ["packages/foo/src/index.ts", "packages/bar/src/index.ts"]
 
 
 @pytest.mark.asyncio

--- a/objectified-rest/tests/repositories/test_tree_walker.py
+++ b/objectified-rest/tests/repositories/test_tree_walker.py
@@ -2,7 +2,7 @@ import pytest
 
 from app.repositories.providers import RepoRef, RepositoryProviderError, RepositoryProviderErrorCode, TreeEntry
 from app.repositories.providers.base import ListReposOpts, ReadFileResult, RepoDetail
-from app.repositories.tree_walker import ScanLimit, walk_repository_tree
+from app.repositories.tree_walker import DEFAULT_SCAN_IGNORE_PATTERNS, ScanLimit, walk_repository_tree
 
 
 class _StubProvider:
@@ -142,6 +142,85 @@ async def test_walk_repository_tree_emits_repository_scan_walked_audit() -> None
                 "subpathGlob": "**/*",
                 "files": 2,
                 "bytes": 15,
+                "files_skipped_by_ignore": 0,
             },
         )
     ]
+
+
+@pytest.mark.asyncio
+async def test_walk_repository_tree_applies_default_ignore_rules_and_reports_skip_count() -> None:
+    provider = _StubProvider(
+        [
+            TreeEntry(path="README.md", type="file", sha="a1", size_bytes=4, mode="100644"),
+            TreeEntry(path="node_modules/package/index.js", type="file", sha="a2", size_bytes=20, mode="100644"),
+            TreeEntry(path="src/main.py", type="file", sha="a3", size_bytes=8, mode="100644"),
+        ]
+    )
+    audits: list[tuple[str, dict[str, object]]] = []
+
+    result = [
+        entry
+        async for entry in walk_repository_tree(
+            provider=provider,
+            token="token-a",
+            repo=RepoRef(owner="acme", name="repo-a"),
+            commit_sha="commit-sha-1",
+            subpath_glob="**/*",
+            audit_emitter=lambda event_type, detail: audits.append((event_type, detail)),
+        )
+    ]
+
+    assert [entry.path for entry in result] == ["README.md", "src/main.py"]
+    assert audits[0][1]["files_skipped_by_ignore"] == 1
+    assert "node_modules/**" in DEFAULT_SCAN_IGNORE_PATTERNS
+
+
+@pytest.mark.asyncio
+async def test_walk_repository_tree_merges_manifest_ignore_with_defaults() -> None:
+    provider = _StubProvider(
+        [
+            TreeEntry(path="dist/app.js", type="file", sha="a1", size_bytes=11, mode="100644"),
+            TreeEntry(path="docs/generated/spec.md", type="file", sha="a2", size_bytes=14, mode="100644"),
+            TreeEntry(path="docs/guide.md", type="file", sha="a3", size_bytes=9, mode="100644"),
+        ]
+    )
+
+    result = [
+        entry
+        async for entry in walk_repository_tree(
+            provider=provider,
+            token="token-a",
+            repo=RepoRef(owner="acme", name="repo-a"),
+            commit_sha="commit-sha-1",
+            subpath_glob="**/*",
+            manifest_ignore=["docs/generated/**"],
+        )
+    ]
+
+    assert [entry.path for entry in result] == ["docs/guide.md"]
+
+
+@pytest.mark.asyncio
+async def test_walk_repository_tree_explicit_specs_override_ignore_patterns() -> None:
+    provider = _StubProvider(
+        [
+            TreeEntry(path="dist/openapi.yaml", type="file", sha="a1", size_bytes=13, mode="100644"),
+            TreeEntry(path="dist/bundle.js", type="file", sha="a2", size_bytes=21, mode="100644"),
+        ]
+    )
+
+    result = [
+        entry
+        async for entry in walk_repository_tree(
+            provider=provider,
+            token="token-a",
+            repo=RepoRef(owner="acme", name="repo-a"),
+            commit_sha="commit-sha-1",
+            subpath_glob="**/*",
+            manifest_specs=["dist/openapi.yaml"],
+            manifest_ignore=["dist/**"],
+        )
+    ]
+
+    assert [entry.path for entry in result] == ["dist/openapi.yaml"]

--- a/objectified-ui/lib/repositories/scanner/defaults.ts
+++ b/objectified-ui/lib/repositories/scanner/defaults.ts
@@ -1,9 +1,9 @@
 export const DEFAULT_REPOSITORY_SCAN_IGNORE_PATTERNS = [
-  ".git/**",
-  "node_modules/**",
-  "vendor/**",
-  "dist/**",
-  "build/**",
-  "coverage/**",
+  "**/.git/**",
+  "**/node_modules/**",
+  "**/vendor/**",
+  "**/dist/**",
+  "**/build/**",
+  "**/coverage/**",
   "**/__pycache__/**",
 ] as const;

--- a/objectified-ui/lib/repositories/scanner/defaults.ts
+++ b/objectified-ui/lib/repositories/scanner/defaults.ts
@@ -1,0 +1,9 @@
+export const DEFAULT_REPOSITORY_SCAN_IGNORE_PATTERNS = [
+  ".git/**",
+  "node_modules/**",
+  "vendor/**",
+  "dist/**",
+  "build/**",
+  "coverage/**",
+  "**/__pycache__/**",
+] as const;

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.10.26",
+  "version": "0.10.27",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -5,6 +5,7 @@ We continue to improve the platform based on your feedback with improvements and
 ---
 
 ## Repositories
+- Added scanner include/exclude rules with published default ignore patterns, manifest-level ignore merges, `files_skipped_by_ignore` telemetry, and explicit spec precedence over ignores.
 - Added a streaming repository tree walker for connector scans with commit-SHA traversal, boundary glob filtering, typed scan-limit errors, and `repository.scan.walked` workflow audit emission.
 - Added repository connector MVP database tables for repository registration, branch tracking, and linked-account credential references.
 - Added a provider abstraction layer for repository connectors with a GitHub adapter, shared provider error taxonomy, and cross-provider contract tests.


### PR DESCRIPTION
## What was done and why
- Added default repository scanner ignore patterns and exposed them in `objectified-ui/lib/repositories/scanner/defaults.ts` so the defaults are published in the expected location.
- Updated REST tree walk scanning to merge manifest `ignore` patterns over defaults, while allowing explicit manifest `specs` entries to override ignore matches.
- Added `files_skipped_by_ignore` telemetry to `repository.scan.walked` audit payloads and expanded walker tests to cover defaults, merge behavior, and spec-over-ignore precedence.
- Updated roadmap/changelog entries and bumped patch versions for `objectified-ui` and `objectified-rest`.

## How to test
- Run `yarn build` from repository root.
- Run `yarn test` from repository root.
- (If Python dev tooling is installed) run `pytest tests/repositories/test_tree_walker.py` and `ruff check src tests` in `objectified-rest`.

## Risk/notes
- The new defaults are additive and only affect file inclusion in scanner walk filtering.
- Python-specific verification is environment-blocked here because `pytest` and `ruff` are unavailable in PATH.

Closes #2763

Made with [Cursor](https://cursor.com)