### PR TITLE
Fix #3008 - MCP tool spec.list_tags

### DIFF
--- a/docs/PLANNED_ROADMAP_MCP.md
+++ b/docs/PLANNED_ROADMAP_MCP.md
@@ -101,7 +101,7 @@ process or via Docker.
 | 3.2 | ~~[#3005](../../issues/3005)~~ | ~~Tool `spec.list` (public, paginated)~~ (**completed**) | 3.1 |
 | 3.3 | ~~[#3006](../../issues/3006)~~ | ~~Tool `spec.describe` (public)~~ (**completed**) | 3.1 |
 | 3.4 | ~~[#3007](../../issues/3007)~~ | ~~Tool `spec.search` (keyword)~~ (**completed**) | 3.1 |
-| 3.5 | [#3008](../../issues/3008) | Tool `spec.list_tags` | 3.1 |
+| 3.5 | ~~[#3008](../../issues/3008)~~ | ~~Tool `spec.list_tags`~~ (**completed**) | 3.1 |
 
 #### E4 — Private Spec Access (#3009)
 

--- a/objectified-mcp/package.json
+++ b/objectified-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-mcp",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "private": true,
   "description": "Yarn workspace anchor for the objectified-mcp Python package (uv + pyproject.toml).",
   "scripts": {

--- a/objectified-mcp/pyproject.toml
+++ b/objectified-mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "objectified-mcp"
-version = "0.1.13"
+version = "0.1.14"
 description = "Model Context Protocol server for Objectified (FastMCP)."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/objectified-mcp/src/objectified_mcp/__init__.py
+++ b/objectified-mcp/src/objectified_mcp/__init__.py
@@ -1,3 +1,3 @@
 """Objectified MCP server package."""
 
-__version__ = "0.1.13"
+__version__ = "0.1.14"

--- a/objectified-mcp/src/objectified_mcp/server.py
+++ b/objectified-mcp/src/objectified_mcp/server.py
@@ -16,6 +16,7 @@ from objectified_mcp.logging_config import configure_logging
 from objectified_mcp.ping_tool import build_ping_response
 from objectified_mcp.settings import get_settings
 from objectified_mcp.spec_describe_tool import build_spec_describe_response
+from objectified_mcp.spec_list_tags_tool import build_spec_list_tags_response
 from objectified_mcp.spec_list_tool import build_spec_list_response
 from objectified_mcp.spec_search_tool import build_spec_search_response
 
@@ -109,3 +110,16 @@ async def spec_search(
 ) -> dict[str, Any]:
     pool = get_db_pool(ctx)
     return await build_spec_search_response(pool, q=q, limit=limit, cursor=cursor)
+
+
+@mcp.tool(
+    name="spec.list_tags",
+    description=(
+        "Distinct version-tag names across published public OpenAPI specs with counts of specs "
+        "that expose each tag (via odb.mcp_v_public_specs). Sorted by count descending, "
+        "then tag name ascending. Response is cached in-memory for 60 seconds."
+    ),
+)
+async def spec_list_tags(ctx: Context) -> list[dict[str, Any]]:
+    pool = get_db_pool(ctx)
+    return await build_spec_list_tags_response(pool)

--- a/objectified-mcp/src/objectified_mcp/spec_list_tags_tool.py
+++ b/objectified-mcp/src/objectified_mcp/spec_list_tags_tool.py
@@ -13,7 +13,15 @@ LIST_TAGS_CACHE_TTL_SEC = 60
 
 _tags_cache_monotonic_until: float = 0.0
 _tags_cache_payload: list[dict[str, Any]] | None = None
-_tags_cache_lock = asyncio.Lock()
+_tags_cache_lock: asyncio.Lock | None = None
+
+
+def _get_cache_lock() -> asyncio.Lock:
+    global _tags_cache_lock
+    if _tags_cache_lock is None:
+        _tags_cache_lock = asyncio.Lock()
+    return _tags_cache_lock
+
 
 _TAGS_QUERY = """
 SELECT tags.tag AS tag, COUNT(*)::bigint AS cnt
@@ -25,10 +33,11 @@ ORDER BY cnt DESC, tags.tag ASC
 
 
 def reset_spec_list_tags_cache_for_tests() -> None:
-    """Clear in-memory cache (tests only)."""
-    global _tags_cache_monotonic_until, _tags_cache_payload
+    """Clear in-memory cache and reset the lock (tests only)."""
+    global _tags_cache_monotonic_until, _tags_cache_payload, _tags_cache_lock
     _tags_cache_payload = None
     _tags_cache_monotonic_until = 0.0
+    _tags_cache_lock = None
 
 
 async def _fetch_tag_counts(pool: AsyncConnectionPool) -> list[dict[str, Any]]:
@@ -42,12 +51,12 @@ async def _fetch_tag_counts(pool: AsyncConnectionPool) -> list[dict[str, Any]]:
 async def build_spec_list_tags_response(pool: AsyncConnectionPool) -> list[dict[str, Any]]:
     """Return ``[{tag, count}, ...]`` sorted by count descending; cached 60s (process-local)."""
     global _tags_cache_monotonic_until, _tags_cache_payload
-    async with _tags_cache_lock:
+    async with _get_cache_lock():
         now = time.monotonic()
         if _tags_cache_payload is not None and now < _tags_cache_monotonic_until:
-            return list(_tags_cache_payload)
+            return [dict(item) for item in _tags_cache_payload]
 
         payload = await _fetch_tag_counts(pool)
         _tags_cache_payload = payload
         _tags_cache_monotonic_until = now + LIST_TAGS_CACHE_TTL_SEC
-        return list(payload)
+        return [dict(item) for item in payload]

--- a/objectified-mcp/src/objectified_mcp/spec_list_tags_tool.py
+++ b/objectified-mcp/src/objectified_mcp/spec_list_tags_tool.py
@@ -1,0 +1,53 @@
+"""MCP ``spec.list_tags`` tool: distinct tag usage counts across public specs (#3008)."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any
+
+from psycopg.rows import dict_row
+from psycopg_pool import AsyncConnectionPool
+
+LIST_TAGS_CACHE_TTL_SEC = 60
+
+_tags_cache_monotonic_until: float = 0.0
+_tags_cache_payload: list[dict[str, Any]] | None = None
+_tags_cache_lock = asyncio.Lock()
+
+_TAGS_QUERY = """
+SELECT tags.tag AS tag, COUNT(*)::bigint AS cnt
+FROM odb.mcp_v_public_specs AS s
+CROSS JOIN LATERAL unnest(s.tags) AS tags(tag)
+GROUP BY tags.tag
+ORDER BY cnt DESC, tags.tag ASC
+"""
+
+
+def reset_spec_list_tags_cache_for_tests() -> None:
+    """Clear in-memory cache (tests only)."""
+    global _tags_cache_monotonic_until, _tags_cache_payload
+    _tags_cache_payload = None
+    _tags_cache_monotonic_until = 0.0
+
+
+async def _fetch_tag_counts(pool: AsyncConnectionPool) -> list[dict[str, Any]]:
+    async with pool.connection() as conn:
+        async with conn.cursor(row_factory=dict_row) as cur:
+            await cur.execute(_TAGS_QUERY)
+            rows = await cur.fetchall()
+    return [{"tag": str(r["tag"]), "count": int(r["cnt"])} for r in rows]
+
+
+async def build_spec_list_tags_response(pool: AsyncConnectionPool) -> list[dict[str, Any]]:
+    """Return ``[{tag, count}, ...]`` sorted by count descending; cached 60s (process-local)."""
+    global _tags_cache_monotonic_until, _tags_cache_payload
+    async with _tags_cache_lock:
+        now = time.monotonic()
+        if _tags_cache_payload is not None and now < _tags_cache_monotonic_until:
+            return list(_tags_cache_payload)
+
+        payload = await _fetch_tag_counts(pool)
+        _tags_cache_payload = payload
+        _tags_cache_monotonic_until = now + LIST_TAGS_CACHE_TTL_SEC
+        return list(payload)

--- a/objectified-mcp/tests/test_spec_list_tags_tool.py
+++ b/objectified-mcp/tests/test_spec_list_tags_tool.py
@@ -114,6 +114,28 @@ def test_cache_expires_after_ttl(monkeypatch: pytest.MonkeyPatch) -> None:
     assert calls["n"] == 2
 
 
+def test_cache_mutation_does_not_corrupt_cached_value(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_fetch(_pool: AsyncConnectionPool) -> list[dict[str, object]]:
+        return [{"tag": "stable", "count": 10}]
+
+    monkeypatch.setattr(
+        "objectified_mcp.spec_list_tags_tool._fetch_tag_counts",
+        fake_fetch,
+    )
+
+    pool = MagicMock(spec=AsyncConnectionPool)
+
+    async def run() -> tuple[list[dict[str, object]], list[dict[str, object]]]:
+        first = await build_spec_list_tags_response(pool)
+        first[0]["count"] = 999  # mutate the returned copy
+        second = await build_spec_list_tags_response(pool)
+        return first, second
+
+    first, second = asyncio.run(run())
+    assert first == [{"tag": "stable", "count": 999}]
+    assert second == [{"tag": "stable", "count": 10}]  # cache is unaffected
+
+
 def test_spec_list_tags_tool_registered_on_mcp() -> None:
     from objectified_mcp.server import mcp
 

--- a/objectified-mcp/tests/test_spec_list_tags_tool.py
+++ b/objectified-mcp/tests/test_spec_list_tags_tool.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from psycopg_pool import AsyncConnectionPool
+
+from objectified_mcp.spec_list_tags_tool import (
+    LIST_TAGS_CACHE_TTL_SEC,
+    build_spec_list_tags_response,
+    reset_spec_list_tags_cache_for_tests,
+)
+
+
+def _pool_mock_for_fetch(rows: list[dict[str, object]]) -> tuple[MagicMock, MagicMock]:
+    pool = MagicMock(spec=AsyncConnectionPool)
+    cur = MagicMock()
+    cur.execute = AsyncMock()
+    cur.fetchall = AsyncMock(return_value=rows)
+    cur_cm = AsyncMock()
+    cur_cm.__aenter__.return_value = cur
+    cur_cm.__aexit__.return_value = None
+    conn = MagicMock()
+    conn.cursor = MagicMock(return_value=cur_cm)
+    conn_cm = AsyncMock()
+    conn_cm.__aenter__.return_value = conn
+    conn_cm.__aexit__.return_value = None
+    pool.connection = MagicMock(return_value=conn_cm)
+    return pool, cur
+
+
+@pytest.fixture(autouse=True)
+def _clear_tags_cache() -> None:
+    reset_spec_list_tags_cache_for_tests()
+    yield
+    reset_spec_list_tags_cache_for_tests()
+
+
+def test_build_spec_list_tags_response_maps_rows() -> None:
+    rows = [
+        {"tag": "stable", "cnt": 5},
+        {"tag": "beta", "cnt": 2},
+    ]
+    pool, _ = _pool_mock_for_fetch(rows)
+
+    async def run() -> list[dict[str, object]]:
+        return await build_spec_list_tags_response(pool)
+
+    out = asyncio.run(run())
+    assert out == [{"tag": "stable", "count": 5}, {"tag": "beta", "count": 2}]
+
+
+def test_build_spec_list_tags_response_empty() -> None:
+    pool, _ = _pool_mock_for_fetch([])
+
+    async def run() -> list[dict[str, object]]:
+        return await build_spec_list_tags_response(pool)
+
+    out = asyncio.run(run())
+    assert out == []
+
+
+def test_cache_returns_second_call_without_extra_db_hit(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = {"n": 0}
+
+    async def fake_fetch(_pool: AsyncConnectionPool) -> list[dict[str, object]]:
+        calls["n"] += 1
+        return [{"tag": "a", "count": 1}]
+
+    monkeypatch.setattr(
+        "objectified_mcp.spec_list_tags_tool._fetch_tag_counts",
+        fake_fetch,
+    )
+
+    pool = MagicMock(spec=AsyncConnectionPool)
+
+    async def run() -> tuple[list[dict[str, object]], list[dict[str, object]]]:
+        first = await build_spec_list_tags_response(pool)
+        second = await build_spec_list_tags_response(pool)
+        return first, second
+
+    first, second = asyncio.run(run())
+    assert first == second == [{"tag": "a", "count": 1}]
+    assert calls["n"] == 1
+
+
+def test_cache_expires_after_ttl(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = {"n": 0}
+
+    async def fake_fetch(_pool: AsyncConnectionPool) -> list[dict[str, object]]:
+        calls["n"] += 1
+        return [{"tag": "x", "count": calls["n"]}]
+
+    monkeypatch.setattr(
+        "objectified_mcp.spec_list_tags_tool._fetch_tag_counts",
+        fake_fetch,
+    )
+
+    t = {"v": 0.0}
+    monkeypatch.setattr("objectified_mcp.spec_list_tags_tool.time.monotonic", lambda: t["v"])
+
+    pool = MagicMock(spec=AsyncConnectionPool)
+
+    async def run() -> tuple[list[dict[str, object]], list[dict[str, object]]]:
+        first = await build_spec_list_tags_response(pool)
+        t["v"] += LIST_TAGS_CACHE_TTL_SEC + 0.001
+        second = await build_spec_list_tags_response(pool)
+        return first, second
+
+    first, second = asyncio.run(run())
+    assert first == [{"tag": "x", "count": 1}]
+    assert second == [{"tag": "x", "count": 2}]
+    assert calls["n"] == 2
+
+
+def test_spec_list_tags_tool_registered_on_mcp() -> None:
+    from objectified_mcp.server import mcp
+
+    async def load() -> object:
+        return await mcp.get_tool("spec.list_tags")
+
+    tool = asyncio.run(load())
+    assert tool is not None
+    assert tool.name == "spec.list_tags"

--- a/objectified-mcp/uv.lock
+++ b/objectified-mcp/uv.lock
@@ -842,7 +842,7 @@ wheels = [
 
 [[package]]
 name = "objectified-mcp"
-version = "0.1.13"
+version = "0.1.14"
 source = { editable = "." }
 dependencies = [
     { name = "bcrypt" },

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.18",
+  "version": "0.11.19",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -20,6 +20,7 @@ We continue to improve the platform based on your feedback with improvements and
 - MCP tool **`spec.list`** lists public specs from that view with optional **`tenant_id`** / **`project_id`** filters, **`limit`** (default 50, max 100), and stable base64url **cursor** pagination (**`next_cursor`**) (#3005).
 - MCP tool **`spec.describe`** loads one public spec by revision UUID and returns **`id`**, **`title`**, **`version`**, **`description`**, **`owner`** (tenant slug), **`tags`**, and **`updated_at`** (UTC **`Z`**); missing, unpublished, or private revisions surface as not-found (#3006).
 - MCP tool **`spec.search`** keyword-searches public specs (**ILIKE** over title, description, and tag names); **`q`** must be non-empty after trimming; results include **`rank_score`** and use the same **`limit`** / **`next_cursor`** pagination pattern as **`spec.list`** (#3007).
+- MCP tool **`spec.list_tags`** returns distinct public-spec tag names with usage counts as **`[{tag, count}, …]`**, sorted by count descending (then tag name ascending); results are cached in-process for **60 seconds** (#3008).
 
 ## Importing
 - Race condition fixed in 3.0.1 specification imports


### PR DESCRIPTION
## What changed
Adds FastMCP tool `spec.list_tags` that aggregates distinct version-tag names from `odb.mcp_v_public_specs` with counts (one row per tag per public spec revision after unnest). Results are ordered by count descending, then tag name ascending. Responses are cached in-process for 60 seconds behind an asyncio lock to avoid stampedes.

## How to test
- **Run** `yarn workspace objectified-mcp test` (ruff, mypy, pytest).
- **Run** `yarn build` and `yarn test` from the repo root.
- With a running MCP server and DB containing public specs, **invoke** `spec.list_tags` twice within 60s and confirm the second call does not hit Postgres (e.g. query log); after TTL, expect a refresh.

## Risk / notes
- Cache is per MCP process only (no cross-instance consistency).
- Counts reflect tag occurrences on published public revisions (same semantics as the view).

Closes #3008

Made with [Cursor](https://cursor.com)