### PR TITLE
Fix #3007 - MCP spec.search (keyword)

### DIFF
--- a/docs/PLANNED_ROADMAP_MCP.md
+++ b/docs/PLANNED_ROADMAP_MCP.md
@@ -100,7 +100,7 @@ process or via Docker.
 | 3.1 | ~~[#3004](../../issues/3004)~~ | ~~SQL view: published+public specs~~ (**completed**) | E1 |
 | 3.2 | ~~[#3005](../../issues/3005)~~ | ~~Tool `spec.list` (public, paginated)~~ (**completed**) | 3.1 |
 | 3.3 | ~~[#3006](../../issues/3006)~~ | ~~Tool `spec.describe` (public)~~ (**completed**) | 3.1 |
-| 3.4 | [#3007](../../issues/3007) | Tool `spec.search` (keyword) | 3.1 |
+| 3.4 | ~~[#3007](../../issues/3007)~~ | ~~Tool `spec.search` (keyword)~~ (**completed**) | 3.1 |
 | 3.5 | [#3008](../../issues/3008) | Tool `spec.list_tags` | 3.1 |
 
 #### E4 — Private Spec Access (#3009)

--- a/objectified-mcp/package.json
+++ b/objectified-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-mcp",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "private": true,
   "description": "Yarn workspace anchor for the objectified-mcp Python package (uv + pyproject.toml).",
   "scripts": {

--- a/objectified-mcp/pyproject.toml
+++ b/objectified-mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "objectified-mcp"
-version = "0.1.12"
+version = "0.1.13"
 description = "Model Context Protocol server for Objectified (FastMCP)."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/objectified-mcp/src/objectified_mcp/__init__.py
+++ b/objectified-mcp/src/objectified_mcp/__init__.py
@@ -1,3 +1,3 @@
 """Objectified MCP server package."""
 
-__version__ = "0.1.12"
+__version__ = "0.1.13"

--- a/objectified-mcp/src/objectified_mcp/server.py
+++ b/objectified-mcp/src/objectified_mcp/server.py
@@ -17,6 +17,7 @@ from objectified_mcp.ping_tool import build_ping_response
 from objectified_mcp.settings import get_settings
 from objectified_mcp.spec_describe_tool import build_spec_describe_response
 from objectified_mcp.spec_list_tool import build_spec_list_response
+from objectified_mcp.spec_search_tool import build_spec_search_response
 
 _log = structlog.get_logger(__name__)
 
@@ -89,3 +90,22 @@ async def spec_list(
 async def spec_describe(ctx: Context, spec_id: str) -> dict[str, Any]:
     pool = get_db_pool(ctx)
     return await build_spec_describe_response(pool, spec_id=spec_id)
+
+
+@mcp.tool(
+    name="spec.search",
+    description=(
+        "Search published public OpenAPI specs by keyword over title, description, and tag names "
+        "(ILIKE, case-insensitive). Required q must be non-empty after trimming. "
+        "Results are ranked (title prefix > title contains > description > tag match). "
+        "limit defaults to 50, capped at 100. Pass next_cursor from the previous response for the next page."
+    ),
+)
+async def spec_search(
+    ctx: Context,
+    q: str,
+    limit: int | None = None,
+    cursor: str | None = None,
+) -> dict[str, Any]:
+    pool = get_db_pool(ctx)
+    return await build_spec_search_response(pool, q=q, limit=limit, cursor=cursor)

--- a/objectified-mcp/src/objectified_mcp/spec_search_tool.py
+++ b/objectified-mcp/src/objectified_mcp/spec_search_tool.py
@@ -1,0 +1,237 @@
+"""MCP ``spec.search`` tool: keyword search over public specs (#3007)."""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import json
+from datetime import datetime, timezone
+from typing import Any
+from uuid import UUID
+
+from psycopg.rows import dict_row
+from psycopg_pool import AsyncConnectionPool
+
+SEARCH_CURSOR_VERSION = 1
+MAX_PAGE_SIZE = 100
+DEFAULT_PAGE_SIZE = 50
+
+
+class InvalidSpecSearchCursorError(ValueError):
+    """Raised when ``cursor`` cannot be decoded or fails validation."""
+
+
+def _utc(dt: datetime) -> datetime:
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def escape_ilike_fragment(raw: str) -> str:
+    """Escape ``\\``, ``%``, and ``_`` for use inside ILIKE patterns with ``ESCAPE '\\'``."""
+    return raw.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
+def normalize_search_query(q: str) -> str:
+    """Strip leading/trailing whitespace; reject empty queries."""
+    s = str(q).strip()
+    if not s:
+        raise ValueError("q must be a non-empty search string.")
+    return s
+
+
+def encode_spec_search_cursor(rank_score: int, updated_at: datetime, spec_id: UUID) -> str:
+    """Return a stable URL-safe cursor (versioned JSON, base64url without ``=`` padding)."""
+    u = _utc(updated_at)
+    payload = {
+        "v": SEARCH_CURSOR_VERSION,
+        "r": int(rank_score),
+        "i": str(spec_id),
+        "u": u.isoformat().replace("+00:00", "Z"),
+    }
+    blob = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    return base64.urlsafe_b64encode(blob).decode("ascii").rstrip("=")
+
+
+def _b64url_pad(s: str) -> str:
+    return s + "=" * ((4 - len(s) % 4) % 4)
+
+
+def decode_spec_search_cursor(raw: str | None) -> tuple[int, datetime, UUID] | None:
+    """Decode ``cursor`` into ``(rank_score, updated_at, id)`` or ``None`` when absent."""
+    if raw is None:
+        return None
+    if not raw.strip():
+        raise InvalidSpecSearchCursorError("Invalid spec.search cursor (empty value).")
+    try:
+        decoded_b = base64.urlsafe_b64decode(_b64url_pad(raw.strip()))
+        obj = json.loads(decoded_b.decode("utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError, ValueError, binascii.Error) as exc:
+        raise InvalidSpecSearchCursorError("Invalid spec.search cursor (malformed encoding).") from exc
+
+    if not isinstance(obj, dict):
+        raise InvalidSpecSearchCursorError("Invalid spec.search cursor (expected JSON object).")
+
+    ver = obj.get("v")
+    if ver != SEARCH_CURSOR_VERSION:
+        raise InvalidSpecSearchCursorError(f"Unsupported spec.search cursor version: {ver!r}.")
+
+    r_raw = obj.get("r")
+    u_raw = obj.get("u")
+    i_raw = obj.get("i")
+    if isinstance(r_raw, bool) or not isinstance(r_raw, int):
+        raise InvalidSpecSearchCursorError("Invalid spec.search cursor (bad rank).")
+    if not isinstance(u_raw, str) or not isinstance(i_raw, str):
+        raise InvalidSpecSearchCursorError("Invalid spec.search cursor (missing fields).")
+
+    iso = u_raw.replace("Z", "+00:00")
+    try:
+        parsed_at = datetime.fromisoformat(iso)
+    except ValueError as exc:
+        raise InvalidSpecSearchCursorError("Invalid spec.search cursor (bad timestamp).") from exc
+
+    if parsed_at.tzinfo is None:
+        raise InvalidSpecSearchCursorError("Invalid spec.search cursor (timestamp must include timezone offset).")
+
+    try:
+        parsed_id = UUID(i_raw.strip())
+    except ValueError as exc:
+        raise InvalidSpecSearchCursorError("Invalid spec.search cursor (bad id).") from exc
+
+    return (int(r_raw), _utc(parsed_at), parsed_id)
+
+
+def _clamp_limit(limit: int | None) -> int:
+    if limit is None:
+        return DEFAULT_PAGE_SIZE
+    if limit < 1:
+        raise ValueError(f"limit must be at least 1, got {limit}.")
+    return min(limit, MAX_PAGE_SIZE)
+
+
+def _row_out(row: dict[str, Any]) -> dict[str, Any]:
+    tags = row["tags"]
+    if tags is None:
+        tag_list: list[str] = []
+    else:
+        tag_list = [str(t) for t in list(tags)]
+
+    ua = row["updated_at"]
+    return {
+        "id": str(row["id"]),
+        "tenant_id": str(row["tenant_id"]),
+        "project_id": str(row["project_id"]),
+        "title": row["title"],
+        "version": row["version"],
+        "description": row["description"],
+        "tags": tag_list,
+        "updated_at": _utc(ua).isoformat().replace("+00:00", "Z"),
+        "rank_score": int(row["rank_score"]),
+    }
+
+
+_SEARCH_QUERY = """
+WITH ranked AS (
+  SELECT
+    id,
+    tenant_id,
+    project_id,
+    title,
+    version,
+    description,
+    tags,
+    updated_at,
+    (
+      CASE
+        WHEN title ILIKE %(prefix)s ESCAPE '\\' THEN 1000
+        WHEN title ILIKE %(contains)s ESCAPE '\\' THEN 600
+        ELSE 0
+      END
+      + CASE
+          WHEN COALESCE(description, '') ILIKE %(contains)s ESCAPE '\\' THEN 200
+          ELSE 0
+        END
+      + CASE
+          WHEN EXISTS (
+            SELECT 1
+            FROM unnest(tags) AS tag
+            WHERE tag ILIKE %(contains)s ESCAPE '\\'
+          )
+          THEN 100
+          ELSE 0
+        END
+    )::integer AS rank_score
+  FROM odb.mcp_v_public_specs
+  WHERE
+    title ILIKE %(contains)s ESCAPE '\\'
+    OR COALESCE(description, '') ILIKE %(contains)s ESCAPE '\\'
+    OR EXISTS (
+      SELECT 1
+      FROM unnest(tags) AS tag
+      WHERE tag ILIKE %(contains)s ESCAPE '\\'
+    )
+)
+SELECT id, tenant_id, project_id, title, version, description, tags, updated_at, rank_score
+FROM ranked
+WHERE
+  CASE
+    WHEN %(has_cursor)s THEN (
+      (rank_score, updated_at, id)
+      < (%(cur_rank)s::integer, %(cur_ts)s::timestamptz, %(cur_id)s::uuid)
+    )
+    ELSE TRUE
+  END
+ORDER BY rank_score DESC, updated_at DESC, id DESC
+LIMIT %(lim)s
+"""
+
+
+async def build_spec_search_response(
+    pool: AsyncConnectionPool,
+    *,
+    q: str,
+    limit: int | None = None,
+    cursor: str | None = None,
+) -> dict[str, Any]:
+    """Return ranked ``items``, ``has_more``, and ``next_cursor`` for keyword search."""
+    query_text = normalize_search_query(q)
+    escaped = escape_ilike_fragment(query_text)
+    prefix = f"{escaped}%"
+    contains = f"%{escaped}%"
+
+    lim = _clamp_limit(limit)
+    decoded = decode_spec_search_cursor(cursor)
+    has_cursor = decoded is not None
+    cur_rank = decoded[0] if decoded else None
+    cur_ts = decoded[1] if decoded else None
+    cur_id = decoded[2] if decoded else None
+
+    params: dict[str, Any] = {
+        "prefix": prefix,
+        "contains": contains,
+        "has_cursor": has_cursor,
+        "cur_rank": cur_rank,
+        "cur_ts": cur_ts,
+        "cur_id": cur_id,
+        "lim": lim + 1,
+    }
+
+    async with pool.connection() as conn:
+        async with conn.cursor(row_factory=dict_row) as cur:
+            await cur.execute(_SEARCH_QUERY, params)
+            rows = await cur.fetchall()
+
+    has_more = len(rows) > lim
+    page = rows[:lim]
+    items = [_row_out(r) for r in page]
+
+    next_cursor: str | None = None
+    if has_more and page:
+        last = page[-1]
+        next_cursor = encode_spec_search_cursor(int(last["rank_score"]), last["updated_at"], last["id"])
+
+    return {
+        "items": items,
+        "has_more": has_more,
+        "next_cursor": next_cursor,
+    }

--- a/objectified-mcp/src/objectified_mcp/spec_search_tool.py
+++ b/objectified-mcp/src/objectified_mcp/spec_search_tool.py
@@ -131,7 +131,31 @@ def _row_out(row: dict[str, Any]) -> dict[str, Any]:
 
 
 _SEARCH_QUERY = """
-WITH ranked AS (
+WITH pre AS (
+  SELECT
+    s.id,
+    s.tenant_id,
+    s.project_id,
+    s.title,
+    s.version,
+    s.description,
+    s.tags,
+    s.updated_at,
+    tm.tag_match
+  FROM odb.mcp_v_public_specs AS s
+  CROSS JOIN LATERAL (
+    SELECT EXISTS (
+      SELECT 1
+      FROM unnest(s.tags) AS tag
+      WHERE tag ILIKE %(contains)s ESCAPE '\\'
+    ) AS tag_match
+  ) AS tm
+  WHERE
+    s.title ILIKE %(contains)s ESCAPE '\\'
+    OR COALESCE(s.description, '') ILIKE %(contains)s ESCAPE '\\'
+    OR tm.tag_match
+),
+ranked AS (
   SELECT
     id,
     tenant_id,
@@ -151,25 +175,9 @@ WITH ranked AS (
           WHEN COALESCE(description, '') ILIKE %(contains)s ESCAPE '\\' THEN 200
           ELSE 0
         END
-      + CASE
-          WHEN EXISTS (
-            SELECT 1
-            FROM unnest(tags) AS tag
-            WHERE tag ILIKE %(contains)s ESCAPE '\\'
-          )
-          THEN 100
-          ELSE 0
-        END
+      + CASE WHEN tag_match THEN 100 ELSE 0 END
     )::integer AS rank_score
-  FROM odb.mcp_v_public_specs
-  WHERE
-    title ILIKE %(contains)s ESCAPE '\\'
-    OR COALESCE(description, '') ILIKE %(contains)s ESCAPE '\\'
-    OR EXISTS (
-      SELECT 1
-      FROM unnest(tags) AS tag
-      WHERE tag ILIKE %(contains)s ESCAPE '\\'
-    )
+  FROM pre
 )
 SELECT id, tenant_id, project_id, title, version, description, tags, updated_at, rank_score
 FROM ranked

--- a/objectified-mcp/tests/test_cli.py
+++ b/objectified-mcp/tests/test_cli.py
@@ -80,9 +80,14 @@ def test_console_script_entrypoint_prints_usage() -> None:
 
 
 def test_package_version_matches_pyproject() -> None:
+    import tomllib
+    from pathlib import Path
+
     from objectified_mcp import __version__
 
-    assert __version__ == "0.1.11"
+    root = Path(__file__).resolve().parents[1]
+    data = tomllib.loads((root / "pyproject.toml").read_text(encoding="utf-8"))
+    assert __version__ == data["project"]["version"]
 
 
 def test_serve_validate_only_exits_without_stdio(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/objectified-mcp/tests/test_spec_search_tool.py
+++ b/objectified-mcp/tests/test_spec_search_tool.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+from uuid import UUID, uuid4
+
+import pytest
+from psycopg_pool import AsyncConnectionPool
+
+from objectified_mcp.spec_search_tool import (
+    MAX_PAGE_SIZE,
+    InvalidSpecSearchCursorError,
+    _clamp_limit,
+    build_spec_search_response,
+    decode_spec_search_cursor,
+    encode_spec_search_cursor,
+    escape_ilike_fragment,
+    normalize_search_query,
+)
+
+
+def _sample_row(
+    *,
+    spec_id: UUID | None = None,
+    updated_at: datetime | None = None,
+    rank_score: int = 900,
+) -> dict[str, object]:
+    sid = spec_id or uuid4()
+    ts = updated_at or datetime(2026, 5, 1, 12, 0, tzinfo=timezone.utc)
+    return {
+        "id": sid,
+        "tenant_id": uuid4(),
+        "project_id": uuid4(),
+        "title": "Payments API",
+        "version": "1.0.0",
+        "description": "demo",
+        "tags": ["alpha"],
+        "updated_at": ts,
+        "rank_score": rank_score,
+    }
+
+
+def _pool_mock_for_fetch(rows: list[dict[str, object]]) -> tuple[MagicMock, MagicMock]:
+    pool = MagicMock(spec=AsyncConnectionPool)
+    cur = MagicMock()
+    cur.execute = AsyncMock()
+    cur.fetchall = AsyncMock(return_value=rows)
+    cur_cm = AsyncMock()
+    cur_cm.__aenter__.return_value = cur
+    cur_cm.__aexit__.return_value = None
+    conn = MagicMock()
+    conn.cursor = MagicMock(return_value=cur_cm)
+    conn_cm = AsyncMock()
+    conn_cm.__aenter__.return_value = conn
+    conn_cm.__aexit__.return_value = None
+    pool.connection = MagicMock(return_value=conn_cm)
+    return pool, cur
+
+
+def test_escape_ilike_fragment_escapes_metacharacters() -> None:
+    assert escape_ilike_fragment(r"a\%_") == r"a\\\%\_"
+
+
+def test_normalize_search_query_strips_and_rejects_empty() -> None:
+    assert normalize_search_query("  hello  ") == "hello"
+    with pytest.raises(ValueError, match="non-empty"):
+        normalize_search_query("")
+    with pytest.raises(ValueError, match="non-empty"):
+        normalize_search_query("   ")
+
+
+def test_encode_spec_search_cursor_roundtrips() -> None:
+    sid = UUID("44444444-4444-4444-8444-444444444444")
+    ts = datetime(2026, 5, 2, 15, 30, 45, 123456, tzinfo=timezone.utc)
+    c1 = encode_spec_search_cursor(1300, ts, sid)
+    c2 = encode_spec_search_cursor(1300, ts, sid)
+    assert c1 == c2
+    assert "=" not in c1
+
+    out = decode_spec_search_cursor(c1)
+    assert out is not None
+    rank, got_ts, got_id = out
+    assert rank == 1300
+    assert got_id == sid
+    assert got_ts == ts.astimezone(timezone.utc)
+
+
+def test_decode_spec_search_cursor_none_returns_none() -> None:
+    assert decode_spec_search_cursor(None) is None
+
+
+def test_decode_spec_search_cursor_blank_raises() -> None:
+    with pytest.raises(InvalidSpecSearchCursorError):
+        decode_spec_search_cursor("")
+    with pytest.raises(InvalidSpecSearchCursorError):
+        decode_spec_search_cursor("   ")
+
+
+def test_decode_spec_search_cursor_rejects_bool_rank_from_json() -> None:
+    import base64
+    import json
+
+    raw = json.dumps({"v": 1, "r": True, "i": str(uuid4()), "u": "2026-01-01T00:00:00Z"}).encode()
+    token = base64.urlsafe_b64encode(raw).decode().rstrip("=")
+    with pytest.raises(InvalidSpecSearchCursorError, match="rank"):
+        decode_spec_search_cursor(token)
+
+
+@pytest.mark.parametrize(
+    ("limit_in", "expected_fetch_limit"),
+    [(None, 51), (1, 2), (100, 101), (500, 101)],
+)
+def test_build_spec_search_response_clamps_limit(limit_in: int | None, expected_fetch_limit: int) -> None:
+    rows = [_sample_row()]
+    pool, cur = _pool_mock_for_fetch(rows)
+
+    async def run() -> None:
+        await build_spec_search_response(pool, q="pay", limit=limit_in)
+
+    asyncio.run(run())
+    _sql, params = cur.execute.await_args.args
+    assert params["lim"] == expected_fetch_limit
+    assert params["prefix"] == "pay%"
+    assert params["contains"] == "%pay%"
+
+
+def test_build_spec_search_response_sql_patterns_escape_percent() -> None:
+    rows = [_sample_row()]
+    pool, cur = _pool_mock_for_fetch(rows)
+
+    async def run() -> None:
+        await build_spec_search_response(pool, q="100%")
+
+    asyncio.run(run())
+    _sql, params = cur.execute.await_args.args
+    assert params["prefix"] == r"100\%%"
+    assert params["contains"] == r"%100\%%"
+
+
+def test_build_spec_search_response_has_more_and_next_cursor() -> None:
+    base_ts = datetime(2026, 5, 1, 12, 0, tzinfo=timezone.utc)
+    id_a = uuid4()
+    id_b = uuid4()
+    rows = [
+        _sample_row(spec_id=id_a, updated_at=base_ts, rank_score=900),
+        _sample_row(spec_id=id_b, updated_at=base_ts.replace(hour=11), rank_score=800),
+    ]
+    pool, _cur = _pool_mock_for_fetch(rows)
+
+    async def run() -> dict[str, object]:
+        return await build_spec_search_response(pool, q="pay", limit=1)
+
+    out = asyncio.run(run())
+    assert out["has_more"] is True
+    assert len(out["items"]) == 1
+    assert out["items"][0]["rank_score"] == 900
+    assert out["next_cursor"] is not None
+    decoded = decode_spec_search_cursor(str(out["next_cursor"]))
+    assert decoded is not None
+    assert decoded[0] == 900
+    assert decoded[2] == id_a
+
+
+def test_build_spec_search_response_no_next_when_last_page() -> None:
+    rows = [_sample_row()]
+    pool, _cur = _pool_mock_for_fetch(rows)
+
+    async def run() -> dict[str, object]:
+        return await build_spec_search_response(pool, q="pay", limit=50)
+
+    out = asyncio.run(run())
+    assert out["has_more"] is False
+    assert out["next_cursor"] is None
+
+
+def test_build_spec_search_response_cursor_binding() -> None:
+    sid = UUID("33333333-3333-4333-8333-333333333333")
+    ts = datetime(2026, 5, 2, 15, 30, 45, tzinfo=timezone.utc)
+    cursor = encode_spec_search_cursor(700, ts, sid)
+    rows = [_sample_row()]
+    pool, cur = _pool_mock_for_fetch(rows)
+
+    async def run() -> None:
+        await build_spec_search_response(pool, q="demo", cursor=cursor)
+
+    asyncio.run(run())
+    _sql, params = cur.execute.await_args.args
+    assert params["has_cursor"] is True
+    assert params["cur_rank"] == 700
+    assert params["cur_ts"] == ts
+    assert params["cur_id"] == sid
+
+
+def test_build_spec_search_empty_query_raises() -> None:
+    pool, _cur = _pool_mock_for_fetch([])
+
+    async def run() -> None:
+        await build_spec_search_response(pool, q="  ")
+
+    with pytest.raises(ValueError, match="non-empty"):
+        asyncio.run(run())
+
+
+def test_clamp_limit_rejects_non_positive() -> None:
+    with pytest.raises(ValueError, match="limit"):
+        _clamp_limit(0)
+
+
+def test_spec_search_tool_registered_on_mcp() -> None:
+    from objectified_mcp.server import mcp
+
+    async def load() -> object:
+        return await mcp.get_tool("spec.search")
+
+    tool = asyncio.run(load())
+    assert tool is not None
+    assert tool.name == "spec.search"
+
+
+def test_max_page_size_constant() -> None:
+    assert MAX_PAGE_SIZE == 100

--- a/objectified-mcp/uv.lock
+++ b/objectified-mcp/uv.lock
@@ -842,7 +842,7 @@ wheels = [
 
 [[package]]
 name = "objectified-mcp"
-version = "0.1.12"
+version = "0.1.13"
 source = { editable = "." }
 dependencies = [
     { name = "bcrypt" },

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.17",
+  "version": "0.11.18",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -19,6 +19,7 @@ We continue to improve the platform based on your feedback with improvements and
 - Database view **`odb.mcp_v_public_specs`** exposes published, public schema revisions for MCP discovery (project title, semantic version, description, sorted tag names, timestamps); dev checklist data lives in **`objectified-db/fixtures/mcp_public_specs_dev.sql`** (#3004).
 - MCP tool **`spec.list`** lists public specs from that view with optional **`tenant_id`** / **`project_id`** filters, **`limit`** (default 50, max 100), and stable base64url **cursor** pagination (**`next_cursor`**) (#3005).
 - MCP tool **`spec.describe`** loads one public spec by revision UUID and returns **`id`**, **`title`**, **`version`**, **`description`**, **`owner`** (tenant slug), **`tags`**, and **`updated_at`** (UTC **`Z`**); missing, unpublished, or private revisions surface as not-found (#3006).
+- MCP tool **`spec.search`** keyword-searches public specs (**ILIKE** over title, description, and tag names); **`q`** must be non-empty after trimming; results include **`rank_score`** and use the same **`limit`** / **`next_cursor`** pagination pattern as **`spec.list`** (#3007).
 
 ## Importing
 - Race condition fixed in 3.0.1 specification imports


### PR DESCRIPTION
## Summary
Adds MCP tool `spec.search` for keyword discovery over `odb.mcp_v_public_specs`: **ILIKE** (with `ESCAPE '\'`) on title, description, and tag names. Results are **ranked** via composite **`rank_score`** (title prefix > title substring > description > tag). **`q`** is required and **empty/whitespace-only queries are rejected**. Pagination matches **`spec.list`** (`limit`, base64url **`next_cursor`** keyed by rank + timestamp + id).

## How to test
- From repo root: **`yarn build`** and **`yarn test`** (runs **`objectified-mcp`** ruff, mypy, pytest plus UI/web tests).
- Manually: run **`objectified-mcp serve`** against a DB with **`odb.mcp_v_public_specs`** populated; call tool **`spec.search`** with **`q`** such as a substring of a public spec title; confirm **`items`** include **`rank_score`**, **`has_more`**, and **`next_cursor`** when applicable; verify blank **`q`** errors.

## Risks / notes
- Ranking is heuristic (integer weights), not full-text **tsvector**; acceptable per issue (**ILIKE** or tsvector).
- Cursor pagination is stable for a fixed **`q`**; changing **`q`** requires starting without **`cursor`**.

Closes #3007

Made with [Cursor](https://cursor.com)