### PR TITLE
Fix #2783 - add poll failure backoff and auto-pause

### DIFF
--- a/docs/PLANNED_FEATURE_ROADMAP_REPOSITORY.md
+++ b/docs/PLANNED_FEATURE_ROADMAP_REPOSITORY.md
@@ -2,6 +2,7 @@
 
 ## Completed
 
+- REPO-4.5 (#2783): Added scheduler failure backoff and auto-pause behavior by persisting per-branch consecutive failure/error metadata, exponentially backing off poll cadence without mutating configured poll intervals, resetting failure state on successful checks, and auto-pausing repositories with `repository.auto_paused` workflow audits after eight consecutive failures.
 - REPO-4.4 (#2782): Added multi-branch scheduler tracking for wildcard patterns by treating branch globs as discovery templates, expanding provider-matched concrete branches at poll time into `repository_branch` rows, and preserving branch scan history by re-tracking existing rows instead of deleting history.
 - REPO-4.2 (#2780): Added commit-SHA change detection in scheduled polling by resolving provider branch HEADs, using conditional `If-None-Match` requests for GitHub checks, recording `skipped_unchanged` scans when HEAD is unchanged, and only dispatching downstream scan jobs when SHA changes.
 - REPO-4.1 (#2779): Added a scheduler tick dispatcher that atomically reserves due tracked branches, skips paused repositories, clamps poll cadence to enterprise/non-enterprise minimums, dispatches poll jobs to `repo.poll.<priority>`, and records `repository.polled` workflow audit rows per dispatch.

--- a/objectified-db/scripts/20260424-150000.sql
+++ b/objectified-db/scripts/20260424-150000.sql
@@ -1,0 +1,16 @@
+-- REPO-4.5 / #2783: Track poll failure backoff state for auto-pause logic.
+SET search_path TO odb, public;
+
+ALTER TABLE odb.repository_branch
+  ADD COLUMN IF NOT EXISTS consecutive_failures INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS last_error_code VARCHAR(128),
+  ADD COLUMN IF NOT EXISTS last_error_detail TEXT;
+
+COMMENT ON COLUMN odb.repository_branch.consecutive_failures IS
+  'Consecutive provider head-detection failures for the tracked branch; reset to 0 after a successful poll head check (#2783).';
+
+COMMENT ON COLUMN odb.repository_branch.last_error_code IS
+  'Most recent provider failure code recorded during poll head detection (#2783).';
+
+COMMENT ON COLUMN odb.repository_branch.last_error_detail IS
+  'Most recent provider failure detail recorded during poll head detection (#2783).';

--- a/objectified-ui/lib/repositories/poll-scheduler.ts
+++ b/objectified-ui/lib/repositories/poll-scheduler.ts
@@ -40,6 +40,9 @@ type QueryRow = {
   effective_poll_interval_sec: number;
   last_known_sha: string | null;
   last_known_etag: string | null;
+  consecutive_failures: number;
+  last_error_code: string | null;
+  last_error_detail: string | null;
 };
 
 type QueryResult = {
@@ -63,12 +66,69 @@ const ENTERPRISE_MIN_POLL_SEC = 60;
 const DEFAULT_BATCH_SIZE = 500;
 const CONCURRENT_HEAD_CHECKS = 8;
 const GITHUB_API_BASE = 'https://api.github.com';
+const MAX_BACKOFF_MULTIPLIER = 32;
+const MAX_BACKOFF_INTERVAL_SEC = 7 * 24 * 60 * 60;
+const AUTO_PAUSE_FAILURE_THRESHOLD = 8;
 
 type DetectedHead = {
   sha: string;
   unchanged: boolean;
   etag: string | null;
 };
+
+type HeadDetectionError = {
+  errorCode: string;
+  errorDetail: string;
+};
+
+type HeadDetectionResult =
+  | {
+      ok: true;
+      head: DetectedHead;
+    }
+  | {
+      ok: false;
+      error: HeadDetectionError;
+    };
+
+function computeBackoffIntervalSec(baseIntervalSec: number, consecutiveFailures: number): number {
+  if (consecutiveFailures <= 0) {
+    return baseIntervalSec;
+  }
+  const multiplier = Math.min(2 ** consecutiveFailures, MAX_BACKOFF_MULTIPLIER);
+  return Math.min(baseIntervalSec * multiplier, MAX_BACKOFF_INTERVAL_SEC);
+}
+
+function classifyGithubHeadError(status: number): HeadDetectionError {
+  if (status === 401) {
+    return {
+      errorCode: 'PROVIDER_UNAUTHORIZED',
+      errorDetail: 'GitHub credentials are unauthorized for this repository.',
+    };
+  }
+  if (status === 403 || status === 429) {
+    return {
+      errorCode: 'PROVIDER_RATE_LIMITED',
+      errorDetail: 'GitHub provider rate limit reached while detecting branch head.',
+    };
+  }
+  if (status === 404) {
+    return {
+      errorCode: 'PROVIDER_REPOSITORY_NOT_FOUND',
+      errorDetail: 'Repository or branch was not found while detecting branch head.',
+    };
+  }
+  if (status >= 500) {
+    return {
+      errorCode: 'PROVIDER_UNAVAILABLE',
+      errorDetail: `GitHub provider error status ${status} while detecting branch head.`,
+    };
+  }
+  return {
+    errorCode: 'PROVIDER_REQUEST_FAILED',
+    errorDetail: `GitHub request failed with status ${status} while detecting branch head.`,
+  };
+}
 
 function isBranchGlobPattern(branch: string): boolean {
   return branch.includes('*') || branch.includes('?');
@@ -285,7 +345,7 @@ async function detectGithubBranchHead(
   deps: PollSchedulerDeps,
   row: QueryRow,
   token: string
-): Promise<DetectedHead | null> {
+): Promise<HeadDetectionResult> {
   const headers: HeadersInit = {
     Authorization: `Bearer ${token}`,
     Accept: 'application/vnd.github+json',
@@ -304,9 +364,12 @@ async function detectGithubBranchHead(
     const response = await deps.fetchImpl(url, { headers });
     if (response.status === 304 && row.last_known_sha) {
       return {
-        sha: row.last_known_sha,
-        unchanged: true,
-        etag: null,
+        ok: true,
+        head: {
+          sha: row.last_known_sha,
+          unchanged: true,
+          etag: null,
+        },
       };
     }
     if (!response.ok) {
@@ -316,23 +379,41 @@ async function detectGithubBranchHead(
         'status',
         response.status
       );
-      return null;
+      return {
+        ok: false,
+        error: classifyGithubHeadError(response.status),
+      };
     }
 
     const payload = (await response.json()) as { sha?: unknown };
     const sha = typeof payload.sha === 'string' ? payload.sha : '';
     if (!sha) {
-      return null;
+      return {
+        ok: false,
+        error: {
+          errorCode: 'PROVIDER_INVALID_RESPONSE',
+          errorDetail: 'GitHub provider response did not include a commit SHA.',
+        },
+      };
     }
     const etag = response.headers.get('ETag') ?? null;
     return {
-      sha,
-      unchanged: row.last_known_sha === sha,
-      etag,
+      ok: true,
+      head: {
+        sha,
+        unchanged: row.last_known_sha === sha,
+        etag,
+      },
     };
   } catch (err) {
     console.error('Failed to call provider for branch SHA detection', row.branch_id, ':', err);
-    return null;
+    return {
+      ok: false,
+      error: {
+        errorCode: 'PROVIDER_NETWORK_ERROR',
+        errorDetail: err instanceof Error ? err.message : 'Unknown network/provider error during branch head detection.',
+      },
+    };
   }
 }
 
@@ -452,6 +533,37 @@ async function insertDispatchAudit(
   }
 }
 
+async function insertAutoPausedAudit(
+  deps: PollSchedulerDeps,
+  args: {
+    tenantId: string;
+    projectId: string | null;
+    repositoryId: string;
+    branch: string;
+    errorCode: string;
+    errorDetail: string;
+    consecutiveFailures: number;
+  }
+): Promise<void> {
+  const detail = {
+    repository_id: args.repositoryId,
+    branch: args.branch,
+    error_code: args.errorCode,
+    error_detail: args.errorDetail,
+    consecutive_failures: args.consecutiveFailures,
+  };
+  try {
+    await deps.query(
+      `INSERT INTO odb.workflow_audit (
+        tenant_id, project_id, version_id, action, outcome, actor_id, detail
+      ) VALUES ($1, $2, NULL, $3, $4, NULL, $5::jsonb)`,
+      [args.tenantId, args.projectId, 'repository.auto_paused', 'success', JSON.stringify(detail)]
+    );
+  } catch (err) {
+    console.error('Failed to insert workflow_audit for repository.auto_paused:', err);
+  }
+}
+
 export function createRepositoryPollScheduler(
   partialDeps: Partial<PollSchedulerDeps>,
   options?: PollSchedulerOptions
@@ -485,6 +597,9 @@ export function createRepositoryPollScheduler(
           MIN(rcr.linked_account_id) AS linked_account_id,
           rb.last_known_sha,
           rb.last_known_etag,
+          COALESCE(rb.consecutive_failures, 0) AS consecutive_failures,
+          rb.last_error_code,
+          rb.last_error_detail,
           COALESCE(MAX(CASE WHEN ue.plan_code ILIKE 'enterprise%' THEN 1 ELSE 0 END), 0) = 1 AS is_enterprise,
           GREATEST(
             rb.poll_interval_sec,
@@ -512,6 +627,9 @@ export function createRepositoryPollScheduler(
           rb.branch,
           rb.last_known_sha,
           rb.last_known_etag,
+          rb.consecutive_failures,
+          rb.last_error_code,
+          rb.last_error_detail,
           rb.poll_interval_sec
         ORDER BY rb.next_poll_at ASC, rb.id ASC
         LIMIT $2
@@ -524,6 +642,23 @@ export function createRepositoryPollScheduler(
     const headShas: string[] = [];
     const headEtagBranchIds: string[] = [];
     const headEtags: string[] = [];
+    const failedBranchIds: string[] = [];
+    const failedBranchCounts: number[] = [];
+    const failedBranchErrorCodes: string[] = [];
+    const failedBranchErrorDetails: string[] = [];
+    const successfulBranchIds: string[] = [];
+    const repositoriesToAutoPause = new Map<
+      string,
+      {
+        tenantId: string;
+        projectId: string | null;
+        repositoryId: string;
+        branch: string;
+        errorCode: string;
+        errorDetail: string;
+        consecutiveFailures: number;
+      }
+    >();
 
     // Batch-prefetch all linked account tokens in one query, checking expiry.
     const githubLinkedAccountIds = rowsResult.rows
@@ -541,7 +676,7 @@ export function createRepositoryPollScheduler(
     const processedIntervalsSec: number[] = [...templateIntervalsSec];
 
     // Detect HEAD commits with bounded concurrency so scheduler latency scales.
-    const detectedHeads: (DetectedHead | null)[] = new Array(dispatchRows.length).fill(null);
+    const detectedHeads: (HeadDetectionResult | null)[] = new Array(dispatchRows.length).fill(null);
     const headTasks = dispatchRows.map((row, index) => async () => {
       if (row.provider !== 'github') return;
       const token = tokenMap.get(row.linked_account_id ?? '');
@@ -554,11 +689,37 @@ export function createRepositoryPollScheduler(
 
     for (let rowIndex = 0; rowIndex < dispatchRows.length; rowIndex++) {
       const row = dispatchRows[rowIndex];
-      const detectedHead = detectedHeads[rowIndex] ?? null;
+      const detectedHeadResult = detectedHeads[rowIndex] ?? null;
+      const detectedHead = detectedHeadResult?.ok ? detectedHeadResult.head : null;
+
+      if (detectedHeadResult && !detectedHeadResult.ok) {
+        const nextConsecutiveFailures = row.consecutive_failures + 1;
+        const backoffIntervalSec = computeBackoffIntervalSec(row.effective_poll_interval_sec, nextConsecutiveFailures);
+        processedBranchIds.push(row.branch_id);
+        processedIntervalsSec.push(backoffIntervalSec);
+        failedBranchIds.push(row.branch_id);
+        failedBranchCounts.push(nextConsecutiveFailures);
+        failedBranchErrorCodes.push(detectedHeadResult.error.errorCode);
+        failedBranchErrorDetails.push(detectedHeadResult.error.errorDetail);
+
+        if (nextConsecutiveFailures >= AUTO_PAUSE_FAILURE_THRESHOLD) {
+          repositoriesToAutoPause.set(row.repository_id, {
+            tenantId: row.tenant_id,
+            projectId: row.project_id,
+            repositoryId: row.repository_id,
+            branch: row.branch,
+            errorCode: detectedHeadResult.error.errorCode,
+            errorDetail: detectedHeadResult.error.errorDetail,
+            consecutiveFailures: nextConsecutiveFailures,
+          });
+        }
+        continue;
+      }
 
       if (detectedHead?.unchanged) {
         processedBranchIds.push(row.branch_id);
         processedIntervalsSec.push(row.effective_poll_interval_sec);
+        successfulBranchIds.push(row.branch_id);
         await insertScheduledScan(deps, {
           repositoryId: row.repository_id,
           branch: row.branch,
@@ -610,6 +771,7 @@ export function createRepositoryPollScheduler(
 
       processedBranchIds.push(job.branchId);
       processedIntervalsSec.push(job.effectivePollIntervalSec);
+      successfulBranchIds.push(job.branchId);
       jobs.push(job);
 
       await insertScheduledScan(deps, {
@@ -685,6 +847,53 @@ export function createRepositoryPollScheduler(
         WHERE rb.id = upd.branch_id`,
         [headEtagBranchIds, headEtags]
       );
+    }
+
+    if (failedBranchIds.length > 0) {
+      await deps.query(
+        `UPDATE odb.repository_branch rb
+        SET
+          consecutive_failures = upd.consecutive_failures,
+          last_error_code = upd.error_code,
+          last_error_detail = upd.error_detail
+        FROM (
+          SELECT
+            unnest($1::uuid[]) AS branch_id,
+            unnest($2::integer[]) AS consecutive_failures,
+            unnest($3::text[]) AS error_code,
+            unnest($4::text[]) AS error_detail
+        ) upd
+        WHERE rb.id = upd.branch_id`,
+        [failedBranchIds, failedBranchCounts, failedBranchErrorCodes, failedBranchErrorDetails]
+      );
+    }
+
+    if (successfulBranchIds.length > 0) {
+      await deps.query(
+        `UPDATE odb.repository_branch rb
+        SET
+          consecutive_failures = 0,
+          last_error_code = NULL,
+          last_error_detail = NULL
+        WHERE rb.id = ANY($1::uuid[])`,
+        [successfulBranchIds]
+      );
+    }
+
+    if (repositoriesToAutoPause.size > 0) {
+      const repositoryIds = Array.from(repositoriesToAutoPause.keys());
+      await deps.query(
+        `UPDATE odb.repository
+        SET
+          status = 'paused',
+          updated_at = $2::timestamptz
+        WHERE id = ANY($1::uuid[])
+          AND status <> 'paused'`,
+        [repositoryIds, now.toISOString()]
+      );
+      for (const autoPaused of repositoriesToAutoPause.values()) {
+        await insertAutoPausedAudit(deps, autoPaused);
+      }
     }
 
     return {

--- a/objectified-ui/lib/repositories/poll-scheduler.ts
+++ b/objectified-ui/lib/repositories/poll-scheduler.ts
@@ -106,7 +106,13 @@ function classifyGithubHeadError(status: number): HeadDetectionError {
       errorDetail: 'GitHub credentials are unauthorized for this repository.',
     };
   }
-  if (status === 403 || status === 429) {
+  if (status === 403) {
+    return {
+      errorCode: 'PROVIDER_FORBIDDEN',
+      errorDetail: 'GitHub credentials are forbidden for this repository.',
+    };
+  }
+  if (status === 429) {
     return {
       errorCode: 'PROVIDER_RATE_LIMITED',
       errorDetail: 'GitHub provider rate limit reached while detecting branch head.',
@@ -702,7 +708,7 @@ export function createRepositoryPollScheduler(
         failedBranchErrorCodes.push(detectedHeadResult.error.errorCode);
         failedBranchErrorDetails.push(detectedHeadResult.error.errorDetail);
 
-        if (nextConsecutiveFailures >= AUTO_PAUSE_FAILURE_THRESHOLD) {
+        if (nextConsecutiveFailures >= AUTO_PAUSE_FAILURE_THRESHOLD && !repositoriesToAutoPause.has(row.repository_id)) {
           repositoriesToAutoPause.set(row.repository_id, {
             tenantId: row.tenant_id,
             projectId: row.project_id,
@@ -771,7 +777,9 @@ export function createRepositoryPollScheduler(
 
       processedBranchIds.push(job.branchId);
       processedIntervalsSec.push(job.effectivePollIntervalSec);
-      successfulBranchIds.push(job.branchId);
+      if (detectedHead) {
+        successfulBranchIds.push(job.branchId);
+      }
       jobs.push(job);
 
       await insertScheduledScan(deps, {
@@ -882,17 +890,28 @@ export function createRepositoryPollScheduler(
 
     if (repositoriesToAutoPause.size > 0) {
       const repositoryIds = Array.from(repositoriesToAutoPause.keys());
-      await deps.query(
+      const pausedRepositoriesResult = await deps.query(
         `UPDATE odb.repository
         SET
           status = 'paused',
           updated_at = $2::timestamptz
         WHERE id = ANY($1::uuid[])
-          AND status <> 'paused'`,
+          AND status <> 'paused'
+        RETURNING id`,
         [repositoryIds, now.toISOString()]
       );
-      for (const autoPaused of repositoriesToAutoPause.values()) {
-        await insertAutoPausedAudit(deps, autoPaused);
+      const pausedRepositoryIds = new Set(
+        pausedRepositoriesResult.rows
+          .map((rawRow) => {
+            const row = rawRow as { id?: unknown };
+            return typeof row.id === 'string' ? row.id : '';
+          })
+          .filter(Boolean)
+      );
+      for (const [repositoryId, autoPaused] of repositoriesToAutoPause.entries()) {
+        if (pausedRepositoryIds.has(repositoryId)) {
+          await insertAutoPausedAudit(deps, autoPaused);
+        }
       }
     }
 

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.10.36",
+  "version": "0.10.37",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -5,6 +5,7 @@ We continue to improve the platform based on your feedback with improvements and
 ---
 
 ## Repositories
+- Added REPO-4.5 failure backoff + auto-pause behavior so repeated provider head-check failures exponentially back off scheduler cadence, reset on success, and auto-pause repositories with `repository.auto_paused` audit events after eight consecutive failures.
 - Added REPO-4.4 multi-branch tracking so wildcard branch templates (for example `release/*`) expand at scheduler time into tracked concrete repository branches without deleting historical scan records for previously seen branches.
 - Added poll-time branch HEAD SHA change detection with GitHub conditional `If-None-Match` checks so unchanged branches write `skipped_unchanged` scan history entries and skip downstream scan dispatch while still advancing poll cadence.
 - Added a repository poll scheduler tick that atomically reserves due tracked branches, skips paused repositories, enforces enterprise/free poll interval floors, dispatches `repo.poll.<priority>` jobs, and records `repository.polled` workflow audits.

--- a/objectified-ui/tests/unit/repository-poll-scheduler.test.ts
+++ b/objectified-ui/tests/unit/repository-poll-scheduler.test.ts
@@ -138,6 +138,12 @@ describe('repository poll scheduler', () => {
         expect(params[1]).toEqual(['"etag-new-1"']);
         return { rowCount: 1, rows: [] };
       },
+      (sql, params) => {
+        expect(sql).toContain('consecutive_failures = 0');
+        expect(sql).toContain('last_error_code = NULL');
+        expect(params[0]).toEqual(['branch-1', 'branch-2']);
+        return { rowCount: 2, rows: [] };
+      },
     ]);
     const enqueue = jest.fn(async () => undefined);
     const fetchImpl = jest
@@ -217,6 +223,11 @@ describe('repository poll scheduler', () => {
       () => ({ rowCount: 1, rows: [] }),
       () => ({ rowCount: 1, rows: [] }),
       () => ({ rowCount: 1, rows: [] }),
+      (sql, params) => {
+        expect(sql).toContain('consecutive_failures = 0');
+        expect(params[0]).toEqual(['branch-1']);
+        return { rowCount: 1, rows: [] };
+      },
       () => ({ rowCount: 0, rows: [] }),
     ]);
     const enqueue = jest.fn(async () => undefined);
@@ -315,6 +326,104 @@ describe('repository poll scheduler', () => {
     expect(enqueue).not.toHaveBeenCalled();
     expect(fetchImpl).toHaveBeenCalledTimes(1);
     expect(fetchImpl.mock.calls[0]?.[0]).toContain('/repos/acme/platform/branches?per_page=100&page=1');
+  });
+
+  it('applies failure backoff and auto-pauses repositories after threshold failures', async () => {
+    const query = makeQueryStub([
+      (sql, params) => {
+        expect(sql).toContain('rb.consecutive_failures');
+        expect(params).toEqual(['2026-04-24T20:03:00.000Z', 500, 60, 300]);
+        return {
+          rowCount: 1,
+          rows: [
+            {
+              branch_id: 'branch-fail',
+              repository_id: 'repo-fail',
+              tenant_id: 'tenant-fail',
+              project_id: null,
+              provider: 'github',
+              owner: 'acme',
+              name: 'broken-repo',
+              branch: 'main',
+              subpath_glob: '**/*',
+              configured_poll_interval_sec: 300,
+              linked_account_id: 'linked-fail',
+              last_known_sha: 'old-sha',
+              last_known_etag: '"etag-old"',
+              consecutive_failures: 7,
+              last_error_code: 'PROVIDER_UNAVAILABLE',
+              last_error_detail: 'Previous failure',
+              is_enterprise: false,
+              effective_poll_interval_sec: 300,
+            },
+          ],
+        };
+      },
+      (sql, params) => {
+        expect(sql).toContain('SELECT id, access_token, token_expires_at');
+        expect(params[0]).toEqual(['linked-fail']);
+        return {
+          rowCount: 1,
+          rows: [{ id: 'linked-fail', access_token: 'token-fail', token_expires_at: null }],
+        };
+      },
+      (sql, params) => {
+        expect(sql).toContain('UPDATE odb.repository_branch rb');
+        expect(params[0]).toEqual(['branch-fail']);
+        // 8 failures => multiplier 32 => 300 * 32 = 9600
+        expect(params[1]).toEqual([9600]);
+        expect(params[2]).toBe('2026-04-24T20:03:00.000Z');
+        return { rowCount: 1, rows: [] };
+      },
+      (sql, params) => {
+        expect(sql).toContain('consecutive_failures = upd.consecutive_failures');
+        expect(params[0]).toEqual(['branch-fail']);
+        expect(params[1]).toEqual([8]);
+        expect(params[2]).toEqual(['PROVIDER_UNAVAILABLE']);
+        return { rowCount: 1, rows: [] };
+      },
+      (sql, params) => {
+        expect(sql).toContain('UPDATE odb.repository');
+        expect(sql).toContain("status = 'paused'");
+        expect(params[0]).toEqual(['repo-fail']);
+        expect(params[1]).toBe('2026-04-24T20:03:00.000Z');
+        return { rowCount: 1, rows: [] };
+      },
+      (sql, params) => {
+        expect(sql).toContain('INSERT INTO odb.workflow_audit');
+        expect(params[2]).toBe('repository.auto_paused');
+        const detail = JSON.parse(String(params[4]));
+        expect(detail).toMatchObject({
+          repository_id: 'repo-fail',
+          branch: 'main',
+          error_code: 'PROVIDER_UNAVAILABLE',
+          consecutive_failures: 8,
+        });
+        return { rowCount: 1, rows: [] };
+      },
+    ]);
+
+    const enqueue = jest.fn(async () => undefined);
+    const fetchImpl = jest.fn<typeof fetch>().mockResolvedValueOnce({
+      ok: false,
+      status: 503,
+      json: async () => ({}),
+      headers: { get: () => null } as unknown as Headers,
+    } as Response);
+
+    const scheduler = createRepositoryPollScheduler({
+      query,
+      enqueue,
+      fetchImpl,
+      now: () => new Date('2026-04-24T20:03:00.000Z'),
+    });
+
+    const result = await scheduler();
+
+    expect(result.dispatched).toBe(0);
+    expect(result.jobs).toEqual([]);
+    expect(enqueue).not.toHaveBeenCalled();
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/objectified-ui/tests/unit/repository-poll-scheduler.test.ts
+++ b/objectified-ui/tests/unit/repository-poll-scheduler.test.ts
@@ -48,6 +48,9 @@ describe('repository poll scheduler', () => {
               linked_account_id: 'linked-1',
               last_known_sha: 'old-sha-1',
               last_known_etag: null,
+              consecutive_failures: 0,
+              last_error_code: null,
+              last_error_detail: null,
               is_enterprise: false,
               effective_poll_interval_sec: 300,
             },
@@ -65,6 +68,9 @@ describe('repository poll scheduler', () => {
               linked_account_id: 'linked-2',
               last_known_sha: 'old-sha-2',
               last_known_etag: '"etag-old-2"',
+              consecutive_failures: 0,
+              last_error_code: null,
+              last_error_detail: null,
               is_enterprise: true,
               effective_poll_interval_sec: 60,
             },
@@ -213,6 +219,9 @@ describe('repository poll scheduler', () => {
             linked_account_id: 'linked-1',
             last_known_sha: 'old-sha-1',
             last_known_etag: null,
+            consecutive_failures: 0,
+            last_error_code: null,
+            last_error_detail: null,
             is_enterprise: false,
             effective_poll_interval_sec: 300,
           },
@@ -275,6 +284,9 @@ describe('repository poll scheduler', () => {
               linked_account_id: 'linked-9',
               last_known_sha: null,
               last_known_etag: null,
+              consecutive_failures: 0,
+              last_error_code: null,
+              last_error_detail: null,
               is_enterprise: false,
               effective_poll_interval_sec: 300,
             },
@@ -385,9 +397,10 @@ describe('repository poll scheduler', () => {
       (sql, params) => {
         expect(sql).toContain('UPDATE odb.repository');
         expect(sql).toContain("status = 'paused'");
+        expect(sql).toContain('RETURNING id');
         expect(params[0]).toEqual(['repo-fail']);
         expect(params[1]).toBe('2026-04-24T20:03:00.000Z');
-        return { rowCount: 1, rows: [] };
+        return { rowCount: 1, rows: [{ id: 'repo-fail' }] };
       },
       (sql, params) => {
         expect(sql).toContain('INSERT INTO odb.workflow_audit');


### PR DESCRIPTION
## Summary
- add persistent poll failure state (`consecutive_failures`, `last_error_code`, `last_error_detail`) for repository branches and apply exponential poll backoff (up to 32x, capped at 7 days) without mutating configured poll intervals
- reset failure state on successful head checks, auto-pause repositories after 8 consecutive failures, and write `repository.auto_paused` workflow audit entries with error metadata
- extend poll scheduler unit coverage for failure backoff/auto-pause, and update roadmap/what's-new docs plus `objectified-ui` patch version

## Test plan
- [x] `yarn workspace objectified-ui test repository-poll-scheduler --runInBand`
- [x] `yarn build` *(fails in existing environment due to missing `@gitbeaker/rest` type/module resolution in `objectified-ui/lib/repositories/providers/gitlab-provider.ts`)*
- [x] `yarn test` *(fails in existing environment due to unrelated existing issues: missing `@gitbeaker/rest` in provider contract tests and `TypeError: (0 , _prettyFormat.format) is not a function` in `tests/llm-streaming.test.ts`)*

## Risk/notes
- migration adds non-breaking nullable error metadata columns and a defaulted failure counter to `repository_branch`
- head detection failures are now classified into structured provider error codes for auditability/backoff behavior

Closes #2783

Made with [Cursor](https://cursor.com)