### PR TITLE
Fix #2767 - add repository scan history models and APIs

### DIFF
--- a/docs/PLANNED_FEATURE_ROADMAP_REPOSITORY.md
+++ b/docs/PLANNED_FEATURE_ROADMAP_REPOSITORY.md
@@ -2,6 +2,7 @@
 
 ## Completed
 
+- REPO-2.6 (#2767): Added `repository_scan` and `repository_file` history support with cursor-paginated scan/file REST endpoints, `force` rescan behavior, and `skipped_unchanged` audit/event tracking.
 - REPO-2.4 (#2765): Added `.objectified/repo.yaml` manifest support with published JSON Schema validation, non-fatal `manifest_error` repository file recording, per-spec format/polling overrides, and untracked discovery output for files not explicitly listed.
 - REPO-2.3 (#2764): Added provider-agnostic spec format detection with filename heuristics plus 64 KB content sniffing, confidence/discriminator output, and stream-mode sniffing for files larger than 5 MB.
 - REPO-2.2 (#2763): Added scanner include/exclude rule support with published default ignore patterns, manifest-level ignore merge behavior, ignore skip telemetry (`files_skipped_by_ignore`), and explicit `specs` precedence over ignores.

--- a/objectified-db/scripts/20260424-120000.sql
+++ b/objectified-db/scripts/20260424-120000.sql
@@ -1,0 +1,111 @@
+-- REPO-2.6 / #2767: scan job history tables for repository connector.
+SET search_path TO odb, public;
+
+DO $$
+BEGIN
+  CREATE TYPE odb.repository_scan_trigger AS ENUM ('manual', 'scheduled', 'webhook', 'register');
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END
+$$;
+
+DO $$
+BEGIN
+  CREATE TYPE odb.repository_scan_status AS ENUM (
+    'pending',
+    'walking',
+    'sniffing',
+    'complete',
+    'failed',
+    'skipped_unchanged'
+  );
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END
+$$;
+
+DO $$
+BEGIN
+  CREATE TYPE odb.repository_file_status AS ENUM (
+    'new',
+    'unchanged',
+    'modified',
+    'removed',
+    'parse_error',
+    'manifest_error'
+  );
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END
+$$;
+
+CREATE TABLE IF NOT EXISTS odb.repository_scan (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  repository_id UUID NOT NULL REFERENCES odb.repository(id) ON DELETE CASCADE,
+  branch VARCHAR(255) NOT NULL,
+  commit_sha VARCHAR(64) NOT NULL,
+  trigger odb.repository_scan_trigger NOT NULL,
+  status odb.repository_scan_status NOT NULL,
+  started_at TIMESTAMPTZ NOT NULL,
+  finished_at TIMESTAMPTZ,
+  duration_ms INTEGER,
+  files_seen INTEGER NOT NULL DEFAULT 0,
+  files_classified INTEGER NOT NULL DEFAULT 0,
+  files_unknown INTEGER NOT NULL DEFAULT 0,
+  files_failed INTEGER NOT NULL DEFAULT 0,
+  event_log JSONB NOT NULL DEFAULT '[]'::jsonb,
+  diff_summary JSONB NOT NULL DEFAULT '{}'::jsonb,
+  error_code VARCHAR(64),
+  error_detail TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_repository_scan_repository_id
+  ON odb.repository_scan (repository_id);
+
+CREATE INDEX IF NOT EXISTS idx_repository_scan_repository_created_at
+  ON odb.repository_scan (repository_id, created_at DESC, id DESC);
+
+CREATE INDEX IF NOT EXISTS idx_repository_scan_repository_branch
+  ON odb.repository_scan (repository_id, branch);
+
+CREATE TABLE IF NOT EXISTS odb.repository_file (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  repository_id UUID NOT NULL REFERENCES odb.repository(id) ON DELETE CASCADE,
+  scan_id UUID NOT NULL REFERENCES odb.repository_scan(id) ON DELETE CASCADE,
+  path TEXT NOT NULL,
+  blob_sha VARCHAR(64),
+  size_bytes INTEGER,
+  format VARCHAR(32),
+  confidence NUMERIC(3,2),
+  discriminator TEXT,
+  tracked BOOLEAN NOT NULL DEFAULT FALSE,
+  project_slug VARCHAR(128),
+  version_strategy VARCHAR(32),
+  status odb.repository_file_status NOT NULL,
+  quality_score SMALLINT,
+  last_import_job_id UUID,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_repository_file_repository_path
+  ON odb.repository_file (repository_id, path);
+
+CREATE INDEX IF NOT EXISTS idx_repository_file_scan_id
+  ON odb.repository_file (scan_id);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'fk_repository_last_scan_id'
+      AND connamespace = 'odb'::regnamespace
+      AND conrelid = 'odb.repository'::regclass
+  ) THEN
+    ALTER TABLE odb.repository
+      ADD CONSTRAINT fk_repository_last_scan_id
+      FOREIGN KEY (last_scan_id) REFERENCES odb.repository_scan(id) ON DELETE SET NULL;
+  END IF;
+END
+$$;

--- a/objectified-rest/pyproject.toml
+++ b/objectified-rest/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "objectified-rest"
-version = "1.0.56"
+version = "1.0.57"
 description = "REST API for serving OpenAPI specifications from the Objectified database"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/objectified-rest/src/app/repositories_routes.py
+++ b/objectified-rest/src/app/repositories_routes.py
@@ -619,8 +619,9 @@ async def delete_repository(
     return Response(status_code=204)
 
 
-@router.get("/{repository_id}/scans", response_model=RepositoryScanPage)
+@router.get("/{tenant_slug}/{repository_id}/scans", response_model=RepositoryScanPage)
 async def list_repository_scans(
+    tenant_slug: str,
     repository_id: str,
     auth_data: Dict[str, Any] = Depends(validate_authentication),
     status: RepositoryScanStatus | None = Query(default=None),
@@ -671,8 +672,9 @@ async def list_repository_scans(
     return RepositoryScanPage(items=page_items, limit=limit, nextCursor=next_cursor)
 
 
-@router.get("/{repository_id}/scans/{scan_id}", response_model=RepositoryScanRecord)
+@router.get("/{tenant_slug}/{repository_id}/scans/{scan_id}", response_model=RepositoryScanRecord)
 async def get_repository_scan(
+    tenant_slug: str,
     repository_id: str,
     scan_id: str,
     auth_data: Dict[str, Any] = Depends(validate_authentication),
@@ -687,8 +689,9 @@ async def get_repository_scan(
     raise HTTPException(status_code=404, detail=f"Scan not found: {scan_id}")
 
 
-@router.get("/{repository_id}/scans/{scan_id}/files", response_model=RepositoryScanFilePage)
+@router.get("/{tenant_slug}/{repository_id}/scans/{scan_id}/files", response_model=RepositoryScanFilePage)
 async def list_repository_scan_files(
+    tenant_slug: str,
     repository_id: str,
     scan_id: str,
     auth_data: Dict[str, Any] = Depends(validate_authentication),
@@ -734,8 +737,9 @@ async def list_repository_scan_files(
     return RepositoryScanFilePage(items=page_items, limit=limit, nextCursor=next_cursor)
 
 
-@router.post("/{repository_id}/scans", response_model=RepositoryScanRecord)
+@router.post("/{tenant_slug}/{repository_id}/scans", response_model=RepositoryScanRecord)
 async def create_repository_scan(
+    tenant_slug: str,
     repository_id: str,
     request: RepositoryScanCreateRequest,
     auth_data: Dict[str, Any] = Depends(validate_authentication),

--- a/objectified-rest/src/app/repositories_routes.py
+++ b/objectified-rest/src/app/repositories_routes.py
@@ -7,12 +7,15 @@ trigger an initial scan job.
 
 from __future__ import annotations
 
+import base64
+import binascii
+import json
 from datetime import datetime, timezone
 from threading import Lock
-from typing import Any, Dict, List, Literal
+from typing import Any, Dict, List, Literal, Optional, Tuple
 from uuid import UUID, uuid4
 
-from fastapi import APIRouter, Body, Depends, HTTPException, Response
+from fastapi import APIRouter, Body, Depends, HTTPException, Query, Response
 from pydantic import BaseModel, Field
 
 from .auth import validate_authentication
@@ -48,6 +51,25 @@ class RepositoryEditRequest(BaseModel):
 
 class RepositoryDeleteRequest(BaseModel):
     confirmFullName: str = Field(min_length=1)
+
+
+RepositoryScanTrigger = Literal["manual", "scheduled", "webhook", "register"]
+RepositoryScanStatus = Literal[
+    "pending",
+    "walking",
+    "sniffing",
+    "complete",
+    "failed",
+    "skipped_unchanged",
+]
+RepositoryFileStatus = Literal[
+    "new",
+    "unchanged",
+    "modified",
+    "removed",
+    "parse_error",
+    "manifest_error",
+]
 
 
 class RepositoryScanTimelineEntry(BaseModel):
@@ -86,13 +108,75 @@ class RegisterRepositoryResponse(BaseModel):
     initialScanJobId: str
 
 
+class RepositoryScanRecord(BaseModel):
+    id: str
+    repositoryId: str
+    branch: str
+    commitSha: str
+    trigger: RepositoryScanTrigger
+    status: RepositoryScanStatus
+    startedAt: str
+    finishedAt: str | None = None
+    durationMs: int | None = None
+    filesSeen: int
+    filesClassified: int
+    filesUnknown: int
+    filesFailed: int
+    eventLog: List[Dict[str, Any]] = Field(default_factory=list)
+    diffSummary: Dict[str, Any] = Field(default_factory=dict)
+    errorCode: str | None = None
+    errorDetail: str | None = None
+    createdAt: str
+
+
+class RepositoryFileRecord(BaseModel):
+    id: str
+    repositoryId: str
+    scanId: str
+    path: str
+    blobSha: str | None = None
+    sizeBytes: int | None = None
+    format: str | None = None
+    confidence: float | None = None
+    discriminator: str | None = None
+    tracked: bool
+    projectSlug: str | None = None
+    versionStrategy: str | None = None
+    status: RepositoryFileStatus
+    qualityScore: int | None = None
+    lastImportJobId: str | None = None
+    createdAt: str
+
+
+class RepositoryScanCreateRequest(BaseModel):
+    branch: str = Field(min_length=1)
+    force: bool = False
+
+
+class RepositoryScanPage(BaseModel):
+    items: List[RepositoryScanRecord]
+    limit: int
+    nextCursor: str | None = None
+
+
+class RepositoryScanFilePage(BaseModel):
+    items: List[RepositoryFileRecord]
+    limit: int
+    nextCursor: str | None = None
+
+
 _REPO_STORE: Dict[str, Dict[str, RepositoryRecord]] = {}
 _REPO_BRANCH_STORE: Dict[str, List[RepositoryBranchRecord]] = {}
 _REPO_SCAN_STORE: Dict[str, List[RepositoryScanTimelineEntry]] = {}
 _REPO_FILE_STORE: Dict[str, List[Dict[str, Any]]] = {}
+_REPO_SCAN_HISTORY_STORE: Dict[str, List[RepositoryScanRecord]] = {}
+_REPO_SCAN_FILE_HISTORY_STORE: Dict[str, List[RepositoryFileRecord]] = {}
 _REPO_CREDENTIAL_REF_STORE: Dict[str, List[Dict[str, Any]]] = {}
 _REPO_AUDIT_STORE: List[Dict[str, Any]] = []
 _STORE_LOCK = Lock()
+
+_DEFAULT_SCAN_PAGE_SIZE = 50
+_MAX_SCAN_PAGE_SIZE = 200
 
 
 def _utc_now_iso() -> str:
@@ -104,6 +188,123 @@ def _validate_uuid(raw: str, field_name: str) -> None:
         UUID(raw)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=f"{field_name} must be a valid UUID") from exc
+
+
+def _parse_iso8601(raw: Optional[str], label: str) -> Optional[datetime]:
+    if raw is None:
+        return None
+    normalized = raw.strip().replace("Z", "+00:00")
+    if not normalized:
+        return None
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=f"Invalid {label}; expected ISO 8601 datetime") from exc
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def _encode_cursor(created_at: str, row_id: str) -> str:
+    payload = json.dumps({"createdAt": created_at, "id": row_id}, separators=(",", ":"))
+    return base64.urlsafe_b64encode(payload.encode("utf-8")).decode("ascii").rstrip("=")
+
+
+def _decode_cursor(token: str) -> Tuple[datetime, str]:
+    raw = token.strip()
+    if not raw:
+        raise HTTPException(status_code=400, detail="Invalid cursor")
+    padding = "=" * (-len(raw) % 4)
+    try:
+        decoded = base64.urlsafe_b64decode(raw + padding).decode("utf-8")
+        parsed = json.loads(decoded)
+    except (binascii.Error, ValueError, json.JSONDecodeError) as exc:
+        raise HTTPException(status_code=400, detail="Invalid cursor") from exc
+    if not isinstance(parsed, dict):
+        raise HTTPException(status_code=400, detail="Invalid cursor")
+    created_at = parsed.get("createdAt")
+    row_id = parsed.get("id")
+    if not isinstance(created_at, str) or not isinstance(row_id, str):
+        raise HTTPException(status_code=400, detail="Invalid cursor")
+    _validate_uuid(row_id, "cursor.id")
+    parsed_time = _parse_iso8601(created_at, "cursor.createdAt")
+    if parsed_time is None:
+        raise HTTPException(status_code=400, detail="Invalid cursor")
+    return parsed_time, row_id
+
+
+def _find_repository_for_tenant(tenant_id: str, repository_id: str) -> RepositoryRecord:
+    repository = _REPO_STORE.get(tenant_id, {}).get(repository_id)
+    if repository is None:
+        raise HTTPException(status_code=404, detail=f"Repository not found: {repository_id}")
+    return repository
+
+
+def _to_sort_key(created_at: str, row_id: str) -> Tuple[datetime, str]:
+    parsed = _parse_iso8601(created_at, "createdAt")
+    if parsed is None:
+        raise HTTPException(status_code=500, detail="scan row missing createdAt")
+    return parsed, row_id
+
+
+def _make_pending_scan(
+    *,
+    repository_id: str,
+    branch: str,
+    trigger: RepositoryScanTrigger,
+    force: bool,
+) -> RepositoryScanRecord:
+    now = _utc_now_iso()
+    return RepositoryScanRecord(
+        id=str(uuid4()),
+        repositoryId=repository_id,
+        branch=branch,
+        commitSha=f"pending-{uuid4().hex[:12]}",
+        trigger=trigger,
+        status="pending",
+        startedAt=now,
+        filesSeen=0,
+        filesClassified=0,
+        filesUnknown=0,
+        filesFailed=0,
+        eventLog=[{"type": "repository.scan.queued", "at": now, "force": force}],
+        diffSummary={},
+        createdAt=now,
+    )
+
+
+def _make_skipped_unchanged_scan(
+    *,
+    repository_id: str,
+    branch: str,
+    trigger: RepositoryScanTrigger,
+    baseline_commit_sha: str | None,
+) -> RepositoryScanRecord:
+    now = _utc_now_iso()
+    return RepositoryScanRecord(
+        id=str(uuid4()),
+        repositoryId=repository_id,
+        branch=branch,
+        commitSha=baseline_commit_sha or f"skipped-{uuid4().hex[:12]}",
+        trigger=trigger,
+        status="skipped_unchanged",
+        startedAt=now,
+        finishedAt=now,
+        durationMs=0,
+        filesSeen=0,
+        filesClassified=0,
+        filesUnknown=0,
+        filesFailed=0,
+        eventLog=[
+            {
+                "type": "repository.scan.skipped_unchanged",
+                "at": now,
+                "reason": "force=false and no detected changes",
+            }
+        ],
+        diffSummary={"changed": 0},
+        createdAt=now,
+    )
 
 
 def _normalize_branch(record: RepositoryBranchInput) -> RepositoryBranchRecord:
@@ -206,6 +407,7 @@ async def register_repository(
 
     manifest_outcome = parse_repo_manifest(request.manifest)
     initial_file_rows: List[Dict[str, Any]] = []
+    initial_scan_files: List[RepositoryFileRecord] = []
     if manifest_outcome.manifest_error_row is not None:
         row = manifest_outcome.manifest_error_row
         initial_file_rows.append(
@@ -218,12 +420,44 @@ async def register_repository(
                 "metadata": row.metadata,
             }
         )
+        initial_scan_files.append(
+            RepositoryFileRecord(
+                id=str(uuid4()),
+                repositoryId=repository_id,
+                scanId=initial_scan_job_id,
+                path=row.path,
+                format=row.format,
+                tracked=row.tracked,
+                status="manifest_error",
+                discriminator=row.metadata["error"] if row.metadata and "error" in row.metadata else None,
+                createdAt=now,
+            )
+        )
+
+    initial_scan = RepositoryScanRecord(
+        id=initial_scan_job_id,
+        repositoryId=repository_id,
+        branch=normalized_branches[0].branch,
+        commitSha=f"pending-{uuid4().hex[:12]}",
+        trigger="register",
+        status="pending",
+        startedAt=now,
+        filesSeen=0,
+        filesClassified=0,
+        filesUnknown=0,
+        filesFailed=0,
+        eventLog=[{"type": "repository.scan.queued", "at": now, "trigger": "register"}],
+        diffSummary={},
+        createdAt=now,
+    )
 
     with _STORE_LOCK:
         tenant_repos = _REPO_STORE.setdefault(tenant_id, {})
         _REPO_BRANCH_STORE[repository.id] = list(normalized_branches)
         _REPO_SCAN_STORE[repository.id] = [timeline_entry]
         _REPO_FILE_STORE[repository.id] = initial_file_rows
+        _REPO_SCAN_HISTORY_STORE[repository.id] = [initial_scan]
+        _REPO_SCAN_FILE_HISTORY_STORE[initial_scan.id] = initial_scan_files
         _REPO_CREDENTIAL_REF_STORE[repository.id] = [{"linkedAccountId": request.linkedAccountId}]
         tenant_repos[repository.id] = repository
 
@@ -376,10 +610,162 @@ async def delete_repository(
         _REPO_BRANCH_STORE.pop(repository_id, None)
         _REPO_SCAN_STORE.pop(repository_id, None)
         _REPO_FILE_STORE.pop(repository_id, None)
+        scan_history = _REPO_SCAN_HISTORY_STORE.pop(repository_id, [])
+        for scan in scan_history:
+            _REPO_SCAN_FILE_HISTORY_STORE.pop(scan.id, None)
         _REPO_CREDENTIAL_REF_STORE.pop(repository_id, None)
         _write_audit_row(tenant_id, repository_id, "repository.removed")
 
     return Response(status_code=204)
+
+
+@router.get("/{repository_id}/scans", response_model=RepositoryScanPage)
+async def list_repository_scans(
+    repository_id: str,
+    auth_data: Dict[str, Any] = Depends(validate_authentication),
+    status: RepositoryScanStatus | None = Query(default=None),
+    branch: str | None = Query(default=None),
+    from_timestamp: str | None = Query(default=None, alias="from"),
+    to_timestamp: str | None = Query(default=None, alias="to"),
+    limit: int = Query(default=_DEFAULT_SCAN_PAGE_SIZE, ge=1, le=_MAX_SCAN_PAGE_SIZE),
+    cursor: str | None = Query(default=None),
+) -> RepositoryScanPage:
+    tenant_id = auth_data["tenant_id"]
+    from_dt = _parse_iso8601(from_timestamp, "from")
+    to_dt = _parse_iso8601(to_timestamp, "to")
+    cursor_key: Tuple[datetime, str] | None = None
+    if cursor:
+        cursor_dt, cursor_id = _decode_cursor(cursor)
+        cursor_key = (cursor_dt, cursor_id)
+
+    with _STORE_LOCK:
+        _find_repository_for_tenant(tenant_id, repository_id)
+        scans = list(_REPO_SCAN_HISTORY_STORE.get(repository_id, []))
+
+    filtered: List[RepositoryScanRecord] = []
+    for scan in scans:
+        if status is not None and scan.status != status:
+            continue
+        if branch is not None and scan.branch != branch:
+            continue
+        scan_dt = _parse_iso8601(scan.createdAt, "createdAt")
+        if scan_dt is None:
+            continue
+        if from_dt is not None and scan_dt < from_dt:
+            continue
+        if to_dt is not None and scan_dt > to_dt:
+            continue
+        if cursor_key is not None and (scan_dt, scan.id) >= cursor_key:
+            continue
+        filtered.append(scan)
+
+    filtered.sort(key=lambda item: _to_sort_key(item.createdAt, item.id), reverse=True)
+    page_rows = filtered[: limit + 1]
+    has_more = len(page_rows) > limit
+    page_items = page_rows[:limit]
+    next_cursor = None
+    if has_more and page_items:
+        tail = page_items[-1]
+        next_cursor = _encode_cursor(tail.createdAt, tail.id)
+
+    return RepositoryScanPage(items=page_items, limit=limit, nextCursor=next_cursor)
+
+
+@router.get("/{repository_id}/scans/{scan_id}", response_model=RepositoryScanRecord)
+async def get_repository_scan(
+    repository_id: str,
+    scan_id: str,
+    auth_data: Dict[str, Any] = Depends(validate_authentication),
+) -> RepositoryScanRecord:
+    tenant_id = auth_data["tenant_id"]
+    with _STORE_LOCK:
+        _find_repository_for_tenant(tenant_id, repository_id)
+        scans = _REPO_SCAN_HISTORY_STORE.get(repository_id, [])
+        for scan in scans:
+            if scan.id == scan_id:
+                return scan
+    raise HTTPException(status_code=404, detail=f"Scan not found: {scan_id}")
+
+
+@router.get("/{repository_id}/scans/{scan_id}/files", response_model=RepositoryScanFilePage)
+async def list_repository_scan_files(
+    repository_id: str,
+    scan_id: str,
+    auth_data: Dict[str, Any] = Depends(validate_authentication),
+    format: str | None = Query(default=None),
+    status: RepositoryFileStatus | None = Query(default=None),
+    limit: int = Query(default=_DEFAULT_SCAN_PAGE_SIZE, ge=1, le=_MAX_SCAN_PAGE_SIZE),
+    cursor: str | None = Query(default=None),
+) -> RepositoryScanFilePage:
+    tenant_id = auth_data["tenant_id"]
+    cursor_key: Tuple[datetime, str] | None = None
+    if cursor:
+        cursor_dt, cursor_id = _decode_cursor(cursor)
+        cursor_key = (cursor_dt, cursor_id)
+
+    with _STORE_LOCK:
+        _find_repository_for_tenant(tenant_id, repository_id)
+        scans = _REPO_SCAN_HISTORY_STORE.get(repository_id, [])
+        if not any(scan.id == scan_id for scan in scans):
+            raise HTTPException(status_code=404, detail=f"Scan not found: {scan_id}")
+        files = list(_REPO_SCAN_FILE_HISTORY_STORE.get(scan_id, []))
+
+    filtered: List[RepositoryFileRecord] = []
+    for file_row in files:
+        if format is not None and file_row.format != format:
+            continue
+        if status is not None and file_row.status != status:
+            continue
+        file_dt = _parse_iso8601(file_row.createdAt, "createdAt")
+        if file_dt is None:
+            continue
+        if cursor_key is not None and (file_dt, file_row.id) >= cursor_key:
+            continue
+        filtered.append(file_row)
+
+    filtered.sort(key=lambda item: _to_sort_key(item.createdAt, item.id), reverse=True)
+    page_rows = filtered[: limit + 1]
+    has_more = len(page_rows) > limit
+    page_items = page_rows[:limit]
+    next_cursor = None
+    if has_more and page_items:
+        tail = page_items[-1]
+        next_cursor = _encode_cursor(tail.createdAt, tail.id)
+    return RepositoryScanFilePage(items=page_items, limit=limit, nextCursor=next_cursor)
+
+
+@router.post("/{repository_id}/scans", response_model=RepositoryScanRecord)
+async def create_repository_scan(
+    repository_id: str,
+    request: RepositoryScanCreateRequest,
+    auth_data: Dict[str, Any] = Depends(validate_authentication),
+) -> RepositoryScanRecord:
+    tenant_id = auth_data["tenant_id"]
+    branch_name = request.branch.strip()
+    if not branch_name:
+        raise HTTPException(status_code=400, detail="branch is required")
+
+    with _STORE_LOCK:
+        _find_repository_for_tenant(tenant_id, repository_id)
+        history = _REPO_SCAN_HISTORY_STORE.setdefault(repository_id, [])
+        latest_for_branch = next((scan for scan in history if scan.branch == branch_name), None)
+        if latest_for_branch is not None and not request.force:
+            scan = _make_skipped_unchanged_scan(
+                repository_id=repository_id,
+                branch=branch_name,
+                trigger="manual",
+                baseline_commit_sha=latest_for_branch.commitSha,
+            )
+        else:
+            scan = _make_pending_scan(
+                repository_id=repository_id,
+                branch=branch_name,
+                trigger="manual",
+                force=request.force,
+            )
+        history.insert(0, scan)
+        _REPO_SCAN_FILE_HISTORY_STORE[scan.id] = []
+        return scan
 
 
 def _reset_repository_state_for_tests() -> None:
@@ -388,13 +774,46 @@ def _reset_repository_state_for_tests() -> None:
         _REPO_BRANCH_STORE.clear()
         _REPO_SCAN_STORE.clear()
         _REPO_FILE_STORE.clear()
+        _REPO_SCAN_HISTORY_STORE.clear()
+        _REPO_SCAN_FILE_HISTORY_STORE.clear()
         _REPO_CREDENTIAL_REF_STORE.clear()
         _REPO_AUDIT_STORE.clear()
 
 
 def _seed_repository_relations_for_tests(repository_id: str) -> None:
     with _STORE_LOCK:
-        _REPO_SCAN_STORE[repository_id] = [RepositoryScanTimelineEntry(id=str(uuid4()), type="scan", status="completed", message="done", createdAt=_utc_now_iso())]
+        now = _utc_now_iso()
+        seeded_scan = RepositoryScanRecord(
+            id=str(uuid4()),
+            repositoryId=repository_id,
+            branch="main",
+            commitSha=f"seeded-{uuid4().hex[:12]}",
+            trigger="manual",
+            status="complete",
+            startedAt=now,
+            finishedAt=now,
+            durationMs=0,
+            filesSeen=1,
+            filesClassified=1,
+            filesUnknown=0,
+            filesFailed=0,
+            eventLog=[{"type": "repository.scan.seeded", "at": now}],
+            diffSummary={"changed": 1},
+            createdAt=now,
+        )
+        _REPO_SCAN_STORE[repository_id] = [RepositoryScanTimelineEntry(id=str(uuid4()), type="scan", status="completed", message="done", createdAt=now)]
+        _REPO_SCAN_HISTORY_STORE[repository_id] = [seeded_scan]
+        _REPO_SCAN_FILE_HISTORY_STORE[seeded_scan.id] = [
+            RepositoryFileRecord(
+                id=str(uuid4()),
+                repositoryId=repository_id,
+                scanId=seeded_scan.id,
+                path="README.md",
+                tracked=True,
+                status="new",
+                createdAt=now,
+            )
+        ]
         _REPO_FILE_STORE[repository_id] = [{"path": "README.md"}]
         _REPO_CREDENTIAL_REF_STORE[repository_id] = [{"linkedAccountId": str(uuid4())}]
 

--- a/objectified-rest/tests/repositories/test_repository_model_roundtrip.py
+++ b/objectified-rest/tests/repositories/test_repository_model_roundtrip.py
@@ -11,27 +11,32 @@ import pytest
 from app.config import settings
 
 
-def _migration_path() -> Path:
+def _migration_paths() -> list[Path]:
     repo_root = Path(__file__).resolve().parents[3]
-    return repo_root / "objectified-db" / "scripts" / "20260423-230000-repository-connector.sql"
+    scripts_dir = repo_root / "objectified-db" / "scripts"
+    return [
+        scripts_dir / "20260423-230000.sql",
+        scripts_dir / "20260424-120000.sql",
+    ]
 
 
 @pytest.fixture()
 def repository_schema():
     """Create an isolated schema, apply migration, and clean it up after each test."""
     schema = f"odb_repo_test_{uuid.uuid4().hex[:8]}"
-    migration = _migration_path()
-    migration_sql = migration.read_text()
+    migration_sql_chunks = [path.read_text() for path in _migration_paths()]
     try:
         conn = psycopg2.connect(settings.effective_database_url)
     except Exception as exc:  # pragma: no cover - environment dependent
         pytest.skip(f"PostgreSQL unavailable for repository round-trip tests: {exc}")
     conn.autocommit = False
 
-    transformed_sql = migration_sql.replace(
-        "SET search_path TO odb, public;",
-        f"SET search_path TO {schema}, public;",
-    ).replace("odb.", f"{schema}.")
+    transformed_sql_chunks = [
+        sql_text.replace("SET search_path TO odb, public;", f"SET search_path TO {schema}, public;").replace(
+            "odb.", f"{schema}."
+        )
+        for sql_text in migration_sql_chunks
+    ]
 
     with conn.cursor() as cur:
         cur.execute(sql.SQL("CREATE SCHEMA {}").format(sql.Identifier(schema)))
@@ -73,7 +78,8 @@ def repository_schema():
                 """
             ).format(sql.Identifier(schema, "external_auth_providers"), sql.Identifier(schema, "users"))
         )
-        cur.execute(transformed_sql)
+        for transformed_sql in transformed_sql_chunks:
+            cur.execute(transformed_sql)
     conn.commit()
 
     try:
@@ -254,6 +260,110 @@ def repository_credential_ref_row(repository_schema, repository_row, base_refs):
     return selected
 
 
+@pytest.fixture()
+def repository_scan_row(repository_schema, repository_row):
+    conn, schema = repository_schema
+    scan_id = "00000000-0000-0000-0000-000000000778"
+    with conn.cursor(cursor_factory=RealDictCursor) as cur:
+        cur.execute(
+            sql.SQL(
+                """
+                INSERT INTO {} (
+                    id, repository_id, branch, commit_sha, trigger, status, started_at, finished_at,
+                    duration_ms, files_seen, files_classified, files_unknown, files_failed, event_log, diff_summary
+                )
+                VALUES (
+                    %s, %s, %s, %s, 'manual', 'complete', now(), now(),
+                    %s, %s, %s, %s, %s, %s::jsonb, %s::jsonb
+                )
+                RETURNING id, repository_id, branch, commit_sha, trigger, status, files_seen, files_classified,
+                          files_unknown, files_failed;
+                """
+            ).format(sql.Identifier(schema, "repository_scan")),
+            (
+                scan_id,
+                repository_row["id"],
+                "main",
+                "abc123def456",
+                1234,
+                5,
+                4,
+                1,
+                0,
+                '[{"type":"repository.scan.complete"}]',
+                '{"changed":2}',
+            ),
+        )
+        inserted = cur.fetchone()
+        cur.execute(
+            sql.SQL(
+                """
+                SELECT id, repository_id, branch, commit_sha, trigger, status, files_seen, files_classified,
+                       files_unknown, files_failed
+                FROM {}
+                WHERE id = %s;
+                """
+            ).format(sql.Identifier(schema, "repository_scan")),
+            (scan_id,),
+        )
+        selected = cur.fetchone()
+    conn.commit()
+    assert inserted == selected
+    return selected
+
+
+@pytest.fixture()
+def repository_file_row(repository_schema, repository_row, repository_scan_row):
+    conn, schema = repository_schema
+    file_id = "00000000-0000-0000-0000-000000000779"
+    with conn.cursor(cursor_factory=RealDictCursor) as cur:
+        cur.execute(
+            sql.SQL(
+                """
+                INSERT INTO {} (
+                    id, repository_id, scan_id, path, blob_sha, size_bytes, format, confidence,
+                    discriminator, tracked, project_slug, version_strategy, status, quality_score
+                )
+                VALUES (
+                    %s, %s, %s, %s, %s, %s, %s, %s,
+                    %s, %s, %s, %s, 'modified', %s
+                )
+                RETURNING id, repository_id, scan_id, path, status, tracked, quality_score;
+                """
+            ).format(sql.Identifier(schema, "repository_file")),
+            (
+                file_id,
+                repository_row["id"],
+                repository_scan_row["id"],
+                "apis/openapi.yaml",
+                "f0f0f0",
+                1024,
+                "openapi_3_1",
+                0.95,
+                "title:openapi",
+                True,
+                "orders",
+                "semver",
+                88,
+            ),
+        )
+        inserted = cur.fetchone()
+        cur.execute(
+            sql.SQL(
+                """
+                SELECT id, repository_id, scan_id, path, status, tracked, quality_score
+                FROM {}
+                WHERE id = %s;
+                """
+            ).format(sql.Identifier(schema, "repository_file")),
+            (file_id,),
+        )
+        selected = cur.fetchone()
+    conn.commit()
+    assert inserted == selected
+    return selected
+
+
 def test_repository_round_trip(repository_row):
     assert repository_row["provider"] == "github"
     assert repository_row["owner"] == "octocat"
@@ -268,6 +378,18 @@ def test_repository_branch_round_trip(repository_branch_row):
 
 def test_repository_credential_ref_round_trip(repository_credential_ref_row):
     assert repository_credential_ref_row["scopes"] == ["repo", "read:org"]
+
+
+def test_repository_scan_round_trip(repository_scan_row):
+    assert repository_scan_row["trigger"] == "manual"
+    assert repository_scan_row["status"] == "complete"
+    assert repository_scan_row["files_seen"] == 5
+
+
+def test_repository_file_round_trip(repository_file_row):
+    assert repository_file_row["path"] == "apis/openapi.yaml"
+    assert repository_file_row["status"] == "modified"
+    assert repository_file_row["tracked"] is True
 
 
 def test_provider_enum_is_github_only(repository_schema):

--- a/objectified-rest/tests/test_repositories_routes.py
+++ b/objectified-rest/tests/test_repositories_routes.py
@@ -270,3 +270,122 @@ def test_delete_repository_requires_confirmation_and_cascades():
     assert all(not exists for exists in relations_exist.values())
     assert detail_response.status_code == 404
     assert [row["eventType"] for row in audit_rows] == ["repository.removed"]
+
+
+def test_list_scans_returns_initial_register_scan_with_default_page_limit():
+    app.dependency_overrides[validate_authentication] = _override_auth
+    try:
+        create_response = client.post(
+            f"/v1/repositories/{_TENANT_SLUG}",
+            json={
+                "linkedAccountId": "aaaaaaaa-bbbb-cccc-dddd-000000000021",
+                "provider": "github",
+                "owner": "acme",
+                "name": "scan-api",
+                "branches": [{"branch": "main"}],
+            },
+        )
+        repository_id = create_response.json()["repository"]["id"]
+        scans_response = client.get(f"/v1/repositories/{repository_id}/scans")
+    finally:
+        app.dependency_overrides.pop(validate_authentication, None)
+
+    assert create_response.status_code == 201
+    assert scans_response.status_code == 200
+    body = scans_response.json()
+    assert body["limit"] == 50
+    assert len(body["items"]) == 1
+    assert body["items"][0]["trigger"] == "register"
+    assert body["items"][0]["status"] == "pending"
+
+
+def test_post_scans_support_force_and_skipped_unchanged_with_single_audit_entry():
+    app.dependency_overrides[validate_authentication] = _override_auth
+    try:
+        create_response = client.post(
+            f"/v1/repositories/{_TENANT_SLUG}",
+            json={
+                "linkedAccountId": "aaaaaaaa-bbbb-cccc-dddd-000000000022",
+                "provider": "github",
+                "owner": "acme",
+                "name": "scan-retry",
+                "branches": [{"branch": "main"}],
+            },
+        )
+        repository_id = create_response.json()["repository"]["id"]
+        skipped_response = client.post(
+            f"/v1/repositories/{repository_id}/scans",
+            json={"branch": "main", "force": False},
+        )
+        forced_response = client.post(
+            f"/v1/repositories/{repository_id}/scans",
+            json={"branch": "main", "force": True},
+        )
+    finally:
+        app.dependency_overrides.pop(validate_authentication, None)
+
+    assert skipped_response.status_code == 200
+    skipped_scan = skipped_response.json()
+    assert skipped_scan["status"] == "skipped_unchanged"
+    assert skipped_scan["filesSeen"] == 0
+    assert len(skipped_scan["eventLog"]) == 1
+    assert skipped_scan["eventLog"][0]["type"] == "repository.scan.skipped_unchanged"
+
+    assert forced_response.status_code == 200
+    forced_scan = forced_response.json()
+    assert forced_scan["status"] == "pending"
+    assert forced_scan["eventLog"][0]["force"] is True
+
+
+def test_list_scans_and_files_support_cursor_pagination_and_filters():
+    app.dependency_overrides[validate_authentication] = _override_auth
+    try:
+        create_response = client.post(
+            f"/v1/repositories/{_TENANT_SLUG}",
+            json={
+                "linkedAccountId": "aaaaaaaa-bbbb-cccc-dddd-000000000023",
+                "provider": "github",
+                "owner": "acme",
+                "name": "scan-pagination",
+                "branches": [{"branch": "main"}],
+                "manifest": "version: 2\nspecs:\n  - path: service.yaml\n",
+            },
+        )
+        repository_id = create_response.json()["repository"]["id"]
+        for _ in range(3):
+            post_response = client.post(
+                f"/v1/repositories/{repository_id}/scans",
+                json={"branch": "main", "force": True},
+            )
+            assert post_response.status_code == 200
+
+        first_page = client.get(f"/v1/repositories/{repository_id}/scans", params={"limit": 2})
+        next_cursor = first_page.json()["nextCursor"]
+        second_page = client.get(
+            f"/v1/repositories/{repository_id}/scans",
+            params={"limit": 2, "cursor": next_cursor},
+        )
+        skipped_only = client.get(
+            f"/v1/repositories/{repository_id}/scans",
+            params={"status": "skipped_unchanged"},
+        )
+        initial_scan_id = create_response.json()["initialScanJobId"]
+        files_response = client.get(
+            f"/v1/repositories/{repository_id}/scans/{initial_scan_id}/files",
+            params={"status": "manifest_error"},
+        )
+    finally:
+        app.dependency_overrides.pop(validate_authentication, None)
+
+    assert first_page.status_code == 200
+    assert len(first_page.json()["items"]) == 2
+    assert next_cursor is not None
+    assert second_page.status_code == 200
+    assert len(second_page.json()["items"]) >= 1
+    assert skipped_only.status_code == 200
+    assert skipped_only.json()["items"] == []
+
+    assert files_response.status_code == 200
+    file_rows = files_response.json()["items"]
+    assert len(file_rows) == 1
+    assert file_rows[0]["status"] == "manifest_error"

--- a/objectified-rest/tests/test_repositories_routes.py
+++ b/objectified-rest/tests/test_repositories_routes.py
@@ -286,7 +286,7 @@ def test_list_scans_returns_initial_register_scan_with_default_page_limit():
             },
         )
         repository_id = create_response.json()["repository"]["id"]
-        scans_response = client.get(f"/v1/repositories/{repository_id}/scans")
+        scans_response = client.get(f"/v1/repositories/{_TENANT_SLUG}/{repository_id}/scans")
     finally:
         app.dependency_overrides.pop(validate_authentication, None)
 
@@ -314,11 +314,11 @@ def test_post_scans_support_force_and_skipped_unchanged_with_single_audit_entry(
         )
         repository_id = create_response.json()["repository"]["id"]
         skipped_response = client.post(
-            f"/v1/repositories/{repository_id}/scans",
+            f"/v1/repositories/{_TENANT_SLUG}/{repository_id}/scans",
             json={"branch": "main", "force": False},
         )
         forced_response = client.post(
-            f"/v1/repositories/{repository_id}/scans",
+            f"/v1/repositories/{_TENANT_SLUG}/{repository_id}/scans",
             json={"branch": "main", "force": True},
         )
     finally:
@@ -354,24 +354,24 @@ def test_list_scans_and_files_support_cursor_pagination_and_filters():
         repository_id = create_response.json()["repository"]["id"]
         for _ in range(3):
             post_response = client.post(
-                f"/v1/repositories/{repository_id}/scans",
+                f"/v1/repositories/{_TENANT_SLUG}/{repository_id}/scans",
                 json={"branch": "main", "force": True},
             )
             assert post_response.status_code == 200
 
-        first_page = client.get(f"/v1/repositories/{repository_id}/scans", params={"limit": 2})
+        first_page = client.get(f"/v1/repositories/{_TENANT_SLUG}/{repository_id}/scans", params={"limit": 2})
         next_cursor = first_page.json()["nextCursor"]
         second_page = client.get(
-            f"/v1/repositories/{repository_id}/scans",
+            f"/v1/repositories/{_TENANT_SLUG}/{repository_id}/scans",
             params={"limit": 2, "cursor": next_cursor},
         )
         skipped_only = client.get(
-            f"/v1/repositories/{repository_id}/scans",
+            f"/v1/repositories/{_TENANT_SLUG}/{repository_id}/scans",
             params={"status": "skipped_unchanged"},
         )
         initial_scan_id = create_response.json()["initialScanJobId"]
         files_response = client.get(
-            f"/v1/repositories/{repository_id}/scans/{initial_scan_id}/files",
+            f"/v1/repositories/{_TENANT_SLUG}/{repository_id}/scans/{initial_scan_id}/files",
             params={"status": "manifest_error"},
         )
     finally:

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -5,6 +5,7 @@ We continue to improve the platform based on your feedback with improvements and
 ---
 
 ## Repositories
+- Added repository scan history models (`repository_scan`/`repository_file`) with cursor-paginated scan/file REST endpoints, `force` re-scan support, and `skipped_unchanged` tracking.
 - Added `.objectified/repo.yaml` manifest support with published schema validation, non-fatal `manifest_error` recording, per-spec format/polling overrides, and untracked discovery rows for files not listed in the manifest.
 - Added provider-agnostic spec format detection with filename heuristics plus 64 KB content sniffing, confidence/discriminator output, and stream-mode sniffing for files over 5 MB.
 - Added scanner include/exclude rules with published default ignore patterns, manifest-level ignore merges, `files_skipped_by_ignore` telemetry, and explicit spec precedence over ignores.


### PR DESCRIPTION
## Summary
- add in-memory scan history models and REST endpoints for listing scans, scan detail, listing scan files, and creating scans with `force` behavior
- implement cursor-based pagination (default 50, max 200) plus status/branch/time filters and `skipped_unchanged` audit/event semantics
- add database migration for `odb.repository_scan` and `odb.repository_file`, extend repository round-trip tests, and update roadmap/what's-new/version notes

## Test plan
- [x] `yarn build`
- [x] `yarn test`
- [ ] `pytest tests/test_repositories_routes.py tests/repositories/test_repository_model_roundtrip.py` *(blocked: python/pytest tooling unavailable in this environment)*

## Risk / Notes
- repository scan APIs currently use the existing in-memory repository route store, consistent with current repository route implementation
- Python test commands could not run locally because `python`/`pytest`/`uv` are not available in this shell

Closes #2767

Made with [Cursor](https://cursor.com)