### PR TITLE
Fix #2930 - add version repository_source provenance support

### DIFF
--- a/docs/PLANNED_FEATURE_ROADMAP_REPOSITORY.md
+++ b/docs/PLANNED_FEATURE_ROADMAP_REPOSITORY.md
@@ -303,7 +303,7 @@ content-keyed pipeline; after Epic E it becomes user-controlled.
 | Roadmap ID | Title                                                  | Description                                                                                                  | Labels                                                                                       | MVP | Parallel | Issue |
 |------------|--------------------------------------------------------|--------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------|-----|----------|-------|
 | REPO-8.1   | `repository_file.content_checksum` column + walker hash ✅ | Add `content_checksum` (SHA-256) + `content_algo` columns; populate in tree walker; index for lookups       | `enhancement`, `mvp`, `repository`, `roadmap-repository`, `repository-provenance`, `database` | Yes | No       | Done |
-| REPO-8.2   | Version provenance tuple (`repository_source`)          | Persist `(repositoryId, branch, path, commitSha, contentChecksum, contentAlgo, importedAt)` on every version created from a repo import | `enhancement`, `mvp`, `repository`, `roadmap-repository`, `repository-provenance`, `database`, `import` | Yes | Yes      | #2930 |
+| REPO-8.2   | Version provenance tuple (`repository_source`) ✅       | Persist `(repositoryId, branch, path, commitSha, contentChecksum, contentAlgo, importedAt)` on every version created from a repo import | `enhancement`, `mvp`, `repository`, `roadmap-repository`, `repository-provenance`, `database`, `import` | Yes | Yes      | Done |
 | REPO-8.3   | Checksum-keyed idempotent re-import                     | Skip dispatch when `(project, source_path, content_checksum)` already mapped to a non-deleted version       | `enhancement`, `mvp`, `repository`, `roadmap-repository`, `repository-provenance`, `import`   | Yes | No       | #2933 |
 | REPO-8.4   | Backfill checksum + provenance for historical scans     | One-shot job to compute checksums for current `tracked` files and stamp `repository_source` on existing versions | `enhancement`, `repository`, `roadmap-repository`, `repository-provenance`, `database`        | No  | Yes      | #2947 |
 
@@ -1182,7 +1182,6 @@ blocking.
 
 | Order | ID         | Issue | Title                                               | MVP | Epic |
 |-------|------------|-------|-----------------------------------------------------|-----|------|
-| 2     | REPO-8.2   | #2930 | version provenance tuple                            | Yes | A    |
 | 3     | REPO-9.1   | #2931 | import_enabled flag                                 | Yes | B    |
 | 4     | REPO-9.2   | #2932 | auto_import_enabled flag                            | Yes | B    |
 | 5     | REPO-8.3   | #2933 | checksum-keyed idempotent re-import                 | Yes | A    |

