### PR TITLE
Fix #2791 - enforce repository promotion gates

### DIFF
--- a/docs/PLANNED_FEATURE_ROADMAP_REPOSITORY.md
+++ b/docs/PLANNED_FEATURE_ROADMAP_REPOSITORY.md
@@ -2,6 +2,7 @@
 
 ## Completed
 
+- REPO-5.6 (#2791): Added manifest-driven promotion gates by defaulting repository sync promotions to `manual`, preserving `repository.sync_committed` audit + change-report persistence for `promote: auto`, and forcing manual review whenever `onBreakingChange: block` is configured.
 - REPO-5.5 (#2790): Added repository-sync conflict detection against the current draft by reusing import-pipeline conflict taxonomy, exposing conflict + resolution event history through sync-history endpoints for REPO-6.2 UI consumption, and persisting resolution choices on each `import_job.event_log`.
 - REPO-5.4 (#2789): Added repository-sync dry-run change report previews by generating a persisted `ChangeReportModel` per dispatched import job (`source_kind='repository_sync'`), keeping manual promotions in review while auto promotions proceed, and preventing dry-run scans from mutating resolved version-head state.
 - REPO-5.3 (#2788): Added commit-SHA draft version auto-binding for repository import jobs by creating `<datestamp>-<short-sha>` versions per resolved project with `(project, sha)` idempotency, recording `metadata.repositorySource` on created versions, and feature-gating manifest-driven project auto-creation to tenant administrators.

--- a/objectified-rest/pyproject.toml
+++ b/objectified-rest/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "objectified-rest"
-version = "1.0.62"
+version = "1.0.63"
 description = "REST API for serving OpenAPI specifications from the Objectified database"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/objectified-rest/src/app/repositories/manifest.py
+++ b/objectified-rest/src/app/repositories/manifest.py
@@ -38,6 +38,8 @@ class RepoManifestSpec:
     format: DetectedRepositorySpecFormat | None
     project: str | None
     version_strategy: str | None
+    promote: Literal["auto", "manual"] | None
+    on_breaking_change: Literal["warn", "block", "autoCreateNewMajor"] | None
     poll_interval_sec: int | None
 
 
@@ -58,6 +60,7 @@ class RepositoryFileRow:
     version_strategy: str | None
     poll_interval_sec: int | None
     status: str
+    promote: Literal["auto", "manual"] | None = None
     metadata: dict[str, Any] | None = None
     settings_json: dict[str, Any] | None = None
 
@@ -79,6 +82,8 @@ class RepositoryMappingDecision:
     tracked: bool
     project_slug: str | None
     version_strategy: str
+    promote: Literal["auto", "manual"]
+    on_breaking_change: Literal["warn", "block", "autoCreateNewMajor"] | None
     settings_json: dict[str, Any] | None = None
 
 
@@ -131,18 +136,29 @@ def resolve_repository_file_mapping(path: str, spec: RepoManifestSpec | None) ->
         if spec is not None and isinstance(spec.version_strategy, str) and spec.version_strategy.strip()
         else _DEFAULT_VERSION_STRATEGY
     )
+    promote: Literal["auto", "manual"] = (
+        spec.promote if spec is not None and spec.promote in {"auto", "manual"} else "manual"
+    )
+    on_breaking_change: Literal["warn", "block", "autoCreateNewMajor"] | None = (
+        spec.on_breaking_change
+        if spec is not None and spec.on_breaking_change in {"warn", "block", "autoCreateNewMajor"}
+        else None
+    )
     tracked = project_slug is not None
-    settings_json = None
+    settings_json: dict[str, Any] = {}
+    if on_breaking_change is not None:
+        settings_json["onBreakingChange"] = on_breaking_change
     if not tracked:
-        settings_json = {
-            "mappingRequired": True,
-            "mappingReason": "project_slug_not_resolved",
-        }
+        settings_json["mappingRequired"] = True
+        settings_json["mappingReason"] = "project_slug_not_resolved"
+    settings_json_or_none = settings_json or None
     return RepositoryMappingDecision(
         tracked=tracked,
         project_slug=project_slug,
         version_strategy=version_strategy,
-        settings_json=settings_json,
+        promote=promote,
+        on_breaking_change=on_breaking_change,
+        settings_json=settings_json_or_none,
     )
 
 
@@ -174,6 +190,7 @@ def build_repository_file_rows(
                 tracked=mapping.tracked,
                 project_slug=mapping.project_slug,
                 version_strategy=mapping.version_strategy,
+                promote=mapping.promote,
                 poll_interval_sec=manifest_spec_poll
                 if manifest_spec_poll is not None
                 else effective_branch_poll_interval,
@@ -207,6 +224,8 @@ def _to_repo_manifest(parsed: dict[str, Any]) -> RepoManifest:
                 format=spec.get("format"),
                 project=spec.get("project"),
                 version_strategy=spec.get("versionStrategy"),
+                promote=spec.get("promote"),
+                on_breaking_change=spec.get("onBreakingChange"),
                 poll_interval_sec=spec.get("pollIntervalSec"),
             )
             for spec in specs
@@ -222,6 +241,7 @@ def _manifest_error_row(message: str) -> RepositoryFileRow:
         tracked=True,
         project_slug=None,
         version_strategy=None,
+        promote=None,
         poll_interval_sec=None,
         status="manifest_error",
         metadata={"error": message},

--- a/objectified-rest/src/app/repositories_routes.py
+++ b/objectified-rest/src/app/repositories_routes.py
@@ -876,6 +876,9 @@ def _dispatch_import_jobs_for_scan(
         operation: ImportJobOperation = "import"
         promote: ImportJobPromotion = file_row.promote if file_row.promote in {"auto", "manual"} else "manual"
         settings_json: Dict[str, Any] = dict(file_row.settingsJson or {})
+        if settings_json.get("onBreakingChange") == "block":
+            promote = "manual"
+            settings_json["requiresExplicitApproval"] = True
         if file_row.status == "removed":
             operation = "removal"
             promote = "manual"
@@ -1552,6 +1555,8 @@ def _complete_repository_scan_for_tests(
             if settings_json_raw is not None and not isinstance(settings_json_raw, dict):
                 raise ValueError("settingsJson must be an object when provided")
             settings_json_value = dict(settings_json_raw or {})
+            if mapping.on_breaking_change is not None:
+                settings_json_value["onBreakingChange"] = mapping.on_breaking_change
             if mapping.settings_json is not None:
                 for key, value in mapping.settings_json.items():
                     settings_json_value[key] = value
@@ -1560,6 +1565,12 @@ def _complete_repository_scan_for_tests(
             promote_raw = item.get("promote")
             if promote_raw is not None and promote_raw not in {"auto", "manual"}:
                 raise ValueError("promote must be either 'auto' or 'manual' when provided")
+            if manifest_spec is not None:
+                promote_value: ImportJobPromotion = mapping.promote
+            elif promote_raw in {"auto", "manual"}:
+                promote_value = promote_raw
+            else:
+                promote_value = mapping.promote
 
             project_slug_value = item.get("projectSlug")
             version_strategy_value = item.get("versionStrategy")
@@ -1586,7 +1597,7 @@ def _complete_repository_scan_for_tests(
                     projectSlug=project_slug_value,
                     versionStrategy=version_strategy_value,
                     settingsJson=settings_json_value,
-                    promote=promote_raw,
+                    promote=promote_value,
                     status="new",
                     qualityScore=item.get("qualityScore"),
                     lastImportJobId=item.get("lastImportJobId"),

--- a/objectified-rest/tests/repositories/test_manifest.py
+++ b/objectified-rest/tests/repositories/test_manifest.py
@@ -17,6 +17,8 @@ specs:
     format: openapi_3_1
     project: checkout
     versionStrategy: branch
+    promote: auto
+    onBreakingChange: autoCreateNewMajor
     pollIntervalSec: 300
 ignore:
   - "**/node_modules/**"
@@ -29,6 +31,8 @@ ignore:
     assert outcome.manifest.specs[0].format == "openapi_3_1"
     assert outcome.manifest.specs[0].project == "checkout"
     assert outcome.manifest.specs[0].version_strategy == "branch"
+    assert outcome.manifest.specs[0].promote == "auto"
+    assert outcome.manifest.specs[0].on_breaking_change == "autoCreateNewMajor"
 
 
 def test_parse_repo_manifest_returns_manifest_error_row_but_allows_scan_to_continue() -> None:
@@ -68,6 +72,8 @@ specs:
     format: asyncapi_3
     project: Orders API
     versionStrategy: file-version
+    promote: auto
+    onBreakingChange: warn
     pollIntervalSec: 30
   - path: apis/events.yaml
 """
@@ -92,12 +98,15 @@ specs:
     # Manifest mapping values win over auto rules.
     assert by_path["apis/openapi.yaml"].project_slug == "orders-api"
     assert by_path["apis/openapi.yaml"].version_strategy == "file-version"
+    assert by_path["apis/openapi.yaml"].promote == "auto"
+    assert by_path["apis/openapi.yaml"].settings_json == {"onBreakingChange": "warn"}
 
     # Missing per-spec pollIntervalSec falls back to branch-level interval.
     assert by_path["apis/events.yaml"].poll_interval_sec == 120
     # Auto mapping derives project slug from path + commit-sha strategy.
     assert by_path["apis/events.yaml"].project_slug == "apis"
     assert by_path["apis/events.yaml"].version_strategy == "commit-sha"
+    assert by_path["apis/events.yaml"].promote == "manual"
     # Files omitted from manifest can still be auto-mapped.
     assert by_path["apis/unlisted.yaml"].tracked is True
     assert by_path["apis/unlisted.yaml"].format == "json_schema"

--- a/objectified-rest/tests/test_repositories_routes.py
+++ b/objectified-rest/tests/test_repositories_routes.py
@@ -904,3 +904,121 @@ def test_noop_dry_run_change_report_is_zero_diff_for_unchanged_file() -> None:
     assert unchanged_report["schemas"]["added"] == []
     assert unchanged_report["schemas"]["removed"] == []
     assert unchanged_report["schemas"]["modified"] == []
+
+
+def test_default_promotion_mode_is_manual_for_new_repositories() -> None:
+    app.dependency_overrides[validate_authentication] = _override_auth
+    try:
+        create_response = client.post(
+            f"/v1/repositories/{_TENANT_SLUG}",
+            json={
+                "linkedAccountId": "aaaaaaaa-bbbb-cccc-dddd-000000000041",
+                "provider": "github",
+                "owner": "acme",
+                "name": "manual-by-default",
+                "branches": [{"branch": "main"}],
+            },
+        )
+        repository_id = create_response.json()["repository"]["id"]
+        scan_id = create_response.json()["initialScanJobId"]
+        _complete_repository_scan_for_tests(
+            repository_id,
+            scan_id,
+            commit_sha="default-manual-sha",
+            files=[{"path": "apis/default.yaml", "blobSha": "111", "tracked": True}],
+        )
+        files_response = client.get(f"/v1/repositories/{_TENANT_SLUG}/{repository_id}/scans/{scan_id}/files")
+        jobs = [job for job in _get_repository_import_jobs_for_tests(repository_id) if job.scanId == scan_id]
+    finally:
+        app.dependency_overrides.pop(validate_authentication, None)
+
+    assert create_response.status_code == 201
+    assert files_response.status_code == 200
+    assert len(jobs) == 1
+    assert jobs[0].state == "pending_review"
+    assert files_response.json()["items"][0]["promote"] == "manual"
+
+
+def test_auto_promotion_records_change_report_and_sync_committed_audit() -> None:
+    app.dependency_overrides[validate_authentication] = _override_auth
+    try:
+        create_response = client.post(
+            f"/v1/repositories/{_TENANT_SLUG}",
+            json={
+                "linkedAccountId": "aaaaaaaa-bbbb-cccc-dddd-000000000042",
+                "provider": "github",
+                "owner": "acme",
+                "name": "auto-commit-audit",
+                "branches": [{"branch": "main"}],
+                "manifest": (
+                    "version: 1\n"
+                    "specs:\n"
+                    "  - path: apis/auto.yaml\n"
+                    "    project: payments\n"
+                    "    promote: auto\n"
+                    "    onBreakingChange: warn\n"
+                ),
+            },
+        )
+        repository_id = create_response.json()["repository"]["id"]
+        scan_id = create_response.json()["initialScanJobId"]
+        _complete_repository_scan_for_tests(
+            repository_id,
+            scan_id,
+            commit_sha="auto-commit-sha",
+            files=[{"path": "apis/auto.yaml", "blobSha": "111"}],
+        )
+        jobs = [job for job in _get_repository_import_jobs_for_tests(repository_id) if job.scanId == scan_id]
+        change_reports = _get_repository_change_reports_for_tests(repository_id)
+        audit_rows = _get_repository_audit_rows_for_tests(repository_id)
+    finally:
+        app.dependency_overrides.pop(validate_authentication, None)
+
+    assert create_response.status_code == 201
+    assert len(jobs) == 1
+    assert jobs[0].state == "committed"
+    assert jobs[0].changeReportId is not None
+    assert any(report.importJobId == jobs[0].id for report in change_reports)
+    assert [row["eventType"] for row in audit_rows] == ["repository.sync_committed"]
+
+
+def test_on_breaking_change_block_forces_manual_even_when_promote_is_auto() -> None:
+    app.dependency_overrides[validate_authentication] = _override_auth
+    try:
+        create_response = client.post(
+            f"/v1/repositories/{_TENANT_SLUG}",
+            json={
+                "linkedAccountId": "aaaaaaaa-bbbb-cccc-dddd-000000000043",
+                "provider": "github",
+                "owner": "acme",
+                "name": "blocking-change-gate",
+                "branches": [{"branch": "main"}],
+                "manifest": (
+                    "version: 1\n"
+                    "specs:\n"
+                    "  - path: apis/blocked.yaml\n"
+                    "    project: payments\n"
+                    "    promote: auto\n"
+                    "    onBreakingChange: block\n"
+                ),
+            },
+        )
+        repository_id = create_response.json()["repository"]["id"]
+        scan_id = create_response.json()["initialScanJobId"]
+        _complete_repository_scan_for_tests(
+            repository_id,
+            scan_id,
+            commit_sha="blocked-commit-sha",
+            files=[{"path": "apis/blocked.yaml", "blobSha": "111"}],
+        )
+        jobs = [job for job in _get_repository_import_jobs_for_tests(repository_id) if job.scanId == scan_id]
+        audit_rows = _get_repository_audit_rows_for_tests(repository_id)
+    finally:
+        app.dependency_overrides.pop(validate_authentication, None)
+
+    assert create_response.status_code == 201
+    assert len(jobs) == 1
+    assert jobs[0].state == "pending_review"
+    assert jobs[0].settingsJson["onBreakingChange"] == "block"
+    assert jobs[0].settingsJson["requiresExplicitApproval"] is True
+    assert [row["eventType"] for row in audit_rows] == ["repository.sync_pending_review"]

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -5,6 +5,7 @@ We continue to improve the platform based on your feedback with improvements and
 ---
 
 ## Repositories
+- Added REPO-5.6 promotion gates so repository sync now defaults to `manual` promotions, still records change reports + `repository.sync_committed` audits for `promote: auto`, and forces manual review whenever `onBreakingChange` is set to `block`.
 - Added REPO-5.5 repository-sync conflict handling so modified-file import jobs now carry import-taxonomy conflict records (`duplicate_schema`/`property_conflict`/`reference_conflict`/`type_mismatch`/`semantic_conflict`), sync-history endpoints expose resolver-ready conflict context for REPO-6.2, and conflict-resolution choices are persisted to each job `eventLog`.
 - Added REPO-5.4 dry-run repository sync previews so each dispatched sync import job now stores a `repository_sync` change report snapshot, manual promotions have inline diff context before commit, auto promotions remain non-blocking, and dry-run scans no longer mutate resolved version-head state.
 - Added REPO-5.3 commit-SHA version auto-creation so repository scan import jobs now bind to idempotent draft versions named `<datestamp>-<short-sha>`, capture `metadata.repositorySource` (repository/branch/SHA/path), and allow manifest-declared missing project auto-creation only when a tenant-admin feature flag is enabled.


### PR DESCRIPTION
## Summary
- Wire manifest `specs[].promote` / `specs[].onBreakingChange` into repository file mapping so promotion defaults to `manual` and policy metadata stays attached through scan completion.
- Enforce promotion gating in sync dispatch: `onBreakingChange=block` always routes jobs to manual review (`pending_review`) with explicit-approval metadata.
- Add route + manifest coverage tests for default manual promotions, auto promotion audit/change-report persistence, and `block` forcing manual.

## Test plan
- [x] `yarn build` (fails in existing unrelated workspace state: `objectified-ui` missing `@gitbeaker/rest` type dependency)
- [x] `yarn test` (fails in existing unrelated workspace state: 2 Jest suites failing with `TypeError: (0 , _prettyFormat.format) is not a function`)
- [ ] Backend Python tests in `objectified-rest` (`uv` and `pytest` are not installed in this environment)

## Risk / notes
- Manifest parsing now carries promotion policy fields and emits `onBreakingChange` metadata for downstream gating logic.
- Scoped to repository sync dry-run dispatch; no changes to non-repository import flows.

Fixes #2791

Made with [Cursor](https://cursor.com)