### PR TITLE
Fix #2780 - add SHA-based poll change detection

### DIFF
--- a/docs/PLANNED_FEATURE_ROADMAP_REPOSITORY.md
+++ b/docs/PLANNED_FEATURE_ROADMAP_REPOSITORY.md
@@ -2,6 +2,7 @@
 
 ## Completed
 
+- REPO-4.2 (#2780): Added commit-SHA change detection in scheduled polling by resolving provider branch HEADs, using conditional `If-None-Match` requests for GitHub checks, recording `skipped_unchanged` scans when HEAD is unchanged, and only dispatching downstream scan jobs when SHA changes.
 - REPO-4.1 (#2779): Added a scheduler tick dispatcher that atomically reserves due tracked branches, skips paused repositories, clamps poll cadence to enterprise/non-enterprise minimums, dispatches poll jobs to `repo.poll.<priority>`, and records `repository.polled` workflow audit rows per dispatch.
 - REPO-3.8 (#2777): Added an in-scan virtual filesystem `$ref` resolver for repository imports that resolves relative file-path and JSON-pointer chains in dependency order, memoizes repeated nodes per scan, and emits deterministic cycle errors for cross-file loops.
 - REPO-3.5 (#2774): Added a standalone repository JSON Schema importer for Draft 7, 2019-09, and 2020-12 documents, preserving source `$id`/draft metadata on class schemas, keeping composition keywords intact, and delegating sibling `$ref` resolution through the REPO-3.8 resolver contract.

--- a/objectified-db/scripts/20260424-140000.sql
+++ b/objectified-db/scripts/20260424-140000.sql
@@ -1,0 +1,8 @@
+-- REPO-3.1 / #2780: Add last_known_etag to repository_branch for proper GitHub conditional request support.
+SET search_path TO odb, public;
+
+ALTER TABLE odb.repository_branch
+  ADD COLUMN IF NOT EXISTS last_known_etag VARCHAR(255);
+
+COMMENT ON COLUMN odb.repository_branch.last_known_etag IS
+  'The ETag header value returned by the provider on the last successful HEAD commit fetch; used for If-None-Match conditional requests (#2780).';

--- a/objectified-ui/lib/repositories/poll-scheduler.ts
+++ b/objectified-ui/lib/repositories/poll-scheduler.ts
@@ -37,6 +37,7 @@ type QueryRow = {
   is_enterprise: boolean;
   effective_poll_interval_sec: number;
   last_known_sha: string | null;
+  last_known_etag: string | null;
 };
 
 type QueryResult = {
@@ -58,56 +59,66 @@ export interface PollSchedulerOptions {
 const NON_ENTERPRISE_MIN_POLL_SEC = 300;
 const ENTERPRISE_MIN_POLL_SEC = 60;
 const DEFAULT_BATCH_SIZE = 500;
+const CONCURRENT_HEAD_CHECKS = 8;
 const GITHUB_API_BASE = 'https://api.github.com';
 
 type DetectedHead = {
   sha: string;
   unchanged: boolean;
+  etag: string | null;
 };
 
-async function resolveLinkedAccountToken(
+async function batchResolveLinkedAccountTokens(
   deps: PollSchedulerDeps,
-  linkedAccountId: string | null
-): Promise<string | null> {
-  if (!linkedAccountId) {
-    return null;
+  linkedAccountIds: string[]
+): Promise<Map<string, string>> {
+  const unique = [...new Set(linkedAccountIds.filter(Boolean))];
+  if (unique.length === 0) {
+    return new Map();
   }
 
   try {
     const result = await deps.query(
-      `SELECT access_token
+      `SELECT id, access_token, token_expires_at
        FROM odb.external_auth_providers
-       WHERE id = $1
-       LIMIT 1`,
-      [linkedAccountId]
+       WHERE id = ANY($1::uuid[])`,
+      [unique]
     );
-    const row = result.rows[0] as { access_token?: unknown } | undefined;
-    if (!row || typeof row.access_token !== 'string' || row.access_token.trim().length === 0) {
-      return null;
+    const now = deps.now();
+    const map = new Map<string, string>();
+    for (const rawRow of result.rows) {
+      const row = rawRow as { id?: unknown; access_token?: unknown; token_expires_at?: unknown };
+      if (typeof row.id !== 'string' || typeof row.access_token !== 'string' || !row.access_token.trim()) {
+        continue;
+      }
+      if (row.token_expires_at != null) {
+        const expiresAt = new Date(row.token_expires_at as string);
+        if (!isNaN(expiresAt.getTime()) && expiresAt <= now) {
+          console.warn('Skipping expired linked account token during poll for account:', row.id);
+          continue;
+        }
+      }
+      map.set(row.id, row.access_token);
     }
-    return row.access_token;
+    return map;
   } catch (err) {
-    console.error('Failed to resolve linked account token for poll branch', linkedAccountId, ':', err);
-    return null;
+    console.error('Failed to batch resolve linked account tokens for poll:', err);
+    return new Map();
   }
 }
 
 async function detectGithubBranchHead(
   deps: PollSchedulerDeps,
-  row: QueryRow
+  row: QueryRow,
+  token: string
 ): Promise<DetectedHead | null> {
-  const token = await resolveLinkedAccountToken(deps, row.linked_account_id);
-  if (!token) {
-    return null;
-  }
-
   const headers: HeadersInit = {
     Authorization: `Bearer ${token}`,
     Accept: 'application/vnd.github+json',
     'X-GitHub-Api-Version': '2022-11-28',
   };
-  if (row.last_known_sha) {
-    headers['If-None-Match'] = `"${row.last_known_sha}"`;
+  if (row.last_known_etag) {
+    headers['If-None-Match'] = row.last_known_etag;
   }
 
   const owner = encodeURIComponent(row.owner);
@@ -121,6 +132,7 @@ async function detectGithubBranchHead(
       return {
         sha: row.last_known_sha,
         unchanged: true,
+        etag: null,
       };
     }
     if (!response.ok) {
@@ -138,9 +150,11 @@ async function detectGithubBranchHead(
     if (!sha) {
       return null;
     }
+    const etag = response.headers.get('ETag') ?? null;
     return {
       sha,
       unchanged: row.last_known_sha === sha,
+      etag,
     };
   } catch (err) {
     console.error('Failed to call provider for branch SHA detection', row.branch_id, ':', err);
@@ -294,6 +308,7 @@ export function createRepositoryPollScheduler(
           rb.branch,
           MIN(rcr.linked_account_id) AS linked_account_id,
           rb.last_known_sha,
+          rb.last_known_etag,
           COALESCE(MAX(CASE WHEN ue.plan_code ILIKE 'enterprise%' THEN 1 ELSE 0 END), 0) = 1 AS is_enterprise,
           GREATEST(
             rb.poll_interval_sec,
@@ -320,6 +335,7 @@ export function createRepositoryPollScheduler(
           r.name,
           rb.branch,
           rb.last_known_sha,
+          rb.last_known_etag,
           rb.poll_interval_sec
         ORDER BY rb.next_poll_at ASC, rb.id ASC
         LIMIT $2
@@ -332,14 +348,31 @@ export function createRepositoryPollScheduler(
     const processedIntervalsSec: number[] = [];
     const headShaBranchIds: string[] = [];
     const headShas: string[] = [];
+    const headEtagBranchIds: string[] = [];
+    const headEtags: string[] = [];
 
-    for (const row of rowsResult.rows) {
-      const detectedHead =
-        row.provider === 'github' ? await detectGithubBranchHead(deps, row) : null;
-      if (detectedHead) {
-        headShaBranchIds.push(row.branch_id);
-        headShas.push(detectedHead.sha);
-      }
+    // Batch-prefetch all linked account tokens in one query, checking expiry.
+    const githubLinkedAccountIds = rowsResult.rows
+      .filter((row) => row.provider === 'github')
+      .map((row) => row.linked_account_id)
+      .filter((id): id is string => !!id);
+    const tokenMap = await batchResolveLinkedAccountTokens(deps, githubLinkedAccountIds);
+
+    // Detect HEAD commits with bounded concurrency so scheduler latency scales.
+    const detectedHeads: (DetectedHead | null)[] = new Array(rowsResult.rows.length).fill(null);
+    const headTasks = rowsResult.rows.map((row, index) => async () => {
+      if (row.provider !== 'github') return;
+      const token = tokenMap.get(row.linked_account_id ?? '');
+      if (!token) return;
+      detectedHeads[index] = await detectGithubBranchHead(deps, row, token);
+    });
+    for (let i = 0; i < headTasks.length; i += CONCURRENT_HEAD_CHECKS) {
+      await Promise.all(headTasks.slice(i, i + CONCURRENT_HEAD_CHECKS).map((fn) => fn()));
+    }
+
+    for (let rowIndex = 0; rowIndex < rowsResult.rows.length; rowIndex++) {
+      const row = rowsResult.rows[rowIndex];
+      const detectedHead = detectedHeads[rowIndex] ?? null;
 
       if (detectedHead?.unchanged) {
         processedBranchIds.push(row.branch_id);
@@ -361,6 +394,9 @@ export function createRepositoryPollScheduler(
           stream: 'repo.poll.skipped_unchanged',
           effectivePollIntervalSec: row.effective_poll_interval_sec,
         });
+        // Persist SHA (ETag is null for 304 responses — no update needed).
+        headShaBranchIds.push(row.branch_id);
+        headShas.push(detectedHead.sha);
         continue;
       }
 
@@ -412,6 +448,16 @@ export function createRepositoryPollScheduler(
         stream: job.stream,
         effectivePollIntervalSec: job.effectivePollIntervalSec,
       });
+
+      // Persist SHA and ETag only after the job was successfully enqueued and recorded.
+      if (detectedHead) {
+        headShaBranchIds.push(row.branch_id);
+        headShas.push(detectedHead.sha);
+        if (detectedHead.etag) {
+          headEtagBranchIds.push(row.branch_id);
+          headEtags.push(detectedHead.etag);
+        }
+      }
     }
 
     if (processedBranchIds.length > 0) {
@@ -442,6 +488,20 @@ export function createRepositoryPollScheduler(
         ) upd
         WHERE rb.id = upd.branch_id`,
         [headShaBranchIds, headShas]
+      );
+    }
+
+    if (headEtagBranchIds.length > 0) {
+      await deps.query(
+        `UPDATE odb.repository_branch rb
+        SET last_known_etag = upd.etag
+        FROM (
+          SELECT
+            unnest($1::uuid[]) AS branch_id,
+            unnest($2::text[]) AS etag
+        ) upd
+        WHERE rb.id = upd.branch_id`,
+        [headEtagBranchIds, headEtags]
       );
     }
 

--- a/objectified-ui/lib/repositories/poll-scheduler.ts
+++ b/objectified-ui/lib/repositories/poll-scheduler.ts
@@ -15,6 +15,7 @@ export interface PollJob {
   priority: PollPriority;
   stream: string;
   effectivePollIntervalSec: number;
+  headCommitSha: string | null;
   dispatchedAt: Date;
 }
 
@@ -35,6 +36,7 @@ type QueryRow = {
   linked_account_id: string | null;
   is_enterprise: boolean;
   effective_poll_interval_sec: number;
+  last_known_sha: string | null;
 };
 
 type QueryResult = {
@@ -46,6 +48,7 @@ interface PollSchedulerDeps {
   query: (sql: string, params: unknown[]) => Promise<QueryResult>;
   enqueue: (job: PollJob) => Promise<void>;
   now: () => Date;
+  fetchImpl: typeof fetch;
 }
 
 export interface PollSchedulerOptions {
@@ -55,6 +58,177 @@ export interface PollSchedulerOptions {
 const NON_ENTERPRISE_MIN_POLL_SEC = 300;
 const ENTERPRISE_MIN_POLL_SEC = 60;
 const DEFAULT_BATCH_SIZE = 500;
+const GITHUB_API_BASE = 'https://api.github.com';
+
+type DetectedHead = {
+  sha: string;
+  unchanged: boolean;
+};
+
+async function resolveLinkedAccountToken(
+  deps: PollSchedulerDeps,
+  linkedAccountId: string | null
+): Promise<string | null> {
+  if (!linkedAccountId) {
+    return null;
+  }
+
+  try {
+    const result = await deps.query(
+      `SELECT access_token
+       FROM odb.external_auth_providers
+       WHERE id = $1
+       LIMIT 1`,
+      [linkedAccountId]
+    );
+    const row = result.rows[0] as { access_token?: unknown } | undefined;
+    if (!row || typeof row.access_token !== 'string' || row.access_token.trim().length === 0) {
+      return null;
+    }
+    return row.access_token;
+  } catch (err) {
+    console.error('Failed to resolve linked account token for poll branch', linkedAccountId, ':', err);
+    return null;
+  }
+}
+
+async function detectGithubBranchHead(
+  deps: PollSchedulerDeps,
+  row: QueryRow
+): Promise<DetectedHead | null> {
+  const token = await resolveLinkedAccountToken(deps, row.linked_account_id);
+  if (!token) {
+    return null;
+  }
+
+  const headers: HeadersInit = {
+    Authorization: `Bearer ${token}`,
+    Accept: 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2022-11-28',
+  };
+  if (row.last_known_sha) {
+    headers['If-None-Match'] = `"${row.last_known_sha}"`;
+  }
+
+  const owner = encodeURIComponent(row.owner);
+  const name = encodeURIComponent(row.name);
+  const branch = encodeURIComponent(row.branch);
+  const url = `${GITHUB_API_BASE}/repos/${owner}/${name}/commits/${branch}`;
+
+  try {
+    const response = await deps.fetchImpl(url, { headers });
+    if (response.status === 304 && row.last_known_sha) {
+      return {
+        sha: row.last_known_sha,
+        unchanged: true,
+      };
+    }
+    if (!response.ok) {
+      console.error(
+        'Failed to detect commit SHA for branch',
+        row.branch_id,
+        'status',
+        response.status
+      );
+      return null;
+    }
+
+    const payload = (await response.json()) as { sha?: unknown };
+    const sha = typeof payload.sha === 'string' ? payload.sha : '';
+    if (!sha) {
+      return null;
+    }
+    return {
+      sha,
+      unchanged: row.last_known_sha === sha,
+    };
+  } catch (err) {
+    console.error('Failed to call provider for branch SHA detection', row.branch_id, ':', err);
+    return null;
+  }
+}
+
+async function insertScheduledScan(
+  deps: PollSchedulerDeps,
+  args: {
+    repositoryId: string;
+    branch: string;
+    commitSha: string;
+    status: 'pending' | 'skipped_unchanged';
+    at: Date;
+  }
+): Promise<void> {
+  const atIso = args.at.toISOString();
+  const eventLog =
+    args.status === 'skipped_unchanged'
+      ? [
+          {
+            type: 'repository.scan.skipped_unchanged',
+            at: atIso,
+            reason: 'scheduled poll detected no changes',
+          },
+        ]
+      : [
+          {
+            type: 'repository.scan.queued',
+            at: atIso,
+            trigger: 'scheduled',
+          },
+        ];
+  const finishedAt = args.status === 'skipped_unchanged' ? atIso : null;
+  const durationMs = args.status === 'skipped_unchanged' ? 0 : null;
+
+  try {
+    await deps.query(
+      `INSERT INTO odb.repository_scan (
+        id,
+        repository_id,
+        branch,
+        commit_sha,
+        trigger,
+        status,
+        started_at,
+        finished_at,
+        duration_ms,
+        files_seen,
+        files_classified,
+        files_unknown,
+        files_failed,
+        event_log,
+        diff_summary
+      ) VALUES (
+        $1::uuid,
+        $2::uuid,
+        $3,
+        $4,
+        'scheduled',
+        $5::odb.repository_scan_status,
+        $6::timestamptz,
+        $7::timestamptz,
+        $8,
+        0,
+        0,
+        0,
+        0,
+        $9::jsonb,
+        '{}'::jsonb
+      )`,
+      [
+        crypto.randomUUID(),
+        args.repositoryId,
+        args.branch,
+        args.commitSha,
+        args.status,
+        atIso,
+        finishedAt,
+        durationMs,
+        JSON.stringify(eventLog),
+      ]
+    );
+  } catch (err) {
+    console.error('Failed to insert repository_scan row for scheduled poll branch', args.branch, ':', err);
+  }
+}
 
 async function insertDispatchAudit(
   deps: PollSchedulerDeps,
@@ -102,6 +276,7 @@ export function createRepositoryPollScheduler(
     query: partialDeps.query,
     enqueue: partialDeps.enqueue,
     now: partialDeps.now ?? (() => new Date()),
+    fetchImpl: partialDeps.fetchImpl ?? fetch,
   };
   const batchSize = options?.batchSize ?? DEFAULT_BATCH_SIZE;
 
@@ -118,6 +293,7 @@ export function createRepositoryPollScheduler(
           r.name,
           rb.branch,
           MIN(rcr.linked_account_id) AS linked_account_id,
+          rb.last_known_sha,
           COALESCE(MAX(CASE WHEN ue.plan_code ILIKE 'enterprise%' THEN 1 ELSE 0 END), 0) = 1 AS is_enterprise,
           GREATEST(
             rb.poll_interval_sec,
@@ -143,6 +319,7 @@ export function createRepositoryPollScheduler(
           r.owner,
           r.name,
           rb.branch,
+          rb.last_known_sha,
           rb.poll_interval_sec
         ORDER BY rb.next_poll_at ASC, rb.id ASC
         LIMIT $2
@@ -151,10 +328,42 @@ export function createRepositoryPollScheduler(
     );
 
     const jobs: PollJob[] = [];
-    const enqueuedBranchIds: string[] = [];
-    const enqueuedIntervalsSec: number[] = [];
+    const processedBranchIds: string[] = [];
+    const processedIntervalsSec: number[] = [];
+    const headShaBranchIds: string[] = [];
+    const headShas: string[] = [];
 
     for (const row of rowsResult.rows) {
+      const detectedHead =
+        row.provider === 'github' ? await detectGithubBranchHead(deps, row) : null;
+      if (detectedHead) {
+        headShaBranchIds.push(row.branch_id);
+        headShas.push(detectedHead.sha);
+      }
+
+      if (detectedHead?.unchanged) {
+        processedBranchIds.push(row.branch_id);
+        processedIntervalsSec.push(row.effective_poll_interval_sec);
+        await insertScheduledScan(deps, {
+          repositoryId: row.repository_id,
+          branch: row.branch,
+          commitSha: detectedHead.sha,
+          status: 'skipped_unchanged',
+          at: now,
+        });
+        await insertDispatchAudit(deps, {
+          tenantId: row.tenant_id,
+          projectId: row.project_id,
+          repositoryId: row.repository_id,
+          branch: row.branch,
+          actorId: null,
+          priority: row.is_enterprise ? 'high' : 'normal',
+          stream: 'repo.poll.skipped_unchanged',
+          effectivePollIntervalSec: row.effective_poll_interval_sec,
+        });
+        continue;
+      }
+
       const priority: PollPriority = row.is_enterprise ? 'high' : 'normal';
       const stream = `repo.poll.${priority}`;
       const job: PollJob = {
@@ -170,6 +379,7 @@ export function createRepositoryPollScheduler(
         priority,
         stream,
         effectivePollIntervalSec: row.effective_poll_interval_sec,
+        headCommitSha: detectedHead?.sha ?? null,
         dispatchedAt: now,
       };
 
@@ -180,9 +390,17 @@ export function createRepositoryPollScheduler(
         continue;
       }
 
-      enqueuedBranchIds.push(job.branchId);
-      enqueuedIntervalsSec.push(job.effectivePollIntervalSec);
+      processedBranchIds.push(job.branchId);
+      processedIntervalsSec.push(job.effectivePollIntervalSec);
       jobs.push(job);
+
+      await insertScheduledScan(deps, {
+        repositoryId: job.repositoryId,
+        branch: job.branch,
+        commitSha: job.headCommitSha ?? `pending-${crypto.randomUUID().replace(/-/g, '').slice(0, 12)}`,
+        status: 'pending',
+        at: now,
+      });
 
       await insertDispatchAudit(deps, {
         tenantId: job.tenantId,
@@ -196,7 +414,7 @@ export function createRepositoryPollScheduler(
       });
     }
 
-    if (enqueuedBranchIds.length > 0) {
+    if (processedBranchIds.length > 0) {
       await deps.query(
         `UPDATE odb.repository_branch rb
         SET
@@ -209,7 +427,21 @@ export function createRepositoryPollScheduler(
             $3::timestamptz AS now
         ) upd
         WHERE rb.id = upd.branch_id`,
-        [enqueuedBranchIds, enqueuedIntervalsSec, now.toISOString()]
+        [processedBranchIds, processedIntervalsSec, now.toISOString()]
+      );
+    }
+
+    if (headShaBranchIds.length > 0) {
+      await deps.query(
+        `UPDATE odb.repository_branch rb
+        SET last_known_sha = upd.sha
+        FROM (
+          SELECT
+            unnest($1::uuid[]) AS branch_id,
+            unnest($2::text[]) AS sha
+        ) upd
+        WHERE rb.id = upd.branch_id`,
+        [headShaBranchIds, headShas]
       );
     }
 

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.10.34",
+  "version": "0.10.35",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -5,6 +5,7 @@ We continue to improve the platform based on your feedback with improvements and
 ---
 
 ## Repositories
+- Added poll-time branch HEAD SHA change detection with GitHub conditional `If-None-Match` checks so unchanged branches write `skipped_unchanged` scan history entries and skip downstream scan dispatch while still advancing poll cadence.
 - Added a repository poll scheduler tick that atomically reserves due tracked branches, skips paused repositories, enforces enterprise/free poll interval floors, dispatches `repo.poll.<priority>` jobs, and records `repository.polled` workflow audits.
 - Added the REPO-3.8 in-scan virtual filesystem resolver for repository imports, with dependency-ordered cross-file `$ref` resolution (relative paths + JSON pointers), per-scan memoization, and deterministic cycle detection errors.
 - Added standalone repository JSON Schema importer support for Draft 7, 2019-09, and 2020-12 schemas, preserving source `$id`/draft metadata while delegating sibling `$ref` resolution through the REPO-3.8 resolver contract.

--- a/objectified-ui/tests/unit/repository-poll-scheduler.test.ts
+++ b/objectified-ui/tests/unit/repository-poll-scheduler.test.ts
@@ -19,7 +19,7 @@ function makeQueryStub(handlers: Array<(sql: string, params: unknown[]) => Query
 }
 
 describe('repository poll scheduler', () => {
-  it('reserves only due tracked branches, skips paused repositories, and enforces poll interval floors', async () => {
+  it('dispatches only changed branches and records skipped_unchanged scans', async () => {
     const query = makeQueryStub([
       (sql, params) => {
         expect(sql).toContain('FROM odb.repository_branch rb');
@@ -28,7 +28,7 @@ describe('repository poll scheduler', () => {
         expect(sql).toContain("ue.plan_code ILIKE 'enterprise%'");
         expect(sql).toContain('GREATEST(');
         expect(sql).toContain('MIN(rcr.linked_account_id)');
-        expect(sql).not.toContain('bumped');
+        expect(sql).toContain('rb.last_known_sha');
         expect(params).toEqual(['2026-04-24T20:00:00.000Z', 500, 60, 300]);
         return {
           rowCount: 2,
@@ -43,6 +43,7 @@ describe('repository poll scheduler', () => {
               name: 'catalog',
               branch: 'main',
               linked_account_id: 'linked-1',
+              last_known_sha: 'old-sha-1',
               is_enterprise: false,
               effective_poll_interval_sec: 300,
             },
@@ -55,7 +56,8 @@ describe('repository poll scheduler', () => {
               owner: 'acme',
               name: 'payments',
               branch: 'develop',
-              linked_account_id: null,
+              linked_account_id: 'linked-2',
+              last_known_sha: 'old-sha-2',
               is_enterprise: true,
               effective_poll_interval_sec: 60,
             },
@@ -63,59 +65,106 @@ describe('repository poll scheduler', () => {
         };
       },
       (sql, params) => {
+        expect(sql).toContain('SELECT access_token');
+        expect(params).toEqual(['linked-1']);
+        return { rowCount: 1, rows: [{ access_token: 'token-1' }] };
+      },
+      (sql, params) => {
+        expect(sql).toContain('INSERT INTO odb.repository_scan');
+        expect(params[2]).toBe('main');
+        expect(params[3]).toBe('new-sha-1');
+        expect(params[4]).toBe('pending');
+        return { rowCount: 1, rows: [] };
+      },
+      (sql, params) => {
         expect(sql).toContain('INSERT INTO odb.workflow_audit');
-        expect(params[2]).toBe('repository.polled');
-        expect(params[3]).toBe('success');
-        expect(params[4]).toBeNull();
         const detail = JSON.parse(String(params[5]));
         expect(detail).toMatchObject({
           repository_id: 'repo-1',
           branch: 'main',
-          priority: 'normal',
           stream: 'repo.poll.normal',
           poll_interval_sec: 300,
         });
         return { rowCount: 1, rows: [] };
       },
       (sql, params) => {
+        expect(sql).toContain('SELECT access_token');
+        expect(params).toEqual(['linked-2']);
+        return { rowCount: 1, rows: [{ access_token: 'token-2' }] };
+      },
+      (sql, params) => {
+        expect(sql).toContain('INSERT INTO odb.repository_scan');
+        expect(params[2]).toBe('develop');
+        expect(params[3]).toBe('old-sha-2');
+        expect(params[4]).toBe('skipped_unchanged');
+        return { rowCount: 1, rows: [] };
+      },
+      (sql, params) => {
         expect(sql).toContain('INSERT INTO odb.workflow_audit');
-        expect(params[2]).toBe('repository.polled');
-        expect(params[3]).toBe('success');
-        expect(params[4]).toBeNull();
         const detail = JSON.parse(String(params[5]));
         expect(detail).toMatchObject({
           repository_id: 'repo-2',
           branch: 'develop',
-          priority: 'high',
-          stream: 'repo.poll.high',
+          stream: 'repo.poll.skipped_unchanged',
           poll_interval_sec: 60,
         });
         return { rowCount: 1, rows: [] };
       },
       (sql, params) => {
         expect(sql).toContain('UPDATE odb.repository_branch rb');
-        expect(sql).toContain('next_poll_at = upd.now + make_interval');
         expect(params[0]).toEqual(['branch-1', 'branch-2']);
         expect(params[1]).toEqual([300, 60]);
         expect(params[2]).toBe('2026-04-24T20:00:00.000Z');
         return { rowCount: 2, rows: [] };
       },
+      (sql, params) => {
+        expect(sql).toContain('SET last_known_sha = upd.sha');
+        expect(params[0]).toEqual(['branch-1', 'branch-2']);
+        expect(params[1]).toEqual(['new-sha-1', 'old-sha-2']);
+        return { rowCount: 2, rows: [] };
+      },
     ]);
     const enqueue = jest.fn(async () => undefined);
+    const fetchImpl = jest
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ sha: 'new-sha-1' }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 304,
+        json: async () => ({}),
+      } as Response);
     const scheduler = createRepositoryPollScheduler({
       query,
       enqueue,
+      fetchImpl,
       now: () => new Date('2026-04-24T20:00:00.000Z'),
     });
 
     const result = await scheduler();
 
-    expect(result.dispatched).toBe(2);
+    expect(result.dispatched).toBe(1);
     expect(result.jobs.map((job) => [job.branchId, job.stream, job.effectivePollIntervalSec])).toEqual([
       ['branch-1', 'repo.poll.normal', 300],
-      ['branch-2', 'repo.poll.high', 60],
     ]);
-    expect(enqueue).toHaveBeenCalledTimes(2);
+    expect(result.jobs[0]?.headCommitSha).toBe('new-sha-1');
+    expect(enqueue).toHaveBeenCalledTimes(1);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(fetchImpl.mock.calls[0]?.[1]).toMatchObject({
+      headers: expect.objectContaining({
+        Authorization: 'Bearer token-1',
+        'If-None-Match': '"old-sha-1"',
+      }),
+    });
+    expect(fetchImpl.mock.calls[1]?.[1]).toMatchObject({
+      headers: expect.objectContaining({
+        Authorization: 'Bearer token-2',
+        'If-None-Match': '"old-sha-2"',
+      }),
+    });
   });
 
   it('is idempotent across adjacent ticks when no rows remain due', async () => {
@@ -133,19 +182,29 @@ describe('repository poll scheduler', () => {
             name: 'catalog',
             branch: 'main',
             linked_account_id: 'linked-1',
+            last_known_sha: 'old-sha-1',
             is_enterprise: false,
             effective_poll_interval_sec: 300,
           },
         ],
       }),
+      () => ({ rowCount: 1, rows: [{ access_token: 'token-1' }] }),
+      () => ({ rowCount: 1, rows: [] }),
+      () => ({ rowCount: 1, rows: [] }),
       () => ({ rowCount: 1, rows: [] }),
       () => ({ rowCount: 1, rows: [] }),
       () => ({ rowCount: 0, rows: [] }),
     ]);
     const enqueue = jest.fn(async () => undefined);
+    const fetchImpl = jest.fn<typeof fetch>().mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ sha: 'new-sha-1' }),
+    } as Response);
     const scheduler = createRepositoryPollScheduler({
       query,
       enqueue,
+      fetchImpl,
       now: () => new Date('2026-04-24T20:01:00.000Z'),
     });
 
@@ -155,5 +214,6 @@ describe('repository poll scheduler', () => {
     expect(first.dispatched).toBe(1);
     expect(second.dispatched).toBe(0);
     expect(enqueue).toHaveBeenCalledTimes(1);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
   });
 });

--- a/objectified-ui/tests/unit/repository-poll-scheduler.test.ts
+++ b/objectified-ui/tests/unit/repository-poll-scheduler.test.ts
@@ -29,6 +29,7 @@ describe('repository poll scheduler', () => {
         expect(sql).toContain('GREATEST(');
         expect(sql).toContain('MIN(rcr.linked_account_id)');
         expect(sql).toContain('rb.last_known_sha');
+        expect(sql).toContain('rb.last_known_etag');
         expect(params).toEqual(['2026-04-24T20:00:00.000Z', 500, 60, 300]);
         return {
           rowCount: 2,
@@ -44,6 +45,7 @@ describe('repository poll scheduler', () => {
               branch: 'main',
               linked_account_id: 'linked-1',
               last_known_sha: 'old-sha-1',
+              last_known_etag: null,
               is_enterprise: false,
               effective_poll_interval_sec: 300,
             },
@@ -58,6 +60,7 @@ describe('repository poll scheduler', () => {
               branch: 'develop',
               linked_account_id: 'linked-2',
               last_known_sha: 'old-sha-2',
+              last_known_etag: '"etag-old-2"',
               is_enterprise: true,
               effective_poll_interval_sec: 60,
             },
@@ -65,9 +68,16 @@ describe('repository poll scheduler', () => {
         };
       },
       (sql, params) => {
-        expect(sql).toContain('SELECT access_token');
-        expect(params).toEqual(['linked-1']);
-        return { rowCount: 1, rows: [{ access_token: 'token-1' }] };
+        expect(sql).toContain('SELECT id, access_token, token_expires_at');
+        expect(sql).toContain('WHERE id = ANY($1::uuid[])');
+        expect(params[0]).toEqual(['linked-1', 'linked-2']);
+        return {
+          rowCount: 2,
+          rows: [
+            { id: 'linked-1', access_token: 'token-1', token_expires_at: null },
+            { id: 'linked-2', access_token: 'token-2', token_expires_at: null },
+          ],
+        };
       },
       (sql, params) => {
         expect(sql).toContain('INSERT INTO odb.repository_scan');
@@ -86,11 +96,6 @@ describe('repository poll scheduler', () => {
           poll_interval_sec: 300,
         });
         return { rowCount: 1, rows: [] };
-      },
-      (sql, params) => {
-        expect(sql).toContain('SELECT access_token');
-        expect(params).toEqual(['linked-2']);
-        return { rowCount: 1, rows: [{ access_token: 'token-2' }] };
       },
       (sql, params) => {
         expect(sql).toContain('INSERT INTO odb.repository_scan');
@@ -123,6 +128,12 @@ describe('repository poll scheduler', () => {
         expect(params[1]).toEqual(['new-sha-1', 'old-sha-2']);
         return { rowCount: 2, rows: [] };
       },
+      (sql, params) => {
+        expect(sql).toContain('SET last_known_etag = upd.etag');
+        expect(params[0]).toEqual(['branch-1']);
+        expect(params[1]).toEqual(['"etag-new-1"']);
+        return { rowCount: 1, rows: [] };
+      },
     ]);
     const enqueue = jest.fn(async () => undefined);
     const fetchImpl = jest
@@ -131,11 +142,13 @@ describe('repository poll scheduler', () => {
         ok: true,
         status: 200,
         json: async () => ({ sha: 'new-sha-1' }),
+        headers: { get: (h: string) => (h === 'ETag' ? '"etag-new-1"' : null) } as unknown as Headers,
       } as Response)
       .mockResolvedValueOnce({
         ok: false,
         status: 304,
         json: async () => ({}),
+        headers: { get: () => null } as unknown as Headers,
       } as Response);
     const scheduler = createRepositoryPollScheduler({
       query,
@@ -153,16 +166,20 @@ describe('repository poll scheduler', () => {
     expect(result.jobs[0]?.headCommitSha).toBe('new-sha-1');
     expect(enqueue).toHaveBeenCalledTimes(1);
     expect(fetchImpl).toHaveBeenCalledTimes(2);
+    // branch-1: no prior ETag so no If-None-Match header
     expect(fetchImpl.mock.calls[0]?.[1]).toMatchObject({
       headers: expect.objectContaining({
         Authorization: 'Bearer token-1',
-        'If-None-Match': '"old-sha-1"',
       }),
     });
+    expect((fetchImpl.mock.calls[0]?.[1] as RequestInit | undefined)?.headers).not.toMatchObject(
+      expect.objectContaining({ 'If-None-Match': expect.anything() })
+    );
+    // branch-2: uses stored ETag for conditional request
     expect(fetchImpl.mock.calls[1]?.[1]).toMatchObject({
       headers: expect.objectContaining({
         Authorization: 'Bearer token-2',
-        'If-None-Match': '"old-sha-2"',
+        'If-None-Match': '"etag-old-2"',
       }),
     });
   });
@@ -183,12 +200,13 @@ describe('repository poll scheduler', () => {
             branch: 'main',
             linked_account_id: 'linked-1',
             last_known_sha: 'old-sha-1',
+            last_known_etag: null,
             is_enterprise: false,
             effective_poll_interval_sec: 300,
           },
         ],
       }),
-      () => ({ rowCount: 1, rows: [{ access_token: 'token-1' }] }),
+      () => ({ rowCount: 1, rows: [{ id: 'linked-1', access_token: 'token-1', token_expires_at: null }] }),
       () => ({ rowCount: 1, rows: [] }),
       () => ({ rowCount: 1, rows: [] }),
       () => ({ rowCount: 1, rows: [] }),
@@ -200,6 +218,7 @@ describe('repository poll scheduler', () => {
       ok: true,
       status: 200,
       json: async () => ({ sha: 'new-sha-1' }),
+      headers: { get: () => null } as unknown as Headers,
     } as Response);
     const scheduler = createRepositoryPollScheduler({
       query,
@@ -217,3 +236,4 @@ describe('repository poll scheduler', () => {
     expect(fetchImpl).toHaveBeenCalledTimes(1);
   });
 });
+


### PR DESCRIPTION
## Summary
- Add scheduled poll commit-SHA detection by resolving GitHub branch HEAD with conditional `If-None-Match` requests keyed from `last_known_sha`.
- Record `repository_scan` rows as `skipped_unchanged` when the branch HEAD has not changed, and enqueue downstream work only for changed branches.
- Persist detected branch SHA updates, keep poll cadence updates for skipped and changed branches, and extend scheduler unit tests for changed-vs-unchanged behavior.

## Test plan
- [x] `yarn test repository-poll-scheduler` (from `objectified-ui`)
- [x] `yarn build` (repo root, fails due existing `@gitbeaker/rest` resolution issue in `objectified-ui`)
- [x] `yarn test` (repo root, scheduler tests pass; fails due existing `@gitbeaker/rest` module issue and existing `tests/llm-streaming.test.ts` pretty-format runtime error)

## Risk / notes
- Introduces poll-time provider API lookups for GitHub branch HEAD detection, including linked-account token resolution.
- If provider SHA lookup fails, scheduler falls back to enqueueing a full scan instead of falsely skipping.

Closes #2780

Made with [Cursor](https://cursor.com)