### PR TITLE
Fix #2794 - repositories index page

### DIFF
--- a/docs/PLANNED_FEATURE_ROADMAP_REPOSITORY.md
+++ b/docs/PLANNED_FEATURE_ROADMAP_REPOSITORY.md
@@ -2,6 +2,7 @@
 
 ## Completed
 
+- REPO-6.1 (#2794): Added an ADE repositories index experience with provider/status/search filters, sortable repository health and last-scan columns, skeleton-loading rows, and quick row actions for scan-now, pause/resume, and detail navigation from Account -> Repositories.
 - REPO-5.6 (#2791): Added manifest-driven promotion gates by defaulting repository sync promotions to `manual`, preserving `repository.sync_committed` audit + change-report persistence for `promote: auto`, and forcing manual review whenever `onBreakingChange: block` is configured.
 - REPO-5.5 (#2790): Added repository-sync conflict detection against the current draft by reusing import-pipeline conflict taxonomy, exposing conflict + resolution event history through sync-history endpoints for REPO-6.2 UI consumption, and persisting resolution choices on each `import_job.event_log`.
 - REPO-5.4 (#2789): Added repository-sync dry-run change report previews by generating a persisted `ChangeReportModel` per dispatched import job (`source_kind='repository_sync'`), keeping manual promotions in review while auto promotions proceed, and preventing dry-run scans from mutating resolved version-head state.

--- a/objectified-rest/pyproject.toml
+++ b/objectified-rest/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "objectified-rest"
-version = "1.0.63"
+version = "1.0.64"
 description = "REST API for serving OpenAPI specifications from the Objectified database"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/objectified-rest/src/app/repositories_routes.py
+++ b/objectified-rest/src/app/repositories_routes.py
@@ -511,6 +511,8 @@ def _normalize_branches(branches: List[RepositoryBranchInput]) -> List[Repositor
 
 
 def _to_summary(repo: RepositoryRecord) -> Dict[str, Any]:
+    timeline_created_at = [entry.createdAt for entry in repo.timeline if entry.createdAt]
+    last_scan_at = max(timeline_created_at) if timeline_created_at else None
     return {
         "id": repo.id,
         "provider": repo.provider,
@@ -519,6 +521,7 @@ def _to_summary(repo: RepositoryRecord) -> Dict[str, Any]:
         "fullName": repo.fullName,
         "status": repo.status,
         "branches": [b.branch for b in repo.branches],
+        "lastScanAt": last_scan_at,
         "createdAt": repo.createdAt,
         "updatedAt": repo.updatedAt,
     }

--- a/objectified-rest/src/app/repositories_routes.py
+++ b/objectified-rest/src/app/repositories_routes.py
@@ -510,9 +510,20 @@ def _normalize_branches(branches: List[RepositoryBranchInput]) -> List[Repositor
     return normalized_branches
 
 
+def _get_repository_last_scan_at(repository_id: str) -> Optional[str]:
+    with _STORE_LOCK:
+        scan_timestamps = [
+            scan.createdAt or scan.startedAt or scan.finishedAt
+            for scan in _REPO_SCAN_HISTORY_STORE.get(repository_id, [])
+            if scan.createdAt or scan.startedAt or scan.finishedAt
+        ]
+    return max(scan_timestamps) if scan_timestamps else None
+
+
 def _to_summary(repo: RepositoryRecord) -> Dict[str, Any]:
     timeline_created_at = [entry.createdAt for entry in repo.timeline if entry.createdAt]
-    last_scan_at = max(timeline_created_at) if timeline_created_at else None
+    timeline_last_scan_at = max(timeline_created_at) if timeline_created_at else None
+    last_scan_at = _get_repository_last_scan_at(repo.id) or timeline_last_scan_at
     return {
         "id": repo.id,
         "provider": repo.provider,

--- a/objectified-rest/tests/test_repositories_routes.py
+++ b/objectified-rest/tests/test_repositories_routes.py
@@ -97,7 +97,8 @@ def test_repository_list_and_detail_are_tenant_scoped():
     assert create_response.status_code == 201
     assert list_response.status_code == 200
     assert detail_response.status_code == 200
-    list_item = next(item for item in list_response.json()["repositories"] if item["id"] == repository_id)
+    list_item = next((item for item in list_response.json()["repositories"] if item["id"] == repository_id), None)
+    assert list_item is not None
     assert list_item["lastScanAt"] == create_response.json()["repository"]["timeline"][0]["createdAt"]
     assert detail_response.json()["id"] == repository_id
 

--- a/objectified-rest/tests/test_repositories_routes.py
+++ b/objectified-rest/tests/test_repositories_routes.py
@@ -97,7 +97,8 @@ def test_repository_list_and_detail_are_tenant_scoped():
     assert create_response.status_code == 201
     assert list_response.status_code == 200
     assert detail_response.status_code == 200
-    assert any(item["id"] == repository_id for item in list_response.json()["repositories"])
+    list_item = next(item for item in list_response.json()["repositories"] if item["id"] == repository_id)
+    assert list_item["lastScanAt"] == create_response.json()["repository"]["timeline"][0]["createdAt"]
     assert detail_response.json()["id"] == repository_id
 
 

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.10.38",
+  "version": "0.10.39",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -5,6 +5,7 @@ We continue to improve the platform based on your feedback with improvements and
 ---
 
 ## Repositories
+- Added REPO-6.1 repository index upgrades with skeleton loading, provider/status/search filters, sortable name/last-scan/status columns, and quick row actions for **Scan now**, **Pause/Resume**, and **Open detail** under Account -> Repositories.
 - Added REPO-5.6 promotion gates so repository sync now defaults to `manual` promotions, still records change reports + `repository.sync_committed` audits for `promote: auto`, and forces manual review whenever `onBreakingChange` is set to `block`.
 - Added REPO-5.5 repository-sync conflict handling so modified-file import jobs now carry import-taxonomy conflict records (`duplicate_schema`/`property_conflict`/`reference_conflict`/`type_mismatch`/`semantic_conflict`), sync-history endpoints expose resolver-ready conflict context for REPO-6.2, and conflict-resolution choices are persisted to each job `eventLog`.
 - Added REPO-5.4 dry-run repository sync previews so each dispatched sync import job now stores a `repository_sync` change report snapshot, manual promotions have inline diff context before commit, auto promotions remain non-blocking, and dry-run scans no longer mutate resolved version-head state.

--- a/objectified-ui/src/app/ade/dashboard/repositories/i18n.ts
+++ b/objectified-ui/src/app/ade/dashboard/repositories/i18n.ts
@@ -7,12 +7,22 @@ export interface RepositoriesI18nBundle {
   searchPlaceholder: string;
   providerAll: string;
   statusAll: string;
+  tableLastScan: string;
+  tableActions: string;
   emptyTitle: string;
   emptyDescription: string;
+  emptyAction: string;
   tableRepo: string;
   tableProvider: string;
   tableBranches: string;
   tableStatus: string;
+  scanNowButton: string;
+  pauseButton: string;
+  resumeButton: string;
+  openDetailButton: string;
+  scanQueuedMessage: string;
+  pausedMessage: string;
+  resumedMessage: string;
   wizardTitle: string;
   wizardDescription: string;
   wizardBack: string;
@@ -77,12 +87,22 @@ export const repositoriesI18n: Record<RepositoriesLocale, RepositoriesI18nBundle
     searchPlaceholder: 'Search repositories...',
     providerAll: 'All providers',
     statusAll: 'All statuses',
+    tableLastScan: 'Last scan',
+    tableActions: 'Actions',
     emptyTitle: 'No repositories yet',
     emptyDescription: 'Register a repository to start scan and sync workflows.',
+    emptyAction: 'Register your first repository',
     tableRepo: 'Repository',
     tableProvider: 'Provider',
     tableBranches: 'Branches',
     tableStatus: 'Status',
+    scanNowButton: 'Scan now',
+    pauseButton: 'Pause',
+    resumeButton: 'Resume',
+    openDetailButton: 'Open detail',
+    scanQueuedMessage: 'Scan queued.',
+    pausedMessage: 'Repository paused.',
+    resumedMessage: 'Repository resumed.',
     wizardTitle: 'Add Repository',
     wizardDescription: 'Connect a repository and kick off an initial scan.',
     wizardBack: 'Back',

--- a/objectified-ui/src/app/ade/dashboard/repositories/page.tsx
+++ b/objectified-ui/src/app/ade/dashboard/repositories/page.tsx
@@ -1,13 +1,14 @@
 'use client';
 
-import { useMemo, useState, useEffect } from 'react';
+import { useMemo, useState, useEffect, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
-import { GitBranchPlus, Search, Loader2 } from 'lucide-react';
+import { GitBranchPlus, Search } from 'lucide-react';
 import { SiGithub } from 'react-icons/si';
 import { Button } from '@/app/components/ui/Button';
 import { Input } from '@/app/components/ui/Input';
 import { Alert } from '@/app/components/ui/Alert';
 import { EmptyState } from '@/app/components/ui/EmptyState';
+import { Skeleton } from '@/app/components/ui/Skeleton';
 import {
   Dialog,
   DialogContent,
@@ -58,6 +59,7 @@ interface RegisteredRepository {
   fullName: string;
   status: string;
   branches: string[];
+  lastScanAt?: string | null;
 }
 
 function formatRepositoryStatus(status: string): string {
@@ -66,12 +68,43 @@ function formatRepositoryStatus(status: string): string {
   return status.replace(/_/g, ' ');
 }
 
+type RepositorySortField = 'name' | 'lastScan' | 'status';
+type RepositorySortDirection = 'asc' | 'desc';
+
+function formatLastScan(lastScanAt: string | null | undefined): string {
+  if (!lastScanAt) return 'Never';
+  return new Date(lastScanAt).toLocaleString();
+}
+
+function statusChipClass(status: string): string {
+  if (status === 'healthy') {
+    return 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/50 dark:text-emerald-200';
+  }
+  if (status === 'warnings') {
+    return 'bg-amber-100 text-amber-700 dark:bg-amber-900/50 dark:text-amber-200';
+  }
+  if (status === 'error') {
+    return 'bg-red-100 text-red-700 dark:bg-red-900/50 dark:text-red-200';
+  }
+  if (status === 'scan_in_progress') {
+    return 'bg-indigo-100 text-indigo-700 dark:bg-indigo-900/50 dark:text-indigo-200';
+  }
+  if (status === 'archived') {
+    return 'bg-slate-200 text-slate-700 dark:bg-slate-700/70 dark:text-slate-200';
+  }
+  return 'bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-200';
+}
+
 const RepositoriesPage = () => {
   const router = useRouter();
   const copy = getRepositoriesI18nBundle('en');
 
   const [repositories, setRepositories] = useState<RegisteredRepository[]>([]);
   const [search, setSearch] = useState('');
+  const [providerFilter, setProviderFilter] = useState('all');
+  const [statusFilter, setStatusFilter] = useState('all');
+  const [sortField, setSortField] = useState<RepositorySortField>('lastScan');
+  const [sortDirection, setSortDirection] = useState<RepositorySortDirection>('desc');
   const [isLoading, setIsLoading] = useState(true);
   const [errorMessage, setErrorMessage] = useState('');
   const [successMessage, setSuccessMessage] = useState('');
@@ -89,25 +122,26 @@ const RepositoriesPage = () => {
   const [manifest, setManifest] = useState('');
   const [isWizardBusy, setIsWizardBusy] = useState(false);
 
-  useEffect(() => {
-    const loadRepositories = async () => {
-      setIsLoading(true);
-      try {
-        const response = await fetch('/api/repositories');
-        const data = await response.json();
-        if (!response.ok || !data.success) {
-          throw new Error(data.error || 'Failed to load repositories');
-        }
-        setRepositories(data.repositories || []);
-      } catch (error) {
-        const message = error instanceof Error ? error.message : 'Failed to load repositories';
-        setErrorMessage(message);
-      } finally {
-        setIsLoading(false);
+  const loadRepositories = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const response = await fetch('/api/repositories');
+      const data = await response.json();
+      if (!response.ok || !data.success) {
+        throw new Error(data.error || 'Failed to load repositories');
       }
-    };
-    void loadRepositories();
+      setRepositories(data.repositories || []);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to load repositories';
+      setErrorMessage(message);
+    } finally {
+      setIsLoading(false);
+    }
   }, []);
+
+  useEffect(() => {
+    void loadRepositories();
+  }, [loadRepositories]);
 
   const openWizard = async () => {
     setWizardOpen(true);
@@ -193,11 +227,91 @@ const RepositoriesPage = () => {
     );
   }, [githubRepos, repoSearch]);
 
-  const filteredRegisteredRepos = useMemo(() => {
+  const providerOptions = useMemo(() => {
+    return Array.from(new Set(repositories.map((repo) => repo.provider))).sort((a, b) => a.localeCompare(b));
+  }, [repositories]);
+
+  const statusOptions = useMemo(() => {
+    return Array.from(new Set(repositories.map((repo) => repo.status))).sort((a, b) => a.localeCompare(b));
+  }, [repositories]);
+
+  const filteredAndSortedRepos = useMemo(() => {
     const q = search.trim().toLowerCase();
-    if (!q) return repositories;
-    return repositories.filter((repo) => repo.fullName.toLowerCase().includes(q));
-  }, [repositories, search]);
+    const filtered = repositories.filter((repo) => {
+      const matchesSearch =
+        q.length === 0 ||
+        repo.fullName.toLowerCase().includes(q) ||
+        repo.name.toLowerCase().includes(q) ||
+        repo.owner.toLowerCase().includes(q);
+      const matchesProvider = providerFilter === 'all' || repo.provider === providerFilter;
+      const matchesStatus = statusFilter === 'all' || repo.status === statusFilter;
+      return matchesSearch && matchesProvider && matchesStatus;
+    });
+
+    const sorted = [...filtered].sort((left, right) => {
+      if (sortField === 'name') {
+        return left.fullName.localeCompare(right.fullName);
+      }
+      if (sortField === 'status') {
+        return formatRepositoryStatus(left.status).localeCompare(formatRepositoryStatus(right.status));
+      }
+      const leftStamp = left.lastScanAt ? Date.parse(left.lastScanAt) : 0;
+      const rightStamp = right.lastScanAt ? Date.parse(right.lastScanAt) : 0;
+      return leftStamp - rightStamp;
+    });
+
+    return sortDirection === 'asc' ? sorted : sorted.reverse();
+  }, [repositories, providerFilter, search, sortDirection, sortField, statusFilter]);
+
+  const handleSort = (field: RepositorySortField) => {
+    if (sortField !== field) {
+      setSortField(field);
+      setSortDirection(field === 'lastScan' ? 'desc' : 'asc');
+      return;
+    }
+    setSortDirection((prev) => (prev === 'asc' ? 'desc' : 'asc'));
+  };
+
+  const triggerScanNow = async (repository: RegisteredRepository) => {
+    setErrorMessage('');
+    setSuccessMessage('');
+    try {
+      const fallbackBranch = repository.branches[0] || 'main';
+      const response = await fetch(`/api/repositories/${repository.id}/scans`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ branch: fallbackBranch, force: true }),
+      });
+      const data = await response.json();
+      if (!response.ok || !data.success) {
+        throw new Error(data.error || 'Failed to queue repository scan');
+      }
+      await loadRepositories();
+      setSuccessMessage(copy.scanQueuedMessage);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to queue repository scan';
+      setErrorMessage(message);
+    }
+  };
+
+  const togglePauseState = async (repository: RegisteredRepository) => {
+    setErrorMessage('');
+    setSuccessMessage('');
+    const isArchived = repository.status === 'archived';
+    const action = isArchived ? 'unarchive' : 'archive';
+    try {
+      const response = await fetch(`/api/repositories/${repository.id}/${action}`, { method: 'POST' });
+      const data = await response.json();
+      if (!response.ok || !data.success) {
+        throw new Error(data.error || `Failed to ${isArchived ? 'resume' : 'pause'} repository`);
+      }
+      await loadRepositories();
+      setSuccessMessage(isArchived ? copy.resumedMessage : copy.pausedMessage);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : `Failed to ${isArchived ? 'resume' : 'pause'} repository`;
+      setErrorMessage(message);
+    }
+  };
 
   const toggleBranch = (branchName: string) => {
     setSelectedBranches((prev) => {
@@ -343,67 +457,131 @@ const RepositoriesPage = () => {
           )}
 
           <section className={`${dashboardPanelClass} p-4`}>
-            <div className="relative">
-              <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
-              <Input
-                value={search}
-                onChange={(event) => setSearch(event.target.value)}
-                placeholder={copy.searchPlaceholder}
-                className="pl-8"
-              />
+            <div className="grid grid-cols-1 gap-3 lg:grid-cols-3">
+              <div className="relative">
+                <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
+                <Input
+                  value={search}
+                  onChange={(event) => setSearch(event.target.value)}
+                  placeholder={copy.searchPlaceholder}
+                  className="pl-8"
+                />
+              </div>
+              <select
+                className="h-10 rounded-md border border-gray-200 bg-white px-3 text-sm text-gray-700 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-200"
+                value={providerFilter}
+                onChange={(event) => setProviderFilter(event.target.value)}
+                aria-label={copy.tableProvider}
+              >
+                <option value="all">{copy.providerAll}</option>
+                {providerOptions.map((provider) => (
+                  <option key={provider} value={provider}>
+                    {provider}
+                  </option>
+                ))}
+              </select>
+              <select
+                className="h-10 rounded-md border border-gray-200 bg-white px-3 text-sm text-gray-700 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-200"
+                value={statusFilter}
+                onChange={(event) => setStatusFilter(event.target.value)}
+                aria-label={copy.tableStatus}
+              >
+                <option value="all">{copy.statusAll}</option>
+                {statusOptions.map((status) => (
+                  <option key={status} value={status}>
+                    {formatRepositoryStatus(status)}
+                  </option>
+                ))}
+              </select>
             </div>
           </section>
 
           <section>
-            {isLoading ? (
-              <div className="flex items-center justify-center py-10 text-sm text-gray-500 dark:text-gray-400">
-                <Loader2 className="h-5 w-5 animate-spin mr-2" />
-                {copy.loadingRepositories}
-              </div>
-            ) : filteredRegisteredRepos.length === 0 ? (
+            {!isLoading && filteredAndSortedRepos.length === 0 ? (
               <EmptyState
                 icon={<GitBranchPlus className="h-10 w-10" />}
                 title={copy.emptyTitle}
                 description={copy.emptyDescription}
+                action={<Button onClick={() => void openWizard()}>{copy.emptyAction}</Button>}
               />
             ) : (
               <div className={dashboardTableWrapClass}>
                 <table className="min-w-full">
                   <thead className={dashboardTableTheadClass}>
                     <tr>
-                      <th className={dashboardThClass}>{copy.tableRepo}</th>
+                      <th className={dashboardThClass}>
+                        <button type="button" onClick={() => handleSort('name')} className="inline-flex items-center gap-1">
+                          {copy.tableRepo}
+                          {sortField === 'name' ? (sortDirection === 'asc' ? '↑' : '↓') : null}
+                        </button>
+                      </th>
                       <th className={dashboardThClass}>{copy.tableProvider}</th>
                       <th className={dashboardThClass}>{copy.tableBranches}</th>
-                      <th className={dashboardThClass}>{copy.tableStatus}</th>
-                      <th className={dashboardThRightClass} />
+                      <th className={dashboardThClass}>
+                        <button type="button" onClick={() => handleSort('status')} className="inline-flex items-center gap-1">
+                          {copy.tableStatus}
+                          {sortField === 'status' ? (sortDirection === 'asc' ? '↑' : '↓') : null}
+                        </button>
+                      </th>
+                      <th className={dashboardThClass}>
+                        <button type="button" onClick={() => handleSort('lastScan')} className="inline-flex items-center gap-1">
+                          {copy.tableLastScan}
+                          {sortField === 'lastScan' ? (sortDirection === 'asc' ? '↑' : '↓') : null}
+                        </button>
+                      </th>
+                      <th className={dashboardThRightClass}>{copy.tableActions}</th>
                     </tr>
                   </thead>
                   <tbody className={dashboardTbodyClass}>
-                    {filteredRegisteredRepos.map((repo) => (
-                      <tr key={repo.id} className={dashboardTrHoverClass}>
-                        <td className="px-6 py-4 text-sm font-medium text-gray-900 dark:text-gray-100">
-                          {repo.fullName}
-                        </td>
-                        <td className="px-6 py-4 text-sm text-gray-600 dark:text-gray-300 capitalize">
-                          {repo.provider}
-                        </td>
-                        <td className="px-6 py-4 text-sm text-gray-600 dark:text-gray-300">
-                          {(repo.branches || []).join(', ')}
-                        </td>
-                        <td className="px-6 py-4 text-sm text-gray-600 dark:text-gray-300">
-                          {formatRepositoryStatus(repo.status)}
-                        </td>
-                        <td className="px-6 py-4 text-right">
-                          <Button
-                            size="sm"
-                            variant="outline"
-                            onClick={() => router.push(`/ade/dashboard/repositories/${repo.id}`)}
-                          >
-                            {copy.viewButton}
-                          </Button>
-                        </td>
-                      </tr>
-                    ))}
+                    {isLoading
+                      ? Array.from({ length: 6 }).map((_, idx) => (
+                          <tr key={`skeleton-${idx}`} className={dashboardTrHoverClass}>
+                            <td className="px-6 py-4"><Skeleton className="h-4 w-52" /></td>
+                            <td className="px-6 py-4"><Skeleton className="h-4 w-20" /></td>
+                            <td className="px-6 py-4"><Skeleton className="h-4 w-24" /></td>
+                            <td className="px-6 py-4"><Skeleton className="h-6 w-28 rounded-full" /></td>
+                            <td className="px-6 py-4"><Skeleton className="h-4 w-32" /></td>
+                            <td className="px-6 py-4"><Skeleton className="h-8 w-60" /></td>
+                          </tr>
+                        ))
+                      : filteredAndSortedRepos.map((repo) => (
+                          <tr key={repo.id} className={dashboardTrHoverClass}>
+                            <td className="px-6 py-4 text-sm font-medium text-gray-900 dark:text-gray-100">
+                              {repo.fullName}
+                            </td>
+                            <td className="px-6 py-4 text-sm text-gray-600 dark:text-gray-300 capitalize">
+                              {repo.provider}
+                            </td>
+                            <td className="px-6 py-4 text-sm text-gray-600 dark:text-gray-300">
+                              {(repo.branches || []).join(', ')}
+                            </td>
+                            <td className="px-6 py-4 text-sm text-gray-600 dark:text-gray-300">
+                              <span className={`inline-flex rounded-full px-2 py-1 text-xs font-medium ${statusChipClass(repo.status)}`}>
+                                {formatRepositoryStatus(repo.status)}
+                              </span>
+                            </td>
+                            <td className="px-6 py-4 text-sm text-gray-600 dark:text-gray-300">
+                              {formatLastScan(repo.lastScanAt)}
+                            </td>
+                            <td className="px-6 py-4">
+                              <div className="flex items-center justify-end gap-2">
+                                <Button size="sm" variant="outline" onClick={() => void triggerScanNow(repo)}>
+                                  {copy.scanNowButton}
+                                </Button>
+                                <Button size="sm" variant="outline" onClick={() => void togglePauseState(repo)}>
+                                  {repo.status === 'archived' ? copy.resumeButton : copy.pauseButton}
+                                </Button>
+                                <Button
+                                  size="sm"
+                                  variant="outline"
+                                  onClick={() => router.push(`/ade/dashboard/repositories/${repo.id}`)}
+                                >
+                                  {copy.openDetailButton}
+                                </Button>
+                              </div>
+                            </td>
+                          </tr>
+                        ))}
                   </tbody>
                 </table>
               </div>

--- a/objectified-ui/src/app/ade/dashboard/repositories/page.tsx
+++ b/objectified-ui/src/app/ade/dashboard/repositories/page.tsx
@@ -509,24 +509,48 @@ const RepositoriesPage = () => {
                 <table className="min-w-full">
                   <thead className={dashboardTableTheadClass}>
                     <tr>
-                      <th className={dashboardThClass}>
+                      <th
+                        className={dashboardThClass}
+                        aria-sort={sortField === 'name' ? (sortDirection === 'asc' ? 'ascending' : 'descending') : 'none'}
+                      >
                         <button type="button" onClick={() => handleSort('name')} className="inline-flex items-center gap-1">
                           {copy.tableRepo}
                           {sortField === 'name' ? (sortDirection === 'asc' ? '↑' : '↓') : null}
+                          <span className="sr-only">
+                            {sortField === 'name'
+                              ? `, sorted ${sortDirection === 'asc' ? 'ascending' : 'descending'}`
+                              : ', not sorted'}
+                          </span>
                         </button>
                       </th>
                       <th className={dashboardThClass}>{copy.tableProvider}</th>
                       <th className={dashboardThClass}>{copy.tableBranches}</th>
-                      <th className={dashboardThClass}>
+                      <th
+                        className={dashboardThClass}
+                        aria-sort={sortField === 'status' ? (sortDirection === 'asc' ? 'ascending' : 'descending') : 'none'}
+                      >
                         <button type="button" onClick={() => handleSort('status')} className="inline-flex items-center gap-1">
                           {copy.tableStatus}
                           {sortField === 'status' ? (sortDirection === 'asc' ? '↑' : '↓') : null}
+                          <span className="sr-only">
+                            {sortField === 'status'
+                              ? `, sorted ${sortDirection === 'asc' ? 'ascending' : 'descending'}`
+                              : ', not sorted'}
+                          </span>
                         </button>
                       </th>
-                      <th className={dashboardThClass}>
+                      <th
+                        className={dashboardThClass}
+                        aria-sort={sortField === 'lastScan' ? (sortDirection === 'asc' ? 'ascending' : 'descending') : 'none'}
+                      >
                         <button type="button" onClick={() => handleSort('lastScan')} className="inline-flex items-center gap-1">
                           {copy.tableLastScan}
                           {sortField === 'lastScan' ? (sortDirection === 'asc' ? '↑' : '↓') : null}
+                          <span className="sr-only">
+                            {sortField === 'lastScan'
+                              ? `, sorted ${sortDirection === 'asc' ? 'ascending' : 'descending'}`
+                              : ', not sorted'}
+                          </span>
                         </button>
                       </th>
                       <th className={dashboardThRightClass}>{copy.tableActions}</th>

--- a/objectified-ui/src/app/api/repositories/[id]/scans/route.ts
+++ b/objectified-ui/src/app/api/repositories/[id]/scans/route.ts
@@ -1,0 +1,60 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/app/api/auth/[...nextauth]/route';
+import { getTenantById } from '@lib/db/helper';
+import { createRestAuthHeaders, REST_API_BASE_URL } from '@lib/rest-auth';
+
+export const dynamic = 'force-dynamic';
+
+type SessionUser = {
+  user_id?: string;
+  email?: string | null;
+  name?: string | null;
+  current_tenant_id?: string;
+};
+
+async function resolveAuthContext() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user) {
+    return { error: NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 }) };
+  }
+  const user = session.user as SessionUser;
+  if (!user.current_tenant_id) {
+    return { error: NextResponse.json({ success: false, error: 'No tenant selected' }, { status: 400 }) };
+  }
+  const tenant = await getTenantById(user.current_tenant_id);
+  if (!tenant?.slug) {
+    return { error: NextResponse.json({ success: false, error: 'Tenant slug not found' }, { status: 400 }) };
+  }
+  return { sessionUser: user, tenantSlug: tenant.slug };
+}
+
+export async function POST(
+  request: Request,
+  context: { params: Promise<{ id: string }> }
+) {
+  try {
+    const auth = await resolveAuthContext();
+    if ('error' in auth) return auth.error;
+
+    const params = await context.params;
+    const body = await request.json().catch(() => ({}));
+    const response = await fetch(
+      `${REST_API_BASE_URL}/repositories/${encodeURIComponent(auth.tenantSlug)}/${encodeURIComponent(params.id)}/scans`,
+      {
+        method: 'POST',
+        headers: createRestAuthHeaders(auth.sessionUser),
+        body: JSON.stringify(body),
+      }
+    );
+    const data = await response.json().catch(() => ({}));
+    if (!response.ok) {
+      const detail = typeof data.detail === 'string' ? data.detail : 'Failed to trigger repository scan';
+      return NextResponse.json({ success: false, error: detail }, { status: response.status });
+    }
+    return NextResponse.json({ success: true, scan: data });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Internal server error';
+    return NextResponse.json({ success: false, error: message }, { status: 500 });
+  }
+}

--- a/objectified-ui/tests/repositories-index.test.tsx
+++ b/objectified-ui/tests/repositories-index.test.tsx
@@ -21,6 +21,8 @@ type RepoRow = {
   lastScanAt?: string | null;
 };
 
+let originalFetch: typeof global.fetch;
+
 function setupFetchMock(repositories: RepoRow[]) {
   const fetchMock = jest.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
     const url = typeof input === 'string' ? input : input.toString();
@@ -55,7 +57,12 @@ function setupFetchMock(repositories: RepoRow[]) {
 }
 
 describe('Repositories index page', () => {
-  beforeEach(() => {
+  beforeAll(() => {
+    originalFetch = global.fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
     mockPush.mockReset();
   });
 
@@ -130,5 +137,109 @@ describe('Repositories index page', () => {
         expect.objectContaining({ method: 'POST' })
       )
     );
+  });
+
+  it('renders skeleton rows while loading', async () => {
+    let resolveFetch!: (value: unknown) => void;
+    const fetchPromise = new Promise((resolve) => { resolveFetch = resolve; });
+    global.fetch = jest.fn(() => fetchPromise) as unknown as typeof fetch;
+
+    render(<RepositoriesPage />);
+
+    const skeletons = document.querySelectorAll('.animate-pulse');
+    expect(skeletons.length).toBeGreaterThan(0);
+
+    resolveFetch({
+      ok: true,
+      json: async () => ({ success: true, repositories: [] }),
+    });
+  });
+
+  it('sorts repositories by name ascending then descending when name header is clicked', async () => {
+    setupFetchMock([
+      {
+        id: 'repo-2',
+        provider: 'github',
+        owner: 'acme',
+        name: 'billing',
+        fullName: 'acme/billing',
+        status: 'healthy',
+        branches: ['main'],
+        lastScanAt: '2026-04-23T10:00:00Z',
+      },
+      {
+        id: 'repo-1',
+        provider: 'github',
+        owner: 'acme',
+        name: 'orders',
+        fullName: 'acme/orders',
+        status: 'healthy',
+        branches: ['main'],
+        lastScanAt: '2026-04-24T14:00:00Z',
+      },
+    ]);
+
+    render(<RepositoriesPage />);
+    await waitFor(() => expect(screen.getByText('acme/orders')).toBeInTheDocument());
+
+    const nameButton = screen.getByRole('button', { name: /Repository/i });
+    fireEvent.click(nameButton);
+
+    await waitFor(() => {
+      const cells = screen.getAllByText(/acme\//);
+      expect(cells[0].textContent).toBe('acme/billing');
+      expect(cells[1].textContent).toBe('acme/orders');
+    });
+
+    fireEvent.click(nameButton);
+
+    await waitFor(() => {
+      const cells = screen.getAllByText(/acme\//);
+      expect(cells[0].textContent).toBe('acme/orders');
+      expect(cells[1].textContent).toBe('acme/billing');
+    });
+  });
+
+  it('sorts repositories by last scan descending by default and toggles to ascending on click', async () => {
+    setupFetchMock([
+      {
+        id: 'repo-1',
+        provider: 'github',
+        owner: 'acme',
+        name: 'alpha',
+        fullName: 'acme/alpha',
+        status: 'healthy',
+        branches: ['main'],
+        lastScanAt: '2026-04-22T10:00:00Z',
+      },
+      {
+        id: 'repo-2',
+        provider: 'github',
+        owner: 'acme',
+        name: 'zeta',
+        fullName: 'acme/zeta',
+        status: 'healthy',
+        branches: ['main'],
+        lastScanAt: '2026-04-24T14:00:00Z',
+      },
+    ]);
+
+    render(<RepositoriesPage />);
+    await waitFor(() => expect(screen.getByText('acme/alpha')).toBeInTheDocument());
+
+    // Default sort is lastScan desc: most recent (zeta) first
+    const initialCells = screen.getAllByText(/acme\//);
+    expect(initialCells[0].textContent).toBe('acme/zeta');
+    expect(initialCells[1].textContent).toBe('acme/alpha');
+
+    // Click lastScan to toggle to ascending
+    const lastScanButton = screen.getByRole('button', { name: /Last scan/i });
+    fireEvent.click(lastScanButton);
+
+    await waitFor(() => {
+      const cells = screen.getAllByText(/acme\//);
+      expect(cells[0].textContent).toBe('acme/alpha');
+      expect(cells[1].textContent).toBe('acme/zeta');
+    });
   });
 });

--- a/objectified-ui/tests/repositories-index.test.tsx
+++ b/objectified-ui/tests/repositories-index.test.tsx
@@ -1,0 +1,134 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+const mockPush = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+const RepositoriesPage = require('../src/app/ade/dashboard/repositories/page').default as React.ComponentType;
+
+type RepoRow = {
+  id: string;
+  provider: string;
+  owner: string;
+  name: string;
+  fullName: string;
+  status: string;
+  branches: string[];
+  lastScanAt?: string | null;
+};
+
+function setupFetchMock(repositories: RepoRow[]) {
+  const fetchMock = jest.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    const method = (init?.method || 'GET').toUpperCase();
+
+    if (url === '/api/repositories' && method === 'GET') {
+      return {
+        ok: true,
+        json: async () => ({ success: true, repositories }),
+      } as Response;
+    }
+    if (url.endsWith('/scans') && method === 'POST') {
+      return {
+        ok: true,
+        json: async () => ({ success: true, scan: { id: 'scan-1' } }),
+      } as Response;
+    }
+    if (url.endsWith('/archive') && method === 'POST') {
+      return {
+        ok: true,
+        json: async () => ({ success: true, repository: { id: 'repo-1', status: 'archived' } }),
+      } as Response;
+    }
+    return {
+      ok: true,
+      json: async () => ({ success: true, repositories }),
+    } as Response;
+  });
+
+  global.fetch = fetchMock as unknown as typeof fetch;
+  return fetchMock;
+}
+
+describe('Repositories index page', () => {
+  beforeEach(() => {
+    mockPush.mockReset();
+  });
+
+  it('filters repositories by provider and status', async () => {
+    setupFetchMock([
+      {
+        id: 'repo-1',
+        provider: 'github',
+        owner: 'acme',
+        name: 'orders',
+        fullName: 'acme/orders',
+        status: 'healthy',
+        branches: ['main'],
+        lastScanAt: '2026-04-24T14:00:00Z',
+      },
+      {
+        id: 'repo-2',
+        provider: 'gitlab',
+        owner: 'acme',
+        name: 'billing',
+        fullName: 'acme/billing',
+        status: 'archived',
+        branches: ['main'],
+        lastScanAt: '2026-04-24T13:00:00Z',
+      },
+    ]);
+
+    render(<RepositoriesPage />);
+
+    await waitFor(() => expect(screen.getByText('acme/orders')).toBeInTheDocument());
+    expect(screen.getByText('acme/billing')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText('Provider'), { target: { value: 'github' } });
+    await waitFor(() => expect(screen.queryByText('acme/billing')).not.toBeInTheDocument());
+
+    fireEvent.change(screen.getByLabelText('Status'), { target: { value: 'healthy' } });
+    expect(screen.getByText('acme/orders')).toBeInTheDocument();
+  });
+
+  it('triggers quick actions for scan and pause', async () => {
+    const fetchMock = setupFetchMock([
+      {
+        id: 'repo-1',
+        provider: 'github',
+        owner: 'acme',
+        name: 'orders',
+        fullName: 'acme/orders',
+        status: 'healthy',
+        branches: ['main'],
+        lastScanAt: '2026-04-24T14:00:00Z',
+      },
+    ]);
+
+    render(<RepositoriesPage />);
+    await waitFor(() => expect(screen.getByText('acme/orders')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole('button', { name: 'Scan now' }));
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/repositories/repo-1/scans',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ branch: 'main', force: true }),
+        })
+      )
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Pause' }));
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/repositories/repo-1/archive',
+        expect.objectContaining({ method: 'POST' })
+      )
+    );
+  });
+});

--- a/objectified-ui/tests/repositories-index.test.tsx
+++ b/objectified-ui/tests/repositories-index.test.tsx
@@ -140,7 +140,7 @@ describe('Repositories index page', () => {
   });
 
   it('renders skeleton rows while loading', async () => {
-    let resolveFetch!: (value: unknown) => void;
+    let resolveFetch: (value: unknown) => void;
     const fetchPromise = new Promise((resolve) => { resolveFetch = resolve; });
     global.fetch = jest.fn(() => fetchPromise) as unknown as typeof fetch;
 
@@ -149,10 +149,11 @@ describe('Repositories index page', () => {
     const skeletons = document.querySelectorAll('.animate-pulse');
     expect(skeletons.length).toBeGreaterThan(0);
 
-    resolveFetch({
+    resolveFetch!({
       ok: true,
       json: async () => ({ success: true, repositories: [] }),
     });
+    await waitFor(() => {});
   });
 
   it('sorts repositories by name ascending then descending when name header is clicked', async () => {


### PR DESCRIPTION
## Summary
- implement REPO-6.1 by upgrading `/ade/dashboard/repositories` with search/provider/status filtering, sortable `Repository`/`Status`/`Last scan` columns, and lazy-loading skeleton rows.
- add per-row quick actions for **Scan now**, **Pause/Resume**, and **Open detail**, including a new Next API proxy route at `/api/repositories/[id]/scans`.
- expose `lastScanAt` in repository list summaries, add coverage for the new field and index interactions, and update roadmap/changelog/version bumps for UI and REST packages.

## Test plan
- [x] `yarn build` (fails in existing baseline on missing `@gitbeaker/rest` module in `objectified-ui/lib/repositories/providers/gitlab-provider.ts`)
- [x] `yarn test` (existing baseline failures: missing `@gitbeaker/rest` in provider contract test and `tests/llm-streaming.test.ts` pretty-format runtime error)
- [x] `cd objectified-ui && yarn test repositories-index --runInBand`
- [ ] `cd objectified-rest && pytest tests/test_repositories_routes.py` (blocked in this environment: `pytest` not installed)

## Risk / notes
- `Scan now` currently queues a forced scan against the first tracked branch (fallback `main`), matching current backend scan-create requirements.
- Existing unrelated build/test failures remain in baseline and were not introduced by this ticket.

Closes #2794

Made with [Cursor](https://cursor.com)