### PR TITLE
Fix #2824 - MCP-1.3 API-key authentication

### DIFF
--- a/docs/PLANNED_FEATURE_ROADMAP_MCP.md
+++ b/docs/PLANNED_FEATURE_ROADMAP_MCP.md
@@ -1410,7 +1410,7 @@ MCP v1 release; `(V2)` items are explicitly enterprise.
 
 1. ~~[#2822] MCP-1.1 — `objectified-mcp` package + MCP SDK bootstrap **(MVP)**~~ **Done**
 2. ~~[#2823] MCP-1.2 — Transport adapters (stdio + Streamable HTTP) **(MVP)**~~ **Done**
-3. [#2824] MCP-1.3 — API-key authentication via Linked Accounts **(MVP)**
+3. ~~[#2824] MCP-1.3 — API-key authentication via Linked Accounts **(MVP)**~~ **Done**
 4. [#2825] MCP-1.4 — Tenant scoping + RBAC scope guard **(MVP, parallel)**
 5. [#2826] MCP-1.5 — Per-key rate limits **(MVP, parallel)**
 6. [#2827] MCP-1.6 — Workflow audit integration **(MVP, parallel)**

--- a/objectified-db/scripts/20260501-170000.sql
+++ b/objectified-db/scripts/20260501-170000.sql
@@ -1,0 +1,56 @@
+-- MCP-1.3 (#2824): api_keys purpose/scopes for MCP vs REST; optional owner linkage.
+SET search_path TO odb, public;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'odb' AND table_name = 'api_keys' AND column_name = 'purpose'
+  ) THEN
+    ALTER TABLE odb.api_keys
+      ADD COLUMN purpose VARCHAR(16) NOT NULL DEFAULT 'rest'
+        CONSTRAINT api_keys_purpose_chk CHECK (purpose IN ('rest', 'mcp', 'both'));
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'odb' AND table_name = 'api_keys' AND column_name = 'scopes'
+  ) THEN
+    ALTER TABLE odb.api_keys
+      ADD COLUMN scopes TEXT[] NOT NULL DEFAULT '{}';
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'odb' AND table_name = 'api_keys' AND column_name = 'label'
+  ) THEN
+    ALTER TABLE odb.api_keys
+      ADD COLUMN label VARCHAR(120);
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'odb' AND table_name = 'api_keys' AND column_name = 'owner_user_id'
+  ) THEN
+    ALTER TABLE odb.api_keys
+      ADD COLUMN owner_user_id UUID REFERENCES odb.users(id) ON DELETE SET NULL;
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS api_keys_purpose_idx
+  ON odb.api_keys (purpose)
+  WHERE deleted_at IS NULL;
+
+COMMENT ON COLUMN odb.api_keys.purpose IS 'rest: REST-only key; mcp: MCP-only key; both: allowed for either surface';
+COMMENT ON COLUMN odb.api_keys.scopes IS 'RBAC scope strings enforced by MCP (MCP-1.4)';
+COMMENT ON COLUMN odb.api_keys.label IS 'Optional short label for MCP keys (Linked Accounts UI)';
+COMMENT ON COLUMN odb.api_keys.owner_user_id IS 'User who owns this key when minted from Linked Accounts; optional for legacy REST keys';

--- a/objectified-mcp/package.json
+++ b/objectified-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-mcp",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "description": "Model Context Protocol server for Objectified (stdio + Streamable HTTP)",
   "type": "module",
@@ -14,10 +14,11 @@
     "build": "tsc",
     "dev": "yarn build && yarn start",
     "start": "node bin/objectified-mcp.js --transport stdio",
-    "test": "yarn build && tsx --test tests/server.test.ts"
+    "test": "yarn build && tsx --test tests/server.test.ts tests/auth.test.ts"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
+    "redis": "^5.10.0",
     "zod": "^4.1.12"
   },
   "devDependencies": {

--- a/objectified-mcp/src/auth/global-cache.ts
+++ b/objectified-mcp/src/auth/global-cache.ts
@@ -1,0 +1,13 @@
+import { SessionAuthCache } from './session-cache.js';
+
+let cache = new SessionAuthCache();
+
+export function getSharedSessionAuthCache(): SessionAuthCache {
+  return cache;
+}
+
+/** Test helper: swap the process-wide cache instance. */
+export function resetSharedSessionAuthCacheForTests(): SessionAuthCache {
+  cache = new SessionAuthCache();
+  return cache;
+}

--- a/objectified-mcp/src/auth/install.ts
+++ b/objectified-mcp/src/auth/install.ts
@@ -1,0 +1,60 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { Implementation, InitializeRequest, InitializeResult } from '@modelcontextprotocol/sdk/types.js';
+import {
+  InitializeRequestSchema,
+  LATEST_PROTOCOL_VERSION,
+  McpError,
+  SUPPORTED_PROTOCOL_VERSIONS,
+} from '@modelcontextprotocol/sdk/types.js';
+
+import type { McpResolveOutcome } from './types.js';
+
+/** Narrow surface we touch on the SDK Server (initialize hook). */
+type SdkServerInitializeHook = {
+  setRequestHandler: (
+    schema: typeof InitializeRequestSchema,
+    handler: (request: InitializeRequest) => Promise<InitializeResult>,
+  ) => void;
+  getCapabilities: () => Record<string, unknown>;
+  _serverInfo: Implementation;
+  _instructions?: string;
+  _clientCapabilities?: unknown;
+  _clientVersion?: unknown;
+};
+
+/**
+ * Replace the default initialize handler so MCP sessions must pass API-key auth first (#2824).
+ * Uses JSON-RPC code -32001 with `{ reason }` per MCP-1.3 acceptance criteria.
+ */
+export function installApiKeyAuthOnInitialize(
+  server: McpServer,
+  deps: {
+    resolveInitialize: () => Promise<McpResolveOutcome>;
+  },
+): void {
+  const inner = server.server as unknown as SdkServerInitializeHook;
+
+  inner.setRequestHandler(InitializeRequestSchema, async (request: InitializeRequest) => {
+    const outcome = await deps.resolveInitialize();
+    if (!outcome.ok) {
+      throw new McpError(-32001, 'Unauthorized', { reason: outcome.reason });
+    }
+
+    const requestedVersion = request.params.protocolVersion;
+    inner._clientCapabilities = request.params.capabilities;
+    inner._clientVersion = request.params.clientInfo;
+    const protocolVersion = SUPPORTED_PROTOCOL_VERSIONS.includes(requestedVersion)
+      ? requestedVersion
+      : LATEST_PROTOCOL_VERSION;
+
+    const payload: InitializeResult = {
+      protocolVersion,
+      capabilities: inner.getCapabilities(),
+      serverInfo: inner._serverInfo,
+    };
+    if (inner._instructions) {
+      payload.instructions = inner._instructions;
+    }
+    return payload;
+  });
+}

--- a/objectified-mcp/src/auth/resolve.ts
+++ b/objectified-mcp/src/auth/resolve.ts
@@ -1,0 +1,74 @@
+import { createHash } from 'node:crypto';
+
+import type { SessionAuthCache } from './session-cache.js';
+import type { AuthRejectReason, McpResolveOutcome, SessionCtx } from './types.js';
+
+export function sha256Hex(input: string): string {
+  return createHash('sha256').update(input, 'utf8').digest('hex');
+}
+
+type ResolveJson =
+  | { valid: true; user_id: string | null; tenant_id: string; scopes: string[]; expires_at: string | null; key_id: string }
+  | { valid: false; reason: AuthRejectReason };
+
+function mapCtx(body: Extract<ResolveJson, { valid: true }>): SessionCtx {
+  return {
+    userId: body.user_id,
+    tenantId: body.tenant_id,
+    scopes: body.scopes ?? [],
+    expiresAt: body.expires_at,
+    keyId: body.key_id,
+  };
+}
+
+export async function resolveMcpKeyViaRest(
+  token: string | undefined,
+  cache: SessionAuthCache,
+  options: {
+    restBaseUrl: string;
+    internalSecret: string;
+    fetchImpl?: typeof fetch;
+  },
+): Promise<McpResolveOutcome> {
+  if (!options.internalSecret) {
+    throw new Error('OBJECTIFIED_INTERNAL_API_SECRET is not set; cannot resolve MCP API keys');
+  }
+  if (!token?.trim()) {
+    return { ok: false, reason: 'KEY_NOT_FOUND' };
+  }
+  const raw = token.trim();
+  const tokenHash = sha256Hex(raw);
+
+  const cached = cache.get(tokenHash);
+  if (cached) {
+    return { ok: true, ctx: cached };
+  }
+
+  const fetchFn = options.fetchImpl ?? fetch;
+  const url = `${options.restBaseUrl.replace(/\/$/, '')}/v1/internal/api_keys/resolve`;
+  const res = await fetchFn(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Objectified-Internal-Secret': options.internalSecret,
+    },
+    body: JSON.stringify({ token: raw, purpose: 'mcp' }),
+  });
+
+  if (!res.ok) {
+    return { ok: false, reason: 'KEY_NOT_FOUND' };
+  }
+
+  const body = (await res.json()) as ResolveJson;
+  if (!body || typeof body !== 'object' || !('valid' in body)) {
+    return { ok: false, reason: 'KEY_NOT_FOUND' };
+  }
+  if (!body.valid) {
+    const r = 'reason' in body ? body.reason : 'KEY_NOT_FOUND';
+    return { ok: false, reason: r };
+  }
+
+  const ctx = mapCtx(body);
+  cache.set(tokenHash, ctx);
+  return { ok: true, ctx };
+}

--- a/objectified-mcp/src/auth/revoke-subscriber.ts
+++ b/objectified-mcp/src/auth/revoke-subscriber.ts
@@ -1,0 +1,34 @@
+import type { SessionAuthCache } from './session-cache.js';
+
+const CHANNEL = 'mcp.key.revoked';
+
+export async function startMcpKeyRevokeSubscriber(cache: SessionAuthCache): Promise<() => Promise<void>> {
+  const url = process.env.OBJECTIFIED_REDIS_URL?.trim();
+  if (!url) {
+    return async () => {};
+  }
+
+  const { createClient } = await import('redis');
+  const client = createClient({ url });
+  client.on('error', () => {});
+
+  await client.connect();
+  await client.subscribe(CHANNEL, (message: string) => {
+    try {
+      const parsed = JSON.parse(message) as { key_id?: string };
+      if (parsed?.key_id) {
+        cache.evictByKeyId(parsed.key_id);
+      }
+    } catch {
+      /* ignore malformed payload */
+    }
+  });
+
+  return async () => {
+    try {
+      await client.quit();
+    } catch {
+      /* ignore */
+    }
+  };
+}

--- a/objectified-mcp/src/auth/server-options.ts
+++ b/objectified-mcp/src/auth/server-options.ts
@@ -1,0 +1,10 @@
+import type { McpResolveOutcome } from './types.js';
+
+export type CreateMcpServerAuth =
+  | { kind: 'none' }
+  | {
+      kind: 'api_key';
+      getToken: () => string | undefined;
+      /** Test injection point; defaults to REST `/v1/internal/api_keys/resolve`. */
+      resolveInitialize?: () => Promise<McpResolveOutcome>;
+    };

--- a/objectified-mcp/src/auth/session-cache.ts
+++ b/objectified-mcp/src/auth/session-cache.ts
@@ -1,0 +1,54 @@
+import type { SessionCtx } from './types.js';
+
+const DEFAULT_TTL_MS = 5 * 60 * 1000;
+
+export class SessionAuthCache {
+  private readonly byHash = new Map<string, { ctx: SessionCtx; expiresAt: number }>();
+  private readonly keyIdToHashes = new Map<string, Set<string>>();
+  private readonly ttlMs: number;
+
+  constructor(ttlMs: number = DEFAULT_TTL_MS) {
+    this.ttlMs = ttlMs;
+  }
+
+  get(tokenHash: string): SessionCtx | undefined {
+    const row = this.byHash.get(tokenHash);
+    if (!row) return undefined;
+    if (Date.now() >= row.expiresAt) {
+      this.evictTokenHash(tokenHash);
+      return undefined;
+    }
+    return row.ctx;
+  }
+
+  set(tokenHash: string, ctx: SessionCtx): void {
+    const expiresAt = Date.now() + this.ttlMs;
+    this.byHash.set(tokenHash, { ctx, expiresAt });
+    let set = this.keyIdToHashes.get(ctx.keyId);
+    if (!set) {
+      set = new Set();
+      this.keyIdToHashes.set(ctx.keyId, set);
+    }
+    set.add(tokenHash);
+  }
+
+  evictTokenHash(tokenHash: string): void {
+    const entry = this.byHash.get(tokenHash);
+    this.byHash.delete(tokenHash);
+    if (!entry) return;
+    const set = this.keyIdToHashes.get(entry.ctx.keyId);
+    if (set) {
+      set.delete(tokenHash);
+      if (set.size === 0) this.keyIdToHashes.delete(entry.ctx.keyId);
+    }
+  }
+
+  evictByKeyId(keyId: string): void {
+    const set = this.keyIdToHashes.get(keyId);
+    if (!set) return;
+    for (const h of set) {
+      this.byHash.delete(h);
+    }
+    this.keyIdToHashes.delete(keyId);
+  }
+}

--- a/objectified-mcp/src/auth/types.ts
+++ b/objectified-mcp/src/auth/types.ts
@@ -1,0 +1,13 @@
+export type AuthRejectReason = 'KEY_NOT_FOUND' | 'KEY_REVOKED' | 'KEY_EXPIRED' | 'KEY_WRONG_PURPOSE';
+
+export type SessionCtx = {
+  userId: string | null;
+  tenantId: string;
+  scopes: string[];
+  expiresAt: string | null;
+  keyId: string;
+};
+
+export type McpResolveOutcome =
+  | { ok: true; ctx: SessionCtx }
+  | { ok: false; reason: AuthRejectReason };

--- a/objectified-mcp/src/cli.ts
+++ b/objectified-mcp/src/cli.ts
@@ -1,5 +1,7 @@
 import { parseArgs } from 'node:util';
 
+import { getSharedSessionAuthCache } from './auth/global-cache.js';
+import { startMcpKeyRevokeSubscriber } from './auth/revoke-subscriber.js';
 import { DEFAULT_HTTP_PORT, listenHttpTransport } from './transports/http.js';
 import { runStdioTransport } from './transports/stdio.js';
 import { ActionRegistry } from './registry/index.js';
@@ -36,23 +38,30 @@ async function main(): Promise<void> {
 
   const registry = ActionRegistry.instance();
   const upstream = RestClient.fromEnv();
+  const anonymous = process.env.OBJECTIFIED_MCP_ALLOW_ANONYMOUS === '1';
 
-  if (transport === 'stdio') {
-    await runStdioTransport({ registry, upstream });
-    return;
+  const stopSubscriber = await startMcpKeyRevokeSubscriber(getSharedSessionAuthCache());
+
+  try {
+    if (transport === 'stdio') {
+      await runStdioTransport({ registry, upstream, anonymous });
+      return;
+    }
+
+    const port = parsePort(process.env.OBJECTIFIED_MCP_PORT, DEFAULT_HTTP_PORT);
+    const host = process.env.OBJECTIFIED_MCP_HOST ?? '0.0.0.0';
+    const http = await listenHttpTransport({ registry, upstream, port, host, anonymous });
+
+    await new Promise<void>((resolve) => {
+      const stop = (): void => {
+        void http.close().finally(() => resolve());
+      };
+      process.once('SIGINT', stop);
+      process.once('SIGTERM', stop);
+    });
+  } finally {
+    await stopSubscriber();
   }
-
-  const port = parsePort(process.env.OBJECTIFIED_MCP_PORT, DEFAULT_HTTP_PORT);
-  const host = process.env.OBJECTIFIED_MCP_HOST ?? '0.0.0.0';
-  const http = await listenHttpTransport({ registry, upstream, port, host });
-
-  await new Promise<void>((resolve) => {
-    const stop = (): void => {
-      void http.close().finally(() => resolve());
-    };
-    process.once('SIGINT', stop);
-    process.once('SIGTERM', stop);
-  });
 }
 
 await main();

--- a/objectified-mcp/src/server.ts
+++ b/objectified-mcp/src/server.ts
@@ -1,11 +1,20 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
 
+import { installApiKeyAuthOnInitialize } from './auth/install.js';
+import type { CreateMcpServerAuth } from './auth/server-options.js';
+import { getSharedSessionAuthCache } from './auth/global-cache.js';
+import { resolveMcpKeyViaRest } from './auth/resolve.js';
 import { packageVersion } from './package-info.js';
 import type { ActionRegistry } from './registry/index.js';
 import { registerPrimitiveTools } from './tools/index.js';
 import type { RestClient } from './upstream/client.js';
 
-export function createObjectifiedMcpServer(registry: ActionRegistry, upstream: RestClient): McpServer {
+export function createObjectifiedMcpServer(
+  registry: ActionRegistry,
+  upstream: RestClient,
+  auth: CreateMcpServerAuth = { kind: 'none' },
+): McpServer {
   const server = new McpServer(
     { name: 'objectified-mcp', version: packageVersion() },
     {
@@ -20,5 +29,27 @@ export function createObjectifiedMcpServer(registry: ActionRegistry, upstream: R
 
   registerPrimitiveTools(server, { registry, upstream });
 
+  if (auth.kind === 'api_key') {
+    const resolveInitialize =
+      auth.resolveInitialize ??
+      (() =>
+        resolveMcpKeyViaRest(auth.getToken(), getSharedSessionAuthCache(), {
+          restBaseUrl: upstream.baseUrl,
+          internalSecret: process.env.OBJECTIFIED_INTERNAL_API_SECRET?.trim() ?? '',
+        }));
+
+    installApiKeyAuthOnInitialize(server, {
+      resolveInitialize: async () => {
+        try {
+          return await resolveInitialize();
+        } catch {
+          throw new McpError(ErrorCode.InternalError, 'Unable to resolve MCP API key');
+        }
+      },
+    });
+  }
+
   return server;
 }
+
+export type { CreateMcpServerAuth } from './auth/server-options.js';

--- a/objectified-mcp/src/transports/http.ts
+++ b/objectified-mcp/src/transports/http.ts
@@ -9,6 +9,7 @@ import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
 import { attachCacheControlNoStore } from './cache-control.js';
 import type { ActionRegistry } from '../registry/index.js';
 import { createObjectifiedMcpServer } from '../server.js';
+import { parseBearerAuthorization, resolveApiKeyFromEnv } from '../upstream/auth.js';
 import type { RestClient } from '../upstream/client.js';
 
 export const DEFAULT_HTTP_PORT = 4040;
@@ -83,6 +84,8 @@ export async function listenHttpTransport(options: {
   upstream: RestClient;
   port: number;
   host?: string;
+  /** Skip MCP API-key gate (tests / local wiring only). */
+  anonymous?: boolean;
 }): Promise<{ port: number; close: () => Promise<void> }> {
   const sessions = new Map<string, SessionEntry>();
   const host = options.host ?? '0.0.0.0';
@@ -103,6 +106,7 @@ export async function listenHttpTransport(options: {
       await dispatchMcpRequest(req, res, {
         registry: options.registry,
         upstream: options.upstream,
+        anonymous: options.anonymous ?? false,
         sessions,
       });
     } catch (err) {
@@ -166,7 +170,12 @@ export async function listenHttpTransport(options: {
 async function dispatchMcpRequest(
   req: IncomingMessage,
   res: ServerResponse,
-  ctx: { registry: ActionRegistry; upstream: RestClient; sessions: Map<string, SessionEntry> },
+  ctx: {
+    registry: ActionRegistry;
+    upstream: RestClient;
+    anonymous: boolean;
+    sessions: Map<string, SessionEntry>;
+  },
 ): Promise<void> {
   const sessionId = getSessionHeader(req);
 
@@ -198,7 +207,16 @@ async function dispatchMcpRequest(
       return;
     }
 
-    const mcpServer = createObjectifiedMcpServer(ctx.registry, ctx.upstream);
+    const mcpServer = createObjectifiedMcpServer(
+      ctx.registry,
+      ctx.upstream,
+      ctx.anonymous
+        ? { kind: 'none' }
+        : {
+            kind: 'api_key',
+            getToken: () => parseBearerAuthorization(req) ?? resolveApiKeyFromEnv(),
+          },
+    );
     const transport = new StreamableHTTPServerTransport({
       sessionIdGenerator: () => randomUUID(),
       onsessioninitialized: (sid) => {

--- a/objectified-mcp/src/transports/stdio.ts
+++ b/objectified-mcp/src/transports/stdio.ts
@@ -2,6 +2,7 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 
 import type { ActionRegistry } from '../registry/index.js';
 import { createObjectifiedMcpServer } from '../server.js';
+import { resolveApiKeyFromEnv } from '../upstream/auth.js';
 import type { RestClient } from '../upstream/client.js';
 
 const DEFAULT_IDLE_MS = 5 * 60 * 1000;
@@ -16,9 +17,15 @@ function parsePositiveMs(raw: string | undefined, fallback: number): number {
 export async function runStdioTransport(deps: {
   registry: ActionRegistry;
   upstream: RestClient;
+  /** Skip MCP API-key gate (tests / local wiring only). */
+  anonymous?: boolean;
 }): Promise<void> {
   const idleMs = parsePositiveMs(process.env.OBJECTIFIED_MCP_STDIO_IDLE_MS, DEFAULT_IDLE_MS);
-  const server = createObjectifiedMcpServer(deps.registry, deps.upstream);
+  const server = createObjectifiedMcpServer(
+    deps.registry,
+    deps.upstream,
+    deps.anonymous ? { kind: 'none' } : { kind: 'api_key', getToken: () => resolveApiKeyFromEnv() },
+  );
   const transport = new StdioServerTransport();
 
   let idleTimer: NodeJS.Timeout | undefined;

--- a/objectified-mcp/src/upstream/auth.ts
+++ b/objectified-mcp/src/upstream/auth.ts
@@ -1,10 +1,20 @@
+import type { IncomingMessage } from 'node:http';
+
 /**
  * API key used against objectified-rest (HTTP header or stdio env).
- * Full resolution ships in MCP-1.3 / MCP-1.4.
  */
 export function resolveApiKeyFromEnv(): string | undefined {
   const key = process.env.OBJECTIFIED_MCP_KEY;
   return key?.trim() || undefined;
+}
+
+/** `Authorization: Bearer <token>` when present (Streamable HTTP). */
+export function parseBearerAuthorization(req: IncomingMessage): string | undefined {
+  const raw = req.headers.authorization ?? req.headers.Authorization;
+  const v = Array.isArray(raw) ? raw[0] : raw;
+  if (!v || !v.startsWith('Bearer ')) return undefined;
+  const t = v.slice('Bearer '.length).trim();
+  return t || undefined;
 }
 
 export function resolveRestBaseUrl(): string {

--- a/objectified-mcp/tests/auth.test.ts
+++ b/objectified-mcp/tests/auth.test.ts
@@ -1,0 +1,178 @@
+import assert from 'node:assert/strict';
+import { describe, it, mock } from 'node:test';
+
+import { resolveMcpKeyViaRest, sha256Hex } from '../src/auth/resolve.js';
+import { SessionAuthCache } from '../src/auth/session-cache.js';
+import type { AuthRejectReason } from '../src/auth/types.js';
+
+function mockJsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('MCP API key resolve (MCP-1.3)', () => {
+  const longToken = 'sk_abcdefghijkl012345678901234567890abcdef';
+
+  it('returns KEY_REVOKED from REST payload', async () => {
+    const cache = new SessionAuthCache();
+    const fetchImpl = mock.fn(async () => mockJsonResponse({ valid: false, reason: 'KEY_REVOKED' }));
+    const out = await resolveMcpKeyViaRest(longToken, cache, {
+      restBaseUrl: 'http://rest',
+      internalSecret: 'sec',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    assert.equal(out.ok, false);
+    if (!out.ok) assert.equal(out.reason, 'KEY_REVOKED');
+  });
+
+  it('returns KEY_EXPIRED from REST payload', async () => {
+    const cache = new SessionAuthCache();
+    const fetchImpl = mock.fn(async () => mockJsonResponse({ valid: false, reason: 'KEY_EXPIRED' }));
+    const out = await resolveMcpKeyViaRest(longToken, cache, {
+      restBaseUrl: 'http://rest',
+      internalSecret: 'sec',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    assert.equal(out.ok, false);
+    if (!out.ok) assert.equal(out.reason, 'KEY_EXPIRED');
+  });
+
+  it('returns KEY_WRONG_PURPOSE from REST payload', async () => {
+    const cache = new SessionAuthCache();
+    const fetchImpl = mock.fn(async () => mockJsonResponse({ valid: false, reason: 'KEY_WRONG_PURPOSE' }));
+    const out = await resolveMcpKeyViaRest(longToken, cache, {
+      restBaseUrl: 'http://rest',
+      internalSecret: 'sec',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    assert.equal(out.ok, false);
+    if (!out.ok) assert.equal(out.reason, 'KEY_WRONG_PURPOSE');
+  });
+
+  it('returns KEY_NOT_FOUND when token missing', async () => {
+    const cache = new SessionAuthCache();
+    const fetchImpl = mock.fn(async () => mockJsonResponse({}));
+    const out = await resolveMcpKeyViaRest(undefined, cache, {
+      restBaseUrl: 'http://rest',
+      internalSecret: 'sec',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    assert.equal(out.ok, false);
+    if (!out.ok) assert.equal(out.reason, 'KEY_NOT_FOUND');
+    assert.equal(fetchImpl.mock.calls.length, 0);
+  });
+
+  it('returns KEY_NOT_FOUND when REST HTTP status is not ok', async () => {
+    const cache = new SessionAuthCache();
+    const fetchImpl = mock.fn(async () => new Response('', { status: 503 }));
+    const out = await resolveMcpKeyViaRest(longToken, cache, {
+      restBaseUrl: 'http://rest',
+      internalSecret: 'sec',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    assert.equal(out.ok, false);
+    if (!out.ok) assert.equal(out.reason, 'KEY_NOT_FOUND');
+  });
+
+  it('caches successful resolve so fetch runs once per token', async () => {
+    const cache = new SessionAuthCache();
+    let calls = 0;
+    const fetchImpl = mock.fn(async () => {
+      calls++;
+      return mockJsonResponse({
+        valid: true,
+        user_id: null,
+        tenant_id: 'tid',
+        scopes: ['read'],
+        expires_at: null,
+        key_id: 'kid',
+      });
+    });
+    const opts = {
+      restBaseUrl: 'http://rest',
+      internalSecret: 'sec',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    };
+    const first = await resolveMcpKeyViaRest(longToken, cache, opts);
+    const second = await resolveMcpKeyViaRest(longToken, cache, opts);
+    assert.equal(first.ok, true);
+    assert.equal(second.ok, true);
+    assert.equal(calls, 1);
+  });
+
+  it('happy path maps SessionCtx', async () => {
+    const cache = new SessionAuthCache();
+    const fetchImpl = mock.fn(async () =>
+      mockJsonResponse({
+        valid: true,
+        user_id: 'usr',
+        tenant_id: 'tid',
+        scopes: ['x'],
+        expires_at: '2099-01-01T00:00:00+00:00',
+        key_id: 'kid',
+      }),
+    );
+    const out = await resolveMcpKeyViaRest(longToken, cache, {
+      restBaseUrl: 'http://rest',
+      internalSecret: 'sec',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    assert.equal(out.ok, true);
+    if (!out.ok) return;
+    assert.equal(out.ctx.userId, 'usr');
+    assert.equal(out.ctx.tenantId, 'tid');
+    assert.deepEqual(out.ctx.scopes, ['x']);
+    assert.equal(out.ctx.keyId, 'kid');
+    assert.equal(out.ctx.expiresAt, '2099-01-01T00:00:00+00:00');
+  });
+
+  it('evicts cache entries by key id (Redis revoke hook)', () => {
+    const cache = new SessionAuthCache();
+    const h = sha256Hex(longToken);
+    cache.set(h, {
+      userId: null,
+      tenantId: 'tid',
+      scopes: [],
+      expiresAt: null,
+      keyId: 'kid',
+    });
+    assert.ok(cache.get(h));
+    cache.evictByKeyId('kid');
+    assert.equal(cache.get(h), undefined);
+  });
+
+  it('missing internal secret throws before fetch', async () => {
+    const cache = new SessionAuthCache();
+    await assert.rejects(
+      async () =>
+        resolveMcpKeyViaRest(longToken, cache, {
+          restBaseUrl: 'http://rest',
+          internalSecret: '',
+          fetchImpl: mock.fn(async () => mockJsonResponse({ valid: true })) as unknown as typeof fetch,
+        }),
+      /OBJECTIFIED_INTERNAL_API_SECRET/,
+    );
+  });
+
+  it('covers each AuthRejectReason literal from REST', async () => {
+    const reasons: AuthRejectReason[] = [
+      'KEY_NOT_FOUND',
+      'KEY_REVOKED',
+      'KEY_EXPIRED',
+      'KEY_WRONG_PURPOSE',
+    ];
+    for (const reason of reasons) {
+      const cache = new SessionAuthCache();
+      const fetchImpl = mock.fn(async () => mockJsonResponse({ valid: false, reason }));
+      const out = await resolveMcpKeyViaRest(longToken, cache, {
+        restBaseUrl: 'http://rest',
+        internalSecret: 'sec',
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      });
+      assert.equal(out.ok, false);
+      if (!out.ok) assert.equal(out.reason, reason);
+    }
+  });
+});

--- a/objectified-mcp/tests/server.test.ts
+++ b/objectified-mcp/tests/server.test.ts
@@ -90,7 +90,13 @@ describe('objectified-mcp transports (integration)', () => {
   it('lists tools over Streamable HTTP', async (t) => {
     const registry = ActionRegistry.instance();
     const upstream = RestClient.withBaseUrl('http://127.0.0.1:8000');
-    const http = await listenHttpTransport({ registry, upstream, port: 0, host: '127.0.0.1' });
+    const http = await listenHttpTransport({
+      registry,
+      upstream,
+      port: 0,
+      host: '127.0.0.1',
+      anonymous: true,
+    });
 
     const transport = new StreamableHTTPClientTransport(
       new URL(`http://127.0.0.1:${http.port}/mcp`),
@@ -112,7 +118,13 @@ describe('objectified-mcp transports (integration)', () => {
   it('sets Cache-Control: no-store on HTTP responses', async (t) => {
     const registry = ActionRegistry.instance();
     const upstream = RestClient.withBaseUrl('http://127.0.0.1:8000');
-    const http = await listenHttpTransport({ registry, upstream, port: 0, host: '127.0.0.1' });
+    const http = await listenHttpTransport({
+      registry,
+      upstream,
+      port: 0,
+      host: '127.0.0.1',
+      anonymous: true,
+    });
     t.after(async () => {
       await http.close();
     });
@@ -128,6 +140,7 @@ describe('objectified-mcp transports (integration)', () => {
       args: [bin, '--transport', 'stdio'],
       cwd: pkgRoot,
       stderr: 'pipe',
+      env: { ...process.env, OBJECTIFIED_MCP_ALLOW_ANONYMOUS: '1' },
     });
     const client = new Client({ name: 'test-harness', version: '0.0.0' }, { capabilities: {} });
     await client.connect(transport);
@@ -146,7 +159,11 @@ describe('objectified-mcp transports (integration)', () => {
     const bin = join(pkgRoot, 'bin', 'objectified-mcp.js');
     const child = spawn('node', [bin, '--transport', 'stdio'], {
       cwd: pkgRoot,
-      env: { ...process.env, OBJECTIFIED_MCP_STDIO_IDLE_MS: '150' },
+      env: {
+        ...process.env,
+        OBJECTIFIED_MCP_STDIO_IDLE_MS: '150',
+        OBJECTIFIED_MCP_ALLOW_ANONYMOUS: '1',
+      },
       stdio: ['ignore', 'ignore', 'ignore'],
     });
 

--- a/objectified-rest/pyproject.toml
+++ b/objectified-rest/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "objectified-rest"
-version = "1.0.49"
+version = "1.0.50"
 description = "REST API for serving OpenAPI specifications from the Objectified database"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -34,6 +34,7 @@ dependencies = [
     "numpy>=2.4.2",
     "pgvector>=0.4.2",
     "chevron>=0.14.0",
+    "redis>=5.0.0",
 ]
 
 [project.optional-dependencies]

--- a/objectified-rest/src/app/config.py
+++ b/objectified-rest/src/app/config.py
@@ -40,6 +40,22 @@ class Settings(BaseSettings):
         ),
     )
 
+    # MCP internal resolve + revocation fan-out (#2824)
+    internal_api_secret: Optional[str] = Field(
+        default=None,
+        validation_alias=AliasChoices(
+            "OBJECTIFIED_INTERNAL_API_SECRET",
+            "internal_api_secret",
+        ),
+    )
+    redis_url: Optional[str] = Field(
+        default=None,
+        validation_alias=AliasChoices(
+            "OBJECTIFIED_REDIS_URL",
+            "redis_url",
+        ),
+    )
+
     @property
     def effective_database_url(self) -> str:
         """Get the database URL, preferring DATABASE_URL over building from components."""

--- a/objectified-rest/src/app/database.py
+++ b/objectified-rest/src/app/database.py
@@ -2,7 +2,7 @@ import psycopg2
 import json
 import logging
 import hashlib
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 import bcrypt
 import numpy as np
 from psycopg2.extras import Json, RealDictCursor
@@ -653,6 +653,7 @@ class Database:
 
         query = """
             SELECT ak.id, ak.tenant_id, ak.key_hash, ak.expires_at, ak.enabled,
+                   ak.purpose,
                    t.id as tenant_id, t.slug as tenant_slug, t.name as tenant_name
             FROM odb.api_keys ak
             JOIN odb.tenants t ON ak.tenant_id = t.id
@@ -661,6 +662,7 @@ class Database:
               AND ak.enabled = true
               AND t.deleted_at IS NULL
               AND t.enabled = true
+              AND (COALESCE(ak.purpose, 'rest') = 'rest' OR COALESCE(ak.purpose, 'rest') = 'both')
               AND (ak.expires_at IS NULL OR ak.expires_at > CURRENT_TIMESTAMP)
         """
         results = self.execute_query(query, (key_prefix,))
@@ -677,9 +679,17 @@ class Database:
             try:
                 if bcrypt.checkpw(api_key_bytes, key_hash):
                     api_key_data = dict(row)
-                    # Update last_used_at
+                    # Update last_used_at at most once per minute per key
                     try:
-                        update_query = "UPDATE odb.api_keys SET last_used_at = CURRENT_TIMESTAMP WHERE id = %s"
+                        update_query = """
+                            UPDATE odb.api_keys
+                            SET last_used_at = CURRENT_TIMESTAMP
+                            WHERE id = %s
+                              AND (
+                                  last_used_at IS NULL
+                                  OR last_used_at < CURRENT_TIMESTAMP - INTERVAL '60 seconds'
+                              )
+                        """
                         conn = self.connect()
                         with conn.cursor() as cursor:
                             cursor.execute(update_query, (api_key_data['id'],))
@@ -691,6 +701,124 @@ class Database:
                 continue
 
         return None
+
+    def resolve_api_key_token(
+        self,
+        token: str,
+        required_purpose: str,
+        *,
+        clock_skew_seconds: int = 30,
+        touch_last_used: bool = True,
+    ) -> Dict[str, Any]:
+        """
+        Resolve a raw API key for REST or MCP internal auth.
+
+        required_purpose: "mcp" or "rest" — key must be "both" or match that purpose.
+
+        Returns a dict with valid: bool, and either success fields or reason in
+        {KEY_NOT_FOUND, KEY_REVOKED, KEY_EXPIRED, KEY_WRONG_PURPOSE}.
+        """
+        if required_purpose not in ("mcp", "rest"):
+            return {"valid": False, "reason": "KEY_NOT_FOUND"}
+
+        if not token or not str(token).strip() or len(str(token).strip()) < 12:
+            return {"valid": False, "reason": "KEY_NOT_FOUND"}
+
+        token = str(token).strip()
+        key_prefix = token[:12] + "..."
+        api_key_bytes = token.encode("utf-8")
+
+        query = """
+            SELECT ak.id, ak.tenant_id, ak.key_hash, ak.expires_at, ak.enabled, ak.deleted_at,
+                   ak.purpose, ak.scopes, ak.owner_user_id,
+                   t.enabled AS tenant_enabled, t.deleted_at AS tenant_deleted_at
+            FROM odb.api_keys ak
+            JOIN odb.tenants t ON ak.tenant_id = t.id
+            WHERE ak.key_prefix = %s
+        """
+        rows = self.execute_query(query, (key_prefix,))
+        if not rows:
+            return {"valid": False, "reason": "KEY_NOT_FOUND"}
+
+        now = datetime.now(timezone.utc)
+        skew = timedelta(seconds=max(0, int(clock_skew_seconds)))
+
+        for row in rows:
+            key_hash = row["key_hash"]
+            if isinstance(key_hash, str):
+                key_hash = key_hash.encode("utf-8")
+            try:
+                if not bcrypt.checkpw(api_key_bytes, key_hash):
+                    continue
+            except (ValueError, TypeError):
+                continue
+
+            purpose = row.get("purpose") or "rest"
+
+            if row.get("deleted_at") is not None or row.get("enabled") is False:
+                return {"valid": False, "reason": "KEY_REVOKED"}
+            if row.get("tenant_deleted_at") is not None or row.get("tenant_enabled") is False:
+                return {"valid": False, "reason": "KEY_REVOKED"}
+
+            exp = row.get("expires_at")
+            if exp is not None:
+                if getattr(exp, "tzinfo", None) is None:
+                    exp = exp.replace(tzinfo=timezone.utc)
+                if exp <= now - skew:
+                    return {"valid": False, "reason": "KEY_EXPIRED"}
+
+            if required_purpose == "mcp" and purpose == "rest":
+                return {"valid": False, "reason": "KEY_WRONG_PURPOSE"}
+            if required_purpose == "rest" and purpose == "mcp":
+                return {"valid": False, "reason": "KEY_WRONG_PURPOSE"}
+
+            scopes = row.get("scopes")
+            if scopes is None:
+                scopes_list: List[str] = []
+            elif isinstance(scopes, list):
+                scopes_list = [str(s) for s in scopes]
+            else:
+                scopes_list = []
+
+            owner = row.get("owner_user_id")
+            user_id_val = str(owner) if owner is not None else None
+
+            if touch_last_used:
+                try:
+                    update_query = """
+                        UPDATE odb.api_keys
+                        SET last_used_at = CURRENT_TIMESTAMP
+                        WHERE id = %s
+                          AND (
+                              last_used_at IS NULL
+                              OR last_used_at < CURRENT_TIMESTAMP - INTERVAL '60 seconds'
+                          )
+                    """
+                    conn = self.connect()
+                    with conn.cursor() as cursor:
+                        cursor.execute(update_query, (row["id"],))
+                        conn.commit()
+                except Exception:
+                    pass
+
+            exp_out = row.get("expires_at")
+            expires_at_out = None
+            if exp_out is not None:
+                if getattr(exp_out, "tzinfo", None) is None:
+                    exp_out = exp_out.replace(tzinfo=timezone.utc)
+                expires_at_out = exp_out.isoformat()
+
+            return {
+                "valid": True,
+                "user_id": user_id_val,
+                "tenant_id": str(row["tenant_id"]),
+                "scopes": scopes_list,
+                "expires_at": expires_at_out,
+                "revoked": False,
+                "key_id": str(row["id"]),
+            }
+
+        return {"valid": False, "reason": "KEY_NOT_FOUND"}
 
     def get_tags_for_project(self, project_id: str) -> List[Dict[str, Any]]:
         """Get all tags for a specific project."""

--- a/objectified-rest/src/app/internal_api_keys_routes.py
+++ b/objectified-rest/src/app/internal_api_keys_routes.py
@@ -1,0 +1,59 @@
+"""Internal routes for MCP API key resolution (#2824)."""
+
+from __future__ import annotations
+
+import secrets
+from typing import Any, Literal, Optional
+from uuid import UUID
+
+from fastapi import APIRouter, Header, HTTPException
+from pydantic import BaseModel, Field
+
+from .config import settings
+from .database import db
+from .mcp_redis import publish_mcp_key_revoked
+
+router = APIRouter(prefix="/v1/internal", tags=["internal"])
+
+
+class ApiKeyResolveRequest(BaseModel):
+    token: str = Field(min_length=1)
+    purpose: Literal["mcp", "rest"] = "mcp"
+
+
+def _require_internal_secret(x_secret: Optional[str]) -> None:
+    expected = settings.internal_api_secret
+    if not expected:
+        raise HTTPException(status_code=503, detail="Internal API secret is not configured")
+    if not x_secret or not secrets.compare_digest(x_secret, expected):
+        raise HTTPException(status_code=403, detail="Forbidden")
+
+
+@router.post("/api_keys/resolve")
+async def resolve_api_key(
+    body: ApiKeyResolveRequest,
+    x_objectified_internal_secret: Optional[str] = Header(None, alias="X-Objectified-Internal-Secret"),
+) -> dict[str, Any]:
+    """
+    Resolve an API key for MCP or REST surfaces (called only by objectified-mcp or trusted services).
+    """
+    _require_internal_secret(x_objectified_internal_secret)
+    return db.resolve_api_key_token(body.token, body.purpose)
+
+
+class ApiKeyRevokedBroadcastRequest(BaseModel):
+    key_id: UUID
+
+
+@router.post("/api_keys/revoked-broadcast")
+async def broadcast_api_key_revoked(
+    body: ApiKeyRevokedBroadcastRequest,
+    x_objectified_internal_secret: Optional[str] = Header(None, alias="X-Objectified-Internal-Secret"),
+) -> dict[str, bool]:
+    """
+    Publish key_id on Redis channel ``mcp.key.revoked`` so MCP servers evict cached sessions.
+    Call after revocation when the DB row is already disabled or soft-deleted.
+    """
+    _require_internal_secret(x_objectified_internal_secret)
+    publish_mcp_key_revoked(str(body.key_id))
+    return {"ok": True}

--- a/objectified-rest/src/app/main.py
+++ b/objectified-rest/src/app/main.py
@@ -33,12 +33,13 @@ from .change_report_routes import router as change_report_router
 from .version_change_report_routes import router as version_change_report_router
 from .change_report_template_routes import router as change_report_template_router
 from .tenant_repositories_routes import router as tenant_repositories_router
+from .internal_api_keys_routes import router as internal_api_keys_router
 
 # Create FastAPI app
 app = FastAPI(
     title="Objectified REST API",
     description="REST API for serving OpenAPI specifications from the Objectified database",
-    version="1.0.44"
+    version="1.0.50"
 )
 
 
@@ -106,6 +107,7 @@ app.include_router(change_report_router)
 app.include_router(version_change_report_router)
 app.include_router(change_report_template_router)
 app.include_router(tenant_repositories_router)
+app.include_router(internal_api_keys_router)
 
 
 _webhook_delivery_task: asyncio.Task | None = None

--- a/objectified-rest/src/app/mcp_redis.py
+++ b/objectified-rest/src/app/mcp_redis.py
@@ -1,0 +1,36 @@
+"""Redis helpers for MCP server coordination (#2824)."""
+
+from __future__ import annotations
+
+import json
+import logging
+
+from .config import settings
+
+_logger = logging.getLogger(__name__)
+
+MCP_KEY_REVOKED_CHANNEL = "mcp.key.revoked"
+
+
+def publish_mcp_key_revoked(key_id: str) -> None:
+    """Publish a revocation notice so MCP servers can drop cached SessionCtx."""
+    url = settings.redis_url
+    if not url:
+        return
+    try:
+        import redis  # type: ignore[import-untyped]
+    except ImportError:
+        _logger.warning("redis package not installed; skipping mcp.key.revoked publish")
+        return
+
+    payload = json.dumps({"key_id": key_id})
+    client = redis.Redis.from_url(url, socket_connect_timeout=2, socket_timeout=2)
+    try:
+        client.publish(MCP_KEY_REVOKED_CHANNEL, payload)
+    except Exception as exc:
+        _logger.warning("redis publish failed for mcp.key.revoked: %s", exc)
+    finally:
+        try:
+            client.close()
+        except Exception:
+            pass

--- a/objectified-rest/tests/test_internal_api_keys_resolve.py
+++ b/objectified-rest/tests/test_internal_api_keys_resolve.py
@@ -1,0 +1,73 @@
+"""Internal MCP API key resolve routes (#2824)."""
+
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from app.config import settings
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_resolve_403_without_secret_header():
+    with patch.object(settings, "internal_api_secret", "only-trusted"):
+        r = client.post("/v1/internal/api_keys/resolve", json={"token": "sk_abcdefghijkl", "purpose": "mcp"})
+        assert r.status_code == 403
+
+
+def test_resolve_403_wrong_secret():
+    with patch.object(settings, "internal_api_secret", "expected"):
+        r = client.post(
+            "/v1/internal/api_keys/resolve",
+            json={"token": "sk_abcdefghijkl", "purpose": "mcp"},
+            headers={"X-Objectified-Internal-Secret": "wrong"},
+        )
+        assert r.status_code == 403
+
+
+def test_resolve_503_when_secret_not_configured():
+    with patch.object(settings, "internal_api_secret", None):
+        r = client.post(
+            "/v1/internal/api_keys/resolve",
+            json={"token": "sk_abcdefghijkl", "purpose": "mcp"},
+            headers={"X-Objectified-Internal-Secret": "x"},
+        )
+        assert r.status_code == 503
+
+
+def test_resolve_delegates_to_database():
+    with patch.object(settings, "internal_api_secret", "ok-secret"):
+        with patch("app.internal_api_keys_routes.db") as mdb:
+            mdb.resolve_api_key_token.return_value = {
+                "valid": True,
+                "user_id": None,
+                "tenant_id": "11111111-1111-1111-1111-111111111111",
+                "scopes": [],
+                "expires_at": None,
+                "revoked": False,
+                "key_id": "22222222-2222-2222-2222-222222222222",
+            }
+            r = client.post(
+                "/v1/internal/api_keys/resolve",
+                json={"token": "sk_abcdefghijklfffffffffff", "purpose": "mcp"},
+                headers={"X-Objectified-Internal-Secret": "ok-secret"},
+            )
+            assert r.status_code == 200
+            body = r.json()
+            assert body["valid"] is True
+            assert body["key_id"] == "22222222-2222-2222-2222-222222222222"
+            mdb.resolve_api_key_token.assert_called_once()
+
+
+def test_revoked_broadcast_requires_secret():
+    with patch.object(settings, "internal_api_secret", "sec"):
+        with patch("app.internal_api_keys_routes.publish_mcp_key_revoked") as pub:
+            r = client.post(
+                "/v1/internal/api_keys/revoked-broadcast",
+                json={"key_id": "33333333-3333-3333-3333-333333333333"},
+                headers={"X-Objectified-Internal-Secret": "sec"},
+            )
+            assert r.status_code == 200
+            assert r.json()["ok"] is True
+            pub.assert_called_once_with("33333333-3333-3333-3333-333333333333")

--- a/objectified-rest/uv.lock
+++ b/objectified-rest/uv.lock
@@ -35,6 +35,15 @@ wheels = [
 ]
 
 [[package]]
+name = "async-timeout"
+version = "5.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a5/ae/136395dfbfe00dfc94da3f3e136d0b13f394cba8f4841120e34226265780/async_timeout-5.0.1.tar.gz", hash = "sha256:d9321a7a3d5a6a5e187e824d2fa0793ce379a202935782d555d6e9d2735677d3", size = 9274, upload-time = "2024-11-06T16:41:39.6Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/ba/e2081de779ca30d473f21f5b30e0e737c438205440784c7dfc81efc2b029/async_timeout-5.0.1-py3-none-any.whl", hash = "sha256:39e3809566ff85354557ec2398b55e096c8364bacac9405a7a1fa429e77fe76c", size = 6233, upload-time = "2024-11-06T16:41:37.9Z" },
+]
+
+[[package]]
 name = "bcrypt"
 version = "4.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -514,7 +523,7 @@ wheels = [
 
 [[package]]
 name = "objectified-rest"
-version = "1.0.49"
+version = "1.0.50"
 source = { editable = "." }
 dependencies = [
     { name = "bcrypt" },
@@ -531,6 +540,7 @@ dependencies = [
     { name = "pyjwt" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
+    { name = "redis" },
     { name = "uvicorn", extra = ["standard"] },
 ]
 
@@ -569,6 +579,7 @@ requires-dist = [
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23.0" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "pyyaml", specifier = ">=6.0.2" },
+    { name = "redis", specifier = ">=5.0.0" },
     { name = "requests", marker = "extra == 'dev'", specifier = ">=2.31.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.31.0" },
 ]
@@ -908,6 +919,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "redis"
+version = "7.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "async-timeout", marker = "python_full_version < '3.11.3'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7b/7f/3759b1d0d72b7c92f0d70ffd9dc962b7b7b5ee74e135f9d7d8ab06b8a318/redis-7.4.0.tar.gz", hash = "sha256:64a6ea7bf567ad43c964d2c30d82853f8df927c5c9017766c55a1d1ed95d18ad", size = 4943913, upload-time = "2026-03-24T09:14:37.53Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/3a/95deec7db1eb53979973ebd156f3369a72732208d1391cd2e5d127062a32/redis-7.4.0-py3-none-any.whl", hash = "sha256:a9c74a5c893a5ef8455a5adb793a31bb70feb821c86eccb62eebef5a19c429ec", size = 409772, upload-time = "2026-03-24T09:14:35.968Z" },
 ]
 
 [[package]]

--- a/objectified-ui/lib/db/helper.ts
+++ b/objectified-ui/lib/db/helper.ts
@@ -2507,6 +2507,7 @@ export async function validateApiKey(apiKey: string) {
        WHERE ak.key_prefix = $1 
        AND ak.deleted_at IS NULL 
        AND ak.enabled = true
+       AND (COALESCE(ak.purpose, 'rest') = 'rest' OR COALESCE(ak.purpose, 'rest') = 'both')
        AND t.deleted_at IS NULL
        AND t.enabled = true`,
       [keyPrefix]

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -7,6 +7,7 @@ We continue to improve the platform based on your feedback with improvements and
 ## MCP (preview)
 - New `objectified-mcp` workspace package bootstraps the MCP server with stdio and the `mcp.search` / `mcp.describe` / `mcp.execute` tools.
 - MCP-1.2: Streamable HTTP transport at `/mcp` (`--transport http`, port from `OBJECTIFIED_MCP_PORT`) alongside stdio; HTTP responses use `Cache-Control: no-store`.
+- MCP-1.3: MCP sessions authenticate via API keys (`Authorization: Bearer …` on HTTP, `OBJECTIFIED_MCP_KEY` on stdio), resolved through `objectified-rest` with optional Redis `mcp.key.revoked` cache eviction; database adds key `purpose` / `scopes` for REST vs MCP separation.
 
 ## Importing
 - Race condition fixed in 3.0.1 specification imports

--- a/yarn.lock
+++ b/yarn.lock
@@ -3436,6 +3436,59 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@redis/bloom@npm:5.12.1":
+  version: 5.12.1
+  resolution: "@redis/bloom@npm:5.12.1"
+  peerDependencies:
+    "@redis/client": ^5.12.1
+  checksum: 10c0/b267b1a80568beb188d89a9f2f07db16c88e4bfd2258873126d13b7ed722616dbb21fffdab0797d54a8547845fe3e4c5dc212d1af94f22a21c2a2a12bae71976
+  languageName: node
+  linkType: hard
+
+"@redis/client@npm:5.12.1":
+  version: 5.12.1
+  resolution: "@redis/client@npm:5.12.1"
+  dependencies:
+    cluster-key-slot: "npm:1.1.2"
+  peerDependencies:
+    "@node-rs/xxhash": ^1.1.0
+    "@opentelemetry/api": ">=1 <2"
+  peerDependenciesMeta:
+    "@node-rs/xxhash":
+      optional: true
+    "@opentelemetry/api":
+      optional: true
+  checksum: 10c0/f475aa936b7cf73c3d2166862377d3502f16deaf5423d31f6899f6387440195aa2524c74d1df26da591a61b4ac0122a1e1f8d783b770e7630c5f7444445c41b0
+  languageName: node
+  linkType: hard
+
+"@redis/json@npm:5.12.1":
+  version: 5.12.1
+  resolution: "@redis/json@npm:5.12.1"
+  peerDependencies:
+    "@redis/client": ^5.12.1
+  checksum: 10c0/c02a94e148944c47c2995bb8df61c6cde51c7a4e380e7f4832fb56ff586754e5cc788edf0a470e5eee3cf19af8ad0b85c94bc759f91c93986d14b52fa1829200
+  languageName: node
+  linkType: hard
+
+"@redis/search@npm:5.12.1":
+  version: 5.12.1
+  resolution: "@redis/search@npm:5.12.1"
+  peerDependencies:
+    "@redis/client": ^5.12.1
+  checksum: 10c0/1dfe70e173e4544ae7c8d8a172e069fbf47f525066fcd43952628f037b61137673ef2dad1454982c9508e4575ec63626f4dc3793c20eef65b61b8b195cc75289
+  languageName: node
+  linkType: hard
+
+"@redis/time-series@npm:5.12.1":
+  version: 5.12.1
+  resolution: "@redis/time-series@npm:5.12.1"
+  peerDependencies:
+    "@redis/client": ^5.12.1
+  checksum: 10c0/8d450fdaa370e3ab7bff31197bf3e5102b3cfccbd0e0997a6d17b00e51f67447c355ae2cd76268e83f9459f1a23f606286eab2e81b57fded147fae6c5438b4ca
+  languageName: node
+  linkType: hard
+
 "@rtsao/scc@npm:^1.1.0":
   version: 1.1.0
   resolution: "@rtsao/scc@npm:1.1.0"
@@ -5542,6 +5595,13 @@ __metadata:
   version: 2.1.1
   resolution: "clsx@npm:2.1.1"
   checksum: 10c0/c4c8eb865f8c82baab07e71bfa8897c73454881c4f99d6bc81585aecd7c441746c1399d08363dc096c550cceaf97bd4ce1e8854e1771e9998d9f94c4fe075839
+  languageName: node
+  linkType: hard
+
+"cluster-key-slot@npm:1.1.2":
+  version: 1.1.2
+  resolution: "cluster-key-slot@npm:1.1.2"
+  checksum: 10c0/d7d39ca28a8786e9e801eeb8c770e3c3236a566625d7299a47bb71113fb2298ce1039596acb82590e598c52dbc9b1f088c8f587803e697cb58e1867a95ff94d3
   languageName: node
   linkType: hard
 
@@ -10855,6 +10915,7 @@ __metadata:
   dependencies:
     "@modelcontextprotocol/sdk": "npm:^1.29.0"
     "@types/node": "npm:^25.6.0"
+    redis: "npm:^5.10.0"
     tsx: "npm:^4.21.0"
     typescript: "npm:^5.9.3"
     zod: "npm:^4.1.12"
@@ -11863,6 +11924,19 @@ __metadata:
     indent-string: "npm:^4.0.0"
     strip-indent: "npm:^3.0.0"
   checksum: 10c0/d64a6b5c0b50eb3ddce3ab770f866658a2b9998c678f797919ceb1b586bab9259b311407280bd80b804e2a7c7539b19238ae6a2a20c843f1a7fcff21d48c2eae
+  languageName: node
+  linkType: hard
+
+"redis@npm:^5.10.0":
+  version: 5.12.1
+  resolution: "redis@npm:5.12.1"
+  dependencies:
+    "@redis/bloom": "npm:5.12.1"
+    "@redis/client": "npm:5.12.1"
+    "@redis/json": "npm:5.12.1"
+    "@redis/search": "npm:5.12.1"
+    "@redis/time-series": "npm:5.12.1"
+  checksum: 10c0/ad80825241bced474b104279339f26207b9bb0e6f4d425061f0ccfe7935576c8d70272389c30f49a77bd06fe8e791a09756dbb9280099f358ce63c79efe0b99e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
Implements **MCP-1.3** (#2824): API-key authentication for `objectified-mcp` via `objectified-rest`, plus schema support for REST vs MCP key purposes.

## What changed
- **Database** (`objectified-db/scripts/20260501-170000.sql`): `purpose`, `scopes`, `label`, `owner_user_id` on `odb.api_keys`; partial index on `purpose`.
- **REST**: `POST /v1/internal/api_keys/resolve` (secret header `X-Objectified-Internal-Secret` / env `OBJECTIFIED_INTERNAL_API_SECRET`) and `POST /v1/internal/api_keys/revoked-broadcast` (Redis channel `mcp.key.revoked`). `Database.resolve_api_key_token` implements bcrypt verification, 30s expiry skew, purpose checks, `last_used_at` coalescing (≤1/min). REST `validate_api_key` only accepts `rest` / `both`.
- **MCP**: Bearer (`Authorization: Bearer …`) or `OBJECTIFIED_MCP_KEY`; resolves via REST; in-memory cache (5 min, keyed by SHA-256 of token); optional Redis subscriber for eviction. Initialize failures use JSON-RPC **-32001** `Unauthorized` with `data.reason`. Opt-in `OBJECTIFIED_MCP_ALLOW_ANONYMOUS=1` for tests/local only.
- **UI**: `validateApiKey` aligns with REST-only keys (`COALESCE(purpose)`).
- Versions: `objectified-rest` 1.0.50, `objectified-mcp` 0.1.2, `objectified-ui` 0.11.5.

## How to test
1. Apply DB migration, set `OBJECTIFIED_INTERNAL_API_SECRET` on REST and MCP, insert or mint an API key with `purpose` `mcp` or `both`.
2. **REST**: `curl` `POST /v1/internal/api_keys/resolve` with header and JSON `{"token":"…","purpose":"mcp"}`.
3. **MCP**: Run MCP with `OBJECTIFIED_MCP_KEY` or HTTP `Authorization: Bearer …`; **initialize** should succeed for valid keys and fail with `-32001` / `reason` for revoked, expired, wrong purpose, or missing key.
4. **Redis** (optional): `PUBLISH mcp.key.revoked "{\"key_id\":\"…\"}"` and confirm a subsequent resolve re-fetches after cache fill.

## Risks / notes
- JSON-RPC **-32001** overlaps with the SDK’s `RequestTimeout` constant; this matches the issue’s required auth error code.
- Linked Accounts “Generate MCP Key” UI is MCP-8.1; keys default to `rest` until minted with `mcp`/`both`.

Closes #2824

Made with [Cursor](https://cursor.com)