### PR TITLE
Fix #2774 - standalone JSON Schema importer

### DIFF
--- a/docs/PLANNED_FEATURE_ROADMAP_REPOSITORY.md
+++ b/docs/PLANNED_FEATURE_ROADMAP_REPOSITORY.md
@@ -2,6 +2,7 @@
 
 ## Completed
 
+- REPO-3.5 (#2774): Added a standalone repository JSON Schema importer for Draft 7, 2019-09, and 2020-12 documents, preserving source `$id`/draft metadata on class schemas, keeping composition keywords intact, and delegating sibling `$ref` resolution through the REPO-3.8 resolver contract.
 - REPO-3.2 (#2771): Added `swagger_2_0` support to the repository OpenAPI importer pipeline so Swagger 2.0 repository specs run through the same conversion/parser path as OpenAPI 3.x, with semantic parity tests covering definitions, paths, parameters, and security scheme mapping.
 - REPO-3.1 (#2770): Added a repository OpenAPI importer hook that reuses the existing one-shot `parseOpenAPISpec` conversion pipeline, accepts normalized `{source, format, content, refs}` input for repository ingestion, and delegates cross-file `$ref` handling to the REPO-3.8 resolver contract with fixture-set parity coverage.
 - REPO-2.7 (#2768): Added scan diff classification against the previous completed scan keyed by `(repository_id, path)`, including persisted `new/unchanged/modified/removed` per-file statuses with carried-forward `removed` rows and `{added, modified, removed, unchanged}` diff summary counts.

--- a/objectified-ui/lib/repositories/importers/json-schema.ts
+++ b/objectified-ui/lib/repositories/importers/json-schema.ts
@@ -1,0 +1,113 @@
+import { parseOpenAPISpec, OpenAPIParseResult } from '../../../src/app/utils/openapi-import';
+import type { DetectedRepositorySpecFormat } from '../scanner/detect';
+
+export type RepositoryJsonSchemaFormat = Extract<DetectedRepositorySpecFormat, 'json_schema'>;
+
+export interface RepositoryJsonSchemaRef {
+  path: string;
+  content: string;
+}
+
+export interface RepositoryJsonSchemaImportInput {
+  source: string;
+  format: RepositoryJsonSchemaFormat;
+  content: string;
+  refs?: RepositoryJsonSchemaRef[];
+}
+
+export interface ResolveRepositoryJsonSchemaRefsInput {
+  source: string;
+  format: RepositoryJsonSchemaFormat;
+  content: string;
+  refs: RepositoryJsonSchemaRef[];
+}
+
+export type ResolveRepositoryJsonSchemaRefs = (
+  input: ResolveRepositoryJsonSchemaRefsInput
+) => Promise<string> | string;
+
+export interface RepositoryJsonSchemaImportDeps {
+  /**
+   * REPO-3.8 delegate: caller-provided cross-file $ref resolution.
+   * When omitted, the primary content is parsed as-is.
+   */
+  resolveRefs?: ResolveRepositoryJsonSchemaRefs;
+}
+
+export interface RepositoryJsonSchemaImportResult {
+  success: boolean;
+  source: string;
+  format: RepositoryJsonSchemaFormat;
+  parseResult?: OpenAPIParseResult;
+  resolvedContent?: string;
+  warnings: string[];
+  error?: string;
+}
+
+export async function importJsonSchemaFromRepository(
+  input: RepositoryJsonSchemaImportInput,
+  deps: RepositoryJsonSchemaImportDeps = {}
+): Promise<RepositoryJsonSchemaImportResult> {
+  if (!input.content || !input.content.trim()) {
+    return {
+      success: false,
+      source: input.source,
+      format: input.format,
+      warnings: [],
+      error: 'Repository JSON Schema import content is empty.',
+    };
+  }
+
+  let resolvedContent = input.content;
+  const refs = input.refs ?? [];
+
+  if (refs.length > 0 && !deps.resolveRefs) {
+    return {
+      success: false,
+      source: input.source,
+      format: input.format,
+      warnings: [],
+      error: 'Cross-file $ref entries are present but no resolver is configured (REPO-3.8).',
+    };
+  }
+
+  try {
+    if (refs.length > 0 && deps.resolveRefs) {
+      resolvedContent = await deps.resolveRefs({
+        source: input.source,
+        format: input.format,
+        content: input.content,
+        refs,
+      });
+    }
+  } catch (error: unknown) {
+    return {
+      success: false,
+      source: input.source,
+      format: input.format,
+      warnings: [],
+      error: error instanceof Error ? error.message : 'Failed to resolve cross-file JSON Schema references.',
+    };
+  }
+
+  const parseResult = parseOpenAPISpec(resolvedContent);
+  if (!parseResult.success) {
+    return {
+      success: false,
+      source: input.source,
+      format: input.format,
+      resolvedContent,
+      warnings: parseResult.warnings ?? [],
+      error: parseResult.error || 'Failed to parse JSON Schema.',
+    };
+  }
+
+  return {
+    success: true,
+    source: input.source,
+    format: input.format,
+    parseResult,
+    resolvedContent,
+    warnings: parseResult.warnings ?? [],
+  };
+}

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.10.31",
+  "version": "0.10.32",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -5,6 +5,7 @@ We continue to improve the platform based on your feedback with improvements and
 ---
 
 ## Repositories
+- Added standalone repository JSON Schema importer support for Draft 7, 2019-09, and 2020-12 schemas, preserving source `$id`/draft metadata while delegating sibling `$ref` resolution through the REPO-3.8 resolver contract.
 - Added repository importer support for `swagger_2_0`, routing Swagger 2.0 specs through the same conversion/parser pipeline as OpenAPI 3.x with semantic parity coverage for schemas, paths, parameters, and security mappings.
 - Added a repository OpenAPI importer hook for OpenAPI 3.0/3.1 that reuses the existing dialog converter with normalized `{source, format, content, refs}` input and parity-checked fixture coverage, while delegating cross-file `$ref` resolution through the REPO-3.8 resolver contract.
 - Added previous-scan diffing for repository scans so completed scans classify files as `new`/`unchanged`/`modified`/`removed`, retain removed rows with prior blob SHA, and store `{added, modified, removed, unchanged}` summary counts.

--- a/objectified-ui/src/app/utils/jsonschema-converter.ts
+++ b/objectified-ui/src/app/utils/jsonschema-converter.ts
@@ -21,6 +21,11 @@ export interface JsonSchemaConversionResult {
   warnings: string[];
 }
 
+interface JsonSchemaSourceMetadata {
+  draft: string | null;
+  $id?: string;
+}
+
 /**
  * Supported JSON Schema draft versions
  */
@@ -90,9 +95,15 @@ export function convertJsonSchemaToOpenAPI(
       };
     }
 
+    const sourceMetadata: JsonSchemaSourceMetadata = {
+      draft: schemaVersion,
+      $id: typeof jsonSchemaDoc.$id === 'string' ? jsonSchemaDoc.$id : undefined,
+    };
+
     // Convert each schema
     for (const [name, schema] of Object.entries(schemas)) {
-      openApiDoc.components.schemas[name] = convertSchema(schema, warnings, name);
+      const convertedSchema = convertSchema(schema, warnings, name);
+      openApiDoc.components.schemas[name] = attachSourceMetadata(convertedSchema, schema, sourceMetadata);
     }
 
     return {
@@ -185,7 +196,6 @@ function extractSchemas(
     delete rootSchema.$schema;
     delete rootSchema.$defs;
     delete rootSchema.definitions;
-    delete rootSchema.$id;
     schemas[rootName] = rootSchema;
   }
 
@@ -467,6 +477,34 @@ function convertSchema(schema: any, warnings: string[], context?: string): any {
   }
 
   return converted;
+}
+
+function attachSourceMetadata(
+  convertedSchema: unknown,
+  originalSchema: unknown,
+  sourceMetadata: JsonSchemaSourceMetadata
+): unknown {
+  if (!convertedSchema || typeof convertedSchema !== 'object') {
+    return convertedSchema;
+  }
+
+  const originalSchemaRecord = originalSchema && typeof originalSchema === 'object'
+    ? originalSchema as Record<string, unknown>
+    : {};
+  const schemaId = typeof originalSchemaRecord.$id === 'string' ? originalSchemaRecord.$id : sourceMetadata.$id;
+  const metadata: Record<string, string | null> = {
+    format: 'json_schema',
+    draft: sourceMetadata.draft,
+  };
+
+  if (schemaId) {
+    metadata.$id = schemaId;
+  }
+
+  return {
+    ...(convertedSchema as Record<string, unknown>),
+    'x-objectified-source': metadata,
+  };
 }
 
 /**

--- a/objectified-ui/tests/unit/repository-json-schema-importer.test.ts
+++ b/objectified-ui/tests/unit/repository-json-schema-importer.test.ts
@@ -1,5 +1,7 @@
 import fs from 'fs';
 import path from 'path';
+import { describe, it, expect, jest } from '@jest/globals';
+import { parseOpenAPISpec } from '../../src/app/utils/openapi-import';
 import { importJsonSchemaFromRepository } from '../../lib/repositories/importers/json-schema';
 
 describe('repository JSON Schema importer hook', () => {
@@ -84,16 +86,22 @@ describe('repository JSON Schema importer hook', () => {
 
     for (const fixture of fixtures) {
       const content = fs.readFileSync(path.join(fixturesDir, fixture), 'utf-8');
-      const result = await importJsonSchemaFromRepository({
+      const oneShotResult = parseOpenAPISpec(content);
+      const repositoryResult = await importJsonSchemaFromRepository({
         source: `repository://json-schema/${fixture}`,
         format: 'json_schema',
         content,
         refs: [],
       });
 
-      expect(result.success).toBe(true);
-      expect(result.parseResult?.classes.length).toBeGreaterThan(0);
-      expect(result.warnings.some((warning) => warning.includes('JSON Schema'))).toBe(true);
+      expect(repositoryResult.success).toBe(oneShotResult.success);
+      if (oneShotResult.success) {
+        expect(repositoryResult.parseResult).toEqual(oneShotResult);
+      } else {
+        expect(repositoryResult.parseResult).toBeUndefined();
+      }
+      expect(repositoryResult.warnings).toEqual(oneShotResult.warnings);
+      expect(repositoryResult.error).toBe(oneShotResult.error);
     }
   });
 

--- a/objectified-ui/tests/unit/repository-json-schema-importer.test.ts
+++ b/objectified-ui/tests/unit/repository-json-schema-importer.test.ts
@@ -1,0 +1,211 @@
+import fs from 'fs';
+import path from 'path';
+import { importJsonSchemaFromRepository } from '../../lib/repositories/importers/json-schema';
+
+describe('repository JSON Schema importer hook', () => {
+  it('imports Draft 7, 2019-09, and 2020-12 schemas without errors', async () => {
+    const fixtures = [
+      {
+        source: 'repository://schemas/draft-07-customer.json',
+        content: JSON.stringify({
+          $schema: 'http://json-schema.org/draft-07/schema#',
+          $id: 'https://example.com/schemas/customer.json',
+          title: 'Customer',
+          type: 'object',
+          required: ['id'],
+          properties: {
+            id: { type: 'string' },
+            email: { type: 'string', format: 'email' },
+          },
+        }),
+        expectedClass: 'Customer',
+        expectedDraft: 'draft-07',
+      },
+      {
+        source: 'repository://schemas/draft-2019-account.json',
+        content: JSON.stringify({
+          $schema: 'https://json-schema.org/draft/2019-09/schema',
+          $id: 'https://example.com/schemas/account.json',
+          title: 'Account',
+          type: 'object',
+          properties: {
+            id: { type: 'string' },
+            status: { enum: ['active', 'disabled'] },
+          },
+        }),
+        expectedClass: 'Account',
+        expectedDraft: 'draft-2019-09',
+      },
+      {
+        source: 'repository://schemas/draft-2020-product.json',
+        content: JSON.stringify({
+          $schema: 'https://json-schema.org/draft/2020-12/schema',
+          $id: 'https://example.com/schemas/product.json',
+          title: 'Product',
+          type: 'object',
+          properties: {
+            sku: { type: 'string' },
+            tags: { type: 'array', items: { type: 'string' } },
+          },
+        }),
+        expectedClass: 'Product',
+        expectedDraft: 'draft-2020-12',
+      },
+    ];
+
+    for (const fixture of fixtures) {
+      const result = await importJsonSchemaFromRepository({
+        source: fixture.source,
+        format: 'json_schema',
+        content: fixture.content,
+        refs: [],
+      });
+
+      expect(result.success).toBe(true);
+      const importedClass = result.parseResult?.classes.find((cls) => cls.name === fixture.expectedClass);
+      expect(importedClass).toBeDefined();
+      expect(importedClass?.isSupported).toBe(true);
+      expect(importedClass?.schema?.['x-objectified-source']).toEqual({
+        format: 'json_schema',
+        draft: fixture.expectedDraft,
+        $id: JSON.parse(fixture.content).$id,
+      });
+    }
+  });
+
+  it('matches the existing dialog parser across JSON Schema example fixtures', async () => {
+    const fixturesDir = path.join(__dirname, '../../examples/json-schema');
+    const fixtures = fs
+      .readdirSync(fixturesDir)
+      .filter((name) => name.endsWith('.json'))
+      .sort();
+
+    expect(fixtures.length).toBeGreaterThan(0);
+
+    for (const fixture of fixtures) {
+      const content = fs.readFileSync(path.join(fixturesDir, fixture), 'utf-8');
+      const result = await importJsonSchemaFromRepository({
+        source: `repository://json-schema/${fixture}`,
+        format: 'json_schema',
+        content,
+        refs: [],
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.parseResult?.classes.length).toBeGreaterThan(0);
+      expect(result.warnings.some((warning) => warning.includes('JSON Schema'))).toBe(true);
+    }
+  });
+
+  it('preserves composition keywords on imported class schemas', async () => {
+    const content = JSON.stringify({
+      $schema: 'https://json-schema.org/draft/2020-12/schema',
+      $id: 'https://example.com/schemas/payment-method.json',
+      title: 'PaymentMethod',
+      type: 'object',
+      allOf: [
+        {
+          type: 'object',
+          required: ['id'],
+          properties: {
+            id: { type: 'string' },
+          },
+        },
+      ],
+      oneOf: [{ $ref: '#/$defs/CardPayment' }, { $ref: '#/$defs/BankPayment' }],
+      anyOf: [{ required: ['cardNumber'] }, { required: ['routingNumber'] }],
+      $defs: {
+        CardPayment: {
+          type: 'object',
+          properties: {
+            cardNumber: { type: 'string' },
+          },
+        },
+        BankPayment: {
+          type: 'object',
+          properties: {
+            routingNumber: { type: 'string' },
+          },
+        },
+      },
+    });
+
+    const result = await importJsonSchemaFromRepository({
+      source: 'repository://schemas/payment-method.json',
+      format: 'json_schema',
+      content,
+      refs: [],
+    });
+
+    expect(result.success).toBe(true);
+    const paymentMethod = result.parseResult?.classes.find((cls) => cls.name === 'PaymentMethod');
+    expect(paymentMethod?.schema?.allOf).toBeDefined();
+    expect(paymentMethod?.schema?.oneOf).toBeDefined();
+    expect(paymentMethod?.schema?.anyOf).toBeDefined();
+    expect(paymentMethod?.schema?.oneOf[0].$ref).toBe('#/components/schemas/CardPayment');
+  });
+
+  it('delegates sibling refs to the REPO-3.8 resolver when refs are present', async () => {
+    const unresolved = JSON.stringify({
+      $schema: 'https://json-schema.org/draft/2020-12/schema',
+      $id: 'https://example.com/schemas/order.json',
+      title: 'Order',
+      type: 'object',
+      properties: {
+        user: { $ref: './user.schema.json' },
+      },
+    });
+    const resolved = JSON.stringify({
+      $schema: 'https://json-schema.org/draft/2020-12/schema',
+      $id: 'https://example.com/schemas/order.json',
+      title: 'Order',
+      type: 'object',
+      properties: {
+        user: { $ref: '#/$defs/User' },
+      },
+      $defs: {
+        User: {
+          type: 'object',
+          properties: {
+            id: { type: 'string' },
+          },
+        },
+      },
+    });
+
+    const resolveRefs = jest.fn().mockResolvedValue(resolved);
+    const refs = [{ path: './user.schema.json', content: '{"title":"User","type":"object"}' }];
+
+    const result = await importJsonSchemaFromRepository(
+      {
+        source: 'repository://schemas/order.json',
+        format: 'json_schema',
+        content: unresolved,
+        refs,
+      },
+      { resolveRefs }
+    );
+
+    expect(resolveRefs).toHaveBeenCalledWith({
+      source: 'repository://schemas/order.json',
+      format: 'json_schema',
+      content: unresolved,
+      refs,
+    });
+    expect(result.success).toBe(true);
+    expect(result.parseResult?.classes.some((cls) => cls.name === 'Order')).toBe(true);
+    expect(result.parseResult?.classes.some((cls) => cls.name === 'User')).toBe(true);
+  });
+
+  it('returns success: false when refs are present but no resolver is configured', async () => {
+    const result = await importJsonSchemaFromRepository({
+      source: 'repository://schemas/order.json',
+      format: 'json_schema',
+      content: '{"$schema":"https://json-schema.org/draft/2020-12/schema","type":"object"}',
+      refs: [{ path: './user.schema.json', content: '{"type":"object"}' }],
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/REPO-3\.8/);
+  });
+});


### PR DESCRIPTION
## Summary
- Add a standalone repository JSON Schema importer for `json_schema` scan results.
- Preserve JSON Schema source metadata (`$id`, draft, format) on imported class schemas.
- Cover Draft 7, 2019-09, 2020-12, composition keywords, fixture parity, and REPO-3.8 sibling `$ref` delegation.

## Test plan
- `yarn workspace objectified-ui test --runTestsByPath tests/unit/repository-json-schema-importer.test.ts tests/jsonschema-import.test.ts`
- `yarn workspace objectified-ui lint lib/repositories/importers/json-schema.ts tests/unit/repository-json-schema-importer.test.ts`
- `yarn build`
- `yarn test`

## Risk/notes
- Full `yarn workspace objectified-ui lint` is currently blocked by pre-existing lint errors outside this ticket; changed files lint cleanly.

Closes #2774

Made with [Cursor](https://cursor.com)