### PR TITLE
Fix #3010 - MCP spec authorization (scope ∩ visibility)

### DIFF
--- a/docs/PLANNED_ROADMAP_MCP.md
+++ b/docs/PLANNED_ROADMAP_MCP.md
@@ -107,7 +107,7 @@ process or via Docker.
 
 | # | Issue | Title | Depends on |
 |---|-------|-------|------------|
-| 4.1 | [#3010](../../issues/3010) | Authorization layer: scope ∩ visibility | 2.5, 3.1 |
+| 4.1 | ~~[#3010](../../issues/3010)~~ | ~~Authorization layer: scope ∩ visibility~~ (**completed**) | 2.5, 3.1 |
 | 4.2 | [#3011](../../issues/3011) | Extend `spec.list` with private results when authorized | 4.1, 3.2 |
 | 4.3 | [#3012](../../issues/3012) | Extend `spec.describe` with private results when authorized | 4.1, 3.3 |
 | 4.4 | [#3013](../../issues/3013) | Audit log table + insert on private read | 2.1 |

--- a/objectified-mcp/package.json
+++ b/objectified-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-mcp",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "private": true,
   "description": "Yarn workspace anchor for the objectified-mcp Python package (uv + pyproject.toml).",
   "scripts": {

--- a/objectified-mcp/pyproject.toml
+++ b/objectified-mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "objectified-mcp"
-version = "0.1.14"
+version = "0.1.15"
 description = "Model Context Protocol server for Objectified (FastMCP)."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/objectified-mcp/src/objectified_mcp/__init__.py
+++ b/objectified-mcp/src/objectified_mcp/__init__.py
@@ -1,3 +1,3 @@
 """Objectified MCP server package."""
 
-__version__ = "0.1.14"
+__version__ = "0.1.15"

--- a/objectified-mcp/src/objectified_mcp/mcp_auth.py
+++ b/objectified-mcp/src/objectified_mcp/mcp_auth.py
@@ -21,7 +21,7 @@ Tools opt in with::
 
 Scoped reads combine :meth:`objectified_mcp.scope.Scope.allows` with revision
 visibility via :func:`objectified_mcp.spec_authorization.authorize_spec` (and
-:parametrized SQL via
+parameterized SQL via
 :func:`objectified_mcp.spec_authorization.build_authorized_spec_sql_predicate`).
 See :class:`objectified_mcp.scope.Scope` for ``scope_json``.
 """

--- a/objectified-mcp/src/objectified_mcp/mcp_auth.py
+++ b/objectified-mcp/src/objectified_mcp/mcp_auth.py
@@ -19,8 +19,11 @@ Tools opt in with::
     async def example(auth: McpAuthContext = Depends(require_mcp_auth)) -> str:
         ...
 
-Scoped reads use :meth:`objectified_mcp.scope.Scope.allows` on ``auth.scope``; see
-:class:`objectified_mcp.scope.Scope` for the JSON persisted in ``scope_json``.
+Scoped reads combine :meth:`objectified_mcp.scope.Scope.allows` with revision
+visibility via :func:`objectified_mcp.spec_authorization.authorize_spec` (and
+:parametrized SQL via
+:func:`objectified_mcp.spec_authorization.build_authorized_spec_sql_predicate`).
+See :class:`objectified_mcp.scope.Scope` for ``scope_json``.
 """
 
 from __future__ import annotations

--- a/objectified-mcp/src/objectified_mcp/spec_authorization.py
+++ b/objectified-mcp/src/objectified_mcp/spec_authorization.py
@@ -1,0 +1,117 @@
+"""Combine MCP API key scope with version visibility for spec reads (#3010).
+
+Public revisions are readable when the key's :class:`~objectified_mcp.scope.Scope`
+allows the resource tenant/project. Private revisions additionally require the
+spec's tenant to match the authenticated key's ``tenant_id`` (no cross-tenant
+private reads, even if scope lists foreign projects).
+
+SQL helpers emit a parameterized predicate suitable for ``WHERE`` clauses; keep
+them aligned with :func:`authorize_spec`.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Mapping
+
+from objectified_mcp.mcp_auth import McpAuthContext
+from objectified_mcp.scope import Scope
+
+_SQL_IDENT_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_.]*$")
+
+
+def _validate_qualified_identifier(name: str, *, role: str) -> str:
+    if not _SQL_IDENT_RE.fullmatch(name):
+        raise ValueError(f"Invalid SQL identifier for {role}: {name!r}")
+    return name
+
+
+def _normalize_visibility(raw: Any) -> str | None:
+    if raw is None:
+        return None
+    s = str(raw).strip().lower()
+    if s in ("public", "private"):
+        return s
+    return None
+
+
+def _as_scope_key(raw: Any) -> str:
+    if raw is None:
+        return ""
+    return str(raw)
+
+
+def authorize_spec(auth_ctx: McpAuthContext, spec_row: Mapping[str, Any]) -> bool:
+    """Return True if *auth_ctx* may read the spec described by *spec_row*.
+
+    *spec_row* must expose ``tenant_id``, ``project_id``, and ``visibility``
+    (as returned from Postgres / MCP views). Unknown visibility values are
+    denied.
+    """
+    visibility = _normalize_visibility(spec_row.get("visibility"))
+    if visibility is None:
+        return False
+
+    tenant_id = _as_scope_key(spec_row.get("tenant_id"))
+    project_id = _as_scope_key(spec_row.get("project_id"))
+
+    if not auth_ctx.scope.allows(tenant_id, project_id):
+        return False
+
+    if visibility == "public":
+        return True
+
+    return tenant_id == str(auth_ctx.tenant_id)
+
+
+def _scope_predicate_sql(scope: Scope, tenant_column: str, project_column: str) -> tuple[str, list[Any]]:
+    parts: list[str] = []
+    params: list[Any] = []
+
+    if scope.tenants:
+        parts.append(f"{tenant_column}::text = ANY(%s)")
+        params.append(list(scope.tenants))
+
+    if scope.projects:
+        parts.append(f"{project_column}::text = ANY(%s)")
+        params.append(list(scope.projects))
+
+    if not parts:
+        return "TRUE", []
+
+    return "(" + " AND ".join(parts) + ")", params
+
+
+def build_authorized_spec_sql_predicate(
+    auth_ctx: McpAuthContext,
+    *,
+    tenant_column: str,
+    project_column: str,
+    visibility_column: str,
+) -> tuple[str, list[Any]]:
+    """Build a parameterized SQL boolean expression for scope ∩ visibility.
+
+    The fragment assumes ``tenant_column`` / ``project_column`` /
+    ``visibility_column`` are trusted qualified identifiers (e.g. ``v.tenant_id``).
+
+    Returns ``FALSE`` with an empty param list when ``auth_ctx.scope`` is deny-all. Otherwise
+    params are ordered: tenant allow-list (if any), project allow-list (if any),
+    then the key's ``tenant_id`` text for the private-spec guard.
+    """
+    if auth_ctx.scope.deny_all:
+        return "FALSE", []
+
+    tenant_column = _validate_qualified_identifier(tenant_column, role="tenant_column")
+    project_column = _validate_qualified_identifier(project_column, role="project_column")
+    visibility_column = _validate_qualified_identifier(visibility_column, role="visibility_column")
+
+    scope_sql, scope_params = _scope_predicate_sql(auth_ctx.scope, tenant_column, project_column)
+
+    visibility_sql = (
+        f"({visibility_column}::text = 'public' OR "
+        f"({visibility_column}::text = 'private' AND {tenant_column}::text = %s))"
+    )
+    params = [*scope_params, str(auth_ctx.tenant_id)]
+
+    combined = f"({scope_sql}) AND {visibility_sql}"
+    return combined, params

--- a/objectified-mcp/src/objectified_mcp/spec_authorization.py
+++ b/objectified-mcp/src/objectified_mcp/spec_authorization.py
@@ -17,7 +17,7 @@ from typing import Any, Mapping
 from objectified_mcp.mcp_auth import McpAuthContext
 from objectified_mcp.scope import Scope
 
-_SQL_IDENT_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_.]*$")
+_SQL_IDENT_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*(\.[a-zA-Z_][a-zA-Z0-9_]*)*$")
 
 
 def _validate_qualified_identifier(name: str, *, role: str) -> str:
@@ -98,12 +98,12 @@ def build_authorized_spec_sql_predicate(
     params are ordered: tenant allow-list (if any), project allow-list (if any),
     then the key's ``tenant_id`` text for the private-spec guard.
     """
-    if auth_ctx.scope.deny_all:
-        return "FALSE", []
-
     tenant_column = _validate_qualified_identifier(tenant_column, role="tenant_column")
     project_column = _validate_qualified_identifier(project_column, role="project_column")
     visibility_column = _validate_qualified_identifier(visibility_column, role="visibility_column")
+
+    if auth_ctx.scope.deny_all:
+        return "FALSE", []
 
     scope_sql, scope_params = _scope_predicate_sql(auth_ctx.scope, tenant_column, project_column)
 

--- a/objectified-mcp/tests/test_spec_authorization.py
+++ b/objectified-mcp/tests/test_spec_authorization.py
@@ -1,0 +1,122 @@
+"""Tests for MCP spec authorization: scope ∩ visibility (#3010)."""
+
+from __future__ import annotations
+
+import pytest
+
+from objectified_mcp.mcp_auth import McpAuthContext
+from objectified_mcp.scope import Scope
+from objectified_mcp.spec_authorization import (
+    authorize_spec,
+    build_authorized_spec_sql_predicate,
+)
+
+
+def _ctx(
+    *,
+    key_tenant: str = "tenant-key",
+    scope: Scope | None = None,
+) -> McpAuthContext:
+    return McpAuthContext(
+        key_id="00000000-0000-4000-8000-000000000001",
+        tenant_id=key_tenant,
+        label="test",
+        scope=scope if scope is not None else Scope(),
+    )
+
+
+def _row(*, tenant: str, project: str, visibility: str) -> dict[str, str]:
+    return {"tenant_id": tenant, "project_id": project, "visibility": visibility}
+
+
+@pytest.mark.parametrize(
+    ("visibility", "spec_tenant", "spec_project", "scope", "key_tenant", "expected"),
+    [
+        # public × in-scope (unrestricted scope)
+        ("public", "t-a", "p-1", Scope(), "tenant-key", True),
+        # public × out-of-scope (tenant allow-list excludes spec tenant)
+        ("public", "t-a", "p-1", Scope(tenants=("t-b",)), "tenant-key", False),
+        # public × out-of-scope (project allow-list excludes spec project)
+        ("public", "t-a", "p-1", Scope(projects=("p-2",)), "tenant-key", False),
+        # private × in-scope × same tenant as key
+        ("private", "tenant-key", "p-1", Scope(), "tenant-key", True),
+        # private × in-scope × different tenant than key (no cross-tenant private)
+        ("private", "t-other", "p-1", Scope(), "tenant-key", False),
+        # private × out-of-scope (wrong tenant in scope lists)
+        ("private", "tenant-key", "p-1", Scope(tenants=("t-b",)), "tenant-key", False),
+    ],
+)
+def test_authorize_spec_public_private_times_scope_matrix(
+    visibility: str,
+    spec_tenant: str,
+    spec_project: str,
+    scope: Scope,
+    key_tenant: str,
+    expected: bool,
+) -> None:
+    auth = _ctx(key_tenant=key_tenant, scope=scope)
+    row = _row(tenant=spec_tenant, project=spec_project, visibility=visibility)
+    assert authorize_spec(auth, row) is expected
+
+
+def test_authorize_spec_deny_all_scope_always_false() -> None:
+    auth = _ctx(scope=Scope(deny_all=True))
+    assert authorize_spec(auth, _row(tenant="t-a", project="p-1", visibility="public")) is False
+
+
+def test_authorize_spec_unknown_visibility_denied() -> None:
+    auth = _ctx()
+    assert authorize_spec(auth, {"tenant_id": "t-a", "project_id": "p-1", "visibility": "internal"}) is False
+
+
+def test_build_sql_deny_all() -> None:
+    auth = _ctx(scope=Scope(deny_all=True))
+    sql, params = build_authorized_spec_sql_predicate(
+        auth,
+        tenant_column="v.tenant_id",
+        project_column="v.project_id",
+        visibility_column="v.visibility",
+    )
+    assert sql == "FALSE"
+    assert params == []
+
+
+def test_build_sql_unrestricted_scope_includes_visibility_guard_params() -> None:
+    auth = _ctx(key_tenant="kt-1")
+    sql, params = build_authorized_spec_sql_predicate(
+        auth,
+        tenant_column="v.tenant_id",
+        project_column="v.project_id",
+        visibility_column="v.visibility",
+    )
+    assert sql.startswith("(TRUE) AND ")
+    assert "v.visibility::text = 'public'" in sql
+    assert "private" in sql
+    assert params == ["kt-1"]
+
+
+def test_build_sql_tenant_and_project_allowlists_order_params() -> None:
+    auth = _ctx(
+        key_tenant="kt-9",
+        scope=Scope(tenants=("t-a", "t-b"), projects=("p-1",)),
+    )
+    sql, params = build_authorized_spec_sql_predicate(
+        auth,
+        tenant_column="s.tenant_id",
+        project_column="s.project_id",
+        visibility_column="s.visibility",
+    )
+    assert "s.tenant_id::text = ANY(%s)" in sql
+    assert "s.project_id::text = ANY(%s)" in sql
+    assert params == [["t-a", "t-b"], ["p-1"], "kt-9"]
+
+
+def test_build_sql_rejects_bad_identifiers() -> None:
+    auth = _ctx()
+    with pytest.raises(ValueError, match="tenant_column"):
+        build_authorized_spec_sql_predicate(
+            auth,
+            tenant_column="v.tenant_id; DROP",
+            project_column="v.project_id",
+            visibility_column="v.visibility",
+        )

--- a/objectified-mcp/tests/test_spec_authorization.py
+++ b/objectified-mcp/tests/test_spec_authorization.py
@@ -120,3 +120,36 @@ def test_build_sql_rejects_bad_identifiers() -> None:
             project_column="v.project_id",
             visibility_column="v.visibility",
         )
+
+
+@pytest.mark.parametrize(
+    "bad_name",
+    [
+        "v..tenant_id",    # consecutive dots
+        "v.tenant_id.",    # trailing dot
+        ".tenant_id",      # leading dot
+        "v. tenant_id",    # space inside
+        "",                # empty string
+    ],
+)
+def test_build_sql_rejects_malformed_dot_identifiers(bad_name: str) -> None:
+    auth = _ctx()
+    with pytest.raises(ValueError):
+        build_authorized_spec_sql_predicate(
+            auth,
+            tenant_column=bad_name,
+            project_column="v.project_id",
+            visibility_column="v.visibility",
+        )
+
+
+def test_build_sql_rejects_bad_identifiers_even_with_deny_all_scope() -> None:
+    """Identifier validation must happen before the deny_all early-return."""
+    auth = _ctx(scope=Scope(deny_all=True))
+    with pytest.raises(ValueError, match="tenant_column"):
+        build_authorized_spec_sql_predicate(
+            auth,
+            tenant_column="v..bad",
+            project_column="v.project_id",
+            visibility_column="v.visibility",
+        )

--- a/objectified-mcp/uv.lock
+++ b/objectified-mcp/uv.lock
@@ -842,7 +842,7 @@ wheels = [
 
 [[package]]
 name = "objectified-mcp"
-version = "0.1.14"
+version = "0.1.15"
 source = { editable = "." }
 dependencies = [
     { name = "bcrypt" },

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.19",
+  "version": "0.11.20",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -21,6 +21,7 @@ We continue to improve the platform based on your feedback with improvements and
 - MCP tool **`spec.describe`** loads one public spec by revision UUID and returns **`id`**, **`title`**, **`version`**, **`description`**, **`owner`** (tenant slug), **`tags`**, and **`updated_at`** (UTC **`Z`**); missing, unpublished, or private revisions surface as not-found (#3006).
 - MCP tool **`spec.search`** keyword-searches public specs (**ILIKE** over title, description, and tag names); **`q`** must be non-empty after trimming; results include **`rank_score`** and use the same **`limit`** / **`next_cursor`** pagination pattern as **`spec.list`** (#3007).
 - MCP tool **`spec.list_tags`** returns distinct public-spec tag names with usage counts as **`[{tag, count}, …]`**, sorted by count descending (then tag name ascending); results are cached in-process for **60 seconds** (#3008).
+- MCP **`authorize_spec`** combines API key **scope** with revision **visibility** (public rows need scope only; private rows also require the spec tenant to match the key); **`build_authorized_spec_sql_predicate`** emits the same rules as a parameterized SQL **`WHERE`** fragment (#3010).
 
 ## Importing
 - Race condition fixed in 3.0.1 specification imports


### PR DESCRIPTION
## Summary
Implements `authorize_spec(auth_ctx, spec_row)` plus `build_authorized_spec_sql_predicate` so MCP reads combine API key **scope** (`Scope.allows`) with revision **visibility**: public specs need scope only; private specs also require the spec tenant to match the key`s tenant (no cross-tenant private reads).

## How to test
- From repo root: **`yarn test`** (runs objectified-mcp ruff, mypy, pytest among workspaces).

## Risk / notes
- SQL builder validates identifier tokens with a conservative regex; callers pass qualified column names (e.g. `v.tenant_id`).
- Follow-up tickets (4.2+) will wire this into list/describe queries.

Closes #3010

Made with [Cursor](https://cursor.com)