### PR TITLE
Fix #2782 - add multi-branch wildcard expansion in scheduler

### DIFF
--- a/docs/PLANNED_FEATURE_ROADMAP_REPOSITORY.md
+++ b/docs/PLANNED_FEATURE_ROADMAP_REPOSITORY.md
@@ -2,6 +2,7 @@
 
 ## Completed
 
+- REPO-4.4 (#2782): Added multi-branch scheduler tracking for wildcard patterns by treating branch globs as discovery templates, expanding provider-matched concrete branches at poll time into `repository_branch` rows, and preserving branch scan history by re-tracking existing rows instead of deleting history.
 - REPO-4.2 (#2780): Added commit-SHA change detection in scheduled polling by resolving provider branch HEADs, using conditional `If-None-Match` requests for GitHub checks, recording `skipped_unchanged` scans when HEAD is unchanged, and only dispatching downstream scan jobs when SHA changes.
 - REPO-4.1 (#2779): Added a scheduler tick dispatcher that atomically reserves due tracked branches, skips paused repositories, clamps poll cadence to enterprise/non-enterprise minimums, dispatches poll jobs to `repo.poll.<priority>`, and records `repository.polled` workflow audit rows per dispatch.
 - REPO-3.8 (#2777): Added an in-scan virtual filesystem `$ref` resolver for repository imports that resolves relative file-path and JSON-pointer chains in dependency order, memoizes repeated nodes per scan, and emits deterministic cycle errors for cross-file loops.

--- a/objectified-ui/lib/repositories/poll-scheduler.ts
+++ b/objectified-ui/lib/repositories/poll-scheduler.ts
@@ -33,6 +33,8 @@ type QueryRow = {
   owner: string;
   name: string;
   branch: string;
+  subpath_glob: string;
+  configured_poll_interval_sec: number;
   linked_account_id: string | null;
   is_enterprise: boolean;
   effective_poll_interval_sec: number;
@@ -67,6 +69,168 @@ type DetectedHead = {
   unchanged: boolean;
   etag: string | null;
 };
+
+function isBranchGlobPattern(branch: string): boolean {
+  return branch.includes('*') || branch.includes('?') || branch.includes('[') || branch.includes(']');
+}
+
+function escapeRegExpLiteral(value: string): string {
+  return value.replace(/[|\\{}()[\]^$+?.]/g, '\\$&');
+}
+
+function branchGlobToRegExp(branchGlob: string): RegExp {
+  let regex = '^';
+  for (let i = 0; i < branchGlob.length; i += 1) {
+    const char = branchGlob[i];
+    if (char === '*') {
+      const isDoubleStar = branchGlob[i + 1] === '*';
+      if (isDoubleStar) {
+        regex += '.*';
+        i += 1;
+      } else {
+        regex += '[^/]*';
+      }
+      continue;
+    }
+    if (char === '?') {
+      regex += '[^/]';
+      continue;
+    }
+    regex += escapeRegExpLiteral(char);
+  }
+  regex += '$';
+  return new RegExp(regex);
+}
+
+async function listGithubRepositoryBranches(
+  deps: PollSchedulerDeps,
+  row: QueryRow,
+  token: string
+): Promise<string[] | null> {
+  const owner = encodeURIComponent(row.owner);
+  const name = encodeURIComponent(row.name);
+  const headers: HeadersInit = {
+    Authorization: `Bearer ${token}`,
+    Accept: 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2022-11-28',
+  };
+  const branchNames: string[] = [];
+  let page = 1;
+  const perPage = 100;
+
+  while (true) {
+    const url = `${GITHUB_API_BASE}/repos/${owner}/${name}/branches?per_page=${perPage}&page=${page}`;
+    let response: Response;
+    try {
+      response = await deps.fetchImpl(url, { headers });
+    } catch (err) {
+      console.error('Failed to list provider branches for wildcard expansion', row.branch_id, ':', err);
+      return null;
+    }
+    if (!response.ok) {
+      console.error(
+        'Failed to list provider branches for wildcard expansion',
+        row.branch_id,
+        'status',
+        response.status
+      );
+      return null;
+    }
+    const payload = (await response.json()) as Array<{ name?: unknown }>;
+    if (!Array.isArray(payload)) {
+      return null;
+    }
+    for (const entry of payload) {
+      if (typeof entry.name === 'string' && entry.name) {
+        branchNames.push(entry.name);
+      }
+    }
+    if (payload.length < perPage) {
+      break;
+    }
+    page += 1;
+  }
+
+  return branchNames;
+}
+
+async function expandWildcardBranchRows(
+  deps: PollSchedulerDeps,
+  rows: QueryRow[],
+  tokenMap: Map<string, string>,
+  now: Date
+): Promise<{ dispatchRows: QueryRow[]; templateBranchIds: string[]; templateIntervalsSec: number[] }> {
+  const dispatchRows: QueryRow[] = [];
+  const templateBranchIds: string[] = [];
+  const templateIntervalsSec: number[] = [];
+
+  for (const row of rows) {
+    if (!isBranchGlobPattern(row.branch)) {
+      dispatchRows.push(row);
+      continue;
+    }
+
+    templateBranchIds.push(row.branch_id);
+    templateIntervalsSec.push(row.effective_poll_interval_sec);
+
+    if (row.provider !== 'github') {
+      continue;
+    }
+    const token = tokenMap.get(row.linked_account_id ?? '');
+    if (!token) {
+      continue;
+    }
+
+    const providerBranches = await listGithubRepositoryBranches(deps, row, token);
+    if (!providerBranches || providerBranches.length === 0) {
+      continue;
+    }
+
+    const matcher = branchGlobToRegExp(row.branch);
+    const matchingBranches = providerBranches.filter((branch) => matcher.test(branch));
+    for (const matchedBranch of matchingBranches) {
+      try {
+        await deps.query(
+          `INSERT INTO odb.repository_branch (
+            repository_id,
+            branch,
+            subpath_glob,
+            is_tracked,
+            poll_interval_sec,
+            next_poll_at
+          ) VALUES (
+            $1::uuid,
+            $2,
+            $3,
+            TRUE,
+            $4,
+            $5::timestamptz
+          )
+          ON CONFLICT (repository_id, branch) DO UPDATE
+          SET
+            is_tracked = TRUE,
+            subpath_glob = EXCLUDED.subpath_glob,
+            poll_interval_sec = EXCLUDED.poll_interval_sec,
+            next_poll_at = LEAST(
+              COALESCE(odb.repository_branch.next_poll_at, EXCLUDED.next_poll_at),
+              EXCLUDED.next_poll_at
+            )`,
+          [
+            row.repository_id,
+            matchedBranch,
+            row.subpath_glob,
+            row.configured_poll_interval_sec,
+            now.toISOString(),
+          ]
+        );
+      } catch (err) {
+        console.error('Failed to upsert expanded wildcard branch', matchedBranch, 'for row', row.branch_id, ':', err);
+      }
+    }
+  }
+
+  return { dispatchRows, templateBranchIds, templateIntervalsSec };
+}
 
 async function batchResolveLinkedAccountTokens(
   deps: PollSchedulerDeps,
@@ -306,6 +470,8 @@ export function createRepositoryPollScheduler(
           r.owner,
           r.name,
           rb.branch,
+          rb.subpath_glob,
+          rb.poll_interval_sec AS configured_poll_interval_sec,
           MIN(rcr.linked_account_id) AS linked_account_id,
           rb.last_known_sha,
           rb.last_known_etag,
@@ -344,8 +510,6 @@ export function createRepositoryPollScheduler(
     );
 
     const jobs: PollJob[] = [];
-    const processedBranchIds: string[] = [];
-    const processedIntervalsSec: number[] = [];
     const headShaBranchIds: string[] = [];
     const headShas: string[] = [];
     const headEtagBranchIds: string[] = [];
@@ -357,10 +521,18 @@ export function createRepositoryPollScheduler(
       .map((row) => row.linked_account_id)
       .filter((id): id is string => !!id);
     const tokenMap = await batchResolveLinkedAccountTokens(deps, githubLinkedAccountIds);
+    const { dispatchRows, templateBranchIds, templateIntervalsSec } = await expandWildcardBranchRows(
+      deps,
+      rowsResult.rows,
+      tokenMap,
+      now
+    );
+    const processedBranchIds: string[] = [...templateBranchIds];
+    const processedIntervalsSec: number[] = [...templateIntervalsSec];
 
     // Detect HEAD commits with bounded concurrency so scheduler latency scales.
-    const detectedHeads: (DetectedHead | null)[] = new Array(rowsResult.rows.length).fill(null);
-    const headTasks = rowsResult.rows.map((row, index) => async () => {
+    const detectedHeads: (DetectedHead | null)[] = new Array(dispatchRows.length).fill(null);
+    const headTasks = dispatchRows.map((row, index) => async () => {
       if (row.provider !== 'github') return;
       const token = tokenMap.get(row.linked_account_id ?? '');
       if (!token) return;
@@ -370,8 +542,8 @@ export function createRepositoryPollScheduler(
       await Promise.all(headTasks.slice(i, i + CONCURRENT_HEAD_CHECKS).map((fn) => fn()));
     }
 
-    for (let rowIndex = 0; rowIndex < rowsResult.rows.length; rowIndex++) {
-      const row = rowsResult.rows[rowIndex];
+    for (let rowIndex = 0; rowIndex < dispatchRows.length; rowIndex++) {
+      const row = dispatchRows[rowIndex];
       const detectedHead = detectedHeads[rowIndex] ?? null;
 
       if (detectedHead?.unchanged) {

--- a/objectified-ui/lib/repositories/poll-scheduler.ts
+++ b/objectified-ui/lib/repositories/poll-scheduler.ts
@@ -71,7 +71,7 @@ type DetectedHead = {
 };
 
 function isBranchGlobPattern(branch: string): boolean {
-  return branch.includes('*') || branch.includes('?') || branch.includes('[') || branch.includes(']');
+  return branch.includes('*') || branch.includes('?');
 }
 
 function escapeRegExpLiteral(value: string): string {
@@ -188,44 +188,54 @@ async function expandWildcardBranchRows(
 
     const matcher = branchGlobToRegExp(row.branch);
     const matchingBranches = providerBranches.filter((branch) => matcher.test(branch));
-    for (const matchedBranch of matchingBranches) {
-      try {
-        await deps.query(
-          `INSERT INTO odb.repository_branch (
-            repository_id,
-            branch,
-            subpath_glob,
-            is_tracked,
-            poll_interval_sec,
-            next_poll_at
-          ) VALUES (
-            $1::uuid,
-            $2,
-            $3,
-            TRUE,
-            $4,
-            $5::timestamptz
-          )
-          ON CONFLICT (repository_id, branch) DO UPDATE
-          SET
-            is_tracked = TRUE,
-            subpath_glob = EXCLUDED.subpath_glob,
-            poll_interval_sec = EXCLUDED.poll_interval_sec,
-            next_poll_at = LEAST(
-              COALESCE(odb.repository_branch.next_poll_at, EXCLUDED.next_poll_at),
-              EXCLUDED.next_poll_at
-            )`,
-          [
-            row.repository_id,
-            matchedBranch,
-            row.subpath_glob,
-            row.configured_poll_interval_sec,
-            now.toISOString(),
-          ]
-        );
-      } catch (err) {
-        console.error('Failed to upsert expanded wildcard branch', matchedBranch, 'for row', row.branch_id, ':', err);
-      }
+    if (matchingBranches.length === 0) {
+      continue;
+    }
+
+    try {
+      await deps.query(
+        `INSERT INTO odb.repository_branch (
+          repository_id,
+          branch,
+          subpath_glob,
+          is_tracked,
+          poll_interval_sec,
+          next_poll_at
+        )
+        SELECT
+          $1::uuid,
+          matched_branch.branch,
+          $3,
+          TRUE,
+          $4,
+          $5::timestamptz
+        FROM unnest($2::text[]) AS matched_branch(branch)
+        ON CONFLICT (repository_id, branch) DO UPDATE
+        SET
+          is_tracked = TRUE,
+          subpath_glob = EXCLUDED.subpath_glob,
+          poll_interval_sec = EXCLUDED.poll_interval_sec,
+          next_poll_at = LEAST(
+            COALESCE(odb.repository_branch.next_poll_at, EXCLUDED.next_poll_at),
+            EXCLUDED.next_poll_at
+          )`,
+        [
+          row.repository_id,
+          matchingBranches,
+          row.subpath_glob,
+          row.configured_poll_interval_sec,
+          now.toISOString(),
+        ]
+      );
+    } catch (err) {
+      console.error(
+        'Failed to upsert expanded wildcard branches',
+        matchingBranches,
+        'for row',
+        row.branch_id,
+        ':',
+        err
+      );
     }
   }
 

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.10.35",
+  "version": "0.10.36",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -5,6 +5,7 @@ We continue to improve the platform based on your feedback with improvements and
 ---
 
 ## Repositories
+- Added REPO-4.4 multi-branch tracking so wildcard branch templates (for example `release/*`) expand at scheduler time into tracked concrete repository branches without deleting historical scan records for previously seen branches.
 - Added poll-time branch HEAD SHA change detection with GitHub conditional `If-None-Match` checks so unchanged branches write `skipped_unchanged` scan history entries and skip downstream scan dispatch while still advancing poll cadence.
 - Added a repository poll scheduler tick that atomically reserves due tracked branches, skips paused repositories, enforces enterprise/free poll interval floors, dispatches `repo.poll.<priority>` jobs, and records `repository.polled` workflow audits.
 - Added the REPO-3.8 in-scan virtual filesystem resolver for repository imports, with dependency-ordered cross-file `$ref` resolution (relative paths + JSON pointers), per-scan memoization, and deterministic cycle detection errors.

--- a/objectified-ui/tests/unit/repository-poll-scheduler.test.ts
+++ b/objectified-ui/tests/unit/repository-poll-scheduler.test.ts
@@ -281,7 +281,7 @@ describe('repository poll scheduler', () => {
       (sql, params) => {
         expect(sql).toContain('INSERT INTO odb.repository_branch');
         expect(sql).toContain('ON CONFLICT (repository_id, branch) DO UPDATE');
-        expect(params).toEqual(['repo-9', 'release/2026.04', 'services/**', 180, '2026-04-24T20:02:00.000Z']);
+        expect(params).toEqual(['repo-9', ['release/2026.04'], 'services/**', 180, '2026-04-24T20:02:00.000Z']);
         return { rowCount: 1, rows: [] };
       },
       (sql, params) => {

--- a/objectified-ui/tests/unit/repository-poll-scheduler.test.ts
+++ b/objectified-ui/tests/unit/repository-poll-scheduler.test.ts
@@ -43,6 +43,8 @@ describe('repository poll scheduler', () => {
               owner: 'acme',
               name: 'catalog',
               branch: 'main',
+              subpath_glob: '**/*',
+              configured_poll_interval_sec: 300,
               linked_account_id: 'linked-1',
               last_known_sha: 'old-sha-1',
               last_known_etag: null,
@@ -58,6 +60,8 @@ describe('repository poll scheduler', () => {
               owner: 'acme',
               name: 'payments',
               branch: 'develop',
+              subpath_glob: '**/*',
+              configured_poll_interval_sec: 60,
               linked_account_id: 'linked-2',
               last_known_sha: 'old-sha-2',
               last_known_etag: '"etag-old-2"',
@@ -198,6 +202,8 @@ describe('repository poll scheduler', () => {
             owner: 'acme',
             name: 'catalog',
             branch: 'main',
+            subpath_glob: '**/*',
+            configured_poll_interval_sec: 300,
             linked_account_id: 'linked-1',
             last_known_sha: 'old-sha-1',
             last_known_etag: null,
@@ -234,6 +240,81 @@ describe('repository poll scheduler', () => {
     expect(second.dispatched).toBe(0);
     expect(enqueue).toHaveBeenCalledTimes(1);
     expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it('expands wildcard branch templates into tracked concrete branches', async () => {
+    const query = makeQueryStub([
+      (sql, params) => {
+        expect(sql).toContain('FROM odb.repository_branch rb');
+        expect(params).toEqual(['2026-04-24T20:02:00.000Z', 500, 60, 300]);
+        return {
+          rowCount: 1,
+          rows: [
+            {
+              branch_id: 'template-1',
+              repository_id: 'repo-9',
+              tenant_id: 'tenant-9',
+              project_id: null,
+              provider: 'github',
+              owner: 'acme',
+              name: 'platform',
+              branch: 'release/*',
+              subpath_glob: 'services/**',
+              configured_poll_interval_sec: 180,
+              linked_account_id: 'linked-9',
+              last_known_sha: null,
+              last_known_etag: null,
+              is_enterprise: false,
+              effective_poll_interval_sec: 300,
+            },
+          ],
+        };
+      },
+      (sql, params) => {
+        expect(sql).toContain('SELECT id, access_token, token_expires_at');
+        expect(params[0]).toEqual(['linked-9']);
+        return {
+          rowCount: 1,
+          rows: [{ id: 'linked-9', access_token: 'token-9', token_expires_at: null }],
+        };
+      },
+      (sql, params) => {
+        expect(sql).toContain('INSERT INTO odb.repository_branch');
+        expect(sql).toContain('ON CONFLICT (repository_id, branch) DO UPDATE');
+        expect(params).toEqual(['repo-9', 'release/2026.04', 'services/**', 180, '2026-04-24T20:02:00.000Z']);
+        return { rowCount: 1, rows: [] };
+      },
+      (sql, params) => {
+        expect(sql).toContain('UPDATE odb.repository_branch rb');
+        expect(params[0]).toEqual(['template-1']);
+        expect(params[1]).toEqual([300]);
+        expect(params[2]).toBe('2026-04-24T20:02:00.000Z');
+        return { rowCount: 1, rows: [] };
+      },
+    ]);
+
+    const enqueue = jest.fn(async () => undefined);
+    const fetchImpl = jest.fn<typeof fetch>().mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => [{ name: 'main' }, { name: 'release/2026.04' }],
+      headers: { get: () => null } as unknown as Headers,
+    } as Response);
+
+    const scheduler = createRepositoryPollScheduler({
+      query,
+      enqueue,
+      fetchImpl,
+      now: () => new Date('2026-04-24T20:02:00.000Z'),
+    });
+
+    const result = await scheduler();
+
+    expect(result.dispatched).toBe(0);
+    expect(result.jobs).toEqual([]);
+    expect(enqueue).not.toHaveBeenCalled();
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(fetchImpl.mock.calls[0]?.[0]).toContain('/repos/acme/platform/branches?per_page=100&page=1');
   });
 });
 


### PR DESCRIPTION
## Summary
- Treat wildcard `repository_branch` entries (for example `release/*`) as scheduler-time discovery templates instead of dispatch targets.
- Expand matching concrete provider branches during poll ticks and upsert them as tracked `repository_branch` rows, re-tracking existing rows to preserve historical scan continuity.
- Add unit coverage for wildcard branch expansion and update roadmap/changelog/version metadata for REPO-4.4.

## Test plan
- [x] `yarn --cwd objectified-ui test tests/unit/repository-poll-scheduler.test.ts --runInBand`
- [x] `yarn build` (fails in existing workspace state: `Cannot find module '@gitbeaker/rest'` during `objectified-ui` type-check)
- [x] `yarn test` (fails in existing workspace state: `Cannot find module '@gitbeaker/rest'` and `TypeError: (0 , _prettyFormat.format) is not a function` in `tests/llm-streaming.test.ts`)

## Risk / Notes
- Wildcard expansion currently applies to GitHub provider rows and paginates via `/branches?per_page=100&page=n`.
- Concrete branch rows discovered from wildcard templates are scheduled immediately by setting `next_poll_at` to the current tick timestamp.

Closes #2782

Made with [Cursor](https://cursor.com)