### PR TITLE
Fix #3004 - MCP published public specs SQL view

### DIFF
--- a/docs/PLANNED_ROADMAP_MCP.md
+++ b/docs/PLANNED_ROADMAP_MCP.md
@@ -97,7 +97,7 @@ process or via Docker.
 
 | # | Issue | Title | Depends on |
 |---|-------|-------|------------|
-| 3.1 | [#3004](../../issues/3004) | SQL view: published+public specs | E1 |
+| 3.1 | ~~[#3004](../../issues/3004)~~ | ~~SQL view: published+public specs~~ (**completed**) | E1 |
 | 3.2 | [#3005](../../issues/3005) | Tool `spec.list` (public, paginated) | 3.1 |
 | 3.3 | [#3006](../../issues/3006) | Tool `spec.describe` (public) | 3.1 |
 | 3.4 | [#3007](../../issues/3007) | Tool `spec.search` (keyword) | 3.1 |

--- a/objectified-db/fixtures/mcp_public_specs_dev.sql
+++ b/objectified-db/fixtures/mcp_public_specs_dev.sql
@@ -1,0 +1,97 @@
+-- Dev fixture for odb.mcp_v_public_specs (#3004).
+-- Apply after all migrations. Idempotent for these UUIDs: deletes the fixture project (cascades versions/tags), then reinserts.
+--
+-- Expect after load:
+--   SELECT count(*) FROM odb.mcp_v_public_specs WHERE project_id = '00000000-0000-4000-8000-000000000003'::uuid;
+--   → 1 (only the 1.0.0 public published revision).
+--
+SET search_path TO odb, public;
+
+BEGIN;
+
+DELETE FROM odb.projects WHERE id = '00000000-0000-4000-8000-000000000003'::uuid;
+DELETE FROM odb.tenant_users
+WHERE tenant_id = '00000000-0000-4000-8000-000000000001'::uuid
+  AND user_id = '00000000-0000-4000-8000-000000000002'::uuid;
+DELETE FROM odb.tenants WHERE id = '00000000-0000-4000-8000-000000000001'::uuid;
+DELETE FROM odb.users WHERE id = '00000000-0000-4000-8000-000000000002'::uuid;
+
+INSERT INTO odb.users (id, name, email, password)
+VALUES (
+  '00000000-0000-4000-8000-000000000002',
+  'MCP Fixture User',
+  'mcp-fixture-3004@objectified.local',
+  '$2b$04$fixture-not-a-real-hash-used-for-dev-only'
+);
+
+INSERT INTO odb.tenants (id, name, slug)
+VALUES (
+  '00000000-0000-4000-8000-000000000001',
+  'MCP Fixture Tenant',
+  'mcp-fixture-tenant-3004'
+);
+
+INSERT INTO odb.tenant_users (tenant_id, user_id)
+VALUES (
+  '00000000-0000-4000-8000-000000000001',
+  '00000000-0000-4000-8000-000000000002'
+);
+
+INSERT INTO odb.projects (id, tenant_id, creator_id, name, slug)
+VALUES (
+  '00000000-0000-4000-8000-000000000003',
+  '00000000-0000-4000-8000-000000000001',
+  '00000000-0000-4000-8000-000000000002',
+  'MCP Fixture Project',
+  'mcp-fixture-project-3004'
+);
+
+INSERT INTO odb.versions (
+  id,
+  project_id,
+  creator_id,
+  version_id,
+  description,
+  published,
+  visibility,
+  enabled
+)
+VALUES (
+  '00000000-0000-4000-8000-000000000004',
+  '00000000-0000-4000-8000-000000000003',
+  '00000000-0000-4000-8000-000000000002',
+  '1.0.0',
+  'Published public revision for MCP view tests',
+  TRUE,
+  'public',
+  TRUE
+),
+(
+  '00000000-0000-4000-8000-000000000005',
+  '00000000-0000-4000-8000-000000000003',
+  '00000000-0000-4000-8000-000000000002',
+  '0.9.0',
+  'Published but private — excluded from mcp_v_public_specs',
+  TRUE,
+  'private',
+  TRUE
+),
+(
+  '00000000-0000-4000-8000-000000000006',
+  '00000000-0000-4000-8000-000000000003',
+  '00000000-0000-4000-8000-000000000002',
+  '0.8.0',
+  'Public visibility but unpublished — excluded from mcp_v_public_specs',
+  FALSE,
+  'public',
+  TRUE
+);
+
+INSERT INTO odb.version_tags (project_id, version_id, name)
+VALUES (
+  '00000000-0000-4000-8000-000000000003',
+  '00000000-0000-4000-8000-000000000004',
+  'release'
+);
+
+COMMIT;

--- a/objectified-db/scripts/20260502-130000.sql
+++ b/objectified-db/scripts/20260502-130000.sql
@@ -10,13 +10,16 @@ SELECT
   v.version_id AS version,
   v.description,
   COALESCE(tg.tags, ARRAY[]::TEXT[]) AS tags,
-  v.updated_at
+  GREATEST(v.updated_at, p.updated_at, COALESCE(tg.max_tag_updated_at, '-infinity'::timestamptz)) AS updated_at
 FROM odb.versions v
 INNER JOIN odb.projects p ON p.id = v.project_id
 LEFT JOIN LATERAL (
-  SELECT array_agg(vt.name ORDER BY vt.name) AS tags
+  SELECT
+    array_agg(vt.name ORDER BY vt.name) AS tags,
+    max(vt.updated_at) AS max_tag_updated_at
   FROM odb.version_tags vt
   WHERE vt.version_id = v.id
+    AND vt.project_id = v.project_id
 ) tg ON TRUE
 WHERE v.deleted_at IS NULL
   AND p.deleted_at IS NULL
@@ -50,4 +53,4 @@ COMMENT ON COLUMN odb.mcp_v_public_specs.tags IS
   'Sorted distinct git-like tag names (version_tags.name) pointing at this revision; empty array if none.';
 
 COMMENT ON COLUMN odb.mcp_v_public_specs.updated_at IS
-  'Last update time of the revision row (versions.updated_at).';
+  'Freshness cursor: GREATEST of versions.updated_at, projects.updated_at, and the latest version_tags.updated_at for this revision. Advances on project renames and tag mutations, not just revision edits.';

--- a/objectified-db/scripts/20260502-130000.sql
+++ b/objectified-db/scripts/20260502-130000.sql
@@ -1,0 +1,53 @@
+-- MCP read model: published + public schema revisions as a stable spec catalog (#3004).
+SET search_path TO odb, public;
+
+CREATE OR REPLACE VIEW odb.mcp_v_public_specs AS
+SELECT
+  v.id,
+  p.tenant_id,
+  v.project_id,
+  p.name AS title,
+  v.version_id AS version,
+  v.description,
+  COALESCE(tg.tags, ARRAY[]::TEXT[]) AS tags,
+  v.updated_at
+FROM odb.versions v
+INNER JOIN odb.projects p ON p.id = v.project_id
+LEFT JOIN LATERAL (
+  SELECT array_agg(vt.name ORDER BY vt.name) AS tags
+  FROM odb.version_tags vt
+  WHERE vt.version_id = v.id
+) tg ON TRUE
+WHERE v.deleted_at IS NULL
+  AND p.deleted_at IS NULL
+  AND v.enabled IS TRUE
+  AND p.enabled IS TRUE
+  AND v.published IS TRUE
+  AND v.visibility = 'public'::odb.visibility_type;
+
+COMMENT ON VIEW odb.mcp_v_public_specs IS
+  'MCP spec discovery: one row per schema revision (versions.id) that is published and public-visible (#3004).';
+
+COMMENT ON COLUMN odb.mcp_v_public_specs.id IS
+  'Schema revision id (versions.id); stable spec identity for MCP tools.';
+
+COMMENT ON COLUMN odb.mcp_v_public_specs.tenant_id IS
+  'Owning tenant (projects.tenant_id).';
+
+COMMENT ON COLUMN odb.mcp_v_public_specs.project_id IS
+  'Project id (versions.project_id).';
+
+COMMENT ON COLUMN odb.mcp_v_public_specs.title IS
+  'Human-readable project title (projects.name).';
+
+COMMENT ON COLUMN odb.mcp_v_public_specs.version IS
+  'Semantic version label (versions.version_id).';
+
+COMMENT ON COLUMN odb.mcp_v_public_specs.description IS
+  'Revision description (versions.description); nullable.';
+
+COMMENT ON COLUMN odb.mcp_v_public_specs.tags IS
+  'Sorted distinct git-like tag names (version_tags.name) pointing at this revision; empty array if none.';
+
+COMMENT ON COLUMN odb.mcp_v_public_specs.updated_at IS
+  'Last update time of the revision row (versions.updated_at).';

--- a/objectified-rest/pyproject.toml
+++ b/objectified-rest/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "objectified-rest"
-version = "1.0.50"
+version = "1.0.51"
 description = "REST API for serving OpenAPI specifications from the Objectified database"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/objectified-rest/tests/test_mcp_public_specs_view_migration.py
+++ b/objectified-rest/tests/test_mcp_public_specs_view_migration.py
@@ -1,0 +1,38 @@
+"""Guardrails for MCP public specs view migration and dev fixture (#3004)."""
+
+from pathlib import Path
+
+_MIGRATION_FRAGMENTS = (
+    "CREATE OR REPLACE VIEW odb.mcp_v_public_specs",
+    "p.name AS title",
+    "v.version_id AS version",
+    "AS tags",
+    "FROM odb.versions v",
+    "INNER JOIN odb.projects p",
+    "version_tags",
+    "v.published IS TRUE",
+    "v.visibility = 'public'::odb.visibility_type",
+    "COMMENT ON VIEW odb.mcp_v_public_specs",
+    "COMMENT ON COLUMN odb.mcp_v_public_specs.tags",
+)
+
+_FIXTURE_FRAGMENTS = (
+    "Dev fixture for odb.mcp_v_public_specs",
+    "SELECT count(*) FROM odb.mcp_v_public_specs",
+    "00000000-0000-4000-8000-000000000004",
+    "INSERT INTO odb.version_tags",
+)
+
+
+def test_migration_defines_mcp_v_public_specs(repo_root: Path) -> None:
+    migration = repo_root / "objectified-db" / "scripts" / "20260502-130000.sql"
+    text = migration.read_text()
+    missing = [frag for frag in _MIGRATION_FRAGMENTS if frag not in text]
+    assert not missing, f"Migration missing expected fragments: {missing}"
+
+
+def test_dev_fixture_documents_public_specs_view(repo_root: Path) -> None:
+    fixture = repo_root / "objectified-db" / "fixtures" / "mcp_public_specs_dev.sql"
+    text = fixture.read_text()
+    missing = [frag for frag in _FIXTURE_FRAGMENTS if frag not in text]
+    assert not missing, f"Fixture missing expected fragments: {missing}"

--- a/objectified-rest/tests/test_mcp_public_specs_view_migration.py
+++ b/objectified-rest/tests/test_mcp_public_specs_view_migration.py
@@ -1,6 +1,10 @@
 """Guardrails for MCP public specs view migration and dev fixture (#3004)."""
 
+import os
+import re
 from pathlib import Path
+
+import pytest
 
 _MIGRATION_FRAGMENTS = (
     "CREATE OR REPLACE VIEW odb.mcp_v_public_specs",
@@ -14,6 +18,11 @@ _MIGRATION_FRAGMENTS = (
     "v.visibility = 'public'::odb.visibility_type",
     "COMMENT ON VIEW odb.mcp_v_public_specs",
     "COMMENT ON COLUMN odb.mcp_v_public_specs.tags",
+    # cross-project tag guard (reviewer feedback)
+    "vt.project_id = v.project_id",
+    # composite freshness cursor (reviewer feedback)
+    "GREATEST",
+    "p.updated_at",
 )
 
 _FIXTURE_FRAGMENTS = (
@@ -31,8 +40,92 @@ def test_migration_defines_mcp_v_public_specs(repo_root: Path) -> None:
     assert not missing, f"Migration missing expected fragments: {missing}"
 
 
+def test_migration_tag_subquery_guards_project_id(repo_root: Path) -> None:
+    """Tag subquery must filter by both version_id and project_id to avoid cross-project contamination."""
+    migration = repo_root / "objectified-db" / "scripts" / "20260502-130000.sql"
+    text = migration.read_text()
+    # The WHERE clause inside the lateral must reference project_id scoped to the outer versions alias
+    assert re.search(r"vt\.project_id\s*=\s*v\.project_id", text), (
+        "Tag subquery must include 'vt.project_id = v.project_id' to prevent cross-project tag associations"
+    )
+
+
+def test_migration_updated_at_is_composite_freshness_cursor(repo_root: Path) -> None:
+    """updated_at must advance on project renames and tag mutations, not just revision edits."""
+    migration = repo_root / "objectified-db" / "scripts" / "20260502-130000.sql"
+    text = migration.read_text()
+    assert re.search(r"GREATEST\s*\(", text, re.IGNORECASE), (
+        "updated_at must use GREATEST(...) to combine updated_at from versions, projects, and version_tags"
+    )
+    assert "p.updated_at" in text, (
+        "updated_at must include p.updated_at so project renames advance the freshness cursor"
+    )
+
+
 def test_dev_fixture_documents_public_specs_view(repo_root: Path) -> None:
     fixture = repo_root / "objectified-db" / "fixtures" / "mcp_public_specs_dev.sql"
     text = fixture.read_text()
     missing = [frag for frag in _FIXTURE_FRAGMENTS if frag not in text]
     assert not missing, f"Fixture missing expected fragments: {missing}"
+
+
+# ---------------------------------------------------------------------------
+# Integration tests – skipped when DATABASE_URL is not set in the environment
+# ---------------------------------------------------------------------------
+
+_db_url = os.environ.get("DATABASE_URL")
+_requires_db = pytest.mark.skipif(
+    not _db_url,
+    reason="DATABASE_URL not set – skipping live-DB integration tests",
+)
+
+
+@_requires_db
+def test_view_exists_and_columns_match_contract(repo_root: Path) -> None:
+    """View must exist with the documented column contract and correct filter behaviour."""
+    psycopg2 = pytest.importorskip("psycopg2")
+    migration = repo_root / "objectified-db" / "scripts" / "20260502-130000.sql"
+
+    with psycopg2.connect(_db_url) as conn:
+        conn.autocommit = False
+        with conn.cursor() as cur:
+            cur.execute(migration.read_text())
+
+            # Column names must match the documented contract
+            cur.execute(
+                "SELECT column_name FROM information_schema.columns "
+                "WHERE table_schema = 'odb' AND table_name = 'mcp_v_public_specs' "
+                "ORDER BY ordinal_position"
+            )
+            cols = [r[0] for r in cur.fetchall()]
+            assert cols == ["id", "tenant_id", "project_id", "title", "version", "description", "tags", "updated_at"], (
+                f"View column contract changed: {cols}"
+            )
+
+        conn.rollback()  # leave the DB clean – this is a read-only check
+
+
+@_requires_db
+def test_fixture_yields_one_visible_row(repo_root: Path) -> None:
+    """Loading the dev fixture must produce exactly one row in mcp_v_public_specs."""
+    psycopg2 = pytest.importorskip("psycopg2")
+    migration = repo_root / "objectified-db" / "scripts" / "20260502-130000.sql"
+    fixture = repo_root / "objectified-db" / "fixtures" / "mcp_public_specs_dev.sql"
+
+    with psycopg2.connect(_db_url) as conn:
+        conn.autocommit = False
+        with conn.cursor() as cur:
+            cur.execute(migration.read_text())
+            cur.execute(fixture.read_text())
+
+            cur.execute(
+                "SELECT count(*) FROM odb.mcp_v_public_specs "
+                "WHERE project_id = '00000000-0000-4000-8000-000000000003'::uuid"
+            )
+            count = cur.fetchone()[0]
+            assert count == 1, (
+                f"Expected 1 visible row for fixture project, got {count}. "
+                "Check that only the published+public revision appears."
+            )
+
+        conn.rollback()  # idempotent – roll back fixture data

--- a/objectified-rest/uv.lock
+++ b/objectified-rest/uv.lock
@@ -514,7 +514,7 @@ wheels = [
 
 [[package]]
 name = "objectified-rest"
-version = "1.0.50"
+version = "1.0.51"
 source = { editable = "." }
 dependencies = [
     { name = "bcrypt" },

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.14",
+  "version": "0.11.15",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -16,6 +16,7 @@ We continue to improve the platform based on your feedback with improvements and
 - Streamable HTTP binds **`Authorization: Bearer`** per request into tool context (**`get_http_bearer_from_context`**) via ASGI middleware plus FastMCP middleware; requests without a Bearer token expose **`None`** (anonymous).
 - MCP API key **`scope_json`** uses a typed **`Scope`** model (`tenants` / `projects` string lists, JSONB): empty lists mean no restriction at that level; **`scope.allows(tenant_id, project_id)`** gates reads (#3001).
 - Successful MCP API key authentication updates **`last_used_at`** in Postgres asynchronously (non-blocking); **`objectified-mcp keys revoke <prefix>`** (also **`mcp keys revoke …`** via the `mcp` console alias) revokes active keys by stored prefix (#3002).
+- Database view **`odb.mcp_v_public_specs`** exposes published, public schema revisions for MCP discovery (project title, semantic version, description, sorted tag names, timestamps); dev checklist data lives in **`objectified-db/fixtures/mcp_public_specs_dev.sql`** (#3004).
 
 ## Importing
 - Race condition fixed in 3.0.1 specification imports


### PR DESCRIPTION
## What changed
Adds **`odb.mcp_v_public_specs`**, a read-only view over **`odb.versions`** joined to **`odb.projects`**, filtered to **published** revisions with **`visibility = public`**, non-deleted rows, and enabled project/version. **Tags** are sorted **`text[]`** of **`version_tags.name`** for that revision (empty array when none). Postgres **COMMENT** on the view and each column documents the stable MCP column contract (#3004).

Includes **`objectified-db/fixtures/mcp_public_specs_dev.sql`** (idempotent UUID fixture + commented verification query expecting **one** visible row).

## How to test
1. **Apply migrations** through `objectified-db/scripts/20260502-130000.sql` on a Postgres DB that already has the Objectified schema.
2. **Load the fixture**: `psql $DATABASE_URL -f objectified-db/fixtures/mcp_public_specs_dev.sql`
3. **Run** `SELECT count(*) FROM odb.mcp_v_public_specs WHERE project_id = '00000000-0000-4000-8000-000000000003'::uuid;` → expect **1**.
4. **Run** `uv run pytest tests/test_mcp_public_specs_view_migration.py -v` from `objectified-rest/`.

## Risk / notes
- View excludes disabled projects/versions and soft-deleted rows (stricter than the literal "published + public" phrase; aligns with a public catalog).
- Roadmap entry **3.1** marked complete in `docs/PLANNED_ROADMAP_MCP.md`.

Closes #3004

Made with [Cursor](https://cursor.com)