### PR TITLE
Fix #2990 - MCP settings module (pydantic-settings)

### DIFF
--- a/docs/PLANNED_ROADMAP_MCP.md
+++ b/docs/PLANNED_ROADMAP_MCP.md
@@ -75,7 +75,7 @@ process or via Docker.
 | # | Issue | Title | Depends on |
 |---|-------|-------|------------|
 | 1.1 | ~~[#2989](../../issues/2989)~~ | ~~Scaffold FastMCP Python project (uv, src layout, pyproject)~~ (**completed**) | — |
-| 1.2 | [#2990](../../issues/2990) | Settings/config module (pydantic-settings, env vars) | 1.1 |
+| 1.2 | ~~[#2990](../../issues/2990)~~ | ~~Settings/config module (pydantic-settings, env vars)~~ (**completed**) | 1.1 |
 | 1.3 | [#2991](../../issues/2991) | Postgres connection pool (psycopg async) | 1.2 |
 | 1.4 | [#2992](../../issues/2992) | Structured JSON logging | 1.2 |
 | 1.5 | [#2993](../../issues/2993) | stdio transport entrypoint | 1.1–1.3 |

--- a/objectified-mcp/.env.example
+++ b/objectified-mcp/.env.example
@@ -1,0 +1,9 @@
+# Required for `objectified-mcp serve`
+OBJECTIFIED_MCP_DATABASE_URL=postgresql://user:password@localhost:5432/objectified
+OBJECTIFIED_MCP_INTERNAL_SECRET=replace-with-at-least-16-chars
+
+# Optional (defaults shown)
+# OBJECTIFIED_MCP_LOG_LEVEL=INFO
+# OBJECTIFIED_MCP_TRANSPORT=stdio
+# OBJECTIFIED_MCP_HTTP_HOST=127.0.0.1
+# OBJECTIFIED_MCP_HTTP_PORT=8765

--- a/objectified-mcp/README.md
+++ b/objectified-mcp/README.md
@@ -9,3 +9,7 @@ cd objectified-mcp
 uv sync
 uv run objectified-mcp --help
 ```
+
+## Configuration
+
+Copy [.env.example](.env.example) to `.env` and set at least **`OBJECTIFIED_MCP_DATABASE_URL`** and **`OBJECTIFIED_MCP_INTERNAL_SECRET`** (minimum 16 characters). Running **`uv run objectified-mcp serve`** loads and validates these variables immediately (stdio / HTTP transports are added in later roadmap tickets).

--- a/objectified-mcp/package.json
+++ b/objectified-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-mcp",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "description": "Yarn workspace anchor for the objectified-mcp Python package (uv + pyproject.toml).",
   "scripts": {

--- a/objectified-mcp/pyproject.toml
+++ b/objectified-mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "objectified-mcp"
-version = "0.1.0"
+version = "0.1.1"
 description = "Model Context Protocol server for Objectified (FastMCP)."
 readme = "README.md"
 requires-python = ">=3.11"
@@ -17,6 +17,8 @@ classifiers = [
 
 dependencies = [
     "fastmcp>=3.2.0",
+    "pydantic>=2.9.2",
+    "pydantic-settings>=2.5.2",
 ]
 
 [project.scripts]

--- a/objectified-mcp/src/objectified_mcp/__init__.py
+++ b/objectified-mcp/src/objectified_mcp/__init__.py
@@ -1,3 +1,3 @@
 """Objectified MCP server package."""
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"

--- a/objectified-mcp/src/objectified_mcp/cli.py
+++ b/objectified-mcp/src/objectified_mcp/cli.py
@@ -27,9 +27,15 @@ def main() -> None:
     args = parser.parse_args()
 
     if args.command == "serve":
+        from pydantic import ValidationError
+
         from objectified_mcp.settings import get_settings
 
-        get_settings()
+        try:
+            get_settings()
+        except ValidationError as exc:
+            print(f"Configuration error:\n{exc}", file=sys.stderr)
+            raise SystemExit(2)
         print(
             "Configuration loaded. MCP transports are wired in roadmap tickets 1.5 (stdio) and 1.6 (HTTP).",
             file=sys.stderr,

--- a/objectified-mcp/src/objectified_mcp/cli.py
+++ b/objectified-mcp/src/objectified_mcp/cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import sys
 
 from objectified_mcp import __version__
 
@@ -17,5 +18,22 @@ def main() -> None:
         action="version",
         version=f"%(prog)s {__version__}",
     )
-    parser.parse_args()
+    subparsers = parser.add_subparsers(dest="command")
+    subparsers.add_parser(
+        "serve",
+        help="Validate environment configuration (stdio / HTTP transports ship in later tickets).",
+    )
+
+    args = parser.parse_args()
+
+    if args.command == "serve":
+        from objectified_mcp.settings import get_settings
+
+        get_settings()
+        print(
+            "Configuration loaded. MCP transports are wired in roadmap tickets 1.5 (stdio) and 1.6 (HTTP).",
+            file=sys.stderr,
+        )
+        raise SystemExit(0)
+
     parser.print_help()

--- a/objectified-mcp/src/objectified_mcp/settings.py
+++ b/objectified-mcp/src/objectified_mcp/settings.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from functools import lru_cache
 from typing import Literal
 
-from pydantic import Field, SecretStr, field_validator
+from pydantic import Field, PostgresDsn, SecretStr, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 LogLevel = Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
@@ -23,9 +23,8 @@ class Settings(BaseSettings):
         extra="ignore",
     )
 
-    database_url: str = Field(
+    database_url: PostgresDsn = Field(
         ...,
-        min_length=1,
         description="PostgreSQL connection URI for the Objectified database.",
     )
     internal_secret: SecretStr = Field(

--- a/objectified-mcp/src/objectified_mcp/settings.py
+++ b/objectified-mcp/src/objectified_mcp/settings.py
@@ -1,0 +1,53 @@
+"""Environment-backed settings for the MCP server process."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Literal
+
+from pydantic import Field, SecretStr, field_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+LogLevel = Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
+Transport = Literal["stdio", "http"]
+
+
+class Settings(BaseSettings):
+    """Configuration loaded when ``objectified-mcp serve`` starts (fail-fast validation)."""
+
+    model_config = SettingsConfigDict(
+        env_prefix="OBJECTIFIED_MCP_",
+        env_file=".env",
+        env_file_encoding="utf-8",
+        case_sensitive=False,
+        extra="ignore",
+    )
+
+    database_url: str = Field(
+        ...,
+        min_length=1,
+        description="PostgreSQL connection URI for the Objectified database.",
+    )
+    internal_secret: SecretStr = Field(
+        ...,
+        min_length=16,
+        description="Secret material for internal signing (e.g. HMAC, session derivation).",
+    )
+    log_level: LogLevel = Field(default="INFO")
+    transport: Transport = Field(default="stdio")
+    http_host: str = Field(default="127.0.0.1", min_length=1)
+    http_port: int = Field(default=8765, ge=1, le=65535)
+
+    @field_validator("log_level", mode="before")
+    @classmethod
+    def normalize_log_level(cls, value: object) -> str:
+        if isinstance(value, str):
+            return value.upper()
+        return str(value).upper()
+
+
+@lru_cache
+def get_settings() -> Settings:
+    """Return process-wide settings (parsed once per interpreter)."""
+    # Required fields are populated from the environment by pydantic-settings.
+    return Settings()  # type: ignore[call-arg]

--- a/objectified-mcp/tests/test_cli.py
+++ b/objectified-mcp/tests/test_cli.py
@@ -24,8 +24,7 @@ def test_module_help_prints_usage() -> None:
 def test_console_script_entrypoint_prints_usage() -> None:
     """Validates the [project.scripts] entrypoint (cli.main) directly."""
     result = subprocess.run(
-        [sys.executable, "-c",
-         "from objectified_mcp.cli import main; main()"],
+        [sys.executable, "-c", "from objectified_mcp.cli import main; main()"],
         capture_output=True,
         text=True,
         cwd=_ROOT,
@@ -38,7 +37,7 @@ def test_console_script_entrypoint_prints_usage() -> None:
 def test_package_version_matches_pyproject() -> None:
     from objectified_mcp import __version__
 
-    assert __version__ == "0.1.0"
+    assert __version__ == "0.1.1"
 
 
 def test_server_module_exposes_mcp() -> None:

--- a/objectified-mcp/tests/test_settings.py
+++ b/objectified-mcp/tests/test_settings.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -26,8 +27,8 @@ def test_settings_loads_required_and_optional_from_env(monkeypatch: pytest.Monke
 
     from objectified_mcp.settings import Settings
 
-    s = Settings()
-    assert s.database_url == "postgresql://localhost/db"
+    s = Settings(_env_file=None)
+    assert str(s.database_url) == "postgresql://localhost/db"
     assert s.internal_secret.get_secret_value() == "x" * 16
     assert s.log_level == "DEBUG"
     assert s.transport == "stdio"
@@ -44,7 +45,7 @@ def test_settings_http_transport_overrides(monkeypatch: pytest.MonkeyPatch) -> N
 
     from objectified_mcp.settings import Settings
 
-    s = Settings()
+    s = Settings(_env_file=None)
     assert s.transport == "http"
     assert s.http_host == "0.0.0.0"
     assert s.http_port == 9000
@@ -59,7 +60,7 @@ def test_settings_missing_database_url_raises(monkeypatch: pytest.MonkeyPatch) -
     monkeypatch.setenv("OBJECTIFIED_MCP_INTERNAL_SECRET", "z" * 16)
 
     with pytest.raises(ValidationError) as exc:
-        Settings()
+        Settings(_env_file=None)
     errs = exc.value.errors()
     assert any(e["loc"] == ("database_url",) for e in errs)
 
@@ -73,26 +74,27 @@ def test_settings_short_internal_secret_raises(monkeypatch: pytest.MonkeyPatch) 
     monkeypatch.setenv("OBJECTIFIED_MCP_INTERNAL_SECRET", "short")
 
     with pytest.raises(ValidationError) as exc:
-        Settings()
+        Settings(_env_file=None)
     assert any(e["loc"] == ("internal_secret",) for e in exc.value.errors())
 
 
 def test_cli_serve_exits_zero_with_valid_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("OBJECTIFIED_MCP_TRANSPORT", raising=False)
     env = {
         **os.environ,
         "PYTHONPATH": str(_ROOT / "src"),
         "OBJECTIFIED_MCP_DATABASE_URL": "postgresql://localhost/db",
         "OBJECTIFIED_MCP_INTERNAL_SECRET": "s" * 16,
     }
-    monkeypatch.delenv("OBJECTIFIED_MCP_TRANSPORT", raising=False)
-    result = subprocess.run(
-        [sys.executable, "-m", "objectified_mcp", "serve"],
-        capture_output=True,
-        text=True,
-        check=False,
-        cwd=_ROOT,
-        env=env,
-    )
+    with tempfile.TemporaryDirectory() as tmpdir:
+        result = subprocess.run(
+            [sys.executable, "-m", "objectified_mcp", "serve"],
+            capture_output=True,
+            text=True,
+            check=False,
+            cwd=tmpdir,
+            env=env,
+        )
     assert result.returncode == 0
     assert "Configuration loaded" in result.stderr
 
@@ -102,14 +104,15 @@ def test_cli_serve_fails_fast_without_database_url(monkeypatch: pytest.MonkeyPat
     env["PYTHONPATH"] = str(_ROOT / "src")
     env["OBJECTIFIED_MCP_INTERNAL_SECRET"] = "t" * 16
 
-    result = subprocess.run(
-        [sys.executable, "-m", "objectified_mcp", "serve"],
-        capture_output=True,
-        text=True,
-        check=False,
-        cwd=_ROOT,
-        env=env,
-    )
+    with tempfile.TemporaryDirectory() as tmpdir:
+        result = subprocess.run(
+            [sys.executable, "-m", "objectified_mcp", "serve"],
+            capture_output=True,
+            text=True,
+            check=False,
+            cwd=tmpdir,
+            env=env,
+        )
     assert result.returncode != 0
     combined = result.stderr + result.stdout
     assert "database_url" in combined.lower() or "DATABASE_URL" in combined

--- a/objectified-mcp/tests/test_settings.py
+++ b/objectified-mcp/tests/test_settings.py
@@ -86,6 +86,7 @@ def test_cli_serve_exits_zero_with_valid_env(monkeypatch: pytest.MonkeyPatch) ->
         "OBJECTIFIED_MCP_DATABASE_URL": "postgresql://localhost/db",
         "OBJECTIFIED_MCP_INTERNAL_SECRET": "s" * 16,
     }
+    env.pop("OBJECTIFIED_MCP_TRANSPORT", None)
     with tempfile.TemporaryDirectory() as tmpdir:
         result = subprocess.run(
             [sys.executable, "-m", "objectified_mcp", "serve"],

--- a/objectified-mcp/tests/test_settings.py
+++ b/objectified-mcp/tests/test_settings.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture(autouse=True)
+def clear_settings_cache() -> None:
+    from objectified_mcp.settings import get_settings
+
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+def test_settings_loads_required_and_optional_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OBJECTIFIED_MCP_DATABASE_URL", "postgresql://localhost/db")
+    monkeypatch.setenv("OBJECTIFIED_MCP_INTERNAL_SECRET", "x" * 16)
+    monkeypatch.setenv("OBJECTIFIED_MCP_LOG_LEVEL", "debug")
+
+    from objectified_mcp.settings import Settings
+
+    s = Settings()
+    assert s.database_url == "postgresql://localhost/db"
+    assert s.internal_secret.get_secret_value() == "x" * 16
+    assert s.log_level == "DEBUG"
+    assert s.transport == "stdio"
+    assert s.http_host == "127.0.0.1"
+    assert s.http_port == 8765
+
+
+def test_settings_http_transport_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OBJECTIFIED_MCP_DATABASE_URL", "postgresql://localhost/db")
+    monkeypatch.setenv("OBJECTIFIED_MCP_INTERNAL_SECRET", "y" * 16)
+    monkeypatch.setenv("OBJECTIFIED_MCP_TRANSPORT", "http")
+    monkeypatch.setenv("OBJECTIFIED_MCP_HTTP_HOST", "0.0.0.0")
+    monkeypatch.setenv("OBJECTIFIED_MCP_HTTP_PORT", "9000")
+
+    from objectified_mcp.settings import Settings
+
+    s = Settings()
+    assert s.transport == "http"
+    assert s.http_host == "0.0.0.0"
+    assert s.http_port == 9000
+
+
+def test_settings_missing_database_url_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    from pydantic import ValidationError
+
+    from objectified_mcp.settings import Settings
+
+    monkeypatch.delenv("OBJECTIFIED_MCP_DATABASE_URL", raising=False)
+    monkeypatch.setenv("OBJECTIFIED_MCP_INTERNAL_SECRET", "z" * 16)
+
+    with pytest.raises(ValidationError) as exc:
+        Settings()
+    errs = exc.value.errors()
+    assert any(e["loc"] == ("database_url",) for e in errs)
+
+
+def test_settings_short_internal_secret_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    from pydantic import ValidationError
+
+    from objectified_mcp.settings import Settings
+
+    monkeypatch.setenv("OBJECTIFIED_MCP_DATABASE_URL", "postgresql://localhost/db")
+    monkeypatch.setenv("OBJECTIFIED_MCP_INTERNAL_SECRET", "short")
+
+    with pytest.raises(ValidationError) as exc:
+        Settings()
+    assert any(e["loc"] == ("internal_secret",) for e in exc.value.errors())
+
+
+def test_cli_serve_exits_zero_with_valid_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    env = {
+        **os.environ,
+        "PYTHONPATH": str(_ROOT / "src"),
+        "OBJECTIFIED_MCP_DATABASE_URL": "postgresql://localhost/db",
+        "OBJECTIFIED_MCP_INTERNAL_SECRET": "s" * 16,
+    }
+    monkeypatch.delenv("OBJECTIFIED_MCP_TRANSPORT", raising=False)
+    result = subprocess.run(
+        [sys.executable, "-m", "objectified_mcp", "serve"],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=_ROOT,
+        env=env,
+    )
+    assert result.returncode == 0
+    assert "Configuration loaded" in result.stderr
+
+
+def test_cli_serve_fails_fast_without_database_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    env = {k: v for k, v in os.environ.items() if not k.startswith("OBJECTIFIED_MCP_")}
+    env["PYTHONPATH"] = str(_ROOT / "src")
+    env["OBJECTIFIED_MCP_INTERNAL_SECRET"] = "t" * 16
+
+    result = subprocess.run(
+        [sys.executable, "-m", "objectified_mcp", "serve"],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=_ROOT,
+        env=env,
+    )
+    assert result.returncode != 0
+    combined = result.stderr + result.stdout
+    assert "database_url" in combined.lower() or "DATABASE_URL" in combined

--- a/objectified-mcp/uv.lock
+++ b/objectified-mcp/uv.lock
@@ -772,10 +772,12 @@ wheels = [
 
 [[package]]
 name = "objectified-mcp"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
 ]
 
 [package.dev-dependencies]
@@ -786,7 +788,11 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "fastmcp", specifier = ">=3.2.0" }]
+requires-dist = [
+    { name = "fastmcp", specifier = ">=3.2.0" },
+    { name = "pydantic", specifier = ">=2.9.2" },
+    { name = "pydantic-settings", specifier = ">=2.5.2" },
+]
 
 [package.metadata.requires-dev]
 dev = [

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -1,4 +1,4 @@
-# Objectified 05-2026
+# Objectified 06-2026
 
 We continue to improve the platform based on your feedback with improvements and new features!
 

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -7,6 +7,7 @@ We continue to improve the platform based on your feedback with improvements and
 ## MCP
 
 - New `objectified-mcp` Python package (FastMCP, uv, ruff, mypy) as the foundation for the Model Context Protocol server.
+- MCP server loads typed configuration from the environment via pydantic-settings (`objectified-mcp serve`); see `objectified-mcp/.env.example`.
 
 ## Importing
 - Race condition fixed in 3.0.1 specification imports


### PR DESCRIPTION
## Summary

Adds typed MCP configuration via **pydantic-settings**: PostgreSQL DSN, internal secret (minimum 16 characters), log level, transport (`stdio` / `http`), and HTTP host/port. Settings load when running `objectified-mcp serve`; missing required environment variables produce pydantic validation errors. `--help` and `--version` do not require env vars.

Also adds `objectified-mcp/.env.example`, README configuration section, marks MCP roadmap ticket 1.2 complete, and notes the change in WHATS_NEW. Patched `objectified-mcp` to 0.1.1 and `objectified-ui` to 0.11.5 (WHATS_NEW edit).

## How to test

1. **`cd objectified-mcp && uv sync`**
2. **Copy `.env.example` to `.env`** and set `OBJECTIFIED_MCP_DATABASE_URL` and `OBJECTIFIED_MCP_INTERNAL_SECRET` (≥16 chars).
3. Run **`uv run objectified-mcp serve`** — expect exit code 0 and a stderr line that configuration loaded.
4. Remove **`OBJECTIFIED_MCP_DATABASE_URL`** from the environment and run **`serve`** again — expect non-zero exit and validation output mentioning the database URL field.

## Risk / notes

- New runtime dependencies: `pydantic`, `pydantic-settings`.
- Root `yarn test` still hits a pre-existing failure in `objectified-ui` `tests/llm-streaming.test.ts` (Jest `prettyFormat`) on `main` as well; **`yarn workspace objectified-mcp test`** passes.

Closes KenSuenobu/objectified#2990

Made with [Cursor](https://cursor.com)