### PR TITLE
Fix #2765 - add repository manifest support

### DIFF
--- a/docs/PLANNED_FEATURE_ROADMAP_REPOSITORY.md
+++ b/docs/PLANNED_FEATURE_ROADMAP_REPOSITORY.md
@@ -2,6 +2,7 @@
 
 ## Completed
 
+- REPO-2.4 (#2765): Added `.objectified/repo.yaml` manifest support with published JSON Schema validation, non-fatal `manifest_error` repository file recording, per-spec format/polling overrides, and untracked discovery output for files not explicitly listed.
 - REPO-2.3 (#2764): Added provider-agnostic spec format detection with filename heuristics plus 64 KB content sniffing, confidence/discriminator output, and stream-mode sniffing for files larger than 5 MB.
 - REPO-2.2 (#2763): Added scanner include/exclude rule support with published default ignore patterns, manifest-level ignore merge behavior, ignore skip telemetry (`files_skipped_by_ignore`), and explicit `specs` precedence over ignores.
 - REPO-2.1 (#2762): Added a streaming repository tree walker that iterates files at a commit SHA, enforces typed scan limits (`SCAN_LIMIT_EXCEEDED`), applies subpath glob filtering at the walker boundary, and emits `repository.scan.walked` workflow audit events.

--- a/objectified-rest/pyproject.toml
+++ b/objectified-rest/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "uvicorn[standard]>=0.31.0",
     "pydantic>=2.9.2",
     "pydantic-settings>=2.5.2",
+    "jsonschema>=4.0.0",
     "psycopg2-binary>=2.9.9",
     "pyyaml>=6.0.2",
     "python-dotenv>=1.0.1",

--- a/objectified-rest/requirements.txt
+++ b/objectified-rest/requirements.txt
@@ -8,3 +8,4 @@ python-dotenv==1.0.1
 pyjwt==2.8.0
 bcrypt>=4.0.0
 numpy
+jsonschema>=4.0.0

--- a/objectified-rest/schemas/repo-manifest.v1.json
+++ b/objectified-rest/schemas/repo-manifest.v1.json
@@ -1,0 +1,91 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://objectified.dev/schemas/repo-manifest.v1.json",
+  "title": "Objectified Repository Manifest v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version"],
+  "properties": {
+    "version": {
+      "type": "integer",
+      "const": 1
+    },
+    "defaults": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "pollIntervalSec": {
+          "type": "integer",
+          "minimum": 15,
+          "maximum": 86400
+        },
+        "branches": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "specs": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["path"],
+        "properties": {
+          "path": {
+            "type": "string",
+            "minLength": 1
+          },
+          "format": {
+            "type": "string",
+            "enum": [
+              "openapi_3_0",
+              "openapi_3_1",
+              "swagger_2_0",
+              "asyncapi_2",
+              "asyncapi_3",
+              "arazzo_1",
+              "json_schema",
+              "graphql_sdl",
+              "protobuf",
+              "avro",
+              "unknown_spec"
+            ]
+          },
+          "project": {
+            "type": "string",
+            "minLength": 1
+          },
+          "versionStrategy": {
+            "type": "string",
+            "enum": ["file-version", "commit-sha", "branch"]
+          },
+          "promote": {
+            "type": "string",
+            "enum": ["auto", "manual"]
+          },
+          "onBreakingChange": {
+            "type": "string",
+            "enum": ["warn", "block", "autoCreateNewMajor"]
+          },
+          "pollIntervalSec": {
+            "type": "integer",
+            "minimum": 15,
+            "maximum": 86400
+          }
+        }
+      }
+    },
+    "ignore": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    }
+  }
+}

--- a/objectified-rest/src/app/repositories/manifest.py
+++ b/objectified-rest/src/app/repositories/manifest.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
+import importlib.resources as pkg_resources
 import json
 from dataclasses import dataclass
-from pathlib import Path
 from typing import Any, Literal, Sequence
 
 import yaml
@@ -23,7 +23,6 @@ DetectedRepositorySpecFormat = Literal[
 ]
 
 _MANIFEST_RELATIVE_PATH = ".objectified/repo.yaml"
