### PR TITLE
Fix #2947 - backfill checksum and provenance for historical scans

### DIFF
--- a/docs/PLANNED_FEATURE_ROADMAP_REPOSITORY.md
+++ b/docs/PLANNED_FEATURE_ROADMAP_REPOSITORY.md
@@ -305,7 +305,7 @@ content-keyed pipeline; after Epic E it becomes user-controlled.
 | REPO-8.1   | `repository_file.content_checksum` column + walker hash ✅ | Add `content_checksum` (SHA-256) + `content_algo` columns; populate in tree walker; index for lookups       | `enhancement`, `mvp`, `repository`, `roadmap-repository`, `repository-provenance`, `database` | Yes | No       | Done |
 | REPO-8.2   | Version provenance tuple (`repository_source`) ✅       | Persist `(repositoryId, branch, path, commitSha, contentChecksum, contentAlgo, importedAt)` on every version created from a repo import | `enhancement`, `mvp`, `repository`, `roadmap-repository`, `repository-provenance`, `database`, `import` | Yes | Yes      | Done |
 | REPO-8.3   | Checksum-keyed idempotent re-import ✅                  | Skip dispatch when `(project, source_path, content_checksum)` already mapped to a non-deleted version       | `enhancement`, `mvp`, `repository`, `roadmap-repository`, `repository-provenance`, `import`   | Yes | No       | Done |
-| REPO-8.4   | Backfill checksum + provenance for historical scans     | One-shot job to compute checksums for current `tracked` files and stamp `repository_source` on existing versions | `enhancement`, `repository`, `roadmap-repository`, `repository-provenance`, `database`        | No  | Yes      | #2947 |
+| REPO-8.4   | Backfill checksum + provenance for historical scans ✅   | One-shot job to compute checksums for current `tracked` files and stamp `repository_source` on existing versions | `enhancement`, `repository`, `roadmap-repository`, `repository-provenance`, `database`        | No  | Yes      | Done |
 
 ### Detailed issues
 
@@ -1198,7 +1198,6 @@ blocking.
 | 17    | REPO-10.1  | #2945 | Scanned Repository Report page                      | Yes | C    |
 | 18    | REPO-10.2  | #2946 | per-repository report drill-in                      | Yes | C    |
 | —     | _Repo-Scan v1 ships here. Items below are post-MVP._               |     |      |
-| 19    | REPO-8.4   | #2947 | backfill checksum + provenance for historical scans | No  | A    |
 | 20    | REPO-9.7   | #2948 | bulk select + apply across discovered files        | No  | B    |
 | 21    | REPO-10.3  | #2949 | cross-repo aggregate stats card                    | No  | C    |
 | 22    | REPO-10.4  | #2950 | report export (CSV + JSON)                         | No  | C    |

--- a/objectified-rest/pyproject.toml
+++ b/objectified-rest/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "objectified-rest"
-version = "1.0.68"
+version = "1.0.69"
 description = "REST API for serving OpenAPI specifications from the Objectified database"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/objectified-rest/scripts/backfill_repository_checksums.py
