### PR TITLE
Fix #2993 - MCP stdio transport entrypoint

### DIFF
--- a/docs/PLANNED_ROADMAP_MCP.md
+++ b/docs/PLANNED_ROADMAP_MCP.md
@@ -78,7 +78,7 @@ process or via Docker.
 | 1.2 | ~~[#2990](../../issues/2990)~~ | ~~Settings/config module (pydantic-settings, env vars)~~ (**completed**) | 1.1 |
 | 1.3 | ~~[#2991](../../issues/2991)~~ | ~~Postgres connection pool (psycopg async)~~ (**completed**) | 1.2 |
 | 1.4 | ~~[#2992](../../issues/2992)~~ | ~~Structured JSON logging~~ (**completed**) | 1.2 |
-| 1.5 | [#2993](../../issues/2993) | stdio transport entrypoint | 1.1–1.3 |
+| 1.5 | ~~[#2993](../../issues/2993)~~ | ~~stdio transport entrypoint~~ (**completed**) | 1.1–1.3 |
 | 1.6 | [#2994](../../issues/2994) | Streamable HTTP transport entrypoint | 1.1–1.3 |
 | 1.7 | [#2995](../../issues/2995) | `ping` tool (service + DB health) | 1.3 |
 

--- a/objectified-mcp/README.md
+++ b/objectified-mcp/README.md
@@ -12,9 +12,9 @@ uv run objectified-mcp --help
 
 ## Configuration
 
-Copy [.env.example](.env.example) to `.env` and set at least **`OBJECTIFIED_MCP_DATABASE_URL`** and **`OBJECTIFIED_MCP_INTERNAL_SECRET`** (minimum 16 characters). Running **`uv run objectified-mcp serve`** loads and validates these variables immediately (stdio / HTTP transports are added in later roadmap tickets).
+Copy [.env.example](.env.example) to `.env` and set at least **`OBJECTIFIED_MCP_DATABASE_URL`** and **`OBJECTIFIED_MCP_INTERNAL_SECRET`** (minimum 16 characters). **`uv run objectified-mcp serve`** validates configuration and exits; **`uv run objectified-mcp serve --transport stdio`** runs the FastMCP stdio transport for local hosts (Claude Desktop, mcp-inspector). Streamable HTTP is roadmap ticket 1.6.
 
-When the MCP runtime starts (stdio / HTTP entrypoints), it opens a shared **`psycopg_pool.AsyncConnectionPool`**, runs **`SELECT 1`** against it, exposes the pool on FastMCP lifespan context under **`db_pool`**, and **`await pool.close()`** in **`finally`** so shutdown (including task cancellation) tears down connections cleanly. Pool sizing is controlled with **`OBJECTIFIED_MCP_DATABASE_POOL_MIN_SIZE`**, **`OBJECTIFIED_MCP_DATABASE_POOL_MAX_SIZE`**, and **`OBJECTIFIED_MCP_DATABASE_POOL_TIMEOUT`** (seconds to wait for a connection).
+When the MCP runtime starts, it opens a shared **`psycopg_pool.AsyncConnectionPool`**, runs **`SELECT 1`** against it, exposes the pool on FastMCP lifespan context under **`db_pool`**, and **`await pool.close()`** in **`finally`** so shutdown (including EOF on stdio or task cancellation) tears down connections cleanly. Pool sizing is controlled with **`OBJECTIFIED_MCP_DATABASE_POOL_MIN_SIZE`**, **`OBJECTIFIED_MCP_DATABASE_POOL_MAX_SIZE`**, and **`OBJECTIFIED_MCP_DATABASE_POOL_TIMEOUT`** (seconds to wait for a connection).
 
 ## Logging
 

--- a/objectified-mcp/package.json
+++ b/objectified-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-mcp",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "description": "Yarn workspace anchor for the objectified-mcp Python package (uv + pyproject.toml).",
   "scripts": {

--- a/objectified-mcp/pyproject.toml
+++ b/objectified-mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "objectified-mcp"
-version = "0.1.3"
+version = "0.1.4"
 description = "Model Context Protocol server for Objectified (FastMCP)."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/objectified-mcp/src/objectified_mcp/__init__.py
+++ b/objectified-mcp/src/objectified_mcp/__init__.py
@@ -1,3 +1,3 @@
 """Objectified MCP server package."""
 
-__version__ = "0.1.3"
+__version__ = "0.1.4"

--- a/objectified-mcp/src/objectified_mcp/cli.py
+++ b/objectified-mcp/src/objectified_mcp/cli.py
@@ -3,9 +3,16 @@
 from __future__ import annotations
 
 import argparse
+import asyncio
 import sys
 
 from objectified_mcp import __version__
+
+
+async def _run_stdio_transport() -> None:
+    from objectified_mcp.server import mcp
+
+    await mcp.run_stdio_async()
 
 
 def main() -> None:
@@ -19,9 +26,16 @@ def main() -> None:
         version=f"%(prog)s {__version__}",
     )
     subparsers = parser.add_subparsers(dest="command")
-    subparsers.add_parser(
+    serve_parser = subparsers.add_parser(
         "serve",
-        help="Validate environment configuration (stdio / HTTP transports ship in later tickets).",
+        help="Validate configuration and optionally run the MCP server.",
+    )
+    serve_parser.add_argument(
+        "--transport",
+        choices=("stdio",),
+        default=None,
+        metavar="NAME",
+        help="Run with this transport (omit to validate env and exit). Use stdio for Claude Desktop.",
     )
 
     args = parser.parse_args()
@@ -41,10 +55,15 @@ def main() -> None:
             raise SystemExit(2)
         configure_logging(settings)
         log = structlog.get_logger(__name__)
+        if args.transport == "stdio":
+            with bound_contextvars(request_id="cli-serve-stdio", tool_name=None):
+                log.info("mcp_stdio_starting")
+            asyncio.run(_run_stdio_transport())
+            return
         with bound_contextvars(request_id="cli-serve", tool_name=None):
             log.info(
                 "mcp_configuration_validated",
-                detail="MCP transports are wired in roadmap tickets 1.5 (stdio) and 1.6 (HTTP).",
+                detail="Pass --transport stdio to run locally; HTTP transport is roadmap ticket 1.6.",
             )
         raise SystemExit(0)
 

--- a/objectified-mcp/src/objectified_mcp/server.py
+++ b/objectified-mcp/src/objectified_mcp/server.py
@@ -1,4 +1,4 @@
-"""FastMCP application instance (stdio / HTTP transports land in later tickets)."""
+"""FastMCP application instance (HTTP transport lands in roadmap ticket 1.6)."""
 
 from __future__ import annotations
 

--- a/objectified-mcp/tests/test_cli.py
+++ b/objectified-mcp/tests/test_cli.py
@@ -4,8 +4,16 @@ import os
 import subprocess
 import sys
 from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
 
 _ROOT = Path(__file__).resolve().parents[1]
+
+_MIN_ENV = {
+    "OBJECTIFIED_MCP_DATABASE_URL": "postgresql://localhost/db",
+    "OBJECTIFIED_MCP_INTERNAL_SECRET": "x" * 16,
+}
 
 
 def test_module_help_prints_usage() -> None:
@@ -37,7 +45,36 @@ def test_console_script_entrypoint_prints_usage() -> None:
 def test_package_version_matches_pyproject() -> None:
     from objectified_mcp import __version__
 
-    assert __version__ == "0.1.3"
+    assert __version__ == "0.1.4"
+
+
+def test_serve_validate_only_exits_without_stdio(monkeypatch: pytest.MonkeyPatch) -> None:
+    from objectified_mcp.cli import main
+    from objectified_mcp.settings import get_settings
+
+    get_settings.cache_clear()
+    for key, value in _MIN_ENV.items():
+        monkeypatch.setenv(key, value)
+    monkeypatch.setattr(sys, "argv", ["objectified-mcp", "serve"])
+    with pytest.raises(SystemExit) as exc_info:
+        main()
+    assert exc_info.value.code == 0
+    get_settings.cache_clear()
+
+
+def test_serve_stdio_runs_fastmcp_stdio(monkeypatch: pytest.MonkeyPatch) -> None:
+    from objectified_mcp.cli import main
+    from objectified_mcp.settings import get_settings
+
+    get_settings.cache_clear()
+    for key, value in _MIN_ENV.items():
+        monkeypatch.setenv(key, value)
+    monkeypatch.setattr(sys, "argv", ["objectified-mcp", "serve", "--transport", "stdio"])
+    mock_stdio = AsyncMock(return_value=None)
+    with patch("objectified_mcp.server.mcp.run_stdio_async", mock_stdio):
+        main()
+    mock_stdio.assert_awaited_once()
+    get_settings.cache_clear()
 
 
 def test_server_module_exposes_mcp() -> None:

--- a/objectified-mcp/uv.lock
+++ b/objectified-mcp/uv.lock
@@ -772,7 +772,7 @@ wheels = [
 
 [[package]]
 name = "objectified-mcp"
-version = "0.1.3"
+version = "0.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.7",
+  "version": "0.11.8",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -7,7 +7,7 @@ We continue to improve the platform based on your feedback with improvements and
 ## MCP
 
 - New `objectified-mcp` Python package (FastMCP, uv, ruff, mypy) as the foundation for the Model Context Protocol server.
-- MCP server loads typed configuration from the environment via pydantic-settings (`objectified-mcp serve`); see `objectified-mcp/.env.example`.
+- MCP server loads typed configuration from the environment via pydantic-settings (`objectified-mcp serve`); **`objectified-mcp serve --transport stdio`** runs the FastMCP stdio transport for Claude Desktop and similar hosts; see `objectified-mcp/.env.example`.
 - MCP runtime opens a shared async Postgres pool (psycopg 3) at startup, exposes it to tools via lifespan context, runs a health probe (`SELECT 1`), and closes the pool cleanly on shutdown.
 - MCP process logs are structured JSON on stderr (structlog): each line includes `timestamp`, `level`, `event`, `request_id`, and `tool_name`; verbosity is controlled with `OBJECTIFIED_MCP_LOG_LEVEL`.
 


### PR DESCRIPTION
## Summary
Adds `objectified-mcp serve --transport stdio`, which runs FastMCP `run_stdio_async()` so local MCP hosts (Claude Desktop, mcp-inspector) can attach over stdio. Omitting `--transport` keeps the existing validate-env-and-exit behavior.

## How to test
1. Copy `objectified-mcp/.env.example` to `.env` with a reachable `OBJECTIFIED_MCP_DATABASE_URL` and `OBJECTIFIED_MCP_INTERNAL_SECRET` (≥16 chars).
2. From `objectified-mcp`, run `uv run objectified-mcp serve --transport stdio`.
3. Point Claude Desktop or `npx @modelcontextprotocol/inspector` at this command; confirm the session initializes.
4. Close stdin or stop the host and confirm the process exits without hanging (pool teardown remains in FastMCP lifespan `finally`).

## Risk / notes
- Full monorepo `yarn test` currently fails on `objectified-ui/tests/llm-streaming.test.ts` (`prettyFormat.format` TypeError); objectified-mcp suite passes (ruff, mypy, pytest).

Closes #2993

Made with [Cursor](https://cursor.com)