### PR TITLE
Fix #2787 - add project/version mapping rules

### DIFF
--- a/docs/PLANNED_FEATURE_ROADMAP_REPOSITORY.md
+++ b/docs/PLANNED_FEATURE_ROADMAP_REPOSITORY.md
@@ -2,6 +2,7 @@
 
 ## Completed
 
+- REPO-5.2 (#2787): Added manifest-first project/version mapping resolution (`specs[].project`, `specs[].versionStrategy`) with persisted `repository_file.project_slug` / `repository_file.version_strategy` decisions, documented auto fallback rules (`project` derived from path segment, `version_strategy='commit-sha'`), and unmapped-file UI affordance metadata via `tracked=false` + `settings_json.mappingRequired=true`.
 - REPO-5.1 (#2786): Added discovered-file to import-job binding in the repository scan completion path so `new`/`modified` files dispatch dry-run git import jobs, `removed` files dispatch manual-approval removal jobs, `unchanged` files skip job creation, parse failures write back `repository_file.status='parse_error'`, and each job records `repository.sync_committed` or `repository.sync_pending_review` audit events.
 - REPO-4.5 (#2783): Added scheduler failure backoff and auto-pause behavior by persisting per-branch consecutive failure/error metadata, exponentially backing off poll cadence without mutating configured poll intervals, resetting failure state on successful checks, and auto-pausing repositories with `repository.auto_paused` workflow audits after eight consecutive failures.
 - REPO-4.4 (#2782): Added multi-branch scheduler tracking for wildcard patterns by treating branch globs as discovery templates, expanding provider-matched concrete branches at poll time into `repository_branch` rows, and preserving branch scan history by re-tracking existing rows instead of deleting history.

--- a/objectified-rest/docs/REPOSITORY_MAPPING_RULES.md
+++ b/objectified-rest/docs/REPOSITORY_MAPPING_RULES.md
@@ -8,8 +8,14 @@ Repository scan classification resolves `repository_file.project_slug` and
 When `.objectified/repo.yaml` includes a matching `specs[].path`, mapping is
 resolved from that spec first:
 
-- `specs[].project` -> `repository_file.project_slug`
+- `specs[].project` -> `repository_file.project_slug` (slugified before
+  persisting)
 - `specs[].versionStrategy` -> `repository_file.version_strategy`
+
+Slugification lowercases the value and replaces non-alphanumeric characters
+with `-`.
+
+- Example: `specs[].project: "Orders API"` -> `project_slug: "orders-api"`
 
 Manifest values are authoritative for matched paths.
 

--- a/objectified-rest/docs/REPOSITORY_MAPPING_RULES.md
+++ b/objectified-rest/docs/REPOSITORY_MAPPING_RULES.md
@@ -1,0 +1,34 @@
+# Repository Mapping Rules
+
+Repository scan classification resolves `repository_file.project_slug` and
+`repository_file.version_strategy` using this precedence order.
+
+## 1) Manifest mapping takes priority
+
+When `.objectified/repo.yaml` includes a matching `specs[].path`, mapping is
+resolved from that spec first:
+
+- `specs[].project` -> `repository_file.project_slug`
+- `specs[].versionStrategy` -> `repository_file.version_strategy`
+
+Manifest values are authoritative for matched paths.
+
+## 2) Auto mapping fallback
+
+When a path is not explicitly mapped in the manifest:
+
+- `project_slug` is derived from the first path segment
+  - Example: `billing/openapi.yaml` -> `billing`
+- `version_strategy` defaults to `commit-sha`
+
+## 3) Unmapped files
+
+If no project slug can be derived (for example root-level files like
+`openapi.yaml`), the row is persisted with:
+
+- `tracked=false`
+- `project_slug=NULL`
+- `version_strategy='commit-sha'`
+- `settings_json.mappingRequired=true`
+
+This gives the UI a deterministic affordance to prompt manual mapping.

--- a/objectified-rest/pyproject.toml
+++ b/objectified-rest/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "objectified-rest"
-version = "1.0.58"
+version = "1.0.59"
 description = "REST API for serving OpenAPI specifications from the Objectified database"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/objectified-rest/src/app/repositories/manifest.py
+++ b/objectified-rest/src/app/repositories/manifest.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib.resources as pkg_resources
 import json
+import re
 from dataclasses import dataclass
 from typing import Any, Literal, Sequence
 
@@ -35,6 +36,8 @@ class RepoManifestDefaults:
 class RepoManifestSpec:
     path: str
     format: DetectedRepositorySpecFormat | None
+    project_slug: str | None
+    version_strategy: str | None
     poll_interval_sec: int | None
 
 
@@ -51,9 +54,12 @@ class RepositoryFileRow:
     path: str
     format: DetectedRepositorySpecFormat | None
     tracked: bool
+    project_slug: str | None
+    version_strategy: str | None
     poll_interval_sec: int | None
     status: str
     metadata: dict[str, Any] | None = None
+    settings_json: dict[str, Any] | None = None
 
 
 @dataclass(frozen=True)
@@ -66,6 +72,18 @@ class RepositoryDiscoveryCandidate:
 class RepoManifestParseOutcome:
     manifest: RepoManifest | None
     manifest_error_row: RepositoryFileRow | None
+
+
+@dataclass(frozen=True)
+class RepositoryMappingDecision:
+    tracked: bool
+    project_slug: str | None
+    version_strategy: str
+    settings_json: dict[str, Any] | None = None
+
+
+_DEFAULT_VERSION_STRATEGY = "commit-sha"
+_SLUG_SANITIZER = re.compile(r"[^a-z0-9]+")
 
 
 def parse_repo_manifest(raw_manifest: str | None) -> RepoManifestParseOutcome:
@@ -104,6 +122,30 @@ def parse_repo_manifest(raw_manifest: str | None) -> RepoManifestParseOutcome:
     return RepoManifestParseOutcome(manifest=manifest, manifest_error_row=None)
 
 
+def resolve_repository_file_mapping(path: str, spec: RepoManifestSpec | None) -> RepositoryMappingDecision:
+    manifest_project_slug = _normalize_project_slug(spec.project_slug) if spec is not None else None
+    auto_project_slug = _derive_project_slug_from_path(path)
+    project_slug = manifest_project_slug or auto_project_slug
+    version_strategy = (
+        spec.version_strategy.strip()
+        if spec is not None and isinstance(spec.version_strategy, str) and spec.version_strategy.strip()
+        else _DEFAULT_VERSION_STRATEGY
+    )
+    tracked = project_slug is not None
+    settings_json = None
+    if not tracked:
+        settings_json = {
+            "mappingRequired": True,
+            "mappingReason": "project_slug_not_resolved",
+        }
+    return RepositoryMappingDecision(
+        tracked=tracked,
+        project_slug=project_slug,
+        version_strategy=version_strategy,
+        settings_json=settings_json,
+    )
+
+
 def build_repository_file_rows(
     *,
     discoveries: Sequence[RepositoryDiscoveryCandidate],
@@ -124,15 +166,19 @@ def build_repository_file_rows(
     for discovery in discoveries:
         spec = spec_by_path.get(discovery.path)
         manifest_spec_poll = spec.poll_interval_sec if spec is not None else None
+        mapping = resolve_repository_file_mapping(discovery.path, spec)
         rows.append(
             RepositoryFileRow(
                 path=discovery.path,
                 format=spec.format if spec is not None and spec.format is not None else discovery.detected_format,
-                tracked=spec is not None,
+                tracked=mapping.tracked,
+                project_slug=mapping.project_slug,
+                version_strategy=mapping.version_strategy,
                 poll_interval_sec=manifest_spec_poll
                 if manifest_spec_poll is not None
                 else effective_branch_poll_interval,
                 status="discovered",
+                settings_json=mapping.settings_json,
             )
         )
     return rows
@@ -159,6 +205,8 @@ def _to_repo_manifest(parsed: dict[str, Any]) -> RepoManifest:
             RepoManifestSpec(
                 path=str(spec["path"]),
                 format=spec.get("format"),
+                project_slug=spec.get("project"),
+                version_strategy=spec.get("versionStrategy"),
                 poll_interval_sec=spec.get("pollIntervalSec"),
             )
             for spec in specs
@@ -172,6 +220,8 @@ def _manifest_error_row(message: str) -> RepositoryFileRow:
         path=_MANIFEST_RELATIVE_PATH,
         format=None,
         tracked=True,
+        project_slug=None,
+        version_strategy=None,
         poll_interval_sec=None,
         status="manifest_error",
         metadata={"error": message},
@@ -183,3 +233,20 @@ def _format_schema_error(error: ValidationError) -> str:
         pointer = ".".join(str(part) for part in error.path)
         return f"schema validation failed at '{pointer}': {error.message}"
     return f"schema validation failed: {error.message}"
+
+
+def _derive_project_slug_from_path(path: str) -> str | None:
+    parts = [segment.strip() for segment in path.strip().split("/") if segment.strip()]
+    if len(parts) < 2:
+        return None
+    return _normalize_project_slug(parts[0])
+
+
+def _normalize_project_slug(raw: str | None) -> str | None:
+    if raw is None:
+        return None
+    lowered = raw.strip().lower()
+    if not lowered:
+        return None
+    normalized = _SLUG_SANITIZER.sub("-", lowered).strip("-")
+    return normalized or None

--- a/objectified-rest/src/app/repositories/manifest.py
+++ b/objectified-rest/src/app/repositories/manifest.py
@@ -36,7 +36,7 @@ class RepoManifestDefaults:
 class RepoManifestSpec:
     path: str
     format: DetectedRepositorySpecFormat | None
-    project_slug: str | None
+    project: str | None
     version_strategy: str | None
     poll_interval_sec: int | None
 
@@ -123,7 +123,7 @@ def parse_repo_manifest(raw_manifest: str | None) -> RepoManifestParseOutcome:
 
 
 def resolve_repository_file_mapping(path: str, spec: RepoManifestSpec | None) -> RepositoryMappingDecision:
-    manifest_project_slug = _normalize_project_slug(spec.project_slug) if spec is not None else None
+    manifest_project_slug = _normalize_project_slug(spec.project) if spec is not None else None
     auto_project_slug = _derive_project_slug_from_path(path)
     project_slug = manifest_project_slug or auto_project_slug
     version_strategy = (
@@ -205,7 +205,7 @@ def _to_repo_manifest(parsed: dict[str, Any]) -> RepoManifest:
             RepoManifestSpec(
                 path=str(spec["path"]),
                 format=spec.get("format"),
-                project_slug=spec.get("project"),
+                project=spec.get("project"),
                 version_strategy=spec.get("versionStrategy"),
                 poll_interval_sec=spec.get("pollIntervalSec"),
             )

--- a/objectified-rest/src/app/repositories_routes.py
+++ b/objectified-rest/src/app/repositories_routes.py
@@ -1041,7 +1041,7 @@ def _complete_repository_scan_for_tests(
                         )
                 else:
                     raise ValueError(
-                        f"Invalid type for 'tracked': {type(tracked_raw).__name__}; expected a boolean"
+                        f"Invalid type for 'tracked': {type(tracked_raw).__name__}; expected a boolean or the string 'true'/'false'"
                     )
 
             if manifest_spec is not None:
@@ -1053,7 +1053,7 @@ def _complete_repository_scan_for_tests(
             settings_json_value = dict(settings_json_raw or {})
             if mapping.settings_json is not None:
                 for key, value in mapping.settings_json.items():
-                    settings_json_value.setdefault(key, value)
+                    settings_json_value[key] = value
             if not settings_json_value:
                 settings_json_value = None
             promote_raw = item.get("promote")
@@ -1061,11 +1061,14 @@ def _complete_repository_scan_for_tests(
                 raise ValueError("promote must be either 'auto' or 'manual' when provided")
 
             project_slug_value = item.get("projectSlug")
-            if project_slug_value is None or manifest_spec is not None:
-                project_slug_value = mapping.project_slug
             version_strategy_value = item.get("versionStrategy")
-            if version_strategy_value is None or manifest_spec is not None:
-                version_strategy_value = mapping.version_strategy
+            if tracked_value:
+                if project_slug_value is None or manifest_spec is not None:
+                    project_slug_value = mapping.project_slug
+                if version_strategy_value is None or manifest_spec is not None:
+                    version_strategy_value = mapping.version_strategy
+            else:
+                project_slug_value = None
 
             current_files.append(
                 RepositoryFileRecord(

--- a/objectified-rest/src/app/repositories_routes.py
+++ b/objectified-rest/src/app/repositories_routes.py
@@ -19,7 +19,7 @@ from fastapi import APIRouter, Body, Depends, HTTPException, Query, Response
 from pydantic import BaseModel, Field
 
 from .auth import validate_authentication
-from .repositories.manifest import parse_repo_manifest
+from .repositories.manifest import parse_repo_manifest, resolve_repository_file_mapping
 
 router = APIRouter(prefix="/v1/repositories", tags=["repositories"])
 
@@ -1009,49 +1009,79 @@ def _complete_repository_scan_for_tests(
             raise ValueError(f"Scan not found: {scan_id}")
 
         target_scan = history[scan_idx]
+        repository = _REPO_STORE.get(_find_tenant_id_for_repository(repository_id), {}).get(repository_id)
+        manifest_specs_by_path: Dict[str, Any] = {}
+        if repository is not None:
+            manifest_outcome = parse_repo_manifest(repository.manifest)
+            if manifest_outcome.manifest is not None:
+                manifest_specs_by_path = {spec.path: spec for spec in manifest_outcome.manifest.specs}
         now = _utc_now_iso()
         current_files: List[RepositoryFileRecord] = []
         for item in files:
             path_raw = item.get("path")
             if not isinstance(path_raw, str) or not path_raw.strip():
                 raise ValueError("Each file must include a non-empty path")
-            tracked_raw = item.get("tracked", False)
-            if isinstance(tracked_raw, bool):
-                tracked_value = tracked_raw
-            elif isinstance(tracked_raw, str):
-                if tracked_raw.lower() == "true":
-                    tracked_value = True
-                elif tracked_raw.lower() == "false":
-                    tracked_value = False
+            normalized_path = path_raw.strip()
+            manifest_spec = manifest_specs_by_path.get(normalized_path)
+            mapping = resolve_repository_file_mapping(normalized_path, manifest_spec)
+
+            tracked_raw = item.get("tracked")
+            tracked_value = mapping.tracked
+            if tracked_raw is not None:
+                if isinstance(tracked_raw, bool):
+                    tracked_value = tracked_raw
+                elif isinstance(tracked_raw, str):
+                    if tracked_raw.lower() == "true":
+                        tracked_value = True
+                    elif tracked_raw.lower() == "false":
+                        tracked_value = False
+                    else:
+                        raise ValueError(
+                            f"Invalid value for 'tracked': {tracked_raw!r}; expected a boolean or 'true'/'false'"
+                        )
                 else:
                     raise ValueError(
-                        f"Invalid value for 'tracked': {tracked_raw!r}; expected a boolean or 'true'/'false'"
+                        f"Invalid type for 'tracked': {type(tracked_raw).__name__}; expected a boolean"
                     )
-            else:
-                raise ValueError(
-                    f"Invalid type for 'tracked': {type(tracked_raw).__name__}; expected a boolean"
-                )
+
+            if manifest_spec is not None:
+                tracked_value = mapping.tracked
+
             settings_json_raw = item.get("settingsJson")
             if settings_json_raw is not None and not isinstance(settings_json_raw, dict):
                 raise ValueError("settingsJson must be an object when provided")
+            settings_json_value = dict(settings_json_raw or {})
+            if mapping.settings_json is not None:
+                for key, value in mapping.settings_json.items():
+                    settings_json_value.setdefault(key, value)
+            if not settings_json_value:
+                settings_json_value = None
             promote_raw = item.get("promote")
             if promote_raw is not None and promote_raw not in {"auto", "manual"}:
                 raise ValueError("promote must be either 'auto' or 'manual' when provided")
+
+            project_slug_value = item.get("projectSlug")
+            if project_slug_value is None or manifest_spec is not None:
+                project_slug_value = mapping.project_slug
+            version_strategy_value = item.get("versionStrategy")
+            if version_strategy_value is None or manifest_spec is not None:
+                version_strategy_value = mapping.version_strategy
+
             current_files.append(
                 RepositoryFileRecord(
                     id=str(uuid4()),
                     repositoryId=repository_id,
                     scanId=scan_id,
-                    path=path_raw.strip(),
+                    path=normalized_path,
                     blobSha=item.get("blobSha"),
                     sizeBytes=item.get("sizeBytes"),
                     format=item.get("format"),
                     confidence=item.get("confidence"),
                     discriminator=item.get("discriminator"),
                     tracked=tracked_value,
-                    projectSlug=item.get("projectSlug"),
-                    versionStrategy=item.get("versionStrategy"),
-                    settingsJson=settings_json_raw,
+                    projectSlug=project_slug_value,
+                    versionStrategy=version_strategy_value,
+                    settingsJson=settings_json_value,
                     promote=promote_raw,
                     status="new",
                     qualityScore=item.get("qualityScore"),

--- a/objectified-rest/tests/repositories/test_manifest.py
+++ b/objectified-rest/tests/repositories/test_manifest.py
@@ -15,6 +15,8 @@ defaults:
 specs:
   - path: services/orders/openapi.yaml
     format: openapi_3_1
+    project: checkout
+    versionStrategy: branch
     pollIntervalSec: 300
 ignore:
   - "**/node_modules/**"
@@ -25,6 +27,8 @@ ignore:
     assert outcome.manifest is not None
     assert outcome.manifest.defaults.poll_interval_sec == 86400
     assert outcome.manifest.specs[0].format == "openapi_3_1"
+    assert outcome.manifest.specs[0].project_slug == "checkout"
+    assert outcome.manifest.specs[0].version_strategy == "branch"
 
 
 def test_parse_repo_manifest_returns_manifest_error_row_but_allows_scan_to_continue() -> None:
@@ -62,6 +66,8 @@ defaults:
 specs:
   - path: apis/openapi.yaml
     format: asyncapi_3
+    project: Orders API
+    versionStrategy: file-version
     pollIntervalSec: 30
   - path: apis/events.yaml
 """
@@ -83,8 +89,31 @@ specs:
     assert by_path["apis/openapi.yaml"].format == "asyncapi_3"
     # Per-spec pollIntervalSec wins over branch-level interval.
     assert by_path["apis/openapi.yaml"].poll_interval_sec == 30
+    # Manifest mapping values win over auto rules.
+    assert by_path["apis/openapi.yaml"].project_slug == "orders-api"
+    assert by_path["apis/openapi.yaml"].version_strategy == "file-version"
+
     # Missing per-spec pollIntervalSec falls back to branch-level interval.
     assert by_path["apis/events.yaml"].poll_interval_sec == 120
-    # Files omitted from manifest still appear as untracked discoveries.
-    assert by_path["apis/unlisted.yaml"].tracked is False
+    # Auto mapping derives project slug from path + commit-sha strategy.
+    assert by_path["apis/events.yaml"].project_slug == "apis"
+    assert by_path["apis/events.yaml"].version_strategy == "commit-sha"
+    # Files omitted from manifest can still be auto-mapped.
+    assert by_path["apis/unlisted.yaml"].tracked is True
     assert by_path["apis/unlisted.yaml"].format == "json_schema"
+
+
+def test_unmapped_root_file_gets_mapping_affordance() -> None:
+    rows = build_repository_file_rows(
+        discoveries=[RepositoryDiscoveryCandidate(path="openapi.yaml", detected_format="openapi_3_0")],
+        manifest=None,
+        branch_poll_interval_sec=120,
+    )
+    assert len(rows) == 1
+    assert rows[0].tracked is False
+    assert rows[0].project_slug is None
+    assert rows[0].version_strategy == "commit-sha"
+    assert rows[0].settings_json == {
+        "mappingRequired": True,
+        "mappingReason": "project_slug_not_resolved",
+    }

--- a/objectified-rest/tests/repositories/test_manifest.py
+++ b/objectified-rest/tests/repositories/test_manifest.py
@@ -27,7 +27,7 @@ ignore:
     assert outcome.manifest is not None
     assert outcome.manifest.defaults.poll_interval_sec == 86400
     assert outcome.manifest.specs[0].format == "openapi_3_1"
-    assert outcome.manifest.specs[0].project_slug == "checkout"
+    assert outcome.manifest.specs[0].project == "checkout"
     assert outcome.manifest.specs[0].version_strategy == "branch"
 
 

--- a/objectified-rest/tests/test_repositories_routes.py
+++ b/objectified-rest/tests/test_repositories_routes.py
@@ -547,3 +547,74 @@ def test_complete_scan_dispatches_import_jobs_and_records_parse_errors():
         "repository.sync_pending_review",
         "repository.sync_pending_review",
     ]
+
+
+def test_complete_scan_applies_manifest_first_mapping_and_auto_fallback_rules():
+    app.dependency_overrides[validate_authentication] = _override_auth
+    try:
+        create_response = client.post(
+            f"/v1/repositories/{_TENANT_SLUG}",
+            json={
+                "linkedAccountId": "aaaaaaaa-bbbb-cccc-dddd-000000000026",
+                "provider": "github",
+                "owner": "acme",
+                "name": "mapping-rules",
+                "branches": [{"branch": "main"}],
+                "manifest": (
+                    "version: 1\n"
+                    "specs:\n"
+                    "  - path: services/orders/openapi.yaml\n"
+                    "    project: checkout-core\n"
+                    "    versionStrategy: branch\n"
+                ),
+            },
+        )
+        repository_id = create_response.json()["repository"]["id"]
+        scan_id = create_response.json()["initialScanJobId"]
+        _complete_repository_scan_for_tests(
+            repository_id,
+            scan_id,
+            commit_sha="commit-mapping-rules",
+            files=[
+                {
+                    "path": "services/orders/openapi.yaml",
+                    "blobSha": "111",
+                    "tracked": False,
+                    "projectSlug": "should-not-win",
+                    "versionStrategy": "commit-sha",
+                },
+                {
+                    "path": "billing/openapi.yaml",
+                    "blobSha": "222",
+                },
+                {
+                    "path": "root-openapi.yaml",
+                    "blobSha": "333",
+                },
+            ],
+        )
+        files_response = client.get(
+            f"/v1/repositories/{_TENANT_SLUG}/{repository_id}/scans/{scan_id}/files",
+        )
+    finally:
+        app.dependency_overrides.pop(validate_authentication, None)
+
+    assert create_response.status_code == 201
+    assert files_response.status_code == 200
+    by_path = {row["path"]: row for row in files_response.json()["items"]}
+
+    assert by_path["services/orders/openapi.yaml"]["tracked"] is True
+    assert by_path["services/orders/openapi.yaml"]["projectSlug"] == "checkout-core"
+    assert by_path["services/orders/openapi.yaml"]["versionStrategy"] == "branch"
+
+    assert by_path["billing/openapi.yaml"]["tracked"] is True
+    assert by_path["billing/openapi.yaml"]["projectSlug"] == "billing"
+    assert by_path["billing/openapi.yaml"]["versionStrategy"] == "commit-sha"
+
+    assert by_path["root-openapi.yaml"]["tracked"] is False
+    assert by_path["root-openapi.yaml"]["projectSlug"] is None
+    assert by_path["root-openapi.yaml"]["versionStrategy"] == "commit-sha"
+    assert by_path["root-openapi.yaml"]["settingsJson"] == {
+        "mappingRequired": True,
+        "mappingReason": "project_slug_not_resolved",
+    }

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -5,6 +5,7 @@ We continue to improve the platform based on your feedback with improvements and
 ---
 
 ## Repositories
+- Added REPO-5.2 project/version mapping rules so manifest `specs[].project` + `specs[].versionStrategy` now take precedence, auto mapping falls back to path-derived project + `commit-sha`, and unmapped root-level specs persist `tracked=false` with `settingsJson.mappingRequired=true` for UI mapping prompts.
 - Added REPO-5.1 discovered-file import binding so repository scan completion now dispatches dry-run git import jobs for `new`/`modified` files (tracked files only), creates manual approval `removal` jobs for `removed` files, skips `unchanged` and untracked files, and records sync audit outcomes (`repository.sync_committed` / `repository.sync_pending_review`) with parse failures setting `repository_file.status='parse_error'`.
 - Added REPO-4.5 failure backoff + auto-pause behavior so repeated provider head-check failures exponentially back off scheduler cadence, reset on success, and auto-pause repositories with `repository.auto_paused` audit events after eight consecutive failures.
 - Added REPO-4.4 multi-branch tracking so wildcard branch templates (for example `release/*`) expand at scheduler time into tracked concrete repository branches without deleting historical scan records for previously seen branches.


### PR DESCRIPTION
## Summary
- apply manifest-first mapping resolution for repository scan files so `specs[].project` and `specs[].versionStrategy` are persisted to `repository_file`
- add deterministic auto fallback mapping (`project_slug` from first path segment, `version_strategy=commit-sha`) plus unmapped-file affordance metadata (`tracked=false`, `settingsJson.mappingRequired=true`)
- add coverage and docs for mapping behavior (`test_manifest`, `test_repositories_routes`, roadmap, and `objectified-rest/docs/REPOSITORY_MAPPING_RULES.md`)

## Test plan
- [x] `yarn build` (fails in `objectified-ui` with existing missing module `@gitbeaker/rest`)
- [x] `yarn test` (fails in existing `objectified-ui` suites: provider contract import + `tests/llm-streaming.test.ts` pretty-format error)
- [x] `python3 -m pytest --version` (pytest not installed in this environment)
- [x] `ReadLints` on edited `objectified-rest` files (no lint errors)

## Risk/notes
- Mapping now auto-tracks files that can derive a project slug from path; root-level specs remain untracked until manually mapped.
- Could not run Python tests locally because this environment lacks `pytest` and `uv`.

Fixes #2787

Made with [Cursor](https://cursor.com)