### PR TITLE
Fix #3002 - MCP last_used_at + keys revoke CLI

### DIFF
--- a/docs/PLANNED_ROADMAP_MCP.md
+++ b/docs/PLANNED_ROADMAP_MCP.md
@@ -91,7 +91,7 @@ process or via Docker.
 | 2.3 | ~~[#2999](../../issues/2999)~~ | ~~API key validator dependency~~ (**completed**) | 2.1 |
 | 2.4 | ~~[#3000](../../issues/3000)~~ | ~~HTTP credential extraction middleware~~ (**completed**) | 1.6, 2.3 |
 | 2.5 | ~~[#3001](../../issues/3001)~~ | ~~Scope model (public, tenant, project)~~ (**completed**) | 2.1 |
-| 2.6 | [#3002](../../issues/3002) | `last_used_at` + revoke command | 2.3 |
+| 2.6 | ~~[#3002](../../issues/3002)~~ | ~~`last_used_at` + revoke command~~ (**completed**) | 2.3 |
 
 #### E3 — Public Read-Only Spec Discovery (#3003)
 

--- a/objectified-mcp/package.json
+++ b/objectified-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-mcp",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "private": true,
   "description": "Yarn workspace anchor for the objectified-mcp Python package (uv + pyproject.toml).",
   "scripts": {

--- a/objectified-mcp/pyproject.toml
+++ b/objectified-mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "objectified-mcp"
-version = "0.1.9"
+version = "0.1.10"
 description = "Model Context Protocol server for Objectified (FastMCP)."
 readme = "README.md"
 requires-python = ">=3.11"
@@ -26,6 +26,7 @@ dependencies = [
 
 [project.scripts]
 objectified-mcp = "objectified_mcp.cli:main"
+mcp = "objectified_mcp.cli:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/objectified-mcp/src/objectified_mcp/__init__.py
+++ b/objectified-mcp/src/objectified_mcp/__init__.py
@@ -1,3 +1,3 @@
 """Objectified MCP server package."""
 
-__version__ = "0.1.9"
+__version__ = "0.1.10"

--- a/objectified-mcp/src/objectified_mcp/cli.py
+++ b/objectified-mcp/src/objectified_mcp/cli.py
@@ -15,6 +15,31 @@ async def _run_stdio_transport() -> None:
     await mcp.run_stdio_async()
 
 
+async def _run_keys_revoke(prefix: str) -> int:
+    import structlog
+
+    from objectified_mcp.database_pool import create_async_pool, ping_pool
+    from objectified_mcp.key_admin import revoke_mcp_keys_by_prefix
+    from objectified_mcp.logging_config import configure_logging
+    from objectified_mcp.mcp_auth import normalize_stored_prefix
+    from objectified_mcp.settings import get_settings
+
+    settings = get_settings()
+    configure_logging(settings)
+    log = structlog.get_logger(__name__)
+    canonical = normalize_stored_prefix(prefix)
+    pool = create_async_pool(settings, open=False)
+    await pool.open()
+    try:
+        await ping_pool(pool)
+        revoked = await revoke_mcp_keys_by_prefix(pool, canonical)
+        log.info("mcp_keys_revoked", prefix=canonical, count=revoked)
+    finally:
+        await pool.close()
+    print(f"Revoked {revoked} active key(s) matching prefix {canonical}.")
+    return 0 if revoked else 1
+
+
 async def _run_http_transport(host: str, port: int, *, log_level: str) -> None:
     """Streamable HTTP via FastMCP (``http_app`` → ``create_streamable_http_app``); serves MCP at ``/mcp``."""
     from starlette.middleware import Middleware as StarletteMiddleware
@@ -71,6 +96,20 @@ def main() -> None:
         help="TCP port for HTTP transport (default: OBJECTIFIED_MCP_HTTP_PORT).",
     )
 
+    keys_parser = subparsers.add_parser(
+        "keys",
+        help="MCP API key administration (same commands as ``mcp keys`` when using the mcp entrypoint).",
+    )
+    keys_sub = keys_parser.add_subparsers(dest="keys_command", required=True)
+    revoke_parser = keys_sub.add_parser(
+        "revoke",
+        help="Revoke all active keys whose stored prefix matches (see key issuance / dashboard prefix).",
+    )
+    revoke_parser.add_argument(
+        "prefix",
+        help="Key prefix: first 12 characters, with or without a trailing '...'.",
+    )
+
     args = parser.parse_args()
 
     if args.command == "serve":
@@ -112,5 +151,27 @@ def main() -> None:
                 detail="Pass --transport stdio or --transport http to run the server.",
             )
         raise SystemExit(0)
+
+    if args.command == "keys":
+        from pydantic import ValidationError
+
+        from objectified_mcp.mcp_auth import normalize_stored_prefix
+        from objectified_mcp.settings import get_settings
+
+        get_settings.cache_clear()
+        try:
+            get_settings()
+        except ValidationError as exc:
+            print(f"Configuration error:\n{exc}", file=sys.stderr)
+            raise SystemExit(2)
+        if args.keys_command == "revoke":
+            try:
+                normalize_stored_prefix(args.prefix)
+            except ValueError as exc:
+                print(str(exc), file=sys.stderr)
+                raise SystemExit(2)
+            code = asyncio.run(_run_keys_revoke(args.prefix))
+            get_settings.cache_clear()
+            raise SystemExit(code)
 
     parser.print_help()

--- a/objectified-mcp/src/objectified_mcp/key_admin.py
+++ b/objectified-mcp/src/objectified_mcp/key_admin.py
@@ -17,4 +17,6 @@ async def revoke_mcp_keys_by_prefix(pool: AsyncConnectionPool, prefix: str) -> i
                 """,
                 (prefix,),
             )
-            return int(cur.rowcount or 0)
+            count = int(cur.rowcount or 0)
+        await conn.commit()
+        return count

--- a/objectified-mcp/src/objectified_mcp/key_admin.py
+++ b/objectified-mcp/src/objectified_mcp/key_admin.py
@@ -1,0 +1,20 @@
+"""MCP API key lifecycle helpers used by the CLI (#3002)."""
+
+from __future__ import annotations
+
+from psycopg_pool import AsyncConnectionPool
+
+
+async def revoke_mcp_keys_by_prefix(pool: AsyncConnectionPool, prefix: str) -> int:
+    """Set ``revoked_at`` for all active keys matching ``prefix``; return rows updated."""
+    async with pool.connection() as conn:
+        async with conn.cursor() as cur:
+            await cur.execute(
+                """
+                UPDATE odb.mcp_api_keys
+                SET revoked_at = CURRENT_TIMESTAMP
+                WHERE prefix = %s AND revoked_at IS NULL
+                """,
+                (prefix,),
+            )
+            return int(cur.rowcount or 0)

--- a/objectified-mcp/src/objectified_mcp/mcp_auth.py
+++ b/objectified-mcp/src/objectified_mcp/mcp_auth.py
@@ -25,6 +25,7 @@ Scoped reads use :meth:`objectified_mcp.scope.Scope.allows` on ``auth.scope``; s
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import re
 from datetime import datetime, timezone
@@ -66,6 +67,20 @@ def mcp_key_prefix(secret: str) -> str:
     if len(secret) < _PREFIX_CHARS:
         return secret + "..."
     return secret[:_PREFIX_CHARS] + "..."
+
+
+def normalize_stored_prefix(user_input: str) -> str:
+    """Normalize CLI or human input to the ``odb.mcp_api_keys.prefix`` format."""
+    s = user_input.strip()
+    if not s:
+        raise ValueError("Prefix must be non-empty.")
+    if s.endswith("..."):
+        s = s[:-3].strip()
+    if not s:
+        raise ValueError("Prefix is invalid.")
+    if len(s) >= _PREFIX_CHARS:
+        return s[:_PREFIX_CHARS] + "..."
+    return s + "..."
 
 
 def hash_mcp_api_key_secret(plain: str) -> bytes:
@@ -170,8 +185,10 @@ async def validate_mcp_api_key(pool: AsyncConnectionPool, raw_secret: str) -> Mc
 
     for row in eligible:
         if _verify_hash(raw_secret, row.get("key_hash")):
+            key_id = str(row["id"])
+            schedule_mcp_key_last_used_touch(pool, key_id)
             return McpAuthContext(
-                key_id=str(row["id"]),
+                key_id=key_id,
                 tenant_id=str(row["tenant_id"]),
                 label=str(row["label"]),
                 scope=parse_scope_json(row.get("scope_json")),
@@ -206,3 +223,27 @@ async def require_mcp_auth(
 
 
 McpAuthDependency = Depends(require_mcp_auth)
+
+
+async def touch_mcp_key_last_used(pool: AsyncConnectionPool, key_id: str) -> None:
+    """Persist ``last_used_at`` for a successfully authenticated key."""
+    async with pool.connection() as conn:
+        await conn.execute(
+            "UPDATE odb.mcp_api_keys SET last_used_at = CURRENT_TIMESTAMP WHERE id = %s::uuid",
+            (key_id,),
+        )
+
+
+def schedule_mcp_key_last_used_touch(pool: AsyncConnectionPool, key_id: str) -> None:
+    """Fire-and-forget ``last_used_at`` update so auth latency stays low."""
+
+    async def _run() -> None:
+        try:
+            await touch_mcp_key_last_used(pool, key_id)
+        except Exception:
+            _log.warning("mcp_api_key_last_used_update_failed", key_id=key_id, exc_info=True)
+
+    try:
+        asyncio.get_running_loop().create_task(_run())
+    except RuntimeError:
+        _log.debug("mcp_api_key_last_used_skip_no_event_loop", key_id=key_id)

--- a/objectified-mcp/src/objectified_mcp/mcp_auth.py
+++ b/objectified-mcp/src/objectified_mcp/mcp_auth.py
@@ -70,7 +70,13 @@ def mcp_key_prefix(secret: str) -> str:
 
 
 def normalize_stored_prefix(user_input: str) -> str:
-    """Normalize CLI or human input to the ``odb.mcp_api_keys.prefix`` format."""
+    """Normalize CLI or human input to the ``odb.mcp_api_keys.prefix`` format.
+
+    Raises :exc:`ValueError` if the bare prefix (after stripping a trailing
+    ``...``) is shorter than :data:`_PREFIX_CHARS` characters, because such a
+    string can never match any stored key and ``keys revoke`` would silently
+    do nothing.
+    """
     s = user_input.strip()
     if not s:
         raise ValueError("Prefix must be non-empty.")
@@ -78,9 +84,12 @@ def normalize_stored_prefix(user_input: str) -> str:
         s = s[:-3].strip()
     if not s:
         raise ValueError("Prefix is invalid.")
-    if len(s) >= _PREFIX_CHARS:
-        return s[:_PREFIX_CHARS] + "..."
-    return s + "..."
+    if len(s) < _PREFIX_CHARS:
+        raise ValueError(
+            f"Prefix is too short ({len(s)} chars); "
+            f"supply at least {_PREFIX_CHARS} characters (the first {_PREFIX_CHARS} of the key)."
+        )
+    return s[:_PREFIX_CHARS] + "..."
 
 
 def hash_mcp_api_key_secret(plain: str) -> bytes:
@@ -232,6 +241,7 @@ async def touch_mcp_key_last_used(pool: AsyncConnectionPool, key_id: str) -> Non
             "UPDATE odb.mcp_api_keys SET last_used_at = CURRENT_TIMESTAMP WHERE id = %s::uuid",
             (key_id,),
         )
+        await conn.commit()
 
 
 def schedule_mcp_key_last_used_touch(pool: AsyncConnectionPool, key_id: str) -> None:

--- a/objectified-mcp/tests/test_cli.py
+++ b/objectified-mcp/tests/test_cli.py
@@ -29,6 +29,43 @@ def test_module_help_prints_usage() -> None:
     assert result.stderr == ""
 
 
+def test_keys_revoke_invokes_runner(monkeypatch: pytest.MonkeyPatch) -> None:
+    from objectified_mcp.cli import main
+    from objectified_mcp.settings import get_settings
+
+    get_settings.cache_clear()
+    for key, value in _MIN_ENV.items():
+        monkeypatch.setenv(key, value)
+
+    recorded: list[str] = []
+
+    async def stub_revoke(prefix: str) -> int:
+        recorded.append(prefix)
+        return 0
+
+    monkeypatch.setattr("objectified_mcp.cli._run_keys_revoke", stub_revoke)
+    monkeypatch.setattr(sys, "argv", ["objectified-mcp", "keys", "revoke", "abcdefghijkl"])
+    with pytest.raises(SystemExit) as exc_info:
+        main()
+    assert exc_info.value.code == 0
+    assert recorded == ["abcdefghijkl"]
+    get_settings.cache_clear()
+
+
+def test_keys_revoke_rejects_invalid_prefix(monkeypatch: pytest.MonkeyPatch) -> None:
+    from objectified_mcp.cli import main
+    from objectified_mcp.settings import get_settings
+
+    get_settings.cache_clear()
+    for key, value in _MIN_ENV.items():
+        monkeypatch.setenv(key, value)
+    monkeypatch.setattr(sys, "argv", ["objectified-mcp", "keys", "revoke", "..."])
+    with pytest.raises(SystemExit) as exc_info:
+        main()
+    assert exc_info.value.code == 2
+    get_settings.cache_clear()
+
+
 def test_console_script_entrypoint_prints_usage() -> None:
     """Validates the [project.scripts] entrypoint (cli.main) directly."""
     result = subprocess.run(
@@ -45,7 +82,7 @@ def test_console_script_entrypoint_prints_usage() -> None:
 def test_package_version_matches_pyproject() -> None:
     from objectified_mcp import __version__
 
-    assert __version__ == "0.1.9"
+    assert __version__ == "0.1.10"
 
 
 def test_serve_validate_only_exits_without_stdio(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/objectified-mcp/tests/test_key_admin.py
+++ b/objectified-mcp/tests/test_key_admin.py
@@ -18,6 +18,7 @@ def test_revoke_mcp_keys_by_prefix_returns_rowcount() -> None:
 
     conn = MagicMock()
     conn.cursor = MagicMock(return_value=cm_cur)
+    conn.commit = AsyncMock()
 
     cm_conn = AsyncMock()
     cm_conn.__aenter__ = AsyncMock(return_value=conn)
@@ -30,3 +31,4 @@ def test_revoke_mcp_keys_by_prefix_returns_rowcount() -> None:
 
     assert asyncio.run(run()) == 2
     cur.execute.assert_awaited_once()
+    conn.commit.assert_awaited_once()

--- a/objectified-mcp/tests/test_key_admin.py
+++ b/objectified-mcp/tests/test_key_admin.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+from psycopg_pool import AsyncConnectionPool
+
+from objectified_mcp.key_admin import revoke_mcp_keys_by_prefix
+
+
+def test_revoke_mcp_keys_by_prefix_returns_rowcount() -> None:
+    cur = AsyncMock()
+    cur.rowcount = 2
+    cur.execute = AsyncMock()
+    cm_cur = AsyncMock()
+    cm_cur.__aenter__ = AsyncMock(return_value=cur)
+    cm_cur.__aexit__ = AsyncMock(return_value=None)
+
+    conn = MagicMock()
+    conn.cursor = MagicMock(return_value=cm_cur)
+
+    cm_conn = AsyncMock()
+    cm_conn.__aenter__ = AsyncMock(return_value=conn)
+    cm_conn.__aexit__ = AsyncMock(return_value=None)
+    pool = MagicMock(spec=AsyncConnectionPool)
+    pool.connection = MagicMock(return_value=cm_conn)
+
+    async def run() -> int:
+        return await revoke_mcp_keys_by_prefix(pool, "abcdefghijkl...")
+
+    assert asyncio.run(run()) == 2
+    cur.execute.assert_awaited_once()

--- a/objectified-mcp/tests/test_mcp_auth.py
+++ b/objectified-mcp/tests/test_mcp_auth.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import uuid
 from datetime import datetime, timedelta, timezone
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastmcp import Context
@@ -17,7 +17,10 @@ from objectified_mcp.mcp_auth import (
     hash_mcp_api_key_secret,
     mcp_key_prefix,
     meta_as_dict,
+    normalize_stored_prefix,
     require_mcp_auth,
+    schedule_mcp_key_last_used_touch,
+    touch_mcp_key_last_used,
     validate_mcp_api_key,
 )
 from objectified_mcp.scope import Scope
@@ -27,6 +30,16 @@ _SECRET = "0123456789ab" + "cursor-test-secret"
 
 def test_mcp_key_prefix_format() -> None:
     assert mcp_key_prefix(_SECRET) == _SECRET[:12] + "..."
+
+
+def test_normalize_stored_prefix_accepts_plain_or_ellipsis() -> None:
+    assert normalize_stored_prefix("abcdefghijkl") == "abcdefghijkl..."
+    assert normalize_stored_prefix("  abcdefghijkl...  ") == "abcdefghijkl..."
+    assert normalize_stored_prefix("abcdefghijklmno") == "abcdefghijkl..."
+    with pytest.raises(ValueError, match="non-empty"):
+        normalize_stored_prefix("   ")
+    with pytest.raises(ValueError, match="invalid"):
+        normalize_stored_prefix("...")
 
 
 def test_extract_prefers_http_authorization_over_meta() -> None:
@@ -59,6 +72,7 @@ def _pool_mock(rows: list[dict]) -> MagicMock:
     cur.fetchall = AsyncMock(return_value=rows)
     cur.execute = AsyncMock()
     conn = MagicMock()
+    conn.execute = AsyncMock()
     cm_cur = AsyncMock()
     cm_cur.__aenter__ = AsyncMock(return_value=cur)
     cm_cur.__aexit__ = AsyncMock(return_value=None)
@@ -88,7 +102,9 @@ def test_validate_success_returns_scope() -> None:
     pool = _pool_mock([row])
 
     async def run() -> None:
-        auth = await validate_mcp_api_key(pool, _SECRET)
+        with patch("objectified_mcp.mcp_auth.schedule_mcp_key_last_used_touch") as sched:
+            auth = await validate_mcp_api_key(pool, _SECRET)
+        sched.assert_called_once_with(pool, kid)
         expected = McpAuthContext(
             key_id=kid,
             tenant_id=tid,
@@ -187,7 +203,51 @@ def test_require_mcp_auth_happy_path() -> None:
     ctx.lifespan_context = {MCP_DB_POOL_KEY: pool}
 
     async def run() -> None:
-        auth = await require_mcp_auth(ctx, {"authorization": f"Bearer {_SECRET}"})
+        with patch("objectified_mcp.mcp_auth.schedule_mcp_key_last_used_touch") as sched:
+            auth = await require_mcp_auth(ctx, {"authorization": f"Bearer {_SECRET}"})
+        sched.assert_called_once_with(pool, kid)
         assert auth.key_id == kid
+
+    asyncio.run(run())
+
+
+def test_touch_mcp_key_last_used_executes_update() -> None:
+    kid = str(uuid.uuid4())
+    conn = MagicMock()
+    conn.execute = AsyncMock()
+    cm = AsyncMock()
+    cm.__aenter__ = AsyncMock(return_value=conn)
+    cm.__aexit__ = AsyncMock(return_value=None)
+    pool = MagicMock(spec=AsyncConnectionPool)
+    pool.connection = MagicMock(return_value=cm)
+
+    async def run() -> None:
+        await touch_mcp_key_last_used(pool, kid)
+
+    asyncio.run(run())
+    conn.execute.assert_awaited_once()
+    call_args = conn.execute.await_args
+    assert kid in str(call_args)
+
+
+def test_schedule_mcp_key_last_used_touch_uses_event_loop() -> None:
+    pool = MagicMock(spec=AsyncConnectionPool)
+    captured: list[object] = []
+
+    async def run() -> None:
+        mock_loop = MagicMock()
+
+        def capture_task(coro: object) -> MagicMock:
+            captured.append(coro)
+            return MagicMock()
+
+        mock_loop.create_task.side_effect = capture_task
+        with patch("objectified_mcp.mcp_auth.touch_mcp_key_last_used", new=AsyncMock()):
+            with patch("asyncio.get_running_loop", return_value=mock_loop):
+                schedule_mcp_key_last_used_touch(pool, "key-id")
+        mock_loop.create_task.assert_called_once()
+        assert len(captured) == 1
+        assert asyncio.iscoroutine(captured[0])
+        await captured[0]  # type: ignore[misc]
 
     asyncio.run(run())

--- a/objectified-mcp/tests/test_mcp_auth.py
+++ b/objectified-mcp/tests/test_mcp_auth.py
@@ -40,6 +40,10 @@ def test_normalize_stored_prefix_accepts_plain_or_ellipsis() -> None:
         normalize_stored_prefix("   ")
     with pytest.raises(ValueError, match="invalid"):
         normalize_stored_prefix("...")
+    with pytest.raises(ValueError, match="too short"):
+        normalize_stored_prefix("abc")
+    with pytest.raises(ValueError, match="too short"):
+        normalize_stored_prefix("abc...")
 
 
 def test_extract_prefers_http_authorization_over_meta() -> None:
@@ -215,6 +219,7 @@ def test_touch_mcp_key_last_used_executes_update() -> None:
     kid = str(uuid.uuid4())
     conn = MagicMock()
     conn.execute = AsyncMock()
+    conn.commit = AsyncMock()
     cm = AsyncMock()
     cm.__aenter__ = AsyncMock(return_value=conn)
     cm.__aexit__ = AsyncMock(return_value=None)
@@ -226,6 +231,7 @@ def test_touch_mcp_key_last_used_executes_update() -> None:
 
     asyncio.run(run())
     conn.execute.assert_awaited_once()
+    conn.commit.assert_awaited_once()
     call_args = conn.execute.await_args
     assert kid in str(call_args)
 

--- a/objectified-mcp/uv.lock
+++ b/objectified-mcp/uv.lock
@@ -842,7 +842,7 @@ wheels = [
 
 [[package]]
 name = "objectified-mcp"
-version = "0.1.9"
+version = "0.1.10"
 source = { editable = "." }
 dependencies = [
     { name = "bcrypt" },

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.13",
+  "version": "0.11.14",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -15,6 +15,7 @@ We continue to improve the platform based on your feedback with improvements and
 - MCP tools can require Postgres-backed API keys via FastMCP **`Depends(require_mcp_auth)`**: accepts **`Authorization: Bearer`** on HTTP or **`tools/call` `_meta`** on stdio, verifies bcrypt(SHA-256(secret)) against **`odb.mcp_api_keys`**, and returns a typed scope payload (clear errors for missing auth, unknown keys, expiry, and revocation).
 - Streamable HTTP binds **`Authorization: Bearer`** per request into tool context (**`get_http_bearer_from_context`**) via ASGI middleware plus FastMCP middleware; requests without a Bearer token expose **`None`** (anonymous).
 - MCP API key **`scope_json`** uses a typed **`Scope`** model (`tenants` / `projects` string lists, JSONB): empty lists mean no restriction at that level; **`scope.allows(tenant_id, project_id)`** gates reads (#3001).
+- Successful MCP API key authentication updates **`last_used_at`** in Postgres asynchronously (non-blocking); **`objectified-mcp keys revoke <prefix>`** (also **`mcp keys revoke …`** via the `mcp` console alias) revokes active keys by stored prefix (#3002).
 
 ## Importing
 - Race condition fixed in 3.0.1 specification imports


### PR DESCRIPTION
## Summary
Implements MCP-2.6: after a successful MCP API key validation, `last_used_at` is updated in Postgres **asynchronously** (non-blocking `asyncio.create_task`) so auth latency stays low; failures are logged and do not affect the request.

Adds **`objectified-mcp keys revoke <prefix>`** (and console alias **`mcp keys revoke <prefix>`**) to set `revoked_at` for active keys matching the stored prefix (normalized from either the first 12 characters or the dashboard-style `xxxxxxxxxxxx...` form). Revoked keys continue to be rejected immediately by the existing validator.

## How to test
- **Unit / CI**: from repo root run **`yarn test`** (includes objectified-mcp ruff, mypy, pytest).
- **Revoke CLI**: set **`OBJECTIFIED_MCP_DATABASE_URL`** and **`OBJECTIFIED_MCP_INTERNAL_SECRET`** (see `objectified-mcp/.env.example`), insert or issue a test key, then run **`uv run --directory objectified-mcp mcp keys revoke <prefix>`** (or `objectified-mcp keys revoke …`) and confirm the row has **`revoked_at`** set and subsequent auth fails with a revocation error.
- **last_used_at**: authenticate once with a valid key (e.g. HTTP Bearer against a tool using `require_mcp_auth`), wait briefly, and confirm **`last_used_at`** advanced on the key row.

## Risk / notes
- Fire-and-forget tasks rely on the running event loop; if no loop exists (should not occur in server paths), the touch is skipped with a debug log.
- Console script name **`mcp`** may collide with other installed tools in the same environment; **`objectified-mcp`** remains the primary entrypoint.

Closes #3002

Made with [Cursor](https://cursor.com)