--- a/objectified-db/scripts/20260426-220000.sql
+++ b/objectified-db/scripts/20260426-220000.sql
@@ -1,0 +1,55 @@
+-- REPO-8.2 / #2930: version provenance tuple (repository_source).
+SET search_path TO odb, public;
+
+ALTER TABLE IF EXISTS odb.versions
+  ADD COLUMN IF NOT EXISTS repository_source JSONB;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'versions_repository_source_shape_check'
+      AND conrelid = 'odb.versions'::regclass
+  ) THEN
+    ALTER TABLE odb.versions
+      ADD CONSTRAINT versions_repository_source_shape_check
+      CHECK (
+        repository_source IS NULL
+        OR (
+          jsonb_typeof(repository_source) = 'object'
+          AND repository_source ?& ARRAY[
+            'repositoryId',
+            'branch',
+            'path',
+            'commitSha',
+            'contentChecksum',
+            'contentAlgo',
+            'importedAt'
+          ]
+          AND jsonb_typeof(repository_source->'repositoryId') = 'string'
+          AND (repository_source->>'repositoryId') ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+          AND jsonb_typeof(repository_source->'branch') = 'string'
+          AND char_length(repository_source->>'branch') <= 256
+          AND jsonb_typeof(repository_source->'path') = 'string'
+          AND char_length(repository_source->>'path') <= 1024
+          AND jsonb_typeof(repository_source->'commitSha') = 'string'
+          AND (repository_source->>'commitSha') ~ '^[0-9a-f]{40,64}$'
+          AND jsonb_typeof(repository_source->'contentChecksum') = 'string'
+          AND (repository_source->>'contentChecksum') ~ '^[0-9a-f]{64}$'
+          AND jsonb_typeof(repository_source->'contentAlgo') = 'string'
+          AND (repository_source->>'contentAlgo') = 'sha256'
+          AND jsonb_typeof(repository_source->'importedAt') = 'string'
+          AND (repository_source->>'importedAt') ~ '^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(?:Z|[+-]\d{2}:\d{2})$'
+        )
+      );
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_version_repo_source_lookup
+  ON odb.versions ((repository_source->>'repositoryId'), (repository_source->>'path'))
+  WHERE repository_source IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_version_content_checksum
+  ON odb.versions ((repository_source->>'contentChecksum'))
+  WHERE repository_source IS NOT NULL;

--- a/objectified-db/scripts/20260426-220000.sql
+++ b/objectified-db/scripts/20260426-220000.sql
@@ -28,7 +28,7 @@ BEGIN
             'importedAt'
           ]
           AND jsonb_typeof(repository_source->'repositoryId') = 'string'
-          AND (repository_source->>'repositoryId') ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+          AND (repository_source->>'repositoryId') ~ '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
           AND jsonb_typeof(repository_source->'branch') = 'string'
           AND char_length(repository_source->>'branch') <= 256
           AND jsonb_typeof(repository_source->'path') = 'string'

--- a/objectified-rest/pyproject.toml
+++ b/objectified-rest/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "objectified-rest"
-version = "1.0.66"
+version = "1.0.67"
 description = "REST API for serving OpenAPI specifications from the Objectified database"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/objectified-rest/src/app/database.py
+++ b/objectified-rest/src/app/database.py
@@ -1437,6 +1437,30 @@ class Database:
         results = self.execute_query(query, (project_id, version_id_str, tenant_id))
         return results[0] if results else None
 
+    def get_latest_version_by_repository_source(
+        self,
+        tenant_id: str,
+        repository_id: str,
+        path: str,
+    ) -> Optional[Dict[str, Any]]:
+        """Get newest revision for a repository-source tuple."""
+        query = """
+            SELECT v.id
+            FROM odb.versions v
+            JOIN odb.projects p ON v.project_id = p.id
+            WHERE p.tenant_id = %s
+              AND v.deleted_at IS NULL
+              AND p.deleted_at IS NULL
+              AND (v.repository_source->>'repositoryId') = %s
+              AND (v.repository_source->>'path') = %s
+            ORDER BY v.created_at DESC
+            LIMIT 1
+        """
+        rows = self.execute_query(query, (tenant_id, repository_id, path))
+        if not rows:
+            return None
+        return self.get_version_by_id(str(rows[0]["id"]), tenant_id)
+
     def revision_has_protected_named_ref(
         self, version_row_id: str, project_id: str, tenant_id: str
     ) -> bool:

--- a/objectified-rest/src/app/repositories_routes.py
+++ b/objectified-rest/src/app/repositories_routes.py
@@ -1164,6 +1164,9 @@ def _ensure_commit_sha_version(
     repository_id: str,
     branch: str,
     path: str,
+    content_checksum: str,
+    content_algo: str,
+    imported_at: str,
 ) -> RepositoryResolvedVersionRecord:
     normalized_sha = commit_sha.strip().lower()
     tenant_versions = _REPO_VERSION_STORE.setdefault(tenant_id, {})
