### PR TITLE
Fix #2823 - MCP-1.2 transport adapters (stdio + Streamable HTTP)

### DIFF
--- a/docs/PLANNED_FEATURE_ROADMAP_MCP.md
+++ b/docs/PLANNED_FEATURE_ROADMAP_MCP.md
@@ -1409,7 +1409,7 @@ same number-prefix can be parallelized across developers because their
 MCP v1 release; `(V2)` items are explicitly enterprise.
 
 1. ~~[#2822] MCP-1.1 — `objectified-mcp` package + MCP SDK bootstrap **(MVP)**~~ **Done**
-2. [#2823] MCP-1.2 — Transport adapters (stdio + Streamable HTTP) **(MVP)**
+2. ~~[#2823] MCP-1.2 — Transport adapters (stdio + Streamable HTTP) **(MVP)**~~ **Done**
 3. [#2824] MCP-1.3 — API-key authentication via Linked Accounts **(MVP)**
 4. [#2825] MCP-1.4 — Tenant scoping + RBAC scope guard **(MVP, parallel)**
 5. [#2826] MCP-1.5 — Per-key rate limits **(MVP, parallel)**

--- a/objectified-mcp/README.md
+++ b/objectified-mcp/README.md
@@ -1,6 +1,6 @@
 # objectified-mcp
 
-Model Context Protocol server for Objectified. Ships the three primitive tools (`mcp.search`, `mcp.describe`, `mcp.execute`) on top of `@modelcontextprotocol/sdk`, with stdio as the first transport (Streamable HTTP arrives in MCP-1.2).
+Model Context Protocol server for Objectified. Ships the three primitive tools (`mcp.search`, `mcp.describe`, `mcp.execute`) on top of `@modelcontextprotocol/sdk`, with **stdio** (desktop clients) and **Streamable HTTP** at `/mcp` (hosted clients).
 
 ## Requirements
 
@@ -21,7 +21,11 @@ Equivalent with pnpm:
 pnpm --filter objectified-mcp build
 ```
 
-## Run locally (stdio)
+## Run locally
+
+Choose transport with **`--transport`** or **`OBJECTIFIED_MCP_TRANSPORT`** (`stdio` or `http`). CLI wins when both are set.
+
+### stdio (local clients)
 
 After a build:
 
@@ -29,7 +33,7 @@ After a build:
 node objectified-mcp/bin/objectified-mcp.js --transport stdio
 ```
 
-Or via the workspace binary name once linked:
+Or via the workspace script:
 
 ```bash
 yarn workspace objectified-mcp start
@@ -37,12 +41,26 @@ yarn workspace objectified-mcp start
 
 The process speaks MCP over stdin/stdout; pair it with an MCP-aware client (Cursor, Claude Desktop, etc.) using a config that launches this command.
 
+### Streamable HTTP (hosted clients)
+
+```bash
+node objectified-mcp/bin/objectified-mcp.js --transport http
+```
+
+Listens on **`OBJECTIFIED_MCP_HOST`** (default `0.0.0.0`) and **`OBJECTIFIED_MCP_PORT`** (default **4040**). MCP requests use **`POST`/`GET`/`DELETE`** on **`/mcp`** per the MCP Streamable HTTP spec (`application/json` + SSE). Responses include **`Cache-Control: no-store`**.
+
+Stop with **SIGINT** / **SIGTERM**.
+
 ## Environment variables
 
 | Variable | Purpose |
 |----------|---------|
 | `OBJECTIFIED_REST_URL` | Base URL for `objectified-rest` (default `http://127.0.0.1:8000`). All HTTP calls must go through `src/upstream/client.ts` — do not use raw `fetch` elsewhere. |
 | `OBJECTIFIED_MCP_KEY` | API key for upstream auth (wired fully in MCP-1.3 / MCP-1.4). |
+| `OBJECTIFIED_MCP_TRANSPORT` | `stdio` or `http` when `--transport` is omitted. |
+| `OBJECTIFIED_MCP_PORT` | HTTP listen port (default `4040`). |
+| `OBJECTIFIED_MCP_HOST` | HTTP bind address (default `0.0.0.0`). |
+| `OBJECTIFIED_MCP_STDIO_IDLE_MS` | Optional override for the stdio idle shutdown timer (default **5 minutes**). Intended for tests; production uses the default unless you set this. |
 
 ## Primitive tools (one-line examples)
 

--- a/objectified-mcp/package.json
+++ b/objectified-mcp/package.json
@@ -1,8 +1,8 @@
 {
   "name": "objectified-mcp",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
-  "description": "Model Context Protocol server for Objectified (stdio bootstrap)",
+  "description": "Model Context Protocol server for Objectified (stdio + Streamable HTTP)",
   "type": "module",
   "bin": "./bin/objectified-mcp.js",
   "files": [

--- a/objectified-mcp/src/cli.ts
+++ b/objectified-mcp/src/cli.ts
@@ -1,10 +1,16 @@
 import { parseArgs } from 'node:util';
 
-import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-
+import { DEFAULT_HTTP_PORT, listenHttpTransport } from './transports/http.js';
+import { runStdioTransport } from './transports/stdio.js';
 import { ActionRegistry } from './registry/index.js';
-import { createObjectifiedMcpServer } from './server.js';
 import { RestClient } from './upstream/client.js';
+
+function parsePort(raw: string | undefined, fallback: number): number {
+  if (raw === undefined || raw === '') return fallback;
+  const n = Number(raw);
+  if (!Number.isInteger(n) || n <= 0 || n > 65535) return fallback;
+  return n;
+}
 
 async function main(): Promise<void> {
   const { values } = parseArgs({
@@ -12,17 +18,17 @@ async function main(): Promise<void> {
     options: {
       transport: {
         type: 'string',
-        default: 'stdio',
       },
     },
     strict: true,
     allowPositionals: false,
   });
 
-  const transport = values.transport ?? 'stdio';
-  if (transport !== 'stdio') {
+  const transport = values.transport ?? process.env.OBJECTIFIED_MCP_TRANSPORT ?? 'stdio';
+
+  if (transport !== 'stdio' && transport !== 'http') {
     console.error(
-      `Transport "${transport}" is not implemented yet. Only --transport stdio is supported (see MCP-1.2).`,
+      `Transport "${transport}" is invalid. Use --transport stdio|http or OBJECTIFIED_MCP_TRANSPORT.`,
     );
     process.exitCode = 2;
     return;
@@ -30,9 +36,23 @@ async function main(): Promise<void> {
 
   const registry = ActionRegistry.instance();
   const upstream = RestClient.fromEnv();
-  const server = createObjectifiedMcpServer(registry, upstream);
 
-  await server.connect(new StdioServerTransport());
+  if (transport === 'stdio') {
+    await runStdioTransport({ registry, upstream });
+    return;
+  }
+
+  const port = parsePort(process.env.OBJECTIFIED_MCP_PORT, DEFAULT_HTTP_PORT);
+  const host = process.env.OBJECTIFIED_MCP_HOST ?? '0.0.0.0';
+  const http = await listenHttpTransport({ registry, upstream, port, host });
+
+  await new Promise<void>((resolve) => {
+    const stop = (): void => {
+      void http.close().finally(() => resolve());
+    };
+    process.once('SIGINT', stop);
+    process.once('SIGTERM', stop);
+  });
 }
 
 await main();

--- a/objectified-mcp/src/transports/cache-control.ts
+++ b/objectified-mcp/src/transports/cache-control.ts
@@ -1,9 +1,9 @@
 import type { ServerResponse } from 'node:http';
 
-/** Ensures Cache-Control: no-store on every outbound byte (MCP-1.2). */
+/** Ensures Cache-Control: no-store on every outbound HTTP response (MCP-1.2). */
 export function attachCacheControlNoStore(res: ServerResponse): void {
   const ensure = (): void => {
-    if (!res.headersSent && res.getHeader('Cache-Control') === undefined) {
+    if (!res.headersSent) {
       res.setHeader('Cache-Control', 'no-store');
     }
   };

--- a/objectified-mcp/src/transports/cache-control.ts
+++ b/objectified-mcp/src/transports/cache-control.ts
@@ -1,0 +1,22 @@
+import type { ServerResponse } from 'node:http';
+
+/** Ensures Cache-Control: no-store on every outbound byte (MCP-1.2). */
+export function attachCacheControlNoStore(res: ServerResponse): void {
+  const ensure = (): void => {
+    if (!res.headersSent && res.getHeader('Cache-Control') === undefined) {
+      res.setHeader('Cache-Control', 'no-store');
+    }
+  };
+
+  const origWriteHead = res.writeHead.bind(res);
+  res.writeHead = ((...args: Parameters<ServerResponse['writeHead']>) => {
+    ensure();
+    return origWriteHead(...args);
+  }) as ServerResponse['writeHead'];
+
+  const origEnd = res.end.bind(res);
+  res.end = ((...args: Parameters<ServerResponse['end']>) => {
+    ensure();
+    return origEnd(...args);
+  }) as ServerResponse['end'];
+}

--- a/objectified-mcp/src/transports/http.ts
+++ b/objectified-mcp/src/transports/http.ts
@@ -1,0 +1,155 @@
+import { randomUUID } from 'node:crypto';
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
+
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
+
+import { attachCacheControlNoStore } from './cache-control.js';
+import type { ActionRegistry } from '../registry/index.js';
+import { createObjectifiedMcpServer } from '../server.js';
+import type { RestClient } from '../upstream/client.js';
+
+export const DEFAULT_HTTP_PORT = 4040;
+
+type SessionEntry = {
+  transport: StreamableHTTPServerTransport;
+  server: McpServer;
+};
+
+function readJsonBody(req: IncomingMessage): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    req.on('data', (c) => chunks.push(Buffer.isBuffer(c) ? c : Buffer.from(c)));
+    req.on('end', () => {
+      if (chunks.length === 0) {
+        resolve(undefined);
+        return;
+      }
+      const raw = Buffer.concat(chunks).toString('utf8').trim();
+      if (!raw) {
+        resolve(undefined);
+        return;
+      }
+      try {
+        resolve(JSON.parse(raw) as unknown);
+      } catch (e) {
+        reject(e);
+      }
+    });
+    req.on('error', reject);
+  });
+}
+
+function sendJson(res: ServerResponse, status: number, body: unknown): void {
+  res.statusCode = status;
+  res.setHeader('Content-Type', 'application/json; charset=utf-8');
+  res.end(JSON.stringify(body));
+}
+
+function getSessionHeader(req: IncomingMessage): string | undefined {
+  const raw = req.headers['mcp-session-id'];
+  if (raw === undefined) return undefined;
+  return Array.isArray(raw) ? raw[0] : raw;
+}
+
+export async function listenHttpTransport(options: {
+  registry: ActionRegistry;
+  upstream: RestClient;
+  port: number;
+  host?: string;
+}): Promise<{ port: number; close: () => Promise<void> }> {
+  const sessions = new Map<string, SessionEntry>();
+  const host = options.host ?? '0.0.0.0';
+
+  const httpServer: Server = createServer(async (req, res) => {
+    attachCacheControlNoStore(res);
+
+    const url = new URL(req.url ?? '/', 'http://localhost');
+    if (url.pathname !== '/mcp') {
+      res.statusCode = 404;
+      res.setHeader('Content-Type', 'application/json; charset=utf-8');
+      res.end(JSON.stringify({ error: 'Not Found' }));
+      return;
+    }
+
+    try {
+      await dispatchMcpRequest(req, res, {
+        registry: options.registry,
+        upstream: options.upstream,
+        sessions,
+      });
+    } catch {
+      if (!res.headersSent) {
+        sendJson(res, 400, { error: 'Bad Request' });
+      }
+    }
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    httpServer.once('error', reject);
+    httpServer.listen(options.port, host, () => {
+      httpServer.off('error', reject);
+      resolve();
+    });
+  });
+
+  const address = httpServer.address();
+  const boundPort =
+    address && typeof address === 'object' && 'port' in address ? address.port : options.port;
+
+  return {
+    port: boundPort,
+    close: async () =>
+      await new Promise<void>((resolve, reject) => {
+        httpServer.close((err) => (err ? reject(err) : resolve()));
+      }),
+  };
+}
+
+async function dispatchMcpRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+  ctx: { registry: ActionRegistry; upstream: RestClient; sessions: Map<string, SessionEntry> },
+): Promise<void> {
+  const sessionId = getSessionHeader(req);
+
+  if (sessionId !== undefined) {
+    const entry = ctx.sessions.get(sessionId);
+    if (!entry) {
+      sendJson(res, 404, { error: 'Session not found' });
+      return;
+    }
+    const parsedBody = req.method === 'POST' ? await readJsonBody(req) : undefined;
+    await entry.transport.handleRequest(req, res, parsedBody);
+    return;
+  }
+
+  if (req.method === 'POST') {
+    const parsedBody = await readJsonBody(req);
+    if (!isInitializeRequest(parsedBody)) {
+      sendJson(res, 400, { error: 'Bad Request' });
+      return;
+    }
+
+    const mcpServer = createObjectifiedMcpServer(ctx.registry, ctx.upstream);
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: () => randomUUID(),
+      onsessioninitialized: (sid) => {
+        ctx.sessions.set(sid, { transport, server: mcpServer });
+      },
+    });
+
+    transport.onclose = () => {
+      const sid = transport.sessionId;
+      if (sid) ctx.sessions.delete(sid);
+      void mcpServer.close();
+    };
+
+    await mcpServer.connect(transport);
+    await transport.handleRequest(req, res, parsedBody);
+    return;
+  }
+
+  sendJson(res, 400, { error: 'Bad Request' });
+}

--- a/objectified-mcp/src/transports/http.ts
+++ b/objectified-mcp/src/transports/http.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
+import type { Socket } from 'node:net';
 
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
@@ -12,6 +13,20 @@ import type { RestClient } from '../upstream/client.js';
 
 export const DEFAULT_HTTP_PORT = 4040;
 
+/** Maximum allowed request body size (1 MiB). Requests larger than this are rejected with 400. */
+const MAX_BODY_BYTES = 1 * 1024 * 1024;
+
+/** Represents a known HTTP error that should be reported to the client (not logged as internal). */
+class HttpError extends Error {
+  constructor(
+    public readonly status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'HttpError';
+  }
+}
+
 type SessionEntry = {
   transport: StreamableHTTPServerTransport;
   server: McpServer;
@@ -20,7 +35,17 @@ type SessionEntry = {
 function readJsonBody(req: IncomingMessage): Promise<unknown> {
   return new Promise((resolve, reject) => {
     const chunks: Buffer[] = [];
-    req.on('data', (c) => chunks.push(Buffer.isBuffer(c) ? c : Buffer.from(c)));
+    let totalBytes = 0;
+    req.on('data', (c) => {
+      const chunk = Buffer.isBuffer(c) ? c : Buffer.from(c);
+      totalBytes += chunk.byteLength;
+      if (totalBytes > MAX_BODY_BYTES) {
+        reject(new Error('Request body too large'));
+        req.destroy();
+        return;
+      }
+      chunks.push(chunk);
+    });
     req.on('end', () => {
       if (chunks.length === 0) {
         resolve(undefined);
@@ -61,6 +86,7 @@ export async function listenHttpTransport(options: {
 }): Promise<{ port: number; close: () => Promise<void> }> {
   const sessions = new Map<string, SessionEntry>();
   const host = options.host ?? '0.0.0.0';
+  const openSockets = new Set<Socket>();
 
   const httpServer: Server = createServer(async (req, res) => {
     attachCacheControlNoStore(res);
@@ -79,11 +105,21 @@ export async function listenHttpTransport(options: {
         upstream: options.upstream,
         sessions,
       });
-    } catch {
+    } catch (err) {
       if (!res.headersSent) {
-        sendJson(res, 400, { error: 'Bad Request' });
+        if (err instanceof HttpError) {
+          sendJson(res, err.status, { error: err.message });
+        } else {
+          console.error('[objectified-mcp] unhandled request error:', err);
+          sendJson(res, 500, { error: 'Internal Server Error' });
+        }
       }
     }
+  });
+
+  httpServer.on('connection', (socket: Socket) => {
+    openSockets.add(socket);
+    socket.once('close', () => openSockets.delete(socket));
   });
 
   await new Promise<void>((resolve, reject) => {
@@ -100,10 +136,30 @@ export async function listenHttpTransport(options: {
 
   return {
     port: boundPort,
-    close: async () =>
+    close: async () => {
+      // Tear down all active MCP sessions before closing the server.
+      // Setting transport.onclose to a no-op first breaks the recursive close loop:
+      // server.close() → transport.close() → onclose → server.close() → ...
+      const entries = Array.from(sessions.values());
+      sessions.clear();
+      await Promise.allSettled(
+        entries.map(async ({ transport, server }) => {
+          transport.onclose = () => {};
+          try {
+            await server.close();
+          } catch (err) {
+            console.error('[objectified-mcp] error closing MCP session:', err);
+          }
+        }),
+      );
+      // Destroy open sockets so httpServer.close() doesn't hang on keep-alive/SSE connections.
+      for (const socket of openSockets) {
+        socket.destroy();
+      }
       await new Promise<void>((resolve, reject) => {
         httpServer.close((err) => (err ? reject(err) : resolve()));
-      }),
+      });
+    },
   };
 }
 
@@ -120,13 +176,23 @@ async function dispatchMcpRequest(
       sendJson(res, 404, { error: 'Session not found' });
       return;
     }
-    const parsedBody = req.method === 'POST' ? await readJsonBody(req) : undefined;
+    let parsedBody: unknown;
+    try {
+      parsedBody = req.method === 'POST' ? await readJsonBody(req) : undefined;
+    } catch {
+      throw new HttpError(400, 'Bad Request');
+    }
     await entry.transport.handleRequest(req, res, parsedBody);
     return;
   }
 
   if (req.method === 'POST') {
-    const parsedBody = await readJsonBody(req);
+    let parsedBody: unknown;
+    try {
+      parsedBody = await readJsonBody(req);
+    } catch {
+      throw new HttpError(400, 'Bad Request');
+    }
     if (!isInitializeRequest(parsedBody)) {
       sendJson(res, 400, { error: 'Bad Request' });
       return;
@@ -151,5 +217,5 @@ async function dispatchMcpRequest(
     return;
   }
 
-  sendJson(res, 400, { error: 'Bad Request' });
+  throw new HttpError(400, 'Bad Request');
 }

--- a/objectified-mcp/src/transports/stdio.ts
+++ b/objectified-mcp/src/transports/stdio.ts
@@ -1,0 +1,54 @@
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+
+import type { ActionRegistry } from '../registry/index.js';
+import { createObjectifiedMcpServer } from '../server.js';
+import type { RestClient } from '../upstream/client.js';
+
+const DEFAULT_IDLE_MS = 5 * 60 * 1000;
+
+function parsePositiveMs(raw: string | undefined, fallback: number): number {
+  if (raw === undefined || raw === '') return fallback;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0) return fallback;
+  return Math.floor(n);
+}
+
+export async function runStdioTransport(deps: {
+  registry: ActionRegistry;
+  upstream: RestClient;
+}): Promise<void> {
+  const idleMs = parsePositiveMs(process.env.OBJECTIFIED_MCP_STDIO_IDLE_MS, DEFAULT_IDLE_MS);
+  const server = createObjectifiedMcpServer(deps.registry, deps.upstream);
+  const transport = new StdioServerTransport();
+
+  let idleTimer: NodeJS.Timeout | undefined;
+
+  const cleanupWatchers = (): void => {
+    process.stdin.off('data', onStdinData);
+    if (idleTimer !== undefined) clearTimeout(idleTimer);
+  };
+
+  const armIdleTimer = (): void => {
+    if (idleTimer !== undefined) clearTimeout(idleTimer);
+    idleTimer = setTimeout(() => {
+      cleanupWatchers();
+      void server.close().finally(() => {
+        process.exitCode = 0;
+        process.exit(0);
+      });
+    }, idleMs);
+  };
+
+  function onStdinData(): void {
+    armIdleTimer();
+  }
+
+  transport.onclose = () => {
+    cleanupWatchers();
+  };
+
+  process.stdin.on('data', onStdinData);
+  armIdleTimer();
+
+  await server.connect(transport);
+}

--- a/objectified-mcp/tests/server.test.ts
+++ b/objectified-mcp/tests/server.test.ts
@@ -1,13 +1,21 @@
 import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { dirname, join } from 'node:path';
 import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
 
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 import { ToolSchema } from '@modelcontextprotocol/sdk/types.js';
 
 import { ActionRegistry } from '../src/registry/index.js';
 import { createObjectifiedMcpServer } from '../src/server.js';
+import { listenHttpTransport } from '../src/transports/http.js';
 import { RestClient } from '../src/upstream/client.js';
+
+const pkgRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
 
 describe('objectified-mcp server bootstrap', () => {
   it('handshakes over in-memory transport and reports serverInfo + capabilities', async (t) => {
@@ -75,5 +83,83 @@ describe('objectified-mcp server bootstrap', () => {
     await server.close();
 
     assert.equal(server.isConnected(), false);
+  });
+});
+
+describe('objectified-mcp transports (integration)', () => {
+  it('lists tools over Streamable HTTP', async (t) => {
+    const registry = ActionRegistry.instance();
+    const upstream = RestClient.withBaseUrl('http://127.0.0.1:8000');
+    const http = await listenHttpTransport({ registry, upstream, port: 0, host: '127.0.0.1' });
+
+    const transport = new StreamableHTTPClientTransport(
+      new URL(`http://127.0.0.1:${http.port}/mcp`),
+    );
+    const client = new Client({ name: 'test-harness', version: '0.0.0' }, { capabilities: {} });
+    await client.connect(transport);
+
+    t.after(async () => {
+      await client.close();
+      await http.close();
+    });
+
+    const { tools } = await client.listTools();
+    assert.equal(tools.length, 3);
+    const names = tools.map((x) => x.name).sort();
+    assert.deepEqual(names, ['mcp.describe', 'mcp.execute', 'mcp.search']);
+  });
+
+  it('sets Cache-Control: no-store on HTTP responses', async (t) => {
+    const registry = ActionRegistry.instance();
+    const upstream = RestClient.withBaseUrl('http://127.0.0.1:8000');
+    const http = await listenHttpTransport({ registry, upstream, port: 0, host: '127.0.0.1' });
+    t.after(async () => {
+      await http.close();
+    });
+
+    const res = await fetch(`http://127.0.0.1:${http.port}/mcp`, { method: 'GET' });
+    assert.equal(res.headers.get('cache-control'), 'no-store');
+  });
+
+  it('lists tools over stdio via subprocess transport', async (t) => {
+    const bin = join(pkgRoot, 'bin', 'objectified-mcp.js');
+    const transport = new StdioClientTransport({
+      command: 'node',
+      args: [bin, '--transport', 'stdio'],
+      cwd: pkgRoot,
+      stderr: 'pipe',
+    });
+    const client = new Client({ name: 'test-harness', version: '0.0.0' }, { capabilities: {} });
+    await client.connect(transport);
+
+    t.after(async () => {
+      await client.close();
+    });
+
+    const { tools } = await client.listTools();
+    assert.equal(tools.length, 3);
+    const names = tools.map((x) => x.name).sort();
+    assert.deepEqual(names, ['mcp.describe', 'mcp.execute', 'mcp.search']);
+  });
+
+  it('exits stdio mode after idle when OBJECTIFIED_MCP_STDIO_IDLE_MS is set', async () => {
+    const bin = join(pkgRoot, 'bin', 'objectified-mcp.js');
+    const child = spawn('node', [bin, '--transport', 'stdio'], {
+      cwd: pkgRoot,
+      env: { ...process.env, OBJECTIFIED_MCP_STDIO_IDLE_MS: '150' },
+      stdio: ['ignore', 'ignore', 'ignore'],
+    });
+
+    const code = await Promise.race([
+      new Promise<number>((resolve, reject) => {
+        child.on('error', reject);
+        child.on('exit', (c) => resolve(c ?? 1));
+      }),
+      new Promise<number>((_, reject) =>
+        setTimeout(() => reject(new Error('stdio idle timeout')), 5000),
+      ),
+    ]);
+
+    assert.equal(code, 0);
   });
 });

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -6,6 +6,7 @@ We continue to improve the platform based on your feedback with improvements and
 
 ## MCP (preview)
 - New `objectified-mcp` workspace package bootstraps the MCP server with stdio and the `mcp.search` / `mcp.describe` / `mcp.execute` tools.
+- MCP-1.2: Streamable HTTP transport at `/mcp` (`--transport http`, port from `OBJECTIFIED_MCP_PORT`) alongside stdio; HTTP responses use `Cache-Control: no-store`.
 
 ## Importing
 - Race condition fixed in 3.0.1 specification imports


### PR DESCRIPTION
## What changed
Implements MCP-1.2 transport selection for `objectified-mcp`: **stdio** (SDK `StdioServerTransport`) and **Streamable HTTP** at `/mcp` via the SDK `StreamableHTTPServerTransport`, with per-session `McpServer` instances (required by the SDK protocol model). Selection uses `--transport` or `OBJECTIFIED_MCP_TRANSPORT`; HTTP bind/port via `OBJECTIFIED_MCP_HOST` / `OBJECTIFIED_MCP_PORT` (default **4040**). All HTTP responses get `Cache-Control: no-store`. Stdio sessions exit after **5 minutes** without stdin traffic (override with `OBJECTIFIED_MCP_STDIO_IDLE_MS` for tests).

## How to test
- **stdio**: `yarn workspace objectified-mcp build && node objectified-mcp/bin/objectified-mcp.js --transport stdio` and connect an MCP client.
- **HTTP**: `OBJECTIFIED_MCP_PORT=4040 node objectified-mcp/bin/objectified-mcp.js --transport http`, then point a Streamable HTTP MCP client at `http://<host>:4040/mcp`.
- **Automated**: `yarn workspace objectified-mcp test` (covers `tools/list` over both transports, cache header, and stdio idle shutdown).

## Risks / notes
- Hosted HTTP binds `0.0.0.0` by default; restrict with firewall or set `OBJECTIFIED_MCP_HOST=127.0.0.1` for local-only.
- Root `yarn test` currently fails in `objectified-ui` with a pre-existing Jest/`pretty-format` error (`llm-streaming.test.ts`); `objectified-mcp` tests pass.

Closes #2823

Made with [Cursor](https://cursor.com)