### PR TITLE
Fix #3001 - MCP Scope model (tenant/project lists, JSONB)

### DIFF
--- a/docs/PLANNED_ROADMAP_MCP.md
+++ b/docs/PLANNED_ROADMAP_MCP.md
@@ -90,7 +90,7 @@ process or via Docker.
 | 2.2 | [#2998](../../issues/2998) | Key issuance CLI (`mcp keys issue`) | 2.1 |
 | 2.3 | ~~[#2999](../../issues/2999)~~ | ~~API key validator dependency~~ (**completed**) | 2.1 |
 | 2.4 | ~~[#3000](../../issues/3000)~~ | ~~HTTP credential extraction middleware~~ (**completed**) | 1.6, 2.3 |
-| 2.5 | [#3001](../../issues/3001) | Scope model (public, tenant, project) | 2.1 |
+| 2.5 | ~~[#3001](../../issues/3001)~~ | ~~Scope model (public, tenant, project)~~ (**completed**) | 2.1 |
 | 2.6 | [#3002](../../issues/3002) | `last_used_at` + revoke command | 2.3 |
 
 #### E3 — Public Read-Only Spec Discovery (#3003)

--- a/objectified-db/scripts/20260502-120000.sql
+++ b/objectified-db/scripts/20260502-120000.sql
@@ -31,7 +31,7 @@ COMMENT ON COLUMN odb.mcp_api_keys.prefix IS
   'Non-secret prefix copied from the issued key for indexed lookup before hash verification.';
 
 COMMENT ON COLUMN odb.mcp_api_keys.scope_json IS
-  'Authorization scopes for this key (shape defined by MCP key issuance; JSON object).';
+  'Read scope JSON: {"tenants":[uuid,...],"projects":[uuid,...]}. Empty lists = public at that dimension; see objectified_mcp.scope.Scope (#3001).';
 
 COMMENT ON COLUMN odb.mcp_api_keys.revoked_at IS
   'When set, the key must be rejected regardless of expires_at.';

--- a/objectified-mcp/README.md
+++ b/objectified-mcp/README.md
@@ -16,6 +16,10 @@ Copy [.env.example](.env.example) to `.env` and set at least **`OBJECTIFIED_MCP_
 
 When the MCP runtime starts, it opens a shared **`psycopg_pool.AsyncConnectionPool`**, runs **`SELECT 1`** against it, exposes the pool on FastMCP lifespan context under **`db_pool`**, and **`await pool.close()`** in **`finally`** so shutdown (including EOF on stdio or task cancellation) tears down connections cleanly. Pool sizing is controlled with **`OBJECTIFIED_MCP_DATABASE_POOL_MIN_SIZE`**, **`OBJECTIFIED_MCP_DATABASE_POOL_MAX_SIZE`**, and **`OBJECTIFIED_MCP_DATABASE_POOL_TIMEOUT`** (seconds to wait for a connection).
 
+## API key read scope
+
+`odb.mcp_api_keys.scope_json` stores **`{"tenants": [...], "projects": [...]}`** (UUID strings). The Python type is **`objectified_mcp.scope.Scope`**: empty **`tenants`** means any tenant; empty **`projects`** means any project within the tenant constraint; **`Scope.allows(tenant_id, project_id)`** returns whether a read is permitted. Parse DB payloads with **`parse_scope_json`**.
+
 ## Logging
 
 Logs go to **stderr** as **JSON** (via **structlog**), one object per line. Each line includes **`timestamp`** (UTC ISO-8601), **`level`**, **`event`**, **`request_id`**, and **`tool_name`** (use **`structlog.contextvars.bound_contextvars`** around MCP tool handlers so tool calls carry the RPC id and tool name). Root verbosity is set with **`OBJECTIFIED_MCP_LOG_LEVEL`** (`DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`).

--- a/objectified-mcp/package.json
+++ b/objectified-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-mcp",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "private": true,
   "description": "Yarn workspace anchor for the objectified-mcp Python package (uv + pyproject.toml).",
   "scripts": {

--- a/objectified-mcp/pyproject.toml
+++ b/objectified-mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "objectified-mcp"
-version = "0.1.8"
+version = "0.1.9"
 description = "Model Context Protocol server for Objectified (FastMCP)."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/objectified-mcp/src/objectified_mcp/__init__.py
+++ b/objectified-mcp/src/objectified_mcp/__init__.py
@@ -1,3 +1,3 @@
 """Objectified MCP server package."""
 
-__version__ = "0.1.8"
+__version__ = "0.1.9"

--- a/objectified-mcp/src/objectified_mcp/mcp_auth.py
+++ b/objectified-mcp/src/objectified_mcp/mcp_auth.py
@@ -18,6 +18,9 @@ Tools opt in with::
     @mcp.tool
     async def example(auth: McpAuthContext = Depends(require_mcp_auth)) -> str:
         ...
+
+Scoped reads use :meth:`objectified_mcp.scope.Scope.allows` on ``auth.scope``; see
+:class:`objectified_mcp.scope.Scope` for the JSON persisted in ``scope_json``.
 """
 
 from __future__ import annotations
@@ -37,6 +40,7 @@ from psycopg_pool import AsyncConnectionPool
 from pydantic import BaseModel, ConfigDict, Field
 
 from objectified_mcp.database_pool import get_db_pool
+from objectified_mcp.scope import Scope, parse_scope_json
 
 _log = structlog.get_logger(__name__)
 
@@ -49,12 +53,12 @@ _BEARER_PREFIX = re.compile(r"(?i)^Bearer\s+")
 class McpAuthContext(BaseModel):
     """Authenticated MCP caller derived from ``odb.mcp_api_keys``."""
 
-    model_config = ConfigDict(frozen=True)
+    model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)
 
     key_id: str
     tenant_id: str
     label: str
-    scope: dict[str, Any] = Field(default_factory=dict)
+    scope: Scope = Field(default_factory=Scope)
 
 
 def mcp_key_prefix(secret: str) -> str:
@@ -166,18 +170,11 @@ async def validate_mcp_api_key(pool: AsyncConnectionPool, raw_secret: str) -> Mc
 
     for row in eligible:
         if _verify_hash(raw_secret, row.get("key_hash")):
-            raw_scope = row.get("scope_json")
-            if raw_scope is None:
-                scope: dict[str, Any] = {}
-            elif not isinstance(raw_scope, dict):
-                scope = dict(raw_scope)
-            else:
-                scope = raw_scope
             return McpAuthContext(
                 key_id=str(row["id"]),
                 tenant_id=str(row["tenant_id"]),
                 label=str(row["label"]),
-                scope=scope,
+                scope=parse_scope_json(row.get("scope_json")),
             )
 
     if not eligible:

--- a/objectified-mcp/src/objectified_mcp/scope.py
+++ b/objectified-mcp/src/objectified_mcp/scope.py
@@ -1,0 +1,70 @@
+"""MCP API key read scope stored in ``odb.mcp_api_keys.scope_json`` (#3001).
+
+Persisted JSON shape::
+
+    {"tenants": ["<tenant_uuid>", ...], "projects": ["<project_uuid>", ...]}
+
+Each list holds string identifiers (typically UUIDs as stored by the platform).
+
+**Semantics**
+
+- **Public** — both lists empty: :meth:`Scope.allows` permits any tenant/project
+  pair passed in (subject to other product rules such as row visibility).
+- **Tenant-limited** — ``tenants`` non-empty: the resource tenant id must be a
+  member of ``tenants``.
+- **Project-limited** — ``projects`` non-empty: the resource project id must be
+  provided and be a member of ``projects``.
+
+Unknown JSON keys are ignored. Missing ``tenants`` / ``projects`` keys behave
+like empty lists. Non-dict ``scope_json`` values yield an empty scope.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+def _coerce_str_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    out: list[str] = []
+    for item in value:
+        if isinstance(item, str):
+            out.append(item)
+    return out
+
+
+@dataclass(frozen=True)
+class Scope:
+    """Declared read scope for an MCP API key (mirrors ``scope_json``)."""
+
+    tenants: list[str] = field(default_factory=list)
+    projects: list[str] = field(default_factory=list)
+
+    def allows(self, tenant: str, project: str | None = None) -> bool:
+        """Return True if reading *tenant* / *project* is allowed by this scope."""
+        if self.tenants and tenant not in self.tenants:
+            return False
+        if self.projects:
+            if project is None or project not in self.projects:
+                return False
+        return True
+
+    def to_json_dict(self) -> dict[str, list[str]]:
+        """Serialize for JSONB (stable keys for issuance and migrations)."""
+        return {"tenants": list(self.tenants), "projects": list(self.projects)}
+
+
+def parse_scope_json(raw: Any) -> Scope:
+    """Build a :class:`Scope` from ``scope_json`` (database value or plain dict)."""
+    if raw is None:
+        return Scope()
+    if isinstance(raw, Scope):
+        return raw
+    if not isinstance(raw, dict):
+        return Scope()
+    return Scope(
+        tenants=_coerce_str_list(raw.get("tenants")),
+        projects=_coerce_str_list(raw.get("projects")),
+    )

--- a/objectified-mcp/src/objectified_mcp/scope.py
+++ b/objectified-mcp/src/objectified_mcp/scope.py
@@ -16,34 +16,51 @@ Each list holds string identifiers (typically UUIDs as stored by the platform).
   provided and be a member of ``projects``.
 
 Unknown JSON keys are ignored. Missing ``tenants`` / ``projects`` keys behave
-like empty lists. Non-dict ``scope_json`` values yield an empty scope.
+like empty lists. Non-dict or structurally invalid ``scope_json`` values yield a
+**deny-all** scope (``deny_all=True``) and emit a ``WARNING`` log entry so that
+mis-scoped keys are detected promptly.
 """
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, field
 from typing import Any
 
+_log = logging.getLogger(__name__)
 
-def _coerce_str_list(value: Any) -> list[str]:
+
+def _coerce_str_tuple(value: Any) -> tuple[str, ...]:
     if not isinstance(value, list):
-        return []
-    out: list[str] = []
-    for item in value:
-        if isinstance(item, str):
-            out.append(item)
-    return out
+        return ()
+    return tuple(item for item in value if isinstance(item, str))
 
 
 @dataclass(frozen=True)
 class Scope:
-    """Declared read scope for an MCP API key (mirrors ``scope_json``)."""
+    """Declared read scope for an MCP API key (mirrors ``scope_json``).
 
-    tenants: list[str] = field(default_factory=list)
-    projects: list[str] = field(default_factory=list)
+    ``tenants`` and ``projects`` are stored as immutable tuples.  Pass lists at
+    construction time — they are coerced to tuples automatically.  This prevents
+    accidental in-place mutation of a ``frozen=True`` dataclass whose fields
+    would otherwise be mutable lists.
+    """
+
+    tenants: tuple[str, ...] = field(default_factory=tuple)
+    projects: tuple[str, ...] = field(default_factory=tuple)
+    deny_all: bool = False
+
+    def __post_init__(self) -> None:
+        """Coerce list inputs to tuples so instances are truly immutable."""
+        if isinstance(self.tenants, list):
+            object.__setattr__(self, "tenants", tuple(self.tenants))
+        if isinstance(self.projects, list):
+            object.__setattr__(self, "projects", tuple(self.projects))
 
     def allows(self, tenant: str, project: str | None = None) -> bool:
         """Return True if reading *tenant* / *project* is allowed by this scope."""
+        if self.deny_all:
+            return False
         if self.tenants and tenant not in self.tenants:
             return False
         if self.projects:
@@ -57,14 +74,42 @@ class Scope:
 
 
 def parse_scope_json(raw: Any) -> Scope:
-    """Build a :class:`Scope` from ``scope_json`` (database value or plain dict)."""
+    """Build a :class:`Scope` from ``scope_json`` (database value or plain dict).
+
+    Returns a **deny-all** :class:`Scope` (``deny_all=True``) and logs a
+    ``WARNING`` for any structurally invalid payload (non-dict, or ``tenants``/
+    ``projects`` present but not a list).  ``None`` and ``{}`` both yield a
+    public (allow-all) scope — they are valid "no restriction" shapes.
+    """
     if raw is None:
         return Scope()
     if isinstance(raw, Scope):
         return raw
     if not isinstance(raw, dict):
-        return Scope()
+        _log.warning(
+            "scope_json has unexpected type %s; denying all access",
+            type(raw).__name__,
+        )
+        return Scope(deny_all=True)
+
+    tenants_raw = raw.get("tenants")
+    projects_raw = raw.get("projects")
+
+    if tenants_raw is not None and not isinstance(tenants_raw, list):
+        _log.warning(
+            "scope_json 'tenants' field is %s, expected list; denying all access",
+            type(tenants_raw).__name__,
+        )
+        return Scope(deny_all=True)
+
+    if projects_raw is not None and not isinstance(projects_raw, list):
+        _log.warning(
+            "scope_json 'projects' field is %s, expected list; denying all access",
+            type(projects_raw).__name__,
+        )
+        return Scope(deny_all=True)
+
     return Scope(
-        tenants=_coerce_str_list(raw.get("tenants")),
-        projects=_coerce_str_list(raw.get("projects")),
+        tenants=_coerce_str_tuple(tenants_raw) if tenants_raw is not None else (),
+        projects=_coerce_str_tuple(projects_raw) if projects_raw is not None else (),
     )

--- a/objectified-mcp/tests/test_cli.py
+++ b/objectified-mcp/tests/test_cli.py
@@ -45,7 +45,7 @@ def test_console_script_entrypoint_prints_usage() -> None:
 def test_package_version_matches_pyproject() -> None:
     from objectified_mcp import __version__
 
-    assert __version__ == "0.1.8"
+    assert __version__ == "0.1.9"
 
 
 def test_serve_validate_only_exits_without_stdio(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/objectified-mcp/tests/test_mcp_auth.py
+++ b/objectified-mcp/tests/test_mcp_auth.py
@@ -20,6 +20,7 @@ from objectified_mcp.mcp_auth import (
     require_mcp_auth,
     validate_mcp_api_key,
 )
+from objectified_mcp.scope import Scope
 
 _SECRET = "0123456789ab" + "cursor-test-secret"
 
@@ -73,12 +74,13 @@ def _pool_mock(rows: list[dict]) -> MagicMock:
 def test_validate_success_returns_scope() -> None:
     kid = str(uuid.uuid4())
     tid = str(uuid.uuid4())
+    pid = str(uuid.uuid4())
     stored_hash = hash_mcp_api_key_secret(_SECRET).decode("ascii")
     row = {
         "id": kid,
         "tenant_id": tid,
         "label": "unit",
-        "scope_json": {"tenant": True},
+        "scope_json": {"tenants": [tid], "projects": [pid]},
         "key_hash": stored_hash,
         "expires_at": None,
         "revoked_at": None,
@@ -87,7 +89,13 @@ def test_validate_success_returns_scope() -> None:
 
     async def run() -> None:
         auth = await validate_mcp_api_key(pool, _SECRET)
-        assert auth == McpAuthContext(key_id=kid, tenant_id=tid, label="unit", scope={"tenant": True})
+        expected = McpAuthContext(
+            key_id=kid,
+            tenant_id=tid,
+            label="unit",
+            scope=Scope(tenants=[tid], projects=[pid]),
+        )
+        assert auth == expected
 
     asyncio.run(run())
 

--- a/objectified-mcp/tests/test_scope.py
+++ b/objectified-mcp/tests/test_scope.py
@@ -1,0 +1,72 @@
+"""Tests for MCP API key :class:`objectified_mcp.scope.Scope` (#3001)."""
+
+from __future__ import annotations
+
+import uuid
+
+from objectified_mcp.scope import Scope, parse_scope_json
+
+
+def test_allows_public_empty_lists() -> None:
+    s = Scope()
+    t, p = str(uuid.uuid4()), str(uuid.uuid4())
+    assert s.allows(t, p)
+    assert s.allows(t, None)
+
+
+def test_allows_tenant_restriction() -> None:
+    a, b = str(uuid.uuid4()), str(uuid.uuid4())
+    s = Scope(tenants=[a])
+    assert s.allows(a, None)
+    assert s.allows(a, str(uuid.uuid4()))
+    assert not s.allows(b, None)
+
+
+def test_allows_project_restriction() -> None:
+    tid = str(uuid.uuid4())
+    p1, p2 = str(uuid.uuid4()), str(uuid.uuid4())
+    s = Scope(projects=[p1])
+    assert s.allows(tid, p1)
+    assert not s.allows(tid, p2)
+    assert not s.allows(tid, None)
+
+
+def test_allows_tenant_and_project() -> None:
+    tid_ok, tid_bad = str(uuid.uuid4()), str(uuid.uuid4())
+    pid_ok, pid_bad = str(uuid.uuid4()), str(uuid.uuid4())
+    s = Scope(tenants=[tid_ok], projects=[pid_ok])
+    assert s.allows(tid_ok, pid_ok)
+    assert not s.allows(tid_bad, pid_ok)
+    assert not s.allows(tid_ok, pid_bad)
+
+
+def test_parse_scope_json_none_and_empty_dict() -> None:
+    assert parse_scope_json(None) == Scope()
+    assert parse_scope_json({}) == Scope()
+
+
+def test_parse_scope_json_round_trip_lists() -> None:
+    t, p = str(uuid.uuid4()), str(uuid.uuid4())
+    raw = {"tenants": [t], "projects": [p]}
+    s = parse_scope_json(raw)
+    assert s == Scope(tenants=[t], projects=[p])
+    assert s.to_json_dict() == raw
+
+
+def test_parse_scope_json_ignores_unknown_keys_and_legacy_shape() -> None:
+    assert parse_scope_json({"tenant": True}) == Scope()
+    assert parse_scope_json({"tenants": ["x"], "extra": 1}) == Scope(tenants=["x"])
+
+
+def test_parse_scope_json_coerces_non_lists_and_non_strings() -> None:
+    assert parse_scope_json({"tenants": "bad"}) == Scope()
+    assert parse_scope_json({"tenants": [1, "keep", None]}) == Scope(tenants=["keep"])
+
+
+def test_parse_scope_json_non_dict() -> None:
+    assert parse_scope_json([1, 2]) == Scope()
+
+
+def test_parse_scope_json_scope_instance() -> None:
+    s = Scope(tenants=["a"])
+    assert parse_scope_json(s) is s

--- a/objectified-mcp/tests/test_scope.py
+++ b/objectified-mcp/tests/test_scope.py
@@ -65,7 +65,7 @@ def test_parse_scope_json_round_trip_lists() -> None:
 
 def test_parse_scope_json_ignores_unknown_keys_and_legacy_shape() -> None:
     assert parse_scope_json({"tenant": True}) == Scope()
-    assert parse_scope_json({"tenants": ["x"], "extra": 1}) == Scope(tenants=["x"])
+    assert parse_scope_json({"tenants": ["x"], "extra": 1}) == Scope(tenants=("x",))
 
 
 def test_parse_scope_json_wrong_field_type_denies_all(caplog: Any) -> None:
@@ -84,7 +84,7 @@ def test_parse_scope_json_wrong_field_type_denies_all(caplog: Any) -> None:
 def test_parse_scope_json_filters_non_string_items() -> None:
     """Non-string items inside a valid list are silently filtered out."""
     s = parse_scope_json({"tenants": [1, "keep", None]})
-    assert s == Scope(tenants=("keep",))
+    assert s == Scope(tenants=["keep"])
 
 
 def test_parse_scope_json_non_dict_denies_all(caplog: Any) -> None:

--- a/objectified-mcp/tests/test_scope.py
+++ b/objectified-mcp/tests/test_scope.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import uuid
+from typing import Any
 
 from objectified_mcp.scope import Scope, parse_scope_json
 
@@ -40,6 +41,15 @@ def test_allows_tenant_and_project() -> None:
     assert not s.allows(tid_ok, pid_bad)
 
 
+def test_scope_tenants_projects_are_tuples() -> None:
+    """Fields are stored as tuples even when constructed with lists."""
+    s = Scope(tenants=["a", "b"], projects=["p"])
+    assert isinstance(s.tenants, tuple)
+    assert isinstance(s.projects, tuple)
+    assert s.tenants == ("a", "b")
+    assert s.projects == ("p",)
+
+
 def test_parse_scope_json_none_and_empty_dict() -> None:
     assert parse_scope_json(None) == Scope()
     assert parse_scope_json({}) == Scope()
@@ -58,13 +68,34 @@ def test_parse_scope_json_ignores_unknown_keys_and_legacy_shape() -> None:
     assert parse_scope_json({"tenants": ["x"], "extra": 1}) == Scope(tenants=["x"])
 
 
-def test_parse_scope_json_coerces_non_lists_and_non_strings() -> None:
-    assert parse_scope_json({"tenants": "bad"}) == Scope()
-    assert parse_scope_json({"tenants": [1, "keep", None]}) == Scope(tenants=["keep"])
+def test_parse_scope_json_wrong_field_type_denies_all(caplog: Any) -> None:
+    """A non-list ``tenants``/``projects`` value is invalid → deny-all + warning."""
+    import logging
+
+    with caplog.at_level(logging.WARNING, logger="objectified_mcp.scope"):
+        bad_tenants = parse_scope_json({"tenants": "bad"})
+        bad_projects = parse_scope_json({"projects": 42})
+    assert bad_tenants.deny_all is True
+    assert not bad_tenants.allows(str(uuid.uuid4()), str(uuid.uuid4()))
+    assert bad_projects.deny_all is True
+    assert len(caplog.records) >= 2
 
 
-def test_parse_scope_json_non_dict() -> None:
-    assert parse_scope_json([1, 2]) == Scope()
+def test_parse_scope_json_filters_non_string_items() -> None:
+    """Non-string items inside a valid list are silently filtered out."""
+    s = parse_scope_json({"tenants": [1, "keep", None]})
+    assert s == Scope(tenants=("keep",))
+
+
+def test_parse_scope_json_non_dict_denies_all(caplog: Any) -> None:
+    """Non-dict (and non-None, non-Scope) raw values → deny-all + warning."""
+    import logging
+
+    with caplog.at_level(logging.WARNING, logger="objectified_mcp.scope"):
+        s = parse_scope_json([1, 2])
+    assert s.deny_all is True
+    assert not s.allows(str(uuid.uuid4()), str(uuid.uuid4()))
+    assert len(caplog.records) >= 1
 
 
 def test_parse_scope_json_scope_instance() -> None:

--- a/objectified-mcp/uv.lock
+++ b/objectified-mcp/uv.lock
@@ -842,7 +842,7 @@ wheels = [
 
 [[package]]
 name = "objectified-mcp"
-version = "0.1.8"
+version = "0.1.9"
 source = { editable = "." }
 dependencies = [
     { name = "bcrypt" },

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.12",
+  "version": "0.11.13",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -14,6 +14,7 @@ We continue to improve the platform based on your feedback with improvements and
 - Database migration adds **`odb.mcp_api_keys`** for MCP API key storage (hashed secret, lookup prefix, tenant, JSON scopes, lifecycle timestamps).
 - MCP tools can require Postgres-backed API keys via FastMCP **`Depends(require_mcp_auth)`**: accepts **`Authorization: Bearer`** on HTTP or **`tools/call` `_meta`** on stdio, verifies bcrypt(SHA-256(secret)) against **`odb.mcp_api_keys`**, and returns a typed scope payload (clear errors for missing auth, unknown keys, expiry, and revocation).
 - Streamable HTTP binds **`Authorization: Bearer`** per request into tool context (**`get_http_bearer_from_context`**) via ASGI middleware plus FastMCP middleware; requests without a Bearer token expose **`None`** (anonymous).
+- MCP API key **`scope_json`** uses a typed **`Scope`** model (`tenants` / `projects` string lists, JSONB): empty lists mean no restriction at that level; **`scope.allows(tenant_id, project_id)`** gates reads (#3001).
 
 ## Importing
 - Race condition fixed in 3.0.1 specification imports


### PR DESCRIPTION
## What / why
Adds a frozen `Scope` dataclass (`tenants`, `projects`: `list[str]`) matching `odb.mcp_api_keys.scope_json`, `Scope.allows(tenant, project)` for read checks, and `parse_scope_json` for DB payloads. `McpAuthContext.scope` is now typed as `Scope` instead of a loose dict.

## How to test
- From repo root: **`yarn workspace objectified-mcp test`** (ruff, mypy, pytest).
- Example: `Scope(tenants=[t], projects=[]).allows(t, any_project_uuid)` is True; wrong tenant or missing project when `projects` is non-empty is False.

## Risks / notes
- Legacy `scope_json` shapes without `tenants`/`projects` (e.g. `{"tenant": true}`) parse as empty lists (**public** scope). Issuers should write the documented JSON shape.

Closes #3001

Made with [Cursor](https://cursor.com)