@@ -1173,6 +1176,9 @@ def _ensure_commit_sha_version(
         return existing
 
     now_dt = datetime.now(timezone.utc)
+    effective_checksum = content_checksum.strip().lower()
+    effective_algo = content_algo.strip().lower()
+    effective_imported_at = imported_at.strip()
     record = RepositoryResolvedVersionRecord(
         id=str(uuid4()),
         tenantId=tenant_id,
@@ -1185,6 +1191,9 @@ def _ensure_commit_sha_version(
                 "branch": branch,
                 "commitSha": commit_sha,
                 "path": path,
+                "contentChecksum": effective_checksum,
+                "contentAlgo": effective_algo,
+                "importedAt": effective_imported_at,
             }
         },
         createdAt=now_dt.isoformat(),

--- a/objectified-rest/src/app/versions_routes.py
+++ b/objectified-rest/src/app/versions_routes.py
@@ -11,6 +11,7 @@ from datetime import date as date_cls
 from datetime import datetime
 from typing import Any, Dict, List, Literal, Optional
 from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
+from uuid import UUID
 
 from fastapi import APIRouter, BackgroundTasks, Body, Depends, HTTPException, Query, Request, Response
 from fastapi.responses import JSONResponse, RedirectResponse
@@ -524,6 +525,32 @@ async def get_sunset_timeline(
         )
 
     return SunsetTimelineResponse(entries=entries)
+
+
+@router.get("/by-repo-source", response_model=VersionSchema)
+async def get_version_by_repo_source(
+    repository_id: str = Query(..., alias="repository_id"),
+    path: str = Query(..., min_length=1),
+    auth_data: Dict[str, Any] = Depends(validate_authentication),
+) -> VersionSchema:
+    """Resolve latest revision by repository source tuple (REPO-8.2)."""
+    repository_id_value = repository_id.strip()
+    path_value = path.strip()
+    if not path_value:
+        raise HTTPException(status_code=400, detail="path is required")
+    try:
+        UUID(repository_id_value)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail="repository_id must be a valid UUID") from exc
+
+    version = db.get_latest_version_by_repository_source(
+        auth_data["tenant_id"],
+        repository_id_value,
+        path_value,
+    )
+    if not version:
+        raise HTTPException(status_code=404, detail="Version not found for repository source")
+    return VersionSchema(**version)
 
 
 @router.get("/{tenant_slug}/{project_id}")

--- a/objectified-rest/src/app/versions_routes.py
+++ b/objectified-rest/src/app/versions_routes.py
@@ -527,8 +527,9 @@ async def get_sunset_timeline(
     return SunsetTimelineResponse(entries=entries)
 
 
-@router.get("/by-repo-source", response_model=VersionSchema)
+@router.get("/{tenant_slug}/by-repo-source", response_model=VersionSchema)
 async def get_version_by_repo_source(
+    tenant_slug: str,
     repository_id: str = Query(..., alias="repository_id"),
     path: str = Query(..., min_length=1),
     auth_data: Dict[str, Any] = Depends(validate_authentication),

--- a/objectified-rest/tests/repositories/test_repository_model_roundtrip.py
+++ b/objectified-rest/tests/repositories/test_repository_model_roundtrip.py
@@ -5,7 +5,7 @@ import uuid
 
 import psycopg2
 from psycopg2 import sql
-from psycopg2.extras import RealDictCursor
+from psycopg2.extras import Json, RealDictCursor
 import pytest
 
 from app.config import settings
@@ -18,6 +18,7 @@ def _migration_paths() -> list[Path]:
         scripts_dir / "20260423-230000.sql",
         scripts_dir / "20260424-120000.sql",
         scripts_dir / "20260426-210000.sql",
+        scripts_dir / "20260426-220000.sql",
     ]
 
 
@@ -413,4 +414,139 @@ def test_provider_enum_is_github_only(repository_schema):
         )
         labels = [row[0] for row in cur.fetchall()]
     assert labels == ["github"]