-_SCHEMA_RELATIVE_PATH = Path("schemas/repo-manifest.v1.json")
 
 
 @dataclass(frozen=True)
@@ -84,7 +83,14 @@ def parse_repo_manifest(raw_manifest: str | None) -> RepoManifestParseOutcome:
     if parsed is None:
         parsed = {}
 
-    schema = _load_manifest_schema()
+    try:
+        schema = _load_manifest_schema()
+    except (FileNotFoundError, json.JSONDecodeError, OSError) as exc:
+        return RepoManifestParseOutcome(
+            manifest=None,
+            manifest_error_row=_manifest_error_row(f"unable to load manifest schema: {exc}"),
+        )
+
     validator = Draft202012Validator(schema)
     try:
         validator.validate(parsed)
@@ -133,9 +139,8 @@ def build_repository_file_rows(
 
 
 def _load_manifest_schema() -> dict[str, Any]:
-    repo_root = Path(__file__).resolve().parents[3]
-    schema_path = repo_root / _SCHEMA_RELATIVE_PATH
-    with schema_path.open("r", encoding="utf-8") as schema_file:
+    ref = pkg_resources.files("app.repositories.schemas") / "repo-manifest.v1.json"
+    with ref.open("r", encoding="utf-8") as schema_file:
         return json.load(schema_file)
 
 

--- a/objectified-rest/src/app/repositories/manifest.py
+++ b/objectified-rest/src/app/repositories/manifest.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal, Sequence
+
+import yaml
+from jsonschema import Draft202012Validator, ValidationError
+
+DetectedRepositorySpecFormat = Literal[
+    "openapi_3_0",
+    "openapi_3_1",
+    "swagger_2_0",
+    "asyncapi_2",
+    "asyncapi_3",
+    "arazzo_1",
+    "json_schema",
+    "graphql_sdl",
+    "protobuf",
+    "avro",
+    "unknown_spec",
+]
+
+_MANIFEST_RELATIVE_PATH = ".objectified/repo.yaml"
+_SCHEMA_RELATIVE_PATH = Path("schemas/repo-manifest.v1.json")
+
+
+@dataclass(frozen=True)
+class RepoManifestDefaults:
+    poll_interval_sec: int | None
+    branches: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class RepoManifestSpec:
+    path: str
+    format: DetectedRepositorySpecFormat | None
+    poll_interval_sec: int | None
+
+
+@dataclass(frozen=True)
+class RepoManifest:
+    version: int
+    defaults: RepoManifestDefaults
+    specs: tuple[RepoManifestSpec, ...]
+    ignore: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class RepositoryFileRow:
+    path: str
+    format: DetectedRepositorySpecFormat | None
+    tracked: bool
+    poll_interval_sec: int | None
+    status: str
+    metadata: dict[str, Any] | None = None
+
+
+@dataclass(frozen=True)
+class RepositoryDiscoveryCandidate:
+    path: str
+    detected_format: DetectedRepositorySpecFormat
+
+
+@dataclass(frozen=True)
+class RepoManifestParseOutcome:
+    manifest: RepoManifest | None
+    manifest_error_row: RepositoryFileRow | None
+
+
+def parse_repo_manifest(raw_manifest: str | None) -> RepoManifestParseOutcome:
+    if raw_manifest is None or not raw_manifest.strip():
+        return RepoManifestParseOutcome(manifest=None, manifest_error_row=None)
+
+    try:
+        parsed: Any = yaml.safe_load(raw_manifest)
+    except yaml.YAMLError as exc:
+        return RepoManifestParseOutcome(
+            manifest=None,
+            manifest_error_row=_manifest_error_row(f"invalid YAML: {exc}"),
+        )
+
+    if parsed is None:
+        parsed = {}
+
+    schema = _load_manifest_schema()
+    validator = Draft202012Validator(schema)
+    try:
+        validator.validate(parsed)
+    except ValidationError as exc:
+        return RepoManifestParseOutcome(
+            manifest=None,
+            manifest_error_row=_manifest_error_row(_format_schema_error(exc)),
+        )
+
+    manifest = _to_repo_manifest(parsed)
+    return RepoManifestParseOutcome(manifest=manifest, manifest_error_row=None)
+
+
+def build_repository_file_rows(
+    *,
+    discoveries: Sequence[RepositoryDiscoveryCandidate],
+    manifest: RepoManifest | None,
+    branch_poll_interval_sec: int | None,
+    manifest_error_row: RepositoryFileRow | None = None,
+) -> list[RepositoryFileRow]:
+    rows: list[RepositoryFileRow] = []
+    if manifest_error_row is not None:
+        rows.append(manifest_error_row)
+
+    spec_by_path = {spec.path: spec for spec in (manifest.specs if manifest is not None else ())}
+    default_poll_interval = manifest.defaults.poll_interval_sec if manifest is not None else None
+    effective_branch_poll_interval = (
+        branch_poll_interval_sec if branch_poll_interval_sec is not None else default_poll_interval
+    )
+
+    for discovery in discoveries:
+        spec = spec_by_path.get(discovery.path)
+        manifest_spec_poll = spec.poll_interval_sec if spec is not None else None
+        rows.append(
+            RepositoryFileRow(
+                path=discovery.path,
+                format=spec.format if spec is not None and spec.format is not None else discovery.detected_format,
+                tracked=spec is not None,
+                poll_interval_sec=manifest_spec_poll
+                if manifest_spec_poll is not None
+                else effective_branch_poll_interval,
+                status="discovered",
+            )
+        )
+    return rows
+
+
+def _load_manifest_schema() -> dict[str, Any]:
+    repo_root = Path(__file__).resolve().parents[3]
+    schema_path = repo_root / _SCHEMA_RELATIVE_PATH
+    with schema_path.open("r", encoding="utf-8") as schema_file:
+        return json.load(schema_file)
+
+
+def _to_repo_manifest(parsed: dict[str, Any]) -> RepoManifest:
+    defaults = parsed.get("defaults") or {}
+    specs = parsed.get("specs") or []
+    ignore = parsed.get("ignore") or []
+
+    return RepoManifest(
+        version=int(parsed["version"]),
+        defaults=RepoManifestDefaults(
+            poll_interval_sec=defaults.get("pollIntervalSec"),
+            branches=tuple(defaults.get("branches") or ()),
+        ),
+        specs=tuple(
+            RepoManifestSpec(
+                path=str(spec["path"]),
+                format=spec.get("format"),
+                poll_interval_sec=spec.get("pollIntervalSec"),
+            )
+            for spec in specs
+        ),
+        ignore=tuple(str(item) for item in ignore),
+    )
+
+
+def _manifest_error_row(message: str) -> RepositoryFileRow:
+    return RepositoryFileRow(
+        path=_MANIFEST_RELATIVE_PATH,
+        format=None,
+        tracked=True,
+        poll_interval_sec=None,
+        status="manifest_error",
+        metadata={"error": message},
+    )
+
+
+def _format_schema_error(error: ValidationError) -> str:
+    if error.path:
+        pointer = ".".join(str(part) for part in error.path)
+        return f"schema validation failed at '{pointer}': {error.message}"
+    return f"schema validation failed: {error.message}"

--- a/objectified-rest/src/app/repositories/schemas/repo-manifest.v1.json
+++ b/objectified-rest/src/app/repositories/schemas/repo-manifest.v1.json
@@ -1,0 +1,91 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://objectified.dev/schemas/repo-manifest.v1.json",
+  "title": "Objectified Repository Manifest v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version"],
+  "properties": {
+    "version": {
+      "type": "integer",
+      "const": 1
+    },
+    "defaults": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "pollIntervalSec": {
+          "type": "integer",
+          "minimum": 15,
+          "maximum": 86400
+        },
+        "branches": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "specs": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["path"],
+        "properties": {
+          "path": {
+            "type": "string",
+            "minLength": 1
+          },
+          "format": {
+            "type": "string",
+            "enum": [
+              "openapi_3_0",
+              "openapi_3_1",
+              "swagger_2_0",
+              "asyncapi_2",
+              "asyncapi_3",
+              "arazzo_1",
+              "json_schema",
+              "graphql_sdl",
+              "protobuf",
+              "avro",
+              "unknown_spec"
+            ]
+          },
+          "project": {
+            "type": "string",
+            "minLength": 1
+          },
+          "versionStrategy": {
+            "type": "string",
+            "enum": ["file-version", "commit-sha", "branch"]
+          },
+          "promote": {
+            "type": "string",
+            "enum": ["auto", "manual"]
+          },
+          "onBreakingChange": {
+            "type": "string",
+            "enum": ["warn", "block", "autoCreateNewMajor"]
+          },
+          "pollIntervalSec": {
+            "type": "integer",
+            "minimum": 15,
+            "maximum": 86400
+          }
+        }
+      }
+    },
+    "ignore": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    }
+  }
+}

