### PR TITLE
Fix #2786 - bind discovered files to import jobs

### DIFF
--- a/docs/PLANNED_FEATURE_ROADMAP_REPOSITORY.md
+++ b/docs/PLANNED_FEATURE_ROADMAP_REPOSITORY.md
@@ -2,6 +2,7 @@
 
 ## Completed
 
+- REPO-5.1 (#2786): Added discovered-file to import-job binding in the repository scan completion path so `new`/`modified` files dispatch dry-run git import jobs, `removed` files dispatch manual-approval removal jobs, `unchanged` files skip job creation, parse failures write back `repository_file.status='parse_error'`, and each job records `repository.sync_committed` or `repository.sync_pending_review` audit events.
 - REPO-4.5 (#2783): Added scheduler failure backoff and auto-pause behavior by persisting per-branch consecutive failure/error metadata, exponentially backing off poll cadence without mutating configured poll intervals, resetting failure state on successful checks, and auto-pausing repositories with `repository.auto_paused` workflow audits after eight consecutive failures.
 - REPO-4.4 (#2782): Added multi-branch scheduler tracking for wildcard patterns by treating branch globs as discovery templates, expanding provider-matched concrete branches at poll time into `repository_branch` rows, and preserving branch scan history by re-tracking existing rows instead of deleting history.
 - REPO-4.2 (#2780): Added commit-SHA change detection in scheduled polling by resolving provider branch HEADs, using conditional `If-None-Match` requests for GitHub checks, recording `skipped_unchanged` scans when HEAD is unchanged, and only dispatching downstream scan jobs when SHA changes.

--- a/objectified-rest/src/app/repositories_routes.py
+++ b/objectified-rest/src/app/repositories_routes.py
@@ -70,6 +70,9 @@ RepositoryFileStatus = Literal[
     "parse_error",
     "manifest_error",
 ]
+ImportJobPromotion = Literal["auto", "manual"]
+ImportJobOperation = Literal["import", "removal"]
+ImportJobStatus = Literal["pending_review", "committed", "failed"]
 
 
 class RepositoryScanTimelineEntry(BaseModel):
@@ -142,9 +145,29 @@ class RepositoryFileRecord(BaseModel):
     tracked: bool
     projectSlug: str | None = None
     versionStrategy: str | None = None
+    settingsJson: Dict[str, Any] | None = None
+    promote: ImportJobPromotion | None = None
     status: RepositoryFileStatus
     qualityScore: int | None = None
     lastImportJobId: str | None = None
+    createdAt: str
+
+
+class RepositoryImportJobRecord(BaseModel):
+    id: str
+    repositoryId: str
+    repositoryFileId: str
+    scanId: str
+    branch: str
+    sourceType: Literal["git"]
+    sourceUri: str
+    operation: ImportJobOperation
+    format: str | None = None
+    settingsJson: Dict[str, Any] = Field(default_factory=dict)
+    dryRun: bool = True
+    state: ImportJobStatus
+    diffSnapshot: Dict[str, Any] = Field(default_factory=dict)
+    errorDetail: str | None = None
     createdAt: str
 
 
@@ -172,6 +195,7 @@ _REPO_FILE_STORE: Dict[str, List[Dict[str, Any]]] = {}
 _REPO_SCAN_HISTORY_STORE: Dict[str, List[RepositoryScanRecord]] = {}
 _REPO_SCAN_FILE_HISTORY_STORE: Dict[str, List[RepositoryFileRecord]] = {}
 _REPO_CREDENTIAL_REF_STORE: Dict[str, List[Dict[str, Any]]] = {}
+_REPO_IMPORT_JOB_STORE: Dict[str, List[RepositoryImportJobRecord]] = {}
 _REPO_AUDIT_STORE: List[Dict[str, Any]] = []
 _STORE_LOCK = Lock()
 
@@ -238,6 +262,13 @@ def _find_repository_for_tenant(tenant_id: str, repository_id: str) -> Repositor
     if repository is None:
         raise HTTPException(status_code=404, detail=f"Repository not found: {repository_id}")
     return repository
+
+
+def _find_tenant_id_for_repository(repository_id: str) -> str:
+    for tenant_id, repositories in _REPO_STORE.items():
+        if repository_id in repositories:
+            return tenant_id
+    raise ValueError(f"Repository not found: {repository_id}")
 
 
 def _to_sort_key(created_at: str, row_id: str) -> Tuple[datetime, str]:
@@ -427,7 +458,17 @@ def _to_summary(repo: RepositoryRecord) -> Dict[str, Any]:
     }
 
 
-def _write_audit_row(tenant_id: str, repository_id: str, event_type: Literal["repository.archived", "repository.unarchived", "repository.removed"]) -> None:
+def _write_audit_row(
+    tenant_id: str,
+    repository_id: str,
+    event_type: Literal[
+        "repository.archived",
+        "repository.unarchived",
+        "repository.removed",
+        "repository.sync_committed",
+        "repository.sync_pending_review",
+    ],
+) -> None:
     _REPO_AUDIT_STORE.append(
         {
             "id": str(uuid4()),
@@ -437,6 +478,87 @@ def _write_audit_row(tenant_id: str, repository_id: str, event_type: Literal["re
             "createdAt": _utc_now_iso(),
         }
     )
+
+
+def _build_repository_source_uri(repository_id: str, path: str, branch: str, commit_sha: str) -> str:
+    normalized_path = path.lstrip("/")
+    return f"repo://{repository_id}/{normalized_path}@{branch}/{commit_sha}"
+
+
+def _build_diff_snapshot(file_row: RepositoryFileRecord) -> Dict[str, Any]:
+    return {
+        "path": file_row.path,
+        "status": file_row.status,
+        "blobSha": file_row.blobSha,
+        "format": file_row.format,
+        "tracked": file_row.tracked,
+    }
+
+
+def _dispatch_import_jobs_for_scan(
+    *,
+    tenant_id: str,
+    repository_id: str,
+    scan_id: str,
+    branch: str,
+    commit_sha: str,
+    scan_files: List[RepositoryFileRecord],
+) -> None:
+    repository_jobs = _REPO_IMPORT_JOB_STORE.setdefault(repository_id, [])
+    for file_row in scan_files:
+        if file_row.status == "unchanged":
+            continue
+
+        operation: ImportJobOperation = "import"
+        promote: ImportJobPromotion = file_row.promote if file_row.promote in {"auto", "manual"} else "manual"
+        settings_json: Dict[str, Any] = dict(file_row.settingsJson or {})
+        if file_row.status == "removed":
+            operation = "removal"
+            promote = "manual"
+            settings_json.setdefault("requiresExplicitApproval", True)
+
+        source_uri = _build_repository_source_uri(repository_id, file_row.path, branch, commit_sha)
+        forced_failure = settings_json.get("forceImportFailure")
+        failure_message: str | None = None
+        if isinstance(forced_failure, str) and forced_failure.strip():
+            failure_message = forced_failure.strip()
+        elif forced_failure is True:
+            failure_message = "forced import failure for test coverage"
+
+        state: ImportJobStatus = "pending_review"
+        if failure_message:
+            state = "failed"
+        elif promote == "auto":
+            state = "committed"
+
+        import_job = RepositoryImportJobRecord(
+            id=str(uuid4()),
+            repositoryId=repository_id,
+            repositoryFileId=file_row.id,
+            scanId=scan_id,
+            branch=branch,
+            sourceType="git",
+            sourceUri=source_uri,
+            operation=operation,
+            format=file_row.format,
+            settingsJson=settings_json,
+            dryRun=True,
+            state=state,
+            diffSnapshot=_build_diff_snapshot(file_row),
+            errorDetail=failure_message,
+            createdAt=file_row.createdAt,
+        )
+        repository_jobs.insert(0, import_job)
+        file_row.lastImportJobId = import_job.id
+
+        if failure_message:
+            file_row.status = "parse_error"
+            file_row.discriminator = failure_message
+            _write_audit_row(tenant_id, repository_id, "repository.sync_pending_review")
+        elif promote == "auto":
+            _write_audit_row(tenant_id, repository_id, "repository.sync_committed")
+        else:
+            _write_audit_row(tenant_id, repository_id, "repository.sync_pending_review")
 
 
 def _list_poll_targets_for_tenant(tenant_id: str) -> List[Dict[str, str]]:
@@ -867,6 +989,7 @@ def _reset_repository_state_for_tests() -> None:
         _REPO_SCAN_HISTORY_STORE.clear()
         _REPO_SCAN_FILE_HISTORY_STORE.clear()
         _REPO_CREDENTIAL_REF_STORE.clear()
+        _REPO_IMPORT_JOB_STORE.clear()
         _REPO_AUDIT_STORE.clear()
 
 
@@ -906,6 +1029,12 @@ def _complete_repository_scan_for_tests(
                 raise ValueError(
                     f"Invalid type for 'tracked': {type(tracked_raw).__name__}; expected a boolean"
                 )
+            settings_json_raw = item.get("settingsJson")
+            if settings_json_raw is not None and not isinstance(settings_json_raw, dict):
+                raise ValueError("settingsJson must be an object when provided")
+            promote_raw = item.get("promote")
+            if promote_raw is not None and promote_raw not in {"auto", "manual"}:
+                raise ValueError("promote must be either 'auto' or 'manual' when provided")
             current_files.append(
                 RepositoryFileRecord(
                     id=str(uuid4()),
@@ -920,6 +1049,8 @@ def _complete_repository_scan_for_tests(
                     tracked=tracked_value,
                     projectSlug=item.get("projectSlug"),
                     versionStrategy=item.get("versionStrategy"),
+                    settingsJson=settings_json_raw,
+                    promote=promote_raw,
                     status="new",
                     qualityScore=item.get("qualityScore"),
                     lastImportJobId=item.get("lastImportJobId"),
@@ -945,6 +1076,15 @@ def _complete_repository_scan_for_tests(
             created_at=now,
             current_files=current_files,
             previous_files=previous_files,
+        )
+        tenant_id = _find_tenant_id_for_repository(repository_id)
+        _dispatch_import_jobs_for_scan(
+            tenant_id=tenant_id,
+            repository_id=repository_id,
+            scan_id=scan_id,
+            branch=target_scan.branch,
+            commit_sha=commit_sha,
+            scan_files=classified_files,
         )
         _REPO_SCAN_FILE_HISTORY_STORE[scan_id] = classified_files
 
@@ -1017,6 +1157,11 @@ def _get_repository_relations_exist_for_tests(repository_id: str) -> Dict[str, b
             "repository_file": repository_id in _REPO_FILE_STORE,
             "repository_credential_ref": repository_id in _REPO_CREDENTIAL_REF_STORE,
         }
+
+
+def _get_repository_import_jobs_for_tests(repository_id: str) -> List[RepositoryImportJobRecord]:
+    with _STORE_LOCK:
+        return list(_REPO_IMPORT_JOB_STORE.get(repository_id, []))
 
 
 def _list_poll_targets_for_tests(tenant_id: str) -> List[Dict[str, str]]:

--- a/objectified-rest/src/app/repositories_routes.py
+++ b/objectified-rest/src/app/repositories_routes.py
@@ -506,7 +506,9 @@ def _dispatch_import_jobs_for_scan(
 ) -> None:
     repository_jobs = _REPO_IMPORT_JOB_STORE.setdefault(repository_id, [])
     for file_row in scan_files:
-        if file_row.status == "unchanged":
+        if file_row.status not in {"new", "modified", "removed"}:
+            continue
+        if not file_row.tracked:
             continue
 
         operation: ImportJobOperation = "import"
@@ -515,7 +517,7 @@ def _dispatch_import_jobs_for_scan(
         if file_row.status == "removed":
             operation = "removal"
             promote = "manual"
-            settings_json.setdefault("requiresExplicitApproval", True)
+            settings_json["requiresExplicitApproval"] = True
 
         source_uri = _build_repository_source_uri(repository_id, file_row.path, branch, commit_sha)
         forced_failure = settings_json.get("forceImportFailure")

--- a/objectified-rest/tests/test_repositories_routes.py
+++ b/objectified-rest/tests/test_repositories_routes.py
@@ -6,6 +6,7 @@ from app.main import app
 from app.repositories_routes import (
     _complete_repository_scan_for_tests,
     _get_repository_audit_rows_for_tests,
+    _get_repository_import_jobs_for_tests,
     _get_repository_relations_exist_for_tests,
     _list_poll_targets_for_tests,
     _reset_repository_state_for_tests,
@@ -452,3 +453,97 @@ def test_complete_scan_classifies_files_and_writes_diff_summary():
     assert by_path["docs/readme.md"]["status"] == "new"
     assert by_path["events/asyncapi.yaml"]["status"] == "removed"
     assert by_path["events/asyncapi.yaml"]["blobSha"] == "222"
+
+
+def test_complete_scan_dispatches_import_jobs_and_records_parse_errors():
+    app.dependency_overrides[validate_authentication] = _override_auth
+    try:
+        create_response = client.post(
+            f"/v1/repositories/{_TENANT_SLUG}",
+            json={
+                "linkedAccountId": "aaaaaaaa-bbbb-cccc-dddd-000000000025",
+                "provider": "github",
+                "owner": "acme",
+                "name": "scan-import-binding",
+                "branches": [{"branch": "main"}],
+            },
+        )
+        repository_id = create_response.json()["repository"]["id"]
+        first_scan_id = create_response.json()["initialScanJobId"]
+        _complete_repository_scan_for_tests(
+            repository_id,
+            first_scan_id,
+            commit_sha="commit-first",
+            files=[
+                {"path": "apis/stable.yaml", "blobSha": "111", "tracked": True, "promote": "auto"},
+                {"path": "apis/error.yaml", "blobSha": "222", "tracked": True, "promote": "auto"},
+                {"path": "apis/removed.yaml", "blobSha": "333", "tracked": True, "promote": "manual"},
+            ],
+        )
+        baseline_job_count = len(_get_repository_import_jobs_for_tests(repository_id))
+        baseline_audit_count = len(_get_repository_audit_rows_for_tests(repository_id))
+
+        next_scan_response = client.post(
+            f"/v1/repositories/{_TENANT_SLUG}/{repository_id}/scans",
+            json={"branch": "main", "force": True},
+        )
+        second_scan_id = next_scan_response.json()["id"]
+        _complete_repository_scan_for_tests(
+            repository_id,
+            second_scan_id,
+            commit_sha="commit-second",
+            files=[
+                {"path": "apis/stable.yaml", "blobSha": "111", "tracked": True},
+                {
+                    "path": "apis/error.yaml",
+                    "blobSha": "999",
+                    "tracked": True,
+                    "promote": "auto",
+                    "settingsJson": {"forceImportFailure": "parser exploded"},
+                },
+            ],
+        )
+        second_scan_files = client.get(
+            f"/v1/repositories/{_TENANT_SLUG}/{repository_id}/scans/{second_scan_id}/files",
+        )
+        import_jobs = _get_repository_import_jobs_for_tests(repository_id)
+        audit_rows = _get_repository_audit_rows_for_tests(repository_id)
+    finally:
+        app.dependency_overrides.pop(validate_authentication, None)
+
+    assert create_response.status_code == 201
+    assert next_scan_response.status_code == 200
+    assert second_scan_files.status_code == 200
+
+    # unchanged files do not dispatch new import jobs
+    assert len(import_jobs) == baseline_job_count + 2
+    second_scan_jobs = [job for job in import_jobs if job.scanId == second_scan_id]
+    assert len(second_scan_jobs) == 2
+    by_path = {job.diffSnapshot["path"]: job for job in second_scan_jobs}
+    assert "apis/stable.yaml" not in by_path
+
+    removed_job = by_path["apis/removed.yaml"]
+    assert removed_job.operation == "removal"
+    assert removed_job.state == "pending_review"
+    assert removed_job.settingsJson["requiresExplicitApproval"] is True
+    assert removed_job.sourceType == "git"
+    assert removed_job.sourceUri == f"repo://{repository_id}/apis/removed.yaml@main/commit-second"
+
+    failed_job = by_path["apis/error.yaml"]
+    assert failed_job.operation == "import"
+    assert failed_job.state == "failed"
+    assert failed_job.errorDetail == "parser exploded"
+    assert failed_job.diffSnapshot["status"] == "modified"
+
+    files_by_path = {row["path"]: row for row in second_scan_files.json()["items"]}
+    assert files_by_path["apis/stable.yaml"]["status"] == "unchanged"
+    assert files_by_path["apis/stable.yaml"]["lastImportJobId"] is None
+    assert files_by_path["apis/removed.yaml"]["status"] == "removed"
+    assert files_by_path["apis/error.yaml"]["status"] == "parse_error"
+    assert files_by_path["apis/error.yaml"]["discriminator"] == "parser exploded"
+
+    new_audit_rows = audit_rows[baseline_audit_count:]
+    assert [row["eventType"] for row in new_audit_rows] == [
+        "repository.sync_pending_review",
+        "repository.sync_pending_review",
+    ]

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.10.37",
+  "version": "0.10.38",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -5,6 +5,7 @@ We continue to improve the platform based on your feedback with improvements and
 ---
 
 ## Repositories
+- Added REPO-5.1 discovered-file import binding so repository scan completion now dispatches dry-run git import jobs for `new`/`modified` files, creates manual approval `removal` jobs for `removed` files, skips `unchanged` files, and records sync audit outcomes (`repository.sync_committed` / `repository.sync_pending_review`) with parse failures surfaced as `repository_file.parse_error`.
 - Added REPO-4.5 failure backoff + auto-pause behavior so repeated provider head-check failures exponentially back off scheduler cadence, reset on success, and auto-pause repositories with `repository.auto_paused` audit events after eight consecutive failures.
 - Added REPO-4.4 multi-branch tracking so wildcard branch templates (for example `release/*`) expand at scheduler time into tracked concrete repository branches without deleting historical scan records for previously seen branches.
 - Added poll-time branch HEAD SHA change detection with GitHub conditional `If-None-Match` checks so unchanged branches write `skipped_unchanged` scan history entries and skip downstream scan dispatch while still advancing poll cadence.

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -5,7 +5,7 @@ We continue to improve the platform based on your feedback with improvements and
 ---
 
 ## Repositories
-- Added REPO-5.1 discovered-file import binding so repository scan completion now dispatches dry-run git import jobs for `new`/`modified` files, creates manual approval `removal` jobs for `removed` files, skips `unchanged` files, and records sync audit outcomes (`repository.sync_committed` / `repository.sync_pending_review`) with parse failures surfaced as `repository_file.parse_error`.
+- Added REPO-5.1 discovered-file import binding so repository scan completion now dispatches dry-run git import jobs for `new`/`modified` files (tracked files only), creates manual approval `removal` jobs for `removed` files, skips `unchanged` and untracked files, and records sync audit outcomes (`repository.sync_committed` / `repository.sync_pending_review`) with parse failures setting `repository_file.status='parse_error'`.
 - Added REPO-4.5 failure backoff + auto-pause behavior so repeated provider head-check failures exponentially back off scheduler cadence, reset on success, and auto-pause repositories with `repository.auto_paused` audit events after eight consecutive failures.
 - Added REPO-4.4 multi-branch tracking so wildcard branch templates (for example `release/*`) expand at scheduler time into tracked concrete repository branches without deleting historical scan records for previously seen branches.
 - Added poll-time branch HEAD SHA change detection with GitHub conditional `If-None-Match` checks so unchanged branches write `skipped_unchanged` scan history entries and skip downstream scan dispatch while still advancing poll cadence.


### PR DESCRIPTION
## Summary
- Add repository scan -> import job binding in `repositories_routes` so `new`/`modified` files create dry-run git import jobs, `removed` files create manual-approval removal jobs, and `unchanged` files do not dispatch jobs.
- Record `repository.sync_committed` / `repository.sync_pending_review` audit rows per dispatched job, and mark repository files as `parse_error` when the import pipeline fails.
- Add regression coverage for unchanged/removed/parse-error behavior, and update roadmap + release notes for REPO-5.1.

## Test plan
- [x] `python3 -m py_compile objectified-rest/src/app/repositories_routes.py objectified-rest/tests/test_repositories_routes.py`
- [ ] `python3 -m pytest objectified-rest/tests/test_repositories_routes.py -q` *(blocked: `pytest` is not installed in this environment)*
- [ ] `yarn build` *(fails in `objectified-ui` due missing module `@gitbeaker/rest` in existing codebase)*
- [ ] `yarn test` *(fails in existing suites: missing `@gitbeaker/rest` and `tests/llm-streaming.test.ts` pretty-format runtime issue)*

## Risk / Notes
- Import-job binding is currently implemented in the repository route in-memory/test harness layer; behavior is covered via route tests and helper assertions.
- Existing workspace build/test failures appear unrelated to this ticket and are documented above.

Closes #2786

Made with [Cursor](https://cursor.com)