+
+
+def test_versions_repository_source_round_trip(repository_schema, base_refs):
+    conn, schema = repository_schema
+    version_id = "00000000-0000-0000-0000-000000000881"
+    repository_source = {
+        "repositoryId": "00000000-0000-0000-0000-000000000555",
+        "branch": "main",
+        "path": "apis/openapi.yaml",
+        "commitSha": "a" * 40,
+        "contentChecksum": "b" * 64,
+        "contentAlgo": "sha256",
+        "importedAt": "2026-04-26T21:30:00Z",
+    }
+    with conn.cursor(cursor_factory=RealDictCursor) as cur:
+        cur.execute(
+            sql.SQL(
+                """
+                INSERT INTO {} (
+                    id, project_id, creator_id, version_id, repository_source
+                )
+                VALUES (%s, %s, %s, %s, %s::jsonb)
+                RETURNING id, version_id, repository_source;
+                """
+            ).format(sql.Identifier(schema, "versions")),
+            (
+                version_id,
+                base_refs["project_id"],
+                base_refs["user_id"],
+                "1.2.3",
+                Json(repository_source),
+            ),
+        )
+        inserted = cur.fetchone()
+        cur.execute(
+            sql.SQL(
+                """
+                SELECT id, version_id, repository_source
+                FROM {}
+                WHERE id = %s;
+                """
+            ).format(sql.Identifier(schema, "versions")),
+            (version_id,),
+        )
+        selected = cur.fetchone()
+    conn.commit()
+    assert inserted == selected
+    assert selected["repository_source"]["contentAlgo"] == "sha256"
+
+
+def test_versions_repository_source_check_rejects_malformed_payload(repository_schema, base_refs):
+    conn, schema = repository_schema
+    with conn.cursor() as cur:
+        with pytest.raises(psycopg2.errors.CheckViolation):
+            cur.execute(
+                sql.SQL(
+                    """
+                    INSERT INTO {} (
+                        id, project_id, creator_id, version_id, repository_source
+                    )
+                    VALUES (%s, %s, %s, %s, %s::jsonb);
+                    """
+                ).format(sql.Identifier(schema, "versions")),
+                (
+                    "00000000-0000-0000-0000-000000000882",
+                    base_refs["project_id"],
+                    base_refs["user_id"],
+                    "1.2.4",
+                    # Missing required keys and invalid commit/content formats.
+                    '{"repositoryId":"not-a-uuid","commitSha":"abc","contentChecksum":"123"}',
+                ),
+            )
+        conn.rollback()
+
+
+def test_versions_repository_source_indexes_are_used_by_planner(repository_schema, base_refs):
+    conn, schema = repository_schema
+    with conn.cursor(cursor_factory=RealDictCursor) as cur:
+        repository_source = {
+            "repositoryId": "00000000-0000-0000-0000-000000000555",
+            "branch": "main",
+            "path": "apis/openapi.yaml",
+            "commitSha": "c" * 40,
+            "contentChecksum": "d" * 64,
+            "contentAlgo": "sha256",
+            "importedAt": "2026-04-26T21:40:00Z",
+        }
+        cur.execute(
+            sql.SQL(
+                """
+                INSERT INTO {} (
+                    id, project_id, creator_id, version_id, repository_source
+                )
+                VALUES (%s, %s, %s, %s, %s::jsonb);
+                """
+            ).format(sql.Identifier(schema, "versions")),
+            (
+                "00000000-0000-0000-0000-000000000883",
+                base_refs["project_id"],
+                base_refs["user_id"],
+                "1.2.5",
+                Json(repository_source),
+            ),
+        )
+        cur.execute(sql.SQL("SET LOCAL enable_seqscan TO off;"))
+        cur.execute(
+            sql.SQL(
+                """
+                EXPLAIN
+                SELECT id
+                FROM {}
+                WHERE (repository_source->>'repositoryId') = %s
+                  AND (repository_source->>'path') = %s;
+                """
+            ).format(sql.Identifier(schema, "versions")),
+            (repository_source["repositoryId"], repository_source["path"]),
+        )
+        lookup_plan = "\n".join(row["QUERY PLAN"] for row in cur.fetchall())
+
+        cur.execute(
+            sql.SQL(
+                """
+                EXPLAIN
+                SELECT id
+                FROM {}
+                WHERE (repository_source->>'contentChecksum') = %s;
+                """
+            ).format(sql.Identifier(schema, "versions")),
+            (repository_source["contentChecksum"],),
+        )
+        checksum_plan = "\n".join(row["QUERY PLAN"] for row in cur.fetchall())
+    conn.commit()
+
+    assert "idx_version_repo_source_lookup" in lookup_plan
+    assert "idx_version_content_checksum" in checksum_plan
 