--- a/objectified-rest/src/app/repositories_routes.py
+++ b/objectified-rest/src/app/repositories_routes.py
@@ -16,6 +16,7 @@ from fastapi import APIRouter, Body, Depends, HTTPException, Response
 from pydantic import BaseModel, Field
 
 from .auth import validate_authentication
+from .repositories.manifest import parse_repo_manifest
 
 router = APIRouter(prefix="/v1/repositories", tags=["repositories"])
 
@@ -203,11 +204,26 @@ async def register_repository(
         timeline=[timeline_entry],
     )
 
+    manifest_outcome = parse_repo_manifest(request.manifest)
+    initial_file_rows: List[Dict[str, Any]] = []
+    if manifest_outcome.manifest_error_row is not None:
+        row = manifest_outcome.manifest_error_row
+        initial_file_rows.append(
+            {
+                "path": row.path,
+                "format": row.format,
+                "tracked": row.tracked,
+                "pollIntervalSec": row.poll_interval_sec,
+                "status": row.status,
+                "metadata": row.metadata,
+            }
+        )
+
     with _STORE_LOCK:
         tenant_repos = _REPO_STORE.setdefault(tenant_id, {})
         _REPO_BRANCH_STORE[repository.id] = list(normalized_branches)
         _REPO_SCAN_STORE[repository.id] = [timeline_entry]
