### PR TITLE
Fix #3000 - HTTP credential extraction middleware

### DIFF
--- a/docs/PLANNED_ROADMAP_MCP.md
+++ b/docs/PLANNED_ROADMAP_MCP.md
@@ -89,7 +89,7 @@ process or via Docker.
 | 2.1 | ~~[#2997](../../issues/2997)~~ | ~~Postgres migration: `mcp_api_keys` table~~ (**completed**) | E1 |
 | 2.2 | [#2998](../../issues/2998) | Key issuance CLI (`mcp keys issue`) | 2.1 |
 | 2.3 | ~~[#2999](../../issues/2999)~~ | ~~API key validator dependency~~ (**completed**) | 2.1 |
-| 2.4 | [#3000](../../issues/3000) | HTTP credential extraction middleware | 1.6, 2.3 |
+| 2.4 | ~~[#3000](../../issues/3000)~~ | ~~HTTP credential extraction middleware~~ (**completed**) | 1.6, 2.3 |
 | 2.5 | [#3001](../../issues/3001) | Scope model (public, tenant, project) | 2.1 |
 | 2.6 | [#3002](../../issues/3002) | `last_used_at` + revoke command | 2.3 |
 

--- a/objectified-mcp/package.json
+++ b/objectified-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-mcp",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "private": true,
   "description": "Yarn workspace anchor for the objectified-mcp Python package (uv + pyproject.toml).",
   "scripts": {

--- a/objectified-mcp/pyproject.toml
+++ b/objectified-mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "objectified-mcp"
-version = "0.1.7"
+version = "0.1.8"
 description = "Model Context Protocol server for Objectified (FastMCP)."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/objectified-mcp/src/objectified_mcp/__init__.py
+++ b/objectified-mcp/src/objectified_mcp/__init__.py
@@ -1,3 +1,3 @@
 """Objectified MCP server package."""
 
-__version__ = "0.1.7"
+__version__ = "0.1.8"

--- a/objectified-mcp/src/objectified_mcp/cli.py
+++ b/objectified-mcp/src/objectified_mcp/cli.py
@@ -17,6 +17,9 @@ async def _run_stdio_transport() -> None:
 
 async def _run_http_transport(host: str, port: int, *, log_level: str) -> None:
     """Streamable HTTP via FastMCP (``http_app`` → ``create_streamable_http_app``); serves MCP at ``/mcp``."""
+    from starlette.middleware import Middleware as StarletteMiddleware
+
+    from objectified_mcp.http_credential_middleware import HttpCredentialExtractionMiddleware
     from objectified_mcp.server import mcp
 
     await mcp.run_http_async(
@@ -25,6 +28,7 @@ async def _run_http_transport(host: str, port: int, *, log_level: str) -> None:
         port=port,
         path="/mcp",
         log_level=log_level.lower(),
+        middleware=[StarletteMiddleware(HttpCredentialExtractionMiddleware)],
     )
 
 

--- a/objectified-mcp/src/objectified_mcp/http_credential_middleware.py
+++ b/objectified-mcp/src/objectified_mcp/http_credential_middleware.py
@@ -1,0 +1,110 @@
+"""HTTP credential extraction for streamable MCP (#3000).
+
+Parses ``Authorization: Bearer …`` at the ASGI boundary and exposes the secret to
+tools via FastMCP ``Context`` request-scoped state (never session-persisted).
+
+- Missing or non-Bearer ``Authorization`` → tools see ``None`` (anonymous).
+- Bearer present → tools read the credential string with ``get_http_bearer_from_context``.
+"""
+
+from __future__ import annotations
+
+import re
+from contextvars import ContextVar, Token
+from typing import Any, cast
+
+import mcp.types as mt
+from fastmcp import Context
+from fastmcp.server.middleware import CallNext, Middleware, MiddlewareContext
+
+_MCP_HTTP_BEARER_TOKEN_KEY = "objectified_mcp_http_bearer_token"
+
+_AUTH_BEARER_PREFIX = re.compile(r"(?i)^Bearer\s+")
+
+_current_http_bearer_token: ContextVar[str | None] = ContextVar(
+    "objectified_mcp_http_bearer_token",
+    default=None,
+)
+
+
+def http_bearer_token_state_key() -> str:
+    """State key tools pass to ``ctx.get_state`` for the stashed Bearer secret."""
+    return _MCP_HTTP_BEARER_TOKEN_KEY
+
+
+def bearer_secret_from_authorization_header(value: str | None) -> str | None:
+    """Return Bearer credential from an ``Authorization`` header value, else ``None``.
+
+    Non-Bearer schemes and empty tokens yield ``None`` so callers treat the request
+    as anonymous at this layer.
+    """
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    if not stripped:
+        return None
+    if not _AUTH_BEARER_PREFIX.match(stripped):
+        return None
+    parts = stripped.split(None, 1)
+    if len(parts) < 2:
+        return None
+    secret = parts[1].strip()
+    return secret or None
+
+
+def _authorization_from_scope(scope: dict[str, Any]) -> str | None:
+    raw_headers = scope.get("headers") or []
+    for name_b, value_b in raw_headers:
+        try:
+            name = name_b.decode("latin-1").lower()
+        except (AttributeError, UnicodeDecodeError):
+            continue
+        if name == "authorization":
+            try:
+                return cast(str, value_b.decode("latin-1"))
+            except (AttributeError, UnicodeDecodeError):
+                return None
+    return None
+
+
+class HttpCredentialExtractionMiddleware:
+    """ASGI middleware: bind per-request Bearer token to a ``ContextVar``."""
+
+    def __init__(self, app: Any) -> None:
+        self.app = app
+
+    async def __call__(self, scope: dict[str, Any], receive: Any, send: Any) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        bearer = bearer_secret_from_authorization_header(_authorization_from_scope(scope))
+        token: Token[str | None] = _current_http_bearer_token.set(bearer)
+        try:
+            await self.app(scope, receive, send)
+        finally:
+            _current_http_bearer_token.reset(token)
+
+
+class StashHttpBearerInToolContextMiddleware(Middleware):
+    """FastMCP middleware: copy ASGI-extracted Bearer into tool ``Context`` (request-scoped)."""
+
+    async def on_call_tool(
+        self,
+        context: MiddlewareContext[mt.CallToolRequestParams],
+        call_next: CallNext[mt.CallToolRequestParams, Any],
+    ) -> Any:
+        fc = context.fastmcp_context
+        if fc is not None:
+            await fc.set_state(
+                _MCP_HTTP_BEARER_TOKEN_KEY,
+                _current_http_bearer_token.get(),
+                serializable=False,
+            )
+        return await call_next(context)
+
+
+async def get_http_bearer_from_context(ctx: Context) -> str | None:
+    """Return the Bearer secret stashed for this HTTP tool call, or ``None`` if anonymous."""
+    value = await ctx.get_state(_MCP_HTTP_BEARER_TOKEN_KEY)
+    return cast(str | None, value)

--- a/objectified-mcp/src/objectified_mcp/server.py
+++ b/objectified-mcp/src/objectified_mcp/server.py
@@ -11,6 +11,7 @@ from fastmcp.server.lifespan import lifespan
 from structlog.contextvars import bound_contextvars
 
 from objectified_mcp.database_pool import MCP_DB_POOL_KEY, create_async_pool, get_db_pool, ping_pool
+from objectified_mcp.http_credential_middleware import StashHttpBearerInToolContextMiddleware
 from objectified_mcp.logging_config import configure_logging
 from objectified_mcp.ping_tool import build_ping_response
 from objectified_mcp.settings import get_settings
@@ -40,6 +41,7 @@ async def database_lifespan(server: Any) -> Any:
 
 
 mcp = FastMCP("Objectified", lifespan=database_lifespan)
+mcp.add_middleware(StashHttpBearerInToolContextMiddleware())
 
 
 @mcp.tool

--- a/objectified-mcp/tests/test_cli.py
+++ b/objectified-mcp/tests/test_cli.py
@@ -45,7 +45,7 @@ def test_console_script_entrypoint_prints_usage() -> None:
 def test_package_version_matches_pyproject() -> None:
     from objectified_mcp import __version__
 
-    assert __version__ == "0.1.7"
+    assert __version__ == "0.1.8"
 
 
 def test_serve_validate_only_exits_without_stdio(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -86,6 +86,9 @@ def test_serve_http_runs_fastmcp_streamable_http(monkeypatch: pytest.MonkeyPatch
     assert call_kw["port"] == 9999
     assert call_kw["path"] == "/mcp"
     assert call_kw["log_level"] == "info"
+    mw = call_kw["middleware"]
+    assert len(mw) == 1
+    assert mw[0].cls.__name__ == "HttpCredentialExtractionMiddleware"
     get_settings.cache_clear()
 
 

--- a/objectified-mcp/tests/test_http_credential_integration.py
+++ b/objectified-mcp/tests/test_http_credential_integration.py
@@ -1,0 +1,207 @@
+"""End-to-end integration tests for HTTP credential extraction (MCP-2.4 / #3000).
+
+These tests spin up a real Uvicorn/Starlette ASGI server so that the full
+middleware chain (``HttpCredentialExtractionMiddleware`` → Starlette routing →
+FastMCP ``StashHttpBearerInToolContextMiddleware``) is exercised against genuine
+streamable-HTTP MCP requests.  This catches regressions in ``ContextVar``
+propagation, middleware ordering, and ``serializable=False`` isolation that the
+unit-test mocks in ``test_http_credential_middleware.py`` cannot detect.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import socket
+import threading
+from collections.abc import Generator
+
+import pytest
+import uvicorn
+from fastmcp import Client, Context, FastMCP
+from fastmcp.client.transports import StreamableHttpTransport
+from starlette.middleware import Middleware as StarletteMiddleware
+
+from objectified_mcp.http_credential_middleware import (
+    HttpCredentialExtractionMiddleware,
+    StashHttpBearerInToolContextMiddleware,
+    get_http_bearer_from_context,
+)
+
+# ---------------------------------------------------------------------------
+# Minimal FastMCP server used only for these integration tests
+# ---------------------------------------------------------------------------
+
+_test_mcp = FastMCP("IntegrationTestServer")
+_test_mcp.add_middleware(StashHttpBearerInToolContextMiddleware())
+
+
+@_test_mcp.tool
+async def echo_bearer(ctx: Context) -> str | None:
+    """Return the Bearer secret visible in the current tool context, or None."""
+    return await get_http_bearer_from_context(ctx)
+
+
+# ---------------------------------------------------------------------------
+# Pytest fixture: real Uvicorn server on a free port
+# ---------------------------------------------------------------------------
+
+
+def _find_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+@pytest.fixture(scope="module")
+def integration_server_url() -> Generator[str, None, None]:
+    """Start a real Uvicorn server for the integration test module; yield its base URL."""
+    starlette_app = _test_mcp.http_app(
+        path="/mcp",
+        middleware=[StarletteMiddleware(HttpCredentialExtractionMiddleware)],
+    )
+
+    port = _find_free_port()
+    config = uvicorn.Config(starlette_app, host="127.0.0.1", port=port, log_level="warning")
+    server = uvicorn.Server(config)
+
+    ready_event = threading.Event()
+    stop_event = threading.Event()
+
+    def _run() -> None:
+        async def _serve() -> None:
+            serve_task = asyncio.ensure_future(server.serve())
+            while not server.started:
+                await asyncio.sleep(0.05)
+            ready_event.set()
+            while not stop_event.is_set():
+                await asyncio.sleep(0.05)
+            server.should_exit = True
+            await serve_task
+
+        asyncio.run(_serve())
+
+    thread = threading.Thread(target=_run, daemon=True)
+    thread.start()
+
+    if not ready_event.wait(timeout=15):
+        raise RuntimeError("Integration test server did not start within 15 s")
+
+    try:
+        yield f"http://127.0.0.1:{port}/mcp"
+    finally:
+        stop_event.set()
+        thread.join(timeout=5)
+
+
+# ---------------------------------------------------------------------------
+# Integration tests
+# ---------------------------------------------------------------------------
+
+
+def test_bearer_token_reaches_tool_context(integration_server_url: str) -> None:
+    """A Bearer secret in the Authorization header is visible inside the tool."""
+
+    async def _run() -> None:
+        transport = StreamableHttpTransport(
+            url=integration_server_url,
+            headers={"Authorization": "Bearer integration-secret"},
+        )
+        async with Client(transport) as client:
+            result = await client.call_tool("echo_bearer", {})
+        assert result.data == "integration-secret"
+
+    asyncio.run(_run())
+
+
+def test_anonymous_request_yields_none(integration_server_url: str) -> None:
+    """A request without an Authorization header causes the tool to see None."""
+
+    async def _run() -> None:
+        transport = StreamableHttpTransport(url=integration_server_url)
+        async with Client(transport) as client:
+            result = await client.call_tool("echo_bearer", {})
+        assert result.data is None
+
+    asyncio.run(_run())
+
+
+def test_non_bearer_auth_yields_none(integration_server_url: str) -> None:
+    """A non-Bearer Authorization header (e.g. Basic) is treated as anonymous."""
+
+    async def _run() -> None:
+        transport = StreamableHttpTransport(
+            url=integration_server_url,
+            headers={"Authorization": "Basic dXNlcjpwYXNz"},
+        )
+        async with Client(transport) as client:
+            result = await client.call_tool("echo_bearer", {})
+        assert result.data is None
+
+    asyncio.run(_run())
+
+
+def test_token_not_persisted_across_sessions(integration_server_url: str) -> None:
+    """A Bearer token from one session is not visible in a subsequent session.
+
+    This verifies that ``serializable=False`` (and ContextVar isolation) prevents
+    the credential from leaking into the FastMCP session state store and being
+    visible to a later, unauthenticated caller.
+    """
+
+    async def _run() -> None:
+        # First session: with Bearer token
+        t1 = StreamableHttpTransport(
+            url=integration_server_url,
+            headers={"Authorization": "Bearer first-session-token"},
+        )
+        async with Client(t1) as c:
+            r1 = await c.call_tool("echo_bearer", {})
+        assert r1.data == "first-session-token"
+
+        # Second session: no Bearer token — must NOT see the first session's token
+        t2 = StreamableHttpTransport(url=integration_server_url)
+        async with Client(t2) as c:
+            r2 = await c.call_tool("echo_bearer", {})
+        assert r2.data is None, f"Token leaked across sessions: second session saw {r2.data!r} instead of None"
+
+    asyncio.run(_run())
+
+
+def test_multiple_calls_in_same_session_see_same_token(integration_server_url: str) -> None:
+    """All tool calls within a single session share the same per-session Bearer token."""
+
+    async def _run() -> None:
+        transport = StreamableHttpTransport(
+            url=integration_server_url,
+            headers={"Authorization": "Bearer stable-session-token"},
+        )
+        async with Client(transport) as client:
+            r1 = await client.call_tool("echo_bearer", {})
+            r2 = await client.call_tool("echo_bearer", {})
+        assert r1.data == "stable-session-token"
+        assert r2.data == "stable-session-token"
+
+    asyncio.run(_run())
+
+
+def test_concurrent_sessions_see_their_own_tokens(integration_server_url: str) -> None:
+    """Concurrent sessions each see their own Bearer token without cross-contamination."""
+
+    async def _call(url: str, token: str | None) -> str | None:
+        headers = {"Authorization": f"Bearer {token}"} if token else {}
+        transport = StreamableHttpTransport(url=url, headers=headers)
+        async with Client(transport) as client:
+            result = await client.call_tool("echo_bearer", {})
+        return result.data  # type: ignore[return-value]
+
+    async def _run() -> None:
+        results = await asyncio.gather(
+            _call(integration_server_url, "token-alpha"),
+            _call(integration_server_url, "token-beta"),
+            _call(integration_server_url, None),
+        )
+        assert results[0] == "token-alpha"
+        assert results[1] == "token-beta"
+        assert results[2] is None
+
+    asyncio.run(_run())

--- a/objectified-mcp/tests/test_http_credential_middleware.py
+++ b/objectified-mcp/tests/test_http_credential_middleware.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from objectified_mcp.http_credential_middleware import (
+    HttpCredentialExtractionMiddleware,
+    StashHttpBearerInToolContextMiddleware,
+    bearer_secret_from_authorization_header,
+    get_http_bearer_from_context,
+    http_bearer_token_state_key,
+)
+
+
+@pytest.mark.parametrize(
+    ("header", "expected"),
+    [
+        (None, None),
+        ("", None),
+        ("   ", None),
+        ("Basic xyz", None),
+        ("Bearer", None),
+        ("Bearer ", None),
+        ("Bearer  ", None),
+        ("bEaReR secret-token", "secret-token"),
+        ("Bearer  secret-token  ", "secret-token"),
+    ],
+)
+def test_bearer_secret_from_authorization_header(header: str | None, expected: str | None) -> None:
+    assert bearer_secret_from_authorization_header(header) == expected
+
+
+def test_http_bearer_token_state_key_stable() -> None:
+    assert http_bearer_token_state_key() == "objectified_mcp_http_bearer_token"
+
+
+def test_asgi_and_fastmcp_middleware_chain_with_bearer() -> None:
+    async def run() -> None:
+        fc = MagicMock()
+        fc.set_state = AsyncMock()
+
+        async def inner_app(scope: dict, receive: object, send: object) -> None:
+            stash = StashHttpBearerInToolContextMiddleware()
+            mctx = MagicMock()
+            mctx.fastmcp_context = fc
+
+            async def call_next(_ctx: object) -> str:
+                return "ok"
+
+            await stash.on_call_tool(mctx, call_next)
+
+        mw = HttpCredentialExtractionMiddleware(inner_app)
+        scope = {
+            "type": "http",
+            "headers": [(b"authorization", b"Bearer chained-secret")],
+        }
+        await mw(scope, None, None)
+        fc.set_state.assert_awaited_once_with(
+            "objectified_mcp_http_bearer_token",
+            "chained-secret",
+            serializable=False,
+        )
+
+    asyncio.run(run())
+
+
+def test_asgi_and_fastmcp_middleware_chain_anonymous_without_bearer() -> None:
+    async def run() -> None:
+        fc = MagicMock()
+        fc.set_state = AsyncMock()
+
+        async def inner_app(scope: dict, receive: object, send: object) -> None:
+            stash = StashHttpBearerInToolContextMiddleware()
+            mctx = MagicMock()
+            mctx.fastmcp_context = fc
+
+            async def call_next(_ctx: object) -> str:
+                return "ok"
+
+            await stash.on_call_tool(mctx, call_next)
+
+        mw = HttpCredentialExtractionMiddleware(inner_app)
+        scope: dict = {"type": "http", "headers": []}
+        await mw(scope, None, None)
+        fc.set_state.assert_awaited_once_with(
+            "objectified_mcp_http_bearer_token",
+            None,
+            serializable=False,
+        )
+
+    asyncio.run(run())
+
+
+def test_http_credential_extraction_skips_non_http() -> None:
+    async def run() -> None:
+        called = False
+
+        async def app(scope: dict, receive: object, send: object) -> None:
+            nonlocal called
+            called = True
+
+        mw = HttpCredentialExtractionMiddleware(app)
+        await mw({"type": "lifespan"}, None, None)
+        assert called
+
+    asyncio.run(run())
+
+
+def test_stash_middleware_skips_when_no_fastmcp_context() -> None:
+    async def run() -> None:
+        mw = StashHttpBearerInToolContextMiddleware()
+        mctx = MagicMock()
+        mctx.fastmcp_context = None
+
+        async def call_next(_ctx: object) -> str:
+            return "ok"
+
+        assert await mw.on_call_tool(mctx, call_next) == "ok"
+
+    asyncio.run(run())
+
+
+def test_get_http_bearer_from_context_reads_state() -> None:
+    async def run() -> None:
+        ctx = MagicMock()
+        ctx.get_state = AsyncMock(return_value="stored")
+
+        assert await get_http_bearer_from_context(ctx) == "stored"
+        ctx.get_state.assert_awaited_once_with("objectified_mcp_http_bearer_token")
+
+    asyncio.run(run())

--- a/objectified-mcp/uv.lock
+++ b/objectified-mcp/uv.lock
@@ -842,7 +842,7 @@ wheels = [
 
 [[package]]
 name = "objectified-mcp"
-version = "0.1.7"
+version = "0.1.8"
 source = { editable = "." }
 dependencies = [
     { name = "bcrypt" },

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.11",
+  "version": "0.11.12",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -13,6 +13,7 @@ We continue to improve the platform based on your feedback with improvements and
 - MCP **`ping`** tool returns service id, package version, UTC timestamp, and **`db_ok`** (Postgres `SELECT 1` via the shared pool); on failure **`db_ok`** is false and **`db_error`** carries the exception message.
 - Database migration adds **`odb.mcp_api_keys`** for MCP API key storage (hashed secret, lookup prefix, tenant, JSON scopes, lifecycle timestamps).
 - MCP tools can require Postgres-backed API keys via FastMCP **`Depends(require_mcp_auth)`**: accepts **`Authorization: Bearer`** on HTTP or **`tools/call` `_meta`** on stdio, verifies bcrypt(SHA-256(secret)) against **`odb.mcp_api_keys`**, and returns a typed scope payload (clear errors for missing auth, unknown keys, expiry, and revocation).
+- Streamable HTTP binds **`Authorization: Bearer`** per request into tool context (**`get_http_bearer_from_context`**) via ASGI middleware plus FastMCP middleware; requests without a Bearer token expose **`None`** (anonymous).
 
 ## Importing
 - Race condition fixed in 3.0.1 specification imports


### PR DESCRIPTION
## Summary
Implements MCP-2.4: streamable HTTP requests parse `Authorization: Bearer` at the ASGI layer, and the Bearer secret is copied into FastMCP tool `Context` as **request-scoped** state (not persisted in the session store). Missing or non-Bearer headers yield `None` so tools see an anonymous caller.

## Changes
- New `http_credential_middleware.py`: `HttpCredentialExtractionMiddleware` (ASGI), `StashHttpBearerInToolContextMiddleware` (FastMCP), helpers `get_http_bearer_from_context` / `http_bearer_token_state_key`.
- HTTP transport registers the Starlette middleware; the FastMCP server registers the stash middleware.
- Tests, roadmap/WHATS_NEW, and patch bumps (`objectified-mcp` 0.1.8, `objectified-ui` 0.11.12 for WHATS_NEW).

## How to test
1. **Run** `uv run objectified-mcp serve --transport http` with valid env (see `objectified-mcp/.env.example`).
2. **Call** a tool over HTTP with `Authorization: Bearer <token>` and assert the tool can read the same string via `await get_http_bearer_from_context(ctx)`.
3. **Repeat** without an `Authorization` header and confirm the helper returns `None`.

## Risks / notes
- Credential is stored with `serializable=False` so it does not enter the JSON session state store; it applies only to the current MCP request.
- Only the Bearer scheme is surfaced here; other `Authorization` schemes are treated as anonymous for this state key (existing `require_mcp_auth` behavior unchanged).

Closes #3000

Made with [Cursor](https://cursor.com)