--- a/objectified-rest/tests/test_versions_by_repo_source.py
+++ b/objectified-rest/tests/test_versions_by_repo_source.py
@@ -53,7 +53,7 @@ def _min_version() -> dict:
 
 def test_get_version_by_repo_source_requires_auth() -> None:
     response = client.get(
-        "/v1/versions/by-repo-source",
+        "/v1/versions/test-tenant/by-repo-source",
         params={
             "repository_id": "00000000-0000-0000-0000-000000000555",
             "path": "apis/openapi.yaml",
@@ -63,12 +63,12 @@ def test_get_version_by_repo_source_requires_auth() -> None:
 
 
 def test_get_version_by_repo_source_returns_latest_version() -> None:
-    app.dependency_overrides[validate_authentication] = lambda: _MOCK_AUTH
+    app.dependency_overrides[validate_authentication] = lambda tenant_slug: _MOCK_AUTH
     try:
         with patch("app.versions_routes.db") as mdb:
             mdb.get_latest_version_by_repository_source.return_value = _min_version()
             response = client.get(
-                "/v1/versions/by-repo-source",
+                "/v1/versions/test-tenant/by-repo-source",
                 params={
                     "repository_id": "00000000-0000-0000-0000-000000000555",
                     "path": "apis/openapi.yaml",
@@ -86,11 +86,11 @@ def test_get_version_by_repo_source_returns_latest_version() -> None:
 
 
 def test_get_version_by_repo_source_rejects_invalid_repository_id() -> None:
-    app.dependency_overrides[validate_authentication] = lambda: _MOCK_AUTH
+    app.dependency_overrides[validate_authentication] = lambda tenant_slug: _MOCK_AUTH
     try:
         with patch("app.versions_routes.db") as mdb:
             response = client.get(
-                "/v1/versions/by-repo-source",
+                "/v1/versions/test-tenant/by-repo-source",
                 params={"repository_id": "not-a-uuid", "path": "apis/openapi.yaml"},
             )
         assert response.status_code == 400
@@ -101,12 +101,12 @@ def test_get_version_by_repo_source_rejects_invalid_repository_id() -> None:
 
 
 def test_get_version_by_repo_source_returns_404_when_not_found() -> None:
-    app.dependency_overrides[validate_authentication] = lambda: _MOCK_AUTH
+    app.dependency_overrides[validate_authentication] = lambda tenant_slug: _MOCK_AUTH
     try:
         with patch("app.versions_routes.db") as mdb:
             mdb.get_latest_version_by_repository_source.return_value = None
             response = client.get(
-                "/v1/versions/by-repo-source",
+                "/v1/versions/test-tenant/by-repo-source",
                 params={
                     "repository_id": "00000000-0000-0000-0000-000000000555",
                     "path": "apis/openapi.yaml",

--- a/objectified-rest/tests/test_versions_by_repo_source.py
+++ b/objectified-rest/tests/test_versions_by_repo_source.py
@@ -1,0 +1,118 @@
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from app.auth import validate_authentication
+from app.main import app
+
+client = TestClient(app)
+
+_MOCK_AUTH = {
+    "tenant_id": "test-tenant-id",
+    "user_id": "test-user-id",
+    "auth_method": "jwt",
+}
+
+
+def _min_version() -> dict:
+    return {
+        "id": "rev-1",
+        "project_id": "proj-1",
+        "creator_id": "test-user-id",
+        "version_id": "1.0.0",
+        "description": "repo import",
+        "change_log": "initial",
+        "visibility": "private",
+        "published": False,
+        "published_at": None,
+        "enabled": True,
+        "parent_version_id": None,
+        "merge_parent_version_id": None,
+        "forked_from_revision_id": None,
+        "upstream_project_id": None,
+        "revision_locked": False,
+        "metadata": {
+            "repositorySource": {
+                "repositoryId": "00000000-0000-0000-0000-000000000555",
+                "branch": "main",
+                "path": "apis/openapi.yaml",
+                "commitSha": "a" * 40,
+                "contentChecksum": "b" * 64,
+                "contentAlgo": "sha256",
+                "importedAt": "2026-04-26T21:55:00Z",
+            }
+        },
+        "created_at": "2026-04-26T21:55:00Z",
+        "updated_at": "2026-04-26T21:55:00Z",
+        "creator_name": "Test User",
+        "creator_email": "test@example.com",
+        "project_name": "Project One",
+        "project_slug": "project-one",
+    }
+
+
+def test_get_version_by_repo_source_requires_auth() -> None:
+    response = client.get(
+        "/v1/versions/by-repo-source",
+        params={
+            "repository_id": "00000000-0000-0000-0000-000000000555",
+            "path": "apis/openapi.yaml",
+        },
+    )
+    assert response.status_code == 401
+
+
+def test_get_version_by_repo_source_returns_latest_version() -> None:
+    app.dependency_overrides[validate_authentication] = lambda: _MOCK_AUTH
+    try:
+        with patch("app.versions_routes.db") as mdb:
+            mdb.get_latest_version_by_repository_source.return_value = _min_version()
+            response = client.get(
+                "/v1/versions/by-repo-source",
+                params={
+                    "repository_id": "00000000-0000-0000-0000-000000000555",
+                    "path": "apis/openapi.yaml",
+                },
+            )
+        assert response.status_code == 200
+        assert response.json()["version_id"] == "1.0.0"
+        mdb.get_latest_version_by_repository_source.assert_called_once_with(
+            "test-tenant-id",
+            "00000000-0000-0000-0000-000000000555",
+            "apis/openapi.yaml",
+        )
+    finally:
+        app.dependency_overrides.pop(validate_authentication, None)
+
+
+def test_get_version_by_repo_source_rejects_invalid_repository_id() -> None:
+    app.dependency_overrides[validate_authentication] = lambda: _MOCK_AUTH
+    try:
+        with patch("app.versions_routes.db") as mdb:
+            response = client.get(
+                "/v1/versions/by-repo-source",
+                params={"repository_id": "not-a-uuid", "path": "apis/openapi.yaml"},
+            )
+        assert response.status_code == 400
+        assert response.json()["detail"] == "repository_id must be a valid UUID"
+        mdb.get_latest_version_by_repository_source.assert_not_called()
+    finally:
+        app.dependency_overrides.pop(validate_authentication, None)
+
+
+def test_get_version_by_repo_source_returns_404_when_not_found() -> None:
+    app.dependency_overrides[validate_authentication] = lambda: _MOCK_AUTH
+    try:
+        with patch("app.versions_routes.db") as mdb:
+            mdb.get_latest_version_by_repository_source.return_value = None
+            response = client.get(
+                "/v1/versions/by-repo-source",
+                params={
+                    "repository_id": "00000000-0000-0000-0000-000000000555",
+                    "path": "apis/openapi.yaml",
+                },
+            )
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Version not found for repository source"
+    finally:
+        app.dependency_overrides.pop(validate_authentication, None)

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -5,6 +5,7 @@ We continue to improve the platform based on your feedback with improvements and
 ---
 
 ## Repositories
+- Added REPO-8.2 version provenance tuple support by adding validated/indexed `versions.repository_source` storage, surfacing `GET /v1/versions/by-repo-source?repository_id&path` for fast lookup, and expanding repository model coverage to assert constraint and planner-index behavior.
 - Added REPO-8.1 provider-agnostic repository file checksums with `content_checksum`/`content_algo` persistence, streaming SHA-256 walker hashing utilities with memory-budget coverage, and per-file `repository.scan.hashed` scan audit entries while reusing checksums for unchanged blob SHAs.
 - Added REPO-7.4 token health monitoring so linked-account credentials are probed and classified (`healthy` / `scope_missing` / `revoked` / `network_error`), revoked credentials auto-pause connected repositories, and the Linked Accounts view now shows usage count, last verification age, health state, plus a reconnect action for non-healthy accounts.
 - Added REPO-7.1 workflow-audit repository events in the shared ledger so repository register/scan/sync/pause/poll/token/archive/remove actions now emit filterable `workflow_audit` rows with actor identity and structured detail payloads.

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -5,7 +5,7 @@ We continue to improve the platform based on your feedback with improvements and
 ---
 
 ## Repositories
-- Added REPO-8.2 version provenance tuple support by adding validated/indexed `versions.repository_source` storage, surfacing `GET /v1/versions/by-repo-source?repository_id&path` for fast lookup, and expanding repository model coverage to assert constraint and planner-index behavior.
+- Added REPO-8.2 version provenance tuple support by adding validated/indexed `versions.repository_source` storage, surfacing `GET /v1/versions/{tenant_slug}/by-repo-source?repository_id&path` for fast tenant-scoped lookup, and expanding repository model coverage to assert constraint and planner-index behavior.
 - Added REPO-8.1 provider-agnostic repository file checksums with `content_checksum`/`content_algo` persistence, streaming SHA-256 walker hashing utilities with memory-budget coverage, and per-file `repository.scan.hashed` scan audit entries while reusing checksums for unchanged blob SHAs.
 - Added REPO-7.4 token health monitoring so linked-account credentials are probed and classified (`healthy` / `scope_missing` / `revoked` / `network_error`), revoked credentials auto-pause connected repositories, and the Linked Accounts view now shows usage count, last verification age, health state, plus a reconnect action for non-healthy accounts.
 - Added REPO-7.1 workflow-audit repository events in the shared ledger so repository register/scan/sync/pause/poll/token/archive/remove actions now emit filterable `workflow_audit` rows with actor identity and structured detail payloads.


### PR DESCRIPTION
## Summary
- Add `versions.repository_source` via migration with JSON-shape validation and expression indexes for `(repositoryId, path)` and `contentChecksum` lookups.
- Add REST helper `GET /v1/versions/by-repo-source?repository_id&path` backed by a tenant-scoped DB lookup on the new provenance tuple.
- Add repository-model roundtrip coverage for valid/invalid `repository_source` payloads plus planner-index checks, and route tests for by-repo-source behavior.

## Test plan
- [x] `yarn build` (repo root)
- [x] `yarn test` (repo root; one pre-existing unrelated failure in `tests/llm-streaming.test.ts`)
- [x] `python3 -m compileall objectified-rest/src/app/database.py objectified-rest/src/app/versions_routes.py objectified-rest/src/app/repositories_routes.py objectified-rest/tests/repositories/test_repository_model_roundtrip.py objectified-rest/tests/test_versions_by_repo_source.py`
- [ ] `pytest` in `objectified-rest` (environment missing `pytest` executable/module)

## Risk / notes
- `repository_source` remains nullable for backward compatibility; malformed non-null payloads are rejected by DB CHECK.
- Existing local change `objectified-rest/uv.lock` was intentionally left untouched.

Fixes #2930

Made with [Cursor](https://cursor.com)