### PR TITLE
Fix #2764 - add repository format detection

### DIFF
--- a/docs/PLANNED_FEATURE_ROADMAP_REPOSITORY.md
+++ b/docs/PLANNED_FEATURE_ROADMAP_REPOSITORY.md
@@ -2,6 +2,7 @@
 
 ## Completed
 
+- REPO-2.3 (#2764): Added provider-agnostic spec format detection with filename heuristics plus 64 KB content sniffing, confidence/discriminator output, and stream-mode sniffing for files larger than 5 MB.
 - REPO-2.2 (#2763): Added scanner include/exclude rule support with published default ignore patterns, manifest-level ignore merge behavior, ignore skip telemetry (`files_skipped_by_ignore`), and explicit `specs` precedence over ignores.
 - REPO-2.1 (#2762): Added a streaming repository tree walker that iterates files at a commit SHA, enforces typed scan limits (`SCAN_LIMIT_EXCEEDED`), applies subpath glob filtering at the walker boundary, and emits `repository.scan.walked` workflow audit events.
 - REPO-1.8 (#2760): Implemented a Bitbucket Cloud repository provider adapter for REST API 2.0 with shared contract coverage, UUID-based webhook verification, and linked-account availability for Bitbucket linking.

--- a/objectified-ui/lib/repositories/scanner/detect.ts
+++ b/objectified-ui/lib/repositories/scanner/detect.ts
@@ -52,7 +52,7 @@ const OPENAPI_FILENAME_RE = /(openapi|swagger|oas)[^/]*(\.ya?ml|\.json)?$/i;
 const ASYNCAPI_FILENAME_RE = /asyncapi[^/]*(\.ya?ml|\.json)?$/i;
 const ARAZZO_FILENAME_RE = /arazzo[^/]*(\.ya?ml|\.json)?$/i;
 const JSON_OR_YAML_RE = /\.(json|ya?ml)$/i;
-const GRAPHQL_BLOCK_RE = /^\s*(schema\s*\{[\s\S]*\}|type\s+query\b[\s\S]*\})\s*$/i;
+const GRAPHQL_BLOCK_RE = /\b(?:schema\s*\{[\s\S]*?\}|type\s+query\b[\s\S]*?\})/i;
 
 export async function detectRepositorySpecFormat(
   input: DetectRepositorySpecInput
@@ -261,16 +261,10 @@ function jsonSchemaDiscriminator(content: string, lower: string): string {
 }
 
 function looksLikeAvro(content: string): boolean {
-  try {
-    const parsed = JSON.parse(content);
-    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-      return false;
-    }
-    const obj = parsed as Record<string, unknown>;
-    return typeof obj.name === "string" && typeof obj.type === "string" && Array.isArray(obj.fields);
-  } catch {
-    return false;
-  }
+  const hasName = /"name"\s*:\s*"[^"]+"/i.test(content);
+  const hasType = /"type"\s*:\s*"[^"]+"/i.test(content);
+  const hasFields = /"fields"\s*:\s*\[/i.test(content);
+  return hasName && hasType && hasFields;
 }
 
 function matchVersionedField(content: string, key: string, valuePattern: RegExp): string | null {
@@ -314,10 +308,15 @@ async function readFromReadableStream(
   const reader = stream.getReader();
   const chunks: Uint8Array[] = [];
   let total = 0;
+  let fullyConsumed = false;
   try {
     while (total < maxBytes) {
       const next = await reader.read();
-      if (next.done || !next.value) {
+      if (next.done) {
+        fullyConsumed = true;
+        break;
+      }
+      if (!next.value) {
         break;
       }
       const value = next.value;
@@ -326,7 +325,15 @@ async function readFromReadableStream(
       total += take;
     }
   } finally {
-    reader.releaseLock();
+    if (fullyConsumed) {
+      reader.releaseLock();
+    } else {
+      try {
+        await reader.cancel();
+      } catch {
+        // Preserve existing behavior if cleanup fails.
+      }
+    }
   }
   return decodeUtf8(joinChunks(chunks, total));
 }

--- a/objectified-ui/lib/repositories/scanner/detect.ts
+++ b/objectified-ui/lib/repositories/scanner/detect.ts
@@ -1,0 +1,367 @@
+export const SNIFF_MAX_BYTES = 64 * 1024;
+export const STREAMING_SNIFF_THRESHOLD_BYTES = 5 * 1024 * 1024;
+
+export type DetectedRepositorySpecFormat =
+  | "openapi_3_0"
+  | "openapi_3_1"
+  | "swagger_2_0"
+  | "asyncapi_2"
+  | "asyncapi_3"
+  | "arazzo_1"
+  | "json_schema"
+  | "graphql_sdl"
+  | "protobuf"
+  | "avro"
+  | "unknown_spec";
+
+export interface DetectRepositorySpecResult {
+  format: DetectedRepositorySpecFormat;
+  confidence: number;
+  discriminator: string;
+}
+
+type SniffMode = "buffer" | "stream";
+type SniffChunk = string | Uint8Array;
+type SniffSource = string | Uint8Array | AsyncIterable<SniffChunk> | ReadableStream<Uint8Array>;
+
+export interface DetectRepositorySpecInput {
+  path: string;
+  sizeBytes: number;
+  readSnippet: (opts: { maxBytes: number; mode: SniffMode }) => Promise<SniffSource>;
+}
+
+interface DetectionEvidence {
+  format: Exclude<DetectedRepositorySpecFormat, "unknown_spec">;
+  confidence: number;
+  discriminator: string;
+}
+
+type DetectionCandidate = Exclude<DetectedRepositorySpecFormat, "unknown_spec">;
+
+const DIRECT_EXTENSION_FORMATS: Array<{
+  regex: RegExp;
+  format: DetectionCandidate;
+}> = [
+  { regex: /\.graphql$/i, format: "graphql_sdl" },
+  { regex: /\.gql$/i, format: "graphql_sdl" },
+  { regex: /\.proto$/i, format: "protobuf" },
+  { regex: /\.avsc$/i, format: "avro" },
+];
+
+const OPENAPI_FILENAME_RE = /(openapi|swagger|oas)[^/]*(\.ya?ml|\.json)?$/i;
+const ASYNCAPI_FILENAME_RE = /asyncapi[^/]*(\.ya?ml|\.json)?$/i;
+const ARAZZO_FILENAME_RE = /arazzo[^/]*(\.ya?ml|\.json)?$/i;
+const JSON_OR_YAML_RE = /\.(json|ya?ml)$/i;
+const GRAPHQL_BLOCK_RE = /^\s*(schema\s*\{[\s\S]*\}|type\s+query\b[\s\S]*\})\s*$/i;
+
+export async function detectRepositorySpecFormat(
+  input: DetectRepositorySpecInput
+): Promise<DetectRepositorySpecResult> {
+  const phaseA = phaseAFilenameHeuristics(input.path);
+  const mode: SniffMode = input.sizeBytes > STREAMING_SNIFF_THRESHOLD_BYTES ? "stream" : "buffer";
+  const source = await input.readSnippet({ maxBytes: SNIFF_MAX_BYTES, mode });
+  const sniffText = await readAtMost(source, SNIFF_MAX_BYTES);
+  const phaseB = phaseBContentSniff(sniffText);
+  const strongest = chooseBestEvidence(phaseA, phaseB);
+
+  if (strongest) {
+    return strongest;
+  }
+
+  return {
+    format: "unknown_spec",
+    confidence: 0.05,
+    discriminator: "no_known_discriminator",
+  };
+}
+
+function phaseAFilenameHeuristics(path: string): Set<DetectionCandidate> {
+  const normalized = path.toLowerCase();
+  const candidates = new Set<DetectionCandidate>();
+
+  for (const item of DIRECT_EXTENSION_FORMATS) {
+    if (item.regex.test(normalized)) {
+      candidates.add(item.format);
+    }
+  }
+
+  if (OPENAPI_FILENAME_RE.test(normalized)) {
+    candidates.add("openapi_3_0");
+    candidates.add("openapi_3_1");
+    candidates.add("swagger_2_0");
+  }
+
+  if (ASYNCAPI_FILENAME_RE.test(normalized)) {
+    candidates.add("asyncapi_2");
+    candidates.add("asyncapi_3");
+  }
+
+  if (ARAZZO_FILENAME_RE.test(normalized)) {
+    candidates.add("arazzo_1");
+  }
+
+  if (JSON_OR_YAML_RE.test(normalized)) {
+    candidates.add("openapi_3_0");
+    candidates.add("openapi_3_1");
+    candidates.add("swagger_2_0");
+    candidates.add("asyncapi_2");
+    candidates.add("asyncapi_3");
+    candidates.add("arazzo_1");
+    candidates.add("json_schema");
+    candidates.add("avro");
+  }
+
+  return candidates;
+}
+
+function phaseBContentSniff(content: string): DetectionEvidence[] {
+  const evidences: DetectionEvidence[] = [];
+  const lower = content.toLowerCase();
+  const trimmed = content.trim();
+
+  const openapi31 = matchVersionedField(content, "openapi", /^3\.1(?:\.\d+)?$/);
+  if (openapi31) {
+    evidences.push({
+      format: "openapi_3_1",
+      confidence: 0.98,
+      discriminator: `openapi:${openapi31}`,
+    });
+  }
+
+  const openapi30 = matchVersionedField(content, "openapi", /^3\.0(?:\.\d+)?$/);
+  if (openapi30) {
+    evidences.push({
+      format: "openapi_3_0",
+      confidence: 0.98,
+      discriminator: `openapi:${openapi30}`,
+    });
+  }
+
+  const swagger20 = matchVersionedField(content, "swagger", /^2\.0$/);
+  if (swagger20) {
+    evidences.push({
+      format: "swagger_2_0",
+      confidence: 0.98,
+      discriminator: `swagger:${swagger20}`,
+    });
+  }
+
+  const async2 = matchVersionedField(content, "asyncapi", /^2(?:\.\d+)?(?:\.\d+)?$/);
+  if (async2) {
+    evidences.push({
+      format: "asyncapi_2",
+      confidence: 0.98,
+      discriminator: `asyncapi:${async2}`,
+    });
+  }
+
+  const async3 = matchVersionedField(content, "asyncapi", /^3(?:\.\d+)?(?:\.\d+)?$/);
+  if (async3) {
+    evidences.push({
+      format: "asyncapi_3",
+      confidence: 0.98,
+      discriminator: `asyncapi:${async3}`,
+    });
+  }
+
+  const arazzo1 = matchVersionedField(content, "arazzo", /^1(?:\.\d+)?(?:\.\d+)?$/);
+  if (arazzo1) {
+    evidences.push({
+      format: "arazzo_1",
+      confidence: 0.98,
+      discriminator: `arazzo:${arazzo1}`,
+    });
+  }
+
+  if (/^\s*syntax\s*=\s*"proto3"\s*;/m.test(content)) {
+    evidences.push({
+      format: "protobuf",
+      confidence: 0.98,
+      discriminator: 'line:syntax="proto3"',
+    });
+  }
+
+  if (GRAPHQL_BLOCK_RE.test(trimmed)) {
+    evidences.push({
+      format: "graphql_sdl",
+      confidence: 0.9,
+      discriminator: trimmed.toLowerCase().startsWith("type query")
+        ? "line:type Query"
+        : "line:schema { ... }",
+    });
+  }
+
+  if (looksLikeJsonSchema(content, lower)) {
+    evidences.push({
+      format: "json_schema",
+      confidence: 0.88,
+      discriminator: jsonSchemaDiscriminator(content, lower),
+    });
+  }
+
+  if (looksLikeAvro(content)) {
+    evidences.push({
+      format: "avro",
+      confidence: 0.9,
+      discriminator: "json_keys:name+type+fields",
+    });
+  }
+
+  return evidences;
+}
+
+function chooseBestEvidence(
+  phaseA: Set<DetectionCandidate>,
+  phaseB: DetectionEvidence[]
+): DetectRepositorySpecResult | null {
+  if (phaseB.length === 0) {
+    return null;
+  }
+
+  const evidence =
+    phaseA.size > 0 ? phaseB.filter((item) => phaseA.has(item.format)) : phaseB;
+  if (evidence.length === 0) {
+    return null;
+  }
+
+  evidence.sort((a, b) => b.confidence - a.confidence);
+  const winner = evidence[0];
+  if (!winner) {
+    return null;
+  }
+
+  return {
+    format: winner.format,
+    confidence: Number(winner.confidence.toFixed(2)),
+    discriminator: winner.discriminator,
+  };
+}
+
+function looksLikeJsonSchema(content: string, lower: string): boolean {
+  if (/"\$schema"\s*:\s*"[^"]*json-schema[^"]*"/i.test(content)) {
+    return true;
+  }
+  if (/\$schema\s*:\s*["'][^"']*json-schema[^"']*["']/i.test(content)) {
+    return true;
+  }
+  return /\btype\b/.test(lower) && /\bproperties\b/.test(lower);
+}
+
+function jsonSchemaDiscriminator(content: string, lower: string): string {
+  if (/"\$schema"\s*:\s*"[^"]*json-schema[^"]*"/i.test(content)) {
+    return "key:$schema(json-schema)";
+  }
+  if (/\$schema\s*:\s*["'][^"']*json-schema[^"']*["']/i.test(content)) {
+    return "key:$schema(json-schema)";
+  }
+  if (/\btype\b/.test(lower) && /\bproperties\b/.test(lower)) {
+    return "keys:type+properties";
+  }
+  return "json_schema_heuristic";
+}
+
+function looksLikeAvro(content: string): boolean {
+  try {
+    const parsed = JSON.parse(content);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return false;
+    }
+    const obj = parsed as Record<string, unknown>;
+    return typeof obj.name === "string" && typeof obj.type === "string" && Array.isArray(obj.fields);
+  } catch {
+    return false;
+  }
+}
+
+function matchVersionedField(content: string, key: string, valuePattern: RegExp): string | null {
+  const jsonPattern = new RegExp(`"${key}"\\s*:\\s*"([^"]+)"`, "i");
+  const yamlPattern = new RegExp(`^\\s*${key}\\s*:\\s*["']?([^"'\\n#]+)["']?`, "im");
+  const jsonMatch = content.match(jsonPattern);
+  if (jsonMatch?.[1] && valuePattern.test(jsonMatch[1].trim())) {
+    return jsonMatch[1].trim();
+  }
+  const yamlMatch = content.match(yamlPattern);
+  if (yamlMatch?.[1] && valuePattern.test(yamlMatch[1].trim())) {
+    return yamlMatch[1].trim();
+  }
+  return null;
+}
+
+async function readAtMost(source: SniffSource, maxBytes: number): Promise<string> {
+  if (typeof source === "string") {
+    return source.slice(0, maxBytes);
+  }
+
+  if (source instanceof Uint8Array) {
+    return decodeUtf8(source.subarray(0, maxBytes));
+  }
+
+  if (isReadableStream(source)) {
+    return readFromReadableStream(source, maxBytes);
+  }
+
+  return readFromAsyncIterable(source, maxBytes);
+}
+
+function isReadableStream(source: SniffSource): source is ReadableStream<Uint8Array> {
+  return typeof source === "object" && source !== null && "getReader" in source;
+}
+
+async function readFromReadableStream(
+  stream: ReadableStream<Uint8Array>,
+  maxBytes: number
+): Promise<string> {
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    while (total < maxBytes) {
+      const next = await reader.read();
+      if (next.done || !next.value) {
+        break;
+      }
+      const value = next.value;
+      const take = Math.min(value.length, maxBytes - total);
+      chunks.push(value.subarray(0, take));
+      total += take;
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  return decodeUtf8(joinChunks(chunks, total));
+}
+
+async function readFromAsyncIterable(
+  iterable: AsyncIterable<SniffChunk>,
+  maxBytes: number
+): Promise<string> {
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  for await (const chunk of iterable) {
+    if (total >= maxBytes) {
+      break;
+    }
+    const bytes = typeof chunk === "string" ? new TextEncoder().encode(chunk) : chunk;
+    const take = Math.min(bytes.length, maxBytes - total);
+    chunks.push(bytes.subarray(0, take));
+    total += take;
+  }
+  return decodeUtf8(joinChunks(chunks, total));
+}
+
+function joinChunks(chunks: Uint8Array[], totalBytes: number): Uint8Array {
+  if (chunks.length === 1) {
+    return chunks[0] ?? new Uint8Array(0);
+  }
+  const output = new Uint8Array(totalBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    output.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return output;
+}
+
+function decodeUtf8(bytes: Uint8Array): string {
+  return new TextDecoder("utf-8", { fatal: false }).decode(bytes);
+}

--- a/objectified-ui/lib/repositories/scanner/detect.ts
+++ b/objectified-ui/lib/repositories/scanner/detect.ts
@@ -261,9 +261,9 @@ function jsonSchemaDiscriminator(content: string, lower: string): string {
 }
 
 function looksLikeAvro(content: string): boolean {
-  const hasName = /"name"\s*:\s*"[^"]+"/i.test(content);
-  const hasType = /"type"\s*:\s*"[^"]+"/i.test(content);
-  const hasFields = /"fields"\s*:\s*\[/i.test(content);
+  const hasName = /"name"\s*:\s*"[^"]+"/.test(content);
+  const hasType = /"type"\s*:\s*"[^"]+"/.test(content);
+  const hasFields = /"fields"\s*:\s*\[/.test(content);
   return hasName && hasType && hasFields;
 }
 

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.10.27",
+  "version": "0.10.28",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -5,6 +5,7 @@ We continue to improve the platform based on your feedback with improvements and
 ---
 
 ## Repositories
+- Added provider-agnostic spec format detection with filename heuristics plus 64 KB content sniffing, confidence/discriminator output, and stream-mode sniffing for files over 5 MB.
 - Added scanner include/exclude rules with published default ignore patterns, manifest-level ignore merges, `files_skipped_by_ignore` telemetry, and explicit spec precedence over ignores.
 - Added a streaming repository tree walker for connector scans with commit-SHA traversal, boundary glob filtering, typed scan-limit errors, and `repository.scan.walked` workflow audit emission.
 - Added repository connector MVP database tables for repository registration, branch tracking, and linked-account credential references.

--- a/objectified-ui/tests/unit/repositories/scanner/detect.test.ts
+++ b/objectified-ui/tests/unit/repositories/scanner/detect.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "@jest/globals";
+import {
+  SNIFF_MAX_BYTES,
+  STREAMING_SNIFF_THRESHOLD_BYTES,
+  detectRepositorySpecFormat,
+  type DetectedRepositorySpecFormat,
+} from "@lib/repositories/scanner/detect";
+
+interface Fixture {
+  format: Exclude<DetectedRepositorySpecFormat, "unknown_spec">;
+  path: string;
+  positive: string;
+  negative: string;
+}
+
+const FIXTURES: Fixture[] = [
+  {
+    format: "openapi_3_0",
+    path: "apis/openapi.yaml",
+    positive: "openapi: 3.0.3\ninfo:\n  title: Store API",
+    negative: "openapi: 4.0.0\ninfo:\n  title: Invalid",
+  },
+  {
+    format: "openapi_3_1",
+    path: "apis/openapi.json",
+    positive: '{"openapi":"3.1.0","info":{"title":"Store API"}}',
+    negative: '{"openapi":"2.9.0","info":{"title":"Invalid"}}',
+  },
+  {
+    format: "swagger_2_0",
+    path: "apis/swagger.yml",
+    positive: "swagger: '2.0'\ninfo:\n  title: Legacy API",
+    negative: "swagger: '2.1'\ninfo:\n  title: Invalid",
+  },
+  {
+    format: "asyncapi_2",
+    path: "events/asyncapi.yaml",
+    positive: "asyncapi: 2.6.0\ninfo:\n  title: Event API",
+    negative: "asyncapi: 1.0.0\ninfo:\n  title: Invalid",
+  },
+  {
+    format: "asyncapi_3",
+    path: "events/asyncapi-v3.yaml",
+    positive: "asyncapi: 3.0.0\ninfo:\n  title: Event API",
+    negative: "asyncapi: 4.0.0\ninfo:\n  title: Invalid",
+  },
+  {
+    format: "arazzo_1",
+    path: "workflows/arazzo.yaml",
+    positive: "arazzo: 1.0.1\ninfo:\n  title: Workflow",
+    negative: "arazzo: 2.0.0\ninfo:\n  title: Invalid",
+  },
+  {
+    format: "json_schema",
+    path: "schemas/user.schema.json",
+    positive:
+      '{"$schema":"https://json-schema.org/draft/2020-12/schema","type":"object","properties":{"id":{"type":"string"}}}',
+    negative: '{"title":"No discriminator keys","description":"schema-like text only"}',
+  },
+  {
+    format: "graphql_sdl",
+    path: "graphql/schema.graphql",
+    positive: "type Query {\n  health: String!\n}",
+    negative: "query Health {\n  health\n}",
+  },
+  {
+    format: "protobuf",
+    path: "proto/service.proto",
+    positive: 'syntax = "proto3";\nmessage User { string id = 1; }',
+    negative: 'syntax = "proto2";\nmessage User { optional string id = 1; }',
+  },
+  {
+    format: "avro",
+    path: "avro/user.avsc",
+    positive:
+      '{"type":"record","name":"User","fields":[{"name":"id","type":"string"},{"name":"email","type":"string"}]}',
+    negative: '{"type":"record","name":"User","doc":"missing fields array"}',
+  },
+];
+
+describe("detectRepositorySpecFormat", () => {
+  for (const fixture of FIXTURES) {
+    it(`detects ${fixture.format} from a positive sample`, async () => {
+      const result = await detectRepositorySpecFormat({
+        path: fixture.path,
+        sizeBytes: fixture.positive.length,
+        readSnippet: async () => fixture.positive,
+      });
+
+      expect(result.format).toBe(fixture.format);
+      expect(result.confidence).toBeGreaterThan(0.3);
+      expect(result.discriminator).not.toBe("no_known_discriminator");
+    });
+
+    it(`does not classify ${fixture.format} from its negative sample`, async () => {
+      const result = await detectRepositorySpecFormat({
+        path: `samples/not-${fixture.path}`,
+        sizeBytes: fixture.negative.length,
+        readSnippet: async () => fixture.negative,
+      });
+
+      expect(result.format).not.toBe(fixture.format);
+    });
+  }
+
+  it("returns unknown_spec when no known discriminators exist", async () => {
+    const result = await detectRepositorySpecFormat({
+      path: "docs/readme.txt",
+      sizeBytes: 64,
+      readSnippet: async () => "This is just plain text with no schema signals.",
+    });
+
+    expect(result).toEqual({
+      format: "unknown_spec",
+      confidence: 0.05,
+      discriminator: "no_known_discriminator",
+    });
+  });
+
+  it("requests stream mode for files over 5MB", async () => {
+    const seenModes: string[] = [];
+    const result = await detectRepositorySpecFormat({
+      path: "huge/spec.proto",
+      sizeBytes: STREAMING_SNIFF_THRESHOLD_BYTES + 1,
+      readSnippet: async ({ mode, maxBytes }) => {
+        seenModes.push(mode);
+        expect(maxBytes).toBe(SNIFF_MAX_BYTES);
+        return (async function* generator() {
+          yield 'syntax = "proto3";\n';
+          yield "message BigFile {}";
+        })();
+      },
+    });
+
+    expect(seenModes).toEqual(["stream"]);
+    expect(result.format).toBe("protobuf");
+  });
+});

--- a/objectified-ui/tests/unit/repositories/scanner/detect.test.ts
+++ b/objectified-ui/tests/unit/repositories/scanner/detect.test.ts
@@ -1,13 +1,13 @@
-import { describe, expect, it } from "@jest/globals";
+import { describe, expect, it } from '@jest/globals';
 import {
   SNIFF_MAX_BYTES,
   STREAMING_SNIFF_THRESHOLD_BYTES,
   detectRepositorySpecFormat,
   type DetectedRepositorySpecFormat,
-} from "@lib/repositories/scanner/detect";
+} from '@lib/repositories/scanner/detect';
 
 interface Fixture {
-  format: Exclude<DetectedRepositorySpecFormat, "unknown_spec">;
+  format: Exclude<DetectedRepositorySpecFormat, 'unknown_spec'>;
   path: string;
   positive: string;
   negative: string;
@@ -15,70 +15,70 @@ interface Fixture {
 
 const FIXTURES: Fixture[] = [
   {
-    format: "openapi_3_0",
-    path: "apis/openapi.yaml",
-    positive: "openapi: 3.0.3\ninfo:\n  title: Store API",
-    negative: "openapi: 4.0.0\ninfo:\n  title: Invalid",
+    format: 'openapi_3_0',
+    path: 'apis/openapi.yaml',
+    positive: 'openapi: 3.0.3\ninfo:\n  title: Store API',
+    negative: 'openapi: 4.0.0\ninfo:\n  title: Invalid',
   },
   {
-    format: "openapi_3_1",
-    path: "apis/openapi.json",
+    format: 'openapi_3_1',
+    path: 'apis/openapi.json',
     positive: '{"openapi":"3.1.0","info":{"title":"Store API"}}',
     negative: '{"openapi":"2.9.0","info":{"title":"Invalid"}}',
   },
   {
-    format: "swagger_2_0",
-    path: "apis/swagger.yml",
+    format: 'swagger_2_0',
+    path: 'apis/swagger.yml',
     positive: "swagger: '2.0'\ninfo:\n  title: Legacy API",
     negative: "swagger: '2.1'\ninfo:\n  title: Invalid",
   },
   {
-    format: "asyncapi_2",
-    path: "events/asyncapi.yaml",
-    positive: "asyncapi: 2.6.0\ninfo:\n  title: Event API",
-    negative: "asyncapi: 1.0.0\ninfo:\n  title: Invalid",
+    format: 'asyncapi_2',
+    path: 'events/asyncapi.yaml',
+    positive: 'asyncapi: 2.6.0\ninfo:\n  title: Event API',
+    negative: 'asyncapi: 1.0.0\ninfo:\n  title: Invalid',
   },
   {
-    format: "asyncapi_3",
-    path: "events/asyncapi-v3.yaml",
-    positive: "asyncapi: 3.0.0\ninfo:\n  title: Event API",
-    negative: "asyncapi: 4.0.0\ninfo:\n  title: Invalid",
+    format: 'asyncapi_3',
+    path: 'events/asyncapi-v3.yaml',
+    positive: 'asyncapi: 3.0.0\ninfo:\n  title: Event API',
+    negative: 'asyncapi: 4.0.0\ninfo:\n  title: Invalid',
   },
   {
-    format: "arazzo_1",
-    path: "workflows/arazzo.yaml",
-    positive: "arazzo: 1.0.1\ninfo:\n  title: Workflow",
-    negative: "arazzo: 2.0.0\ninfo:\n  title: Invalid",
+    format: 'arazzo_1',
+    path: 'workflows/arazzo.yaml',
+    positive: 'arazzo: 1.0.1\ninfo:\n  title: Workflow',
+    negative: 'arazzo: 2.0.0\ninfo:\n  title: Invalid',
   },
   {
-    format: "json_schema",
-    path: "schemas/user.schema.json",
+    format: 'json_schema',
+    path: 'schemas/user.schema.json',
     positive:
       '{"$schema":"https://json-schema.org/draft/2020-12/schema","type":"object","properties":{"id":{"type":"string"}}}',
     negative: '{"title":"No discriminator keys","description":"schema-like text only"}',
   },
   {
-    format: "graphql_sdl",
-    path: "graphql/schema.graphql",
-    positive: "type Query {\n  health: String!\n}",
-    negative: "query Health {\n  health\n}",
+    format: 'graphql_sdl',
+    path: 'graphql/schema.graphql',
+    positive: 'type Query {\n  health: String!\n}',
+    negative: 'query Health {\n  health\n}',
   },
   {
-    format: "protobuf",
-    path: "proto/service.proto",
+    format: 'protobuf',
+    path: 'proto/service.proto',
     positive: 'syntax = "proto3";\nmessage User { string id = 1; }',
     negative: 'syntax = "proto2";\nmessage User { optional string id = 1; }',
   },
   {
-    format: "avro",
-    path: "avro/user.avsc",
+    format: 'avro',
+    path: 'avro/user.avsc',
     positive:
       '{"type":"record","name":"User","fields":[{"name":"id","type":"string"},{"name":"email","type":"string"}]}',
     negative: '{"type":"record","name":"User","doc":"missing fields array"}',
   },
 ];
 
-describe("detectRepositorySpecFormat", () => {
+describe('detectRepositorySpecFormat', () => {
   for (const fixture of FIXTURES) {
     it(`detects ${fixture.format} from a positive sample`, async () => {
       const result = await detectRepositorySpecFormat({
@@ -89,7 +89,7 @@ describe("detectRepositorySpecFormat", () => {
 
       expect(result.format).toBe(fixture.format);
       expect(result.confidence).toBeGreaterThan(0.3);
-      expect(result.discriminator).not.toBe("no_known_discriminator");
+      expect(result.discriminator).not.toBe('no_known_discriminator');
     });
 
     it(`does not classify ${fixture.format} from its negative sample`, async () => {
@@ -103,36 +103,36 @@ describe("detectRepositorySpecFormat", () => {
     });
   }
 
-  it("returns unknown_spec when no known discriminators exist", async () => {
+  it('returns unknown_spec when no known discriminators exist', async () => {
     const result = await detectRepositorySpecFormat({
-      path: "docs/readme.txt",
+      path: 'docs/readme.txt',
       sizeBytes: 64,
-      readSnippet: async () => "This is just plain text with no schema signals.",
+      readSnippet: async () => 'This is just plain text with no schema signals.',
     });
 
     expect(result).toEqual({
-      format: "unknown_spec",
+      format: 'unknown_spec',
       confidence: 0.05,
-      discriminator: "no_known_discriminator",
+      discriminator: 'no_known_discriminator',
     });
   });
 
-  it("requests stream mode for files over 5MB", async () => {
+  it('requests stream mode for files over 5MB', async () => {
     const seenModes: string[] = [];
     const result = await detectRepositorySpecFormat({
-      path: "huge/spec.proto",
+      path: 'huge/spec.proto',
       sizeBytes: STREAMING_SNIFF_THRESHOLD_BYTES + 1,
       readSnippet: async ({ mode, maxBytes }) => {
         seenModes.push(mode);
         expect(maxBytes).toBe(SNIFF_MAX_BYTES);
         return (async function* generator() {
           yield 'syntax = "proto3";\n';
-          yield "message BigFile {}";
+          yield 'message BigFile {}';
         })();
       },
     });
 
-    expect(seenModes).toEqual(["stream"]);
-    expect(result.format).toBe("protobuf");
+    expect(seenModes).toEqual(['stream']);
+    expect(result.format).toBe('protobuf');
   });
 });


### PR DESCRIPTION
## Summary
- Add `detectRepositorySpecFormat` in `objectified-ui/lib/repositories/scanner/detect.ts` with two-phase detection: filename/path candidate narrowing and content sniffing over the first 64 KB.
- Return a single detected format with `confidence` and `discriminator`, and return `unknown_spec` when no content discriminator is found.
- Add comprehensive unit tests for positive/negative coverage across each supported format and verify stream-mode sniffing for files larger than 5 MB.
- Update roadmap/changelog entries and bump `objectified-ui` patch version for this ticket.

## Test plan
- [x] `yarn workspace objectified-ui test tests/unit/repositories/scanner/detect.test.ts`
- [x] `yarn build`
- [x] `yarn test`
- [x] `yarn workspace objectified-ui lint` *(currently fails due to pre-existing repo-wide lint violations unrelated to this ticket)*

## Risk / Notes
- Filename/path heuristics intentionally do not finalize classification; they only constrain content-sniff candidates to reduce false positives.
- Large file handling requests stream mode when `sizeBytes > 5MB` and reads at most 64 KB.

Closes #2764

Made with [Cursor](https://cursor.com)