### PR TITLE
Fix #2933 - checksum-keyed idempotent re-import gating

### DIFF
--- a/docs/PLANNED_FEATURE_ROADMAP_REPOSITORY.md
+++ b/docs/PLANNED_FEATURE_ROADMAP_REPOSITORY.md
@@ -304,7 +304,7 @@ content-keyed pipeline; after Epic E it becomes user-controlled.
 |------------|--------------------------------------------------------|--------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------|-----|----------|-------|
 | REPO-8.1   | `repository_file.content_checksum` column + walker hash ✅ | Add `content_checksum` (SHA-256) + `content_algo` columns; populate in tree walker; index for lookups       | `enhancement`, `mvp`, `repository`, `roadmap-repository`, `repository-provenance`, `database` | Yes | No       | Done |
 | REPO-8.2   | Version provenance tuple (`repository_source`) ✅       | Persist `(repositoryId, branch, path, commitSha, contentChecksum, contentAlgo, importedAt)` on every version created from a repo import | `enhancement`, `mvp`, `repository`, `roadmap-repository`, `repository-provenance`, `database`, `import` | Yes | Yes      | Done |
-| REPO-8.3   | Checksum-keyed idempotent re-import                     | Skip dispatch when `(project, source_path, content_checksum)` already mapped to a non-deleted version       | `enhancement`, `mvp`, `repository`, `roadmap-repository`, `repository-provenance`, `import`   | Yes | No       | #2933 |
+| REPO-8.3   | Checksum-keyed idempotent re-import ✅                  | Skip dispatch when `(project, source_path, content_checksum)` already mapped to a non-deleted version       | `enhancement`, `mvp`, `repository`, `roadmap-repository`, `repository-provenance`, `import`   | Yes | No       | Done |
 | REPO-8.4   | Backfill checksum + provenance for historical scans     | One-shot job to compute checksums for current `tracked` files and stamp `repository_source` on existing versions | `enhancement`, `repository`, `roadmap-repository`, `repository-provenance`, `database`        | No  | Yes      | #2947 |
 
 ### Detailed issues
@@ -1184,7 +1184,6 @@ blocking.
 |-------|------------|-------|-----------------------------------------------------|-----|------|
 | 3     | REPO-9.1   | #2931 | import_enabled flag                                 | Yes | B    |
 | 4     | REPO-9.2   | #2932 | auto_import_enabled flag                            | Yes | B    |
-| 5     | REPO-8.3   | #2933 | checksum-keyed idempotent re-import                 | Yes | A    |
 | 6     | REPO-9.3   | #2934 | REST: list/toggle/bulk spec selection               | Yes | B    |
 | 7     | REPO-12.1  | #2935 | auto-import worker + dispatch                       | Yes | E    |
 | 8     | REPO-12.3  | #2936 | version creation with provenance                    | Yes | E    |

--- a/objectified-rest/pyproject.toml
+++ b/objectified-rest/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "objectified-rest"
-version = "1.0.67"
+version = "1.0.68"
 description = "REST API for serving OpenAPI specifications from the Objectified database"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/objectified-rest/src/app/database.py
+++ b/objectified-rest/src/app/database.py
@@ -1468,7 +1468,7 @@ class Database:
         path: str,
         project_id: str,
     ) -> Optional[str]:
