### PR TITLE
Fix #2799 - add repository workflow audit coverage

### DIFF
--- a/docs/PLANNED_FEATURE_ROADMAP_REPOSITORY.md
+++ b/docs/PLANNED_FEATURE_ROADMAP_REPOSITORY.md
@@ -2,6 +2,7 @@
 
 ## Completed
 
+- REPO-7.1 (#2799): Added repository workflow-audit coverage in the shared `workflow_audit` ledger, documenting and emitting repository action codes (`registered/scanned/sync/pause/poll/token/archive/remove`) with structured per-event detail payloads and actor identities.
 - REPO-6.3 (#2796): Added scan timeline upgrades in the repository detail view with trigger/status/branch filter chips, per-row trigger/SHA/duration/file-count summaries, and expandable failed-scan error consoles that render `repository_scan.event_log` plus `error_detail`.
 - REPO-6.2 (#2795): Added the repository detail experience at `/ade/dashboard/repositories/{id}` with deep-link tabs (`branches/files/scans/sync/manifest/settings`), virtualized file rendering + drawer details, scan timeline links for REPO-6.3 and `repository_scan` drill-in, and Monaco-based manifest editing with REPO-2.4 schema validation.
 - REPO-6.1 (#2794): Added an ADE repositories index experience with provider/status/search filters, sortable repository health and last-scan columns, skeleton-loading rows, and quick row actions for scan-now, pause/resume, and detail navigation from Account -> Repositories.

--- a/objectified-rest/docs/WORKFLOW_AUDIT_API.md
+++ b/objectified-rest/docs/WORKFLOW_AUDIT_API.md
@@ -103,8 +103,8 @@ Repository connector events use the same ledger and filter surface through `acti
 - `repository.token_resolved`
 - `repository.polled`
 
-Each repository row includes tenant scope (`tenant_id`), repository context in `detail.repositoryId`,
-an `actor_id` (user or system identity), and a structured `detail` JSON payload with no secrets.
+Each repository row includes tenant scope (`tenantId`, underlying DB column `tenant_id`), repository context in `detail.repositoryId`,
+an `actorId` (underlying DB column `actor_id`, user or system identity), and a structured `detail` JSON payload with no secrets.
 
 ## Errors
 

--- a/objectified-rest/docs/WORKFLOW_AUDIT_API.md
+++ b/objectified-rest/docs/WORKFLOW_AUDIT_API.md
@@ -86,6 +86,26 @@ For **`action`** = **`version.rollback`**, **`detail`** is a JSON object that ma
 
 **`actorId`** and **`createdAt`** on the audit row identify **who** and **when**; they are not duplicated inside **`detail`**.
 
+## Repository action codes (`#2799`)
+
+Repository connector events use the same ledger and filter surface through `action`:
+
+- `repository.registered`
+- `repository.scanned`
+- `repository.sync_committed`
+- `repository.sync_pending_review`
+- `repository.sync_failed`
+- `repository.removed`
+- `repository.archived`
+- `repository.unarchived`
+- `repository.paused`
+- `repository.auto_paused`
+- `repository.token_resolved`
+- `repository.polled`
+
+Each repository row includes tenant scope (`tenant_id`), repository context in `detail.repositoryId`,
+an `actor_id` (user or system identity), and a structured `detail` JSON payload with no secrets.
+
 ## Errors
 
 | Code | When |

--- a/objectified-rest/pyproject.toml
+++ b/objectified-rest/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "objectified-rest"
-version = "1.0.64"
+version = "1.0.65"
 description = "REST API for serving OpenAPI specifications from the Objectified database"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/objectified-rest/src/app/repositories_routes.py
+++ b/objectified-rest/src/app/repositories_routes.py
@@ -555,7 +555,7 @@ def _to_summary(repo: RepositoryRecord) -> Dict[str, Any]:
     }
 
 
-def _write_audit_row(
+def _append_audit_row(
     tenant_id: str,
     repository_id: str,
     event_type: RepositoryAuditEvent,
@@ -563,34 +563,52 @@ def _write_audit_row(
     actor_id: str | None,
     detail: Dict[str, Any] | None = None,
     outcome: Literal["success", "failure"] = "success",
-) -> None:
+) -> Dict[str, Any]:
+    """Append an audit row to the in-memory store and return it.
+
+    This function is safe to call while holding ``_STORE_LOCK`` because it
+    performs no I/O.  Pass the returned dict to :func:`_persist_audit_row`
+    *after* releasing the lock to write the row to the database.
+    """
     created_at = _utc_now_iso()
     normalized_actor_id = actor_id if actor_id else _SYSTEM_ACTOR_ID
     payload = dict(detail or {})
-    _REPO_AUDIT_STORE.append(
-        {
-            "id": str(uuid4()),
-            "tenantId": tenant_id,
-            "repositoryId": repository_id,
-            "eventType": event_type,
-            "actorId": normalized_actor_id,
-            "detail": payload,
-            "outcome": outcome,
-            "createdAt": created_at,
-        }
-    )
-    db.insert_workflow_audit(
-        tenant_id=tenant_id,
-        project_id=None,
-        version_id=None,
-        action=event_type,
-        outcome=outcome,
-        actor_id=normalized_actor_id,
-        detail={
-            "repositoryId": repository_id,
-            **payload,
-        },
-    )
+    row: Dict[str, Any] = {
+        "id": str(uuid4()),
+        "tenantId": tenant_id,
+        "repositoryId": repository_id,
+        "eventType": event_type,
+        "actorId": normalized_actor_id,
+        "detail": payload,
+        "outcome": outcome,
+        "createdAt": created_at,
+    }
+    _REPO_AUDIT_STORE.append(row)
+    return row
+
+
+def _persist_audit_row(row: Dict[str, Any]) -> None:
+    """Persist a previously-built audit row to the database.
+
+    Must be called **outside** ``_STORE_LOCK`` to avoid blocking other
+    repository operations on slow DB connections.  All DB failures are
+    swallowed so that audit persistence is always best-effort.
+    """
+    try:
+        db.insert_workflow_audit(
+            tenant_id=row["tenantId"],
+            project_id=None,
+            version_id=None,
+            action=row["eventType"],
+            outcome=row["outcome"],
+            actor_id=row["actorId"],
+            detail={
+                **row["detail"],
+                "repositoryId": row["repositoryId"],
+            },
+        )
+    except Exception:
+        pass
 
 
 def _resolve_actor_id(auth_data: Dict[str, Any] | None) -> str:
@@ -923,9 +941,10 @@ def _dispatch_import_jobs_for_scan(
     commit_sha: str,
     scan_files: List[RepositoryFileRecord],
     actor_id: str,
-) -> None:
+) -> List[Dict[str, Any]]:
     repository_jobs = _REPO_IMPORT_JOB_STORE.setdefault(repository_id, [])
     manifest_project_slug_by_path = _manifest_project_slug_by_path(repository_id)
+    pending_audit_rows: List[Dict[str, Any]] = []
     for file_row in scan_files:
         if file_row.status not in {"new", "modified", "removed"}:
             continue
@@ -1021,7 +1040,7 @@ def _dispatch_import_jobs_for_scan(
         if failure_message:
             file_row.status = "parse_error"
             file_row.discriminator = failure_message
-            _write_audit_row(
+            pending_audit_rows.append(_append_audit_row(
                 tenant_id,
                 repository_id,
                 "repository.sync_failed",
@@ -1034,9 +1053,9 @@ def _dispatch_import_jobs_for_scan(
                     "operation": operation,
                     "error": failure_message,
                 },
-            )
+            ))
         elif promote == "auto":
-            _write_audit_row(
+            pending_audit_rows.append(_append_audit_row(
                 tenant_id,
                 repository_id,
                 "repository.sync_committed",
@@ -1048,9 +1067,9 @@ def _dispatch_import_jobs_for_scan(
                     "operation": operation,
                     "promotion": promote,
                 },
-            )
+            ))
         else:
-            _write_audit_row(
+            pending_audit_rows.append(_append_audit_row(
                 tenant_id,
                 repository_id,
                 "repository.sync_pending_review",
@@ -1062,7 +1081,8 @@ def _dispatch_import_jobs_for_scan(
                     "operation": operation,
                     "promotion": promote,
                 },
-            )
+            ))
+    return pending_audit_rows
 
 
 def _list_poll_targets_for_tenant(tenant_id: str) -> List[Dict[str, str]]:
@@ -1185,7 +1205,7 @@ async def register_repository(
             and _is_manifest_project_auto_create_enabled(auth_data),
         }
         tenant_repos[repository.id] = repository
-        _write_audit_row(
+        _audit_token_row = _append_audit_row(
             tenant_id,
             repository_id,
             "repository.token_resolved",
@@ -1195,7 +1215,7 @@ async def register_repository(
                 "linkedAccountId": request.linkedAccountId,
             },
         )
-        _write_audit_row(
+        _audit_registered_row = _append_audit_row(
             tenant_id,
             repository_id,
             "repository.registered",
@@ -1207,6 +1227,8 @@ async def register_repository(
             },
         )
 
+    _persist_audit_row(_audit_token_row)
+    _persist_audit_row(_audit_registered_row)
     return RegisterRepositoryResponse(
         repository=repository,
         initialScanJobId=initial_scan_job_id,
@@ -1314,14 +1336,15 @@ async def archive_repository(
         repository.status = "archived"
         repository.archivedAt = now
         repository.updatedAt = now
-        _write_audit_row(
+        _audit_row = _append_audit_row(
             tenant_id,
             repository_id,
             "repository.archived",
             actor_id=actor_id,
             detail={"status": repository.status},
         )
-        return repository
+    _persist_audit_row(_audit_row)
+    return repository
 
 
 @router.post("/{tenant_slug}/{repository_id}/unarchive", response_model=RepositoryRecord)
@@ -1340,14 +1363,15 @@ async def unarchive_repository(
         repository.status = "healthy"
         repository.archivedAt = None
         repository.updatedAt = _utc_now_iso()
-        _write_audit_row(
+        _audit_row = _append_audit_row(
             tenant_id,
             repository_id,
             "repository.unarchived",
             actor_id=actor_id,
             detail={"status": repository.status},
         )
-        return repository
+    _persist_audit_row(_audit_row)
+    return repository
 
 
 @router.post("/{tenant_slug}/{repository_id}/pause", response_model=RepositoryRecord)
@@ -1365,14 +1389,15 @@ async def pause_repository(
         now = _utc_now_iso()
         repository.status = "paused"
         repository.updatedAt = now
-        _write_audit_row(
+        _audit_row = _append_audit_row(
             tenant_id,
             repository_id,
             "repository.paused",
             actor_id=actor_id,
             detail={"status": repository.status},
         )
-        return repository
+    _persist_audit_row(_audit_row)
+    return repository
 
 
 @router.post("/{tenant_slug}/{repository_id}/auto-pause", response_model=RepositoryRecord)
@@ -1390,14 +1415,15 @@ async def auto_pause_repository(
         now = _utc_now_iso()
         repository.status = "paused"
         repository.updatedAt = now
-        _write_audit_row(
+        _audit_row = _append_audit_row(
             tenant_id,
             repository_id,
             "repository.auto_paused",
             actor_id=actor_id,
             detail={"status": repository.status},
         )
-        return repository
+    _persist_audit_row(_audit_row)
+    return repository
 
 
 @router.delete("/{tenant_slug}/{repository_id}", status_code=204)
@@ -1425,7 +1451,7 @@ async def delete_repository(
         for scan in scan_history:
             _REPO_SCAN_FILE_HISTORY_STORE.pop(scan.id, None)
         _REPO_CREDENTIAL_REF_STORE.pop(repository_id, None)
-        _write_audit_row(
+        _audit_row = _append_audit_row(
             tenant_id,
             repository_id,
             "repository.removed",
@@ -1433,6 +1459,7 @@ async def delete_repository(
             detail={"fullName": repository.fullName},
         )
 
+    _persist_audit_row(_audit_row)
     return Response(status_code=204)
 
 
@@ -1669,7 +1696,7 @@ async def create_repository_scan(
             )
         history.insert(0, scan)
         _REPO_SCAN_FILE_HISTORY_STORE[scan.id] = []
-        _write_audit_row(
+        _audit_row = _append_audit_row(
             tenant_id,
             repository_id,
             "repository.polled",
@@ -1681,7 +1708,8 @@ async def create_repository_scan(
                 "scanId": scan.id,
             },
         )
-        return scan
+    _persist_audit_row(_audit_row)
+    return scan
 
 
 def _reset_repository_state_for_tests() -> None:
@@ -1827,7 +1855,7 @@ def _complete_repository_scan_for_tests(
             previous_files=previous_files,
         )
         tenant_id = _find_tenant_id_for_repository(repository_id)
-        _dispatch_import_jobs_for_scan(
+        pending_audit_rows = _dispatch_import_jobs_for_scan(
             tenant_id=tenant_id,
             repository_id=repository_id,
             scan_id=scan_id,
@@ -1853,7 +1881,7 @@ def _complete_repository_scan_for_tests(
             }
         )
         history[scan_idx] = completed_scan
-        _write_audit_row(
+        pending_audit_rows.append(_append_audit_row(
             tenant_id,
             repository_id,
             "repository.scanned",
@@ -1865,8 +1893,11 @@ def _complete_repository_scan_for_tests(
                 "status": completed_scan.status,
                 "diffSummary": completed_scan.diffSummary,
             },
-        )
-        return completed_scan
+        ))
+
+    for _audit_row in pending_audit_rows:
+        _persist_audit_row(_audit_row)
+    return completed_scan
 
 
 def _seed_repository_relations_for_tests(repository_id: str) -> None:

--- a/objectified-rest/src/app/repositories_routes.py
+++ b/objectified-rest/src/app/repositories_routes.py
@@ -20,6 +20,7 @@ from fastapi import APIRouter, Body, Depends, HTTPException, Query, Response
 from pydantic import BaseModel, Field
 
 from .auth import validate_authentication
+from .database import db
 from .openapi_change_report import build_change_report
 from .repositories.manifest import parse_repo_manifest, resolve_repository_file_mapping
 
@@ -107,7 +108,7 @@ class RepositoryRecord(BaseModel):
     owner: str
     name: str
     fullName: str
-    status: Literal["healthy", "warnings", "error", "scan_in_progress", "archived"] = "scan_in_progress"
+    status: Literal["healthy", "warnings", "error", "scan_in_progress", "archived", "paused"] = "scan_in_progress"
     branches: List[RepositoryBranchRecord]
     manifest: str | None = None
     createdAt: str
@@ -258,6 +259,22 @@ _REPO_IMPORT_POLICY_STORE: Dict[str, Dict[str, bool]] = {}
 _REPO_PROJECT_STORE: Dict[str, Dict[str, RepositoryResolvedProjectRecord]] = {}
 _REPO_VERSION_STORE: Dict[str, Dict[str, Dict[str, RepositoryResolvedVersionRecord]]] = {}
 _STORE_LOCK = Lock()
+_SYSTEM_ACTOR_ID = "00000000-0000-0000-0000-000000000000"
+
+RepositoryAuditEvent = Literal[
+    "repository.registered",
+    "repository.scanned",
+    "repository.sync_committed",
+    "repository.sync_pending_review",
+    "repository.sync_failed",
+    "repository.removed",
+    "repository.archived",
+    "repository.unarchived",
+    "repository.paused",
+    "repository.auto_paused",
+    "repository.token_resolved",
+    "repository.polled",
+]
 
 _DEFAULT_SCAN_PAGE_SIZE = 50
 _MAX_SCAN_PAGE_SIZE = 200
@@ -541,23 +558,50 @@ def _to_summary(repo: RepositoryRecord) -> Dict[str, Any]:
 def _write_audit_row(
     tenant_id: str,
     repository_id: str,
-    event_type: Literal[
-        "repository.archived",
-        "repository.unarchived",
-        "repository.removed",
-        "repository.sync_committed",
-        "repository.sync_pending_review",
-    ],
+    event_type: RepositoryAuditEvent,
+    *,
+    actor_id: str | None,
+    detail: Dict[str, Any] | None = None,
+    outcome: Literal["success", "failure"] = "success",
 ) -> None:
+    created_at = _utc_now_iso()
+    normalized_actor_id = actor_id if actor_id else _SYSTEM_ACTOR_ID
+    payload = dict(detail or {})
     _REPO_AUDIT_STORE.append(
         {
             "id": str(uuid4()),
             "tenantId": tenant_id,
             "repositoryId": repository_id,
             "eventType": event_type,
-            "createdAt": _utc_now_iso(),
+            "actorId": normalized_actor_id,
+            "detail": payload,
+            "outcome": outcome,
+            "createdAt": created_at,
         }
     )
+    db.insert_workflow_audit(
+        tenant_id=tenant_id,
+        project_id=None,
+        version_id=None,
+        action=event_type,
+        outcome=outcome,
+        actor_id=normalized_actor_id,
+        detail={
+            "repositoryId": repository_id,
+            **payload,
+        },
+    )
+
+
+def _resolve_actor_id(auth_data: Dict[str, Any] | None) -> str:
+    if auth_data:
+        raw_user_id = auth_data.get("user_id")
+        if isinstance(raw_user_id, str):
+            try:
+                return str(UUID(raw_user_id))
+            except ValueError:
+                pass
+    return _SYSTEM_ACTOR_ID
 
 
 def _build_repository_source_uri(repository_id: str, path: str, branch: str, commit_sha: str) -> str:
@@ -878,6 +922,7 @@ def _dispatch_import_jobs_for_scan(
     branch: str,
     commit_sha: str,
     scan_files: List[RepositoryFileRecord],
+    actor_id: str,
 ) -> None:
     repository_jobs = _REPO_IMPORT_JOB_STORE.setdefault(repository_id, [])
     manifest_project_slug_by_path = _manifest_project_slug_by_path(repository_id)
@@ -976,17 +1021,54 @@ def _dispatch_import_jobs_for_scan(
         if failure_message:
             file_row.status = "parse_error"
             file_row.discriminator = failure_message
-            _write_audit_row(tenant_id, repository_id, "repository.sync_pending_review")
+            _write_audit_row(
+                tenant_id,
+                repository_id,
+                "repository.sync_failed",
+                actor_id=actor_id,
+                outcome="failure",
+                detail={
+                    "scanId": scan_id,
+                    "importJobId": import_job.id,
+                    "path": file_row.path,
+                    "operation": operation,
+                    "error": failure_message,
+                },
+            )
         elif promote == "auto":
-            _write_audit_row(tenant_id, repository_id, "repository.sync_committed")
+            _write_audit_row(
+                tenant_id,
+                repository_id,
+                "repository.sync_committed",
+                actor_id=actor_id,
+                detail={
+                    "scanId": scan_id,
+                    "importJobId": import_job.id,
+                    "path": file_row.path,
+                    "operation": operation,
+                    "promotion": promote,
+                },
+            )
         else:
-            _write_audit_row(tenant_id, repository_id, "repository.sync_pending_review")
+            _write_audit_row(
+                tenant_id,
+                repository_id,
+                "repository.sync_pending_review",
+                actor_id=actor_id,
+                detail={
+                    "scanId": scan_id,
+                    "importJobId": import_job.id,
+                    "path": file_row.path,
+                    "operation": operation,
+                    "promotion": promote,
+                },
+            )
 
 
 def _list_poll_targets_for_tenant(tenant_id: str) -> List[Dict[str, str]]:
     poll_targets: List[Dict[str, str]] = []
     for repository in _REPO_STORE.get(tenant_id, {}).values():
-        if repository.status == "archived":
+        if repository.status in {"archived", "paused"}:
             continue
         for branch in _REPO_BRANCH_STORE.get(repository.id, repository.branches):
             poll_targets.append({"repositoryId": repository.id, "branch": branch.branch})
@@ -1008,6 +1090,7 @@ async def register_repository(
     auth_data: Dict[str, Any] = Depends(validate_authentication),
 ) -> RegisterRepositoryResponse:
     tenant_id = auth_data["tenant_id"]
+    actor_id = _resolve_actor_id(auth_data)
 
     _validate_uuid(request.linkedAccountId, "linkedAccountId")
     owner = request.owner.strip()
@@ -1102,6 +1185,27 @@ async def register_repository(
             and _is_manifest_project_auto_create_enabled(auth_data),
         }
         tenant_repos[repository.id] = repository
+        _write_audit_row(
+            tenant_id,
+            repository_id,
+            "repository.token_resolved",
+            actor_id=actor_id,
+            detail={
+                "provider": repository.provider,
+                "linkedAccountId": request.linkedAccountId,
+            },
+        )
+        _write_audit_row(
+            tenant_id,
+            repository_id,
+            "repository.registered",
+            actor_id=actor_id,
+            detail={
+                "provider": repository.provider,
+                "fullName": repository.fullName,
+                "branchCount": len(normalized_branches),
+            },
+        )
 
     return RegisterRepositoryResponse(
         repository=repository,
@@ -1200,6 +1304,7 @@ async def archive_repository(
     auth_data: Dict[str, Any] = Depends(validate_authentication),
 ) -> RepositoryRecord:
     tenant_id = auth_data["tenant_id"]
+    actor_id = _resolve_actor_id(auth_data)
     with _STORE_LOCK:
         repository = _REPO_STORE.get(tenant_id, {}).get(repository_id)
         if repository is None:
@@ -1209,7 +1314,13 @@ async def archive_repository(
         repository.status = "archived"
         repository.archivedAt = now
         repository.updatedAt = now
-        _write_audit_row(tenant_id, repository_id, "repository.archived")
+        _write_audit_row(
+            tenant_id,
+            repository_id,
+            "repository.archived",
+            actor_id=actor_id,
+            detail={"status": repository.status},
+        )
         return repository
 
 
@@ -1220,6 +1331,7 @@ async def unarchive_repository(
     auth_data: Dict[str, Any] = Depends(validate_authentication),
 ) -> RepositoryRecord:
     tenant_id = auth_data["tenant_id"]
+    actor_id = _resolve_actor_id(auth_data)
     with _STORE_LOCK:
         repository = _REPO_STORE.get(tenant_id, {}).get(repository_id)
         if repository is None:
@@ -1228,7 +1340,63 @@ async def unarchive_repository(
         repository.status = "healthy"
         repository.archivedAt = None
         repository.updatedAt = _utc_now_iso()
-        _write_audit_row(tenant_id, repository_id, "repository.unarchived")
+        _write_audit_row(
+            tenant_id,
+            repository_id,
+            "repository.unarchived",
+            actor_id=actor_id,
+            detail={"status": repository.status},
+        )
+        return repository
+
+
+@router.post("/{tenant_slug}/{repository_id}/pause", response_model=RepositoryRecord)
+async def pause_repository(
+    tenant_slug: str,
+    repository_id: str,
+    auth_data: Dict[str, Any] = Depends(validate_authentication),
+) -> RepositoryRecord:
+    tenant_id = auth_data["tenant_id"]
+    actor_id = _resolve_actor_id(auth_data)
+    with _STORE_LOCK:
+        repository = _REPO_STORE.get(tenant_id, {}).get(repository_id)
+        if repository is None:
+            raise HTTPException(status_code=404, detail=f"Repository not found: {repository_id}")
+        now = _utc_now_iso()
+        repository.status = "paused"
+        repository.updatedAt = now
+        _write_audit_row(
+            tenant_id,
+            repository_id,
+            "repository.paused",
+            actor_id=actor_id,
+            detail={"status": repository.status},
+        )
+        return repository
+
+
+@router.post("/{tenant_slug}/{repository_id}/auto-pause", response_model=RepositoryRecord)
+async def auto_pause_repository(
+    tenant_slug: str,
+    repository_id: str,
+    auth_data: Dict[str, Any] = Depends(validate_authentication),
+) -> RepositoryRecord:
+    tenant_id = auth_data["tenant_id"]
+    actor_id = _resolve_actor_id(auth_data)
+    with _STORE_LOCK:
+        repository = _REPO_STORE.get(tenant_id, {}).get(repository_id)
+        if repository is None:
+            raise HTTPException(status_code=404, detail=f"Repository not found: {repository_id}")
+        now = _utc_now_iso()
+        repository.status = "paused"
+        repository.updatedAt = now
+        _write_audit_row(
+            tenant_id,
+            repository_id,
+            "repository.auto_paused",
+            actor_id=actor_id,
+            detail={"status": repository.status},
+        )
         return repository
 
 
@@ -1240,6 +1408,7 @@ async def delete_repository(
     auth_data: Dict[str, Any] = Depends(validate_authentication),
 ) -> Response:
     tenant_id = auth_data["tenant_id"]
+    actor_id = _resolve_actor_id(auth_data)
     with _STORE_LOCK:
         tenant_repos = _REPO_STORE.get(tenant_id, {})
         repository = tenant_repos.get(repository_id)
@@ -1256,7 +1425,13 @@ async def delete_repository(
         for scan in scan_history:
             _REPO_SCAN_FILE_HISTORY_STORE.pop(scan.id, None)
         _REPO_CREDENTIAL_REF_STORE.pop(repository_id, None)
-        _write_audit_row(tenant_id, repository_id, "repository.removed")
+        _write_audit_row(
+            tenant_id,
+            repository_id,
+            "repository.removed",
+            actor_id=actor_id,
+            detail={"fullName": repository.fullName},
+        )
 
     return Response(status_code=204)
 
@@ -1469,6 +1644,7 @@ async def create_repository_scan(
     auth_data: Dict[str, Any] = Depends(validate_authentication),
 ) -> RepositoryScanRecord:
     tenant_id = auth_data["tenant_id"]
+    actor_id = _resolve_actor_id(auth_data)
     branch_name = request.branch.strip()
     if not branch_name:
         raise HTTPException(status_code=400, detail="branch is required")
@@ -1493,6 +1669,18 @@ async def create_repository_scan(
             )
         history.insert(0, scan)
         _REPO_SCAN_FILE_HISTORY_STORE[scan.id] = []
+        _write_audit_row(
+            tenant_id,
+            repository_id,
+            "repository.polled",
+            actor_id=actor_id,
+            detail={
+                "trigger": scan.trigger,
+                "branch": branch_name,
+                "force": request.force,
+                "scanId": scan.id,
+            },
+        )
         return scan
 
 
@@ -1646,6 +1834,7 @@ def _complete_repository_scan_for_tests(
             branch=target_scan.branch,
             commit_sha=commit_sha,
             scan_files=classified_files,
+            actor_id=_SYSTEM_ACTOR_ID,
         )
         _REPO_SCAN_FILE_HISTORY_STORE[scan_id] = classified_files
 
@@ -1664,6 +1853,19 @@ def _complete_repository_scan_for_tests(
             }
         )
         history[scan_idx] = completed_scan
+        _write_audit_row(
+            tenant_id,
+            repository_id,
+            "repository.scanned",
+            actor_id=_SYSTEM_ACTOR_ID,
+            detail={
+                "scanId": completed_scan.id,
+                "branch": completed_scan.branch,
+                "trigger": completed_scan.trigger,
+                "status": completed_scan.status,
+                "diffSummary": completed_scan.diffSummary,
+            },
+        )
         return completed_scan
 
 

--- a/objectified-rest/src/app/repositories_routes.py
+++ b/objectified-rest/src/app/repositories_routes.py
@@ -1192,6 +1192,8 @@ async def register_repository(
         createdAt=now,
     )
 
+    _audit_token_row: Dict[str, Any] | None = None
+    _audit_registered_row: Dict[str, Any] | None = None
     with _STORE_LOCK:
         tenant_repos = _REPO_STORE.setdefault(tenant_id, {})
         _REPO_BRANCH_STORE[repository.id] = list(normalized_branches)
@@ -1227,8 +1229,10 @@ async def register_repository(
             },
         )
 
-    _persist_audit_row(_audit_token_row)
-    _persist_audit_row(_audit_registered_row)
+    if _audit_token_row is not None:
+        _persist_audit_row(_audit_token_row)
+    if _audit_registered_row is not None:
+        _persist_audit_row(_audit_registered_row)
     return RegisterRepositoryResponse(
         repository=repository,
         initialScanJobId=initial_scan_job_id,
@@ -1327,6 +1331,7 @@ async def archive_repository(
 ) -> RepositoryRecord:
     tenant_id = auth_data["tenant_id"]
     actor_id = _resolve_actor_id(auth_data)
+    _audit_row: Dict[str, Any] | None = None
     with _STORE_LOCK:
         repository = _REPO_STORE.get(tenant_id, {}).get(repository_id)
         if repository is None:
@@ -1343,7 +1348,8 @@ async def archive_repository(
             actor_id=actor_id,
             detail={"status": repository.status},
         )
-    _persist_audit_row(_audit_row)
+    if _audit_row is not None:
+        _persist_audit_row(_audit_row)
     return repository
 
 
@@ -1355,6 +1361,7 @@ async def unarchive_repository(
 ) -> RepositoryRecord:
     tenant_id = auth_data["tenant_id"]
     actor_id = _resolve_actor_id(auth_data)
+    _audit_row: Dict[str, Any] | None = None
     with _STORE_LOCK:
         repository = _REPO_STORE.get(tenant_id, {}).get(repository_id)
         if repository is None:
@@ -1370,7 +1377,8 @@ async def unarchive_repository(
             actor_id=actor_id,
             detail={"status": repository.status},
         )
-    _persist_audit_row(_audit_row)
+    if _audit_row is not None:
+        _persist_audit_row(_audit_row)
     return repository
 
 
@@ -1382,6 +1390,7 @@ async def pause_repository(
 ) -> RepositoryRecord:
     tenant_id = auth_data["tenant_id"]
     actor_id = _resolve_actor_id(auth_data)
+    _audit_row: Dict[str, Any] | None = None
     with _STORE_LOCK:
         repository = _REPO_STORE.get(tenant_id, {}).get(repository_id)
         if repository is None:
@@ -1396,7 +1405,8 @@ async def pause_repository(
             actor_id=actor_id,
             detail={"status": repository.status},
         )
-    _persist_audit_row(_audit_row)
+    if _audit_row is not None:
+        _persist_audit_row(_audit_row)
     return repository
 
 
@@ -1408,6 +1418,7 @@ async def auto_pause_repository(
 ) -> RepositoryRecord:
     tenant_id = auth_data["tenant_id"]
     actor_id = _resolve_actor_id(auth_data)
+    _audit_row: Dict[str, Any] | None = None
     with _STORE_LOCK:
         repository = _REPO_STORE.get(tenant_id, {}).get(repository_id)
         if repository is None:
@@ -1422,7 +1433,8 @@ async def auto_pause_repository(
             actor_id=actor_id,
             detail={"status": repository.status},
         )
-    _persist_audit_row(_audit_row)
+    if _audit_row is not None:
+        _persist_audit_row(_audit_row)
     return repository
 
 
@@ -1435,6 +1447,7 @@ async def delete_repository(
 ) -> Response:
     tenant_id = auth_data["tenant_id"]
     actor_id = _resolve_actor_id(auth_data)
+    _audit_row: Dict[str, Any] | None = None
     with _STORE_LOCK:
         tenant_repos = _REPO_STORE.get(tenant_id, {})
         repository = tenant_repos.get(repository_id)
@@ -1459,7 +1472,8 @@ async def delete_repository(
             detail={"fullName": repository.fullName},
         )
 
-    _persist_audit_row(_audit_row)
+    if _audit_row is not None:
+        _persist_audit_row(_audit_row)
     return Response(status_code=204)
 
 
@@ -1676,6 +1690,7 @@ async def create_repository_scan(
     if not branch_name:
         raise HTTPException(status_code=400, detail="branch is required")
 
+    _audit_row: Dict[str, Any] | None = None
     with _STORE_LOCK:
         _find_repository_for_tenant(tenant_id, repository_id)
         history = _REPO_SCAN_HISTORY_STORE.setdefault(repository_id, [])
@@ -1708,7 +1723,8 @@ async def create_repository_scan(
                 "scanId": scan.id,
             },
         )
-    _persist_audit_row(_audit_row)
+    if _audit_row is not None:
+        _persist_audit_row(_audit_row)
     return scan
 
 

--- a/objectified-rest/tests/test_repositories_routes.py
+++ b/objectified-rest/tests/test_repositories_routes.py
@@ -73,6 +73,10 @@ def test_register_repository_returns_scan_job_and_timeline_entry():
     assert body["repository"]["status"] == "scan_in_progress"
     assert body["repository"]["timeline"][0]["message"] == "Scan in progress..."
     assert body["repository"]["branches"] == [{"branch": "main", "subpathGlob": "specs/**", "pollIntervalSec": None}]
+    audit_rows = _get_repository_audit_rows_for_tests(body["repository"]["id"])
+    assert [row["eventType"] for row in audit_rows] == ["repository.token_resolved", "repository.registered"]
+    assert all(row["actorId"] == _MOCK_AUTH["user_id"] for row in audit_rows)
+    assert all(isinstance(row["detail"], dict) for row in audit_rows)
 
 
 def test_repository_list_and_detail_are_tenant_scoped():
@@ -247,7 +251,48 @@ def test_archive_unarchive_writes_audit_and_scheduler_skips_archived():
     assert unarchive_response.json()["archivedAt"] is None
     assert sorted(target["branch"] for target in poll_targets_after_unarchive) == ["main", "release/*"]
 
-    assert [row["eventType"] for row in audit_rows] == ["repository.archived", "repository.unarchived"]
+    assert [row["eventType"] for row in audit_rows] == [
+        "repository.token_resolved",
+        "repository.registered",
+        "repository.archived",
+        "repository.unarchived",
+    ]
+
+
+def test_pause_and_auto_pause_write_audit_and_scheduler_skips_paused():
+    app.dependency_overrides[validate_authentication] = _override_auth
+    try:
+        create_response = client.post(
+            f"/v1/repositories/{_TENANT_SLUG}",
+            json={
+                "linkedAccountId": "aaaaaaaa-bbbb-cccc-dddd-000000000018",
+                "provider": "github",
+                "owner": "acme",
+                "name": "service-paused",
+                "branches": [{"branch": "main"}],
+            },
+        )
+        repository_id = create_response.json()["repository"]["id"]
+        pause_response = client.post(f"/v1/repositories/{_TENANT_SLUG}/{repository_id}/pause")
+        poll_targets_after_pause = _list_poll_targets_for_tests(_MOCK_AUTH["tenant_id"])
+        auto_pause_response = client.post(f"/v1/repositories/{_TENANT_SLUG}/{repository_id}/auto-pause")
+        poll_targets_after_auto_pause = _list_poll_targets_for_tests(_MOCK_AUTH["tenant_id"])
+        audit_rows = _get_repository_audit_rows_for_tests(repository_id)
+    finally:
+        app.dependency_overrides.pop(validate_authentication, None)
+
+    assert pause_response.status_code == 200
+    assert pause_response.json()["status"] == "paused"
+    assert poll_targets_after_pause == []
+    assert auto_pause_response.status_code == 200
+    assert auto_pause_response.json()["status"] == "paused"
+    assert poll_targets_after_auto_pause == []
+    assert [row["eventType"] for row in audit_rows] == [
+        "repository.token_resolved",
+        "repository.registered",
+        "repository.paused",
+        "repository.auto_paused",
+    ]
 
 
 def test_delete_repository_requires_confirmation_and_cascades():
@@ -286,7 +331,11 @@ def test_delete_repository_requires_confirmation_and_cascades():
     assert delete_response.status_code == 204
     assert all(not exists for exists in relations_exist.values())
     assert detail_response.status_code == 404
-    assert [row["eventType"] for row in audit_rows] == ["repository.removed"]
+    assert [row["eventType"] for row in audit_rows] == [
+        "repository.token_resolved",
+        "repository.registered",
+        "repository.removed",
+    ]
 
 
 def test_list_scans_returns_initial_register_scan_with_default_page_limit():
@@ -579,8 +628,10 @@ def test_complete_scan_dispatches_import_jobs_and_records_parse_errors():
 
     new_audit_rows = audit_rows[baseline_audit_count:]
     assert [row["eventType"] for row in new_audit_rows] == [
+        "repository.polled",
         "repository.sync_pending_review",
-        "repository.sync_pending_review",
+        "repository.sync_failed",
+        "repository.scanned",
     ]
 
 
@@ -981,7 +1032,12 @@ def test_auto_promotion_records_change_report_and_sync_committed_audit() -> None
     assert jobs[0].state == "committed"
     assert jobs[0].changeReportId is not None
     assert any(report.importJobId == jobs[0].id for report in change_reports)
-    assert [row["eventType"] for row in audit_rows] == ["repository.sync_committed"]
+    assert [row["eventType"] for row in audit_rows] == [
+        "repository.token_resolved",
+        "repository.registered",
+        "repository.sync_committed",
+        "repository.scanned",
+    ]
 
 
 def test_on_breaking_change_block_forces_manual_even_when_promote_is_auto() -> None:
@@ -1023,4 +1079,9 @@ def test_on_breaking_change_block_forces_manual_even_when_promote_is_auto() -> N
     assert jobs[0].state == "pending_review"
     assert jobs[0].settingsJson["onBreakingChange"] == "block"
     assert jobs[0].settingsJson["requiresExplicitApproval"] is True
-    assert [row["eventType"] for row in audit_rows] == ["repository.sync_pending_review"]
+    assert [row["eventType"] for row in audit_rows] == [
+        "repository.token_resolved",
+        "repository.registered",
+        "repository.sync_pending_review",
+        "repository.scanned",
+    ]

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.10.41",
+  "version": "0.10.42",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -5,6 +5,7 @@ We continue to improve the platform based on your feedback with improvements and
 ---
 
 ## Repositories
+- Added REPO-7.1 workflow-audit repository events in the shared ledger so repository register/scan/sync/pause/poll/token/archive/remove actions now emit filterable `workflow_audit` rows with actor identity and structured detail payloads.
 - Added REPO-6.3 scan timeline upgrades with trigger/status/branch filter chips, per-scan trigger/SHA/duration/file-count summaries, and expandable failed-scan error console details from `event_log` + `error_detail`.
 - Added REPO-6.2 repository detail tabs with deep-link navigation (`branches/files/scans/sync/manifest/settings`), virtualized file lists with side-drawer file details/promote action, scan timeline links, and Monaco manifest editing with REPO-2.4 schema validation.
 - Added REPO-6.1 repository index upgrades with skeleton loading, provider/status/search filters, sortable name/last-scan/status columns, and quick row actions for **Scan now**, **Pause/Resume**, and **Open detail** under Account -> Repositories.


### PR DESCRIPTION
## Summary
- add repository workflow audit action coverage in `repositories_routes` and persist events into the shared `workflow_audit` ledger via `db.insert_workflow_audit`
- emit structured actor/detail payloads for repository lifecycle, token resolution, poll dispatch, scan completion, and sync outcomes (`sync_committed`, `sync_pending_review`, `sync_failed`)
- document REPO-7.1 action codes, add route-level tests for new audit behavior, and update roadmap/what's-new plus patch versions

## Test plan
- [x] `yarn build`
- [x] `yarn test` *(fails on existing unrelated suites: `tests/repositories-index.test.tsx` ambiguous role query and `tests/llm-streaming.test.ts` pretty-format runtime error)*
- [x] `python3 -m compileall objectified-rest/src/app/repositories_routes.py`
- [ ] `pytest objectified-rest/tests/test_repositories_routes.py -q` *(blocked: `pytest` is not installed in this environment)*

## Risk / Notes
- Introduces new repository pause/auto-pause endpoints and `paused` status handling in poll-target filtering.
- Workflow-audit inserts are best-effort and continue to swallow DB failures via existing `insert_workflow_audit` behavior.

Fixes #2799

Made with [Cursor](https://cursor.com)