### PR TITLE
Fix #2771 - add Swagger 2.0 repository importer parity

### DIFF
--- a/docs/PLANNED_FEATURE_ROADMAP_REPOSITORY.md
+++ b/docs/PLANNED_FEATURE_ROADMAP_REPOSITORY.md
@@ -2,6 +2,7 @@
 
 ## Completed
 
+- REPO-3.2 (#2771): Added `swagger_2_0` support to the repository OpenAPI importer pipeline so Swagger 2.0 repository specs run through the same conversion/parser path as OpenAPI 3.x, with semantic parity tests covering definitions, paths, parameters, and security scheme mapping.
 - REPO-3.1 (#2770): Added a repository OpenAPI importer hook that reuses the existing one-shot `parseOpenAPISpec` conversion pipeline, accepts normalized `{source, format, content, refs}` input for repository ingestion, and delegates cross-file `$ref` handling to the REPO-3.8 resolver contract with fixture-set parity coverage.
 - REPO-2.7 (#2768): Added scan diff classification against the previous completed scan keyed by `(repository_id, path)`, including persisted `new/unchanged/modified/removed` per-file statuses with carried-forward `removed` rows and `{added, modified, removed, unchanged}` diff summary counts.
 - REPO-2.6 (#2767): Added `repository_scan` and `repository_file` history support with cursor-paginated scan/file REST endpoints, `force` rescan behavior, and `skipped_unchanged` audit/event tracking.

--- a/objectified-ui/lib/repositories/importers/openapi.ts
+++ b/objectified-ui/lib/repositories/importers/openapi.ts
@@ -1,7 +1,10 @@
 import { parseOpenAPISpec, OpenAPIParseResult } from '../../../src/app/utils/openapi-import';
 import type { DetectedRepositorySpecFormat } from '../scanner/detect';
 
-export type RepositoryOpenApiFormat = Extract<DetectedRepositorySpecFormat, 'openapi_3_0' | 'openapi_3_1'>;
+export type RepositoryOpenApiFormat = Extract<
+  DetectedRepositorySpecFormat,
+  'openapi_3_0' | 'openapi_3_1' | 'swagger_2_0'
+>;
 
 export interface RepositoryOpenApiRef {
   path: string;

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.10.30",
+  "version": "0.10.31",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -5,6 +5,7 @@ We continue to improve the platform based on your feedback with improvements and
 ---
 
 ## Repositories
+- Added repository importer support for `swagger_2_0`, routing Swagger 2.0 specs through the same conversion/parser pipeline as OpenAPI 3.x with semantic parity coverage for schemas, paths, parameters, and security mappings.
 - Added a repository OpenAPI importer hook for OpenAPI 3.0/3.1 that reuses the existing dialog converter with normalized `{source, format, content, refs}` input and parity-checked fixture coverage, while delegating cross-file `$ref` resolution through the REPO-3.8 resolver contract.
 - Added previous-scan diffing for repository scans so completed scans classify files as `new`/`unchanged`/`modified`/`removed`, retain removed rows with prior blob SHA, and store `{added, modified, removed, unchanged}` summary counts.
 - Added repository scan history models (`repository_scan`/`repository_file`) with cursor-paginated scan/file REST endpoints, `force` re-scan support, and `skipped_unchanged` tracking.

--- a/objectified-ui/tests/unit/repository-openapi-importer.test.ts
+++ b/objectified-ui/tests/unit/repository-openapi-importer.test.ts
@@ -1,9 +1,13 @@
 import fs from 'fs';
 import path from 'path';
+import YAML from 'yaml';
 import { parseOpenAPISpec } from '../../src/app/utils/openapi-import';
+import { convertSwaggerToOpenAPI } from '../../src/app/utils/swagger-converter';
 import { importOpenApiFromRepository, RepositoryOpenApiFormat } from '../../lib/repositories/importers/openapi';
 
 function deriveOpenApiFormat(content: string): RepositoryOpenApiFormat {
+  const swaggerMatch = content.match(/^\s*swagger\s*:\s*["']?(\d+\.\d+)/m);
+  if (swaggerMatch?.[1]?.startsWith('2.0')) return 'swagger_2_0';
   const match = content.match(/^\s*openapi\s*:\s*["']?(\d+\.\d+)/m);
   if (match?.[1]?.startsWith('3.0')) return 'openapi_3_0';
   return 'openapi_3_1';
@@ -89,5 +93,59 @@ components:
 
     expect(result.success).toBe(false);
     expect(result.error).toMatch(/REPO-3\.8/);
+  });
+
+  it('maps Swagger 2.0 repository fixtures to the same internal entities as the 3.x parse pipeline', async () => {
+    const swaggerPath = path.join(__dirname, '../../examples/swagger/01-swagger-2-petstore.yaml');
+    const swaggerContent = fs.readFileSync(swaggerPath, 'utf-8');
+
+    const swaggerImportResult = await importOpenApiFromRepository({
+      source: 'repository://swagger/01-swagger-2-petstore.yaml',
+      format: 'swagger_2_0',
+      content: swaggerContent,
+      refs: [],
+    });
+
+    expect(swaggerImportResult.success).toBe(true);
+    expect(swaggerImportResult.parseResult?.success).toBe(true);
+
+    const convertedSwagger = convertSwaggerToOpenAPI(YAML.parse(swaggerContent));
+    expect(convertedSwagger.success).toBe(true);
+    const openApiEquivalentContent = YAML.stringify(convertedSwagger.document);
+
+    const openApiEquivalentResult = await importOpenApiFromRepository({
+      source: 'repository://openapi/swagger-equivalent.yaml',
+      format: 'openapi_3_1',
+      content: openApiEquivalentContent,
+      refs: [],
+    });
+
+    expect(openApiEquivalentResult.success).toBe(true);
+
+    const swaggerParsed = swaggerImportResult.parseResult;
+    const openApiParsed = openApiEquivalentResult.parseResult;
+    expect(openApiParsed?.classes).toEqual(swaggerParsed?.classes);
+    expect(openApiParsed?.paths).toEqual(swaggerParsed?.paths);
+    expect(openApiParsed?.securitySchemes).toEqual(swaggerParsed?.securitySchemes);
+    expect(openApiParsed?.title).toBe(swaggerParsed?.title);
+    expect(openApiParsed?.version).toBe(swaggerParsed?.version);
+    expect(openApiParsed?.description).toBe(swaggerParsed?.description);
+    expect(openApiParsed?.info).toEqual(swaggerParsed?.info);
+    expect(openApiParsed?.servers).toEqual(swaggerParsed?.servers);
+    expect(openApiParsed?.tags).toEqual(swaggerParsed?.tags);
+
+    const parsed = swaggerParsed;
+    expect(parsed?.classes.some((cls) => cls.name === 'Pet')).toBe(true);
+    expect(parsed?.paths?.some((entry) => entry.path === '/pets')).toBe(true);
+
+    const listPets = parsed?.paths
+      ?.find((entry) => entry.path === '/pets')
+      ?.operations.find((operation) => operation.operationId === 'listPets');
+    expect(listPets?.parameters.some((parameter) => parameter.name === 'status' && parameter.in === 'query')).toBe(
+      true
+    );
+
+    const schemeNames = (parsed?.securitySchemes ?? []).map((scheme) => scheme.scheme_name);
+    expect(schemeNames).toEqual(expect.arrayContaining(['api_key', 'basic_auth', 'oauth2']));
   });
 });

--- a/objectified-ui/tests/unit/repository-openapi-importer.test.ts
+++ b/objectified-ui/tests/unit/repository-openapi-importer.test.ts
@@ -124,9 +124,26 @@ components:
 
     const swaggerParsed = swaggerImportResult.parseResult;
     const openApiParsed = openApiEquivalentResult.parseResult;
-    expect(openApiParsed?.classes).toEqual(swaggerParsed?.classes);
-    expect(openApiParsed?.paths).toEqual(swaggerParsed?.paths);
-    expect(openApiParsed?.securitySchemes).toEqual(swaggerParsed?.securitySchemes);
+
+    const sortClasses = (classes: typeof swaggerParsed.classes) =>
+      [...(classes ?? [])].sort((a, b) => a.name.localeCompare(b.name));
+
+    const sortPaths = (paths: typeof swaggerParsed.paths) =>
+      [...(paths ?? [])]
+        .sort((a, b) => a.path.localeCompare(b.path))
+        .map((entry) => ({
+          ...entry,
+          operations: [...entry.operations].sort((a, b) =>
+            (a.operationId ?? '').localeCompare(b.operationId ?? '')
+          ),
+        }));
+
+    const sortSecuritySchemes = (schemes: typeof swaggerParsed.securitySchemes) =>
+      [...(schemes ?? [])].sort((a, b) => a.scheme_name.localeCompare(b.scheme_name));
+
+    expect(sortClasses(openApiParsed?.classes)).toEqual(sortClasses(swaggerParsed?.classes));
+    expect(sortPaths(openApiParsed?.paths)).toEqual(sortPaths(swaggerParsed?.paths));
+    expect(sortSecuritySchemes(openApiParsed?.securitySchemes)).toEqual(sortSecuritySchemes(swaggerParsed?.securitySchemes));
     expect(openApiParsed?.title).toBe(swaggerParsed?.title);
     expect(openApiParsed?.version).toBe(swaggerParsed?.version);
     expect(openApiParsed?.description).toBe(swaggerParsed?.description);


### PR DESCRIPTION
## What was done and why
- Added `swagger_2_0` to the repository OpenAPI importer format contract so repository scans can route Swagger 2.0 specs through the same parser pipeline as OpenAPI 3.x.
- Added a semantic parity test that imports the Swagger 2.0 fixture through the repository hook and verifies the resulting internal entities match its OpenAPI-equivalent representation for schemas, paths, parameters, and security schemes.
- Updated roadmap/changelog entries and bumped `objectified-ui` patch version for this repository import capability.

## How to test
- From repo root run `yarn build`.
- From repo root run `yarn test`.
- Optionally run `yarn workspace objectified-ui test tests/unit/repository-openapi-importer.test.ts --verbose` to validate the new parity assertion directly.

## Risk / notes
- The importer behavior is unchanged for OpenAPI 3.x; this change broadens the accepted format union and validates parity for Swagger inputs.
- `yarn test` output includes an existing trailing "No tests found, exiting with code 0" line after suite completion from workspace test orchestration.

Closes #2771

Made with [Cursor](https://cursor.com)