-        _REPO_FILE_STORE[repository.id] = []
+        _REPO_FILE_STORE[repository.id] = initial_file_rows
         _REPO_CREDENTIAL_REF_STORE[repository.id] = [{"linkedAccountId": request.linkedAccountId}]
         tenant_repos[repository.id] = repository
 

--- a/objectified-rest/tests/repositories/test_manifest.py
+++ b/objectified-rest/tests/repositories/test_manifest.py
@@ -1,0 +1,90 @@
+from app.repositories.manifest import (
+    RepositoryDiscoveryCandidate,
+    build_repository_file_rows,
+    parse_repo_manifest,
+)
+
+
+def test_parse_repo_manifest_validates_against_schema() -> None:
+    outcome = parse_repo_manifest(
+        """
+version: 1
+defaults:
+  pollIntervalSec: 86400
+  branches: [main]
+specs:
+  - path: services/orders/openapi.yaml
+    format: openapi_3_1
+    pollIntervalSec: 300
+ignore:
+  - "**/node_modules/**"
+"""
+    )
+
+    assert outcome.manifest_error_row is None
+    assert outcome.manifest is not None
+    assert outcome.manifest.defaults.poll_interval_sec == 86400
+    assert outcome.manifest.specs[0].format == "openapi_3_1"
+
+
+def test_parse_repo_manifest_returns_manifest_error_row_but_allows_scan_to_continue() -> None:
+    outcome = parse_repo_manifest(
+        """
+version: 2
+specs:
+  - path: service.yaml
+"""
+    )
+
+    assert outcome.manifest is None
+    assert outcome.manifest_error_row is not None
+    assert outcome.manifest_error_row.path == ".objectified/repo.yaml"
+    assert outcome.manifest_error_row.status == "manifest_error"
+    assert outcome.manifest_error_row.metadata is not None
+    assert "schema validation failed" in outcome.manifest_error_row.metadata["error"]
+
+    rows = build_repository_file_rows(
+        discoveries=[RepositoryDiscoveryCandidate(path="service.yaml", detected_format="openapi_3_0")],
+        manifest=None,
+        branch_poll_interval_sec=120,
+        manifest_error_row=outcome.manifest_error_row,
+    )
+    assert [row.status for row in rows] == ["manifest_error", "discovered"]
+    assert rows[1].path == "service.yaml"
+
+
+def test_manifest_spec_format_and_poll_interval_override_detection_and_branch_defaults() -> None:
+    outcome = parse_repo_manifest(
+        """
+version: 1
+defaults:
+  pollIntervalSec: 600
+specs:
+  - path: apis/openapi.yaml
+    format: asyncapi_3
+    pollIntervalSec: 30
+  - path: apis/events.yaml
+"""
+    )
+    assert outcome.manifest is not None
+
+    rows = build_repository_file_rows(
+        discoveries=[
+            RepositoryDiscoveryCandidate(path="apis/openapi.yaml", detected_format="openapi_3_0"),
+            RepositoryDiscoveryCandidate(path="apis/events.yaml", detected_format="asyncapi_2"),
+            RepositoryDiscoveryCandidate(path="apis/unlisted.yaml", detected_format="json_schema"),
+        ],
+        manifest=outcome.manifest,
+        branch_poll_interval_sec=120,
+    )
+    by_path = {row.path: row for row in rows}
+
+    # Per-spec format override wins over scanner phase-B detection.
+    assert by_path["apis/openapi.yaml"].format == "asyncapi_3"
+    # Per-spec pollIntervalSec wins over branch-level interval.
+    assert by_path["apis/openapi.yaml"].poll_interval_sec == 30
+    # Missing per-spec pollIntervalSec falls back to branch-level interval.
+    assert by_path["apis/events.yaml"].poll_interval_sec == 120
+    # Files omitted from manifest still appear as untracked discoveries.
+    assert by_path["apis/unlisted.yaml"].tracked is False
+    assert by_path["apis/unlisted.yaml"].format == "json_schema"

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.10.28",
+  "version": "0.10.29",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -5,6 +5,7 @@ We continue to improve the platform based on your feedback with improvements and
 ---
 
 ## Repositories
