### PR TITLE
Fix #3013 - MCP access audit for private spec reads

### DIFF
--- a/docs/PLANNED_ROADMAP_MCP.md
+++ b/docs/PLANNED_ROADMAP_MCP.md
@@ -110,7 +110,7 @@ process or via Docker.
 | 4.1 | ~~[#3010](../../issues/3010)~~ | ~~Authorization layer: scope ∩ visibility~~ (**completed**) | 2.5, 3.1 |
 | 4.2 | ~~[#3011](../../issues/3011)~~ | ~~Extend `spec.list` with private results when authorized~~ (**completed**) | 4.1, 3.2 |
 | 4.3 | ~~[#3012](../../issues/3012)~~ | ~~Extend `spec.describe` with private results when authorized~~ (**completed**) | 4.1, 3.3 |
-| 4.4 | [#3013](../../issues/3013) | Audit log table + insert on private read | 2.1 |
+| 4.4 | ~~[#3013](../../issues/3013)~~ | ~~Audit log table + insert on private read~~ (**completed**) | 2.1 |
 | 4.5 | [#3014](../../issues/3014) | Tool `spec.list_my_specs` (key-bound) | 4.1 |
 
 #### E5 — OpenAPI Inspection Tools (#3015)

--- a/objectified-db/scripts/20260502-140000.sql
+++ b/objectified-db/scripts/20260502-140000.sql
@@ -1,0 +1,33 @@
+-- MCP private access audit trail (#3013).
+SET search_path TO odb, public;
+
+CREATE TABLE IF NOT EXISTS mcp_access_audit (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  key_id UUID REFERENCES odb.mcp_api_keys(id) ON DELETE SET NULL,
+  tool TEXT NOT NULL,
+  spec_id UUID NOT NULL REFERENCES odb.versions(id),
+  at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  success BOOLEAN NOT NULL,
+  error TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_mcp_access_audit_key_at ON odb.mcp_access_audit (key_id, at DESC);
+CREATE INDEX IF NOT EXISTS idx_mcp_access_audit_spec_at ON odb.mcp_access_audit (spec_id, at DESC);
+
+COMMENT ON TABLE odb.mcp_access_audit IS
+  'Append-only audit of MCP tool reads that expose private published revisions (#3013).';
+
+COMMENT ON COLUMN odb.mcp_access_audit.key_id IS
+  'API key used for the read; NULL if the key row was deleted after the event.';
+
+COMMENT ON COLUMN odb.mcp_access_audit.tool IS
+  'MCP tool name (e.g. spec.list, spec.describe).';
+
+COMMENT ON COLUMN odb.mcp_access_audit.spec_id IS
+  'Schema revision id (versions.id) that was returned from the private branch.';
+
+COMMENT ON COLUMN odb.mcp_access_audit.success IS
+  'Whether the read completed successfully (reserved for future failure logging).';
+
+COMMENT ON COLUMN odb.mcp_access_audit.error IS
+  'Optional error detail when success is false.';

--- a/objectified-mcp/package.json
+++ b/objectified-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-mcp",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "private": true,
   "description": "Yarn workspace anchor for the objectified-mcp Python package (uv + pyproject.toml).",
   "scripts": {

--- a/objectified-mcp/pyproject.toml
+++ b/objectified-mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "objectified-mcp"
-version = "0.1.17"
+version = "0.1.18"
 description = "Model Context Protocol server for Objectified (FastMCP)."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/objectified-mcp/src/objectified_mcp/__init__.py
+++ b/objectified-mcp/src/objectified_mcp/__init__.py
@@ -1,3 +1,3 @@
 """Objectified MCP server package."""
 
-__version__ = "0.1.17"
+__version__ = "0.1.18"

--- a/objectified-mcp/src/objectified_mcp/mcp_access_audit.py
+++ b/objectified-mcp/src/objectified_mcp/mcp_access_audit.py
@@ -1,0 +1,67 @@
+"""Append-only audit for MCP reads of private published revisions (#3013)."""
+
+from __future__ import annotations
+
+import asyncio
+
+import structlog
+from psycopg_pool import AsyncConnectionPool
+
+_log = structlog.get_logger(__name__)
+
+
+async def insert_mcp_access_audit(
+    pool: AsyncConnectionPool,
+    *,
+    key_id: str,
+    tool: str,
+    spec_id: str,
+    success: bool,
+    error: str | None,
+) -> None:
+    """Persist one audit row; callers should use :func:`schedule_mcp_private_access_audit` from tools."""
+    async with pool.connection() as conn:
+        await conn.execute(
+            """
+            INSERT INTO odb.mcp_access_audit (key_id, tool, spec_id, at, success, error)
+            VALUES (%s::uuid, %s, %s::uuid, CURRENT_TIMESTAMP, %s, %s)
+            """,
+            (key_id, tool, spec_id, success, error),
+        )
+        await conn.commit()
+
+
+def schedule_mcp_private_access_audit(
+    pool: AsyncConnectionPool,
+    *,
+    key_id: str,
+    tool: str,
+    spec_id: str,
+    success: bool = True,
+    error: str | None = None,
+) -> None:
+    """Fire-and-forget audit insert so MCP tool latency stays low."""
+
+    async def _run() -> None:
+        try:
+            await insert_mcp_access_audit(
+                pool,
+                key_id=key_id,
+                tool=tool,
+                spec_id=spec_id,
+                success=success,
+                error=error,
+            )
+        except Exception:
+            _log.warning(
+                "mcp_access_audit_insert_failed",
+                key_id=key_id,
+                tool=tool,
+                spec_id=spec_id,
+                exc_info=True,
+            )
+
+    try:
+        asyncio.get_running_loop().create_task(_run())
+    except RuntimeError:
+        _log.debug("mcp_access_audit_skip_no_event_loop", key_id=key_id, tool=tool)

--- a/objectified-mcp/src/objectified_mcp/mcp_access_audit.py
+++ b/objectified-mcp/src/objectified_mcp/mcp_access_audit.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from typing import Sequence
 
 import structlog
 from psycopg_pool import AsyncConnectionPool
@@ -27,6 +28,28 @@ async def insert_mcp_access_audit(
             VALUES (%s::uuid, %s, %s::uuid, CURRENT_TIMESTAMP, %s, %s)
             """,
             (key_id, tool, spec_id, success, error),
+        )
+        await conn.commit()
+
+
+async def insert_mcp_access_audit_batch(
+    pool: AsyncConnectionPool,
+    *,
+    key_id: str,
+    tool: str,
+    spec_ids: Sequence[str],
+    success: bool,
+    error: str | None,
+) -> None:
+    """Persist one audit row per spec_id in a single INSERT; callers should use
+    :func:`schedule_mcp_private_access_audit_batch` from tools."""
+    async with pool.connection() as conn:
+        await conn.execute(
+            """
+            INSERT INTO odb.mcp_access_audit (key_id, tool, spec_id, at, success, error)
+            SELECT %s::uuid, %s, unnest(%s::uuid[]), CURRENT_TIMESTAMP, %s, %s
+            """,
+            (key_id, tool, list(spec_ids), success, error),
         )
         await conn.commit()
 
@@ -64,4 +87,56 @@ def schedule_mcp_private_access_audit(
     try:
         asyncio.get_running_loop().create_task(_run())
     except RuntimeError:
-        _log.debug("mcp_access_audit_skip_no_event_loop", key_id=key_id, tool=tool)
+        _log.debug(
+            "mcp_access_audit_skip_no_event_loop",
+            key_id=key_id,
+            tool=tool,
+            spec_id=spec_id,
+            success=success,
+            error=error,
+        )
+
+
+def schedule_mcp_private_access_audit_batch(
+    pool: AsyncConnectionPool,
+    *,
+    key_id: str,
+    tool: str,
+    spec_ids: Sequence[str],
+    success: bool = True,
+    error: str | None = None,
+) -> None:
+    """Fire-and-forget batch audit insert (one DB round-trip for the whole page)."""
+    if not spec_ids:
+        return
+
+    async def _run() -> None:
+        try:
+            await insert_mcp_access_audit_batch(
+                pool,
+                key_id=key_id,
+                tool=tool,
+                spec_ids=spec_ids,
+                success=success,
+                error=error,
+            )
+        except Exception:
+            _log.warning(
+                "mcp_access_audit_batch_insert_failed",
+                key_id=key_id,
+                tool=tool,
+                spec_ids=list(spec_ids),
+                exc_info=True,
+            )
+
+    try:
+        asyncio.get_running_loop().create_task(_run())
+    except RuntimeError:
+        _log.debug(
+            "mcp_access_audit_skip_no_event_loop",
+            key_id=key_id,
+            tool=tool,
+            spec_ids=list(spec_ids),
+            success=success,
+            error=error,
+        )

--- a/objectified-mcp/src/objectified_mcp/spec_describe_tool.py
+++ b/objectified-mcp/src/objectified_mcp/spec_describe_tool.py
@@ -10,6 +10,7 @@ from fastmcp.exceptions import NotFoundError
 from psycopg.rows import dict_row
 from psycopg_pool import AsyncConnectionPool
 
+from objectified_mcp.mcp_access_audit import schedule_mcp_private_access_audit
 from objectified_mcp.mcp_auth import McpAuthContext
 from objectified_mcp.spec_authorization import (
     build_authorized_spec_sql_predicate,
@@ -35,7 +36,7 @@ _DESCRIBE_QUERY_ANONYMOUS = """
 
 # Positional %%s — ``public_scope`` / ``private_auth`` fragments add their own placeholders.
 _DESCRIBE_QUERY_AUTHENTICATED = """
-SELECT id, title, version, description, owner, tags, updated_at
+SELECT id, title, version, description, owner, tags, updated_at, spec_visibility
 FROM (
   SELECT
     s.id,
@@ -44,7 +45,8 @@ FROM (
     s.description,
     t.slug AS owner,
     s.tags,
-    s.updated_at
+    s.updated_at,
+    'public'::text AS spec_visibility
   FROM odb.mcp_v_public_specs s
   INNER JOIN odb.tenants t ON t.id = s.tenant_id
   WHERE s.id = %s::uuid
@@ -61,7 +63,8 @@ FROM (
     v.description,
     tn.slug AS owner,
     COALESCE(tg.tags, ARRAY[]::TEXT[]) AS tags,
-    GREATEST(v.updated_at, p.updated_at, COALESCE(tg.max_tag_updated_at, '-infinity'::timestamptz)) AS updated_at
+    GREATEST(v.updated_at, p.updated_at, COALESCE(tg.max_tag_updated_at, '-infinity'::timestamptz)) AS updated_at,
+    'private'::text AS spec_visibility
   FROM odb.versions v
   INNER JOIN odb.projects p ON p.id = v.project_id
   INNER JOIN odb.tenants tn ON tn.id = p.tenant_id
@@ -165,5 +168,13 @@ async def build_spec_describe_response(
 
     if row is None:
         raise NotFoundError("Unknown or non-public spec.")
+
+    if auth_ctx is not None and row.get("spec_visibility") == "private":
+        schedule_mcp_private_access_audit(
+            pool,
+            key_id=auth_ctx.key_id,
+            tool="spec.describe",
+            spec_id=str(row["id"]),
+        )
 
     return _row_to_metadata(row)

--- a/objectified-mcp/src/objectified_mcp/spec_list_tool.py
+++ b/objectified-mcp/src/objectified_mcp/spec_list_tool.py
@@ -12,6 +12,7 @@ from uuid import UUID
 from psycopg.rows import dict_row
 from psycopg_pool import AsyncConnectionPool
 
+from objectified_mcp.mcp_access_audit import schedule_mcp_private_access_audit
 from objectified_mcp.mcp_auth import McpAuthContext
 from objectified_mcp.spec_authorization import (
     build_authorized_spec_sql_predicate,
@@ -142,9 +143,10 @@ _LIST_QUERY_ANONYMOUS = """
 
 # Positional %%s — filled via str.format with scope/auth fragments from spec_authorization.
 _LIST_QUERY_AUTHENTICATED = """
-SELECT id, tenant_id, project_id, title, version, description, tags, updated_at
+SELECT id, tenant_id, project_id, title, version, description, tags, updated_at, spec_visibility
 FROM (
-  SELECT id, tenant_id, project_id, title, version, description, tags, updated_at
+  SELECT id, tenant_id, project_id, title, version, description, tags, updated_at,
+         'public'::text AS spec_visibility
   FROM odb.mcp_v_public_specs AS ps
   WHERE (%s::uuid IS NULL OR ps.tenant_id = %s::uuid)
     AND (%s::uuid IS NULL OR ps.project_id = %s::uuid)
@@ -155,7 +157,8 @@ FROM (
   SELECT v.id, p.tenant_id, v.project_id, p.name AS title, v.version_id AS version,
          v.description,
          COALESCE(tg.tags, ARRAY[]::TEXT[]) AS tags,
-         GREATEST(v.updated_at, p.updated_at, COALESCE(tg.max_tag_updated_at, '-infinity'::timestamptz)) AS updated_at
+         GREATEST(v.updated_at, p.updated_at, COALESCE(tg.max_tag_updated_at, '-infinity'::timestamptz)) AS updated_at,
+         'private'::text AS spec_visibility
   FROM odb.versions v
   INNER JOIN odb.projects p ON p.id = v.project_id
   LEFT JOIN LATERAL (
@@ -255,6 +258,17 @@ async def build_spec_list_response(
 
     has_more = len(rows) > lim
     page = rows[:lim]
+
+    if auth_ctx is not None:
+        for r in page:
+            if r.get("spec_visibility") == "private":
+                schedule_mcp_private_access_audit(
+                    pool,
+                    key_id=auth_ctx.key_id,
+                    tool="spec.list",
+                    spec_id=str(r["id"]),
+                )
+
     items = [_row_out(r) for r in page]
 
     next_cursor: str | None = None

--- a/objectified-mcp/src/objectified_mcp/spec_list_tool.py
+++ b/objectified-mcp/src/objectified_mcp/spec_list_tool.py
@@ -12,7 +12,7 @@ from uuid import UUID
 from psycopg.rows import dict_row
 from psycopg_pool import AsyncConnectionPool
 
-from objectified_mcp.mcp_access_audit import schedule_mcp_private_access_audit
+from objectified_mcp.mcp_access_audit import schedule_mcp_private_access_audit_batch
 from objectified_mcp.mcp_auth import McpAuthContext
 from objectified_mcp.spec_authorization import (
     build_authorized_spec_sql_predicate,
@@ -260,14 +260,14 @@ async def build_spec_list_response(
     page = rows[:lim]
 
     if auth_ctx is not None:
-        for r in page:
-            if r.get("spec_visibility") == "private":
-                schedule_mcp_private_access_audit(
-                    pool,
-                    key_id=auth_ctx.key_id,
-                    tool="spec.list",
-                    spec_id=str(r["id"]),
-                )
+        private_spec_ids = [str(r["id"]) for r in page if r.get("spec_visibility") == "private"]
+        if private_spec_ids:
+            schedule_mcp_private_access_audit_batch(
+                pool,
+                key_id=auth_ctx.key_id,
+                tool="spec.list",
+                spec_ids=private_spec_ids,
+            )
 
     items = [_row_out(r) for r in page]
 

--- a/objectified-mcp/tests/test_mcp_access_audit.py
+++ b/objectified-mcp/tests/test_mcp_access_audit.py
@@ -5,7 +5,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from psycopg_pool import AsyncConnectionPool
 
-from objectified_mcp.mcp_access_audit import insert_mcp_access_audit, schedule_mcp_private_access_audit
+from objectified_mcp.mcp_access_audit import (
+    insert_mcp_access_audit,
+    insert_mcp_access_audit_batch,
+    schedule_mcp_private_access_audit,
+    schedule_mcp_private_access_audit_batch,
+)
 
 
 def test_insert_mcp_access_audit_executes_insert() -> None:
@@ -33,6 +38,39 @@ def test_insert_mcp_access_audit_executes_insert() -> None:
     conn.commit.assert_awaited_once()
 
 
+def test_insert_mcp_access_audit_batch_executes_single_insert() -> None:
+    conn = MagicMock()
+    conn.execute = AsyncMock()
+    conn.commit = AsyncMock()
+    cm_conn = AsyncMock()
+    cm_conn.__aenter__ = AsyncMock(return_value=conn)
+    cm_conn.__aexit__ = AsyncMock(return_value=None)
+    pool = MagicMock(spec=AsyncConnectionPool)
+    pool.connection = MagicMock(return_value=cm_conn)
+
+    spec_ids = [
+        "11111111-1111-4111-8111-111111111111",
+        "22222222-2222-4222-8222-222222222222",
+    ]
+
+    async def run() -> None:
+        await insert_mcp_access_audit_batch(
+            pool,
+            key_id="00000000-0000-4000-8000-000000000001",
+            tool="spec.list",
+            spec_ids=spec_ids,
+            success=True,
+            error=None,
+        )
+
+    asyncio.run(run())
+    # Only one INSERT regardless of the number of spec_ids
+    conn.execute.assert_awaited_once()
+    conn.commit.assert_awaited_once()
+    _sql, params = conn.execute.await_args.args
+    assert params[2] == spec_ids
+
+
 def test_schedule_mcp_private_access_audit_creates_background_task() -> None:
     pool = MagicMock(spec=AsyncConnectionPool)
 
@@ -55,3 +93,77 @@ def test_schedule_mcp_private_access_audit_creates_background_task() -> None:
             )
 
     asyncio.run(run_inner())
+
+
+def test_schedule_mcp_private_access_audit_skip_includes_spec_id_and_success() -> None:
+    """When there is no running event loop the skip log must include spec_id, success, error."""
+    import structlog.testing
+
+    pool = MagicMock(spec=AsyncConnectionPool)
+
+    with patch("objectified_mcp.mcp_access_audit.asyncio") as mock_asyncio:
+        mock_asyncio.get_running_loop.side_effect = RuntimeError("no loop")
+
+        with structlog.testing.capture_logs() as captured:
+            schedule_mcp_private_access_audit(
+                pool,
+                key_id="00000000-0000-4000-8000-000000000003",
+                tool="spec.describe",
+                spec_id="33333333-3333-4333-8333-333333333333",
+                success=False,
+                error="some error",
+            )
+
+    skip_events = [e for e in captured if e.get("event") == "mcp_access_audit_skip_no_event_loop"]
+    assert skip_events, "Expected a skip log event"
+    ev = skip_events[0]
+    assert ev["spec_id"] == "33333333-3333-4333-8333-333333333333"
+    assert ev["success"] is False
+    assert ev["error"] == "some error"
+
+
+def test_schedule_mcp_private_access_audit_batch_creates_background_task() -> None:
+    pool = MagicMock(spec=AsyncConnectionPool)
+
+    spec_ids = [
+        "11111111-1111-4111-8111-111111111111",
+        "22222222-2222-4222-8222-222222222222",
+    ]
+
+    async def run_inner() -> None:
+        with patch("objectified_mcp.mcp_access_audit.insert_mcp_access_audit_batch", new=AsyncMock()) as ins:
+            schedule_mcp_private_access_audit_batch(
+                pool,
+                key_id="00000000-0000-4000-8000-000000000004",
+                tool="spec.list",
+                spec_ids=spec_ids,
+            )
+            await asyncio.sleep(0)
+            ins.assert_awaited_once_with(
+                pool,
+                key_id="00000000-0000-4000-8000-000000000004",
+                tool="spec.list",
+                spec_ids=spec_ids,
+                success=True,
+                error=None,
+            )
+
+    asyncio.run(run_inner())
+
+
+def test_schedule_mcp_private_access_audit_batch_noop_for_empty_list() -> None:
+    pool = MagicMock(spec=AsyncConnectionPool)
+
+    async def run_inner() -> None:
+        with patch("objectified_mcp.mcp_access_audit.insert_mcp_access_audit_batch", new=AsyncMock()) as ins:
+            schedule_mcp_private_access_audit_batch(
+                pool,
+                key_id="00000000-0000-4000-8000-000000000005",
+                tool="spec.list",
+                spec_ids=[],
+            )
+            await asyncio.sleep(0)
+            ins.assert_not_awaited()
+
+    asyncio.run(run_inner())
+

--- a/objectified-mcp/tests/test_mcp_access_audit.py
+++ b/objectified-mcp/tests/test_mcp_access_audit.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from psycopg_pool import AsyncConnectionPool
+
+from objectified_mcp.mcp_access_audit import insert_mcp_access_audit, schedule_mcp_private_access_audit
+
+
+def test_insert_mcp_access_audit_executes_insert() -> None:
+    conn = MagicMock()
+    conn.execute = AsyncMock()
+    conn.commit = AsyncMock()
+    cm_conn = AsyncMock()
+    cm_conn.__aenter__ = AsyncMock(return_value=conn)
+    cm_conn.__aexit__ = AsyncMock(return_value=None)
+    pool = MagicMock(spec=AsyncConnectionPool)
+    pool.connection = MagicMock(return_value=cm_conn)
+
+    async def run() -> None:
+        await insert_mcp_access_audit(
+            pool,
+            key_id="00000000-0000-4000-8000-000000000001",
+            tool="spec.list",
+            spec_id="11111111-1111-4111-8111-111111111111",
+            success=True,
+            error=None,
+        )
+
+    asyncio.run(run())
+    conn.execute.assert_awaited_once()
+    conn.commit.assert_awaited_once()
+
+
+def test_schedule_mcp_private_access_audit_creates_background_task() -> None:
+    pool = MagicMock(spec=AsyncConnectionPool)
+
+    async def run_inner() -> None:
+        with patch("objectified_mcp.mcp_access_audit.insert_mcp_access_audit", new=AsyncMock()) as ins:
+            schedule_mcp_private_access_audit(
+                pool,
+                key_id="00000000-0000-4000-8000-000000000002",
+                tool="spec.describe",
+                spec_id="22222222-2222-4222-8222-222222222222",
+            )
+            await asyncio.sleep(0)
+            ins.assert_awaited_once_with(
+                pool,
+                key_id="00000000-0000-4000-8000-000000000002",
+                tool="spec.describe",
+                spec_id="22222222-2222-4222-8222-222222222222",
+                success=True,
+                error=None,
+            )
+
+    asyncio.run(run_inner())

--- a/objectified-mcp/tests/test_spec_describe_tool.py
+++ b/objectified-mcp/tests/test_spec_describe_tool.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from datetime import datetime, timezone
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import UUID, uuid4
 
 import pytest
@@ -19,6 +19,7 @@ def _sample_row(
     spec_id: UUID | None = None,
     updated_at: datetime | None = None,
     owner: str = "acme",
+    spec_visibility: str = "public",
 ) -> dict[str, object]:
     sid = spec_id or uuid4()
     ts = updated_at or datetime(2026, 5, 1, 12, 0, tzinfo=timezone.utc)
@@ -30,6 +31,7 @@ def _sample_row(
         "owner": owner,
         "tags": ["stable"],
         "updated_at": ts,
+        "spec_visibility": spec_visibility,
     }
 
 
@@ -139,10 +141,36 @@ def test_build_spec_describe_response_authenticated_merged_sql() -> None:
     assert "UNION ALL" in sql
     assert "mcp_v_public_specs" in sql
     assert "visibility = 'private'" in sql
+    assert "spec_visibility" in sql
     assert isinstance(params, tuple)
     assert params[0] == sid
     assert params[1] == sid
     assert params[2] == str(auth.tenant_id)
+
+
+def test_build_spec_describe_response_schedules_audit_for_private_row() -> None:
+    sid = uuid4()
+    tid = uuid4()
+    auth = McpAuthContext(
+        key_id="00000000-0000-4000-8000-000000000088",
+        tenant_id=str(tid),
+        label="k",
+        scope=Scope(),
+    )
+    row = _sample_row(spec_id=sid, spec_visibility="private")
+    pool, _cur = _pool_mock_for_fetchone(row)
+
+    async def run() -> None:
+        with patch("objectified_mcp.spec_describe_tool.schedule_mcp_private_access_audit") as sched:
+            await build_spec_describe_response(pool, spec_id=str(sid), auth_ctx=auth)
+            sched.assert_called_once_with(
+                pool,
+                key_id=auth.key_id,
+                tool="spec.describe",
+                spec_id=str(sid),
+            )
+
+    asyncio.run(run())
 
 
 def test_build_spec_describe_invalid_uuid() -> None:

--- a/objectified-mcp/tests/test_spec_list_tool.py
+++ b/objectified-mcp/tests/test_spec_list_tool.py
@@ -293,7 +293,7 @@ def test_build_spec_list_response_authenticated_merged_sql() -> None:
     assert params[-4:] == (None, None, None, 6)
 
 
-def test_build_spec_list_response_schedules_audit_per_private_row() -> None:
+def test_build_spec_list_response_schedules_audit_batch_for_private_rows() -> None:
     tid = uuid4()
     pid = uuid4()
     auth = McpAuthContext(
@@ -302,23 +302,44 @@ def test_build_spec_list_response_schedules_audit_per_private_row() -> None:
         label="k",
         scope=Scope(),
     )
-    priv_id = uuid4()
+    priv_id1 = uuid4()
+    priv_id2 = uuid4()
     rows = [
         _sample_row(),
-        _sample_row(spec_id=priv_id, spec_visibility="private"),
+        _sample_row(spec_id=priv_id1, spec_visibility="private"),
+        _sample_row(spec_id=priv_id2, spec_visibility="private"),
     ]
     pool, _cur = _pool_mock_for_fetch(rows)
 
     async def run() -> None:
-        with patch("objectified_mcp.spec_list_tool.schedule_mcp_private_access_audit") as sched:
+        with patch("objectified_mcp.spec_list_tool.schedule_mcp_private_access_audit_batch") as sched:
             await build_spec_list_response(pool, tenant_id=str(tid), project_id=str(pid), limit=10, auth_ctx=auth)
-            assert sched.call_count == 1
             sched.assert_called_once_with(
                 pool,
                 key_id=auth.key_id,
                 tool="spec.list",
-                spec_id=str(priv_id),
+                spec_ids=[str(priv_id1), str(priv_id2)],
             )
+
+    asyncio.run(run())
+
+
+def test_build_spec_list_response_no_audit_when_no_private_rows() -> None:
+    tid = uuid4()
+    pid = uuid4()
+    auth = McpAuthContext(
+        key_id="00000000-0000-4000-8000-000000000099",
+        tenant_id=str(tid),
+        label="k",
+        scope=Scope(),
+    )
+    rows = [_sample_row(), _sample_row()]  # both public
+    pool, _cur = _pool_mock_for_fetch(rows)
+
+    async def run() -> None:
+        with patch("objectified_mcp.spec_list_tool.schedule_mcp_private_access_audit_batch") as sched:
+            await build_spec_list_response(pool, tenant_id=str(tid), project_id=str(pid), limit=10, auth_ctx=auth)
+            sched.assert_not_called()
 
     asyncio.run(run())
 

--- a/objectified-mcp/tests/test_spec_list_tool.py
+++ b/objectified-mcp/tests/test_spec_list_tool.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from datetime import datetime, timezone
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import UUID, uuid4
 
 import pytest
@@ -24,6 +24,7 @@ def _sample_row(
     *,
     spec_id: UUID | None = None,
     updated_at: datetime | None = None,
+    spec_visibility: str = "public",
 ) -> dict[str, object]:
     sid = spec_id or uuid4()
     ts = updated_at or datetime(2026, 5, 1, 12, 0, tzinfo=timezone.utc)
@@ -36,6 +37,7 @@ def _sample_row(
         "description": None,
         "tags": ["alpha"],
         "updated_at": ts,
+        "spec_visibility": spec_visibility,
     }
 
 
@@ -283,11 +285,42 @@ def test_build_spec_list_response_authenticated_merged_sql() -> None:
     assert "UNION ALL" in sql
     assert "mcp_v_public_specs" in sql
     assert "visibility = 'private'" in sql
+    assert "spec_visibility" in sql
     assert isinstance(params, tuple)
     assert params[0:4] == (tid, tid, pid, pid)
     assert params[4] == str(auth.tenant_id)
     assert params[5:9] == (tid, tid, pid, pid)
     assert params[-4:] == (None, None, None, 6)
+
+
+def test_build_spec_list_response_schedules_audit_per_private_row() -> None:
+    tid = uuid4()
+    pid = uuid4()
+    auth = McpAuthContext(
+        key_id="00000000-0000-4000-8000-000000000099",
+        tenant_id=str(tid),
+        label="k",
+        scope=Scope(),
+    )
+    priv_id = uuid4()
+    rows = [
+        _sample_row(),
+        _sample_row(spec_id=priv_id, spec_visibility="private"),
+    ]
+    pool, _cur = _pool_mock_for_fetch(rows)
+
+    async def run() -> None:
+        with patch("objectified_mcp.spec_list_tool.schedule_mcp_private_access_audit") as sched:
+            await build_spec_list_response(pool, tenant_id=str(tid), project_id=str(pid), limit=10, auth_ctx=auth)
+            assert sched.call_count == 1
+            sched.assert_called_once_with(
+                pool,
+                key_id=auth.key_id,
+                tool="spec.list",
+                spec_id=str(priv_id),
+            )
+
+    asyncio.run(run())
 
 
 def test_build_spec_list_response_authenticated_cursor_binding_tuple() -> None:

--- a/objectified-mcp/uv.lock
+++ b/objectified-mcp/uv.lock
@@ -842,7 +842,7 @@ wheels = [
 
 [[package]]
 name = "objectified-mcp"
-version = "0.1.17"
+version = "0.1.18"
 source = { editable = "." }
 dependencies = [
     { name = "bcrypt" },

--- a/objectified-rest/pyproject.toml
+++ b/objectified-rest/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "objectified-rest"
-version = "1.0.51"
+version = "1.0.52"
 description = "REST API for serving OpenAPI specifications from the Objectified database"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/objectified-rest/tests/test_mcp_access_audit_migration.py
+++ b/objectified-rest/tests/test_mcp_access_audit_migration.py
@@ -1,0 +1,23 @@
+"""Guardrails for MCP access audit table migration (#3013)."""
+
+from pathlib import Path
+
+_REQUIRED_FRAGMENTS = (
+    "CREATE TABLE IF NOT EXISTS mcp_access_audit",
+    "key_id",
+    "tool",
+    "spec_id",
+    "success",
+    "error",
+    "idx_mcp_access_audit_key_at",
+    "idx_mcp_access_audit_spec_at",
+    "REFERENCES odb.mcp_api_keys(id)",
+    "REFERENCES odb.versions(id)",
+)
+
+
+def test_migration_creates_mcp_access_audit_table(repo_root: Path) -> None:
+    migration = repo_root / "objectified-db" / "scripts" / "20260502-140000.sql"
+    text = migration.read_text()
+    missing = [frag for frag in _REQUIRED_FRAGMENTS if frag not in text]
+    assert not missing, f"Migration missing expected fragments: {missing}"

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.22",
+  "version": "0.11.23",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -24,6 +24,7 @@ We continue to improve the platform based on your feedback with improvements and
 - MCP **`authorize_spec`** combines API key **scope** with revision **visibility** (public rows need scope only; private rows also require the spec tenant to match the key); **`build_authorized_spec_sql_predicate`** emits the same rules as a parameterized SQL **`WHERE`** fragment (#3010).
 - MCP **`spec.list`** with a valid API key merges **in-scope public** rows with **in-scope private** published revisions for the key's tenant (same **`items`** / **`has_more`** / **`next_cursor`** shape as anonymous listing); **`resolve_optional_mcp_auth`** resolves credentials from headers, **`tools/call`** meta, or the HTTP Bearer stash (#3011).
 - MCP **`spec.describe`** uses the same optional auth path: anonymous callers resolve **public** revisions only; with a valid API key, **in-scope private** published revisions for that tenant return the same metadata shape (**`id`**, **`title`**, **`version`**, **`description`**, **`owner`**, **`tags`**, **`updated_at`**); missing or inaccessible revisions stay **not-found** (#3012).
+- Database table **`odb.mcp_access_audit`** records MCP API key **`key_id`**, tool name, **`spec_id`** (revision UUID), timestamp **`at`**, **`success`**, and optional **`error`** for traceability; **`spec.list`** and **`spec.describe`** enqueue **non-blocking** inserts after each **private** revision returned to an authenticated caller (#3013).
 
 ## Importing
 - Race condition fixed in 3.0.1 specification imports


### PR DESCRIPTION
## Summary
Adds `odb.mcp_access_audit` (migration `20260502-140000.sql`) with columns `id`, `key_id`, `tool`, `spec_id`, `at`, `success`, and `error`, plus indexes on `(key_id, at)` and `(spec_id, at)`.

When an authenticated MCP caller receives **private** published revisions from **`spec.list`** or **`spec.describe`**, the server schedules a **fire-and-forget** background task that inserts an audit row (same pattern as `last_used_at` updates). Anonymous and deny-all paths are unchanged.

## How to test
1. Apply DB scripts through your usual migration path (include `objectified-db/scripts/20260502-140000.sql`).
2. **Call `spec.list`** or **`spec.describe`** with a valid MCP API key against a tenant that has **private** published revisions in scope.
3. **Query** `SELECT * FROM odb.mcp_access_audit ORDER BY at DESC LIMIT 20;` and confirm rows with the expected `tool`, `key_id`, and `spec_id`.

## Risks / notes
- Audit inserts run in `asyncio.create_task`; failures are logged but do not fail the tool response.
- `spec_id` references `odb.versions(id)`; deleting a revision may be blocked while FK applies (no CASCADE).

Closes #3013

Made with [Cursor](https://cursor.com)