### PR TITLE
Fix #3011 - Extend spec.list with private results when authorized

### DIFF
--- a/docs/PLANNED_ROADMAP_MCP.md
+++ b/docs/PLANNED_ROADMAP_MCP.md
@@ -108,7 +108,7 @@ process or via Docker.
 | # | Issue | Title | Depends on |
 |---|-------|-------|------------|
 | 4.1 | ~~[#3010](../../issues/3010)~~ | ~~Authorization layer: scope ∩ visibility~~ (**completed**) | 2.5, 3.1 |
-| 4.2 | [#3011](../../issues/3011) | Extend `spec.list` with private results when authorized | 4.1, 3.2 |
+| 4.2 | ~~[#3011](../../issues/3011)~~ | ~~Extend `spec.list` with private results when authorized~~ (**completed**) | 4.1, 3.2 |
 | 4.3 | [#3012](../../issues/3012) | Extend `spec.describe` with private results when authorized | 4.1, 3.3 |
 | 4.4 | [#3013](../../issues/3013) | Audit log table + insert on private read | 2.1 |
 | 4.5 | [#3014](../../issues/3014) | Tool `spec.list_my_specs` (key-bound) | 4.1 |

--- a/objectified-mcp/pyproject.toml
+++ b/objectified-mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "objectified-mcp"
-version = "0.1.15"
+version = "0.1.16"
 description = "Model Context Protocol server for Objectified (FastMCP)."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/objectified-mcp/src/objectified_mcp/__init__.py
+++ b/objectified-mcp/src/objectified_mcp/__init__.py
@@ -1,3 +1,3 @@
 """Objectified MCP server package."""
 
-__version__ = "0.1.15"
+__version__ = "0.1.16"

--- a/objectified-mcp/src/objectified_mcp/mcp_auth.py
+++ b/objectified-mcp/src/objectified_mcp/mcp_auth.py
@@ -23,6 +23,8 @@ Scoped reads combine :meth:`objectified_mcp.scope.Scope.allows` with revision
 visibility via :func:`objectified_mcp.spec_authorization.authorize_spec` (and
 parameterized SQL via
 :func:`objectified_mcp.spec_authorization.build_authorized_spec_sql_predicate`).
+Tools that accept anonymous callers but upgrade when a secret is present use
+:func:`resolve_optional_mcp_auth`.
 See :class:`objectified_mcp.scope.Scope` for ``scope_json``.
 """
 
@@ -44,6 +46,7 @@ from psycopg_pool import AsyncConnectionPool
 from pydantic import BaseModel, ConfigDict, Field
 
 from objectified_mcp.database_pool import get_db_pool
+from objectified_mcp.http_credential_middleware import get_http_bearer_from_context
 from objectified_mcp.scope import Scope, parse_scope_json
 
 _log = structlog.get_logger(__name__)
@@ -214,6 +217,27 @@ async def validate_mcp_api_key(pool: AsyncConnectionPool, raw_secret: str) -> Mc
 
     _log.debug("mcp_api_key_hash_mismatch")
     raise AuthorizationError("Invalid or unknown MCP API key.")
+
+
+async def resolve_optional_mcp_auth(
+    ctx: Context,
+    pool: AsyncConnectionPool,
+    *,
+    headers: dict[str, str],
+) -> McpAuthContext | None:
+    """Return validated :class:`McpAuthContext` when a credential is present, else ``None``.
+
+    Checks HTTP headers and JSON-RPC ``meta`` like :func:`require_mcp_auth`, then the
+    Bearer secret stashed from streamable HTTP middleware when headers omit it (#3011).
+    """
+    rc = ctx.request_context
+    meta = rc.meta if rc else None
+    raw = extract_raw_mcp_api_key(http_headers=headers, request_meta=meta)
+    if raw is None:
+        raw = await get_http_bearer_from_context(ctx)
+    if raw is None:
+        return None
+    return await validate_mcp_api_key(pool, raw)
 
 
 async def require_mcp_auth(

--- a/objectified-mcp/src/objectified_mcp/server.py
+++ b/objectified-mcp/src/objectified_mcp/server.py
@@ -7,12 +7,14 @@ from typing import Any
 
 import structlog
 from fastmcp import Context, FastMCP
+from fastmcp.dependencies import CurrentHeaders
 from fastmcp.server.lifespan import lifespan
 from structlog.contextvars import bound_contextvars
 
 from objectified_mcp.database_pool import MCP_DB_POOL_KEY, create_async_pool, get_db_pool, ping_pool
 from objectified_mcp.http_credential_middleware import StashHttpBearerInToolContextMiddleware
 from objectified_mcp.logging_config import configure_logging
+from objectified_mcp.mcp_auth import resolve_optional_mcp_auth
 from objectified_mcp.ping_tool import build_ping_response
 from objectified_mcp.settings import get_settings
 from objectified_mcp.spec_describe_tool import build_spec_describe_response
@@ -58,7 +60,9 @@ async def ping(ctx: Context) -> dict[str, Any]:
 @mcp.tool(
     name="spec.list",
     description=(
-        "List published public OpenAPI specs (cursor pagination over odb.mcp_v_public_specs). "
+        "List published OpenAPI specs with cursor pagination. Anonymous callers see the public catalog "
+        "(odb.mcp_v_public_specs). With Authorization: Bearer <MCP API key> (or stdio meta credentials), "
+        "results merge in-scope public rows plus in-scope private revisions for the key's tenant (#3011). "
         "Optional filters: tenant_id, project_id (UUID strings). "
         "limit defaults to 50, capped at 100. Pass next_cursor from the previous response for the next page."
     ),
@@ -69,14 +73,17 @@ async def spec_list(
     project_id: str | None = None,
     limit: int | None = None,
     cursor: str | None = None,
+    headers: dict[str, str] = CurrentHeaders(),
 ) -> dict[str, Any]:
     pool = get_db_pool(ctx)
+    auth_ctx = await resolve_optional_mcp_auth(ctx, pool, headers=headers)
     return await build_spec_list_response(
         pool,
         tenant_id=tenant_id,
         project_id=project_id,
         limit=limit,
         cursor=cursor,
+        auth_ctx=auth_ctx,
     )
 
 

--- a/objectified-mcp/src/objectified_mcp/spec_authorization.py
+++ b/objectified-mcp/src/objectified_mcp/spec_authorization.py
@@ -115,3 +115,25 @@ def build_authorized_spec_sql_predicate(
 
     combined = f"({scope_sql}) AND {visibility_sql}"
     return combined, params
+
+
+def build_mcp_scope_sql_predicate(
+    auth_ctx: McpAuthContext,
+    *,
+    tenant_column: str,
+    project_column: str,
+) -> tuple[str, list[Any]]:
+    """Parameterized SQL for scope-only checks on rows that are already public-visible.
+
+    Use on ``odb.mcp_v_public_specs`` (no ``visibility`` column): callers already
+    exclude private revisions. Mirrors the scope half of :func:`authorize_spec`
+    for public visibility (``visibility == "public"``).
+    """
+
+    tenant_column = _validate_qualified_identifier(tenant_column, role="tenant_column")
+    project_column = _validate_qualified_identifier(project_column, role="project_column")
+
+    if auth_ctx.scope.deny_all:
+        return "FALSE", []
+
+    return _scope_predicate_sql(auth_ctx.scope, tenant_column, project_column)

--- a/objectified-mcp/src/objectified_mcp/spec_list_tool.py
+++ b/objectified-mcp/src/objectified_mcp/spec_list_tool.py
@@ -1,4 +1,4 @@
-"""MCP ``spec.list`` tool: paginated public specs from ``odb.mcp_v_public_specs`` (#3005)."""
+"""MCP ``spec.list`` tool: paginated specs — public catalog plus private rows when authed (#3005, #3011)."""
 
 from __future__ import annotations
 
@@ -11,6 +11,12 @@ from uuid import UUID
 
 from psycopg.rows import dict_row
 from psycopg_pool import AsyncConnectionPool
+
+from objectified_mcp.mcp_auth import McpAuthContext
+from objectified_mcp.spec_authorization import (
+    build_authorized_spec_sql_predicate,
+    build_mcp_scope_sql_predicate,
+)
 
 CURSOR_VERSION = 1
 MAX_PAGE_SIZE = 100
@@ -121,7 +127,7 @@ def _row_out(row: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-_LIST_QUERY = """
+_LIST_QUERY_ANONYMOUS = """
     SELECT id, tenant_id, project_id, title, version, description, tags, updated_at
     FROM odb.mcp_v_public_specs
     WHERE (%(tenant)s::uuid IS NULL OR tenant_id = %(tenant)s::uuid)
@@ -134,6 +140,45 @@ _LIST_QUERY = """
     LIMIT %(lim)s
 """
 
+# Positional %%s — filled via str.format with scope/auth fragments from spec_authorization.
+_LIST_QUERY_AUTHENTICATED = """
+SELECT id, tenant_id, project_id, title, version, description, tags, updated_at
+FROM (
+  SELECT id, tenant_id, project_id, title, version, description, tags, updated_at
+  FROM odb.mcp_v_public_specs AS ps
+  WHERE (%s::uuid IS NULL OR ps.tenant_id = %s::uuid)
+    AND (%s::uuid IS NULL OR ps.project_id = %s::uuid)
+    AND ({public_scope})
+
+  UNION ALL
+
+  SELECT v.id, p.tenant_id, v.project_id, p.name AS title, v.version_id AS version,
+         v.description,
+         COALESCE(tg.tags, ARRAY[]::TEXT[]) AS tags,
+         GREATEST(v.updated_at, p.updated_at, COALESCE(tg.max_tag_updated_at, '-infinity'::timestamptz)) AS updated_at
+  FROM odb.versions v
+  INNER JOIN odb.projects p ON p.id = v.project_id
+  LEFT JOIN LATERAL (
+    SELECT array_agg(vt.name ORDER BY vt.name) AS tags,
+           max(vt.updated_at) AS max_tag_updated_at
+    FROM odb.version_tags vt
+    WHERE vt.version_id = v.id AND vt.project_id = v.project_id
+  ) tg ON TRUE
+  WHERE v.deleted_at IS NULL
+    AND p.deleted_at IS NULL
+    AND v.enabled IS TRUE
+    AND p.enabled IS TRUE
+    AND v.published IS TRUE
+    AND v.visibility = 'private'::odb.visibility_type
+    AND ({private_auth})
+    AND (%s::uuid IS NULL OR p.tenant_id = %s::uuid)
+    AND (%s::uuid IS NULL OR v.project_id = %s::uuid)
+) AS merged
+WHERE (%s::timestamptz IS NULL OR (merged.updated_at, merged.id) < (%s::timestamptz, %s::uuid))
+ORDER BY merged.updated_at DESC, merged.id DESC
+LIMIT %s
+"""
+
 
 async def build_spec_list_response(
     pool: AsyncConnectionPool,
@@ -142,8 +187,14 @@ async def build_spec_list_response(
     project_id: str | None = None,
     limit: int | None = None,
     cursor: str | None = None,
+    auth_ctx: McpAuthContext | None = None,
 ) -> dict[str, Any]:
-    """Return ``items``, ``has_more``, and ``next_cursor`` for public specs."""
+    """Return ``items``, ``has_more``, and ``next_cursor``.
+
+    Anonymous callers see published public specs only. Authenticated callers get the
+    same response shape with public rows filtered by key scope plus in-scope private
+    revisions for their tenant (see #3011).
+    """
     tenant = _parse_optional_uuid("tenant_id", tenant_id)
     project = _parse_optional_uuid("project_id", project_id)
     lim = _clamp_limit(limit)
@@ -151,17 +202,54 @@ async def build_spec_list_response(
     cur_ts = decoded[0] if decoded else None
     cur_id = decoded[1] if decoded else None
 
-    params: dict[str, Any] = {
-        "tenant": tenant,
-        "project": project,
-        "cur_ts": cur_ts,
-        "cur_id": cur_id,
-        "lim": lim + 1,
-    }
+    if auth_ctx is not None and auth_ctx.scope.deny_all:
+        return {"items": [], "has_more": False, "next_cursor": None}
+
+    if auth_ctx is None:
+        params: dict[str, Any] = {
+            "tenant": tenant,
+            "project": project,
+            "cur_ts": cur_ts,
+            "cur_id": cur_id,
+            "lim": lim + 1,
+        }
+        query = _LIST_QUERY_ANONYMOUS
+        exec_params: dict[str, Any] | tuple[Any, ...] = params
+    else:
+        public_scope_sql, public_scope_params = build_mcp_scope_sql_predicate(
+            auth_ctx,
+            tenant_column="ps.tenant_id",
+            project_column="ps.project_id",
+        )
+        private_auth_sql, private_auth_params = build_authorized_spec_sql_predicate(
+            auth_ctx,
+            tenant_column="p.tenant_id",
+            project_column="v.project_id",
+            visibility_column="v.visibility",
+        )
+        query = _LIST_QUERY_AUTHENTICATED.format(
+            public_scope=public_scope_sql,
+            private_auth=private_auth_sql,
+        )
+        exec_params = (
+            tenant,
+            tenant,
+            project,
+            project,
+            *public_scope_params,
+            *private_auth_params,
+            tenant,
+            tenant,
+            project,
+            project,
+            cur_ts,
+            cur_id,
+            lim + 1,
+        )
 
     async with pool.connection() as conn:
         async with conn.cursor(row_factory=dict_row) as cur:
-            await cur.execute(_LIST_QUERY, params)
+            await cur.execute(query, exec_params)
             rows = await cur.fetchall()
 
     has_more = len(rows) > lim

--- a/objectified-mcp/src/objectified_mcp/spec_list_tool.py
+++ b/objectified-mcp/src/objectified_mcp/spec_list_tool.py
@@ -243,6 +243,7 @@ async def build_spec_list_response(
             project,
             project,
             cur_ts,
+            cur_ts,
             cur_id,
             lim + 1,
         )

--- a/objectified-mcp/tests/test_spec_authorization.py
+++ b/objectified-mcp/tests/test_spec_authorization.py
@@ -9,6 +9,7 @@ from objectified_mcp.scope import Scope
 from objectified_mcp.spec_authorization import (
     authorize_spec,
     build_authorized_spec_sql_predicate,
+    build_mcp_scope_sql_predicate,
 )
 
 
@@ -125,11 +126,11 @@ def test_build_sql_rejects_bad_identifiers() -> None:
 @pytest.mark.parametrize(
     "bad_name",
     [
-        "v..tenant_id",    # consecutive dots
-        "v.tenant_id.",    # trailing dot
-        ".tenant_id",      # leading dot
-        "v. tenant_id",    # space inside
-        "",                # empty string
+        "v..tenant_id",  # consecutive dots
+        "v.tenant_id.",  # trailing dot
+        ".tenant_id",  # leading dot
+        "v. tenant_id",  # space inside
+        "",  # empty string
     ],
 )
 def test_build_sql_rejects_malformed_dot_identifiers(bad_name: str) -> None:
@@ -153,3 +154,25 @@ def test_build_sql_rejects_bad_identifiers_even_with_deny_all_scope() -> None:
             project_column="v.project_id",
             visibility_column="v.visibility",
         )
+
+
+def test_build_mcp_scope_sql_predicate_deny_all() -> None:
+    auth = _ctx(scope=Scope(deny_all=True))
+    sql, params = build_mcp_scope_sql_predicate(
+        auth,
+        tenant_column="ps.tenant_id",
+        project_column="ps.project_id",
+    )
+    assert sql == "FALSE"
+    assert params == []
+
+
+def test_build_mcp_scope_sql_predicate_unrestricted() -> None:
+    auth = _ctx()
+    sql, params = build_mcp_scope_sql_predicate(
+        auth,
+        tenant_column="ps.tenant_id",
+        project_column="ps.project_id",
+    )
+    assert sql == "TRUE"
+    assert params == []

--- a/objectified-mcp/tests/test_spec_list_tool.py
+++ b/objectified-mcp/tests/test_spec_list_tool.py
@@ -8,6 +8,8 @@ from uuid import UUID, uuid4
 import pytest
 from psycopg_pool import AsyncConnectionPool
 
+from objectified_mcp.mcp_auth import McpAuthContext
+from objectified_mcp.scope import Scope
 from objectified_mcp.spec_list_tool import (
     MAX_PAGE_SIZE,
     InvalidSpecListCursorError,
@@ -240,3 +242,72 @@ def test_build_spec_list_response_cursor_binding() -> None:
     _sql, params = cur.execute.await_args.args
     assert params["cur_ts"] == ts
     assert params["cur_id"] == sid
+
+
+def test_build_spec_list_response_deny_all_returns_empty_without_query() -> None:
+    pool = MagicMock(spec=AsyncConnectionPool)
+    pool.connection = MagicMock()
+
+    auth = McpAuthContext(
+        key_id="00000000-0000-4000-8000-000000000001",
+        tenant_id=str(uuid4()),
+        label="x",
+        scope=Scope(deny_all=True),
+    )
+
+    async def run() -> dict[str, object]:
+        return await build_spec_list_response(pool, auth_ctx=auth)
+
+    out = asyncio.run(run())
+    assert out == {"items": [], "has_more": False, "next_cursor": None}
+    pool.connection.assert_not_called()
+
+
+def test_build_spec_list_response_authenticated_merged_sql() -> None:
+    tid = uuid4()
+    pid = uuid4()
+    auth = McpAuthContext(
+        key_id="00000000-0000-4000-8000-000000000002",
+        tenant_id=str(tid),
+        label="k",
+        scope=Scope(),
+    )
+    rows = [_sample_row()]
+    pool, cur = _pool_mock_for_fetch(rows)
+
+    async def run() -> None:
+        await build_spec_list_response(pool, tenant_id=str(tid), project_id=str(pid), limit=5, auth_ctx=auth)
+
+    asyncio.run(run())
+    sql, params = cur.execute.await_args.args
+    assert "UNION ALL" in sql
+    assert "mcp_v_public_specs" in sql
+    assert "visibility = 'private'" in sql
+    assert isinstance(params, tuple)
+    assert params[0:4] == (tid, tid, pid, pid)
+    assert params[4] == str(auth.tenant_id)
+    assert params[5:9] == (tid, tid, pid, pid)
+    assert params[-3:] == (None, None, 6)
+
+
+def test_build_spec_list_response_authenticated_cursor_binding_tuple() -> None:
+    sid = UUID("44444444-4444-4444-8444-444444444444")
+    ts = datetime(2026, 5, 3, 10, 0, tzinfo=timezone.utc)
+    cursor = encode_spec_list_cursor(ts, sid)
+    auth = McpAuthContext(
+        key_id="00000000-0000-4000-8000-000000000003",
+        tenant_id=str(uuid4()),
+        label="k",
+        scope=Scope(),
+    )
+    rows = [_sample_row()]
+    pool, cur = _pool_mock_for_fetch(rows)
+
+    async def run() -> None:
+        await build_spec_list_response(pool, cursor=cursor, auth_ctx=auth)
+
+    asyncio.run(run())
+    _sql, params = cur.execute.await_args.args
+    assert isinstance(params, tuple)
+    assert params[-3] == ts
+    assert params[-2] == sid

--- a/objectified-mcp/tests/test_spec_list_tool.py
+++ b/objectified-mcp/tests/test_spec_list_tool.py
@@ -287,7 +287,7 @@ def test_build_spec_list_response_authenticated_merged_sql() -> None:
     assert params[0:4] == (tid, tid, pid, pid)
     assert params[4] == str(auth.tenant_id)
     assert params[5:9] == (tid, tid, pid, pid)
-    assert params[-3:] == (None, None, 6)
+    assert params[-4:] == (None, None, None, 6)
 
 
 def test_build_spec_list_response_authenticated_cursor_binding_tuple() -> None:
@@ -309,5 +309,6 @@ def test_build_spec_list_response_authenticated_cursor_binding_tuple() -> None:
     asyncio.run(run())
     _sql, params = cur.execute.await_args.args
     assert isinstance(params, tuple)
+    assert params[-4] == ts
     assert params[-3] == ts
     assert params[-2] == sid

--- a/objectified-mcp/uv.lock
+++ b/objectified-mcp/uv.lock
@@ -842,7 +842,7 @@ wheels = [
 
 [[package]]
 name = "objectified-mcp"
-version = "0.1.15"
+version = "0.1.16"
 source = { editable = "." }
 dependencies = [
     { name = "bcrypt" },

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.20",
+  "version": "0.11.21",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -22,6 +22,7 @@ We continue to improve the platform based on your feedback with improvements and
 - MCP tool **`spec.search`** keyword-searches public specs (**ILIKE** over title, description, and tag names); **`q`** must be non-empty after trimming; results include **`rank_score`** and use the same **`limit`** / **`next_cursor`** pagination pattern as **`spec.list`** (#3007).
 - MCP tool **`spec.list_tags`** returns distinct public-spec tag names with usage counts as **`[{tag, count}, …]`**, sorted by count descending (then tag name ascending); results are cached in-process for **60 seconds** (#3008).
 - MCP **`authorize_spec`** combines API key **scope** with revision **visibility** (public rows need scope only; private rows also require the spec tenant to match the key); **`build_authorized_spec_sql_predicate`** emits the same rules as a parameterized SQL **`WHERE`** fragment (#3010).
+- MCP **`spec.list`** with a valid API key merges **in-scope public** rows with **in-scope private** published revisions for the key's tenant (same **`items`** / **`has_more`** / **`next_cursor`** shape as anonymous listing); **`resolve_optional_mcp_auth`** resolves credentials from headers, **`tools/call`** meta, or the HTTP Bearer stash (#3011).
 
 ## Importing
 - Race condition fixed in 3.0.1 specification imports


### PR DESCRIPTION
## Summary
MCP `spec.list` now resolves an optional API key (HTTP headers, JSON-RPC `_meta`, or the streamable-HTTP Bearer stash). When a key validates, results are a single merged, cursor-paginated stream: **in-scope public** rows from `odb.mcp_v_public_specs` plus **in-scope private** published revisions for the key tenant, using the same scope ∩ visibility rules as `build_authorized_spec_sql_predicate`. Deny-all scopes return an empty list without querying.

Anonymous callers keep the previous behavior (public catalog only). Response shape is unchanged (`items`, `has_more`, `next_cursor`).

## How to test
1. **Apply DB migrations** so `mcp_v_public_specs` and `mcp_api_keys` exist; optionally load `objectified-db/fixtures/mcp_public_specs_dev.sql`.
2. **Run MCP** with `uv run objectified-mcp serve --transport http` (or stdio with `_meta` credentials).
3. **Call `spec.list` without auth** and confirm only public published specs appear (baseline).
4. **Issue or reuse an MCP API key** for a tenant that has a **published private** revision in scope; **call `spec.list`** with `Authorization: Bearer <key>` (or stdio `_meta`) and confirm private rows appear in `items` alongside allowed public rows.
5. **Use `next_cursor`** to page and confirm ordering stability across the merged set.

## Risks / notes
- Invalid or expired Bearer secrets still raise authorization errors (not treated as anonymous).
- Keys with `deny_all` scope intentionally see no specs (aligned with `authorize_spec`).

Closes #3011

Made with [Cursor](https://cursor.com)