+- Added `.objectified/repo.yaml` manifest support with published schema validation, non-fatal `manifest_error` recording, per-spec format/polling overrides, and untracked discovery rows for files not listed in the manifest.
 - Added provider-agnostic spec format detection with filename heuristics plus 64 KB content sniffing, confidence/discriminator output, and stream-mode sniffing for files over 5 MB.
 - Added scanner include/exclude rules with published default ignore patterns, manifest-level ignore merges, `files_skipped_by_ignore` telemetry, and explicit spec precedence over ignores.
 - Added a streaming repository tree walker for connector scans with commit-SHA traversal, boundary glob filtering, typed scan-limit errors, and `repository.scan.walked` workflow audit emission.


### PR DESCRIPTION
## What was done and why
- Added the published schema at `objectified-rest/schemas/repo-manifest.v1.json` and implemented manifest parsing/validation in `objectified-rest/src/app/repositories/manifest.py`.
- Added scan reconciliation behavior so invalid manifests produce a non-fatal `repository_file`-style row with `status='manifest_error'`, then continue discovery processing.
- Added override handling where manifest `spec.format` wins over detected format and `spec.pollIntervalSec` wins over branch/default poll interval.
- Ensured files not listed in manifest still appear as discoveries with `tracked=false`.
- Added test coverage in `objectified-rest/tests/repositories/test_manifest.py` and documented release/roadmap updates.

## How to test
- Run **build checks**: `yarn build`
- Run **workspace tests**: `yarn test`
- (When Python tooling is available) run **manifest unit tests**: `python3 -m pytest objectified-rest/tests/repositories/test_manifest.py`

## Risk / notes
- New logic is additive and isolated to repository-manifest parsing/reconciliation.
- Runtime dependency is now explicit on `jsonschema` in `objectified-rest/pyproject.toml`.
- Local environment lacked `pytest`/`ruff` executables, so Python lint/test verification used syntax compilation (`python3 -m compileall`) plus workspace build/test.

Closes #2765

Made with [Cursor](https://cursor.com)