### PR TITLE
Fix #3005 - MCP spec.list (public, paginated)

### DIFF
--- a/docs/PLANNED_ROADMAP_MCP.md
+++ b/docs/PLANNED_ROADMAP_MCP.md
@@ -98,7 +98,7 @@ process or via Docker.
 | # | Issue | Title | Depends on |
 |---|-------|-------|------------|
 | 3.1 | ~~[#3004](../../issues/3004)~~ | ~~SQL view: published+public specs~~ (**completed**) | E1 |
-| 3.2 | [#3005](../../issues/3005) | Tool `spec.list` (public, paginated) | 3.1 |
+| 3.2 | ~~[#3005](../../issues/3005)~~ | ~~Tool `spec.list` (public, paginated)~~ (**completed**) | 3.1 |
 | 3.3 | [#3006](../../issues/3006) | Tool `spec.describe` (public) | 3.1 |
 | 3.4 | [#3007](../../issues/3007) | Tool `spec.search` (keyword) | 3.1 |
 | 3.5 | [#3008](../../issues/3008) | Tool `spec.list_tags` | 3.1 |

--- a/objectified-mcp/package.json
+++ b/objectified-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-mcp",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "private": true,
   "description": "Yarn workspace anchor for the objectified-mcp Python package (uv + pyproject.toml).",
   "scripts": {

--- a/objectified-mcp/pyproject.toml
+++ b/objectified-mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "objectified-mcp"
-version = "0.1.10"
+version = "0.1.11"
 description = "Model Context Protocol server for Objectified (FastMCP)."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/objectified-mcp/src/objectified_mcp/__init__.py
+++ b/objectified-mcp/src/objectified_mcp/__init__.py
@@ -1,3 +1,3 @@
 """Objectified MCP server package."""
 
-__version__ = "0.1.10"
+__version__ = "0.1.11"

--- a/objectified-mcp/src/objectified_mcp/server.py
+++ b/objectified-mcp/src/objectified_mcp/server.py
@@ -15,6 +15,7 @@ from objectified_mcp.http_credential_middleware import StashHttpBearerInToolCont
 from objectified_mcp.logging_config import configure_logging
 from objectified_mcp.ping_tool import build_ping_response
 from objectified_mcp.settings import get_settings
+from objectified_mcp.spec_list_tool import build_spec_list_response
 
 _log = structlog.get_logger(__name__)
 
@@ -49,3 +50,28 @@ async def ping(ctx: Context) -> dict[str, Any]:
     """Smoke-test: service name, package version, Postgres reachability, UTC timestamp."""
     pool = get_db_pool(ctx)
     return await build_ping_response(pool)
+
+
+@mcp.tool(
+    name="spec.list",
+    description=(
+        "List published public OpenAPI specs (cursor pagination over odb.mcp_v_public_specs). "
+        "Optional filters: tenant_id, project_id (UUID strings). "
+        "limit defaults to 50, capped at 100. Pass next_cursor from the previous response for the next page."
+    ),
+)
+async def spec_list(
+    ctx: Context,
+    tenant_id: str | None = None,
+    project_id: str | None = None,
+    limit: int | None = None,
+    cursor: str | None = None,
+) -> dict[str, Any]:
+    pool = get_db_pool(ctx)
+    return await build_spec_list_response(
+        pool,
+        tenant_id=tenant_id,
+        project_id=project_id,
+        limit=limit,
+        cursor=cursor,
+    )

--- a/objectified-mcp/src/objectified_mcp/spec_list_tool.py
+++ b/objectified-mcp/src/objectified_mcp/spec_list_tool.py
@@ -1,0 +1,175 @@
+"""MCP ``spec.list`` tool: paginated public specs from ``odb.mcp_v_public_specs`` (#3005)."""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import json
+from datetime import datetime, timezone
+from typing import Any
+from uuid import UUID
+
+from psycopg.rows import dict_row
+from psycopg_pool import AsyncConnectionPool
+
+CURSOR_VERSION = 1
+MAX_PAGE_SIZE = 100
+DEFAULT_PAGE_SIZE = 50
+
+
+class InvalidSpecListCursorError(ValueError):
+    """Raised when ``cursor`` cannot be decoded or fails validation."""
+
+
+def _utc(dt: datetime) -> datetime:
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def encode_spec_list_cursor(updated_at: datetime, spec_id: UUID) -> str:
+    """Return a stable URL-safe cursor (versioned JSON, base64url without ``=`` padding)."""
+    u = _utc(updated_at)
+    payload = {
+        "v": CURSOR_VERSION,
+        "i": str(spec_id),
+        "u": u.isoformat().replace("+00:00", "Z"),
+    }
+    raw = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+
+def _b64url_pad(s: str) -> str:
+    return s + "=" * ((4 - len(s) % 4) % 4)
+
+
+def decode_spec_list_cursor(raw: str | None) -> tuple[datetime, UUID] | None:
+    """Decode ``cursor`` into ``(updated_at, id)`` or ``None`` when absent."""
+    if raw is None or not raw.strip():
+        return None
+    try:
+        blob = base64.urlsafe_b64decode(_b64url_pad(raw.strip()))
+        obj = json.loads(blob.decode("utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError, ValueError, binascii.Error) as exc:
+        raise InvalidSpecListCursorError("Invalid spec.list cursor (malformed encoding).") from exc
+
+    if not isinstance(obj, dict):
+        raise InvalidSpecListCursorError("Invalid spec.list cursor (expected JSON object).")
+
+    ver = obj.get("v")
+    if ver != CURSOR_VERSION:
+        raise InvalidSpecListCursorError(f"Unsupported spec.list cursor version: {ver!r}.")
+
+    u_raw = obj.get("u")
+    i_raw = obj.get("i")
+    if not isinstance(u_raw, str) or not isinstance(i_raw, str):
+        raise InvalidSpecListCursorError("Invalid spec.list cursor (missing fields).")
+
+    iso = u_raw.replace("Z", "+00:00")
+    try:
+        parsed_at = datetime.fromisoformat(iso)
+    except ValueError as exc:
+        raise InvalidSpecListCursorError("Invalid spec.list cursor (bad timestamp).") from exc
+
+    try:
+        parsed_id = UUID(i_raw.strip())
+    except ValueError as exc:
+        raise InvalidSpecListCursorError("Invalid spec.list cursor (bad id).") from exc
+
+    return (_utc(parsed_at), parsed_id)
+
+
+def _clamp_limit(limit: int | None) -> int:
+    if limit is None:
+        return DEFAULT_PAGE_SIZE
+    if limit < 1:
+        return 1
+    return min(limit, MAX_PAGE_SIZE)
+
+
+def _parse_optional_uuid(label: str, raw: str | None) -> UUID | None:
+    if raw is None or not str(raw).strip():
+        return None
+    try:
+        return UUID(str(raw).strip())
+    except ValueError as exc:
+        raise ValueError(f"Invalid {label}: expected a UUID.") from exc
+
+
+def _row_out(row: dict[str, Any]) -> dict[str, Any]:
+    tags = row["tags"]
+    if tags is None:
+        tag_list: list[str] = []
+    else:
+        tag_list = [str(t) for t in list(tags)]
+
+    ua = row["updated_at"]
+    return {
+        "id": str(row["id"]),
+        "tenant_id": str(row["tenant_id"]),
+        "project_id": str(row["project_id"]),
+        "title": row["title"],
+        "version": row["version"],
+        "description": row["description"],
+        "tags": tag_list,
+        "updated_at": _utc(ua).isoformat().replace("+00:00", "Z"),
+    }
+
+
+_LIST_QUERY = """
+    SELECT id, tenant_id, project_id, title, version, description, tags, updated_at
+    FROM odb.mcp_v_public_specs
+    WHERE (%(tenant)s::uuid IS NULL OR tenant_id = %(tenant)s::uuid)
+      AND (%(project)s::uuid IS NULL OR project_id = %(project)s::uuid)
+      AND (
+        %(cur_ts)s::timestamptz IS NULL
+        OR (updated_at, id) < (%(cur_ts)s::timestamptz, %(cur_id)s::uuid)
+      )
+    ORDER BY updated_at DESC, id DESC
+    LIMIT %(lim)s
+"""
+
+
+async def build_spec_list_response(
+    pool: AsyncConnectionPool,
+    *,
+    tenant_id: str | None = None,
+    project_id: str | None = None,
+    limit: int | None = None,
+    cursor: str | None = None,
+) -> dict[str, Any]:
+    """Return ``items``, ``has_more``, and ``next_cursor`` for public specs."""
+    tenant = _parse_optional_uuid("tenant_id", tenant_id)
+    project = _parse_optional_uuid("project_id", project_id)
+    lim = _clamp_limit(limit)
+    decoded = decode_spec_list_cursor(cursor)
+    cur_ts = decoded[0] if decoded else None
+    cur_id = decoded[1] if decoded else None
+
+    params: dict[str, Any] = {
+        "tenant": tenant,
+        "project": project,
+        "cur_ts": cur_ts,
+        "cur_id": cur_id,
+        "lim": lim + 1,
+    }
+
+    async with pool.connection() as conn:
+        async with conn.cursor(row_factory=dict_row) as cur:
+            await cur.execute(_LIST_QUERY, params)
+            rows = await cur.fetchall()
+
+    has_more = len(rows) > lim
+    page = rows[:lim]
+    items = [_row_out(r) for r in page]
+
+    next_cursor: str | None = None
+    if has_more and page:
+        last = page[-1]
+        next_cursor = encode_spec_list_cursor(last["updated_at"], last["id"])
+
+    return {
+        "items": items,
+        "has_more": has_more,
+        "next_cursor": next_cursor,
+    }

--- a/objectified-mcp/src/objectified_mcp/spec_list_tool.py
+++ b/objectified-mcp/src/objectified_mcp/spec_list_tool.py
@@ -45,8 +45,10 @@ def _b64url_pad(s: str) -> str:
 
 def decode_spec_list_cursor(raw: str | None) -> tuple[datetime, UUID] | None:
     """Decode ``cursor`` into ``(updated_at, id)`` or ``None`` when absent."""
-    if raw is None or not raw.strip():
+    if raw is None:
         return None
+    if not raw.strip():
+        raise InvalidSpecListCursorError("Invalid spec.list cursor (empty value).")
     try:
         blob = base64.urlsafe_b64decode(_b64url_pad(raw.strip()))
         obj = json.loads(blob.decode("utf-8"))
@@ -71,6 +73,11 @@ def decode_spec_list_cursor(raw: str | None) -> tuple[datetime, UUID] | None:
     except ValueError as exc:
         raise InvalidSpecListCursorError("Invalid spec.list cursor (bad timestamp).") from exc
 
+    if parsed_at.tzinfo is None:
+        raise InvalidSpecListCursorError(
+            "Invalid spec.list cursor (timestamp must include timezone offset)."
+        )
+
     try:
         parsed_id = UUID(i_raw.strip())
     except ValueError as exc:
@@ -83,7 +90,7 @@ def _clamp_limit(limit: int | None) -> int:
     if limit is None:
         return DEFAULT_PAGE_SIZE
     if limit < 1:
-        return 1
+        raise ValueError(f"limit must be at least 1, got {limit}.")
     return min(limit, MAX_PAGE_SIZE)
 
 

--- a/objectified-mcp/tests/test_cli.py
+++ b/objectified-mcp/tests/test_cli.py
@@ -82,7 +82,7 @@ def test_console_script_entrypoint_prints_usage() -> None:
 def test_package_version_matches_pyproject() -> None:
     from objectified_mcp import __version__
 
-    assert __version__ == "0.1.10"
+    assert __version__ == "0.1.11"
 
 
 def test_serve_validate_only_exits_without_stdio(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/objectified-mcp/tests/test_spec_list_tool.py
+++ b/objectified-mcp/tests/test_spec_list_tool.py
@@ -11,6 +11,7 @@ from psycopg_pool import AsyncConnectionPool
 from objectified_mcp.spec_list_tool import (
     MAX_PAGE_SIZE,
     InvalidSpecListCursorError,
+    _clamp_limit,
     build_spec_list_response,
     decode_spec_list_cursor,
     encode_spec_list_cursor,
@@ -68,10 +69,15 @@ def test_encode_spec_list_cursor_is_stable_and_roundtrips() -> None:
     assert got_ts == ts.astimezone(timezone.utc)
 
 
-def test_decode_spec_list_cursor_none_and_blank() -> None:
+def test_decode_spec_list_cursor_none_returns_none() -> None:
     assert decode_spec_list_cursor(None) is None
-    assert decode_spec_list_cursor("") is None
-    assert decode_spec_list_cursor("   ") is None
+
+
+def test_decode_spec_list_cursor_blank_raises() -> None:
+    with pytest.raises(InvalidSpecListCursorError):
+        decode_spec_list_cursor("")
+    with pytest.raises(InvalidSpecListCursorError):
+        decode_spec_list_cursor("   ")
 
 
 def test_decode_spec_list_cursor_rejects_garbage() -> None:
@@ -165,3 +171,72 @@ def test_spec_list_tool_registered_on_mcp() -> None:
 
 def test_max_page_size_constant() -> None:
     assert MAX_PAGE_SIZE == 100
+
+
+def test_decode_spec_list_cursor_rejects_naive_timestamp() -> None:
+    import base64
+    import json
+
+    raw = json.dumps({"v": 1, "i": str(uuid4()), "u": "2026-01-01T00:00:00"}).encode()
+    token = base64.urlsafe_b64encode(raw).decode().rstrip("=")
+    with pytest.raises(InvalidSpecListCursorError, match="timezone"):
+        decode_spec_list_cursor(token)
+
+
+def test_clamp_limit_rejects_non_positive() -> None:
+    with pytest.raises(ValueError, match="limit"):
+        _clamp_limit(0)
+    with pytest.raises(ValueError, match="limit"):
+        _clamp_limit(-5)
+
+
+def test_build_spec_list_response_rejects_non_positive_limit() -> None:
+    pool, _cur = _pool_mock_for_fetch([])
+
+    async def run() -> None:
+        await build_spec_list_response(pool, limit=0)
+
+    with pytest.raises(ValueError, match="limit"):
+        asyncio.run(run())
+
+
+def test_build_spec_list_response_tenant_filter_binding() -> None:
+    tid = uuid4()
+    rows = [_sample_row()]
+    pool, cur = _pool_mock_for_fetch(rows)
+
+    async def run() -> None:
+        await build_spec_list_response(pool, tenant_id=str(tid))
+
+    asyncio.run(run())
+    _sql, params = cur.execute.await_args.args
+    assert params["tenant"] == tid
+
+
+def test_build_spec_list_response_project_filter_binding() -> None:
+    pid = uuid4()
+    rows = [_sample_row()]
+    pool, cur = _pool_mock_for_fetch(rows)
+
+    async def run() -> None:
+        await build_spec_list_response(pool, project_id=str(pid))
+
+    asyncio.run(run())
+    _sql, params = cur.execute.await_args.args
+    assert params["project"] == pid
+
+
+def test_build_spec_list_response_cursor_binding() -> None:
+    sid = UUID("33333333-3333-4333-8333-333333333333")
+    ts = datetime(2026, 5, 2, 15, 30, 45, tzinfo=timezone.utc)
+    cursor = encode_spec_list_cursor(ts, sid)
+    rows = [_sample_row()]
+    pool, cur = _pool_mock_for_fetch(rows)
+
+    async def run() -> None:
+        await build_spec_list_response(pool, cursor=cursor)
+
+    asyncio.run(run())
+    _sql, params = cur.execute.await_args.args
+    assert params["cur_ts"] == ts
+    assert params["cur_id"] == sid

--- a/objectified-mcp/tests/test_spec_list_tool.py
+++ b/objectified-mcp/tests/test_spec_list_tool.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+from uuid import UUID, uuid4
+
+import pytest
+from psycopg_pool import AsyncConnectionPool
+
+from objectified_mcp.spec_list_tool import (
+    MAX_PAGE_SIZE,
+    InvalidSpecListCursorError,
+    build_spec_list_response,
+    decode_spec_list_cursor,
+    encode_spec_list_cursor,
+)
+
+
+def _sample_row(
+    *,
+    spec_id: UUID | None = None,
+    updated_at: datetime | None = None,
+) -> dict[str, object]:
+    sid = spec_id or uuid4()
+    ts = updated_at or datetime(2026, 5, 1, 12, 0, tzinfo=timezone.utc)
+    return {
+        "id": sid,
+        "tenant_id": uuid4(),
+        "project_id": uuid4(),
+        "title": "Demo",
+        "version": "1.0.0",
+        "description": None,
+        "tags": ["alpha"],
+        "updated_at": ts,
+    }
+
+
+def _pool_mock_for_fetch(rows: list[dict[str, object]]) -> tuple[MagicMock, MagicMock]:
+    pool = MagicMock(spec=AsyncConnectionPool)
+    cur = MagicMock()
+    cur.execute = AsyncMock()
+    cur.fetchall = AsyncMock(return_value=rows)
+    cur_cm = AsyncMock()
+    cur_cm.__aenter__.return_value = cur
+    cur_cm.__aexit__.return_value = None
+    conn = MagicMock()
+    conn.cursor = MagicMock(return_value=cur_cm)
+    conn_cm = AsyncMock()
+    conn_cm.__aenter__.return_value = conn
+    conn_cm.__aexit__.return_value = None
+    pool.connection = MagicMock(return_value=conn_cm)
+    return pool, cur
+
+
+def test_encode_spec_list_cursor_is_stable_and_roundtrips() -> None:
+    sid = UUID("33333333-3333-4333-8333-333333333333")
+    ts = datetime(2026, 5, 2, 15, 30, 45, 123456, tzinfo=timezone.utc)
+    c1 = encode_spec_list_cursor(ts, sid)
+    c2 = encode_spec_list_cursor(ts, sid)
+    assert c1 == c2
+    assert "=" not in c1
+
+    out = decode_spec_list_cursor(c1)
+    assert out is not None
+    got_ts, got_id = out
+    assert got_id == sid
+    assert got_ts == ts.astimezone(timezone.utc)
+
+
+def test_decode_spec_list_cursor_none_and_blank() -> None:
+    assert decode_spec_list_cursor(None) is None
+    assert decode_spec_list_cursor("") is None
+    assert decode_spec_list_cursor("   ") is None
+
+
+def test_decode_spec_list_cursor_rejects_garbage() -> None:
+    with pytest.raises(InvalidSpecListCursorError):
+        decode_spec_list_cursor("not-valid-base64???")
+
+    with pytest.raises(InvalidSpecListCursorError):
+        decode_spec_list_cursor("aaaa")
+
+
+def test_decode_spec_list_cursor_rejects_wrong_version() -> None:
+    import base64
+    import json
+
+    raw = json.dumps({"v": 99, "i": str(uuid4()), "u": "2026-01-01T00:00:00Z"}).encode()
+    token = base64.urlsafe_b64encode(raw).decode().rstrip("=")
+    with pytest.raises(InvalidSpecListCursorError, match="version"):
+        decode_spec_list_cursor(token)
+
+
+@pytest.mark.parametrize(
+    ("limit_in", "expected_fetch_limit"),
+    [(None, 51), (1, 2), (100, 101), (500, 101)],
+)
+def test_build_spec_list_response_clamps_limit(limit_in: int | None, expected_fetch_limit: int) -> None:
+    rows = [_sample_row()]
+    pool, cur = _pool_mock_for_fetch(rows)
+
+    async def run() -> None:
+        await build_spec_list_response(pool, limit=limit_in)
+
+    asyncio.run(run())
+    _sql, params = cur.execute.await_args.args
+    assert params["lim"] == expected_fetch_limit
+
+
+def test_build_spec_list_response_has_more_and_next_cursor() -> None:
+    base_ts = datetime(2026, 5, 1, 12, 0, tzinfo=timezone.utc)
+    id_a = uuid4()
+    id_b = uuid4()
+    rows = [
+        _sample_row(spec_id=id_a, updated_at=base_ts),
+        _sample_row(spec_id=id_b, updated_at=base_ts.replace(hour=11)),
+    ]
+    pool, _cur = _pool_mock_for_fetch(rows)
+
+    async def run() -> dict[str, object]:
+        return await build_spec_list_response(pool, limit=1)
+
+    out = asyncio.run(run())
+    assert out["has_more"] is True
+    assert len(out["items"]) == 1
+    assert out["next_cursor"] is not None
+    decoded = decode_spec_list_cursor(str(out["next_cursor"]))
+    assert decoded is not None
+    assert decoded[1] == id_a
+
+
+def test_build_spec_list_response_no_next_when_last_page() -> None:
+    rows = [_sample_row()]
+    pool, _cur = _pool_mock_for_fetch(rows)
+
+    async def run() -> dict[str, object]:
+        return await build_spec_list_response(pool, limit=50)
+
+    out = asyncio.run(run())
+    assert out["has_more"] is False
+    assert out["next_cursor"] is None
+
+
+def test_build_spec_list_invalid_tenant_uuid() -> None:
+    pool, _cur = _pool_mock_for_fetch([])
+
+    async def run() -> None:
+        await build_spec_list_response(pool, tenant_id="not-a-uuid")
+
+    with pytest.raises(ValueError, match="tenant_id"):
+        asyncio.run(run())
+
+
+def test_spec_list_tool_registered_on_mcp() -> None:
+    from objectified_mcp.server import mcp
+
+    async def load() -> object:
+        return await mcp.get_tool("spec.list")
+
+    tool = asyncio.run(load())
+    assert tool is not None
+    assert tool.name == "spec.list"
+
+
+def test_max_page_size_constant() -> None:
+    assert MAX_PAGE_SIZE == 100

--- a/objectified-mcp/uv.lock
+++ b/objectified-mcp/uv.lock
@@ -842,7 +842,7 @@ wheels = [
 
 [[package]]
 name = "objectified-mcp"
-version = "0.1.10"
+version = "0.1.11"
 source = { editable = "." }
 dependencies = [
     { name = "bcrypt" },

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.15",
+  "version": "0.11.16",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -17,6 +17,7 @@ We continue to improve the platform based on your feedback with improvements and
 - MCP API key **`scope_json`** uses a typed **`Scope`** model (`tenants` / `projects` string lists, JSONB): empty lists mean no restriction at that level; **`scope.allows(tenant_id, project_id)`** gates reads (#3001).
 - Successful MCP API key authentication updates **`last_used_at`** in Postgres asynchronously (non-blocking); **`objectified-mcp keys revoke <prefix>`** (also **`mcp keys revoke …`** via the `mcp` console alias) revokes active keys by stored prefix (#3002).
 - Database view **`odb.mcp_v_public_specs`** exposes published, public schema revisions for MCP discovery (project title, semantic version, description, sorted tag names, timestamps); dev checklist data lives in **`objectified-db/fixtures/mcp_public_specs_dev.sql`** (#3004).
+- MCP tool **`spec.list`** lists public specs from that view with optional **`tenant_id`** / **`project_id`** filters, **`limit`** (default 50, max 100), and stable base64url **cursor** pagination (**`next_cursor`**) (#3005).
 
 ## Importing
 - Race condition fixed in 3.0.1 specification imports


### PR DESCRIPTION
## Summary
Implements MCP tool `spec.list` that reads published public specs from `odb.mcp_v_public_specs` with optional `tenant_id` and `project_id` filters, `limit` (default 50, max 100 per page), and stable versioned base64url cursor pagination (`next_cursor`).

## How to test
1. Apply DB migrations so `odb.mcp_v_public_specs` exists (and optionally load `objectified-db/fixtures/mcp_public_specs_dev.sql`).
2. Run `objectified-mcp serve` with valid `OBJECTIFIED_MCP_DATABASE_URL`.
3. Call tool `spec.list` via an MCP client with `{}` or `{"limit": 10}`; confirm `items` shape and pagination via `next_cursor`.

## Risks / notes
- Invalid `cursor` or filter UUIDs surface as tool errors (`InvalidSpecListCursorError` / `ValueError`).
- Ordering is `updated_at DESC, id DESC` for deterministic keyset paging.

Closes #3005

Made with [Cursor](https://cursor.com)