### PR TITLE
Fix #2770 - add repository OpenAPI importer hook

### DIFF
--- a/docs/PLANNED_FEATURE_ROADMAP_REPOSITORY.md
+++ b/docs/PLANNED_FEATURE_ROADMAP_REPOSITORY.md
@@ -2,6 +2,7 @@
 
 ## Completed
 
+- REPO-3.1 (#2770): Added a repository OpenAPI importer hook that reuses the existing one-shot `parseOpenAPISpec` conversion pipeline, accepts normalized `{source, format, content, refs}` input for repository ingestion, and delegates cross-file `$ref` handling to the REPO-3.8 resolver contract with fixture-set parity coverage.
 - REPO-2.7 (#2768): Added scan diff classification against the previous completed scan keyed by `(repository_id, path)`, including persisted `new/unchanged/modified/removed` per-file statuses with carried-forward `removed` rows and `{added, modified, removed, unchanged}` diff summary counts.
 - REPO-2.6 (#2767): Added `repository_scan` and `repository_file` history support with cursor-paginated scan/file REST endpoints, `force` rescan behavior, and `skipped_unchanged` audit/event tracking.
 - REPO-2.4 (#2765): Added `.objectified/repo.yaml` manifest support with published JSON Schema validation, non-fatal `manifest_error` repository file recording, per-spec format/polling overrides, and untracked discovery output for files not explicitly listed.

--- a/objectified-ui/lib/repositories/importers/openapi.ts
+++ b/objectified-ui/lib/repositories/importers/openapi.ts
@@ -1,0 +1,101 @@
+import { parseOpenAPISpec, OpenAPIParseResult } from '../../../src/app/utils/openapi-import';
+
+export type RepositoryOpenApiFormat = 'openapi_3_0' | 'openapi_3_1';
+
+export interface RepositoryOpenApiRef {
+  path: string;
+  content: string;
+}
+
+export interface RepositoryOpenApiImportInput {
+  source: string;
+  format: RepositoryOpenApiFormat;
+  content: string;
+  refs?: RepositoryOpenApiRef[];
+}
+
+export interface ResolveRepositoryOpenApiRefsInput {
+  source: string;
+  format: RepositoryOpenApiFormat;
+  content: string;
+  refs: RepositoryOpenApiRef[];
+}
+
+export type ResolveRepositoryOpenApiRefs = (
+  input: ResolveRepositoryOpenApiRefsInput
+) => Promise<string> | string;
+
+export interface RepositoryOpenApiImportDeps {
+  /**
+   * REPO-3.8 delegate: caller-provided cross-file $ref resolution.
+   * When omitted, the primary content is parsed as-is.
+   */
+  resolveRefs?: ResolveRepositoryOpenApiRefs;
+}
+
+export interface RepositoryOpenApiImportResult {
+  success: boolean;
+  source: string;
+  format: RepositoryOpenApiFormat;
+  parseResult?: OpenAPIParseResult;
+  resolvedContent?: string;
+  warnings: string[];
+  error?: string;
+}
+
+export async function importOpenApiFromRepository(
+  input: RepositoryOpenApiImportInput,
+  deps: RepositoryOpenApiImportDeps = {}
+): Promise<RepositoryOpenApiImportResult> {
+  if (!input.content || !input.content.trim()) {
+    return {
+      success: false,
+      source: input.source,
+      format: input.format,
+      warnings: [],
+      error: 'Repository OpenAPI import content is empty.',
+    };
+  }
+
+  let resolvedContent = input.content;
+  const refs = input.refs ?? [];
+
+  try {
+    if (refs.length > 0 && deps.resolveRefs) {
+      resolvedContent = await deps.resolveRefs({
+        source: input.source,
+        format: input.format,
+        content: input.content,
+        refs,
+      });
+    }
+  } catch (error: any) {
+    return {
+      success: false,
+      source: input.source,
+      format: input.format,
+      warnings: [],
+      error: error?.message || 'Failed to resolve cross-file OpenAPI references.',
+    };
+  }
+
+  const parseResult = parseOpenAPISpec(resolvedContent);
+  if (!parseResult.success) {
+    return {
+      success: false,
+      source: input.source,
+      format: input.format,
+      warnings: parseResult.warnings ?? [],
+      error: parseResult.error || 'Failed to parse OpenAPI specification.',
+    };
+  }
+
+  return {
+    success: true,
+    source: input.source,
+    format: input.format,
+    parseResult,
+    resolvedContent,
+    warnings: parseResult.warnings ?? [],
+  };
+}

--- a/objectified-ui/lib/repositories/importers/openapi.ts
+++ b/objectified-ui/lib/repositories/importers/openapi.ts
@@ -1,6 +1,7 @@
 import { parseOpenAPISpec, OpenAPIParseResult } from '../../../src/app/utils/openapi-import';
+import type { DetectedRepositorySpecFormat } from '../scanner/detect';
 
-export type RepositoryOpenApiFormat = 'openapi_3_0' | 'openapi_3_1';
+export type RepositoryOpenApiFormat = Extract<DetectedRepositorySpecFormat, 'openapi_3_0' | 'openapi_3_1'>;
 
 export interface RepositoryOpenApiRef {
   path: string;
@@ -60,6 +61,16 @@ export async function importOpenApiFromRepository(
   let resolvedContent = input.content;
   const refs = input.refs ?? [];
 
+  if (refs.length > 0 && !deps.resolveRefs) {
+    return {
+      success: false,
+      source: input.source,
+      format: input.format,
+      warnings: [],
+      error: 'Cross-file $ref entries are present but no resolver is configured (REPO-3.8).',
+    };
+  }
+
   try {
     if (refs.length > 0 && deps.resolveRefs) {
       resolvedContent = await deps.resolveRefs({
@@ -85,6 +96,7 @@ export async function importOpenApiFromRepository(
       success: false,
       source: input.source,
       format: input.format,
+      resolvedContent,
       warnings: parseResult.warnings ?? [],
       error: parseResult.error || 'Failed to parse OpenAPI specification.',
     };

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.10.29",
+  "version": "0.10.30",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -5,6 +5,7 @@ We continue to improve the platform based on your feedback with improvements and
 ---
 
 ## Repositories
+- Added a repository OpenAPI importer hook for OpenAPI 3.0/3.1 that reuses the existing dialog converter with normalized `{source, format, content, refs}` input and parity-checked fixture coverage, while delegating cross-file `$ref` resolution through the REPO-3.8 resolver contract.
 - Added previous-scan diffing for repository scans so completed scans classify files as `new`/`unchanged`/`modified`/`removed`, retain removed rows with prior blob SHA, and store `{added, modified, removed, unchanged}` summary counts.
 - Added repository scan history models (`repository_scan`/`repository_file`) with cursor-paginated scan/file REST endpoints, `force` re-scan support, and `skipped_unchanged` tracking.
 - Added `.objectified/repo.yaml` manifest support with published schema validation, non-fatal `manifest_error` recording, per-spec format/polling overrides, and untracked discovery rows for files not listed in the manifest.

--- a/objectified-ui/tests/unit/repository-openapi-importer.test.ts
+++ b/objectified-ui/tests/unit/repository-openapi-importer.test.ts
@@ -1,0 +1,75 @@
+import fs from 'fs';
+import path from 'path';
+import { parseOpenAPISpec } from '../../src/app/utils/openapi-import';
+import { importOpenApiFromRepository } from '../../lib/repositories/importers/openapi';
+
+describe('repository OpenAPI importer hook', () => {
+  it('matches one-shot OpenAPI dialog parsing across the OpenAPI fixture set', async () => {
+    const fixturesDir = path.join(__dirname, '../../examples/openapi');
+    const fixtures = fs
+      .readdirSync(fixturesDir)
+      .filter((name) => name.endsWith('.yaml') || name.endsWith('.yml') || name.endsWith('.json'))
+      .sort();
+
+    expect(fixtures.length).toBeGreaterThan(0);
+
+    for (const fixture of fixtures) {
+      const content = fs.readFileSync(path.join(fixturesDir, fixture), 'utf-8');
+      const oneShotResult = parseOpenAPISpec(content);
+      const repositoryResult = await importOpenApiFromRepository({
+        source: `repository://${fixture}`,
+        format: fixture.includes('30-openapi-3.0') ? 'openapi_3_0' : 'openapi_3_1',
+        content,
+        refs: [],
+      });
+
+      expect(repositoryResult.success).toBe(oneShotResult.success);
+      if (oneShotResult.success) {
+        expect(repositoryResult.parseResult).toEqual(oneShotResult);
+      } else {
+        expect(repositoryResult.parseResult).toBeUndefined();
+      }
+      expect(repositoryResult.warnings).toEqual(oneShotResult.warnings);
+      expect(repositoryResult.error).toBe(oneShotResult.error);
+    }
+  });
+
+  it('delegates cross-file refs to the REPO-3.8 resolver when refs are present', async () => {
+    const resolved = `
+openapi: 3.1.0
+info:
+  title: Resolved
+  version: 1.0.0
+components:
+  schemas:
+    User:
+      type: object
+      properties:
+        id:
+          type: string
+`;
+
+    const resolveRefs = jest.fn().mockResolvedValue(resolved);
+
+    const result = await importOpenApiFromRepository(
+      {
+        source: 'repository://services/openapi.yaml',
+        format: 'openapi_3_1',
+        content: 'openapi: 3.1.0',
+        refs: [{ path: './schemas/user.yaml', content: 'type: object' }],
+      },
+      { resolveRefs }
+    );
+
+    expect(resolveRefs).toHaveBeenCalledTimes(1);
+    expect(resolveRefs).toHaveBeenCalledWith({
+      source: 'repository://services/openapi.yaml',
+      format: 'openapi_3_1',
+      content: 'openapi: 3.1.0',
+      refs: [{ path: './schemas/user.yaml', content: 'type: object' }],
+    });
+    expect(result.success).toBe(true);
+    expect(result.parseResult?.success).toBe(true);
+    expect(result.parseResult?.classes.some((cls) => cls.name === 'User')).toBe(true);
+  });
+});

--- a/objectified-ui/tests/unit/repository-openapi-importer.test.ts
+++ b/objectified-ui/tests/unit/repository-openapi-importer.test.ts
@@ -1,7 +1,13 @@
 import fs from 'fs';
 import path from 'path';
 import { parseOpenAPISpec } from '../../src/app/utils/openapi-import';
-import { importOpenApiFromRepository } from '../../lib/repositories/importers/openapi';
+import { importOpenApiFromRepository, RepositoryOpenApiFormat } from '../../lib/repositories/importers/openapi';
+
+function deriveOpenApiFormat(content: string): RepositoryOpenApiFormat {
+  const match = content.match(/^\s*openapi\s*:\s*["']?(\d+\.\d+)/m);
+  if (match?.[1]?.startsWith('3.0')) return 'openapi_3_0';
+  return 'openapi_3_1';
+}
 
 describe('repository OpenAPI importer hook', () => {
   it('matches one-shot OpenAPI dialog parsing across the OpenAPI fixture set', async () => {
@@ -18,7 +24,7 @@ describe('repository OpenAPI importer hook', () => {
       const oneShotResult = parseOpenAPISpec(content);
       const repositoryResult = await importOpenApiFromRepository({
         source: `repository://${fixture}`,
-        format: fixture.includes('30-openapi-3.0') ? 'openapi_3_0' : 'openapi_3_1',
+        format: deriveOpenApiFormat(content),
         content,
         refs: [],
       });
@@ -71,5 +77,17 @@ components:
     expect(result.success).toBe(true);
     expect(result.parseResult?.success).toBe(true);
     expect(result.parseResult?.classes.some((cls) => cls.name === 'User')).toBe(true);
+  });
+
+  it('returns success: false when refs are present but no resolver is configured', async () => {
+    const result = await importOpenApiFromRepository({
+      source: 'repository://services/openapi.yaml',
+      format: 'openapi_3_1',
+      content: 'openapi: 3.1.0',
+      refs: [{ path: './schemas/user.yaml', content: 'type: object' }],
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/REPO-3\.8/);
   });
 });


### PR DESCRIPTION
## Summary
- add `lib/repositories/importers/openapi.ts` with a repository-focused OpenAPI import hook that reuses `parseOpenAPISpec` from the one-shot dialog pipeline
- accept normalized `{ source, format, content, refs }` input and provide an explicit `resolveRefs` delegate for REPO-3.8 cross-file `$ref` resolution
- add fixture parity coverage in `tests/unit/repository-openapi-importer.test.ts` and update roadmap/what's-new/version metadata for ticket completion

## Test plan
- [x] `yarn workspace objectified-ui test repository-openapi-importer --verbose`
- [x] `yarn build`
- [x] `yarn test`

## Risk / notes
- REPO-3.8 is not implemented yet; this change intentionally adds a resolver delegation contract so repository sync can plug in cross-file resolution once that ticket lands.

Closes #2770

Made with [Cursor](https://cursor.com)