### PR TITLE
Fix #2796 - scan timeline filters and error console

### DIFF
--- a/docs/PLANNED_FEATURE_ROADMAP_REPOSITORY.md
+++ b/docs/PLANNED_FEATURE_ROADMAP_REPOSITORY.md
@@ -2,6 +2,7 @@
 
 ## Completed
 
+- REPO-6.3 (#2796): Added scan timeline upgrades in the repository detail view with trigger/status/branch filter chips, per-row trigger/SHA/duration/file-count summaries, and expandable failed-scan error consoles that render `repository_scan.event_log` plus `error_detail`.
 - REPO-6.2 (#2795): Added the repository detail experience at `/ade/dashboard/repositories/{id}` with deep-link tabs (`branches/files/scans/sync/manifest/settings`), virtualized file rendering + drawer details, scan timeline links for REPO-6.3 and `repository_scan` drill-in, and Monaco-based manifest editing with REPO-2.4 schema validation.
 - REPO-6.1 (#2794): Added an ADE repositories index experience with provider/status/search filters, sortable repository health and last-scan columns, skeleton-loading rows, and quick row actions for scan-now, pause/resume, and detail navigation from Account -> Repositories.
 - REPO-5.6 (#2791): Added manifest-driven promotion gates by defaulting repository sync promotions to `manual`, preserving `repository.sync_committed` audit + change-report persistence for `promote: auto`, and forcing manual review whenever `onBreakingChange: block` is configured.

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.10.40",
+  "version": "0.10.41",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -5,6 +5,7 @@ We continue to improve the platform based on your feedback with improvements and
 ---
 
 ## Repositories
+- Added REPO-6.3 scan timeline upgrades with trigger/status/branch filter chips, per-scan trigger/SHA/duration/file-count summaries, and expandable failed-scan error console details from `event_log` + `error_detail`.
 - Added REPO-6.2 repository detail tabs with deep-link navigation (`branches/files/scans/sync/manifest/settings`), virtualized file lists with side-drawer file details/promote action, scan timeline links, and Monaco manifest editing with REPO-2.4 schema validation.
 - Added REPO-6.1 repository index upgrades with skeleton loading, provider/status/search filters, sortable name/last-scan/status columns, and quick row actions for **Scan now**, **Pause/Resume**, and **Open detail** under Account -> Repositories.
 - Added REPO-5.6 promotion gates so repository sync now defaults to `manual` promotions, still records change reports + `repository.sync_committed` audits for `promote: auto`, and forces manual review whenever `onBreakingChange` is set to `block`.

--- a/objectified-ui/src/app/ade/dashboard/repositories/[id]/page.tsx
+++ b/objectified-ui/src/app/ade/dashboard/repositories/[id]/page.tsx
@@ -456,29 +456,31 @@ export default function RepositoryDetailPage() {
     [filteredFiles, visibleRange.end, visibleRange.start]
   );
 
+  const normalizeScanFilterValue = useCallback((value?: string | null) => value || 'unknown', []);
+
   const scanTriggerOptions = useMemo(
-    () => Array.from(new Set(scans.map((scan) => scan.trigger || 'unknown'))),
-    [scans]
+    () => Array.from(new Set(scans.map((scan) => normalizeScanFilterValue(scan.trigger)))),
+    [normalizeScanFilterValue, scans]
   );
 
   const scanStatusOptions = useMemo(
-    () => Array.from(new Set(scans.map((scan) => scan.status || 'unknown'))),
-    [scans]
+    () => Array.from(new Set(scans.map((scan) => normalizeScanFilterValue(scan.status)))),
+    [normalizeScanFilterValue, scans]
   );
 
   const scanBranchOptions = useMemo(
-    () => Array.from(new Set(scans.map((scan) => scan.branch || 'unknown'))),
-    [scans]
+    () => Array.from(new Set(scans.map((scan) => normalizeScanFilterValue(scan.branch)))),
+    [normalizeScanFilterValue, scans]
   );
 
   const filteredScans = useMemo(() => {
     return scans.filter((scan) => {
-      if (scanTriggerFilter !== 'all' && scan.trigger !== scanTriggerFilter) return false;
-      if (scanStatusFilter !== 'all' && scan.status !== scanStatusFilter) return false;
-      if (scanBranchFilter !== 'all' && scan.branch !== scanBranchFilter) return false;
+      if (scanTriggerFilter !== 'all' && normalizeScanFilterValue(scan.trigger) !== scanTriggerFilter) return false;
+      if (scanStatusFilter !== 'all' && normalizeScanFilterValue(scan.status) !== scanStatusFilter) return false;
+      if (scanBranchFilter !== 'all' && normalizeScanFilterValue(scan.branch) !== scanBranchFilter) return false;
       return true;
     });
-  }, [scanBranchFilter, scanStatusFilter, scanTriggerFilter, scans]);
+  }, [normalizeScanFilterValue, scanBranchFilter, scanStatusFilter, scanTriggerFilter, scans]);
 
   const saveBranches = async () => {
     if (!repository || branchRows.length === 0) {

--- a/objectified-ui/src/app/ade/dashboard/repositories/[id]/page.tsx
+++ b/objectified-ui/src/app/ade/dashboard/repositories/[id]/page.tsx
@@ -75,6 +75,10 @@ interface ScanRecord {
     removed?: number;
     unchanged?: number;
   };
+  eventLog?: unknown;
+  event_log?: unknown;
+  errorDetail?: unknown;
+  error_detail?: unknown;
 }
 
 interface ScanFileRecord {
@@ -129,6 +133,82 @@ function formatTimestamp(value: string | null | undefined): string {
   return new Date(value).toLocaleString();
 }
 
+function formatDuration(startedAt: string, finishedAt: string | null): string {
+  if (!startedAt || !finishedAt) return 'n/a';
+  const started = Date.parse(startedAt);
+  const finished = Date.parse(finishedAt);
+  if (!Number.isFinite(started) || !Number.isFinite(finished) || finished < started) return 'n/a';
+  const elapsedSec = Math.floor((finished - started) / 1000);
+  if (elapsedSec < 60) return `${elapsedSec}s`;
+  const minutes = Math.floor(elapsedSec / 60);
+  const seconds = elapsedSec % 60;
+  if (minutes < 60) return `${minutes}m ${seconds}s`;
+  const hours = Math.floor(minutes / 60);
+  const remainingMinutes = minutes % 60;
+  return `${hours}h ${remainingMinutes}m ${seconds}s`;
+}
+
+function toErrorDetailText(value: unknown): string {
+  if (!value) return '';
+  if (typeof value === 'string') return value;
+  if (Array.isArray(value)) return value.map((entry) => String(entry)).join('\n');
+  if (typeof value === 'object') {
+    const detail = value as { detail?: unknown; message?: unknown };
+    if (typeof detail.detail === 'string') return detail.detail;
+    if (typeof detail.message === 'string') return detail.message;
+    return JSON.stringify(value, null, 2);
+  }
+  return String(value);
+}
+
+function toEventLogLines(value: unknown): string[] {
+  if (!value) return [];
+  if (Array.isArray(value)) {
+    return value.flatMap((entry) => {
+      if (typeof entry === 'string') return [entry];
+      if (entry && typeof entry === 'object') {
+        const item = entry as {
+          timestamp?: string;
+          level?: string;
+          message?: string;
+          error?: string;
+          stack?: string;
+          detail?: string;
+        };
+        const prefixBits = [item.timestamp, item.level].filter(Boolean).join(' ');
+        const body = item.message || item.error || item.detail || '';
+        const line = [prefixBits, body].filter(Boolean).join(' ').trim();
+        if (item.stack && line) return [line, item.stack];
+        if (item.stack) return [item.stack];
+        if (line) return [line];
+        return [JSON.stringify(entry, null, 2)];
+      }
+      return [String(entry)];
+    });
+  }
+  if (typeof value === 'string') return [value];
+  if (typeof value === 'object') return [JSON.stringify(value, null, 2)];
+  return [String(value)];
+}
+
+function extractScanErrorConsole(scan: ScanRecord): string {
+  const eventLogValue = scan.eventLog ?? scan.event_log;
+  const detailValue = scan.errorDetail ?? scan.error_detail;
+  const sections: string[] = [];
+  const eventLines = toEventLogLines(eventLogValue);
+  if (eventLines.length > 0) {
+    sections.push(eventLines.join('\n'));
+  }
+  const detailText = toErrorDetailText(detailValue);
+  if (detailText) {
+    sections.push(detailText);
+  }
+  if (sections.length === 0) {
+    return 'No event log or error detail available for this failed scan.';
+  }
+  return sections.join('\n\n');
+}
+
 export default function RepositoryDetailPage() {
   const params = useParams<{ id: string }>();
   const router = useRouter();
@@ -176,6 +256,10 @@ export default function RepositoryDetailPage() {
   const fileDrawerRef = useRef<HTMLElement | null>(null);
 
   const [manifestValidation, setManifestValidation] = useState<{ valid: boolean; errors: string[] }>({ valid: true, errors: [] });
+  const [scanTriggerFilter, setScanTriggerFilter] = useState('all');
+  const [scanStatusFilter, setScanStatusFilter] = useState('all');
+  const [scanBranchFilter, setScanBranchFilter] = useState('all');
+  const [expandedScanErrorId, setExpandedScanErrorId] = useState('');
 
   useEffect(() => {
     const source = manifestDraft.trim();
@@ -371,6 +455,30 @@ export default function RepositoryDetailPage() {
     () => filteredFiles.slice(visibleRange.start, visibleRange.end),
     [filteredFiles, visibleRange.end, visibleRange.start]
   );
+
+  const scanTriggerOptions = useMemo(
+    () => Array.from(new Set(scans.map((scan) => scan.trigger || 'unknown'))),
+    [scans]
+  );
+
+  const scanStatusOptions = useMemo(
+    () => Array.from(new Set(scans.map((scan) => scan.status || 'unknown'))),
+    [scans]
+  );
+
+  const scanBranchOptions = useMemo(
+    () => Array.from(new Set(scans.map((scan) => scan.branch || 'unknown'))),
+    [scans]
+  );
+
+  const filteredScans = useMemo(() => {
+    return scans.filter((scan) => {
+      if (scanTriggerFilter !== 'all' && scan.trigger !== scanTriggerFilter) return false;
+      if (scanStatusFilter !== 'all' && scan.status !== scanStatusFilter) return false;
+      if (scanBranchFilter !== 'all' && scan.branch !== scanBranchFilter) return false;
+      return true;
+    });
+  }, [scanBranchFilter, scanStatusFilter, scanTriggerFilter, scans]);
 
   const saveBranches = async () => {
     if (!repository || branchRows.length === 0) {
@@ -767,26 +875,109 @@ export default function RepositoryDetailPage() {
                   </div>
                 </div>
                 {isLoadingScans ? <div className="text-sm text-gray-500">Loading scans...</div> : null}
+                <div className="space-y-2">
+                  <div className="text-xs font-semibold uppercase tracking-wide text-gray-500">Filter by trigger</div>
+                  <div className="flex flex-wrap gap-2">
+                    <Button
+                      size="sm"
+                      variant={scanTriggerFilter === 'all' ? 'secondary' : 'outline'}
+                      onClick={() => setScanTriggerFilter('all')}
+                    >
+                      Trigger: All
+                    </Button>
+                    {scanTriggerOptions.map((trigger) => (
+                      <Button
+                        key={trigger}
+                        size="sm"
+                        variant={scanTriggerFilter === trigger ? 'secondary' : 'outline'}
+                        onClick={() => setScanTriggerFilter(trigger)}
+                      >
+                        Trigger: {trigger}
+                      </Button>
+                    ))}
+                  </div>
+                  <div className="text-xs font-semibold uppercase tracking-wide text-gray-500">Filter by status</div>
+                  <div className="flex flex-wrap gap-2">
+                    <Button
+                      size="sm"
+                      variant={scanStatusFilter === 'all' ? 'secondary' : 'outline'}
+                      onClick={() => setScanStatusFilter('all')}
+                    >
+                      Status: All
+                    </Button>
+                    {scanStatusOptions.map((status) => (
+                      <Button
+                        key={status}
+                        size="sm"
+                        variant={scanStatusFilter === status ? 'secondary' : 'outline'}
+                        onClick={() => setScanStatusFilter(status)}
+                      >
+                        Status: {status}
+                      </Button>
+                    ))}
+                  </div>
+                  <div className="text-xs font-semibold uppercase tracking-wide text-gray-500">Filter by branch</div>
+                  <div className="flex flex-wrap gap-2">
+                    <Button
+                      size="sm"
+                      variant={scanBranchFilter === 'all' ? 'secondary' : 'outline'}
+                      onClick={() => setScanBranchFilter('all')}
+                    >
+                      Branch: All
+                    </Button>
+                    {scanBranchOptions.map((branch) => (
+                      <Button
+                        key={branch}
+                        size="sm"
+                        variant={scanBranchFilter === branch ? 'secondary' : 'outline'}
+                        onClick={() => setScanBranchFilter(branch)}
+                      >
+                        Branch: {branch}
+                      </Button>
+                    ))}
+                  </div>
+                </div>
                 <ul className="space-y-2">
-                  {scans.map((scan) => (
+                  {filteredScans.map((scan) => (
                     <li key={scan.id} className="rounded-lg border border-gray-200 dark:border-gray-700 px-3 py-2">
-                      <div className="flex flex-wrap items-center justify-between gap-2">
+                      <div className="flex flex-wrap items-start justify-between gap-2">
                         <div>
                           <div className="font-medium">{scan.branch} · {scan.status}</div>
                           <div className="text-xs text-gray-500">{formatTimestamp(scan.startedAt)} · commit {scan.commitSha}</div>
+                          <div className="text-xs text-gray-500">Trigger {scan.trigger} · Duration {formatDuration(scan.startedAt, scan.finishedAt)}</div>
+                          <div className="text-xs text-gray-500">
+                            Files seen {scan.filesSeen} · classified {scan.filesClassified} · unknown {scan.filesUnknown} · failed {scan.filesFailed}
+                          </div>
                           <div className="text-xs text-gray-500">
                             +{scan.diffSummary.added ?? 0} / ~{scan.diffSummary.modified ?? 0} / -{scan.diffSummary.removed ?? 0}
                           </div>
                         </div>
-                        <a
-                          className="text-xs text-indigo-600 hover:text-indigo-500"
-                          href={`/api/repositories/${repository.id}/scans/${scan.id}`}
-                          target="_blank"
-                          rel="noreferrer"
-                        >
-                          View repository_scan
-                        </a>
+                        <div className="flex flex-col items-end gap-2">
+                          <a
+                            className="text-xs text-indigo-600 hover:text-indigo-500"
+                            href={`/api/repositories/${repository.id}/scans/${scan.id}`}
+                            target="_blank"
+                            rel="noreferrer"
+                          >
+                            View repository_scan
+                          </a>
+                          {scan.status === 'failed' ? (
+                            <Button
+                              type="button"
+                              size="sm"
+                              variant="outline"
+                              onClick={() => setExpandedScanErrorId((current) => (current === scan.id ? '' : scan.id))}
+                            >
+                              {expandedScanErrorId === scan.id ? 'Hide errors' : 'Show errors'}
+                            </Button>
+                          ) : null}
+                        </div>
                       </div>
+                      {scan.status === 'failed' && expandedScanErrorId === scan.id ? (
+                        <pre className="mt-3 max-h-72 overflow-auto rounded-lg bg-gray-100 p-3 text-xs text-gray-700 dark:bg-gray-900 dark:text-gray-200">
+                          {extractScanErrorConsole(scan)}
+                        </pre>
+                      ) : null}
                     </li>
                   ))}
                 </ul>

--- a/objectified-ui/tests/repositories-detail.test.tsx
+++ b/objectified-ui/tests/repositories-detail.test.tsx
@@ -183,10 +183,34 @@ describe('Repository detail page tabs', () => {
     expect(screen.getByText(/Trigger manual/)).toBeInTheDocument();
     expect(screen.getByText(/Files seen 11 .* classified 7 .* unknown 2 .* failed 2/)).toBeInTheDocument();
 
+    // status filter
     fireEvent.click(screen.getByRole('button', { name: 'Status: failed' }));
     expect(screen.queryByText('main · complete')).not.toBeInTheDocument();
     expect(screen.getByText('release/2026.04 · failed')).toBeInTheDocument();
 
+    // reset status filter before next assertion
+    fireEvent.click(screen.getByRole('button', { name: 'Status: All' }));
+    await waitFor(() => expect(screen.getByText('main · complete')).toBeInTheDocument());
+
+    // trigger filter
+    fireEvent.click(screen.getByRole('button', { name: 'Trigger: scheduled' }));
+    expect(screen.queryByText('main · complete')).not.toBeInTheDocument();
+    expect(screen.getByText('release/2026.04 · failed')).toBeInTheDocument();
+
+    // reset trigger filter before next assertion
+    fireEvent.click(screen.getByRole('button', { name: 'Trigger: All' }));
+    await waitFor(() => expect(screen.getByText('main · complete')).toBeInTheDocument());
+
+    // branch filter
+    fireEvent.click(screen.getByRole('button', { name: 'Branch: main' }));
+    expect(screen.getByText('main · complete')).toBeInTheDocument();
+    expect(screen.queryByText('release/2026.04 · failed')).not.toBeInTheDocument();
+
+    // reset branch filter
+    fireEvent.click(screen.getByRole('button', { name: 'Branch: All' }));
+    await waitFor(() => expect(screen.getByText('release/2026.04 · failed')).toBeInTheDocument());
+
+    // failed scan error console
     fireEvent.click(screen.getByRole('button', { name: 'Show errors' }));
     await waitFor(() => expect(screen.getByText(/Repository import failed for openapi\.yaml/)).toBeInTheDocument());
   });

--- a/objectified-ui/tests/repositories-detail.test.tsx
+++ b/objectified-ui/tests/repositories-detail.test.tsx
@@ -80,6 +80,24 @@ function setupFetchMock() {
               filesFailed: 0,
               diffSummary: { added: 1, modified: 0, removed: 0, unchanged: 0 },
             },
+            {
+              id: 'scan-2',
+              branch: 'release/2026.04',
+              commitSha: 'def456',
+              trigger: 'scheduled',
+              status: 'failed',
+              startedAt: '2026-04-24T13:00:00Z',
+              finishedAt: '2026-04-24T13:03:00Z',
+              filesSeen: 11,
+              filesClassified: 7,
+              filesUnknown: 2,
+              filesFailed: 2,
+              diffSummary: { added: 0, modified: 2, removed: 1, unchanged: 8 },
+              event_log: [
+                { timestamp: '2026-04-24T13:02:00Z', level: 'error', message: 'Parse failed', stack: 'Error: boom\n at parser.ts:1:1' },
+              ],
+              error_detail: 'Repository import failed for openapi.yaml',
+            },
           ],
         }),
       } as Response;
@@ -154,5 +172,22 @@ describe('Repository detail page tabs', () => {
 
     await waitFor(() => expect(screen.getByRole('button', { name: 'Promotion UI coming soon' })).toBeInTheDocument());
     expect(screen.getByText('Classification details')).toBeInTheDocument();
+  });
+
+  it('renders scan metrics, filter chips, and failed error console', async () => {
+    currentSearch = '?tab=scans';
+    setupFetchMock();
+    render(<RepositoryDetailPage />);
+
+    await waitFor(() => expect(screen.getByText('Scan timeline')).toBeInTheDocument());
+    expect(screen.getByText(/Trigger manual/)).toBeInTheDocument();
+    expect(screen.getByText(/Files seen 11 .* classified 7 .* unknown 2 .* failed 2/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Status: failed' }));
+    expect(screen.queryByText('main · complete')).not.toBeInTheDocument();
+    expect(screen.getByText('release/2026.04 · failed')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show errors' }));
+    await waitFor(() => expect(screen.getByText(/Repository import failed for openapi\.yaml/)).toBeInTheDocument());
   });
 });


### PR DESCRIPTION
## What was done and why
- Added REPO-6.3 scan timeline enhancements in repository detail so each scan row now shows trigger, branch, commit SHA, duration, and files seen/classified/unknown/failed for quicker operator diagnosis.
- Added trigger/status/branch filter chips to the scan timeline to isolate relevant scans without leaving the page.
- Added expandable failed-scan error console output that renders `event_log` and `error_detail` directly in the row so failure triage is immediate.
- Updated coverage in `repositories-detail.test.tsx` for timeline metrics, chip filtering, and failed error expansion.
- Marked REPO-6.3 complete in roadmap docs, added a one-line release note, and bumped `objectified-ui` patch version.

## How to test
- Run **build**: `yarn build`
- Run focused UI tests: `yarn workspace objectified-ui test repositories-detail.test.tsx --runInBand`
- Open **Account -> Repositories -> repository detail -> Scans** and verify:
  - each row shows trigger, branch, SHA, duration, and file counters
  - filter chips narrow rows by trigger/status/branch
  - failed rows show **Show errors** and expand to stack-trace-like error details

## Risk / notes
- UI-only behavior changes are scoped to the repository detail scans tab plus test/docs/version updates.
- Full `yarn test` still reports pre-existing unrelated failures in `tests/repositories-index.test.tsx` and `tests/llm-streaming.test.ts`.

Closes #2796

Made with [Cursor](https://cursor.com)