### PR TITLE
Fix #3012 - spec.describe returns private specs when authorized

### DIFF
--- a/docs/PLANNED_ROADMAP_MCP.md
+++ b/docs/PLANNED_ROADMAP_MCP.md
@@ -109,7 +109,7 @@ process or via Docker.
 |---|-------|-------|------------|
 | 4.1 | ~~[#3010](../../issues/3010)~~ | ~~Authorization layer: scope ∩ visibility~~ (**completed**) | 2.5, 3.1 |
 | 4.2 | ~~[#3011](../../issues/3011)~~ | ~~Extend `spec.list` with private results when authorized~~ (**completed**) | 4.1, 3.2 |
-| 4.3 | [#3012](../../issues/3012) | Extend `spec.describe` with private results when authorized | 4.1, 3.3 |
+| 4.3 | ~~[#3012](../../issues/3012)~~ | ~~Extend `spec.describe` with private results when authorized~~ (**completed**) | 4.1, 3.3 |
 | 4.4 | [#3013](../../issues/3013) | Audit log table + insert on private read | 2.1 |
 | 4.5 | [#3014](../../issues/3014) | Tool `spec.list_my_specs` (key-bound) | 4.1 |
 

--- a/objectified-mcp/package.json
+++ b/objectified-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-mcp",
-  "version": "0.1.15",
+  "version": "0.1.17",
   "private": true,
   "description": "Yarn workspace anchor for the objectified-mcp Python package (uv + pyproject.toml).",
   "scripts": {

--- a/objectified-mcp/pyproject.toml
+++ b/objectified-mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "objectified-mcp"
-version = "0.1.16"
+version = "0.1.17"
 description = "Model Context Protocol server for Objectified (FastMCP)."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/objectified-mcp/src/objectified_mcp/__init__.py
+++ b/objectified-mcp/src/objectified_mcp/__init__.py
@@ -1,3 +1,3 @@
 """Objectified MCP server package."""
 
-__version__ = "0.1.16"
+__version__ = "0.1.17"

--- a/objectified-mcp/src/objectified_mcp/server.py
+++ b/objectified-mcp/src/objectified_mcp/server.py
@@ -90,14 +90,22 @@ async def spec_list(
 @mcp.tool(
     name="spec.describe",
     description=(
-        "Return metadata for a single published public OpenAPI spec revision by id (UUID). "
+        "Return metadata for a single published OpenAPI spec revision by id (UUID). "
         "Fields: id, title, version, description, owner (tenant slug), tags, updated_at (UTC Z). "
-        "Raises not-found when the revision is missing, unpublished, private, or unknown."
+        "Anonymous callers see public revisions only (odb.mcp_v_public_specs). "
+        "With Authorization: Bearer <MCP API key> (or stdio meta credentials), in-scope private "
+        "published revisions for the key's tenant are included (#3012). "
+        "Raises not-found when the revision is missing, out of scope, or not accessible."
     ),
 )
-async def spec_describe(ctx: Context, spec_id: str) -> dict[str, Any]:
+async def spec_describe(
+    ctx: Context,
+    spec_id: str,
+    headers: dict[str, str] = CurrentHeaders(),
+) -> dict[str, Any]:
     pool = get_db_pool(ctx)
-    return await build_spec_describe_response(pool, spec_id=spec_id)
+    auth_ctx = await resolve_optional_mcp_auth(ctx, pool, headers=headers)
+    return await build_spec_describe_response(pool, spec_id=spec_id, auth_ctx=auth_ctx)
 
 
 @mcp.tool(

--- a/objectified-mcp/src/objectified_mcp/spec_describe_tool.py
+++ b/objectified-mcp/src/objectified_mcp/spec_describe_tool.py
@@ -1,4 +1,4 @@
-"""MCP ``spec.describe`` tool: public spec metadata by revision id (#3006)."""
+"""MCP ``spec.describe`` tool: spec metadata by revision id (#3006, #3012)."""
 
 from __future__ import annotations
 
@@ -10,7 +10,13 @@ from fastmcp.exceptions import NotFoundError
 from psycopg.rows import dict_row
 from psycopg_pool import AsyncConnectionPool
 
-_DESCRIBE_QUERY = """
+from objectified_mcp.mcp_auth import McpAuthContext
+from objectified_mcp.spec_authorization import (
+    build_authorized_spec_sql_predicate,
+    build_mcp_scope_sql_predicate,
+)
+
+_DESCRIBE_QUERY_ANONYMOUS = """
     SELECT
       s.id,
       s.title,
@@ -25,6 +31,58 @@ _DESCRIBE_QUERY = """
       AND t.deleted_at IS NULL
       AND t.enabled IS TRUE
     LIMIT 1
+"""
+
+# Positional %%s — ``public_scope`` / ``private_auth`` fragments add their own placeholders.
+_DESCRIBE_QUERY_AUTHENTICATED = """
+SELECT id, title, version, description, owner, tags, updated_at
+FROM (
+  SELECT
+    s.id,
+    s.title,
+    s.version,
+    s.description,
+    t.slug AS owner,
+    s.tags,
+    s.updated_at
+  FROM odb.mcp_v_public_specs s
+  INNER JOIN odb.tenants t ON t.id = s.tenant_id
+  WHERE s.id = %s::uuid
+    AND t.deleted_at IS NULL
+    AND t.enabled IS TRUE
+    AND ({public_scope})
+
+  UNION ALL
+
+  SELECT
+    v.id,
+    p.name AS title,
+    v.version_id AS version,
+    v.description,
+    tn.slug AS owner,
+    COALESCE(tg.tags, ARRAY[]::TEXT[]) AS tags,
+    GREATEST(v.updated_at, p.updated_at, COALESCE(tg.max_tag_updated_at, '-infinity'::timestamptz)) AS updated_at
+  FROM odb.versions v
+  INNER JOIN odb.projects p ON p.id = v.project_id
+  INNER JOIN odb.tenants tn ON tn.id = p.tenant_id
+  LEFT JOIN LATERAL (
+    SELECT array_agg(vt.name ORDER BY vt.name) AS tags,
+           max(vt.updated_at) AS max_tag_updated_at
+    FROM odb.version_tags vt
+    WHERE vt.version_id = v.id AND vt.project_id = v.project_id
+  ) tg ON TRUE
+  WHERE v.id = %s::uuid
+    AND v.deleted_at IS NULL
+    AND p.deleted_at IS NULL
+    AND v.enabled IS TRUE
+    AND p.enabled IS TRUE
+    AND tn.deleted_at IS NULL
+    AND tn.enabled IS TRUE
+    AND v.published IS TRUE
+    AND v.visibility = 'private'::odb.visibility_type
+    AND ({private_auth})
+) AS merged
+LIMIT 1
 """
 
 
@@ -64,13 +122,45 @@ def _row_to_metadata(row: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-async def build_spec_describe_response(pool: AsyncConnectionPool, *, spec_id: str) -> dict[str, Any]:
-    """Return canonical public metadata for ``spec_id``, or raise ``NotFoundError``."""
+async def build_spec_describe_response(
+    pool: AsyncConnectionPool,
+    *,
+    spec_id: str,
+    auth_ctx: McpAuthContext | None = None,
+) -> dict[str, Any]:
+    """Return canonical metadata for ``spec_id``, or raise ``NotFoundError``.
+
+    Anonymous callers only resolve revisions present in ``odb.mcp_v_public_specs``.
+    Authenticated callers additionally resolve in-scope private published revisions
+    for their tenant (same rules as ``spec.list``, #3011).
+    """
     sid = _parse_spec_id(spec_id)
+
+    if auth_ctx is not None and auth_ctx.scope.deny_all:
+        raise NotFoundError("Unknown or non-public spec.")
 
     async with pool.connection() as conn:
         async with conn.cursor(row_factory=dict_row) as cur:
-            await cur.execute(_DESCRIBE_QUERY, {"spec_id": sid})
+            if auth_ctx is None:
+                await cur.execute(_DESCRIBE_QUERY_ANONYMOUS, {"spec_id": sid})
+            else:
+                public_scope_sql, public_scope_params = build_mcp_scope_sql_predicate(
+                    auth_ctx,
+                    tenant_column="s.tenant_id",
+                    project_column="s.project_id",
+                )
+                private_auth_sql, private_auth_params = build_authorized_spec_sql_predicate(
+                    auth_ctx,
+                    tenant_column="p.tenant_id",
+                    project_column="v.project_id",
+                    visibility_column="v.visibility",
+                )
+                query = _DESCRIBE_QUERY_AUTHENTICATED.format(
+                    public_scope=public_scope_sql,
+                    private_auth=private_auth_sql,
+                )
+                exec_params = (sid, *public_scope_params, sid, *private_auth_params)
+                await cur.execute(query, exec_params)
             row = await cur.fetchone()
 
     if row is None:

--- a/objectified-mcp/tests/test_spec_describe_tool.py
+++ b/objectified-mcp/tests/test_spec_describe_tool.py
@@ -9,6 +9,8 @@ import pytest
 from fastmcp.exceptions import NotFoundError
 from psycopg_pool import AsyncConnectionPool
 
+from objectified_mcp.mcp_auth import McpAuthContext
+from objectified_mcp.scope import Scope
 from objectified_mcp.spec_describe_tool import build_spec_describe_response
 
 
@@ -94,6 +96,53 @@ def test_build_spec_describe_response_not_found() -> None:
 
     with pytest.raises(NotFoundError, match="Unknown or non-public"):
         asyncio.run(run())
+
+
+def test_build_spec_describe_response_deny_all_raises_without_query() -> None:
+    pool = MagicMock(spec=AsyncConnectionPool)
+    pool.connection = MagicMock()
+
+    auth = McpAuthContext(
+        key_id="00000000-0000-4000-8000-000000000001",
+        tenant_id=str(uuid4()),
+        label="x",
+        scope=Scope(deny_all=True),
+    )
+
+    async def run() -> None:
+        await build_spec_describe_response(pool, spec_id=str(uuid4()), auth_ctx=auth)
+
+    with pytest.raises(NotFoundError, match="Unknown or non-public"):
+        asyncio.run(run())
+    pool.connection.assert_not_called()
+
+
+def test_build_spec_describe_response_authenticated_merged_sql() -> None:
+    sid = uuid4()
+    tid = uuid4()
+    auth = McpAuthContext(
+        key_id="00000000-0000-4000-8000-000000000002",
+        tenant_id=str(tid),
+        label="k",
+        scope=Scope(),
+    )
+    row = _sample_row(spec_id=sid)
+    pool, cur = _pool_mock_for_fetchone(row)
+
+    async def run() -> dict[str, object]:
+        return await build_spec_describe_response(pool, spec_id=str(sid), auth_ctx=auth)
+
+    out = asyncio.run(run())
+    assert out["id"] == str(sid)
+
+    sql, params = cur.execute.await_args.args
+    assert "UNION ALL" in sql
+    assert "mcp_v_public_specs" in sql
+    assert "visibility = 'private'" in sql
+    assert isinstance(params, tuple)
+    assert params[0] == sid
+    assert params[1] == sid
+    assert params[2] == str(auth.tenant_id)
 
 
 def test_build_spec_describe_invalid_uuid() -> None:

--- a/objectified-mcp/uv.lock
+++ b/objectified-mcp/uv.lock
@@ -842,7 +842,7 @@ wheels = [
 
 [[package]]
 name = "objectified-mcp"
-version = "0.1.16"
+version = "0.1.17"
 source = { editable = "." }
 dependencies = [
     { name = "bcrypt" },

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.21",
+  "version": "0.11.22",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -23,6 +23,7 @@ We continue to improve the platform based on your feedback with improvements and
 - MCP tool **`spec.list_tags`** returns distinct public-spec tag names with usage counts as **`[{tag, count}, …]`**, sorted by count descending (then tag name ascending); results are cached in-process for **60 seconds** (#3008).
 - MCP **`authorize_spec`** combines API key **scope** with revision **visibility** (public rows need scope only; private rows also require the spec tenant to match the key); **`build_authorized_spec_sql_predicate`** emits the same rules as a parameterized SQL **`WHERE`** fragment (#3010).
 - MCP **`spec.list`** with a valid API key merges **in-scope public** rows with **in-scope private** published revisions for the key's tenant (same **`items`** / **`has_more`** / **`next_cursor`** shape as anonymous listing); **`resolve_optional_mcp_auth`** resolves credentials from headers, **`tools/call`** meta, or the HTTP Bearer stash (#3011).
+- MCP **`spec.describe`** uses the same optional auth path: anonymous callers resolve **public** revisions only; with a valid API key, **in-scope private** published revisions for that tenant return the same metadata shape (**`id`**, **`title`**, **`version`**, **`description`**, **`owner`**, **`tags`**, **`updated_at`**); missing or inaccessible revisions stay **not-found** (#3012).
 
 ## Importing
 - Race condition fixed in 3.0.1 specification imports


### PR DESCRIPTION
## Summary
Extends MCP `spec.describe` so callers with a valid MCP API key can load metadata for **in-scope private** published revisions (same scope ∩ visibility rules as `spec.list`, #3011). Anonymous behavior is unchanged (public catalog only). Out-of-scope or inaccessible revisions still surface as **not-found** (no information leak).

## How to test
1. **Run checks**: `yarn workspace objectified-mcp test` (ruff, mypy, pytest).
2. **Anonymous**: call `spec.describe` with a **private** revision UUID → expect not-found.
3. **Authenticated**: use **Bearer** (HTTP) or **tools/call** `_meta` with an API key whose scope includes that tenant/project → expect the same metadata shape as public (`id`, `title`, `version`, `description`, `owner`, `tags`, `updated_at`).
4. **Out of scope**: describe a spec outside the key scope → not-found.

## Risk / notes
- **Deny-all** scopes raise not-found without hitting Postgres (consistent with treating the revision as inaccessible).
- SQL mirrors the authenticated branch of `spec.list` (public scoped UNION private authorized).

Closes #3012

Made with [Cursor](https://cursor.com)