-        """Get latest repository_source.contentChecksum for a specific project/path tuple."""
+        """Get latest repository_source.contentChecksum for a specific (tenant_id, project_id, repository_id, path) tuple."""
         query = """
             SELECT v.repository_source->>'contentChecksum' AS content_checksum
             FROM odb.versions v

--- a/objectified-rest/src/app/database.py
+++ b/objectified-rest/src/app/database.py
@@ -1461,6 +1461,36 @@ class Database:
             return None
         return self.get_version_by_id(str(rows[0]["id"]), tenant_id)
 
+    def get_latest_repository_source_checksum_for_project(
+        self,
+        tenant_id: str,
+        repository_id: str,
+        path: str,
+        project_id: str,
+    ) -> Optional[str]:
+        """Get latest repository_source.contentChecksum for a specific project/path tuple."""
+        query = """
+            SELECT v.repository_source->>'contentChecksum' AS content_checksum
+            FROM odb.versions v
+            JOIN odb.projects p ON v.project_id = p.id
+            WHERE p.tenant_id = %s
+              AND p.deleted_at IS NULL
+              AND v.deleted_at IS NULL
+              AND v.project_id = %s
+              AND (v.repository_source->>'repositoryId') = %s
+              AND (v.repository_source->>'path') = %s
+            ORDER BY v.created_at DESC
+            LIMIT 1
+        """
+        rows = self.execute_query(query, (tenant_id, project_id, repository_id, path))
+        if not rows:
+            return None
+        raw_checksum = rows[0].get("content_checksum")
+        if not isinstance(raw_checksum, str):
+            return None
+        normalized = raw_checksum.strip().lower()
+        return normalized or None
+
     def revision_has_protected_named_ref(
         self, version_row_id: str, project_id: str, tenant_id: str
     ) -> bool:

--- a/objectified-rest/src/app/repositories_routes.py
+++ b/objectified-rest/src/app/repositories_routes.py
@@ -71,6 +71,7 @@ RepositoryScanStatus = Literal[
 RepositoryFileStatus = Literal[
     "new",
     "unchanged",
+    "unchanged_checksum",
     "modified",
     "removed",
     "parse_error",
@@ -369,7 +370,16 @@ def _to_sort_key(created_at: str, row_id: str) -> Tuple[datetime, str]:
 
 
 def _empty_scan_diff_summary() -> Dict[str, int]:
-    return {"added": 0, "modified": 0, "removed": 0, "unchanged": 0}
+    return {"added": 0, "modified": 0, "removed": 0, "unchanged": 0, "skipped_unchanged_by_checksum": 0}
+
+
+def _scan_force_enabled(scan: RepositoryScanRecord) -> bool:
+    for event in scan.eventLog:
+        if not isinstance(event, dict):
+            continue
+        if event.get("force") is True:
+            return True
+    return False
 
 
 def _normalize_content_checksum(raw: Any) -> str | None:
@@ -801,6 +811,8 @@ def _process_single_pending_repository_scan(
             commit_sha=commit_sha,
             scan_files=classified_files,
             actor_id=_SYSTEM_ACTOR_ID,
+            force=_scan_force_enabled(history[scan_index]),
+            diff_summary=diff_summary,
         )
 
         completed_scan = history[scan_index].model_copy(
@@ -1377,6 +1389,33 @@ def _resolve_target_project_slug_for_dry_run(
     return None
 
 
+def _latest_repository_source_checksum_for_file(
+    *,
+    tenant_id: str,
+    repository_id: str,
+    file_row: RepositoryFileRecord,
+) -> str | None:
+    project_slug = _normalize_slug(file_row.projectSlug)
+    if project_slug is None:
+        return None
+    try:
+        project = db.get_project_by_slug(project_slug, tenant_id)
+        if not project:
+            return None
+        project_id = project.get("id")
+        if not isinstance(project_id, str) or not project_id.strip():
+            return None
+        return db.get_latest_repository_source_checksum_for_project(
+            tenant_id,
+            repository_id,
+            file_row.path,
+            project_id,
+        )
+    except Exception:
+        # Best-effort optimization; scan completion should not fail on lookup issues.
+        return None
+
+
 def _dispatch_import_jobs_for_scan(
     *,
     tenant_id: str,
@@ -1386,6 +1425,8 @@ def _dispatch_import_jobs_for_scan(
     commit_sha: str,
     scan_files: List[RepositoryFileRecord],
     actor_id: str,
+    force: bool,
+    diff_summary: Dict[str, int],
 ) -> List[Dict[str, Any]]:
     repository_jobs = _REPO_IMPORT_JOB_STORE.setdefault(repository_id, [])
     manifest_project_slug_by_path = _manifest_project_slug_by_path(repository_id)
@@ -1395,6 +1436,34 @@ def _dispatch_import_jobs_for_scan(
             continue
         if not file_row.tracked:
             continue
+        if file_row.status == "modified" and not force:
+            current_checksum = _normalize_content_checksum(file_row.contentChecksum)
+            if current_checksum is not None:
+                latest_checksum = _latest_repository_source_checksum_for_file(
+                    tenant_id=tenant_id,
+                    repository_id=repository_id,
+                    file_row=file_row,
+                )
+                if latest_checksum == current_checksum:
+                    file_row.status = "unchanged_checksum"
+                    diff_summary["modified"] = max(0, int(diff_summary.get("modified", 0)) - 1)
+                    diff_summary["skipped_unchanged_by_checksum"] = int(
+                        diff_summary.get("skipped_unchanged_by_checksum", 0)
+                    ) + 1
+                    pending_audit_rows.append(
+                        _append_audit_row(
+                            tenant_id,
+                            repository_id,
+                            "repository.scan.skipped_checksum",
+                            actor_id=actor_id,
+                            detail={
+                                "scanId": scan_id,
+                                "path": file_row.path,
+                                "contentChecksumShort": _short_checksum(current_checksum),
+                            },
+                        )
+                    )
+                    continue
 
         operation: ImportJobOperation = "import"
         promote: ImportJobPromotion = file_row.promote if file_row.promote in {"auto", "manual"} else "manual"
@@ -2356,6 +2425,8 @@ def _complete_repository_scan_for_tests(
             commit_sha=commit_sha,
             scan_files=classified_files,
             actor_id=_SYSTEM_ACTOR_ID,
+            force=_scan_force_enabled(target_scan),
+            diff_summary=diff_summary,
         )
         _REPO_SCAN_FILE_HISTORY_STORE[scan_id] = classified_files
 

--- a/objectified-rest/src/app/repositories_routes.py
+++ b/objectified-rest/src/app/repositories_routes.py
@@ -270,6 +270,7 @@ _SYSTEM_ACTOR_ID = "00000000-0000-0000-0000-000000000000"
 RepositoryAuditEvent = Literal[
     "repository.registered",
     "repository.scanned",
+    "repository.scan.skipped_checksum",
     "repository.sync_committed",
     "repository.sync_pending_review",
     "repository.sync_failed",
@@ -767,6 +768,7 @@ def _process_single_pending_repository_scan(
         return True, [audit]
 
     now = _utc_now_iso()
+    # Phase 3a: classify files under lock (read-heavy, no DB calls).
     with _STORE_LOCK:
         repository = _REPO_STORE.get(tenant_id, {}).get(repository_id)
         history = _REPO_SCAN_HISTORY_STORE.get(repository_id, [])
@@ -801,6 +803,26 @@ def _process_single_pending_repository_scan(
             current_files=current_files,
             previous_files=previous_files,
         )
+        force = _scan_force_enabled(history[scan_index])
+
+    # Phase 3b: precompute checksums outside lock (blocking DB lookups).
+    precomputed_checksums = _precompute_latest_checksums(
+        tenant_id=tenant_id,
+        repository_id=repository_id,
+        scan_files=classified_files,
+        force=force,
+    )
+
+    # Phase 4: dispatch import jobs and commit scan state under lock.
+    with _STORE_LOCK:
+        repository = _REPO_STORE.get(tenant_id, {}).get(repository_id)
+        history = _REPO_SCAN_HISTORY_STORE.get(repository_id, [])
+        if repository is None or not history:
+            return False, []
+        scan_index = next((idx for idx, row in enumerate(history) if row.id == scan_id and row.status == "pending"), None)
+        if scan_index is None:
+            return False, []
+
         _REPO_SCAN_FILE_HISTORY_STORE[scan_id] = classified_files
 
         pending_audit_rows = _dispatch_import_jobs_for_scan(
@@ -811,8 +833,9 @@ def _process_single_pending_repository_scan(
             commit_sha=commit_sha,
             scan_files=classified_files,
             actor_id=_SYSTEM_ACTOR_ID,
-            force=_scan_force_enabled(history[scan_index]),
+            force=force,
             diff_summary=diff_summary,
+            precomputed_checksums=precomputed_checksums,
         )
 
         completed_scan = history[scan_index].model_copy(
@@ -1416,6 +1439,55 @@ def _latest_repository_source_checksum_for_file(
         return None
 
 
+def _precompute_latest_checksums(
+    *,
+    tenant_id: str,
+    repository_id: str,
+    scan_files: List[RepositoryFileRecord],
+    force: bool,
+) -> Dict[str, str | None]:
+    """Pre-fetch the latest stored contentChecksum for each modified tracked file.
+
+    Must be called **outside** ``_STORE_LOCK`` as it performs blocking DB lookups.
+    Returns a mapping of file path -> latest stored checksum (or None when unavailable).
+    Caches per-slug project_id to avoid redundant ``get_project_by_slug`` calls per scan.
+    """
+    if force:
+        return {}
+    project_id_cache: Dict[str, str | None] = {}
+    result: Dict[str, str | None] = {}
+    for file_row in scan_files:
+        if file_row.status != "modified" or not file_row.tracked:
+            continue
+        if _normalize_content_checksum(file_row.contentChecksum) is None:
+            continue
+        project_slug = _normalize_slug(file_row.projectSlug)
+        if project_slug is None:
+            result[file_row.path] = None
+            continue
+        try:
+            if project_slug not in project_id_cache:
+                project = db.get_project_by_slug(project_slug, tenant_id)
+                raw_id = project.get("id") if project else None
+                project_id_cache[project_slug] = (
+                    raw_id if isinstance(raw_id, str) and raw_id.strip() else None
+                )
+            project_id = project_id_cache[project_slug]
+            if project_id is None:
+                result[file_row.path] = None
+                continue
+            result[file_row.path] = db.get_latest_repository_source_checksum_for_project(
+                tenant_id,
+                repository_id,
+                file_row.path,
+                project_id,
+            )
+        except Exception:
+            # Best-effort optimization; scan completion should not fail on lookup issues.
+            result[file_row.path] = None
+    return result
+
+
 def _dispatch_import_jobs_for_scan(
     *,
     tenant_id: str,
@@ -1427,10 +1499,12 @@ def _dispatch_import_jobs_for_scan(
     actor_id: str,
     force: bool,
     diff_summary: Dict[str, int],
+    precomputed_checksums: Dict[str, str | None] | None = None,
 ) -> List[Dict[str, Any]]:
     repository_jobs = _REPO_IMPORT_JOB_STORE.setdefault(repository_id, [])
     manifest_project_slug_by_path = _manifest_project_slug_by_path(repository_id)
     pending_audit_rows: List[Dict[str, Any]] = []
+    checksums = precomputed_checksums or {}
     for file_row in scan_files:
         if file_row.status not in {"new", "modified", "removed"}:
             continue
@@ -1439,11 +1513,7 @@ def _dispatch_import_jobs_for_scan(
         if file_row.status == "modified" and not force:
             current_checksum = _normalize_content_checksum(file_row.contentChecksum)
             if current_checksum is not None:
-                latest_checksum = _latest_repository_source_checksum_for_file(
-                    tenant_id=tenant_id,
-                    repository_id=repository_id,
-                    file_row=file_row,
-                )
+                latest_checksum = checksums.get(file_row.path)
                 if latest_checksum == current_checksum:
                     file_row.status = "unchanged_checksum"
                     diff_summary["modified"] = max(0, int(diff_summary.get("modified", 0)) - 1)

--- a/objectified-rest/tests/test_repositories_routes.py
+++ b/objectified-rest/tests/test_repositories_routes.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timezone
+from unittest.mock import patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -6,8 +7,10 @@ from fastapi.testclient import TestClient
 from app.auth import validate_authentication
 from app.main import app
 from app.repositories_routes import (
+    RepositoryFileRecord,
     _build_repository_sync_change_report_for_test_status,
     _complete_repository_scan_for_tests,
+    _dispatch_import_jobs_for_scan,
     _get_repository_audit_rows_for_tests,
     _get_repository_change_reports_for_tests,
     _get_repository_import_jobs_for_tests,
@@ -514,10 +517,22 @@ def test_complete_scan_classifies_files_and_writes_diff_summary():
     assert next_scan_response.status_code == 200
 
     assert first_completed.status == "complete"
-    assert first_completed.diffSummary == {"added": 2, "modified": 0, "removed": 0, "unchanged": 0}
+    assert first_completed.diffSummary == {
+        "added": 2,
+        "modified": 0,
+        "removed": 0,
+        "unchanged": 0,
+        "skipped_unchanged_by_checksum": 0,
+    }
 
     assert second_completed.status == "complete"
-    assert second_completed.diffSummary == {"added": 1, "modified": 1, "removed": 1, "unchanged": 0}
+    assert second_completed.diffSummary == {
+        "added": 1,
+        "modified": 1,
+        "removed": 1,
+        "unchanged": 0,
+        "skipped_unchanged_by_checksum": 0,
+    }
 
     assert files_response.status_code == 200
     by_path = {row["path"]: row for row in files_response.json()["items"]}
@@ -714,6 +729,133 @@ def test_complete_scan_dispatches_import_jobs_and_records_parse_errors():
         "repository.sync_failed",
         "repository.scanned",
     ]
+
+
+def test_checksum_matched_modified_file_skips_dispatch_and_updates_diff_summary() -> None:
+    file_row = RepositoryFileRecord(
+        id="11111111-1111-1111-1111-111111111111",
+        repositoryId="22222222-2222-2222-2222-222222222222",
+        scanId="33333333-3333-3333-3333-333333333333",
+        path="apis/orders.yaml",
+        blobSha="new-blob-sha",
+        contentAlgo="sha256",
+        contentChecksum="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        tracked=True,
+        projectSlug="payments",
+        versionStrategy="commit-sha",
+        status="modified",
+        createdAt="2026-04-26T00:00:00Z",
+    )
+    diff_summary = {
+        "added": 0,
+        "modified": 1,
+        "removed": 0,
+        "unchanged": 0,
+        "skipped_unchanged_by_checksum": 0,
+    }
+
+    with patch("app.repositories_routes.db") as mdb:
+        mdb.get_project_by_slug.return_value = {"id": "44444444-4444-4444-4444-444444444444"}
+        mdb.get_latest_repository_source_checksum_for_project.return_value = (
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        )
+        audit_rows = _dispatch_import_jobs_for_scan(
+            tenant_id=_MOCK_AUTH["tenant_id"],
+            repository_id=file_row.repositoryId,
+            scan_id=file_row.scanId,
+            branch="main",
+            commit_sha="commit-second",
+            scan_files=[file_row],
+            actor_id=_MOCK_AUTH["user_id"],
+            force=False,
+            diff_summary=diff_summary,
+        )
+
+    assert _get_repository_import_jobs_for_tests(file_row.repositoryId) == []
+    assert file_row.status == "unchanged_checksum"
+    assert file_row.lastImportJobId is None
+    assert diff_summary["modified"] == 0
+    assert diff_summary["skipped_unchanged_by_checksum"] == 1
+    assert len(audit_rows) == 1
+    assert audit_rows[0]["eventType"] == "repository.scan.skipped_checksum"
+    assert audit_rows[0]["detail"]["path"] == "apis/orders.yaml"
+    assert audit_rows[0]["detail"]["contentChecksumShort"] == "aaaaaaaaaaaa"
+
+
+def test_force_scan_ignores_checksum_skip_and_dispatches_modified_file() -> None:
+    app.dependency_overrides[validate_authentication] = _override_auth
+    try:
+        create_response = client.post(
+            f"/v1/repositories/{_TENANT_SLUG}",
+            json={
+                "linkedAccountId": "aaaaaaaa-bbbb-cccc-dddd-000000000044",
+                "provider": "github",
+                "owner": "acme",
+                "name": "checksum-force-override",
+                "branches": [{"branch": "main"}],
+            },
+        )
+        repository_id = create_response.json()["repository"]["id"]
+        first_scan_id = create_response.json()["initialScanJobId"]
+        _complete_repository_scan_for_tests(
+            repository_id,
+            first_scan_id,
+            commit_sha="commit-first",
+            files=[
+                {
+                    "path": "apis/orders.yaml",
+                    "blobSha": "111",
+                    "contentAlgo": "sha256",
+                    "contentChecksum": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                    "tracked": True,
+                    "projectSlug": "payments",
+                }
+            ],
+        )
+
+        next_scan_response = client.post(
+            f"/v1/repositories/{_TENANT_SLUG}/{repository_id}/scans",
+            json={"branch": "main", "force": True},
+        )
+        second_scan_id = next_scan_response.json()["id"]
+        with patch("app.repositories_routes.db") as mdb:
+            mdb.get_project_by_slug.return_value = {"id": "55555555-5555-5555-5555-555555555555"}
+            mdb.get_latest_repository_source_checksum_for_project.return_value = (
+                "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+            )
+            second_completed = _complete_repository_scan_for_tests(
+                repository_id,
+                second_scan_id,
+                commit_sha="commit-second",
+                files=[
+                    {
+                        "path": "apis/orders.yaml",
+                        "blobSha": "999",
+                        "contentAlgo": "sha256",
+                        "contentChecksum": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                        "tracked": True,
+                        "projectSlug": "payments",
+                    }
+                ],
+            )
+        second_scan_files = client.get(
+            f"/v1/repositories/{_TENANT_SLUG}/{repository_id}/scans/{second_scan_id}/files",
+        )
+    finally:
+        app.dependency_overrides.pop(validate_authentication, None)
+
+    assert create_response.status_code == 201
+    assert next_scan_response.status_code == 200
+    assert second_scan_files.status_code == 200
+
+    second_scan_jobs = [job for job in _get_repository_import_jobs_for_tests(repository_id) if job.scanId == second_scan_id]
+    assert len(second_scan_jobs) == 1
+    assert second_scan_jobs[0].diffSnapshot["path"] == "apis/orders.yaml"
+
+    only_file = second_scan_files.json()["items"][0]
+    assert only_file["status"] == "modified"
+    assert second_completed.diffSummary["modified"] == 1
+    assert second_completed.diffSummary["skipped_unchanged_by_checksum"] == 0
 
 
 def test_sync_history_routes_persist_conflict_resolution_on_import_job_event_log() -> None:

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -5,6 +5,7 @@ We continue to improve the platform based on your feedback with improvements and
 ---
 
 ## Repositories
+- Added REPO-8.3 checksum-keyed idempotent re-import dispatch gating so modified tracked files with unchanged repository-source checksums are marked `unchanged_checksum`, emit `repository.scan.skipped_checksum` audit rows, and increment `diffSummary.skipped_unchanged_by_checksum` unless scans run with `force=true`.
 - Added REPO-8.2 version provenance tuple support by adding validated/indexed `versions.repository_source` storage, surfacing `GET /v1/versions/{tenant_slug}/by-repo-source?repository_id&path` for fast tenant-scoped lookup, and expanding repository model coverage to assert constraint and planner-index behavior.
 - Added REPO-8.1 provider-agnostic repository file checksums with `content_checksum`/`content_algo` persistence, streaming SHA-256 walker hashing utilities with memory-budget coverage, and per-file `repository.scan.hashed` scan audit entries while reusing checksums for unchanged blob SHAs.
 - Added REPO-7.4 token health monitoring so linked-account credentials are probed and classified (`healthy` / `scope_missing` / `revoked` / `network_error`), revoked credentials auto-pause connected repositories, and the Linked Accounts view now shows usage count, last verification age, health state, plus a reconnect action for non-healthy accounts.


### PR DESCRIPTION
## Summary
- add project-scoped checksum lookup plumbing in `objectified-rest` and gate modified-file dispatch in the REPO-5.1 scan completion dispatcher when checksum matches the latest non-deleted repository source revision
- mark gated files as `unchanged_checksum`, emit `repository.scan.skipped_checksum` workflow-audit rows, and surface `diffSummary.skipped_unchanged_by_checksum`
- keep `force=true` scans dispatching regardless, add focused repository-route tests for both skip and force override paths, and update roadmap/what's-new/version notes

## Test plan
- [x] `yarn build`
- [x] `yarn test` *(fails in unrelated existing suite: `tests/llm-streaming.test.ts` with `TypeError: (0 , _prettyFormat.format) is not a function`)*
- [ ] `pytest objectified-rest/tests/test_repositories_routes.py -q` *(blocked in this environment: `pytest` is not installed and `python3 -m pytest` reports missing module)*

## Risk / Notes
- checksum skip behavior is best-effort: checksum lookup errors are intentionally non-fatal so scan completion still succeeds
- diff summary now includes `skipped_unchanged_by_checksum` for all scans

Closes #2933

Made with [Cursor](https://cursor.com)