### PR TITLE
Fix #2939 - REPO-9.5 Import Now one-shot action

### DIFF
--- a/docs/PLANNED_FEATURE_ROADMAP_REPOSITORY.md
+++ b/docs/PLANNED_FEATURE_ROADMAP_REPOSITORY.md
@@ -500,7 +500,7 @@ entries.
 | REPO-9.2   | `auto_import_enabled` flag on `repository_file` | New boolean defaulting `false`; toggling triggers REPO-12.1 worker eligibility                              | `enhancement`, `mvp`, `repository`, `roadmap-repository`, `repository-selection`, `database` | Yes | Yes | Done (#2932) |
 | REPO-9.3   | REST: list / toggle / bulk-update spec selection | `GET /v1/repositories/{id}/specs`, `PATCH /v1/repositories/{id}/specs/{file_id}`, bulk variant              | `enhancement`, `mvp`, `repository`, `roadmap-repository`, `repository-selection`, `rest` | Yes | No  | Done (#2934) |
 | REPO-9.4   | ADE Repository Detail "Specs" tab               | Replace existing Files tab spec list with switches (Import / Auto-Import) + status pill + last-imported-version link | `enhancement`, `mvp`, `repository`, `roadmap-repository`, `repository-selection`, `ui`   | Yes | Yes | Done (#2938) |
-| REPO-9.5   | "Import Now" one-shot action                    | Trigger a manual import for any discovered spec regardless of `auto_import_enabled`                         | `enhancement`, `mvp`, `repository`, `roadmap-repository`, `repository-selection`, `import`, `ui` | Yes | Yes | #2939 |
+| REPO-9.5   | "Import Now" one-shot action                    | Trigger a manual import for any discovered spec regardless of `auto_import_enabled`                         | `enhancement`, `mvp`, `repository`, `roadmap-repository`, `repository-selection`, `import`, `ui` | Yes | Yes | Done (#2939) |
 | REPO-9.6   | Spec detail drawer                              | Read-only Monaco preview, lint summary, last 5 import attempts, current selection state                     | `enhancement`, `mvp`, `repository`, `roadmap-repository`, `repository-selection`, `ui`   | Yes | Yes | #2940 |
 | REPO-9.7   | Bulk select + apply across discovered files     | Multi-select with sticky toolbar; "Enable import for selected", "Disable", "Set auto-import"                 | `enhancement`, `repository`, `roadmap-repository`, `repository-selection`, `ui`          | No  | Yes | #2948 |
 
@@ -1186,7 +1186,6 @@ blocking.
 | 7     | REPO-12.1  | #2935 | auto-import worker + dispatch                       | Yes | E    |
 | 8     | REPO-12.3  | #2936 | version creation with provenance                    | Yes | E    |
 | 9     | REPO-12.4  | #2937 | repository_scan_report artifact                     | Yes | E    |
-| 11    | REPO-9.5   | #2939 | "Import Now" one-shot action                        | Yes | B    |
 | 12    | REPO-9.6   | #2940 | spec detail drawer                                  | Yes | B    |
 | 13    | REPO-11.1  | #2941 | repository_attention rollup table + computer        | Yes | D    |
 | 14    | REPO-11.2  | #2942 | dashboard widget: Repositories Needing Attention    | Yes | D    |

--- a/objectified-rest/pyproject.toml
+++ b/objectified-rest/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "objectified-rest"
-version = "1.0.73"
+version = "1.0.74"
 description = "REST API for serving OpenAPI specifications from the Objectified database"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/objectified-rest/src/app/repositories_routes.py
+++ b/objectified-rest/src/app/repositories_routes.py
@@ -11,6 +11,7 @@ import base64
 import binascii
 import json
 import re
+import time
 from urllib import error as urllib_error
 from urllib import parse as urllib_parse
 from urllib import request as urllib_request
@@ -20,6 +21,7 @@ from typing import Any, Dict, List, Literal, Optional, Sequence, Tuple
 from uuid import UUID, uuid4
 
 from fastapi import APIRouter, Body, Depends, HTTPException, Query, Response
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 
 from .auth import validate_authentication
@@ -178,6 +180,9 @@ class RepositoryFileRecord(BaseModel):
     createdAt: str
 
 
+RepositoryImportJobSourceKind = Literal["repository_auto_import", "repository_manual_import"]
+
+
 class RepositoryImportJobRecord(BaseModel):
     id: str
     repositoryId: str
@@ -185,6 +190,7 @@ class RepositoryImportJobRecord(BaseModel):
     scanId: str
     branch: str
     sourceType: Literal["git"]
+    sourceKind: RepositoryImportJobSourceKind = "repository_auto_import"
     sourceUri: str
     operation: ImportJobOperation
     format: str | None = None
@@ -252,6 +258,7 @@ class RepositoryFileAutoImportEnabledRequest(BaseModel):
 
 
 RepositorySpecSelectionStatus = Literal[
+    "importing",
     "imported",
     "parse_error",
     "manifest_error",
@@ -299,6 +306,15 @@ class RepositorySpecBulkUpdateResponse(BaseModel):
     items: List[RepositorySpecRecord]
 
 
+class RepositorySpecImportNowRequest(BaseModel):
+    branch: str | None = None
+    force: bool = False
+
+
+class RepositorySpecImportNowResponse(BaseModel):
+    importJobId: str
+
+
 class RepositoryResolvedProjectRecord(BaseModel):
     id: str
     tenantId: str
@@ -330,6 +346,8 @@ _REPO_AUDIT_STORE: List[Dict[str, Any]] = []
 _REPO_IMPORT_POLICY_STORE: Dict[str, Dict[str, bool]] = {}
 _REPO_PROJECT_STORE: Dict[str, Dict[str, RepositoryResolvedProjectRecord]] = {}
 _REPO_VERSION_STORE: Dict[str, Dict[str, Dict[str, RepositoryResolvedVersionRecord]]] = {}
+# (repository_id, file_id, branch) -> (import_job_id, monotonic_timestamp) for 30s idempotency (REPO-9.5)
+_REPO_IMPORT_NOW_IDEMPOTENCY: Dict[Tuple[str, str, str], Tuple[str, float]] = {}
 _STORE_LOCK = Lock()
 _SYSTEM_ACTOR_ID = "00000000-0000-0000-0000-000000000000"
 
@@ -348,6 +366,7 @@ RepositoryAuditEvent = Literal[
     "repository.auto_paused",
     "repository.token_resolved",
     "repository.polled",
+    "repository.spec.import_now_triggered",
 ]
 
 _DEFAULT_SCAN_PAGE_SIZE = 50
@@ -1206,6 +1225,8 @@ def _derive_repository_spec_status(
     file_row: RepositoryFileRecord,
     latest_import_job: RepositoryImportJobRecord | None,
 ) -> RepositorySpecSelectionStatus:
+    if latest_import_job is not None and latest_import_job.state == "pending_review":
+        return "importing"
     if latest_import_job is not None and latest_import_job.state == "committed":
         return "imported"
     if file_row.status == "parse_error":
@@ -1716,6 +1737,176 @@ def _precompute_latest_checksums(
     return result
 
 
+def _prune_import_now_idempotency() -> None:
+    now = time.monotonic()
+    for key, (_job_id, t0) in list(_REPO_IMPORT_NOW_IDEMPOTENCY.items()):
+        if now - t0 > 30.0:
+            _REPO_IMPORT_NOW_IDEMPOTENCY.pop(key, None)
+
+
+def _import_now_idempotency_lookup(repository_id: str, file_id: str, branch: str) -> str | None:
+    _prune_import_now_idempotency()
+    rec = _REPO_IMPORT_NOW_IDEMPOTENCY.get((repository_id, file_id, branch))
+    if rec is None:
+        return None
+    return rec[0]
+
+
+def _import_now_idempotency_store(repository_id: str, file_id: str, branch: str, import_job_id: str) -> None:
+    _prune_import_now_idempotency()
+    _REPO_IMPORT_NOW_IDEMPOTENCY[(repository_id, file_id, branch)] = (import_job_id, time.monotonic())
+
+
+def _materialize_repository_dry_run_import_job(
+    *,
+    tenant_id: str,
+    repository_id: str,
+    scan_id: str,
+    branch: str,
+    commit_sha: str,
+    file_row: RepositoryFileRecord,
+    actor_id: str,
+    source_kind: RepositoryImportJobSourceKind,
+) -> tuple[RepositoryImportJobRecord, List[Dict[str, Any]]]:
+    """Build and persist a dry-run repository import job + change report (REPO-8.3 / 9.5)."""
+    repository_jobs = _REPO_IMPORT_JOB_STORE.setdefault(repository_id, [])
+    manifest_project_slug_by_path = _manifest_project_slug_by_path(repository_id)
+    operation: ImportJobOperation = "import"
+    promote: ImportJobPromotion = file_row.promote if file_row.promote in {"auto", "manual"} else "manual"
+    settings_json: Dict[str, Any] = dict(file_row.settingsJson or {})
+    if settings_json.get("onBreakingChange") == "block":
+        promote = "manual"
+        settings_json["requiresExplicitApproval"] = True
+    if file_row.status == "removed":
+        operation = "removal"
+        promote = "manual"
+        settings_json["requiresExplicitApproval"] = True
+
+    source_uri = _build_repository_source_uri(repository_id, file_row.path, branch, commit_sha)
+    forced_failure = settings_json.get("forceImportFailure")
+    failure_message: str | None = None
+    if isinstance(forced_failure, str) and forced_failure.strip():
+        failure_message = forced_failure.strip()
+    elif forced_failure is True:
+        failure_message = "forced import failure for test coverage"
+
+    state: ImportJobStatus = "pending_review"
+    if failure_message:
+        state = "failed"
+    elif promote == "auto":
+        state = "committed"
+
+    target_project_slug: str | None = None
+    target_version_id: str | None = None
+    if file_row.versionStrategy == "commit-sha":
+        resolved_project_slug = _resolve_target_project_slug_for_dry_run(
+            tenant_id=tenant_id,
+            repository_id=repository_id,
+            file_row=file_row,
+            manifest_project_slug_by_path=manifest_project_slug_by_path,
+        )
+        if resolved_project_slug is not None:
+            target_project_slug = resolved_project_slug
+            target_version_id = _preview_target_version_id_for_dry_run(commit_sha, file_row.createdAt)
+
+    change_report = RepositorySyncChangeReportRecord(
+        id=str(uuid4()),
+        sourceKind="repository_sync",
+        repositoryId=repository_id,
+        importJobId="",
+        scanId=scan_id,
+        changeModelJson=_build_repository_sync_change_report_model(file_row),
+        createdAt=file_row.createdAt,
+    )
+    conflict_records = _derive_import_conflicts(
+        file_row=file_row,
+        operation=operation,
+        settings_json=settings_json,
+    )
+    event_log = _build_import_job_event_log(
+        file_row=file_row,
+        operation=operation,
+        state=state,
+        conflicts=conflict_records,
+    )
+
+    import_job = RepositoryImportJobRecord(
+        id=str(uuid4()),
+        repositoryId=repository_id,
+        repositoryFileId=file_row.id,
+        scanId=scan_id,
+        branch=branch,
+        sourceType="git",
+        sourceKind=source_kind,
+        sourceUri=source_uri,
+        operation=operation,
+        format=file_row.format,
+        settingsJson=settings_json,
+        dryRun=True,
+        state=state,
+        diffSnapshot=_build_diff_snapshot(file_row),
+        conflictRecords=conflict_records,
+        eventLog=event_log,
+        errorDetail=failure_message,
+        targetProjectSlug=target_project_slug,
+        targetVersionId=target_version_id,
+        changeReportId=change_report.id,
+        createdAt=file_row.createdAt,
+    )
+    change_report.importJobId = import_job.id
+    repository_jobs.insert(0, import_job)
+    _REPO_CHANGE_REPORT_STORE.setdefault(repository_id, []).insert(0, change_report)
+    file_row.lastImportJobId = import_job.id
+
+    pending_audit_rows: List[Dict[str, Any]] = []
+    if failure_message:
+        file_row.status = "parse_error"
+        file_row.discriminator = failure_message
+        pending_audit_rows.append(_append_audit_row(
+            tenant_id,
+            repository_id,
+            "repository.sync_failed",
+            actor_id=actor_id,
+            outcome="failure",
+            detail={
+                "scanId": scan_id,
+                "importJobId": import_job.id,
+                "path": file_row.path,
+                "operation": operation,
+                "error": failure_message,
+            },
+        ))
+    elif promote == "auto":
+        pending_audit_rows.append(_append_audit_row(
+            tenant_id,
+            repository_id,
+            "repository.sync_committed",
+            actor_id=actor_id,
+            detail={
+                "scanId": scan_id,
+                "importJobId": import_job.id,
+                "path": file_row.path,
+                "operation": operation,
+                "promotion": promote,
+            },
+        ))
+    else:
+        pending_audit_rows.append(_append_audit_row(
+            tenant_id,
+            repository_id,
+            "repository.sync_pending_review",
+            actor_id=actor_id,
+            detail={
+                "scanId": scan_id,
+                "importJobId": import_job.id,
+                "path": file_row.path,
+                "operation": operation,
+                "promotion": promote,
+            },
+        ))
+    return import_job, pending_audit_rows
+
+
 def _dispatch_import_jobs_for_scan(
     *,
     tenant_id: str,
@@ -1729,8 +1920,6 @@ def _dispatch_import_jobs_for_scan(
     diff_summary: Dict[str, int],
     precomputed_checksums: Dict[str, str | None] | None = None,
 ) -> List[Dict[str, Any]]:
-    repository_jobs = _REPO_IMPORT_JOB_STORE.setdefault(repository_id, [])
-    manifest_project_slug_by_path = _manifest_project_slug_by_path(repository_id)
     pending_audit_rows: List[Dict[str, Any]] = []
     checksums = precomputed_checksums or {}
     for file_row in scan_files:
@@ -1767,137 +1956,18 @@ def _dispatch_import_jobs_for_scan(
                     )
                     continue
 
-        operation: ImportJobOperation = "import"
-        promote: ImportJobPromotion = file_row.promote if file_row.promote in {"auto", "manual"} else "manual"
-        settings_json: Dict[str, Any] = dict(file_row.settingsJson or {})
-        if settings_json.get("onBreakingChange") == "block":
-            promote = "manual"
-            settings_json["requiresExplicitApproval"] = True
-        if file_row.status == "removed":
-            operation = "removal"
-            promote = "manual"
-            settings_json["requiresExplicitApproval"] = True
-
-        source_uri = _build_repository_source_uri(repository_id, file_row.path, branch, commit_sha)
-        forced_failure = settings_json.get("forceImportFailure")
-        failure_message: str | None = None
-        if isinstance(forced_failure, str) and forced_failure.strip():
-            failure_message = forced_failure.strip()
-        elif forced_failure is True:
-            failure_message = "forced import failure for test coverage"
-
-        state: ImportJobStatus = "pending_review"
-        if failure_message:
-            state = "failed"
-        elif promote == "auto":
-            state = "committed"
-
-        target_project_slug: str | None = None
-        target_version_id: str | None = None
-        if file_row.versionStrategy == "commit-sha":
-            resolved_project_slug = _resolve_target_project_slug_for_dry_run(
-                tenant_id=tenant_id,
-                repository_id=repository_id,
-                file_row=file_row,
-                manifest_project_slug_by_path=manifest_project_slug_by_path,
-            )
-            if resolved_project_slug is not None:
-                target_project_slug = resolved_project_slug
-                target_version_id = _preview_target_version_id_for_dry_run(commit_sha, file_row.createdAt)
-
-        change_report = RepositorySyncChangeReportRecord(
-            id=str(uuid4()),
-            sourceKind="repository_sync",
-            repositoryId=repository_id,
-            importJobId="",
-            scanId=scan_id,
-            changeModelJson=_build_repository_sync_change_report_model(file_row),
-            createdAt=file_row.createdAt,
-        )
-        conflict_records = _derive_import_conflicts(
-            file_row=file_row,
-            operation=operation,
-            settings_json=settings_json,
-        )
-        event_log = _build_import_job_event_log(
-            file_row=file_row,
-            operation=operation,
-            state=state,
-            conflicts=conflict_records,
-        )
-
-        import_job = RepositoryImportJobRecord(
-            id=str(uuid4()),
-            repositoryId=repository_id,
-            repositoryFileId=file_row.id,
-            scanId=scan_id,
+        _created_job, materialize_audits = _materialize_repository_dry_run_import_job(
+            tenant_id=tenant_id,
+            repository_id=repository_id,
+            scan_id=scan_id,
             branch=branch,
-            sourceType="git",
-            sourceUri=source_uri,
-            operation=operation,
-            format=file_row.format,
-            settingsJson=settings_json,
-            dryRun=True,
-            state=state,
-            diffSnapshot=_build_diff_snapshot(file_row),
-            conflictRecords=conflict_records,
-            eventLog=event_log,
-            errorDetail=failure_message,
-            targetProjectSlug=target_project_slug,
-            targetVersionId=target_version_id,
-            changeReportId=change_report.id,
-            createdAt=file_row.createdAt,
+            commit_sha=commit_sha,
+            file_row=file_row,
+            actor_id=actor_id,
+            source_kind="repository_auto_import",
         )
-        change_report.importJobId = import_job.id
-        repository_jobs.insert(0, import_job)
-        _REPO_CHANGE_REPORT_STORE.setdefault(repository_id, []).insert(0, change_report)
-        file_row.lastImportJobId = import_job.id
-
-        if failure_message:
-            file_row.status = "parse_error"
-            file_row.discriminator = failure_message
-            pending_audit_rows.append(_append_audit_row(
-                tenant_id,
-                repository_id,
-                "repository.sync_failed",
-                actor_id=actor_id,
-                outcome="failure",
-                detail={
-                    "scanId": scan_id,
-                    "importJobId": import_job.id,
-                    "path": file_row.path,
-                    "operation": operation,
-                    "error": failure_message,
-                },
-            ))
-        elif promote == "auto":
-            pending_audit_rows.append(_append_audit_row(
-                tenant_id,
-                repository_id,
-                "repository.sync_committed",
-                actor_id=actor_id,
-                detail={
-                    "scanId": scan_id,
-                    "importJobId": import_job.id,
-                    "path": file_row.path,
-                    "operation": operation,
-                    "promotion": promote,
-                },
-            ))
-        else:
-            pending_audit_rows.append(_append_audit_row(
-                tenant_id,
-                repository_id,
-                "repository.sync_pending_review",
-                actor_id=actor_id,
-                detail={
-                    "scanId": scan_id,
-                    "importJobId": import_job.id,
-                    "path": file_row.path,
-                    "operation": operation,
-                    "promotion": promote,
-                },
-            ))
+        pending_audit_rows.extend(materialize_audits)
+        _ = _created_job
     return pending_audit_rows
 
 
@@ -2554,6 +2624,195 @@ async def update_repository_spec_selection(
 
 
 @router.post(
+    "/{tenant_slug}/{repository_id}/specs/{file_id}:importNow",
+    status_code=202,
+    response_model=RepositorySpecImportNowResponse,
+    responses={202: {"model": RepositorySpecImportNowResponse}},
+)
+async def import_repository_spec_now(
+    tenant_slug: str,
+    repository_id: str,
+    file_id: str,
+    request: RepositorySpecImportNowRequest = Body(...),
+    auth_data: Dict[str, Any] = Depends(validate_authentication),
+) -> JSONResponse:
+    """Dispatch a one-shot dry-run import for the latest scan snapshot (REPO-9.5)."""
+    tenant_id = auth_data["tenant_id"]
+    actor_id = _resolve_actor_id(auth_data)
+    _require_repository_scope(auth_data, _REPOSITORY_SCOPE_WRITE)
+    _validate_uuid(file_id, "fileId")
+
+    with _STORE_LOCK:
+        repository = _find_repository_for_tenant(tenant_id, repository_id)
+        if not repository.branches:
+            raise HTTPException(status_code=400, detail="Repository has no branch configuration")
+
+        requested_branch = (request.branch or "").strip()
+        if not requested_branch:
+            effective_branch = repository.branches[0].branch
+        else:
+            if not any(branch.branch == requested_branch for branch in repository.branches):
+                raise HTTPException(
+                    status_code=404,
+                    detail=f"Branch {requested_branch!r} is not configured for this repository",
+                )
+            effective_branch = requested_branch
+
+        _TERMINAL = {"complete", "skipped_unchanged"}
+        scans = _REPO_SCAN_HISTORY_STORE.get(repository_id, [])
+        latest_scan: RepositoryScanRecord | None = next(
+            (scan for scan in scans if scan.branch == effective_branch and scan.status in _TERMINAL),
+            None,
+        )
+        if latest_scan is None:
+            raise HTTPException(
+                status_code=404,
+                detail=f"No completed scan for branch: {effective_branch}",
+            )
+        file_list = _REPO_SCAN_FILE_HISTORY_STORE.get(latest_scan.id, [])
+        file_row: RepositoryFileRecord | None = next(
+            (row for row in file_list if row.id == file_id),
+            None,
+        )
+        if file_row is None:
+            raise HTTPException(status_code=404, detail=f"Repository file not found: {file_id}")
+        if file_row.status == "removed":
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "code": "SPEC_REMOVED",
+                    "message": "This path was removed in the latest scan; re-import is not available.",
+                },
+            )
+        if not file_row.tracked:
+            raise HTTPException(
+                status_code=400,
+                detail={"code": "SPEC_NOT_TRACKED", "message": "This path is not tracked in the scan manifest."},
+            )
+        if not file_row.importEnabled:
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "code": "IMPORT_NOT_ENABLED",
+                    "message": "import_enabled is false; enable import for this spec before using Import Now.",
+                },
+            )
+
+        dup_id = _import_now_idempotency_lookup(repository_id, file_id, effective_branch)
+        if dup_id is not None:
+            return JSONResponse(
+                status_code=202,
+                content=RepositorySpecImportNowResponse(importJobId=dup_id).model_dump(),
+            )
+
+    assert file_row is not None
+    if not request.force:
+        current_checksum = _normalize_content_checksum(file_row.contentChecksum)
+        if current_checksum is not None:
+            try:
+                latest_checksum = _latest_repository_source_checksum_for_file(
+                    tenant_id=tenant_id,
+                    repository_id=repository_id,
+                    file_row=file_row,
+                )
+            except Exception:
+                latest_checksum = None
+            if latest_checksum is not None and latest_checksum == current_checksum:
+                raise HTTPException(
+                    status_code=409,
+                    detail={
+                        "code": "IMPORT_UNCHANGED_CHECKSUM",
+                        "message": "No import dispatched; file content matches the last imported snapshot (re-run with force: true to bypass).",
+                    },
+                )
+
+    with _STORE_LOCK:
+        dup_id2 = _import_now_idempotency_lookup(repository_id, file_id, effective_branch)
+        if dup_id2 is not None:
+            return JSONResponse(
+                status_code=202,
+                content=RepositorySpecImportNowResponse(importJobId=dup_id2).model_dump(),
+            )
+
+        _TERMINAL2 = {"complete", "skipped_unchanged"}
+        latest_scan2 = next(
+            (
+                scan
+                for scan in _REPO_SCAN_HISTORY_STORE.get(repository_id, [])
+                if scan.branch == effective_branch and scan.status in _TERMINAL2
+            ),
+            None,
+        )
+        if latest_scan2 is None or latest_scan2.id != latest_scan.id:
+            raise HTTPException(
+                status_code=409,
+                detail={
+                    "code": "REPOSITORY_STALE",
+                    "message": "The repository scan changed; refresh and try again.",
+                },
+            )
+        file_list2 = _REPO_SCAN_FILE_HISTORY_STORE.get(latest_scan2.id, [])
+        file_idx = next(
+            (idx for idx, row in enumerate(file_list2) if row.id == file_id),
+            None,
+        )
+        if file_idx is None:
+            raise HTTPException(status_code=404, detail=f"Repository file not found: {file_id}")
+        working_row = file_list2[file_idx]
+        if not working_row.importEnabled or not working_row.tracked or working_row.status == "removed":
+            raise HTTPException(
+                status_code=409,
+                detail={
+                    "code": "REPOSITORY_STALE",
+                    "message": "The spec state changed; refresh and try again.",
+                },
+            )
+
+        commit_sha = latest_scan2.commitSha
+        if not (isinstance(commit_sha, str) and commit_sha.strip()):
+            raise HTTPException(
+                status_code=500,
+                detail="Repository scan is missing a commit reference for import dispatch.",
+            )
+
+        new_job, job_audits = _materialize_repository_dry_run_import_job(
+            tenant_id=tenant_id,
+            repository_id=repository_id,
+            scan_id=latest_scan2.id,
+            branch=effective_branch,
+            commit_sha=commit_sha,
+            file_row=working_row,
+            actor_id=actor_id,
+            source_kind="repository_manual_import",
+        )
+        _import_now_idempotency_store(repository_id, file_id, effective_branch, new_job.id)
+
+        import_audit = _append_audit_row(
+            tenant_id,
+            repository_id,
+            "repository.spec.import_now_triggered",
+            actor_id=actor_id,
+            detail={
+                "path": working_row.path,
+                "fileId": file_id,
+                "branch": effective_branch,
+                "force": request.force,
+                "actorId": actor_id,
+                "importJobId": new_job.id,
+                "scanId": latest_scan2.id,
+            },
+        )
+        all_audits = job_audits + [import_audit]
+
+    for row in all_audits:
+        _persist_audit_row(row)
+    return JSONResponse(
+        status_code=202,
+        content=RepositorySpecImportNowResponse(importJobId=new_job.id).model_dump(),
+    )
+
+
+@router.post(
     "/{tenant_slug}/{repository_id}/specs:bulkUpdate",
     response_model=RepositorySpecBulkUpdateResponse,
 )
@@ -2930,6 +3189,7 @@ def _reset_repository_state_for_tests() -> None:
         _REPO_IMPORT_POLICY_STORE.clear()
         _REPO_PROJECT_STORE.clear()
         _REPO_VERSION_STORE.clear()
+        _REPO_IMPORT_NOW_IDEMPOTENCY.clear()
 
 
 def _complete_repository_scan_for_tests(

--- a/objectified-rest/tests/test_repositories_routes.py
+++ b/objectified-rest/tests/test_repositories_routes.py
@@ -2065,11 +2065,11 @@ def test_import_now_rejects_disabled_import_and_unchanged_checksum() -> None:
             f"/v1/repositories/{_TENANT_SLUG}/{repository_id}/specs/{file_id}:importNow",
             json={"force": False},
         )
-        patch = client.patch(
+        patch_response = client.patch(
             f"/v1/repositories/{_TENANT_SLUG}/{repository_id}/specs/{file_id}",
             json={"importEnabled": True},
         )
-        opened_id = patch.json()["fileId"]
+        opened_id = patch_response.json()["fileId"]
         with patch("app.repositories_routes.db") as mdb:
             mdb.get_project_by_slug.return_value = {"id": "88888888-8888-8888-8888-888888888888"}
             mdb.get_latest_repository_source_checksum_for_project.return_value = (
@@ -2085,6 +2085,6 @@ def test_import_now_rejects_disabled_import_and_unchanged_checksum() -> None:
     assert create_response.status_code == 201
     assert disabled.status_code == 400
     assert disabled.json()["detail"]["code"] == "IMPORT_NOT_ENABLED"
-    assert patch.status_code == 200
+    assert patch_response.status_code == 200
     assert conflict.status_code == 409
     assert conflict.json()["detail"]["code"] == "IMPORT_UNCHANGED_CHECKSUM"

--- a/objectified-rest/tests/test_repositories_routes.py
+++ b/objectified-rest/tests/test_repositories_routes.py
@@ -1946,3 +1946,145 @@ def test_list_specs_exposes_confidence_and_supports_min_confidence_filter() -> N
     assert importable_paths == ["apis/high.yaml", "apis/medium.yaml"]
 
     assert invalid_threshold.status_code == 422
+
+
+def test_import_now_dispatches_manual_job_idempotency_and_audit() -> None:
+    app.dependency_overrides[validate_authentication] = _override_auth_with_repository_scopes
+    r1 = None
+    r2 = None
+    by_path: dict = {}
+    import_audits: list = []
+    file_id = ""
+    create_response = None
+    repository_id = ""
+    try:
+        create_response = client.post(
+            f"/v1/repositories/{_TENANT_SLUG}",
+            json={
+                "linkedAccountId": "aaaaaaaa-bbbb-cccc-dddd-000000000070",
+                "provider": "github",
+                "owner": "acme",
+                "name": "import-now",
+                "branches": [{"branch": "main"}],
+            },
+        )
+        repository_id = create_response.json()["repository"]["id"]
+        scan_id = create_response.json()["initialScanJobId"]
+        _complete_repository_scan_for_tests(
+            repository_id,
+            scan_id,
+            commit_sha="import-now-seed",
+            files=[
+                {
+                    "path": "apis/manual.yaml",
+                    "blobSha": "1",
+                    "contentAlgo": "sha256",
+                    "contentChecksum": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+                    "tracked": True,
+                    "importEnabled": True,
+                    "autoImportEnabled": False,
+                    "projectSlug": "payments",
+                }
+            ],
+        )
+        file_id = client.get(
+            f"/v1/repositories/{_TENANT_SLUG}/{repository_id}/scans/{scan_id}/files",
+        ).json()["items"][0]["id"]
+        with patch("app.repositories_routes.db") as mdb:
+            mdb.get_project_by_slug.return_value = {"id": "99999999-9999-9999-9999-999999999999"}
+            mdb.get_latest_repository_source_checksum_for_project.return_value = None
+            r1 = client.post(
+                f"/v1/repositories/{_TENANT_SLUG}/{repository_id}/specs/{file_id}:importNow",
+                json={"branch": "main", "force": True},
+            )
+            r2 = client.post(
+                f"/v1/repositories/{_TENANT_SLUG}/{repository_id}/specs/{file_id}:importNow",
+                json={"branch": "main", "force": True},
+            )
+        spec_row = client.get(
+            f"/v1/repositories/{_TENANT_SLUG}/{repository_id}/specs",
+            params={"branch": "main"},
+        ).json()["items"]
+        by_path = {r["path"]: r for r in spec_row}
+        audit_rows = _get_repository_audit_rows_for_tests(repository_id)
+        import_audits = [a for a in audit_rows if a["eventType"] == "repository.spec.import_now_triggered"]
+    finally:
+        app.dependency_overrides.pop(validate_authentication, None)
+
+    assert create_response is not None and create_response.status_code == 201
+    assert r1 is not None and r1.status_code == 202
+    assert r2 is not None and r2.status_code == 202
+    job_id_1 = r1.json()["importJobId"]
+    assert r2.json()["importJobId"] == job_id_1
+    assert by_path["apis/manual.yaml"]["status"] == "importing"
+    assert len(import_audits) == 1
+    assert import_audits[0]["detail"]["fileId"] == file_id
+    assert import_audits[0]["detail"]["branch"] == "main"
+    assert import_audits[0]["detail"]["force"] is True
+    jobs = [j for j in _get_repository_import_jobs_for_tests(repository_id) if j.id == job_id_1]
+    assert len(jobs) == 1
+    assert jobs[0].sourceKind == "repository_manual_import"
+
+
+def test_import_now_rejects_disabled_import_and_unchanged_checksum() -> None:
+    app.dependency_overrides[validate_authentication] = _override_auth_with_repository_scopes
+    try:
+        create_response = client.post(
+            f"/v1/repositories/{_TENANT_SLUG}",
+            json={
+                "linkedAccountId": "aaaaaaaa-bbbb-cccc-dddd-000000000071",
+                "provider": "github",
+                "owner": "acme",
+                "name": "import-now-gate",
+                "branches": [{"branch": "main"}],
+            },
+        )
+        repository_id = create_response.json()["repository"]["id"]
+        scan_id = create_response.json()["initialScanJobId"]
+        _complete_repository_scan_for_tests(
+            repository_id,
+            scan_id,
+            commit_sha="gate-seed",
+            files=[
+                {
+                    "path": "apis/locked.yaml",
+                    "blobSha": "1",
+                    "contentAlgo": "sha256",
+                    "contentChecksum": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+                    "tracked": True,
+                    "importEnabled": False,
+                    "autoImportEnabled": False,
+                    "projectSlug": "pay",
+                },
+            ],
+        )
+        file_id = client.get(
+            f"/v1/repositories/{_TENANT_SLUG}/{repository_id}/scans/{scan_id}/files",
+        ).json()["items"][0]["id"]
+        disabled = client.post(
+            f"/v1/repositories/{_TENANT_SLUG}/{repository_id}/specs/{file_id}:importNow",
+            json={"force": False},
+        )
+        patch = client.patch(
+            f"/v1/repositories/{_TENANT_SLUG}/{repository_id}/specs/{file_id}",
+            json={"importEnabled": True},
+        )
+        opened_id = patch.json()["fileId"]
+        with patch("app.repositories_routes.db") as mdb:
+            mdb.get_project_by_slug.return_value = {"id": "88888888-8888-8888-8888-888888888888"}
+            mdb.get_latest_repository_source_checksum_for_project.return_value = (
+                "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+            )
+            conflict = client.post(
+                f"/v1/repositories/{_TENANT_SLUG}/{repository_id}/specs/{opened_id}:importNow",
+                json={"force": False},
+            )
+    finally:
+        app.dependency_overrides.pop(validate_authentication, None)
+
+    assert create_response.status_code == 201
+    assert disabled.status_code == 400
+    assert disabled.json()["detail"]["code"] == "IMPORT_NOT_ENABLED"
+    assert patch.status_code == 200
+    assert conflict.status_code == 409
+    assert conflict.json()["detail"]["code"] == "IMPORT_UNCHANGED_CHECKSUM"

--- a/objectified-ui/e2e/repositories-specs-tab.spec.ts
+++ b/objectified-ui/e2e/repositories-specs-tab.spec.ts
@@ -237,6 +237,17 @@ test.describe('REPO-9.4 — Specs tab', () => {
   });
 
   test('Import Now overflow action surfaces a success notification', async ({ page }) => {
+    const importNowFileId = seededSpecs[0].fileId;
+    await page.route(
+      `**/api/repositories/${repositoryId}/specs/${importNowFileId}/import-now`,
+      async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ success: true, importJobId: 'abcdef12-0000-0000-0000-000000000000' }),
+        });
+      },
+    );
     await login(page);
     if (page.url().includes('/login')) {
       test.skip(true);
@@ -245,7 +256,7 @@ test.describe('REPO-9.4 — Specs tab', () => {
     await page.goto(`/ade/dashboard/repositories/${repositoryId}?tab=specs`);
     await page.getByTestId('spec-overflow-openapi/orders-v3.yaml').click();
     await page.getByTestId('spec-import-now-openapi/orders-v3.yaml').click();
-    await expect(page.getByTestId('spec-success')).toContainText('Queued import');
+    await expect(page.getByTestId('spec-success')).toContainText('Import started');
   });
 
   test('filter chip changes deep-link via the status query string', async ({ page }) => {

--- a/objectified-ui/e2e/repositories-specs-tab.spec.ts
+++ b/objectified-ui/e2e/repositories-specs-tab.spec.ts
@@ -7,7 +7,7 @@ interface MockSpec {
   format: string | null;
   confidence: number | null;
   discriminator: string | null;
-  status: 'imported' | 'parse_error' | 'manifest_error' | 'not_imported' | 'unchanged_checksum';
+  status: 'importing' | 'imported' | 'parse_error' | 'manifest_error' | 'not_imported' | 'unchanged_checksum';
   importEnabled: boolean;
   autoImportEnabled: boolean;
   lastImportedVersionId: string | null;

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.10.48",
+  "version": "0.10.49",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -5,6 +5,7 @@ We continue to improve the platform based on your feedback with improvements and
 ---
 
 ## Repositories
+- Added REPO-9.5 **Import Now** (`POST .../specs/{fileId}:importNow`) to queue a manual dry-run import when `import_enabled` is on (independent of auto-import), with 30s idempotency per file/branch, `repository_manual_import` job `sourceKind`, `repository.spec.import_now_triggered` audit, and Specs tab / drawer actions that link to the Sync history tab; specs list a new `importing` status while a job is `pending_review`.
 - Added REPO-9.4 ADE Repository Detail "Specs" tab listing importable specs (confidence ≥ 50%) with format/status/last-import metadata, optimistic Import + Auto-Import toggles with REST 4xx rollback and atomic auto-import cleanup, deep-linkable filter chips (`?status=…`), bulk-edit toolbar, an Import Now overflow action, and a spec detail drawer.
 - Added REPO-9.3 repository specs REST endpoints for cursor-paginated listing (`GET /v1/repositories/{tenant_slug}/{repository_id}/specs`), single-spec selection updates, and transactional bulk selection updates with typed invariant errors and `repository.spec.selection_changed` audit rows.
 - Added REPO-9.2 per-spec `auto_import_enabled` on `repository_file` (default false), including `PATCH /v1/repositories/{tenant_slug}/{repository_id}/files/{file_id}/auto-import-enabled`, independent `repository.spec.selection_changed` audit discrimination by `field`, scan dispatch gating that requires both import and auto-import enabled, and automatic clearing of auto-import whenever import is disabled.

--- a/objectified-ui/src/app/api/repositories/[id]/specs/[fileId]/import-now/route.ts
+++ b/objectified-ui/src/app/api/repositories/[id]/specs/[fileId]/import-now/route.ts
@@ -1,0 +1,81 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/app/api/auth/[...nextauth]/route';
+import { getTenantById } from '@lib/db/helper';
+import { createRestAuthHeaders, REST_API_BASE_URL } from '@lib/rest-auth';
+
+export const dynamic = 'force-dynamic';
+
+type SessionUser = {
+  user_id?: string;
+  email?: string | null;
+  name?: string | null;
+  current_tenant_id?: string;
+};
+
+async function resolveAuthContext() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user) {
+    return { error: NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 }) };
+  }
+  const user = session.user as SessionUser;
+  if (!user.current_tenant_id) {
+    return { error: NextResponse.json({ success: false, error: 'No tenant selected' }, { status: 400 }) };
+  }
+  const tenant = await getTenantById(user.current_tenant_id);
+  if (!tenant?.slug) {
+    return { error: NextResponse.json({ success: false, error: 'Tenant slug not found' }, { status: 400 }) };
+  }
+  return { sessionUser: user, tenantSlug: tenant.slug };
+}
+
+export async function POST(
+  request: Request,
+  context: { params: Promise<{ id: string; fileId: string }> }
+) {
+  try {
+    const auth = await resolveAuthContext();
+    if ('error' in auth) return auth.error;
+
+    const params = await context.params;
+    const body = await request.json().catch(() => ({}));
+    const path = [
+      'repositories',
+      encodeURIComponent(auth.tenantSlug),
+      encodeURIComponent(params.id),
+      'specs',
+      `${encodeURIComponent(params.fileId)}:importNow`,
+    ].join('/');
+
+    const response = await fetch(`${REST_API_BASE_URL}/${path}`, {
+      method: 'POST',
+      headers: {
+        ...createRestAuthHeaders(auth.sessionUser),
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+    const data = await response.json().catch(() => ({}));
+    if (!response.ok) {
+      const detail = data.detail;
+      if (typeof detail === 'object' && detail !== null && 'message' in detail) {
+        return NextResponse.json(
+          { success: false, error: (detail as { message?: string }).message, detail },
+          { status: response.status },
+        );
+      }
+      const errText = typeof data.detail === 'string' ? data.detail : 'Import Now failed';
+      return NextResponse.json(
+        { success: false, error: errText, detail: data.detail ?? null },
+        { status: response.status },
+      );
+    }
+    return NextResponse.json(
+      { success: true, importJobId: (data as { importJobId?: string }).importJobId },
+      { status: 202 },
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Internal server error';
+    return NextResponse.json({ success: false, error: message }, { status: 500 });
+  }
+}

--- a/objectified-ui/src/app/components/ade/dashboard/RepositorySpecsTab.tsx
+++ b/objectified-ui/src/app/components/ade/dashboard/RepositorySpecsTab.tsx
@@ -19,6 +19,7 @@ import { Input } from '@/app/components/ui/Input';
 import { Switch } from '@/app/components/ui/Switch';
 
 export type RepositorySpecStatus =
+  | 'importing'
   | 'imported'
   | 'parse_error'
   | 'manifest_error'
@@ -111,6 +112,7 @@ function getFormatPillClass(format: string | null | undefined): string {
 }
 
 const statusPillClass: Record<RepositorySpecStatus, string> = {
+  importing: 'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200',
   imported: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300',
   parse_error: 'bg-rose-100 text-rose-700 dark:bg-rose-900/40 dark:text-rose-300',
   manifest_error: 'bg-rose-100 text-rose-700 dark:bg-rose-900/40 dark:text-rose-300',
@@ -119,6 +121,7 @@ const statusPillClass: Record<RepositorySpecStatus, string> = {
 };
 
 const statusLabel: Record<RepositorySpecStatus, string> = {
+  importing: 'Importing',
   imported: 'Imported',
   parse_error: 'Parse error',
   manifest_error: 'Manifest error',
@@ -129,6 +132,8 @@ const statusLabel: Record<RepositorySpecStatus, string> = {
 function StatusPill({ status }: { status: RepositorySpecStatus }) {
   const Icon = status === 'imported'
     ? CheckCircle2
+    : status === 'importing'
+      ? Loader2
     : status === 'parse_error' || status === 'manifest_error'
       ? AlertCircle
       : status === 'unchanged_checksum'
@@ -139,7 +144,7 @@ function StatusPill({ status }: { status: RepositorySpecStatus }) {
       className={`inline-flex items-center gap-1 text-[10px] font-semibold uppercase tracking-wider px-1.5 py-0.5 rounded ${statusPillClass[status]}`}
       data-testid={`spec-status-${status}`}
     >
-      <Icon className="w-3 h-3" />
+      <Icon className={status === 'importing' ? 'w-3 h-3 animate-spin' : 'w-3 h-3'} />
       {statusLabel[status]}
     </span>
   );
@@ -180,6 +185,7 @@ export function RepositorySpecsTab({
   const [isLoading, setIsLoading] = useState(false);
   const [errorMessage, setErrorMessage] = useState('');
   const [successMessage, setSuccessMessage] = useState('');
+  const [importNowJobId, setImportNowJobId] = useState<string | null>(null);
   const [openMenuFileId, setOpenMenuFileId] = useState<string | null>(null);
   const [selectedSpec, setSelectedSpec] = useState<RepositorySpecRecord | null>(null);
   const [pendingPatchIds, setPendingPatchIds] = useState<Set<string>>(new Set());
@@ -329,6 +335,7 @@ export function RepositorySpecsTab({
       setIsBulkPending(true);
       setErrorMessage('');
       setSuccessMessage('');
+      setImportNowJobId(null);
       try {
         const response = await fetch(`/api/repositories/${repositoryId}/specs/bulk-update`, {
           method: 'POST',
@@ -354,11 +361,43 @@ export function RepositorySpecsTab({
   );
 
   const handleImportNow = useCallback(
-    (spec: RepositorySpecRecord) => {
+    async (spec: RepositorySpecRecord) => {
       setOpenMenuFileId(null);
-      setSuccessMessage(`Queued import for ${spec.path}. Tracking will appear in Sync history once REPO-9.5 lands.`);
+      setErrorMessage('');
+      try {
+        const response = await fetch(
+          `/api/repositories/${repositoryId}/specs/${spec.fileId}/import-now`,
+          {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ branch: spec.branch, force: false }),
+          },
+        );
+        const data = (await response.json()) as { success?: boolean; importJobId?: string; error?: string; detail?: unknown };
+        if (!response.ok || !data.success) {
+          const d = data.detail as { message?: string } | undefined;
+          const msg = (typeof d === 'object' && d?.message) || data.error || 'Import Now failed';
+          throw new Error(msg);
+        }
+        const jobId = data.importJobId ?? '';
+        setSpecs((current) =>
+          current.map((row) => (row.fileId === spec.fileId ? { ...row, status: 'importing' } : row)),
+        );
+        setSelectedSpec((prev) =>
+          prev && prev.fileId === spec.fileId ? { ...prev, status: 'importing' } : prev,
+        );
+        setImportNowJobId(jobId);
+        setSuccessMessage(
+          `Import started (job ${jobId ? `${jobId.slice(0, 8)}…` : 'queued'}).`,
+        );
+        setTimeout(() => { void loadSpecs(); }, 1500);
+        setTimeout(() => { void loadSpecs(); }, 5000);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Import Now failed';
+        setErrorMessage(message);
+      }
     },
-    [],
+    [loadSpecs, repositoryId],
   );
 
   const filteredSpecs = useMemo(() => {
@@ -453,11 +492,24 @@ export function RepositorySpecsTab({
           className="mx-5 rounded-md border border-emerald-200 dark:border-emerald-700/40 bg-emerald-50 dark:bg-emerald-900/20 px-3 py-2 text-xs text-emerald-700 dark:text-emerald-300 flex items-center justify-between gap-3"
           data-testid="spec-success"
         >
-          <span>{successMessage}</span>
+          <span>
+            {successMessage}
+            {importNowJobId ? (
+              <a
+                className="ml-2 text-indigo-600 hover:text-indigo-700 font-medium"
+                href={`/ade/dashboard/repositories/${repositoryId}?tab=sync&importJobId=${encodeURIComponent(importNowJobId)}`}
+              >
+                View in Sync history
+              </a>
+            ) : null}
+          </span>
           <button
             type="button"
             aria-label="Dismiss success"
-            onClick={() => setSuccessMessage('')}
+            onClick={() => {
+              setSuccessMessage('');
+              setImportNowJobId(null);
+            }}
             className="text-emerald-600 hover:text-emerald-800"
           >
             <X className="w-3.5 h-3.5" />
@@ -656,7 +708,7 @@ export function RepositorySpecsTab({
                             type="button"
                             role="menuitem"
                             className="w-full px-3 py-2 hover:bg-gray-100 dark:hover:bg-gray-800 flex items-center gap-2"
-                            onClick={() => handleImportNow(spec)}
+                            onClick={() => { void handleImportNow(spec); }}
                             data-testid={`spec-import-now-${spec.path}`}
                           >
                             <Download className="w-3.5 h-3.5" />
@@ -783,6 +835,18 @@ export function RepositorySpecsTab({
                     <span className="font-mono text-gray-400">—</span>
                   )}
                 </DrawerRow>
+              </div>
+              <div className="pt-1">
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="secondary"
+                  onClick={() => { void handleImportNow(selectedSpec); }}
+                  data-testid="spec-drawer-import-now"
+                >
+                  <Download className="w-3.5 h-3.5 mr-1.5" />
+                  Import now
+                </Button>
               </div>
               <p className="text-[11px] text-gray-500">
                 Full spec detail UI ships with REPO-9.6. The drawer above shows the values

--- a/objectified-ui/src/app/components/ade/dashboard/RepositorySpecsTab.tsx
+++ b/objectified-ui/src/app/components/ade/dashboard/RepositorySpecsTab.tsx
@@ -192,6 +192,8 @@ export function RepositorySpecsTab({
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [isBulkPending, setIsBulkPending] = useState(false);
   const drawerRef = useRef<HTMLElement | null>(null);
+  const importNowEarlyRefreshTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const importNowLateRefreshTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     if (initialBranch && initialBranch !== branch) {
@@ -210,6 +212,13 @@ export function RepositorySpecsTab({
       drawerRef.current?.focus();
     }
   }, [selectedSpec]);
+
+  useEffect(() => {
+    return () => {
+      if (importNowEarlyRefreshTimerRef.current !== null) clearTimeout(importNowEarlyRefreshTimerRef.current);
+      if (importNowLateRefreshTimerRef.current !== null) clearTimeout(importNowLateRefreshTimerRef.current);
+    };
+  }, []);
 
   const loadSpecs = useCallback(async () => {
     if (!repositoryId) return;
@@ -364,6 +373,8 @@ export function RepositorySpecsTab({
     async (spec: RepositorySpecRecord) => {
       setOpenMenuFileId(null);
       setErrorMessage('');
+      setSuccessMessage('');
+      setImportNowJobId(null);
       try {
         const response = await fetch(
           `/api/repositories/${repositoryId}/specs/${spec.fileId}/import-now`,
@@ -390,10 +401,14 @@ export function RepositorySpecsTab({
         setSuccessMessage(
           `Import started (job ${jobId ? `${jobId.slice(0, 8)}…` : 'queued'}).`,
         );
-        setTimeout(() => { void loadSpecs(); }, 1500);
-        setTimeout(() => { void loadSpecs(); }, 5000);
+        if (importNowEarlyRefreshTimerRef.current !== null) clearTimeout(importNowEarlyRefreshTimerRef.current);
+        if (importNowLateRefreshTimerRef.current !== null) clearTimeout(importNowLateRefreshTimerRef.current);
+        importNowEarlyRefreshTimerRef.current = setTimeout(() => { void loadSpecs(); }, 1500);
+        importNowLateRefreshTimerRef.current = setTimeout(() => { void loadSpecs(); }, 5000);
       } catch (error) {
         const message = error instanceof Error ? error.message : 'Import Now failed';
+        setSuccessMessage('');
+        setImportNowJobId(null);
         setErrorMessage(message);
       }
     },


### PR DESCRIPTION
## What
- Adds `POST /v1/repositories/{tenant_slug}/{repository_id}/specs/{file_id}:importNow` (body: `branch?`, `force?`) returning **202** with `{ importJobId }` for a dry-run import of the latest scanned file snapshot. Requires `import_enabled` and `repository.write`; ignores `auto_import_enabled`. Jobs use `sourceKind: repository_manual_import`; auto-scan dispatch sets `repository_auto_import`.
- **30s idempotency** on `(repositoryId, fileId, branch)` to avoid double-post duplicate jobs. **Checksum** match vs last imported source (REPO-8.3) returns **409** unless `force: true`. Audit `repository.spec.import_now_triggered` includes actor, branch, force, and job id.
- Spec list **status** adds `importing` while the latest import job is `pending_review`. UI: **Import now** in row menu and spec drawer; success toast with link to `/ade/dashboard/repositories/{id}?tab=sync&importJobId=…`; optimistic **Importing** pill and refetch.

## How to test
- **API**: `POST .../specs/{fileId}:importNow` with `{ "force": true }` twice within 30s — same `importJobId`. With `import_enabled: false` expect **400** `IMPORT_NOT_ENABLED`. With matching checksum and `force: false` expect **409** (when DB returns a stored checksum).
- **UI**: open **Account → Repositories → repo → Specs**, **open overflow** on a row → **Import Now** (or open drawer → **Import now**). **Confirm** toast and **View in Sync history** link; status shows **Importing** until the job is no longer pending.

## Risk / notes
- In-memory idempotency map (same as other repository stores). REST tests added; run `pytest objectified-rest/tests/test_repositories_routes.py` in an environment with dev dependencies.

Closes #2939

Made with [Cursor](https://cursor.com)