### PR TITLE
Fix #2777 - add in-scan cross-file  resolver

### DIFF
--- a/docs/PLANNED_FEATURE_ROADMAP_REPOSITORY.md
+++ b/docs/PLANNED_FEATURE_ROADMAP_REPOSITORY.md
@@ -2,6 +2,7 @@
 
 ## Completed
 
+- REPO-3.8 (#2777): Added an in-scan virtual filesystem `$ref` resolver for repository imports that resolves relative file-path and JSON-pointer chains in dependency order, memoizes repeated nodes per scan, and emits deterministic cycle errors for cross-file loops.
 - REPO-3.5 (#2774): Added a standalone repository JSON Schema importer for Draft 7, 2019-09, and 2020-12 documents, preserving source `$id`/draft metadata on class schemas, keeping composition keywords intact, and delegating sibling `$ref` resolution through the REPO-3.8 resolver contract.
 - REPO-3.2 (#2771): Added `swagger_2_0` support to the repository OpenAPI importer pipeline so Swagger 2.0 repository specs run through the same conversion/parser path as OpenAPI 3.x, with semantic parity tests covering definitions, paths, parameters, and security scheme mapping.
 - REPO-3.1 (#2770): Added a repository OpenAPI importer hook that reuses the existing one-shot `parseOpenAPISpec` conversion pipeline, accepts normalized `{source, format, content, refs}` input for repository ingestion, and delegates cross-file `$ref` handling to the REPO-3.8 resolver contract with fixture-set parity coverage.

--- a/objectified-ui/lib/repositories/importers/cross-file-ref-resolver.ts
+++ b/objectified-ui/lib/repositories/importers/cross-file-ref-resolver.ts
@@ -69,12 +69,14 @@ function buildVirtualFs(
 function computeResolutionOrder(virtualFs: Map<string, unknown>): string[] {
   const reverseDependencies = new Map<string, Set<string>>();
   const pendingDependencyCount = new Map<string, number>();
+  const forwardDependencies = new Map<string, Set<string>>();
 
   for (const [filePath, document] of virtualFs.entries()) {
     const refs = collectExternalRefTargets(document, filePath);
     const existingTargets = [...refs].filter((target) => virtualFs.has(target));
     const dependencySet = new Set(existingTargets);
     pendingDependencyCount.set(filePath, dependencySet.size);
+    forwardDependencies.set(filePath, dependencySet);
 
     for (const target of dependencySet) {
       const reverse = reverseDependencies.get(target) ?? new Set<string>();
@@ -108,14 +110,60 @@ function computeResolutionOrder(virtualFs: Map<string, unknown>): string[] {
   }
 
   if (ordered.length !== virtualFs.size) {
-    const cycleMembers = [...pendingDependencyCount.entries()]
-      .filter(([, depCount]) => depCount > 0)
-      .map(([filePath]) => filePath)
-      .sort((a, b) => a.localeCompare(b));
-    throw new Error(`Cross-file $ref cycle detected: ${cycleMembers.join(' -> ')} -> ${cycleMembers[0]}`);
+    const cycleSet = new Set(
+      [...pendingDependencyCount.entries()]
+        .filter(([, depCount]) => depCount > 0)
+        .map(([filePath]) => filePath)
+    );
+    const cyclePath = extractCyclePath(cycleSet, forwardDependencies);
+    throw new Error(`Cross-file $ref cycle detected: ${cyclePath}`);
   }
 
   return ordered;
+}
+
+function extractCyclePath(cycleSet: Set<string>, forwardDeps: Map<string, Set<string>>): string {
+  const start = [...cycleSet].sort((a, b) => a.localeCompare(b))[0];
+  const visited = new Set<string>();
+  const onPath = new Set<string>();
+  const pathStack: string[] = [];
+
+  function dfs(node: string): string[] | null {
+    if (onPath.has(node)) {
+      const idx = pathStack.indexOf(node);
+      return [...pathStack.slice(idx), node];
+    }
+    if (visited.has(node)) {
+      return null;
+    }
+    visited.add(node);
+    onPath.add(node);
+    pathStack.push(node);
+
+    const deps = [...(forwardDeps.get(node) ?? new Set<string>())]
+      .filter((dep) => cycleSet.has(dep))
+      .sort((a, b) => a.localeCompare(b));
+
+    for (const dep of deps) {
+      const result = dfs(dep);
+      if (result !== null) {
+        return result;
+      }
+    }
+
+    pathStack.pop();
+    onPath.delete(node);
+    return null;
+  }
+
+  const cyclePath = dfs(start);
+  if (cyclePath !== null) {
+    return cyclePath.join(' -> ');
+  }
+
+  // Fallback: should not occur for a valid cycle set
+  const members = [...cycleSet].sort((a, b) => a.localeCompare(b));
+  return `${members.join(' -> ')} -> ${members[0]}`;
 }
 
 function resolveDocumentRefs(input: {
@@ -145,16 +193,19 @@ function resolveDocumentRefs(input: {
 
       if (typeof value.$ref === 'string') {
         const parsedRef = parseRef(value.$ref);
-        const targetPath = parsedRef.filePath
+        const isExternalRef = parsedRef.filePath.length > 0;
+        const targetPath = isExternalRef
           ? normalizeVirtualPath(parsedRef.filePath, path.posix.dirname(input.filePath))
           : input.filePath;
-        const memoKey = parsedRef.filePath ? `${targetPath}#${parsedRef.fragment}` : null;
+        const memoKey = isExternalRef ? `${targetPath}#${parsedRef.fragment}` : null;
 
         let replacement: unknown;
         if (memoKey && externalMemo.has(memoKey)) {
           replacement = deepClone(externalMemo.get(memoKey));
         } else {
-          const targetDocument = input.resolvedDocs.get(targetPath);
+          const targetDocument = isExternalRef
+            ? input.resolvedDocs.get(targetPath)
+            : rootHolder.value;
           if (targetDocument === undefined) {
             throw new Error(`Unable to resolve $ref '${value.$ref}' from '${input.filePath}': missing '${targetPath}'.`);
           }

--- a/objectified-ui/lib/repositories/importers/cross-file-ref-resolver.ts
+++ b/objectified-ui/lib/repositories/importers/cross-file-ref-resolver.ts
@@ -1,0 +1,331 @@
+import path from 'path';
+import YAML from 'yaml';
+
+export interface RepositoryResolverRefFile {
+  path: string;
+  content: string;
+}
+
+export interface ResolveRepositoryCrossFileRefsInput {
+  source: string;
+  content: string;
+  refs: RepositoryResolverRefFile[];
+}
+
+const MAX_PASSES_PER_DOCUMENT = 2048;
+
+export function resolveRepositoryCrossFileRefs(input: ResolveRepositoryCrossFileRefsInput): string {
+  const sourcePath = normalizeSourcePath(input.source);
+  const virtualFs = buildVirtualFs(sourcePath, input.content, input.refs);
+  const resolutionOrder = computeResolutionOrder(virtualFs);
+  const resolvedDocs = new Map<string, unknown>();
+
+  for (const filePath of resolutionOrder) {
+    const originalDoc = virtualFs.get(filePath);
+    if (originalDoc === undefined) {
+      throw new Error(`Missing virtual filesystem entry for '${filePath}'.`);
+    }
+    resolvedDocs.set(
+      filePath,
+      resolveDocumentRefs({
+        filePath,
+        document: originalDoc,
+        resolvedDocs,
+      })
+    );
+  }
+
+  const resolvedRoot = resolvedDocs.get(sourcePath);
+  if (resolvedRoot === undefined) {
+    throw new Error(`Unable to resolve root document '${sourcePath}'.`);
+  }
+
+  return shouldSerializeAsJson(input.content)
+    ? JSON.stringify(resolvedRoot, null, 2)
+    : YAML.stringify(resolvedRoot);
+}
+
+function buildVirtualFs(
+  sourcePath: string,
+  sourceContent: string,
+  refs: RepositoryResolverRefFile[]
+): Map<string, unknown> {
+  const fsMap = new Map<string, unknown>();
+  fsMap.set(sourcePath, parseSpecDocument(sourceContent, sourcePath));
+
+  for (const ref of refs) {
+    const normalizedPath = normalizeVirtualPath(ref.path);
+    if (!normalizedPath) {
+      continue;
+    }
+    if (!fsMap.has(normalizedPath)) {
+      fsMap.set(normalizedPath, parseSpecDocument(ref.content, normalizedPath));
+    }
+  }
+
+  return fsMap;
+}
+
+function computeResolutionOrder(virtualFs: Map<string, unknown>): string[] {
+  const reverseDependencies = new Map<string, Set<string>>();
+  const pendingDependencyCount = new Map<string, number>();
+
+  for (const [filePath, document] of virtualFs.entries()) {
+    const refs = collectExternalRefTargets(document, filePath);
+    const existingTargets = [...refs].filter((target) => virtualFs.has(target));
+    const dependencySet = new Set(existingTargets);
+    pendingDependencyCount.set(filePath, dependencySet.size);
+
+    for (const target of dependencySet) {
+      const reverse = reverseDependencies.get(target) ?? new Set<string>();
+      reverse.add(filePath);
+      reverseDependencies.set(target, reverse);
+    }
+  }
+
+  const queue = [...pendingDependencyCount.entries()]
+    .filter(([, depCount]) => depCount === 0)
+    .map(([filePath]) => filePath)
+    .sort((a, b) => a.localeCompare(b));
+  const ordered: string[] = [];
+  let index = 0;
+
+  while (index < queue.length) {
+    const current = queue[index];
+    index += 1;
+    ordered.push(current);
+
+    const dependents = [...(reverseDependencies.get(current) ?? new Set<string>())].sort((a, b) =>
+      a.localeCompare(b)
+    );
+    for (const dependent of dependents) {
+      const nextCount = (pendingDependencyCount.get(dependent) ?? 0) - 1;
+      pendingDependencyCount.set(dependent, nextCount);
+      if (nextCount === 0) {
+        queue.push(dependent);
+      }
+    }
+  }
+
+  if (ordered.length !== virtualFs.size) {
+    const cycleMembers = [...pendingDependencyCount.entries()]
+      .filter(([, depCount]) => depCount > 0)
+      .map(([filePath]) => filePath)
+      .sort((a, b) => a.localeCompare(b));
+    throw new Error(`Cross-file $ref cycle detected: ${cycleMembers.join(' -> ')} -> ${cycleMembers[0]}`);
+  }
+
+  return ordered;
+}
+
+function resolveDocumentRefs(input: {
+  filePath: string;
+  document: unknown;
+  resolvedDocs: Map<string, unknown>;
+}): unknown {
+  const workingRoot = deepClone(input.document);
+  const rootHolder: { value: unknown } = { value: workingRoot };
+  const externalMemo = new Map<string, unknown>();
+  let pass = 0;
+
+  while (pass < MAX_PASSES_PER_DOCUMENT) {
+    let refsResolved = 0;
+    const stack: Array<{ holder: Record<string, unknown>; key: string }> = [{ holder: rootHolder, key: 'value' }];
+
+    while (stack.length > 0) {
+      const item = stack.pop();
+      if (!item) {
+        continue;
+      }
+
+      const value = item.holder[item.key];
+      if (!isObject(value)) {
+        continue;
+      }
+
+      if (typeof value.$ref === 'string') {
+        const parsedRef = parseRef(value.$ref);
+        const targetPath = parsedRef.filePath
+          ? normalizeVirtualPath(parsedRef.filePath, path.posix.dirname(input.filePath))
+          : input.filePath;
+        const memoKey = parsedRef.filePath ? `${targetPath}#${parsedRef.fragment}` : null;
+
+        let replacement: unknown;
+        if (memoKey && externalMemo.has(memoKey)) {
+          replacement = deepClone(externalMemo.get(memoKey));
+        } else {
+          const targetDocument = input.resolvedDocs.get(targetPath);
+          if (targetDocument === undefined) {
+            throw new Error(`Unable to resolve $ref '${value.$ref}' from '${input.filePath}': missing '${targetPath}'.`);
+          }
+
+          replacement = deepClone(resolveJsonPointer(targetDocument, parsedRef.fragment, targetPath, value.$ref));
+          if (memoKey) {
+            externalMemo.set(memoKey, deepClone(replacement));
+          }
+        }
+
+        item.holder[item.key] = replacement;
+        refsResolved += 1;
+        continue;
+      }
+
+      if (Array.isArray(value)) {
+        for (let idx = value.length - 1; idx >= 0; idx -= 1) {
+          const key = String(idx);
+          stack.push({ holder: value as unknown as Record<string, unknown>, key });
+        }
+        continue;
+      }
+
+      const entries = Object.keys(value).sort((a, b) => b.localeCompare(a));
+      for (const key of entries) {
+        stack.push({ holder: value as Record<string, unknown>, key });
+      }
+    }
+
+    if (refsResolved === 0) {
+      return rootHolder.value;
+    }
+    pass += 1;
+  }
+
+  throw new Error(`Unable to fully resolve $ref values in '${input.filePath}': maximum pass limit reached.`);
+}
+
+function collectExternalRefTargets(document: unknown, basePath: string): Set<string> {
+  const targets = new Set<string>();
+  const stack: unknown[] = [document];
+
+  while (stack.length > 0) {
+    const value = stack.pop();
+    if (!isObject(value)) {
+      continue;
+    }
+
+    if (typeof value.$ref === 'string') {
+      const parsedRef = parseRef(value.$ref);
+      if (parsedRef.filePath) {
+        targets.add(normalizeVirtualPath(parsedRef.filePath, path.posix.dirname(basePath)));
+      }
+    }
+
+    if (Array.isArray(value)) {
+      for (let idx = value.length - 1; idx >= 0; idx -= 1) {
+        stack.push(value[idx]);
+      }
+      continue;
+    }
+
+    for (const key of Object.keys(value)) {
+      stack.push((value as Record<string, unknown>)[key]);
+    }
+  }
+
+  return targets;
+}
+
+function parseSpecDocument(content: string, filePath: string): unknown {
+  const trimmed = content.trim();
+  if (!trimmed) {
+    throw new Error(`Cannot resolve refs in '${filePath}': file content is empty.`);
+  }
+
+  try {
+    return YAML.parse(trimmed);
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : 'unknown parse error';
+    throw new Error(`Failed to parse '${filePath}' while resolving refs: ${message}`);
+  }
+}
+
+function parseRef(ref: string): { filePath: string; fragment: string } {
+  const hashIndex = ref.indexOf('#');
+  if (hashIndex < 0) {
+    return { filePath: ref, fragment: '' };
+  }
+  return {
+    filePath: ref.slice(0, hashIndex),
+    fragment: ref.slice(hashIndex + 1),
+  };
+}
+
+function normalizeSourcePath(source: string): string {
+  if (source.startsWith('repository://')) {
+    return normalizeVirtualPath(source.slice('repository://'.length));
+  }
+  return normalizeVirtualPath(source);
+}
+
+function normalizeVirtualPath(rawPath: string, baseDir?: string): string {
+  const stripped = rawPath.trim();
+  if (!stripped) {
+    return '';
+  }
+
+  const withoutScheme = stripped.startsWith('repository://')
+    ? stripped.slice('repository://'.length)
+    : stripped;
+
+  const resolved = withoutScheme.startsWith('/')
+    ? path.posix.normalize(withoutScheme.slice(1))
+    : path.posix.normalize(path.posix.join(baseDir ?? '', withoutScheme));
+
+  if (resolved === '..' || resolved.startsWith('../')) {
+    throw new Error(`$ref path '${rawPath}' escapes the repository root.`);
+  }
+
+  return resolved.replace(/^\.\/+/, '');
+}
+
+function resolveJsonPointer(
+  source: unknown,
+  fragment: string,
+  filePath: string,
+  originalRef: string
+): unknown {
+  if (!fragment) {
+    return source;
+  }
+  const normalized = fragment.startsWith('/') ? fragment : `/${fragment}`;
+  const parts = normalized
+    .slice(1)
+    .split('/')
+    .map((part) => part.replace(/~1/g, '/').replace(/~0/g, '~'));
+
+  let current: unknown = source;
+  for (const part of parts) {
+    if (Array.isArray(current)) {
+      const index = Number(part);
+      if (!Number.isInteger(index) || index < 0 || index >= current.length) {
+        throw new Error(`Invalid JSON pointer '${originalRef}' in '${filePath}'.`);
+      }
+      current = current[index];
+      continue;
+    }
+
+    if (isObject(current) && Object.prototype.hasOwnProperty.call(current, part)) {
+      current = (current as Record<string, unknown>)[part];
+      continue;
+    }
+
+    throw new Error(`Invalid JSON pointer '${originalRef}' in '${filePath}'.`);
+  }
+  return current;
+}
+
+function shouldSerializeAsJson(content: string): boolean {
+  const trimmed = content.trim();
+  return trimmed.startsWith('{') || trimmed.startsWith('[');
+}
+
+function deepClone<T>(value: T): T {
+  if (value === undefined) {
+    return value;
+  }
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}

--- a/objectified-ui/lib/repositories/importers/json-schema.ts
+++ b/objectified-ui/lib/repositories/importers/json-schema.ts
@@ -1,5 +1,6 @@
 import { parseOpenAPISpec, OpenAPIParseResult } from '../../../src/app/utils/openapi-import';
 import type { DetectedRepositorySpecFormat } from '../scanner/detect';
+import { resolveRepositoryCrossFileRefs } from './cross-file-ref-resolver';
 
 export type RepositoryJsonSchemaFormat = Extract<DetectedRepositorySpecFormat, 'json_schema'>;
 
@@ -28,8 +29,8 @@ export type ResolveRepositoryJsonSchemaRefs = (
 
 export interface RepositoryJsonSchemaImportDeps {
   /**
-   * REPO-3.8 delegate: caller-provided cross-file $ref resolution.
-   * When omitted, the primary content is parsed as-is.
+   * Optional override for REPO-3.8 cross-file $ref resolution.
+   * When omitted, the built-in repository virtual filesystem resolver is used.
    */
   resolveRefs?: ResolveRepositoryJsonSchemaRefs;
 }
@@ -60,20 +61,18 @@ export async function importJsonSchemaFromRepository(
 
   let resolvedContent = input.content;
   const refs = input.refs ?? [];
-
-  if (refs.length > 0 && !deps.resolveRefs) {
-    return {
-      success: false,
-      source: input.source,
-      format: input.format,
-      warnings: [],
-      error: 'Cross-file $ref entries are present but no resolver is configured (REPO-3.8).',
-    };
-  }
+  const resolver: ResolveRepositoryJsonSchemaRefs =
+    deps.resolveRefs ??
+    ((resolveInput) =>
+      resolveRepositoryCrossFileRefs({
+        source: resolveInput.source,
+        content: resolveInput.content,
+        refs: resolveInput.refs,
+      }));
 
   try {
-    if (refs.length > 0 && deps.resolveRefs) {
-      resolvedContent = await deps.resolveRefs({
+    if (refs.length > 0) {
+      resolvedContent = await resolver({
         source: input.source,
         format: input.format,
         content: input.content,

--- a/objectified-ui/lib/repositories/importers/openapi.ts
+++ b/objectified-ui/lib/repositories/importers/openapi.ts
@@ -1,5 +1,6 @@
 import { parseOpenAPISpec, OpenAPIParseResult } from '../../../src/app/utils/openapi-import';
 import type { DetectedRepositorySpecFormat } from '../scanner/detect';
+import { resolveRepositoryCrossFileRefs } from './cross-file-ref-resolver';
 
 export type RepositoryOpenApiFormat = Extract<
   DetectedRepositorySpecFormat,
@@ -31,8 +32,8 @@ export type ResolveRepositoryOpenApiRefs = (
 
 export interface RepositoryOpenApiImportDeps {
   /**
-   * REPO-3.8 delegate: caller-provided cross-file $ref resolution.
-   * When omitted, the primary content is parsed as-is.
+   * Optional override for REPO-3.8 cross-file $ref resolution.
+   * When omitted, the built-in repository virtual filesystem resolver is used.
    */
   resolveRefs?: ResolveRepositoryOpenApiRefs;
 }
@@ -63,20 +64,18 @@ export async function importOpenApiFromRepository(
 
   let resolvedContent = input.content;
   const refs = input.refs ?? [];
-
-  if (refs.length > 0 && !deps.resolveRefs) {
-    return {
-      success: false,
-      source: input.source,
-      format: input.format,
-      warnings: [],
-      error: 'Cross-file $ref entries are present but no resolver is configured (REPO-3.8).',
-    };
-  }
+  const resolver: ResolveRepositoryOpenApiRefs =
+    deps.resolveRefs ??
+    ((resolveInput) =>
+      resolveRepositoryCrossFileRefs({
+        source: resolveInput.source,
+        content: resolveInput.content,
+        refs: resolveInput.refs,
+      }));
 
   try {
-    if (refs.length > 0 && deps.resolveRefs) {
-      resolvedContent = await deps.resolveRefs({
+    if (refs.length > 0) {
+      resolvedContent = await resolver({
         source: input.source,
         format: input.format,
         content: input.content,

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.10.32",
+  "version": "0.10.33",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -5,6 +5,7 @@ We continue to improve the platform based on your feedback with improvements and
 ---
 
 ## Repositories
+- Added the REPO-3.8 in-scan virtual filesystem resolver for repository imports, with dependency-ordered cross-file `$ref` resolution (relative paths + JSON pointers), per-scan memoization, and deterministic cycle detection errors.
 - Added standalone repository JSON Schema importer support for Draft 7, 2019-09, and 2020-12 schemas, preserving source `$id`/draft metadata while delegating sibling `$ref` resolution through the REPO-3.8 resolver contract.
 - Added repository importer support for `swagger_2_0`, routing Swagger 2.0 specs through the same conversion/parser pipeline as OpenAPI 3.x with semantic parity coverage for schemas, paths, parameters, and security mappings.
 - Added a repository OpenAPI importer hook for OpenAPI 3.0/3.1 that reuses the existing dialog converter with normalized `{source, format, content, refs}` input and parity-checked fixture coverage, while delegating cross-file `$ref` resolution through the REPO-3.8 resolver contract.
@@ -60,5 +61,5 @@ We'd love to hear your thoughts! Your feedback helps us make Objectified better.
 
 **Thank you for using Objectified!**
 
-*Last updated: April 23, 2026*
+*Last updated: April 24, 2026*
 

--- a/objectified-ui/tests/unit/repository-cross-file-ref-resolver.test.ts
+++ b/objectified-ui/tests/unit/repository-cross-file-ref-resolver.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect } from '@jest/globals';
 import YAML from 'yaml';
 import { resolveRepositoryCrossFileRefs } from '../../lib/repositories/importers/cross-file-ref-resolver';
 

--- a/objectified-ui/tests/unit/repository-cross-file-ref-resolver.test.ts
+++ b/objectified-ui/tests/unit/repository-cross-file-ref-resolver.test.ts
@@ -1,0 +1,128 @@
+import YAML from 'yaml';
+import { resolveRepositoryCrossFileRefs } from '../../lib/repositories/importers/cross-file-ref-resolver';
+
+describe('repository cross-file ref resolver', () => {
+  it('resolves relative file refs with JSON pointer fragments', () => {
+    const content = `
+openapi: 3.1.0
+info:
+  title: Relative refs
+  version: 1.0.0
+components:
+  schemas:
+    Account:
+      type: object
+      properties:
+        owner:
+          $ref: ./schemas/user.yaml#/User
+`;
+
+    const resolved = resolveRepositoryCrossFileRefs({
+      source: 'repository://services/openapi.yaml',
+      content,
+      refs: [
+        {
+          path: 'services/schemas/user.yaml',
+          content: `
+User:
+  type: object
+  properties:
+    id:
+      type: string
+`,
+        },
+      ],
+    });
+
+    const parsed = YAML.parse(resolved);
+    expect(parsed.components.schemas.Account.properties.owner.properties.id.type).toBe('string');
+  });
+
+  it('resolves chained refs deeper than five levels without recursion', () => {
+    const refs = [
+      {
+        path: 'specs/level-2.yaml',
+        content: 'value:\n  $ref: ./level-3.yaml#/value\n',
+      },
+      {
+        path: 'specs/level-3.yaml',
+        content: 'value:\n  $ref: ./level-4.yaml#/value\n',
+      },
+      {
+        path: 'specs/level-4.yaml',
+        content: 'value:\n  $ref: ./level-5.yaml#/value\n',
+      },
+      {
+        path: 'specs/level-5.yaml',
+        content: 'value:\n  $ref: ./level-6.yaml#/value\n',
+      },
+      {
+        path: 'specs/level-6.yaml',
+        content: 'value:\n  $ref: ./level-7.yaml#/value\n',
+      },
+      {
+        path: 'specs/level-7.yaml',
+        content: 'value:\n  type: object\n  properties:\n    id:\n      type: string\n',
+      },
+    ];
+
+    const resolved = resolveRepositoryCrossFileRefs({
+      source: 'repository://specs/root.yaml',
+      content: 'value:\n  $ref: ./level-2.yaml#/value\n',
+      refs,
+    });
+
+    const parsed = YAML.parse(resolved);
+    expect(parsed.value.properties.id.type).toBe('string');
+  });
+
+  it('detects cross-file cycles with deterministic member names', () => {
+    expect(() =>
+      resolveRepositoryCrossFileRefs({
+        source: 'repository://specs/a.yaml',
+        content: 'value:\n  $ref: ./b.yaml#/value\n',
+        refs: [
+          { path: 'specs/b.yaml', content: 'value:\n  $ref: ./c.yaml#/value\n' },
+          { path: 'specs/c.yaml', content: 'value:\n  $ref: ./a.yaml#/value\n' },
+        ],
+      })
+    ).toThrow('Cross-file $ref cycle detected: specs/a.yaml -> specs/b.yaml -> specs/c.yaml -> specs/a.yaml');
+  });
+
+  it('memoizes repeated external refs within the same scan', () => {
+    const resolved = resolveRepositoryCrossFileRefs({
+      source: 'repository://services/openapi.yaml',
+      content: `
+openapi: 3.1.0
+info:
+  title: Memoized refs
+  version: 1.0.0
+components:
+  schemas:
+    Team:
+      type: object
+      properties:
+        lead:
+          $ref: ./schemas/user.yaml#/User
+        reviewer:
+          $ref: ./schemas/user.yaml#/User
+`,
+      refs: [
+        {
+          path: 'services/schemas/user.yaml',
+          content: `
+User:
+  type: object
+  properties:
+    id:
+      type: string
+`,
+        },
+      ],
+    });
+
+    const parsed = YAML.parse(resolved);
+    expect(parsed.components.schemas.Team.properties.lead.properties.id.type).toBe('string');
+    expect(parsed.components.schemas.Team.properties.reviewer.properties.id.type).toBe('string');
+  });
+});

--- a/objectified-ui/tests/unit/repository-json-schema-importer.test.ts
+++ b/objectified-ui/tests/unit/repository-json-schema-importer.test.ts
@@ -205,15 +205,36 @@ describe('repository JSON Schema importer hook', () => {
     expect(result.parseResult?.classes.some((cls) => cls.name === 'User')).toBe(true);
   });
 
-  it('returns success: false when refs are present but no resolver is configured', async () => {
+  it('uses the built-in REPO-3.8 resolver when refs are present and no override is provided', async () => {
     const result = await importJsonSchemaFromRepository({
       source: 'repository://schemas/order.json',
       format: 'json_schema',
-      content: '{"$schema":"https://json-schema.org/draft/2020-12/schema","type":"object"}',
-      refs: [{ path: './user.schema.json', content: '{"type":"object"}' }],
+      content: JSON.stringify({
+        $schema: 'https://json-schema.org/draft/2020-12/schema',
+        title: 'Order',
+        type: 'object',
+        properties: {
+          user: { $ref: './user.schema.json#/User' },
+        },
+      }),
+      refs: [
+        {
+          path: 'schemas/user.schema.json',
+          content: JSON.stringify({
+            User: {
+              type: 'object',
+              properties: {
+                id: { type: 'string' },
+              },
+            },
+          }),
+        },
+      ],
     });
 
-    expect(result.success).toBe(false);
-    expect(result.error).toMatch(/REPO-3\.8/);
+    expect(result.success).toBe(true);
+    expect(result.parseResult?.classes.some((cls) => cls.name === 'Order')).toBe(true);
+    expect(result.resolvedContent).toContain('"type": "string"');
+    expect(result.resolvedContent).not.toContain('./user.schema.json#/User');
   });
 });

--- a/objectified-ui/tests/unit/repository-openapi-importer.test.ts
+++ b/objectified-ui/tests/unit/repository-openapi-importer.test.ts
@@ -83,16 +83,41 @@ components:
     expect(result.parseResult?.classes.some((cls) => cls.name === 'User')).toBe(true);
   });
 
-  it('returns success: false when refs are present but no resolver is configured', async () => {
+  it('uses the built-in REPO-3.8 resolver when refs are present and no override is provided', async () => {
     const result = await importOpenApiFromRepository({
       source: 'repository://services/openapi.yaml',
       format: 'openapi_3_1',
-      content: 'openapi: 3.1.0',
-      refs: [{ path: './schemas/user.yaml', content: 'type: object' }],
+      content: `
+openapi: 3.1.0
+info:
+  title: Test API
+  version: 1.0.0
+components:
+  schemas:
+    Account:
+      type: object
+      properties:
+        owner:
+          $ref: './schemas/user.yaml#/User'
+`,
+      refs: [
+        {
+          path: 'services/schemas/user.yaml',
+          content: `
+User:
+  type: object
+  properties:
+    id:
+      type: string
+`,
+        },
+      ],
     });
 
-    expect(result.success).toBe(false);
-    expect(result.error).toMatch(/REPO-3\.8/);
+    expect(result.success).toBe(true);
+    expect(result.parseResult?.classes.some((cls) => cls.name === 'Account')).toBe(true);
+    expect(result.resolvedContent).toContain('type: string');
+    expect(result.resolvedContent).not.toContain('./schemas/user.yaml#/User');
   });
 
   it('maps Swagger 2.0 repository fixtures to the same internal entities as the 3.x parse pipeline', async () => {


### PR DESCRIPTION
## Summary
- add a built-in REPO-3.8 resolver that builds an in-scan virtual filesystem from repository file contents and resolves cross-file `$ref` dependencies in deterministic order
- support relative file paths and JSON pointer fragments, memoize repeated external nodes within a scan, and emit deterministic cycle errors for cross-file loops
- wire the resolver as the default for repository OpenAPI/JSON Schema importers, add focused resolver/importer tests, and update roadmap + What's New + objectified-ui patch version

## Test plan
- [x] `yarn workspace objectified-ui test repository-cross-file-ref-resolver repository-openapi-importer repository-json-schema-importer --verbose`
- [x] `yarn build`
- [x] `yarn test`
- [x] `yarn workspace objectified-ui lint` *(currently fails due to pre-existing repo-wide lint debt unrelated to this ticket)*

## Risk / Notes
- Resolver now inlines resolved external refs by default for repository import flows; this is intended to unblock cross-file import parity but can expand large schemas at import time.

Closes #2777

Made with [Cursor](https://cursor.com)