### PR TITLE
Fix #3014 - MCP tool spec.list_my_specs (key-bound)

### DIFF
--- a/docs/PLANNED_ROADMAP_MCP.md
+++ b/docs/PLANNED_ROADMAP_MCP.md
@@ -111,7 +111,7 @@ process or via Docker.
 | 4.2 | ~~[#3011](../../issues/3011)~~ | ~~Extend `spec.list` with private results when authorized~~ (**completed**) | 4.1, 3.2 |
 | 4.3 | ~~[#3012](../../issues/3012)~~ | ~~Extend `spec.describe` with private results when authorized~~ (**completed**) | 4.1, 3.3 |
 | 4.4 | ~~[#3013](../../issues/3013)~~ | ~~Audit log table + insert on private read~~ (**completed**) | 2.1 |
-| 4.5 | [#3014](../../issues/3014) | Tool `spec.list_my_specs` (key-bound) | 4.1 |
+| 4.5 | ~~[#3014](../../issues/3014)~~ | ~~Tool `spec.list_my_specs` (key-bound)~~ (**completed**) | 4.1 |
 
 #### E5 — OpenAPI Inspection Tools (#3015)
 

--- a/objectified-mcp/pyproject.toml
+++ b/objectified-mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "objectified-mcp"
-version = "0.1.18"
+version = "0.1.19"
 description = "Model Context Protocol server for Objectified (FastMCP)."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/objectified-mcp/src/objectified_mcp/__init__.py
+++ b/objectified-mcp/src/objectified_mcp/__init__.py
@@ -1,3 +1,3 @@
 """Objectified MCP server package."""
 
-__version__ = "0.1.18"
+__version__ = "0.1.19"

--- a/objectified-mcp/src/objectified_mcp/mcp_auth.py
+++ b/objectified-mcp/src/objectified_mcp/mcp_auth.py
@@ -244,10 +244,16 @@ async def require_mcp_auth(
     ctx: Context,
     headers: dict[str, str] = CurrentHeaders(),
 ) -> McpAuthContext:
-    """FastMCP dependency: bearer / meta credential → ``McpAuthContext``."""
+    """FastMCP dependency: bearer / meta credential → ``McpAuthContext``.
+
+    Like :func:`resolve_optional_mcp_auth`, falls back to the HTTP Bearer stash when headers
+    and meta omit the secret (#3011).
+    """
     rc = ctx.request_context
     meta = rc.meta if rc else None
     raw = extract_raw_mcp_api_key(http_headers=headers, request_meta=meta)
+    if raw is None:
+        raw = await get_http_bearer_from_context(ctx)
     if raw is None:
         raise AuthorizationError(
             "MCP authentication required: send Authorization: Bearer <api_key> over HTTP, "

--- a/objectified-mcp/src/objectified_mcp/server.py
+++ b/objectified-mcp/src/objectified_mcp/server.py
@@ -7,14 +7,14 @@ from typing import Any
 
 import structlog
 from fastmcp import Context, FastMCP
-from fastmcp.dependencies import CurrentHeaders
+from fastmcp.dependencies import CurrentHeaders, Depends
 from fastmcp.server.lifespan import lifespan
 from structlog.contextvars import bound_contextvars
 
 from objectified_mcp.database_pool import MCP_DB_POOL_KEY, create_async_pool, get_db_pool, ping_pool
 from objectified_mcp.http_credential_middleware import StashHttpBearerInToolContextMiddleware
 from objectified_mcp.logging_config import configure_logging
-from objectified_mcp.mcp_auth import resolve_optional_mcp_auth
+from objectified_mcp.mcp_auth import McpAuthContext, require_mcp_auth, resolve_optional_mcp_auth
 from objectified_mcp.ping_tool import build_ping_response
 from objectified_mcp.settings import get_settings
 from objectified_mcp.spec_describe_tool import build_spec_describe_response
@@ -84,6 +84,36 @@ async def spec_list(
         limit=limit,
         cursor=cursor,
         auth_ctx=auth_ctx,
+    )
+
+
+@mcp.tool(
+    name="spec.list_my_specs",
+    description=(
+        "List OpenAPI spec revisions this MCP API key can read: in-scope public catalog rows "
+        "(odb.mcp_v_public_specs) plus in-scope private published revisions for the key's tenant "
+        "(same rules as spec.list when authenticated). Requires API key — anonymous calls are rejected. "
+        "Response shape matches spec.list: items, has_more, next_cursor. "
+        "Optional tenant_id / project_id (UUID strings). limit defaults to 50, capped at 100 (#3014)."
+    ),
+)
+async def spec_list_my_specs(
+    ctx: Context,
+    tenant_id: str | None = None,
+    project_id: str | None = None,
+    limit: int | None = None,
+    cursor: str | None = None,
+    auth: McpAuthContext = Depends(require_mcp_auth),
+) -> dict[str, Any]:
+    pool = get_db_pool(ctx)
+    return await build_spec_list_response(
+        pool,
+        tenant_id=tenant_id,
+        project_id=project_id,
+        limit=limit,
+        cursor=cursor,
+        auth_ctx=auth,
+        private_access_audit_tool="spec.list_my_specs",
     )
 
 

--- a/objectified-mcp/src/objectified_mcp/spec_list_tool.py
+++ b/objectified-mcp/src/objectified_mcp/spec_list_tool.py
@@ -191,6 +191,7 @@ async def build_spec_list_response(
     limit: int | None = None,
     cursor: str | None = None,
     auth_ctx: McpAuthContext | None = None,
+    private_access_audit_tool: str = "spec.list",
 ) -> dict[str, Any]:
     """Return ``items``, ``has_more``, and ``next_cursor``.
 
@@ -265,7 +266,7 @@ async def build_spec_list_response(
             schedule_mcp_private_access_audit_batch(
                 pool,
                 key_id=auth_ctx.key_id,
-                tool="spec.list",
+                tool=private_access_audit_tool,
                 spec_ids=private_spec_ids,
             )
 

--- a/objectified-mcp/tests/test_mcp_access_audit.py
+++ b/objectified-mcp/tests/test_mcp_access_audit.py
@@ -166,4 +166,3 @@ def test_schedule_mcp_private_access_audit_batch_noop_for_empty_list() -> None:
             ins.assert_not_awaited()
 
     asyncio.run(run_inner())
-

--- a/objectified-mcp/tests/test_mcp_auth.py
+++ b/objectified-mcp/tests/test_mcp_auth.py
@@ -182,8 +182,43 @@ def test_require_mcp_auth_missing_credential() -> None:
     ctx.request_context = None
 
     async def run() -> None:
-        with pytest.raises(AuthorizationError, match="MCP authentication required"):
-            await require_mcp_auth(ctx, {})
+        with patch(
+            "objectified_mcp.mcp_auth.get_http_bearer_from_context",
+            new=AsyncMock(return_value=None),
+        ):
+            with pytest.raises(AuthorizationError, match="MCP authentication required"):
+                await require_mcp_auth(ctx, {})
+
+    asyncio.run(run())
+
+
+def test_require_mcp_auth_uses_http_bearer_stash_when_headers_missing_token() -> None:
+    kid = str(uuid.uuid4())
+    tid = str(uuid.uuid4())
+    stored_hash = hash_mcp_api_key_secret(_SECRET).decode("ascii")
+    row = {
+        "id": kid,
+        "tenant_id": tid,
+        "label": "live",
+        "scope_json": {},
+        "key_hash": stored_hash,
+        "expires_at": None,
+        "revoked_at": None,
+    }
+    pool = _pool_mock([row])
+    ctx = MagicMock(spec=Context)
+    ctx.request_context = None
+    ctx.lifespan_context = {MCP_DB_POOL_KEY: pool}
+
+    async def run() -> None:
+        with patch("objectified_mcp.mcp_auth.schedule_mcp_key_last_used_touch") as sched:
+            with patch(
+                "objectified_mcp.mcp_auth.get_http_bearer_from_context",
+                new=AsyncMock(return_value=_SECRET),
+            ):
+                auth = await require_mcp_auth(ctx, {})
+        sched.assert_called_once_with(pool, kid)
+        assert auth.key_id == kid
 
     asyncio.run(run())
 

--- a/objectified-mcp/tests/test_spec_list_tool.py
+++ b/objectified-mcp/tests/test_spec_list_tool.py
@@ -173,6 +173,17 @@ def test_spec_list_tool_registered_on_mcp() -> None:
     assert tool.name == "spec.list"
 
 
+def test_spec_list_my_specs_tool_registered_on_mcp() -> None:
+    from objectified_mcp.server import mcp
+
+    async def load() -> object:
+        return await mcp.get_tool("spec.list_my_specs")
+
+    tool = asyncio.run(load())
+    assert tool is not None
+    assert tool.name == "spec.list_my_specs"
+
+
 def test_max_page_size_constant() -> None:
     assert MAX_PAGE_SIZE == 100
 
@@ -319,6 +330,39 @@ def test_build_spec_list_response_schedules_audit_batch_for_private_rows() -> No
                 key_id=auth.key_id,
                 tool="spec.list",
                 spec_ids=[str(priv_id1), str(priv_id2)],
+            )
+
+    asyncio.run(run())
+
+
+def test_build_spec_list_response_schedules_audit_with_custom_tool_name() -> None:
+    tid = uuid4()
+    pid = uuid4()
+    auth = McpAuthContext(
+        key_id="00000000-0000-4000-8000-000000000099",
+        tenant_id=str(tid),
+        label="k",
+        scope=Scope(),
+    )
+    priv_id = uuid4()
+    rows = [_sample_row(spec_id=priv_id, spec_visibility="private")]
+    pool, _cur = _pool_mock_for_fetch(rows)
+
+    async def run() -> None:
+        with patch("objectified_mcp.spec_list_tool.schedule_mcp_private_access_audit_batch") as sched:
+            await build_spec_list_response(
+                pool,
+                tenant_id=str(tid),
+                project_id=str(pid),
+                limit=10,
+                auth_ctx=auth,
+                private_access_audit_tool="spec.list_my_specs",
+            )
+            sched.assert_called_once_with(
+                pool,
+                key_id=auth.key_id,
+                tool="spec.list_my_specs",
+                spec_ids=[str(priv_id)],
             )
 
     asyncio.run(run())

--- a/objectified-mcp/uv.lock
+++ b/objectified-mcp/uv.lock
@@ -842,7 +842,7 @@ wheels = [
 
 [[package]]
 name = "objectified-mcp"
-version = "0.1.18"
+version = "0.1.19"
 source = { editable = "." }
 dependencies = [
     { name = "bcrypt" },

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.23",
+  "version": "0.11.24",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -25,6 +25,7 @@ We continue to improve the platform based on your feedback with improvements and
 - MCP **`spec.list`** with a valid API key merges **in-scope public** rows with **in-scope private** published revisions for the key's tenant (same **`items`** / **`has_more`** / **`next_cursor`** shape as anonymous listing); **`resolve_optional_mcp_auth`** resolves credentials from headers, **`tools/call`** meta, or the HTTP Bearer stash (#3011).
 - MCP **`spec.describe`** uses the same optional auth path: anonymous callers resolve **public** revisions only; with a valid API key, **in-scope private** published revisions for that tenant return the same metadata shape (**`id`**, **`title`**, **`version`**, **`description`**, **`owner`**, **`tags`**, **`updated_at`**); missing or inaccessible revisions stay **not-found** (#3012).
 - Database table **`odb.mcp_access_audit`** records MCP API key **`key_id`**, tool name, **`spec_id`** (revision UUID), timestamp **`at`**, **`success`**, and optional **`error`** for traceability; **`spec.list`** and **`spec.describe`** enqueue **non-blocking** inserts after each **private** revision returned to an authenticated caller (#3013).
+- MCP tool **`spec.list_my_specs`** lists specs readable by the **current API key only** (same merged public/private semantics and pagination as authenticated **`spec.list`**); calls **without** a key are rejected (**`Depends(require_mcp_auth)`**); private rows are audited under tool name **`spec.list_my_specs`** (#3014).
 
 ## Importing
 - Race condition fixed in 3.0.1 specification imports


### PR DESCRIPTION
## What / why
Adds MCP tool `spec.list_my_specs`: paginated listing of spec revisions readable by the **current API key** (same merged public + in-scope private semantics as authenticated `spec.list`). Anonymous callers receive a clear auth error via `Depends(require_mcp_auth)`.

`require_mcp_auth` now falls back to the HTTP Bearer stash (`get_http_bearer_from_context`), matching `resolve_optional_mcp_auth`. Private-row access audit records use tool name `spec.list_my_specs` via a `private_access_audit_tool` parameter on `build_spec_list_response`.

## How to test
1. Run `yarn build` and `yarn test` from the repo root (already green).
2. Start MCP with DB fixtures and call `spec.list_my_specs` **without** credentials → expect MCP authentication error.
3. Call with a valid MCP API key (header or stdio meta) → expect `items` / `has_more` / `next_cursor` matching `spec.list` when authed; use `next_cursor` for the next page.

## Risk / notes
Low: reuses existing SQL path and pagination cursors from `spec.list`. Format-only change in `tests/test_mcp_access_audit.py` from ruff.

Closes #3014

Made with [Cursor](https://cursor.com)