### PR TITLE
Fix #2788 - auto-create version on detected change

### DIFF
--- a/docs/PLANNED_FEATURE_ROADMAP_REPOSITORY.md
+++ b/docs/PLANNED_FEATURE_ROADMAP_REPOSITORY.md
@@ -2,6 +2,7 @@
 
 ## Completed
 
+- REPO-5.3 (#2788): Added commit-SHA draft version auto-binding for repository import jobs by creating `<datestamp>-<short-sha>` versions per resolved project with `(project, sha)` idempotency, recording `metadata.repositorySource` on created versions, and feature-gating manifest-driven project auto-creation to tenant administrators.
 - REPO-5.2 (#2787): Added manifest-first project/version mapping resolution (`specs[].project`, `specs[].versionStrategy`) with persisted `repository_file.project_slug` / `repository_file.version_strategy` decisions, documented auto fallback rules (`project` derived from path segment, `version_strategy='commit-sha'`), and unmapped-file UI affordance metadata via `tracked=false` + `settings_json.mappingRequired=true`.
 - REPO-5.1 (#2786): Added discovered-file to import-job binding in the repository scan completion path so `new`/`modified` files dispatch dry-run git import jobs, `removed` files dispatch manual-approval removal jobs, `unchanged` files skip job creation, parse failures write back `repository_file.status='parse_error'`, and each job records `repository.sync_committed` or `repository.sync_pending_review` audit events.
 - REPO-4.5 (#2783): Added scheduler failure backoff and auto-pause behavior by persisting per-branch consecutive failure/error metadata, exponentially backing off poll cadence without mutating configured poll intervals, resetting failure state on successful checks, and auto-pausing repositories with `repository.auto_paused` workflow audits after eight consecutive failures.

--- a/objectified-rest/pyproject.toml
+++ b/objectified-rest/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "objectified-rest"
-version = "1.0.59"
+version = "1.0.60"
 description = "REST API for serving OpenAPI specifications from the Objectified database"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/objectified-rest/src/app/repositories_routes.py
+++ b/objectified-rest/src/app/repositories_routes.py
@@ -619,9 +619,10 @@ def _ensure_commit_sha_version(
     branch: str,
     path: str,
 ) -> RepositoryResolvedVersionRecord:
+    normalized_sha = commit_sha.strip().lower()
     tenant_versions = _REPO_VERSION_STORE.setdefault(tenant_id, {})
     project_versions = tenant_versions.setdefault(project_slug, {})
-    existing = project_versions.get(commit_sha)
+    existing = project_versions.get(normalized_sha)
     if existing is not None:
         return existing
 
@@ -642,7 +643,7 @@ def _ensure_commit_sha_version(
         },
         createdAt=now_dt.isoformat(),
     )
-    project_versions[commit_sha] = record
+    project_versions[normalized_sha] = record
     return record
 
 

--- a/objectified-rest/src/app/repositories_routes.py
+++ b/objectified-rest/src/app/repositories_routes.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import base64
 import binascii
 import json
+import re
 from datetime import datetime, timezone
 from threading import Lock
 from typing import Any, Dict, List, Literal, Optional, Sequence, Tuple
@@ -168,6 +169,8 @@ class RepositoryImportJobRecord(BaseModel):
     state: ImportJobStatus
     diffSnapshot: Dict[str, Any] = Field(default_factory=dict)
     errorDetail: str | None = None
+    targetProjectSlug: str | None = None
+    targetVersionId: str | None = None
     createdAt: str
 
 
@@ -188,6 +191,24 @@ class RepositoryScanFilePage(BaseModel):
     nextCursor: str | None = None
 
 
+class RepositoryResolvedProjectRecord(BaseModel):
+    id: str
+    tenantId: str
+    slug: str
+    name: str
+    createdAt: str
+
+
+class RepositoryResolvedVersionRecord(BaseModel):
+    id: str
+    tenantId: str
+    projectSlug: str
+    commitSha: str
+    versionId: str
+    metadata: Dict[str, Any]
+    createdAt: str
+
+
 _REPO_STORE: Dict[str, Dict[str, RepositoryRecord]] = {}
 _REPO_BRANCH_STORE: Dict[str, List[RepositoryBranchRecord]] = {}
 _REPO_SCAN_STORE: Dict[str, List[RepositoryScanTimelineEntry]] = {}
@@ -197,10 +218,19 @@ _REPO_SCAN_FILE_HISTORY_STORE: Dict[str, List[RepositoryFileRecord]] = {}
 _REPO_CREDENTIAL_REF_STORE: Dict[str, List[Dict[str, Any]]] = {}
 _REPO_IMPORT_JOB_STORE: Dict[str, List[RepositoryImportJobRecord]] = {}
 _REPO_AUDIT_STORE: List[Dict[str, Any]] = []
+_REPO_IMPORT_POLICY_STORE: Dict[str, Dict[str, bool]] = {}
+_REPO_PROJECT_STORE: Dict[str, Dict[str, RepositoryResolvedProjectRecord]] = {}
+_REPO_VERSION_STORE: Dict[str, Dict[str, Dict[str, RepositoryResolvedVersionRecord]]] = {}
 _STORE_LOCK = Lock()
 
 _DEFAULT_SCAN_PAGE_SIZE = 50
 _MAX_SCAN_PAGE_SIZE = 200
+_SLUG_SANITIZER = re.compile(r"[^a-z0-9]+")
+_VERSION_SHA_SANITIZER = re.compile(r"[^a-z0-9]+")
+_MANIFEST_PROJECT_AUTO_CREATE_FLAG_KEYS = (
+    "repoManifestProjectAutoCreate",
+    "repo_manifest_project_auto_create",
+)
 
 
 def _utc_now_iso() -> str:
@@ -485,6 +515,137 @@ def _build_repository_source_uri(repository_id: str, path: str, branch: str, com
     return f"repo://{repository_id}/{normalized_path}@{branch}/{commit_sha}"
 
 
+def _normalize_slug(raw: str | None) -> str | None:
+    if raw is None:
+        return None
+    lowered = raw.strip().lower()
+    if not lowered:
+        return None
+    normalized = _SLUG_SANITIZER.sub("-", lowered).strip("-")
+    return normalized or None
+
+
+def _short_sha(commit_sha: str) -> str:
+    normalized = _VERSION_SHA_SANITIZER.sub("-", commit_sha.strip().lower()).strip("-")
+    return (normalized[:12] if normalized else "unknown")
+
+
+def _build_version_id_for_commit(commit_sha: str, created_at: datetime) -> str:
+    return f"{created_at.strftime('%Y%m%d')}-{_short_sha(commit_sha)}"
+
+
+def _coerce_tenant_admin_flag(auth_data: Dict[str, Any]) -> bool:
+    if bool(auth_data.get("is_tenant_admin")) or bool(auth_data.get("tenant_admin")):
+        return True
+    roles = auth_data.get("roles")
+    if isinstance(roles, list):
+        normalized_roles = {str(role).strip().lower() for role in roles}
+        if "tenant_admin" in normalized_roles or "tenant-administrator" in normalized_roles:
+            return True
+    return False
+
+
+def _is_manifest_project_auto_create_enabled(auth_data: Dict[str, Any]) -> bool:
+    containers = (
+        auth_data.get("featureFlags"),
+        auth_data.get("feature_flags"),
+        auth_data.get("flags"),
+    )
+    for container in containers:
+        if not isinstance(container, dict):
+            continue
+        for key in _MANIFEST_PROJECT_AUTO_CREATE_FLAG_KEYS:
+            if container.get(key) is True:
+                return True
+    return False
+
+
+def _manifest_project_slug_by_path(repository_id: str) -> Dict[str, str]:
+    tenant_id = _find_tenant_id_for_repository(repository_id)
+    repository = _REPO_STORE.get(tenant_id, {}).get(repository_id)
+    if repository is None:
+        return {}
+    manifest_outcome = parse_repo_manifest(repository.manifest)
+    if manifest_outcome.manifest is None:
+        return {}
+    manifest_map: Dict[str, str] = {}
+    for spec in manifest_outcome.manifest.specs:
+        normalized_slug = _normalize_slug(spec.project)
+        if normalized_slug is None:
+            continue
+        manifest_map[spec.path] = normalized_slug
+    return manifest_map
+
+
+def _ensure_project_for_scan_file(
+    *,
+    tenant_id: str,
+    repository_id: str,
+    file_row: RepositoryFileRecord,
+    manifest_project_slug_by_path: Dict[str, str],
+) -> RepositoryResolvedProjectRecord | None:
+    normalized_project_slug = _normalize_slug(file_row.projectSlug)
+    if normalized_project_slug is None:
+        return None
+    tenant_projects = _REPO_PROJECT_STORE.setdefault(tenant_id, {})
+    existing = tenant_projects.get(normalized_project_slug)
+    if existing is not None:
+        return existing
+
+    policy = _REPO_IMPORT_POLICY_STORE.get(repository_id, {})
+    allow_auto_create = bool(policy.get("allowManifestProjectAutoCreate"))
+    manifest_slug = manifest_project_slug_by_path.get(file_row.path)
+    if not allow_auto_create or manifest_slug != normalized_project_slug:
+        return None
+
+    now = _utc_now_iso()
+    created = RepositoryResolvedProjectRecord(
+        id=str(uuid4()),
+        tenantId=tenant_id,
+        slug=normalized_project_slug,
+        name=normalized_project_slug.replace("-", " ").title(),
+        createdAt=now,
+    )
+    tenant_projects[normalized_project_slug] = created
+    return created
+
+
+def _ensure_commit_sha_version(
+    *,
+    tenant_id: str,
+    project_slug: str,
+    commit_sha: str,
+    repository_id: str,
+    branch: str,
+    path: str,
+) -> RepositoryResolvedVersionRecord:
+    tenant_versions = _REPO_VERSION_STORE.setdefault(tenant_id, {})
+    project_versions = tenant_versions.setdefault(project_slug, {})
+    existing = project_versions.get(commit_sha)
+    if existing is not None:
+        return existing
+
+    now_dt = datetime.now(timezone.utc)
+    record = RepositoryResolvedVersionRecord(
+        id=str(uuid4()),
+        tenantId=tenant_id,
+        projectSlug=project_slug,
+        commitSha=commit_sha,
+        versionId=_build_version_id_for_commit(commit_sha, now_dt),
+        metadata={
+            "repositorySource": {
+                "repositoryId": repository_id,
+                "branch": branch,
+                "commitSha": commit_sha,
+                "path": path,
+            }
+        },
+        createdAt=now_dt.isoformat(),
+    )
+    project_versions[commit_sha] = record
+    return record
+
+
 def _build_diff_snapshot(file_row: RepositoryFileRecord) -> Dict[str, Any]:
     return {
         "path": file_row.path,
@@ -505,6 +666,7 @@ def _dispatch_import_jobs_for_scan(
     scan_files: List[RepositoryFileRecord],
 ) -> None:
     repository_jobs = _REPO_IMPORT_JOB_STORE.setdefault(repository_id, [])
+    manifest_project_slug_by_path = _manifest_project_slug_by_path(repository_id)
     for file_row in scan_files:
         if file_row.status not in {"new", "modified", "removed"}:
             continue
@@ -533,6 +695,27 @@ def _dispatch_import_jobs_for_scan(
         elif promote == "auto":
             state = "committed"
 
+        target_project_slug: str | None = None
+        target_version_id: str | None = None
+        if file_row.versionStrategy == "commit-sha":
+            resolved_project = _ensure_project_for_scan_file(
+                tenant_id=tenant_id,
+                repository_id=repository_id,
+                file_row=file_row,
+                manifest_project_slug_by_path=manifest_project_slug_by_path,
+            )
+            if resolved_project is not None:
+                resolved_version = _ensure_commit_sha_version(
+                    tenant_id=tenant_id,
+                    project_slug=resolved_project.slug,
+                    commit_sha=commit_sha,
+                    repository_id=repository_id,
+                    branch=branch,
+                    path=file_row.path,
+                )
+                target_project_slug = resolved_project.slug
+                target_version_id = resolved_version.versionId
+
         import_job = RepositoryImportJobRecord(
             id=str(uuid4()),
             repositoryId=repository_id,
@@ -548,6 +731,8 @@ def _dispatch_import_jobs_for_scan(
             state=state,
             diffSnapshot=_build_diff_snapshot(file_row),
             errorDetail=failure_message,
+            targetProjectSlug=target_project_slug,
+            targetVersionId=target_version_id,
             createdAt=file_row.createdAt,
         )
         repository_jobs.insert(0, import_job)
@@ -669,6 +854,10 @@ async def register_repository(
         _REPO_SCAN_HISTORY_STORE[repository.id] = [initial_scan]
         _REPO_SCAN_FILE_HISTORY_STORE[initial_scan.id] = initial_scan_files
         _REPO_CREDENTIAL_REF_STORE[repository.id] = [{"linkedAccountId": request.linkedAccountId}]
+        _REPO_IMPORT_POLICY_STORE[repository.id] = {
+            "allowManifestProjectAutoCreate": _coerce_tenant_admin_flag(auth_data)
+            and _is_manifest_project_auto_create_enabled(auth_data),
+        }
         tenant_repos[repository.id] = repository
 
     return RegisterRepositoryResponse(
@@ -993,6 +1182,9 @@ def _reset_repository_state_for_tests() -> None:
         _REPO_CREDENTIAL_REF_STORE.clear()
         _REPO_IMPORT_JOB_STORE.clear()
         _REPO_AUDIT_STORE.clear()
+        _REPO_IMPORT_POLICY_STORE.clear()
+        _REPO_PROJECT_STORE.clear()
+        _REPO_VERSION_STORE.clear()
 
 
 def _complete_repository_scan_for_tests(
@@ -1177,6 +1369,7 @@ def _seed_repository_relations_for_tests(repository_id: str) -> None:
         ]
         _REPO_FILE_STORE[repository_id] = [{"path": "README.md"}]
         _REPO_CREDENTIAL_REF_STORE[repository_id] = [{"linkedAccountId": str(uuid4())}]
+        _REPO_IMPORT_POLICY_STORE.setdefault(repository_id, {"allowManifestProjectAutoCreate": False})
 
 
 def _get_repository_audit_rows_for_tests(repository_id: str) -> List[Dict[str, Any]]:
@@ -1197,6 +1390,16 @@ def _get_repository_relations_exist_for_tests(repository_id: str) -> Dict[str, b
 def _get_repository_import_jobs_for_tests(repository_id: str) -> List[RepositoryImportJobRecord]:
     with _STORE_LOCK:
         return list(_REPO_IMPORT_JOB_STORE.get(repository_id, []))
+
+
+def _get_repository_resolved_versions_for_tests(tenant_id: str) -> List[RepositoryResolvedVersionRecord]:
+    with _STORE_LOCK:
+        tenant_versions = _REPO_VERSION_STORE.get(tenant_id, {})
+        rows: List[RepositoryResolvedVersionRecord] = []
+        for per_commit in tenant_versions.values():
+            rows.extend(per_commit.values())
+        rows.sort(key=lambda row: row.createdAt, reverse=True)
+        return rows
 
 
 def _list_poll_targets_for_tests(tenant_id: str) -> List[Dict[str, str]]:

--- a/objectified-rest/tests/test_repositories_routes.py
+++ b/objectified-rest/tests/test_repositories_routes.py
@@ -1,3 +1,5 @@
+from datetime import datetime, timezone
+
 import pytest
 from fastapi.testclient import TestClient
 
@@ -8,6 +10,7 @@ from app.repositories_routes import (
     _get_repository_audit_rows_for_tests,
     _get_repository_import_jobs_for_tests,
     _get_repository_relations_exist_for_tests,
+    _get_repository_resolved_versions_for_tests,
     _list_poll_targets_for_tests,
     _reset_repository_state_for_tests,
     _seed_repository_relations_for_tests,
@@ -27,6 +30,14 @@ _TENANT_SLUG = "test-tenant"
 
 def _override_auth():
     return _MOCK_AUTH
+
+
+def _override_auth_tenant_admin_with_repo_project_autocreate():
+    return {
+        **_MOCK_AUTH,
+        "is_tenant_admin": True,
+        "featureFlags": {"repoManifestProjectAutoCreate": True},
+    }
 
 
 @pytest.fixture(autouse=True)
@@ -618,3 +629,122 @@ def test_complete_scan_applies_manifest_first_mapping_and_auto_fallback_rules():
         "mappingRequired": True,
         "mappingReason": "project_slug_not_resolved",
     }
+
+
+def test_commit_sha_jobs_bind_to_idempotent_auto_created_versions() -> None:
+    app.dependency_overrides[validate_authentication] = _override_auth_tenant_admin_with_repo_project_autocreate
+    try:
+        create_response = client.post(
+            f"/v1/repositories/{_TENANT_SLUG}",
+            json={
+                "linkedAccountId": "aaaaaaaa-bbbb-cccc-dddd-000000000027",
+                "provider": "github",
+                "owner": "acme",
+                "name": "version-binding",
+                "branches": [{"branch": "main"}],
+                "manifest": (
+                    "version: 1\n"
+                    "specs:\n"
+                    "  - path: services/orders/openapi.yaml\n"
+                    "    project: checkout-core\n"
+                    "    versionStrategy: commit-sha\n"
+                ),
+            },
+        )
+        repository_id = create_response.json()["repository"]["id"]
+        first_scan_id = create_response.json()["initialScanJobId"]
+        _complete_repository_scan_for_tests(
+            repository_id,
+            first_scan_id,
+            commit_sha="abc123def4567890",
+            files=[
+                {
+                    "path": "services/orders/openapi.yaml",
+                    "blobSha": "111",
+                }
+            ],
+        )
+        first_jobs = [job for job in _get_repository_import_jobs_for_tests(repository_id) if job.scanId == first_scan_id]
+        first_versions = _get_repository_resolved_versions_for_tests(_MOCK_AUTH["tenant_id"])
+
+        second_scan_response = client.post(
+            f"/v1/repositories/{_TENANT_SLUG}/{repository_id}/scans",
+            json={"branch": "main", "force": True},
+        )
+        second_scan_id = second_scan_response.json()["id"]
+        _complete_repository_scan_for_tests(
+            repository_id,
+            second_scan_id,
+            commit_sha="abc123def4567890",
+            files=[
+                {
+                    "path": "services/orders/openapi.yaml",
+                    "blobSha": "222",
+                }
+            ],
+        )
+        second_jobs = [job for job in _get_repository_import_jobs_for_tests(repository_id) if job.scanId == second_scan_id]
+        second_versions = _get_repository_resolved_versions_for_tests(_MOCK_AUTH["tenant_id"])
+    finally:
+        app.dependency_overrides.pop(validate_authentication, None)
+
+    assert create_response.status_code == 201
+    assert second_scan_response.status_code == 200
+    assert len(first_jobs) == 1
+    assert len(second_jobs) == 1
+    assert len(first_versions) == 1
+    assert len(second_versions) == 1
+
+    first_job = first_jobs[0]
+    second_job = second_jobs[0]
+    created_version = first_versions[0]
+    assert first_job.targetProjectSlug == "checkout-core"
+    assert first_job.targetVersionId == created_version.versionId
+    assert second_job.targetVersionId == created_version.versionId
+    assert created_version.versionId == f"{datetime.now(timezone.utc).strftime('%Y%m%d')}-abc123def456"
+    assert created_version.metadata["repositorySource"] == {
+        "repositoryId": repository_id,
+        "branch": "main",
+        "commitSha": "abc123def4567890",
+        "path": "services/orders/openapi.yaml",
+    }
+
+
+def test_manifest_project_does_not_autocreate_without_flag_or_tenant_admin() -> None:
+    app.dependency_overrides[validate_authentication] = _override_auth
+    try:
+        create_response = client.post(
+            f"/v1/repositories/{_TENANT_SLUG}",
+            json={
+                "linkedAccountId": "aaaaaaaa-bbbb-cccc-dddd-000000000028",
+                "provider": "github",
+                "owner": "acme",
+                "name": "version-binding-guard",
+                "branches": [{"branch": "main"}],
+                "manifest": (
+                    "version: 1\n"
+                    "specs:\n"
+                    "  - path: services/orders/openapi.yaml\n"
+                    "    project: checkout-core\n"
+                    "    versionStrategy: commit-sha\n"
+                ),
+            },
+        )
+        repository_id = create_response.json()["repository"]["id"]
+        scan_id = create_response.json()["initialScanJobId"]
+        _complete_repository_scan_for_tests(
+            repository_id,
+            scan_id,
+            commit_sha="abc123def4567890",
+            files=[{"path": "services/orders/openapi.yaml", "blobSha": "111"}],
+        )
+        jobs = [job for job in _get_repository_import_jobs_for_tests(repository_id) if job.scanId == scan_id]
+        versions = _get_repository_resolved_versions_for_tests(_MOCK_AUTH["tenant_id"])
+    finally:
+        app.dependency_overrides.pop(validate_authentication, None)
+
+    assert create_response.status_code == 201
+    assert len(jobs) == 1
+    assert jobs[0].targetProjectSlug is None
+    assert jobs[0].targetVersionId is None
+    assert versions == []

--- a/objectified-rest/tests/test_repositories_routes.py
+++ b/objectified-rest/tests/test_repositories_routes.py
@@ -632,6 +632,7 @@ def test_complete_scan_applies_manifest_first_mapping_and_auto_fallback_rules():
 
 
 def test_commit_sha_jobs_bind_to_idempotent_auto_created_versions() -> None:
+    expected_date_prefix = datetime.now(timezone.utc).strftime('%Y%m%d')
     app.dependency_overrides[validate_authentication] = _override_auth_tenant_admin_with_repo_project_autocreate
     try:
         create_response = client.post(
@@ -701,7 +702,7 @@ def test_commit_sha_jobs_bind_to_idempotent_auto_created_versions() -> None:
     assert first_job.targetProjectSlug == "checkout-core"
     assert first_job.targetVersionId == created_version.versionId
     assert second_job.targetVersionId == created_version.versionId
-    assert created_version.versionId == f"{datetime.now(timezone.utc).strftime('%Y%m%d')}-abc123def456"
+    assert created_version.versionId == f"{expected_date_prefix}-abc123def456"
     assert created_version.metadata["repositorySource"] == {
         "repositoryId": repository_id,
         "branch": "main",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -5,6 +5,7 @@ We continue to improve the platform based on your feedback with improvements and
 ---
 
 ## Repositories
+- Added REPO-5.3 commit-SHA version auto-creation so repository scan import jobs now bind to idempotent draft versions named `<datestamp>-<short-sha>`, capture `metadata.repositorySource` (repository/branch/SHA/path), and allow manifest-declared missing project auto-creation only when a tenant-admin feature flag is enabled.
 - Added REPO-5.2 project/version mapping rules so manifest `specs[].project` + `specs[].versionStrategy` now take precedence, auto mapping falls back to path-derived project + `commit-sha`, and unmapped root-level specs persist `tracked=false` with `settingsJson.mappingRequired=true` for UI mapping prompts.
 - Added REPO-5.1 discovered-file import binding so repository scan completion now dispatches dry-run git import jobs for `new`/`modified` files (tracked files only), creates manual approval `removal` jobs for `removed` files, skips `unchanged` and untracked files, and records sync audit outcomes (`repository.sync_committed` / `repository.sync_pending_review`) with parse failures setting `repository_file.status='parse_error'`.
 - Added REPO-4.5 failure backoff + auto-pause behavior so repeated provider head-check failures exponentially back off scheduler cadence, reset on success, and auto-pause repositories with `repository.auto_paused` audit events after eight consecutive failures.


### PR DESCRIPTION
## Summary
- Bind repository `commit-sha` import jobs to draft versions named `<datestamp>-<short-sha>` so each changed file can target a concrete version.
- Enforce `(project_slug, commit_sha)` idempotency and persist `metadata.repositorySource` (`repositoryId`, `branch`, `commitSha`, `path`) on newly created versions.
- Gate manifest-driven missing-project auto-creation behind a tenant-admin feature flag and add route tests for both the enabled and blocked paths.
- Update repository roadmap/WHATS_NEW entries for REPO-5.3 and bump `objectified-rest` patch version.

## Test plan
- [x] `yarn build` (fails in existing workspace state: missing `@gitbeaker/rest` in `objectified-ui`)
- [x] `yarn test` (fails in existing workspace state: missing `@gitbeaker/rest` + unrelated `tests/llm-streaming.test.ts` pretty-format runtime error)
- [x] `python3 -m py_compile objectified-rest/src/app/repositories_routes.py objectified-rest/tests/test_repositories_routes.py`
- [ ] `pytest objectified-rest/tests/test_repositories_routes.py objectified-rest/tests/repositories/test_manifest.py` (blocked in this environment: `pytest` not installed)

## Risk / Notes
- Version/project binding is currently in-memory in repository route test scaffolding; DB-backed persistence will be needed when this path is wired into production repository import execution.
- Feature flag detection accepts both camelCase and snake_case keys to remain compatible with multiple auth payload shapes.

Closes #2788

Made with [Cursor](https://cursor.com)