+++ b/objectified-rest/scripts/backfill_repository_checksums.py
@@ -1,0 +1,556 @@
+#!/usr/bin/env python3
+"""
+REPO-8.4 / #2947.
+
+Backfill script for historical repository scan data:
+- Hash tracked repository files missing content checksums.
+- Migrate legacy versions.metadata.repositorySource into versions.repository_source.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable
+from uuid import UUID
+
+import httpx
+import psycopg2
+from psycopg2.extras import Json, RealDictCursor
+
+# Ensure project root is on path so app modules can be imported from scripts/
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+SRC_DIR = PROJECT_ROOT / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+from app.config import settings
+from app.repositories.tree_walker import hash_streamed_bytes
+
+_DEFAULT_BATCH_SIZE = 500
+_DEFAULT_GITHUB_REQUESTS_PER_SECOND = 2.0
+_CONTENT_CHECKSUM_SHORT_LEN = 12
+_COMMIT_SHA_RE = re.compile(r"^[0-9a-f]{40,64}$")
+_CHECKSUM_RE = re.compile(r"^[0-9a-f]{64}$")
+_ISO_8601_TS_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$")
+
+
+class BackfillError(RuntimeError):
+    """Typed script-level error for deterministic exits."""
+
+
+@dataclass(frozen=True)
+class FileChecksumCandidate:
+    file_id: str
+    tenant_id: str
+    repository_id: str
+    provider: str
+    owner: str
+    name: str
+    path: str
+    blob_sha: str
+    linked_account_id: str | None
+    access_token: str | None
+
+
+@dataclass(frozen=True)
+class VersionSourceCandidate:
+    version_id: str
+    metadata: dict[str, Any]
+
+
+@dataclass
+class BackfillReport:
+    rows_hashed: int = 0
+    rows_reused: int = 0
+    rows_failed: int = 0
+    versions_migrated: int = 0
+    versions_rejected: int = 0
+    file_failures: list[dict[str, Any]] = field(default_factory=list)
+    version_rejections: list[dict[str, Any]] = field(default_factory=list)
+
+
+class CredentialRateLimiter:
+    """Per-credential request budget gate."""
+
+    def __init__(self, requests_per_second: float) -> None:
+        if requests_per_second <= 0:
+            raise ValueError("requests_per_second must be > 0")
+        self._min_interval_sec = 1.0 / requests_per_second
+        self._next_allowed_by_key: dict[str, float] = {}
+
+    def wait(self, key: str) -> None:
+        now = time.monotonic()
+        next_allowed = self._next_allowed_by_key.get(key, now)
+        if now < next_allowed:
+            time.sleep(next_allowed - now)
+            now = time.monotonic()
+        self._next_allowed_by_key[key] = now + self._min_interval_sec
+
+
+def _short_checksum(checksum: str) -> str:
+    return checksum[:_CONTENT_CHECKSUM_SHORT_LEN]
+
+
+def _normalize_uuid(raw: Any) -> str | None:
+    if not isinstance(raw, str):
+        return None
+    candidate = raw.strip().lower()
+    if not candidate:
+        return None
+    try:
+        return str(UUID(candidate))
+    except ValueError:
+        return None
+
+
+def _normalize_non_empty_str(raw: Any, *, max_length: int, field_name: str) -> tuple[str | None, str | None]:
+    if not isinstance(raw, str):
+        return None, f"{field_name} must be a string"
+    value = raw.strip()
+    if not value:
+        return None, f"{field_name} must not be empty"
+    if len(value) > max_length:
+        return None, f"{field_name} exceeds max length {max_length}"
+    return value, None
+
+
+def validate_repository_source_payload(payload: Any) -> tuple[dict[str, str] | None, str | None]:
+    """
+    Validate legacy metadata.repositorySource payload against REPO-8.2 constraints.
+    Returns normalized payload on success.
+    """
+    if not isinstance(payload, dict):
+        return None, "repositorySource must be a JSON object"
+
+    required = {
+        "repositoryId",
+        "branch",
+        "path",
+        "commitSha",
+        "contentChecksum",
+        "contentAlgo",
+        "importedAt",
+    }
+    missing = sorted(key for key in required if key not in payload)
+    if missing:
+        return None, f"repositorySource missing required fields: {', '.join(missing)}"
+
+    repository_id = _normalize_uuid(payload.get("repositoryId"))
+    if repository_id is None:
+        return None, "repositoryId must be a valid UUID"
+
+    branch, branch_error = _normalize_non_empty_str(payload.get("branch"), max_length=256, field_name="branch")
+    if branch_error:
+        return None, branch_error
+
+    path, path_error = _normalize_non_empty_str(payload.get("path"), max_length=1024, field_name="path")
+    if path_error:
+        return None, path_error
+
+    commit_sha, commit_error = _normalize_non_empty_str(payload.get("commitSha"), max_length=64, field_name="commitSha")
+    if commit_error:
+        return None, commit_error
+    commit_sha = commit_sha.lower()
+    if not _COMMIT_SHA_RE.fullmatch(commit_sha):
+        return None, "commitSha must be a 40-64 char lowercase hex string"
+
+    checksum, checksum_error = _normalize_non_empty_str(
+        payload.get("contentChecksum"), max_length=64, field_name="contentChecksum"
+    )
+    if checksum_error:
+        return None, checksum_error
+    checksum = checksum.lower()
+    if not _CHECKSUM_RE.fullmatch(checksum):
+        return None, "contentChecksum must be a 64-char lowercase hex string"
+
+    algo, algo_error = _normalize_non_empty_str(payload.get("contentAlgo"), max_length=16, field_name="contentAlgo")
+    if algo_error:
+        return None, algo_error
+    algo = algo.lower()
+    if algo != "sha256":
+        return None, "contentAlgo must be 'sha256'"
+
+    imported_at, imported_at_error = _normalize_non_empty_str(
+        payload.get("importedAt"), max_length=64, field_name="importedAt"
+    )
+    if imported_at_error:
+        return None, imported_at_error
+    if not _ISO_8601_TS_RE.fullmatch(imported_at):
+        return None, "importedAt must be an ISO 8601 timestamp string"
+
+    normalized = {
+        "repositoryId": repository_id,
+        "branch": branch,
+        "path": path,
+        "commitSha": commit_sha,
+        "contentChecksum": checksum,
+        "contentAlgo": algo,
+        "importedAt": imported_at,
+    }
+    return normalized, None
+
+
+def _fetch_github_blob_checksum(
+    *,
+    client: httpx.Client,
+    owner: str,
+    name: str,
+    blob_sha: str,
+    access_token: str,
+) -> str:
+    url = f"https://api.github.com/repos/{owner}/{name}/git/blobs/{blob_sha}"
+    headers = {
+        "Authorization": f"Bearer {access_token}",
+        "Accept": "application/vnd.github.raw",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    with client.stream("GET", url, headers=headers, timeout=30.0) as response:
+        if response.status_code >= 400:
+            body = response.text
+            raise BackfillError(
+                f"GitHub blob fetch failed for {owner}/{name}@{blob_sha}: "
+                f"status={response.status_code} body={body[:300]}"
+            )
+        hashed = hash_streamed_bytes(response.iter_bytes(chunk_size=64 * 1024))
+    return hashed.checksum
+
+
+def _count_reused_rows(conn: psycopg2.extensions.connection) -> int:
+    with conn.cursor() as cursor:
+        cursor.execute(
+            """
+            SELECT COUNT(*)::bigint AS cnt
+            FROM odb.repository_file
+            WHERE tracked = TRUE
+              AND content_checksum IS NOT NULL
+            """
+        )
+        row = cursor.fetchone()
+    return int(row[0]) if row else 0
+
+
+def _iter_checksum_candidates(
+    conn: psycopg2.extensions.connection,
+    *,
+    batch_size: int,
+) -> Iterable[list[FileChecksumCandidate]]:
+    last_seen_id: str | None = None
+    while True:
+        with conn.cursor(cursor_factory=RealDictCursor) as cursor:
+            cursor.execute(
+                """
+                SELECT
+                    rf.id::text AS file_id,
+                    r.tenant_id::text AS tenant_id,
+                    r.id::text AS repository_id,
+                    r.provider::text AS provider,
+                    r.owner,
+                    r.name,
+                    rf.path,
+                    rf.blob_sha,
+                    cred.linked_account_id::text AS linked_account_id,
+                    cred.access_token
+                FROM odb.repository_file rf
+                JOIN odb.repository r ON r.id = rf.repository_id
+                LEFT JOIN LATERAL (
+                    SELECT eap.id AS linked_account_id, eap.access_token
+                    FROM odb.repository_credential_ref rcr
+                    JOIN odb.external_auth_providers eap ON eap.id = rcr.linked_account_id
+                    WHERE rcr.repository_id = r.id
+                    ORDER BY rcr.created_at ASC
+                    LIMIT 1
+                ) cred ON TRUE
+                WHERE rf.tracked = TRUE
+                  AND rf.content_checksum IS NULL
+                  AND rf.blob_sha IS NOT NULL
+                  AND (%s::uuid IS NULL OR rf.id > %s::uuid)
+                ORDER BY rf.id
+                LIMIT %s
+                """,
+                (last_seen_id, last_seen_id, batch_size),
+            )
+            rows = cursor.fetchall()
+
+        if not rows:
+            return
+
+        batch: list[FileChecksumCandidate] = []
+        for row in rows:
+            batch.append(
+                FileChecksumCandidate(
+                    file_id=str(row["file_id"]),
+                    tenant_id=str(row["tenant_id"]),
+                    repository_id=str(row["repository_id"]),
+                    provider=str(row["provider"]),
+                    owner=str(row["owner"]),
+                    name=str(row["name"]),
+                    path=str(row["path"]),
+                    blob_sha=str(row["blob_sha"]),
+                    linked_account_id=row.get("linked_account_id"),
+                    access_token=row.get("access_token"),
+                )
+            )
+        yield batch
+        last_seen_id = batch[-1].file_id
+
+
+def _backfill_file_checksums(
+    conn: psycopg2.extensions.connection,
+    *,
+    report: BackfillReport,
+    batch_size: int,
+    limiter: CredentialRateLimiter,
+) -> None:
+    with httpx.Client() as client:
+        for batch in _iter_checksum_candidates(conn, batch_size=batch_size):
+            for candidate in batch:
+                if candidate.provider != "github":
+                    report.rows_failed += 1
+                    report.file_failures.append(
+                        {
+                            "fileId": candidate.file_id,
+                            "repositoryId": candidate.repository_id,
+                            "path": candidate.path,
+                            "error": f"unsupported provider: {candidate.provider}",
+                        }
+                    )
+                    continue
+
+                if not candidate.access_token or not candidate.access_token.strip():
+                    report.rows_failed += 1
+                    report.file_failures.append(
+                        {
+                            "fileId": candidate.file_id,
+                            "repositoryId": candidate.repository_id,
+                            "path": candidate.path,
+                            "error": "missing linked account access token",
+                        }
+                    )
+                    continue
+
+                limiter.wait(candidate.linked_account_id or f"{candidate.repository_id}:fallback")
+                try:
+                    checksum = _fetch_github_blob_checksum(
+                        client=client,
+                        owner=candidate.owner,
+                        name=candidate.name,
+                        blob_sha=candidate.blob_sha,
+                        access_token=candidate.access_token.strip(),
+                    )
+                except Exception as exc:
+                    report.rows_failed += 1
+                    report.file_failures.append(
+                        {
+                            "fileId": candidate.file_id,
+                            "repositoryId": candidate.repository_id,
+                            "path": candidate.path,
+                            "error": str(exc),
+                        }
+                    )
+                    continue
+
+                with conn.cursor() as cursor:
+                    cursor.execute(
+                        """
+                        UPDATE odb.repository_file
+                        SET content_checksum = %s,
+                            content_algo = 'sha256'
+                        WHERE id = %s::uuid
+                          AND content_checksum IS NULL
+                        """,
+                        (checksum, candidate.file_id),
+                    )
+                    updated = cursor.rowcount
+
+                    if updated == 1:
+                        cursor.execute(
+                            """
+                            INSERT INTO odb.workflow_audit
+                              (tenant_id, project_id, version_id, action, outcome, actor_id, detail)
+                            VALUES
+                              (%s::uuid, NULL, NULL, 'repository.scan.backfilled', 'success', NULL, %s::jsonb)
+                            """,
+                            (
+                                candidate.tenant_id,
+                                json.dumps(
+                                    {
+                                        "repositoryId": candidate.repository_id,
+                                        "path": candidate.path,
+                                        "content_checksum_short": _short_checksum(checksum),
+                                    }
+                                ),
+                            ),
+                        )
+                        report.rows_hashed += 1
+                    else:
+                        # Concurrent writer or previously completed row.
+                        report.rows_reused += 1
+
+            conn.commit()
+
+
+def _iter_version_source_candidates(
+    conn: psycopg2.extensions.connection,
+    *,
+    batch_size: int,
+) -> Iterable[list[VersionSourceCandidate]]:
+    last_seen_id: str | None = None
+    while True:
+        with conn.cursor(cursor_factory=RealDictCursor) as cursor:
+            cursor.execute(
+                """
+                SELECT
+                    v.id::text AS version_id,
+                    v.metadata
+                FROM odb.versions v
+                JOIN odb.projects p ON p.id = v.project_id
+                WHERE v.deleted_at IS NULL
+                  AND p.deleted_at IS NULL
+                  AND v.repository_source IS NULL
+                  AND v.metadata IS NOT NULL
+                  AND (v.metadata ? 'repositorySource')
+                  AND (%s::uuid IS NULL OR v.id > %s::uuid)
+                ORDER BY v.id
+                LIMIT %s
+                """,
+                (last_seen_id, last_seen_id, batch_size),
+            )
+            rows = cursor.fetchall()
+
+        if not rows:
+            return
+
+        batch: list[VersionSourceCandidate] = []
+        for row in rows:
+            metadata = row.get("metadata")
+            if not isinstance(metadata, dict):
+                metadata = {}
+            batch.append(
+                VersionSourceCandidate(
+                    version_id=str(row["version_id"]),
+                    metadata=metadata,
+                )
+            )
+        yield batch
+        last_seen_id = batch[-1].version_id
+
+
+def _migrate_version_repository_source(
+    conn: psycopg2.extensions.connection,
+    *,
+    report: BackfillReport,
+    batch_size: int,
+) -> None:
+    for batch in _iter_version_source_candidates(conn, batch_size=batch_size):
+        for candidate in batch:
+            legacy_payload = candidate.metadata.get("repositorySource")
+            normalized, validation_error = validate_repository_source_payload(legacy_payload)
+            if validation_error is not None or normalized is None:
+                report.versions_rejected += 1
+                report.version_rejections.append(
+                    {
+                        "versionId": candidate.version_id,
+                        "reason": validation_error or "unknown validation error",
+                    }
+                )
+                continue
+
+            with conn.cursor() as cursor:
+                cursor.execute(
+                    """
+                    UPDATE odb.versions
+                    SET repository_source = %s::jsonb
+                    WHERE id = %s::uuid
+                      AND repository_source IS NULL
+                    """,
+                    (Json(normalized), candidate.version_id),
+                )
+                if cursor.rowcount == 1:
+                    report.versions_migrated += 1
+
+        conn.commit()
+
+
+def run_backfill(
+    *,
+    batch_size: int,
+    github_requests_per_second: float,
+    error_report_path: Path,
+) -> BackfillReport:
+    report = BackfillReport()
+    conn = psycopg2.connect(settings.effective_database_url)
+    conn.autocommit = False
+    try:
+        report.rows_reused = _count_reused_rows(conn)
+        _backfill_file_checksums(
+            conn,
+            report=report,
+            batch_size=batch_size,
+            limiter=CredentialRateLimiter(github_requests_per_second),
+        )
+        _migrate_version_repository_source(conn, report=report, batch_size=batch_size)
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+    error_report = {
+        "generatedAtEpochMs": int(time.time() * 1000),
+        "fileFailures": report.file_failures,
+        "versionRejections": report.version_rejections,
+    }
+    error_report_path.parent.mkdir(parents=True, exist_ok=True)
+    error_report_path.write_text(json.dumps(error_report, indent=2), encoding="utf-8")
+    return report
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Backfill historical repository content checksums and version repository_source tuples."
+    )
+    parser.add_argument("--batch-size", type=int, default=_DEFAULT_BATCH_SIZE)
+    parser.add_argument("--github-rps", type=float, default=_DEFAULT_GITHUB_REQUESTS_PER_SECOND)
+    parser.add_argument(
+        "--error-report-path",
+        type=Path,
+        default=Path(__file__).resolve().with_suffix(".errors.json"),
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    if args.batch_size < 1:
+        raise SystemExit("--batch-size must be >= 1")
+    if args.github_rps <= 0:
+        raise SystemExit("--github-rps must be > 0")
+
+    report = run_backfill(
+        batch_size=args.batch_size,
+        github_requests_per_second=args.github_rps,
+        error_report_path=args.error_report_path,
+    )
+    print(
+        json.dumps(
+            {
+                "rows_hashed": report.rows_hashed,
+                "rows_reused": report.rows_reused,
+                "rows_failed": report.rows_failed,
+                "versions_migrated": report.versions_migrated,
+                "versions_rejected": report.versions_rejected,
+                "error_report_path": str(args.error_report_path),
+            },
+            indent=2,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/objectified-rest/scripts/backfill_repository_checksums.py
+++ b/objectified-rest/scripts/backfill_repository_checksums.py
@@ -17,7 +17,7 @@ import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Iterable
-from uuid import UUID
+from uuid import UUID, RFC_4122
 
 import httpx
 import psycopg2
@@ -104,7 +104,12 @@ def _normalize_uuid(raw: Any) -> str | None:
     if not candidate:
         return None
     try:
-        return str(UUID(candidate))
+        parsed = UUID(candidate)
+        if parsed.variant != RFC_4122:
+            return None
+        if parsed.version not in (1, 2, 3, 4, 5):
+            return None
+        return str(parsed)
     except ValueError:
         return None
 

--- a/objectified-rest/tests/scripts/test_backfill_repository_checksums.py
+++ b/objectified-rest/tests/scripts/test_backfill_repository_checksums.py
@@ -64,7 +64,7 @@ class _FakeConnection:
 def test_validate_repository_source_payload_normalizes_expected_fields() -> None:
     mod = _load_backfill_module()
     payload = {
-        "repositoryId": "00000000-0000-0000-0000-000000000555",
+        "repositoryId": "123e4567-e89b-42d3-a456-426614174000",
         "branch": "main",
         "path": "apis/openapi.yaml",
         "commitSha": "A" * 40,
@@ -84,7 +84,7 @@ def test_validate_repository_source_payload_normalizes_expected_fields() -> None
 
 def test_validate_repository_source_payload_rejects_missing_required_fields() -> None:
     mod = _load_backfill_module()
-    normalized, error = mod.validate_repository_source_payload({"repositoryId": "00000000-0000-0000-0000-000000000555"})
+    normalized, error = mod.validate_repository_source_payload({"repositoryId": "123e4567-e89b-42d3-a456-426614174000"})
 
     assert normalized is None
     assert error is not None
@@ -194,7 +194,7 @@ def test_migrate_version_repository_source_migrates_valid_and_rejects_invalid(mo
 
     valid_metadata = {
         "repositorySource": {
-            "repositoryId": "00000000-0000-0000-0000-000000000555",
+            "repositoryId": "123e4567-e89b-42d3-a456-426614174000",
             "branch": "main",
             "path": "apis/openapi.yaml",
             "commitSha": "a" * 40,

--- a/objectified-rest/tests/scripts/test_backfill_repository_checksums.py
+++ b/objectified-rest/tests/scripts/test_backfill_repository_checksums.py
@@ -1,0 +1,218 @@
+import importlib.util
+import json
+from pathlib import Path
+from typing import Any
+
+
+def _load_backfill_module():
+    script_path = Path(__file__).resolve().parents[2] / "scripts" / "backfill_repository_checksums.py"
+    spec = importlib.util.spec_from_file_location("backfill_repository_checksums", script_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class _FakeCursor:
+    def __init__(self, connection: "_FakeConnection") -> None:
+        self.connection = connection
+        self.rowcount = 0
+
+    def __enter__(self) -> "_FakeCursor":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        return False
+
+    def execute(self, query: str, params: tuple[Any, ...] | None = None) -> None:
+        normalized = " ".join(query.split())
+        if "UPDATE odb.repository_file" in normalized:
+            file_id = str(params[1]) if params is not None else ""
+            self.rowcount = 1 if file_id in self.connection.updatable_file_ids else 0
+            self.connection.file_updates.append(file_id)
+            return
+        if "INSERT INTO odb.workflow_audit" in normalized:
+            detail_json = str(params[1]) if params is not None else "{}"
+            self.connection.audit_rows.append(json.loads(detail_json))
+            self.rowcount = 1
+            return
+        if "UPDATE odb.versions" in normalized:
+            version_id = str(params[1]) if params is not None else ""
+            self.rowcount = 1 if version_id in self.connection.updatable_version_ids else 0
+            self.connection.version_updates.append(version_id)
+            return
+        raise AssertionError(f"Unexpected SQL in fake cursor: {normalized}")
+
+
+class _FakeConnection:
+    def __init__(self) -> None:
+        self.updatable_file_ids: set[str] = set()
+        self.updatable_version_ids: set[str] = set()
+        self.file_updates: list[str] = []
+        self.version_updates: list[str] = []
+        self.audit_rows: list[dict[str, Any]] = []
+        self.commit_calls = 0
+
+    def cursor(self, cursor_factory=None):  # noqa: ARG002
+        return _FakeCursor(self)
+
+    def commit(self) -> None:
+        self.commit_calls += 1
+
+
+def test_validate_repository_source_payload_normalizes_expected_fields() -> None:
+    mod = _load_backfill_module()
+    payload = {
+        "repositoryId": "00000000-0000-0000-0000-000000000555",
+        "branch": "main",
+        "path": "apis/openapi.yaml",
+        "commitSha": "A" * 40,
+        "contentChecksum": "B" * 64,
+        "contentAlgo": "SHA256",
+        "importedAt": "2026-04-26T21:30:00Z",
+    }
+
+    normalized, error = mod.validate_repository_source_payload(payload)
+
+    assert error is None
+    assert normalized is not None
+    assert normalized["commitSha"] == "a" * 40
+    assert normalized["contentChecksum"] == "b" * 64
+    assert normalized["contentAlgo"] == "sha256"
+
+
+def test_validate_repository_source_payload_rejects_missing_required_fields() -> None:
+    mod = _load_backfill_module()
+    normalized, error = mod.validate_repository_source_payload({"repositoryId": "00000000-0000-0000-0000-000000000555"})
+
+    assert normalized is None
+    assert error is not None
+    assert "missing required fields" in error
+
+
+def test_backfill_file_checksums_updates_rows_writes_audit_and_tracks_failures(monkeypatch) -> None:
+    mod = _load_backfill_module()
+    conn = _FakeConnection()
+    conn.updatable_file_ids.add("file-1")
+    report = mod.BackfillReport()
+
+    candidates = [
+        mod.FileChecksumCandidate(
+            file_id="file-1",
+            tenant_id="00000000-0000-0000-0000-000000000111",
+            repository_id="00000000-0000-0000-0000-000000000222",
+            provider="github",
+            owner="acme",
+            name="repo",
+            path="apis/openapi.yaml",
+            blob_sha="abc123",
+            linked_account_id="00000000-0000-0000-0000-000000000333",
+            access_token="token-1",
+        ),
+        mod.FileChecksumCandidate(
+            file_id="file-2",
+            tenant_id="00000000-0000-0000-0000-000000000111",
+            repository_id="00000000-0000-0000-0000-000000000222",
+            provider="github",
+            owner="acme",
+            name="repo",
+            path="apis/other.yaml",
+            blob_sha="def456",
+            linked_account_id="00000000-0000-0000-0000-000000000333",
+            access_token=None,
+        ),
+    ]
+
+    monkeypatch.setattr(mod, "_iter_checksum_candidates", lambda _conn, batch_size: [candidates])
+    monkeypatch.setattr(mod, "_fetch_github_blob_checksum", lambda **kwargs: "c" * 64)
+
+    class _NoopClient:
+        def __enter__(self):
+            return object()
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    monkeypatch.setattr(mod.httpx, "Client", _NoopClient)
+
+    limiter = mod.CredentialRateLimiter(1000.0)
+    mod._backfill_file_checksums(conn, report=report, batch_size=100, limiter=limiter)
+
+    assert report.rows_hashed == 1
+    assert report.rows_failed == 1
+    assert conn.commit_calls == 1
+    assert len(conn.audit_rows) == 1
+    assert conn.audit_rows[0]["path"] == "apis/openapi.yaml"
+    assert conn.audit_rows[0]["content_checksum_short"] == ("c" * 12)
+
+
+def test_backfill_file_checksums_counts_reused_when_row_already_updated(monkeypatch) -> None:
+    mod = _load_backfill_module()
+    conn = _FakeConnection()
+    report = mod.BackfillReport(rows_reused=7)
+
+    candidates = [
+        mod.FileChecksumCandidate(
+            file_id="file-existing",
+            tenant_id="00000000-0000-0000-0000-000000000111",
+            repository_id="00000000-0000-0000-0000-000000000222",
+            provider="github",
+            owner="acme",
+            name="repo",
+            path="apis/openapi.yaml",
+            blob_sha="abc123",
+            linked_account_id="00000000-0000-0000-0000-000000000333",
+            access_token="token-1",
+        )
+    ]
+
+    monkeypatch.setattr(mod, "_iter_checksum_candidates", lambda _conn, batch_size: [candidates])
+    monkeypatch.setattr(mod, "_fetch_github_blob_checksum", lambda **kwargs: "d" * 64)
+
+    class _NoopClient:
+        def __enter__(self):
+            return object()
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    monkeypatch.setattr(mod.httpx, "Client", _NoopClient)
+
+    mod._backfill_file_checksums(conn, report=report, batch_size=100, limiter=mod.CredentialRateLimiter(1000.0))
+
+    assert report.rows_hashed == 0
+    assert report.rows_reused == 8
+    assert conn.audit_rows == []
+
+
+def test_migrate_version_repository_source_migrates_valid_and_rejects_invalid(monkeypatch) -> None:
+    mod = _load_backfill_module()
+    conn = _FakeConnection()
+    conn.updatable_version_ids.add("00000000-0000-0000-0000-000000000901")
+    report = mod.BackfillReport()
+
+    valid_metadata = {
+        "repositorySource": {
+            "repositoryId": "00000000-0000-0000-0000-000000000555",
+            "branch": "main",
+            "path": "apis/openapi.yaml",
+            "commitSha": "a" * 40,
+            "contentChecksum": "b" * 64,
+            "contentAlgo": "sha256",
+            "importedAt": "2026-04-26T21:30:00Z",
+        }
+    }
+    invalid_metadata = {"repositorySource": {"repositoryId": "bad-id"}}
+    candidates = [
+        mod.VersionSourceCandidate(version_id="00000000-0000-0000-0000-000000000901", metadata=valid_metadata),
+        mod.VersionSourceCandidate(version_id="00000000-0000-0000-0000-000000000902", metadata=invalid_metadata),
+    ]
+    monkeypatch.setattr(mod, "_iter_version_source_candidates", lambda _conn, batch_size: [candidates])
+
+    mod._migrate_version_repository_source(conn, report=report, batch_size=100)
+
+    assert report.versions_migrated == 1
+    assert report.versions_rejected == 1
+    assert report.version_rejections[0]["versionId"] == "00000000-0000-0000-0000-000000000902"
+    assert conn.commit_calls == 1

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.10.44",
+  "version": "0.10.45",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -5,6 +5,7 @@ We continue to improve the platform based on your feedback with improvements and
 ---
 
 ## Repositories
+- Added REPO-8.4 historical backfill tooling via `objectified-rest/scripts/backfill_repository_checksums.py` to stream-hash tracked repository files missing `content_checksum`, migrate valid legacy `metadata.repositorySource` payloads into typed `versions.repository_source`, and emit structured rejection/error reports with `repository.scan.backfilled` audit rows.
 - Added REPO-8.3 checksum-keyed idempotent re-import dispatch gating so modified tracked files with unchanged repository-source checksums are marked `unchanged_checksum`, emit `repository.scan.skipped_checksum` audit rows, and increment `diffSummary.skipped_unchanged_by_checksum` unless scans run with `force=true`.
 - Added REPO-8.2 version provenance tuple support by adding validated/indexed `versions.repository_source` storage, surfacing `GET /v1/versions/{tenant_slug}/by-repo-source?repository_id&path` for fast tenant-scoped lookup, and expanding repository model coverage to assert constraint and planner-index behavior.
 - Added REPO-8.1 provider-agnostic repository file checksums with `content_checksum`/`content_algo` persistence, streaming SHA-256 walker hashing utilities with memory-budget coverage, and per-file `repository.scan.hashed` scan audit entries while reusing checksums for unchanged blob SHAs.


### PR DESCRIPTION
## Summary
- add `objectified-rest/scripts/backfill_repository_checksums.py` one-shot backfill CLI that hashes tracked `repository_file` rows missing `content_checksum` from provider blobs, migrates legacy `metadata.repositorySource` payloads into typed `versions.repository_source`, enforces REPO-8.2 shape validation, and writes structured failure/rejection reports
- make checksum backfill idempotent via selective `WHERE content_checksum IS NULL` updates, write `repository.scan.backfilled` audit rows per successful file, and throttle GitHub calls per linked credential (`--github-rps`)
- add focused tests for payload validation plus checksum/provenance migration accounting, and update roadmap/whats-new plus patch bumps in `objectified-rest` and `objectified-ui`

## Test plan
- [x] `python3 -m py_compile scripts/backfill_repository_checksums.py tests/scripts/test_backfill_repository_checksums.py`
- [x] `yarn build`
- [ ] `yarn test` *(fails on existing unrelated test: `tests/llm-streaming.test.ts` with `TypeError: (0 , _prettyFormat.format) is not a function`)*
- [ ] `python3 -m pytest tests/scripts/test_backfill_repository_checksums.py tests/test_versions_by_repo_source.py tests/repositories/test_repository_model_roundtrip.py` *(environment missing `pytest`)*

## Risk / Notes
- backfill script expects valid GitHub linked-account tokens in `external_auth_providers.access_token`; rows missing tokens/providers are captured in the generated error report rather than aborting the full run
- version migration intentionally rejects malformed legacy payloads and records deterministic reason strings for manual cleanup/re-run

Closes #2947

Made with [Cursor](https://cursor.com)