### PR TITLE
Fix #2992 - MCP structured JSON logging

### DIFF
--- a/docs/PLANNED_ROADMAP_MCP.md
+++ b/docs/PLANNED_ROADMAP_MCP.md
@@ -77,7 +77,7 @@ process or via Docker.
 | 1.1 | ~~[#2989](../../issues/2989)~~ | ~~Scaffold FastMCP Python project (uv, src layout, pyproject)~~ (**completed**) | — |
 | 1.2 | ~~[#2990](../../issues/2990)~~ | ~~Settings/config module (pydantic-settings, env vars)~~ (**completed**) | 1.1 |
 | 1.3 | ~~[#2991](../../issues/2991)~~ | ~~Postgres connection pool (psycopg async)~~ (**completed**) | 1.2 |
-| 1.4 | [#2992](../../issues/2992) | Structured JSON logging | 1.2 |
+| 1.4 | ~~[#2992](../../issues/2992)~~ | ~~Structured JSON logging~~ (**completed**) | 1.2 |
 | 1.5 | [#2993](../../issues/2993) | stdio transport entrypoint | 1.1–1.3 |
 | 1.6 | [#2994](../../issues/2994) | Streamable HTTP transport entrypoint | 1.1–1.3 |
 | 1.7 | [#2995](../../issues/2995) | `ping` tool (service + DB health) | 1.3 |

--- a/objectified-mcp/README.md
+++ b/objectified-mcp/README.md
@@ -15,3 +15,7 @@ uv run objectified-mcp --help
 Copy [.env.example](.env.example) to `.env` and set at least **`OBJECTIFIED_MCP_DATABASE_URL`** and **`OBJECTIFIED_MCP_INTERNAL_SECRET`** (minimum 16 characters). Running **`uv run objectified-mcp serve`** loads and validates these variables immediately (stdio / HTTP transports are added in later roadmap tickets).
 
 When the MCP runtime starts (stdio / HTTP entrypoints), it opens a shared **`psycopg_pool.AsyncConnectionPool`**, runs **`SELECT 1`** against it, exposes the pool on FastMCP lifespan context under **`db_pool`**, and **`await pool.close()`** in **`finally`** so shutdown (including task cancellation) tears down connections cleanly. Pool sizing is controlled with **`OBJECTIFIED_MCP_DATABASE_POOL_MIN_SIZE`**, **`OBJECTIFIED_MCP_DATABASE_POOL_MAX_SIZE`**, and **`OBJECTIFIED_MCP_DATABASE_POOL_TIMEOUT`** (seconds to wait for a connection).
+
+## Logging
+
+Logs go to **stderr** as **JSON** (via **structlog**), one object per line. Each line includes **`timestamp`** (UTC ISO-8601), **`level`**, **`event`**, **`request_id`**, and **`tool_name`** (use **`structlog.contextvars.bound_contextvars`** around MCP tool handlers so tool calls carry the RPC id and tool name). Root verbosity is set with **`OBJECTIFIED_MCP_LOG_LEVEL`** (`DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`).

--- a/objectified-mcp/package.json
+++ b/objectified-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-mcp",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": true,
   "description": "Yarn workspace anchor for the objectified-mcp Python package (uv + pyproject.toml).",
   "scripts": {

--- a/objectified-mcp/pyproject.toml
+++ b/objectified-mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "objectified-mcp"
-version = "0.1.2"
+version = "0.1.3"
 description = "Model Context Protocol server for Objectified (FastMCP)."
 readme = "README.md"
 requires-python = ">=3.11"
@@ -17,6 +17,7 @@ classifiers = [
 
 dependencies = [
     "fastmcp>=3.2.0",
+    "structlog>=24.4.0",
     "psycopg[binary,pool]>=3.2.0",
     "pydantic>=2.9.2",
     "pydantic-settings>=2.5.2",

--- a/objectified-mcp/src/objectified_mcp/__init__.py
+++ b/objectified-mcp/src/objectified_mcp/__init__.py
@@ -1,3 +1,3 @@
 """Objectified MCP server package."""
 
-__version__ = "0.1.2"
+__version__ = "0.1.3"

--- a/objectified-mcp/src/objectified_mcp/cli.py
+++ b/objectified-mcp/src/objectified_mcp/cli.py
@@ -27,19 +27,25 @@ def main() -> None:
     args = parser.parse_args()
 
     if args.command == "serve":
+        import structlog
         from pydantic import ValidationError
+        from structlog.contextvars import bound_contextvars
 
+        from objectified_mcp.logging_config import configure_logging
         from objectified_mcp.settings import get_settings
 
         try:
-            get_settings()
+            settings = get_settings()
         except ValidationError as exc:
             print(f"Configuration error:\n{exc}", file=sys.stderr)
             raise SystemExit(2)
-        print(
-            "Configuration loaded. MCP transports are wired in roadmap tickets 1.5 (stdio) and 1.6 (HTTP).",
-            file=sys.stderr,
-        )
+        configure_logging(settings)
+        log = structlog.get_logger(__name__)
+        with bound_contextvars(request_id="cli-serve", tool_name=None):
+            log.info(
+                "mcp_configuration_validated",
+                detail="MCP transports are wired in roadmap tickets 1.5 (stdio) and 1.6 (HTTP).",
+            )
         raise SystemExit(0)
 
     parser.print_help()

--- a/objectified-mcp/src/objectified_mcp/logging_config.py
+++ b/objectified-mcp/src/objectified_mcp/logging_config.py
@@ -23,6 +23,8 @@ def reset_logging_state_for_tests() -> None:
     root = logging.getLogger()
     for h in root.handlers[:]:
         root.removeHandler(h)
+        h.close()
+    root.setLevel(logging.WARNING)
     clear_contextvars()
     _CONFIGURED = False
 
@@ -78,7 +80,6 @@ def configure_logging(settings: Settings, *, force: bool = False) -> None:
     global _CONFIGURED
     if _CONFIGURED and not force:
         return
-    _CONFIGURED = True
 
     level: Final[int] = getattr(logging, settings.log_level)
 
@@ -105,3 +106,4 @@ def configure_logging(settings: Settings, *, force: bool = False) -> None:
     handler.setFormatter(formatter)
     root.addHandler(handler)
     root.setLevel(level)
+    _CONFIGURED = True

--- a/objectified-mcp/src/objectified_mcp/logging_config.py
+++ b/objectified-mcp/src/objectified_mcp/logging_config.py
@@ -1,0 +1,107 @@
+"""Structured JSON logging via structlog (stdlib bridge for library loggers)."""
+
+from __future__ import annotations
+
+import logging
+import sys
+import uuid
+from typing import Any, Final, MutableMapping
+
+import structlog
+from structlog.contextvars import bind_contextvars, clear_contextvars
+from structlog.typing import Processor
+
+from objectified_mcp.settings import Settings
+
+_CONFIGURED: bool = False
+
+
+def reset_logging_state_for_tests() -> None:
+    """Undo `configure_logging` (pytest only)."""
+    global _CONFIGURED
+    structlog.reset_defaults()
+    root = logging.getLogger()
+    for h in root.handlers[:]:
+        root.removeHandler(h)
+    clear_contextvars()
+    _CONFIGURED = False
+
+
+def _ensure_observability_keys(
+    _logger: Any,
+    _method_name: str,
+    event_dict: MutableMapping[str, Any],
+) -> MutableMapping[str, Any]:
+    event_dict.setdefault("request_id", None)
+    event_dict.setdefault("tool_name", None)
+    return event_dict
+
+
+def _timestamper() -> Processor:
+    return structlog.processors.TimeStamper(fmt="iso", utc=True, key="timestamp")
+
+
+def _structlog_processor_chain(*, wrap_for_formatter: bool) -> list[Processor]:
+    chain: list[Processor] = [
+        structlog.contextvars.merge_contextvars,
+        _ensure_observability_keys,
+        structlog.stdlib.filter_by_level,
+        structlog.stdlib.add_logger_name,
+        structlog.stdlib.add_log_level,
+        structlog.stdlib.PositionalArgumentsFormatter(),
+        _timestamper(),
+        structlog.processors.StackInfoRenderer(),
+        structlog.processors.format_exc_info,
+        structlog.processors.UnicodeDecoder(),
+    ]
+    if wrap_for_formatter:
+        chain.append(structlog.stdlib.ProcessorFormatter.wrap_for_formatter)
+    return chain
+
+
+def _foreign_pre_chain() -> list[Processor]:
+    return [
+        structlog.contextvars.merge_contextvars,
+        _ensure_observability_keys,
+        structlog.stdlib.add_log_level,
+        structlog.stdlib.add_logger_name,
+        structlog.stdlib.ExtraAdder(),
+        _timestamper(),
+        structlog.processors.StackInfoRenderer(),
+        structlog.processors.format_exc_info,
+        structlog.processors.UnicodeDecoder(),
+    ]
+
+
+def configure_logging(settings: Settings, *, force: bool = False) -> None:
+    """Emit JSON lines to stderr with timestamp, level, event, request_id, tool_name."""
+    global _CONFIGURED
+    if _CONFIGURED and not force:
+        return
+    _CONFIGURED = True
+
+    level: Final[int] = getattr(logging, settings.log_level)
+
+    clear_contextvars()
+    bind_contextvars(request_id=f"process-{uuid.uuid4()}", tool_name=None)
+
+    structlog.configure(
+        processors=_structlog_processor_chain(wrap_for_formatter=True),
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        wrapper_class=structlog.stdlib.BoundLogger,
+        cache_logger_on_first_use=True,
+    )
+
+    formatter = structlog.stdlib.ProcessorFormatter(
+        processor=structlog.processors.JSONRenderer(),
+        foreign_pre_chain=_foreign_pre_chain(),
+    )
+
+    root = logging.getLogger()
+    for h in root.handlers[:]:
+        root.removeHandler(h)
+
+    handler = logging.StreamHandler(sys.stderr)
+    handler.setFormatter(formatter)
+    root.addHandler(handler)
+    root.setLevel(level)

--- a/objectified-mcp/src/objectified_mcp/server.py
+++ b/objectified-mcp/src/objectified_mcp/server.py
@@ -2,26 +2,37 @@
 
 from __future__ import annotations
 
+import uuid
 from typing import Any
 
+import structlog
 from fastmcp import FastMCP
 from fastmcp.server.lifespan import lifespan
+from structlog.contextvars import bound_contextvars
 
 from objectified_mcp.database_pool import MCP_DB_POOL_KEY, create_async_pool, ping_pool
+from objectified_mcp.logging_config import configure_logging
 from objectified_mcp.settings import get_settings
+
+_log = structlog.get_logger(__name__)
 
 
 @lifespan
 async def database_lifespan(server: Any) -> Any:
     """Open the shared async pool at MCP startup; close it on shutdown (including cancellation)."""
     settings = get_settings()
-    pool = create_async_pool(settings, open=False)
-    try:
-        await pool.open()
-        await ping_pool(pool)
-        yield {MCP_DB_POOL_KEY: pool}
-    finally:
-        await pool.close()
+    configure_logging(settings)
+    with bound_contextvars(request_id=str(uuid.uuid4()), tool_name="lifespan.database"):
+        pool = create_async_pool(settings, open=False)
+        try:
+            _log.info("database_pool_opening")
+            await pool.open()
+            await ping_pool(pool)
+            _log.info("database_pool_ready")
+            yield {MCP_DB_POOL_KEY: pool}
+        finally:
+            _log.info("database_pool_closing")
+            await pool.close()
 
 
 mcp = FastMCP("Objectified", lifespan=database_lifespan)

--- a/objectified-mcp/tests/conftest.py
+++ b/objectified-mcp/tests/conftest.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def reset_mcp_logging_state() -> None:
+    from objectified_mcp.logging_config import reset_logging_state_for_tests
+
+    reset_logging_state_for_tests()
+    yield
+    reset_logging_state_for_tests()

--- a/objectified-mcp/tests/test_cli.py
+++ b/objectified-mcp/tests/test_cli.py
@@ -37,7 +37,7 @@ def test_console_script_entrypoint_prints_usage() -> None:
 def test_package_version_matches_pyproject() -> None:
     from objectified_mcp import __version__
 
-    assert __version__ == "0.1.2"
+    assert __version__ == "0.1.3"
 
 
 def test_server_module_exposes_mcp() -> None:

--- a/objectified-mcp/tests/test_logging.py
+++ b/objectified-mcp/tests/test_logging.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import json
+import logging
+
+import pytest
+import structlog
+
+from objectified_mcp.logging_config import configure_logging, reset_logging_state_for_tests
+from objectified_mcp.settings import Settings
+
+
+def _minimal_settings(**overrides: object) -> Settings:
+    data = {
+        "database_url": "postgresql://localhost/db",
+        "internal_secret": "x" * 16,
+        "log_level": "INFO",
+    }
+    data.update(overrides)
+    return Settings(_env_file=None, **data)
+
+
+def test_json_log_line_contains_required_fields(capsys: pytest.CaptureFixture[str]) -> None:
+    reset_logging_state_for_tests()
+    configure_logging(_minimal_settings(), force=True)
+    log = structlog.get_logger("test.logger")
+    log.info("hello_world", extra_field=42)
+    err = capsys.readouterr().err.strip()
+    payload = json.loads(err)
+    assert payload["event"] == "hello_world"
+    assert payload["level"] == "info"
+    assert "timestamp" in payload
+    assert "request_id" in payload
+    assert "tool_name" in payload
+    assert payload["extra_field"] == 42
+
+
+def test_bound_contextvars_override_request_and_tool(capsys: pytest.CaptureFixture[str]) -> None:
+    reset_logging_state_for_tests()
+    configure_logging(_minimal_settings(), force=True)
+    from structlog.contextvars import bound_contextvars
+
+    log = structlog.get_logger("ctx.test")
+    with bound_contextvars(request_id="rpc-99", tool_name="spec.list"):
+        log.warning("inside_tool")
+    err = capsys.readouterr().err.strip()
+    payload = json.loads(err)
+    assert payload["request_id"] == "rpc-99"
+    assert payload["tool_name"] == "spec.list"
+    assert payload["event"] == "inside_tool"
+    assert payload["level"] == "warning"
+
+
+def test_stdlib_logging_foreign_chain_is_json(capsys: pytest.CaptureFixture[str]) -> None:
+    reset_logging_state_for_tests()
+    configure_logging(_minimal_settings(log_level="DEBUG"), force=True)
+    logging.getLogger("foreign.lib").info("stdlib_message")
+    err = capsys.readouterr().err.strip()
+    payload = json.loads(err)
+    assert payload["level"] == "info"
+    assert "timestamp" in payload
+    assert "request_id" in payload
+    assert "tool_name" in payload
+    assert "stdlib_message" in payload["event"]
+
+
+def test_log_level_respects_settings(capsys: pytest.CaptureFixture[str]) -> None:
+    reset_logging_state_for_tests()
+    configure_logging(_minimal_settings(log_level="WARNING"), force=True)
+    log = structlog.get_logger("lvl.test")
+    log.info("should_not_appear")
+    assert capsys.readouterr().err.strip() == ""
+    log.error("should_appear")
+    payload = json.loads(capsys.readouterr().err.strip())
+    assert payload["event"] == "should_appear"
+    assert payload["level"] == "error"
+
+
+def test_configure_logging_is_idempotent_by_default(capsys: pytest.CaptureFixture[str]) -> None:
+    reset_logging_state_for_tests()
+    s = _minimal_settings(log_level="WARNING")
+    configure_logging(s, force=True)
+    configure_logging(_minimal_settings(log_level="DEBUG"))
+    log = structlog.get_logger("idempotent")
+    log.info("still_filtered")
+    assert capsys.readouterr().err.strip() == ""

--- a/objectified-mcp/tests/test_settings.py
+++ b/objectified-mcp/tests/test_settings.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 import subprocess
 import sys
@@ -127,7 +128,13 @@ def test_cli_serve_exits_zero_with_valid_env(monkeypatch: pytest.MonkeyPatch) ->
             env=env,
         )
     assert result.returncode == 0
-    assert "Configuration loaded" in result.stderr
+    line = result.stderr.strip().splitlines()[-1]
+    payload = json.loads(line)
+    assert payload["event"] == "mcp_configuration_validated"
+    assert payload["request_id"] == "cli-serve"
+    assert "tool_name" in payload
+    assert "timestamp" in payload
+    assert payload["level"] == "info"
 
 
 def test_cli_serve_fails_fast_without_database_url(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/objectified-mcp/uv.lock
+++ b/objectified-mcp/uv.lock
@@ -772,13 +772,14 @@ wheels = [
 
 [[package]]
 name = "objectified-mcp"
-version = "0.1.2"
+version = "0.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },
     { name = "psycopg", extra = ["binary", "pool"] },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "structlog" },
 ]
 
 [package.dev-dependencies]
@@ -794,6 +795,7 @@ requires-dist = [
     { name = "psycopg", extras = ["binary", "pool"], specifier = ">=3.2.0" },
     { name = "pydantic", specifier = ">=2.9.2" },
     { name = "pydantic-settings", specifier = ">=2.5.2" },
+    { name = "structlog", specifier = ">=24.4.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -1486,6 +1488,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+]
+
+[[package]]
+name = "structlog"
+version = "25.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/52/9ba0f43b686e7f3ddfeaa78ac3af750292662284b3661e91ad5494f21dbc/structlog-25.5.0.tar.gz", hash = "sha256:098522a3bebed9153d4570c6d0288abf80a031dfdb2048d59a49e9dc2190fc98", size = 1460830, upload-time = "2025-10-27T08:28:23.028Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/45/a132b9074aa18e799b891b91ad72133c98d8042c70f6240e4c5f9dabee2f/structlog-25.5.0-py3-none-any.whl", hash = "sha256:a8453e9b9e636ec59bd9e79bbd4a72f025981b3ba0f5837aebf48f02f37a7f9f", size = 72510, upload-time = "2025-10-27T08:28:21.535Z" },
 ]
 
 [[package]]

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.6",
+  "version": "0.11.7",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -9,6 +9,7 @@ We continue to improve the platform based on your feedback with improvements and
 - New `objectified-mcp` Python package (FastMCP, uv, ruff, mypy) as the foundation for the Model Context Protocol server.
 - MCP server loads typed configuration from the environment via pydantic-settings (`objectified-mcp serve`); see `objectified-mcp/.env.example`.
 - MCP runtime opens a shared async Postgres pool (psycopg 3) at startup, exposes it to tools via lifespan context, runs a health probe (`SELECT 1`), and closes the pool cleanly on shutdown.
+- MCP process logs are structured JSON on stderr (structlog): each line includes `timestamp`, `level`, `event`, `request_id`, and `tool_name`; verbosity is controlled with `OBJECTIFIED_MCP_LOG_LEVEL`.
 
 ## Importing
 - Race condition fixed in 3.0.1 specification imports


### PR DESCRIPTION
## Summary
Implements MCP-1.4 structured observability for objectified-mcp: structlog with JSON lines on stderr, shared processor chain for both structlog and stdlib loggers (ProcessorFormatter), and contextvars so every line carries timestamp, level, event, request_id, and tool_name. Log verbosity remains OBJECTIFIED_MCP_LOG_LEVEL.

## How to test
- From repo root: cd objectified-mcp && uv sync && uv run pytest (or yarn workspace objectified-mcp test).
- CLI: set required env vars, run uv run objectified-mcp serve; stderr should be one JSON object with event mcp_configuration_validated, request_id cli-serve, and tool_name present (null unless bound).
- Lifespan (when exercised): logs include tool_name lifespan.database and lifecycle events database_pool_opening, database_pool_ready, database_pool_closing.

## Risk / notes
- Root logging handlers are replaced when configure_logging runs; intended for a dedicated MCP process.
- yarn test currently fails in objectified-ui on tests/llm-streaming.test.ts (prettyFormat.format is not a function); appears unrelated to this change; objectified-mcp and yarn build succeed.

Closes #2992

Made with [Cursor](https://cursor.com)