### PR TITLE
Fix #3006 - MCP spec.describe (public metadata)

### DIFF
--- a/docs/PLANNED_ROADMAP_MCP.md
+++ b/docs/PLANNED_ROADMAP_MCP.md
@@ -99,7 +99,7 @@ process or via Docker.
 |---|-------|-------|------------|
 | 3.1 | ~~[#3004](../../issues/3004)~~ | ~~SQL view: published+public specs~~ (**completed**) | E1 |
 | 3.2 | ~~[#3005](../../issues/3005)~~ | ~~Tool `spec.list` (public, paginated)~~ (**completed**) | 3.1 |
-| 3.3 | [#3006](../../issues/3006) | Tool `spec.describe` (public) | 3.1 |
+| 3.3 | ~~[#3006](../../issues/3006)~~ | ~~Tool `spec.describe` (public)~~ (**completed**) | 3.1 |
 | 3.4 | [#3007](../../issues/3007) | Tool `spec.search` (keyword) | 3.1 |
 | 3.5 | [#3008](../../issues/3008) | Tool `spec.list_tags` | 3.1 |
 

--- a/objectified-mcp/package.json
+++ b/objectified-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-mcp",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "private": true,
   "description": "Yarn workspace anchor for the objectified-mcp Python package (uv + pyproject.toml).",
   "scripts": {

--- a/objectified-mcp/pyproject.toml
+++ b/objectified-mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "objectified-mcp"
-version = "0.1.11"
+version = "0.1.12"
 description = "Model Context Protocol server for Objectified (FastMCP)."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/objectified-mcp/src/objectified_mcp/__init__.py
+++ b/objectified-mcp/src/objectified_mcp/__init__.py
@@ -1,3 +1,3 @@
 """Objectified MCP server package."""
 
-__version__ = "0.1.11"
+__version__ = "0.1.12"

--- a/objectified-mcp/src/objectified_mcp/server.py
+++ b/objectified-mcp/src/objectified_mcp/server.py
@@ -15,6 +15,7 @@ from objectified_mcp.http_credential_middleware import StashHttpBearerInToolCont
 from objectified_mcp.logging_config import configure_logging
 from objectified_mcp.ping_tool import build_ping_response
 from objectified_mcp.settings import get_settings
+from objectified_mcp.spec_describe_tool import build_spec_describe_response
 from objectified_mcp.spec_list_tool import build_spec_list_response
 
 _log = structlog.get_logger(__name__)
@@ -75,3 +76,16 @@ async def spec_list(
         limit=limit,
         cursor=cursor,
     )
+
+
+@mcp.tool(
+    name="spec.describe",
+    description=(
+        "Return metadata for a single published public OpenAPI spec revision by id (UUID). "
+        "Fields: id, title, version, description, owner (tenant slug), tags, updated_at (UTC Z). "
+        "Raises not-found when the revision is missing, unpublished, private, or unknown."
+    ),
+)
+async def spec_describe(ctx: Context, spec_id: str) -> dict[str, Any]:
+    pool = get_db_pool(ctx)
+    return await build_spec_describe_response(pool, spec_id=spec_id)

--- a/objectified-mcp/src/objectified_mcp/spec_describe_tool.py
+++ b/objectified-mcp/src/objectified_mcp/spec_describe_tool.py
@@ -1,0 +1,79 @@
+"""MCP ``spec.describe`` tool: public spec metadata by revision id (#3006)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+from uuid import UUID
+
+from fastmcp.exceptions import NotFoundError
+from psycopg.rows import dict_row
+from psycopg_pool import AsyncConnectionPool
+
+_DESCRIBE_QUERY = """
+    SELECT
+      s.id,
+      s.title,
+      s.version,
+      s.description,
+      t.slug AS owner,
+      s.tags,
+      s.updated_at
+    FROM odb.mcp_v_public_specs s
+    INNER JOIN odb.tenants t ON t.id = s.tenant_id
+    WHERE s.id = %(spec_id)s::uuid
+      AND t.deleted_at IS NULL
+      AND t.enabled IS TRUE
+    LIMIT 1
+"""
+
+
+def _utc(dt: datetime) -> datetime:
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def _parse_spec_id(raw: str) -> UUID:
+    s = str(raw).strip()
+    if not s:
+        raise ValueError("spec_id is required.")
+    try:
+        return UUID(s)
+    except ValueError as exc:
+        raise ValueError("Invalid spec_id: expected a UUID.") from exc
+
+
+def _row_to_metadata(row: dict[str, Any]) -> dict[str, Any]:
+    tags = row["tags"]
+    if tags is None:
+        tag_list: list[str] = []
+    else:
+        tag_list = [str(t) for t in list(tags)]
+
+    ua = row["updated_at"]
+    desc = row["description"]
+    return {
+        "id": str(row["id"]),
+        "title": row["title"],
+        "version": row["version"],
+        "description": None if desc is None else str(desc),
+        "owner": str(row["owner"]),
+        "tags": tag_list,
+        "updated_at": _utc(ua).isoformat().replace("+00:00", "Z"),
+    }
+
+
+async def build_spec_describe_response(pool: AsyncConnectionPool, *, spec_id: str) -> dict[str, Any]:
+    """Return canonical public metadata for ``spec_id``, or raise ``NotFoundError``."""
+    sid = _parse_spec_id(spec_id)
+
+    async with pool.connection() as conn:
+        async with conn.cursor(row_factory=dict_row) as cur:
+            await cur.execute(_DESCRIBE_QUERY, {"spec_id": sid})
+            row = await cur.fetchone()
+
+    if row is None:
+        raise NotFoundError("Unknown or non-public spec.")
+
+    return _row_to_metadata(row)

--- a/objectified-mcp/src/objectified_mcp/spec_list_tool.py
+++ b/objectified-mcp/src/objectified_mcp/spec_list_tool.py
@@ -74,9 +74,7 @@ def decode_spec_list_cursor(raw: str | None) -> tuple[datetime, UUID] | None:
         raise InvalidSpecListCursorError("Invalid spec.list cursor (bad timestamp).") from exc
 
     if parsed_at.tzinfo is None:
-        raise InvalidSpecListCursorError(
-            "Invalid spec.list cursor (timestamp must include timezone offset)."
-        )
+        raise InvalidSpecListCursorError("Invalid spec.list cursor (timestamp must include timezone offset).")
 
     try:
         parsed_id = UUID(i_raw.strip())

--- a/objectified-mcp/tests/test_spec_describe_tool.py
+++ b/objectified-mcp/tests/test_spec_describe_tool.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+from uuid import UUID, uuid4
+
+import pytest
+from fastmcp.exceptions import NotFoundError
+from psycopg_pool import AsyncConnectionPool
+
+from objectified_mcp.spec_describe_tool import build_spec_describe_response
+
+
+def _sample_row(
+    *,
+    spec_id: UUID | None = None,
+    updated_at: datetime | None = None,
+    owner: str = "acme",
+) -> dict[str, object]:
+    sid = spec_id or uuid4()
+    ts = updated_at or datetime(2026, 5, 1, 12, 0, tzinfo=timezone.utc)
+    return {
+        "id": sid,
+        "title": "Payments API",
+        "version": "2.1.0",
+        "description": "Core payment flows",
+        "owner": owner,
+        "tags": ["stable"],
+        "updated_at": ts,
+    }
+
+
+def _pool_mock_for_fetchone(row: dict[str, object] | None) -> tuple[MagicMock, MagicMock]:
+    pool = MagicMock(spec=AsyncConnectionPool)
+    cur = MagicMock()
+    cur.execute = AsyncMock()
+    cur.fetchone = AsyncMock(return_value=row)
+    cur_cm = AsyncMock()
+    cur_cm.__aenter__.return_value = cur
+    cur_cm.__aexit__.return_value = None
+    conn = MagicMock()
+    conn.cursor = MagicMock(return_value=cur_cm)
+    conn_cm = AsyncMock()
+    conn_cm.__aenter__.return_value = conn
+    conn_cm.__aexit__.return_value = None
+    pool.connection = MagicMock(return_value=conn_cm)
+    return pool, cur
+
+
+def test_build_spec_describe_response_success() -> None:
+    sid = uuid4()
+    row = _sample_row(spec_id=sid)
+    pool, cur = _pool_mock_for_fetchone(row)
+
+    async def run() -> dict[str, object]:
+        return await build_spec_describe_response(pool, spec_id=str(sid))
+
+    out = asyncio.run(run())
+
+    assert out["id"] == str(sid)
+    assert out["title"] == "Payments API"
+    assert out["version"] == "2.1.0"
+    assert out["description"] == "Core payment flows"
+    assert out["owner"] == "acme"
+    assert out["tags"] == ["stable"]
+    assert out["updated_at"] == "2026-05-01T12:00:00Z"
+
+    cur.execute.assert_awaited_once()
+    cur.fetchone.assert_awaited_once()
+
+
+def test_build_spec_describe_response_null_description_and_tags() -> None:
+    sid = uuid4()
+    row = _sample_row(spec_id=sid)
+    row["description"] = None
+    row["tags"] = None
+    pool, _ = _pool_mock_for_fetchone(row)
+
+    async def run() -> dict[str, object]:
+        return await build_spec_describe_response(pool, spec_id=str(sid))
+
+    out = asyncio.run(run())
+
+    assert out["description"] is None
+    assert out["tags"] == []
+
+
+def test_build_spec_describe_response_not_found() -> None:
+    pool, _ = _pool_mock_for_fetchone(None)
+
+    async def run() -> None:
+        await build_spec_describe_response(pool, spec_id=str(uuid4()))
+
+    with pytest.raises(NotFoundError, match="Unknown or non-public"):
+        asyncio.run(run())
+
+
+def test_build_spec_describe_invalid_uuid() -> None:
+    pool, _ = _pool_mock_for_fetchone(None)
+
+    async def _run() -> None:
+        await build_spec_describe_response(pool, spec_id="not-a-uuid")
+
+    with pytest.raises(ValueError, match="spec_id"):
+        asyncio.run(_run())
+
+
+def test_build_spec_describe_empty_spec_id() -> None:
+    pool, _ = _pool_mock_for_fetchone(None)
+
+    async def _run() -> None:
+        await build_spec_describe_response(pool, spec_id="   ")
+
+    with pytest.raises(ValueError, match="required"):
+        asyncio.run(_run())
+
+
+def test_spec_describe_tool_registered_on_mcp() -> None:
+    from objectified_mcp.server import mcp
+
+    async def load() -> object:
+        return await mcp.get_tool("spec.describe")
+
+    tool = asyncio.run(load())
+    assert tool is not None
+    assert tool.name == "spec.describe"

--- a/objectified-mcp/uv.lock
+++ b/objectified-mcp/uv.lock
@@ -842,7 +842,7 @@ wheels = [
 
 [[package]]
 name = "objectified-mcp"
-version = "0.1.11"
+version = "0.1.12"
 source = { editable = "." }
 dependencies = [
     { name = "bcrypt" },

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.16",
+  "version": "0.11.17",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -18,6 +18,7 @@ We continue to improve the platform based on your feedback with improvements and
 - Successful MCP API key authentication updates **`last_used_at`** in Postgres asynchronously (non-blocking); **`objectified-mcp keys revoke <prefix>`** (also **`mcp keys revoke …`** via the `mcp` console alias) revokes active keys by stored prefix (#3002).
 - Database view **`odb.mcp_v_public_specs`** exposes published, public schema revisions for MCP discovery (project title, semantic version, description, sorted tag names, timestamps); dev checklist data lives in **`objectified-db/fixtures/mcp_public_specs_dev.sql`** (#3004).
 - MCP tool **`spec.list`** lists public specs from that view with optional **`tenant_id`** / **`project_id`** filters, **`limit`** (default 50, max 100), and stable base64url **cursor** pagination (**`next_cursor`**) (#3005).
+- MCP tool **`spec.describe`** loads one public spec by revision UUID and returns **`id`**, **`title`**, **`version`**, **`description`**, **`owner`** (tenant slug), **`tags`**, and **`updated_at`** (UTC **`Z`**); missing, unpublished, or private revisions surface as not-found (#3006).
 
 ## Importing
 - Race condition fixed in 3.0.1 specification imports


### PR DESCRIPTION
## Summary
Adds FastMCP tool `spec.describe` that loads a single published public schema revision by UUID from `odb.mcp_v_public_specs`, joined to `odb.tenants` for `owner` (tenant slug). Private, unpublished, missing, disabled-tenant, or malformed-id cases do not leak rows; unknown/non-public specs raise `NotFoundError`.

## How to test
- **Run** `yarn workspace objectified-mcp test` (or full `yarn test`).
- With Postgres containing public specs from the dev fixture, **run** `objectified-mcp serve` and **invoke** tool `spec.describe` with a **revision id** present in `odb.mcp_v_public_specs`; expect metadata with **`updated_at`** as UTC **`Z`**.
- **Use** an id from a private or unpublished revision (see fixture comments in `objectified-db/fixtures/mcp_public_specs_dev.sql`) and confirm **not-found**.

## Risks / notes
- `owner` is the **tenant slug** (canonical for public URLs); future authorized (`#3012`) describe may extend fields.

Closes #3006

Made with [Cursor](https://cursor.com)