### PR TITLE
Fix #2802 - token health monitor for linked accounts

### DIFF
--- a/docs/PLANNED_FEATURE_ROADMAP_REPOSITORY.md
+++ b/docs/PLANNED_FEATURE_ROADMAP_REPOSITORY.md
@@ -2,6 +2,7 @@
 
 ## Completed
 
+- REPO-7.4 (#2802): Added linked-account token health monitoring by introducing per-credential probe persistence, classifying daily probe outcomes (`healthy` / `scope_missing` / `revoked` / `network_error`), auto-pausing repositories bound to revoked credentials, and surfacing usage + verification + reconnect states in Linked Accounts UI.
 - REPO-7.1 (#2799): Added repository workflow-audit coverage in the shared `workflow_audit` ledger, documenting and emitting repository action codes (`registered/scanned/sync/pause/poll/token/archive/remove`) with structured per-event detail payloads and actor identities.
 - REPO-6.3 (#2796): Added scan timeline upgrades in the repository detail view with trigger/status/branch filter chips, per-row trigger/SHA/duration/file-count summaries, and expandable failed-scan error consoles that render `repository_scan.event_log` plus `error_detail`.
 - REPO-6.2 (#2795): Added the repository detail experience at `/ade/dashboard/repositories/{id}` with deep-link tabs (`branches/files/scans/sync/manifest/settings`), virtualized file rendering + drawer details, scan timeline links for REPO-6.3 and `repository_scan` drill-in, and Monaco-based manifest editing with REPO-2.4 schema validation.

--- a/objectified-db/scripts/20260424-210000.sql
+++ b/objectified-db/scripts/20260424-210000.sql
@@ -1,0 +1,22 @@
+-- REPO-7.4 / #2802: Persist linked-account credential health probe state.
+SET search_path TO odb, public;
+
+CREATE TABLE IF NOT EXISTS odb.repository_credential_health (
+  linked_account_id UUID PRIMARY KEY
+    REFERENCES odb.external_auth_providers(id)
+    ON DELETE CASCADE,
+  status VARCHAR(32) NOT NULL
+    CHECK (status IN ('healthy', 'scope_missing', 'revoked', 'network_error')),
+  checked_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  detail TEXT,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+COMMENT ON TABLE odb.repository_credential_health IS
+  'Daily token health probe result per linked account credential (#2802).';
+
+COMMENT ON COLUMN odb.repository_credential_health.status IS
+  'Latest classified token health status: healthy, scope_missing, revoked, or network_error.';
+
+COMMENT ON COLUMN odb.repository_credential_health.checked_at IS
+  'Timestamp for the most recent linked-account probe.';

--- a/objectified-ui/lib/db/helper.ts
+++ b/objectified-ui/lib/db/helper.ts
@@ -2613,9 +2613,19 @@ export async function getLinkedAccountsForUser(userId: string) {
     const result = await connectionPool.query(
       `SELECT id, provider, provider_user_id, provider_email, provider_username,
               (CASE WHEN access_token IS NOT NULL THEN RIGHT(access_token, 6) ELSE NULL END) AS access_token_suffix,
-              created_at, last_login_at
-       FROM odb.external_auth_providers
-       WHERE user_id = $1
+              created_at, last_login_at,
+              COALESCE(repo_usage.repository_count, 0) AS repository_count,
+              credential_health.status AS health_status,
+              credential_health.checked_at AS health_checked_at
+       FROM odb.external_auth_providers eap
+       LEFT JOIN (
+         SELECT linked_account_id, COUNT(DISTINCT repository_id) AS repository_count
+         FROM odb.repository_credential_ref
+         GROUP BY linked_account_id
+       ) repo_usage ON repo_usage.linked_account_id = eap.id
+       LEFT JOIN odb.repository_credential_health credential_health
+         ON credential_health.linked_account_id = eap.id
+       WHERE eap.user_id = $1
        ORDER BY created_at DESC`,
       [userId]
     );

--- a/objectified-ui/lib/repositories/providers/__tests__/contract.test.ts
+++ b/objectified-ui/lib/repositories/providers/__tests__/contract.test.ts
@@ -58,6 +58,9 @@ async function collect<T>(iterable: AsyncIterable<T>): Promise<T[]> {
 
 function makeGitlabApiMock() {
   return {
+    Users: {
+      current: jest.fn(),
+    },
     Projects: {
       all: jest.fn(),
       show: jest.fn(),
@@ -131,6 +134,11 @@ describe('RepositoryProvider contract', () => {
           sha: 'f1',
           size: 7,
         })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          login: 'acme-user',
+        })
       );
 
     const provider = new GithubRepositoryProvider(fetchMock);
@@ -141,6 +149,7 @@ describe('RepositoryProvider contract', () => {
     const sha = await provider.getCommitSha('token-1', { owner: 'acme', name: 'repo-a' }, 'main');
     const tree = await collect(provider.walkTree('token-1', { owner: 'acme', name: 'repo-a' }, 'main', 'docs'));
     const file = await provider.readFile('token-1', { owner: 'acme', name: 'repo-a' }, 'main', 'docs/readme.md');
+    await provider.probeIdentity('token-1');
 
     expect(repos).toHaveLength(1);
     expect(repo.fullName).toBe('acme/repo-a');
@@ -274,6 +283,7 @@ describe('GitLab RepositoryProvider contract', () => {
       blob_id: 'f1',
       size: 7,
     });
+    api.Users.current.mockResolvedValueOnce({ id: 101, username: 'acme-user' });
     api.ProjectHooks.add.mockResolvedValueOnce({ id: 42 });
     api.ProjectHooks.remove.mockResolvedValueOnce(undefined);
 
@@ -285,6 +295,7 @@ describe('GitLab RepositoryProvider contract', () => {
     const sha = await provider.getCommitSha('token-1', { owner: 'acme', name: 'repo-a' }, 'main');
     const tree = await collect(provider.walkTree('token-1', { owner: 'acme', name: 'repo-a' }, 'main', 'docs'));
     const file = await provider.readFile('token-1', { owner: 'acme', name: 'repo-a' }, 'main', 'docs/readme.md');
+    await provider.probeIdentity('token-1');
     const webhook = await provider.registerWebhook('token-1', { owner: 'acme', name: 'repo-a' }, {
       url: 'https://example.com/hooks/gitlab',
       events: ['push'],
@@ -435,7 +446,8 @@ describe('Bitbucket RepositoryProvider contract', () => {
       )
       .mockResolvedValueOnce(textResponse('content'))
       .mockResolvedValueOnce(jsonResponse({ uuid: '{hook-123}' }))
-      .mockResolvedValueOnce(jsonResponse({}, { status: 204 }));
+      .mockResolvedValueOnce(jsonResponse({}, { status: 204 }))
+      .mockResolvedValueOnce(jsonResponse({ username: 'acme-user' }));
 
     const provider = new BitbucketRepositoryProvider(fetchMock);
 
@@ -450,6 +462,7 @@ describe('Bitbucket RepositoryProvider contract', () => {
       events: ['repo:push'],
     });
     await provider.removeWebhook('token-1', { owner: 'acme', name: 'repo-a' }, webhook.id);
+    await provider.probeIdentity('token-1');
 
     const validHeaders = new Headers({ 'x-hook-uuid': '{hook-123}' });
     const invalidHeaders = new Headers({ 'x-hook-uuid': '{hook-999}' });

--- a/objectified-ui/lib/repositories/providers/bitbucket-provider.ts
+++ b/objectified-ui/lib/repositories/providers/bitbucket-provider.ts
@@ -121,6 +121,13 @@ export class BitbucketRepositoryProvider implements RepositoryProvider {
     return String(target?.hash ?? '');
   }
 
+  async probeIdentity(token: string): Promise<void> {
+    await this.requestJson({
+      pathOrUrl: '/user',
+      token,
+    });
+  }
+
   async *walkTree(token: string, repo: RepoRef, branch: string, subpath?: string): AsyncIterable<TreeEntry> {
     const normalizedSubpath = normalizePath(subpath ?? '');
     const queue: string[] = [normalizedSubpath];
@@ -385,6 +392,9 @@ function normalizeBitbucketEvents(events: string[]): string[] {
 function normalizeBitbucketError(status: number, body: string, headers: Headers): RepositoryProviderError {
   if (status === 401) {
     return new RepositoryProviderError('UNAUTHORIZED', 'Unauthorized Bitbucket token', status);
+  }
+  if (status === 403 && !isBitbucketRateLimited(status, body, headers)) {
+    return new RepositoryProviderError('FORBIDDEN', 'Bitbucket token is missing required scope', status);
   }
   if (status === 404) {
     return new RepositoryProviderError('NOT_FOUND', 'Bitbucket resource not found', status);

--- a/objectified-ui/lib/repositories/providers/github-provider.ts
+++ b/objectified-ui/lib/repositories/providers/github-provider.ts
@@ -129,6 +129,13 @@ export class GithubRepositoryProvider implements RepositoryProvider {
     return String(commit.sha ?? '');
   }
 
+  async probeIdentity(token: string): Promise<void> {
+    await this.requestJson<Record<string, unknown>>({
+      path: '/user',
+      token,
+    });
+  }
+
   async *walkTree(token: string, repo: RepoRef, branch: string, subpath?: string): AsyncIterable<TreeEntry> {
     const normalizedSubpath = normalizeSubpath(subpath);
     const response = await this.requestJson<Record<string, unknown>>({
@@ -262,6 +269,9 @@ function mapTreeType(value: unknown): TreeEntry['type'] | null {
 function normalizeError(status: number, body: string, headers: Headers): RepositoryProviderError {
   if (status === 401) {
     return new RepositoryProviderError('UNAUTHORIZED', 'Unauthorized GitHub token', status);
+  }
+  if (status === 403 && !isRateLimited(status, body, headers)) {
+    return new RepositoryProviderError('FORBIDDEN', 'GitHub token is missing required scope', status);
   }
   if (status === 404) {
     return new RepositoryProviderError('NOT_FOUND', 'GitHub resource not found', status);

--- a/objectified-ui/lib/repositories/providers/gitlab-provider.ts
+++ b/objectified-ui/lib/repositories/providers/gitlab-provider.ts
@@ -19,6 +19,9 @@ type GitlabApiFactory = (token: string) => GitlabApi;
 type SecretGenerator = () => string;
 
 interface GitlabApi {
+  Users: {
+    current(): Promise<unknown>;
+  };
   Projects: {
     all(options: Record<string, unknown>): Promise<unknown[]>;
     show(projectId: string): Promise<unknown>;
@@ -235,6 +238,11 @@ export class GitlabRepositoryProvider implements RepositoryProvider {
     };
   }
 
+  async probeIdentity(token: string): Promise<void> {
+    const api = this.apiFactory(token);
+    await this.request(() => api.Users.current());
+  }
+
   async registerWebhook(token: string, repo: RepoRef, target: WebhookTarget): Promise<{ id: string; secret: string }> {
     const api = this.apiFactory(token);
     const secret = this.secretGenerator();
@@ -410,6 +418,9 @@ function normalizeGitlabError(error: unknown): RepositoryProviderError {
   const status = extractStatus(error);
   if (status === 401) {
     return new RepositoryProviderError('UNAUTHORIZED', 'Unauthorized GitLab token', status, { cause: error });
+  }
+  if (status === 403) {
+    return new RepositoryProviderError('FORBIDDEN', 'GitLab token is missing required scope', status, { cause: error });
   }
   if (status === 404) {
     return new RepositoryProviderError('NOT_FOUND', 'GitLab resource not found', status, { cause: error });

--- a/objectified-ui/lib/repositories/providers/repository-provider.ts
+++ b/objectified-ui/lib/repositories/providers/repository-provider.ts
@@ -36,6 +36,7 @@ export interface RepositoryProvider {
     branch: string,
     path: string
   ): Promise<{ contentBase64: string; sha: string; sizeBytes: number }>;
+  probeIdentity(token: string): Promise<void>;
 
   registerWebhook?(token: string, repo: RepoRef, target: WebhookTarget): Promise<{ id: string; secret: string }>;
   removeWebhook?(token: string, repo: RepoRef, id: string): Promise<void>;

--- a/objectified-ui/lib/repositories/providers/types.ts
+++ b/objectified-ui/lib/repositories/providers/types.ts
@@ -47,6 +47,7 @@ export interface WebhookTarget {
 export type RepositoryProviderErrorCode =
   | 'RATE_LIMITED'
   | 'UNAUTHORIZED'
+  | 'FORBIDDEN'
   | 'NOT_FOUND'
   | 'NETWORK'
   | 'SCAN_LIMIT_EXCEEDED'

--- a/objectified-ui/lib/repositories/token-health-monitor.ts
+++ b/objectified-ui/lib/repositories/token-health-monitor.ts
@@ -111,34 +111,48 @@ async function pauseRepositoriesForRevokedCredential(
       status = 'paused',
       updated_at = $2::timestamptz
     WHERE id = ANY($1::uuid[])
-      AND status <> 'paused'
+      AND status = 'active'
     RETURNING id, tenant_id, project_id`,
     [repositoryIds, checkedAt]
   );
 
-  for (const rawRow of pausedResult.rows) {
-    const repositoryId = typeof rawRow.id === 'string' ? rawRow.id : null;
-    const tenantId = typeof rawRow.tenant_id === 'string' ? rawRow.tenant_id : null;
-    const projectId = typeof rawRow.project_id === 'string' ? rawRow.project_id : null;
-    if (!repositoryId || !tenantId) {
-      continue;
+  if (pausedResult.rows.length > 0) {
+    const auditRows = pausedResult.rows
+      .filter(
+        (rawRow) => typeof rawRow.id === 'string' && typeof rawRow.tenant_id === 'string'
+      )
+      .map((rawRow) => ({
+        repositoryId: rawRow.id as string,
+        tenantId: rawRow.tenant_id as string,
+        projectId: typeof rawRow.project_id === 'string' ? rawRow.project_id : null,
+      }));
+
+    if (auditRows.length > 0) {
+      const PARAMS_PER_AUDIT_ROW = 5;
+      const valuePlaceholders = auditRows
+        .map((_, i) => `($${i * PARAMS_PER_AUDIT_ROW + 1}, $${i * PARAMS_PER_AUDIT_ROW + 2}, NULL, $${i * PARAMS_PER_AUDIT_ROW + 3}, $${i * PARAMS_PER_AUDIT_ROW + 4}, NULL, $${i * PARAMS_PER_AUDIT_ROW + 5}::jsonb)`)
+        .join(', ');
+      const flatParams: unknown[] = [];
+      for (const row of auditRows) {
+        flatParams.push(
+          row.tenantId,
+          row.projectId,
+          'repository.auto_paused',
+          'success',
+          JSON.stringify({
+            repository_id: row.repositoryId,
+            linked_account_id: linkedAccountId,
+            reason: 'credential_revoked',
+          })
+        );
+      }
+      await deps.query(
+        `INSERT INTO odb.workflow_audit (
+          tenant_id, project_id, version_id, action, outcome, actor_id, detail
+        ) VALUES ${valuePlaceholders}`,
+        flatParams
+      );
     }
-    await deps.query(
-      `INSERT INTO odb.workflow_audit (
-        tenant_id, project_id, version_id, action, outcome, actor_id, detail
-      ) VALUES ($1, $2, NULL, $3, $4, NULL, $5::jsonb)`,
-      [
-        tenantId,
-        projectId,
-        'repository.auto_paused',
-        'success',
-        JSON.stringify({
-          repository_id: repositoryId,
-          linked_account_id: linkedAccountId,
-          reason: 'credential_revoked',
-        }),
-      ]
-    );
   }
 
   return pausedResult.rowCount ?? 0;

--- a/objectified-ui/lib/repositories/token-health-monitor.ts
+++ b/objectified-ui/lib/repositories/token-health-monitor.ts
@@ -1,0 +1,221 @@
+'use server';
+
+const connectionPool = require('../db/db');
+
+import { BitbucketRepositoryProvider } from './providers/bitbucket-provider';
+import { GithubRepositoryProvider } from './providers/github-provider';
+import { GitlabRepositoryProvider } from './providers/gitlab-provider';
+import { RepositoryProviderError, type RepositoryProvider } from './providers/repository-provider';
+
+export type RepositoryCredentialHealthStatus = 'healthy' | 'scope_missing' | 'revoked' | 'network_error';
+
+type QueryResult = {
+  rowCount: number | null;
+  rows: Record<string, unknown>[];
+};
+
+interface RepositoryCredentialHealthProbeRow {
+  linked_account_id: string;
+  provider: string;
+  access_token: string | null;
+  repository_ids: string[];
+}
+
+interface RepositoryCredentialHealthMonitorDeps {
+  query: (sql: string, params: unknown[]) => Promise<QueryResult>;
+  now: () => Date;
+  providers: Partial<Record<string, RepositoryProvider>>;
+}
+
+export interface RepositoryCredentialHealthMonitorResult {
+  processedCredentials: number;
+  pausedRepositories: number;
+}
+
+function toStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.filter((item): item is string => typeof item === 'string' && item.length > 0);
+}
+
+function toProbeRow(raw: Record<string, unknown>): RepositoryCredentialHealthProbeRow | null {
+  if (typeof raw.linked_account_id !== 'string' || typeof raw.provider !== 'string') {
+    return null;
+  }
+
+  return {
+    linked_account_id: raw.linked_account_id,
+    provider: raw.provider,
+    access_token: typeof raw.access_token === 'string' ? raw.access_token : null,
+    repository_ids: toStringArray(raw.repository_ids),
+  };
+}
+
+function classifyProbeFailure(error: unknown): { status: RepositoryCredentialHealthStatus; detail: string } {
+  if (!(error instanceof RepositoryProviderError)) {
+    return {
+      status: 'network_error',
+      detail: error instanceof Error ? error.message : 'Unexpected provider probe error.',
+    };
+  }
+
+  switch (error.code) {
+    case 'UNAUTHORIZED':
+      return { status: 'revoked', detail: error.message };
+    case 'FORBIDDEN':
+      return { status: 'scope_missing', detail: error.message };
+    default:
+      return { status: 'network_error', detail: error.message };
+  }
+}
+
+async function upsertCredentialHealth(
+  deps: RepositoryCredentialHealthMonitorDeps,
+  linkedAccountId: string,
+  status: RepositoryCredentialHealthStatus,
+  checkedAt: string,
+  detail: string | null
+): Promise<void> {
+  await deps.query(
+    `INSERT INTO odb.repository_credential_health (
+      linked_account_id,
+      status,
+      checked_at,
+      detail,
+      updated_at
+    ) VALUES ($1::uuid, $2, $3::timestamptz, $4, $3::timestamptz)
+    ON CONFLICT (linked_account_id) DO UPDATE
+    SET
+      status = EXCLUDED.status,
+      checked_at = EXCLUDED.checked_at,
+      detail = EXCLUDED.detail,
+      updated_at = EXCLUDED.updated_at`,
+    [linkedAccountId, status, checkedAt, detail]
+  );
+}
+
+async function pauseRepositoriesForRevokedCredential(
+  deps: RepositoryCredentialHealthMonitorDeps,
+  linkedAccountId: string,
+  repositoryIds: string[],
+  checkedAt: string
+): Promise<number> {
+  if (repositoryIds.length === 0) {
+    return 0;
+  }
+
+  const pausedResult = await deps.query(
+    `UPDATE odb.repository
+    SET
+      status = 'paused',
+      updated_at = $2::timestamptz
+    WHERE id = ANY($1::uuid[])
+      AND status <> 'paused'
+    RETURNING id, tenant_id, project_id`,
+    [repositoryIds, checkedAt]
+  );
+
+  for (const rawRow of pausedResult.rows) {
+    const repositoryId = typeof rawRow.id === 'string' ? rawRow.id : null;
+    const tenantId = typeof rawRow.tenant_id === 'string' ? rawRow.tenant_id : null;
+    const projectId = typeof rawRow.project_id === 'string' ? rawRow.project_id : null;
+    if (!repositoryId || !tenantId) {
+      continue;
+    }
+    await deps.query(
+      `INSERT INTO odb.workflow_audit (
+        tenant_id, project_id, version_id, action, outcome, actor_id, detail
+      ) VALUES ($1, $2, NULL, $3, $4, NULL, $5::jsonb)`,
+      [
+        tenantId,
+        projectId,
+        'repository.auto_paused',
+        'success',
+        JSON.stringify({
+          repository_id: repositoryId,
+          linked_account_id: linkedAccountId,
+          reason: 'credential_revoked',
+        }),
+      ]
+    );
+  }
+
+  return pausedResult.rowCount ?? 0;
+}
+
+export function createRepositoryCredentialHealthMonitor(partialDeps?: Partial<RepositoryCredentialHealthMonitorDeps>) {
+  const deps: RepositoryCredentialHealthMonitorDeps = {
+    query: partialDeps?.query ?? ((sql: string, params: unknown[]) => connectionPool.query(sql, params)),
+    now: partialDeps?.now ?? (() => new Date()),
+    providers: partialDeps?.providers ?? {
+      github: new GithubRepositoryProvider(),
+      gitlab: new GitlabRepositoryProvider(),
+      bitbucket: new BitbucketRepositoryProvider(),
+    },
+  };
+
+  return async function runRepositoryCredentialHealthMonitor(): Promise<RepositoryCredentialHealthMonitorResult> {
+    const checkedAt = deps.now().toISOString();
+    const probeRowsResult = await deps.query(
+      `SELECT
+        eap.id AS linked_account_id,
+        eap.provider::text AS provider,
+        eap.access_token,
+        ARRAY_AGG(DISTINCT rcr.repository_id) AS repository_ids
+      FROM odb.repository_credential_ref rcr
+      JOIN odb.external_auth_providers eap ON eap.id = rcr.linked_account_id
+      GROUP BY eap.id, eap.provider, eap.access_token
+      ORDER BY eap.id`,
+      []
+    );
+
+    let pausedRepositories = 0;
+    for (const rawRow of probeRowsResult.rows) {
+      const row = toProbeRow(rawRow);
+      if (!row) {
+        continue;
+      }
+
+      let status: RepositoryCredentialHealthStatus = 'healthy';
+      let detail: string | null = null;
+      const provider = deps.providers[row.provider];
+
+      if (!row.access_token) {
+        status = 'revoked';
+        detail = 'Linked account token is missing or was revoked.';
+      } else if (!provider) {
+        status = 'network_error';
+        detail = `Provider "${row.provider}" is not configured for token probing.`;
+      } else {
+        try {
+          await provider.probeIdentity(row.access_token);
+        } catch (error) {
+          const classified = classifyProbeFailure(error);
+          status = classified.status;
+          detail = classified.detail;
+        }
+      }
+
+      await upsertCredentialHealth(deps, row.linked_account_id, status, checkedAt, detail);
+
+      if (status === 'revoked') {
+        pausedRepositories += await pauseRepositoriesForRevokedCredential(
+          deps,
+          row.linked_account_id,
+          row.repository_ids,
+          checkedAt
+        );
+      }
+    }
+
+    return {
+      processedCredentials: probeRowsResult.rows.length,
+      pausedRepositories,
+    };
+  };
+}
+
+export async function runRepositoryCredentialHealthMonitor(): Promise<RepositoryCredentialHealthMonitorResult> {
+  return createRepositoryCredentialHealthMonitor()();
+}

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.10.42",
+  "version": "0.10.43",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -5,6 +5,7 @@ We continue to improve the platform based on your feedback with improvements and
 ---
 
 ## Repositories
+- Added REPO-7.4 token health monitoring so linked-account credentials are probed and classified (`healthy` / `scope_missing` / `revoked` / `network_error`), revoked credentials auto-pause connected repositories, and the Linked Accounts view now shows usage count, last verification age, health state, plus a reconnect action for non-healthy accounts.
 - Added REPO-7.1 workflow-audit repository events in the shared ledger so repository register/scan/sync/pause/poll/token/archive/remove actions now emit filterable `workflow_audit` rows with actor identity and structured detail payloads.
 - Added REPO-6.3 scan timeline upgrades with trigger/status/branch filter chips, per-scan trigger/SHA/duration/file-count summaries, and expandable failed-scan error console details from `event_log` + `error_detail`.
 - Added REPO-6.2 repository detail tabs with deep-link navigation (`branches/files/scans/sync/manifest/settings`), virtualized file lists with side-drawer file details/promote action, scan timeline links, and Monaco manifest editing with REPO-2.4 schema validation.

--- a/objectified-ui/src/app/ade/dashboard/linked-accounts/page.tsx
+++ b/objectified-ui/src/app/ade/dashboard/linked-accounts/page.tsx
@@ -45,6 +45,9 @@ interface LinkedAccount {
   access_token_suffix?: string | null;
   created_at: string;
   last_login_at: string | null;
+  repository_count: number;
+  health_status: 'healthy' | 'scope_missing' | 'revoked' | 'network_error' | null;
+  health_checked_at: string | null;
 }
 
 interface ProviderConfig {
@@ -96,7 +99,21 @@ const LinkedAccounts = () => {
     setIsLoading(true);
     try {
       const result = await getLinkedAccountsForUser(userId);
-      setLinkedAccounts(JSON.parse(result));
+      const parsed = JSON.parse(result) as Array<Record<string, unknown>>;
+      setLinkedAccounts(
+        parsed.map((account) => ({
+          ...(account as unknown as LinkedAccount),
+          repository_count: Number(account.repository_count ?? 0),
+          health_status:
+            account.health_status === 'healthy' ||
+            account.health_status === 'scope_missing' ||
+            account.health_status === 'revoked' ||
+            account.health_status === 'network_error'
+              ? account.health_status
+              : null,
+          health_checked_at: typeof account.health_checked_at === 'string' ? account.health_checked_at : null,
+        }))
+      );
     } catch (error: any) {
       setErrorMessage('Failed to load linked accounts');
     } finally {
@@ -233,6 +250,36 @@ const LinkedAccounts = () => {
     return `${datePart} ${timePart}`;
   };
 
+  const formatVerificationAge = (checkedAt: string | null) => {
+    if (!checkedAt) {
+      return 'not yet verified';
+    }
+    const deltaMs = Date.now() - new Date(checkedAt).getTime();
+    if (!Number.isFinite(deltaMs) || deltaMs < 0) {
+      return 'just now';
+    }
+    const hours = Math.floor(deltaMs / (60 * 60 * 1000));
+    if (hours < 1) {
+      return 'just now';
+    }
+    return `${hours}h ago`;
+  };
+
+  const getHealthPresentation = (status: LinkedAccount['health_status']) => {
+    switch (status) {
+      case 'healthy':
+        return { label: '\u2713 healthy', toneClass: 'text-emerald-600 dark:text-emerald-400', needsReconnect: false };
+      case 'scope_missing':
+        return { label: '\u26a0 scope missing', toneClass: 'text-amber-600 dark:text-amber-400', needsReconnect: true };
+      case 'revoked':
+        return { label: '\u2716 revoked', toneClass: 'text-red-600 dark:text-red-400', needsReconnect: true };
+      case 'network_error':
+        return { label: '\u26a0 network error', toneClass: 'text-amber-600 dark:text-amber-400', needsReconnect: true };
+      default:
+        return { label: '\u2026 pending verification', toneClass: 'text-gray-500 dark:text-gray-400', needsReconnect: false };
+    }
+  };
+
   if (!session) {
     return (
       <div className="p-6">
@@ -292,6 +339,7 @@ const LinkedAccounts = () => {
                     const Icon = getProviderIcon(account.provider);
                     const displayName = getProviderDisplayName(account.provider);
                     const config = providerConfigs[account.provider];
+                    const health = getHealthPresentation(account.health_status);
 
                     return (
                       <tr key={account.id} className={dashboardTrHoverClass}>
@@ -306,6 +354,9 @@ const LinkedAccounts = () => {
                             <div>
                               <div className="text-sm font-semibold text-gray-900 dark:text-white">{displayName}</div>
                               <div className="text-sm text-gray-500 dark:text-gray-400">{account.provider_username || account.provider_email}</div>
+                              <div className={`text-xs mt-1 ${health.toneClass}`}>
+                                {`Used by ${account.repository_count} repositories \u00b7 last verified ${formatVerificationAge(account.health_checked_at)} \u00b7 ${health.label}`}
+                              </div>
                             </div>
                           </div>
                         </td>
@@ -316,10 +367,22 @@ const LinkedAccounts = () => {
                           {account.last_login_at ? formatDate(account.last_login_at) : '—'}
                         </td>
                         <td className="px-6 py-4 whitespace-nowrap text-right">
-                          <Button variant="outline" size="sm" onClick={() => handleUnlinkAccount(account)} disabled={isLoading} className="text-red-600 hover:bg-red-50 hover:text-red-700 dark:text-red-400 dark:hover:bg-red-950/30 dark:hover:text-red-300">
-                            <Trash2 className="h-4 w-4" />
-                            Unlink
-                          </Button>
+                          <div className="flex justify-end items-center gap-2">
+                            {health.needsReconnect && (
+                              <Button
+                                variant="outline"
+                                size="sm"
+                                onClick={() => handleLinkAccount(account.provider)}
+                                disabled={isLoading}
+                              >
+                                Reconnect
+                              </Button>
+                            )}
+                            <Button variant="outline" size="sm" onClick={() => handleUnlinkAccount(account)} disabled={isLoading} className="text-red-600 hover:bg-red-50 hover:text-red-700 dark:text-red-400 dark:hover:bg-red-950/30 dark:hover:text-red-300">
+                              <Trash2 className="h-4 w-4" />
+                              Unlink
+                            </Button>
+                          </div>
                         </td>
                       </tr>
                     );

--- a/objectified-ui/src/app/ade/dashboard/linked-accounts/page.tsx
+++ b/objectified-ui/src/app/ade/dashboard/linked-accounts/page.tsx
@@ -355,7 +355,7 @@ const LinkedAccounts = () => {
                               <div className="text-sm font-semibold text-gray-900 dark:text-white">{displayName}</div>
                               <div className="text-sm text-gray-500 dark:text-gray-400">{account.provider_username || account.provider_email}</div>
                               <div className={`text-xs mt-1 ${health.toneClass}`}>
-                                {`Used by ${account.repository_count} repositories \u00b7 last verified ${formatVerificationAge(account.health_checked_at)} \u00b7 ${health.label}`}
+                                {`Used by ${account.repository_count} ${account.repository_count === 1 ? 'repository' : 'repositories'} \u00b7 last verified ${formatVerificationAge(account.health_checked_at)} \u00b7 ${health.label}`}
                               </div>
                             </div>
                           </div>

--- a/objectified-ui/src/app/api/admin/credential-health/route.ts
+++ b/objectified-ui/src/app/api/admin/credential-health/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from 'next/server';
+import { isAdminAuthenticated } from '@/app/utils/adminAuth';
+import { runRepositoryCredentialHealthMonitor } from '@/lib/repositories/token-health-monitor';
+
+/**
+ * POST /api/admin/credential-health
+ *
+ * Triggers the linked-account token health monitor. Intended to be invoked by
+ * an external scheduler (e.g. a daily cron job) and protected by admin
+ * authentication so that it cannot be called by unprivileged users.
+ */
+export async function POST() {
+  const isAuthenticated = await isAdminAuthenticated();
+
+  if (!isAuthenticated) {
+    return NextResponse.json(
+      { error: 'Unauthorized access', message: 'Admin authentication required' },
+      { status: 401 }
+    );
+  }
+
+  try {
+    const result = await runRepositoryCredentialHealthMonitor();
+    return NextResponse.json(result);
+  } catch (error) {
+    console.error('Credential health monitor failed:', error);
+    return NextResponse.json(
+      { error: 'Credential health monitor failed', message: error instanceof Error ? error.message : 'Unknown error' },
+      { status: 500 }
+    );
+  }
+}

--- a/objectified-ui/tests/unit/repository-credential-health-monitor.test.ts
+++ b/objectified-ui/tests/unit/repository-credential-health-monitor.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it, jest } from '@jest/globals';
+
+import { createRepositoryCredentialHealthMonitor } from '../../lib/repositories/token-health-monitor';
+import { RepositoryProviderError } from '../../lib/repositories/providers/repository-provider';
+
+type QueryResult = { rowCount: number; rows: Record<string, unknown>[] };
+
+function makeQueryStub(handlers: Array<(sql: string, params: unknown[]) => QueryResult>): jest.MockedFunction<
+  (sql: string, params: unknown[]) => Promise<QueryResult>
+> {
+  let index = 0;
+  return jest.fn(async (sql: string, params: unknown[]) => {
+    const handler = handlers[index];
+    if (!handler) {
+      throw new Error(`Unexpected query #${index + 1}: ${sql}`);
+    }
+    index += 1;
+    return handler(sql, params);
+  });
+}
+
+function makeProvider(probe: () => Promise<void>) {
+  return {
+    id: 'github',
+    listRepositories: async function* () {},
+    getRepository: async () => ({ id: '', name: '', fullName: '', description: null, isPrivate: true, defaultBranch: 'main', htmlUrl: '', updatedAt: null }),
+    listBranches: async function* () {},
+    getCommitSha: async () => '',
+    walkTree: async function* () {},
+    readFile: async () => ({ contentBase64: '', sha: '', sizeBytes: 0 }),
+    probeIdentity: probe,
+  };
+}
+
+describe('repository credential health monitor', () => {
+  it('stores probe classifications and auto-pauses repositories for revoked credentials', async () => {
+    const githubProbe = jest.fn(async () => undefined);
+    const gitlabProbe = jest.fn(async () => {
+      throw new RepositoryProviderError('FORBIDDEN', 'missing scope', 403);
+    });
+    const query = makeQueryStub([
+      (sql) => {
+        expect(sql).toContain('FROM odb.repository_credential_ref rcr');
+        return {
+          rowCount: 3,
+          rows: [
+            {
+              linked_account_id: 'linked-healthy',
+              provider: 'github',
+              access_token: 'token-healthy',
+              repository_ids: ['repo-a'],
+            },
+            {
+              linked_account_id: 'linked-scope',
+              provider: 'gitlab',
+              access_token: 'token-scope',
+              repository_ids: ['repo-b'],
+            },
+            {
+              linked_account_id: 'linked-revoked',
+              provider: 'github',
+              access_token: null,
+              repository_ids: ['repo-c', 'repo-d'],
+            },
+          ],
+        };
+      },
+      (sql, params) => {
+        expect(sql).toContain('INSERT INTO odb.repository_credential_health');
+        expect(params[0]).toBe('linked-healthy');
+        expect(params[1]).toBe('healthy');
+        expect(params[3]).toBeNull();
+        return { rowCount: 1, rows: [] };
+      },
+      (sql, params) => {
+        expect(sql).toContain('INSERT INTO odb.repository_credential_health');
+        expect(params[0]).toBe('linked-scope');
+        expect(params[1]).toBe('scope_missing');
+        expect(String(params[3])).toContain('missing scope');
+        return { rowCount: 1, rows: [] };
+      },
+      (sql, params) => {
+        expect(sql).toContain('INSERT INTO odb.repository_credential_health');
+        expect(params[0]).toBe('linked-revoked');
+        expect(params[1]).toBe('revoked');
+        return { rowCount: 1, rows: [] };
+      },
+      (sql, params) => {
+        expect(sql).toContain('UPDATE odb.repository');
+        expect(params[0]).toEqual(['repo-c', 'repo-d']);
+        return {
+          rowCount: 2,
+          rows: [
+            { id: 'repo-c', tenant_id: 'tenant-1', project_id: 'project-1' },
+            { id: 'repo-d', tenant_id: 'tenant-1', project_id: null },
+          ],
+        };
+      },
+      (sql, params) => {
+        expect(sql).toContain('INSERT INTO odb.workflow_audit');
+        expect(params[2]).toBe('repository.auto_paused');
+        const detail = JSON.parse(String(params[4]));
+        expect(detail).toMatchObject({
+          repository_id: 'repo-c',
+          linked_account_id: 'linked-revoked',
+          reason: 'credential_revoked',
+        });
+        return { rowCount: 1, rows: [] };
+      },
+      (sql, params) => {
+        expect(sql).toContain('INSERT INTO odb.workflow_audit');
+        const detail = JSON.parse(String(params[4]));
+        expect(detail.repository_id).toBe('repo-d');
+        return { rowCount: 1, rows: [] };
+      },
+    ]);
+
+    const monitor = createRepositoryCredentialHealthMonitor({
+      query,
+      now: () => new Date('2026-04-24T20:20:00.000Z'),
+      providers: {
+        github: makeProvider(githubProbe),
+        gitlab: makeProvider(gitlabProbe),
+      },
+    });
+
+    const result = await monitor();
+
+    expect(result).toEqual({
+      processedCredentials: 3,
+      pausedRepositories: 2,
+    });
+    expect(githubProbe).toHaveBeenCalledTimes(1);
+    expect(githubProbe).toHaveBeenCalledWith('token-healthy');
+    expect(gitlabProbe).toHaveBeenCalledTimes(1);
+  });
+});

--- a/objectified-ui/tests/unit/repository-credential-health-monitor.test.ts
+++ b/objectified-ui/tests/unit/repository-credential-health-monitor.test.ts
@@ -98,20 +98,18 @@ describe('repository credential health monitor', () => {
       },
       (sql, params) => {
         expect(sql).toContain('INSERT INTO odb.workflow_audit');
+        // Batched insert: params are laid out as 5 values per row
         expect(params[2]).toBe('repository.auto_paused');
-        const detail = JSON.parse(String(params[4]));
-        expect(detail).toMatchObject({
+        const detailC = JSON.parse(String(params[4]));
+        expect(detailC).toMatchObject({
           repository_id: 'repo-c',
           linked_account_id: 'linked-revoked',
           reason: 'credential_revoked',
         });
-        return { rowCount: 1, rows: [] };
-      },
-      (sql, params) => {
-        expect(sql).toContain('INSERT INTO odb.workflow_audit');
-        const detail = JSON.parse(String(params[4]));
-        expect(detail.repository_id).toBe('repo-d');
-        return { rowCount: 1, rows: [] };
+        expect(params[7]).toBe('repository.auto_paused');
+        const detailD = JSON.parse(String(params[9]));
+        expect(detailD.repository_id).toBe('repo-d');
+        return { rowCount: 2, rows: [] };
       },
     ]);
 


### PR DESCRIPTION
## Summary
- Add linked-account token health monitoring with provider identity probes and a persisted `repository_credential_health` table.
- Classify each probe as `healthy`, `scope_missing`, `revoked`, or `network_error`, and auto-pause repositories tied to revoked credentials with `repository.auto_paused` workflow audits.
- Extend Linked Accounts UI/data to show `Used by N repositories · last verified ... · status` and show a `Reconnect` action for non-healthy credentials.

## Test plan
- [x] `yarn build`
- [x] `yarn --cwd objectified-ui test repository-credential-health-monitor --runInBand`
- [x] `yarn --cwd objectified-ui test contract.test --runInBand`
- [ ] `yarn test` *(fails due existing unrelated failures in `tests/repositories-index.test.tsx` and `tests/llm-streaming.test.ts`)*

## Risk / Notes
- Introduces new table `odb.repository_credential_health` via migration script `20260424-210000.sql`.
- Full test suite remains red for two pre-existing failures outside this ticket's change scope.

Closes #2802

Made with [Cursor](https://cursor.com)