### PR TITLE
Fix #3017 - MCP tool spec.export_yaml

### DIFF
--- a/docs/PLANNED_ROADMAP_MCP.md
+++ b/docs/PLANNED_ROADMAP_MCP.md
@@ -118,7 +118,7 @@ process or via Docker.
 | # | Issue | Title | Depends on |
 |---|-------|-------|------------|
 | 5.1 | ~~[#3016](../../issues/3016)~~ | ~~Tool `spec.get_openapi` (JSON)~~ (**completed**) | 3.1, 4.1 |
-| 5.2 | [#3017](../../issues/3017) | Tool `spec.export_yaml` | 5.1 |
+| 5.2 | ~~[#3017](../../issues/3017)~~ | ~~Tool `spec.export_yaml`~~ (**completed**) | 5.1 |
 | 5.3 | [#3018](../../issues/3018) | Tool `spec.list_operations` | 5.1 |
 | 5.4 | [#3019](../../issues/3019) | Tool `spec.describe_operation` | 5.3 |
 | 5.5 | [#3020](../../issues/3020) | Tool `spec.list_components` | 5.1 |

--- a/objectified-mcp/pyproject.toml
+++ b/objectified-mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "objectified-mcp"
-version = "0.1.20"
+version = "0.1.21"
 description = "Model Context Protocol server for Objectified (FastMCP)."
 readme = "README.md"
 requires-python = ">=3.11"
@@ -16,6 +16,7 @@ classifiers = [
 ]
 
 dependencies = [
+    "pyyaml>=6.0.2",
     "objectified-rest>=1.0.53",
     "bcrypt>=4.0",
     "fastmcp>=3.2.0",
@@ -41,6 +42,7 @@ dev = [
     "pytest>=8.0.0",
     "ruff>=0.8.0",
     "mypy>=1.13.0",
+    "types-PyYAML>=6.0.12",
 ]
 
 [tool.ruff]

--- a/objectified-mcp/src/objectified_mcp/__init__.py
+++ b/objectified-mcp/src/objectified_mcp/__init__.py
@@ -1,3 +1,3 @@
 """Objectified MCP server package."""
 
-__version__ = "0.1.20"
+__version__ = "0.1.21"

--- a/objectified-mcp/src/objectified_mcp/server.py
+++ b/objectified-mcp/src/objectified_mcp/server.py
@@ -18,6 +18,7 @@ from objectified_mcp.mcp_auth import McpAuthContext, require_mcp_auth, resolve_o
 from objectified_mcp.ping_tool import build_ping_response
 from objectified_mcp.settings import get_settings
 from objectified_mcp.spec_describe_tool import build_spec_describe_response
+from objectified_mcp.spec_export_yaml_tool import build_spec_export_yaml_response
 from objectified_mcp.spec_get_openapi_tool import build_spec_get_openapi_response
 from objectified_mcp.spec_list_tags_tool import build_spec_list_tags_response
 from objectified_mcp.spec_list_tool import build_spec_list_response
@@ -158,6 +159,27 @@ async def spec_get_openapi(
     pool = get_db_pool(ctx)
     auth_ctx = await resolve_optional_mcp_auth(ctx, pool, headers=headers)
     return await build_spec_get_openapi_response(pool, spec_id=spec_id, auth_ctx=auth_ctx)
+
+
+@mcp.tool(
+    name="spec.export_yaml",
+    description=(
+        "Return the generated OpenAPI 3.1 document as YAML text for a published spec revision by id (UUID). "
+        "Same semantics as spec.get_openapi: anonymous callers see public revisions only; with "
+        "Authorization: Bearer <MCP API key>, in-scope private published revisions are included (#3017). "
+        "Response field openapi_yaml round-trips with YAML loaders to the same structure as the JSON tool. "
+        "If UTF-8 YAML exceeds OBJECTIFIED_MCP_OPENAPI_MAX_JSON_BYTES (default 2 MiB), returns an error "
+        "analogous to HTTP 413."
+    ),
+)
+async def spec_export_yaml(
+    ctx: Context,
+    spec_id: str,
+    headers: dict[str, str] = CurrentHeaders(),
+) -> dict[str, str]:
+    pool = get_db_pool(ctx)
+    auth_ctx = await resolve_optional_mcp_auth(ctx, pool, headers=headers)
+    return await build_spec_export_yaml_response(pool, spec_id=spec_id, auth_ctx=auth_ctx)
 
 
 @mcp.tool(

--- a/objectified-mcp/src/objectified_mcp/settings.py
+++ b/objectified-mcp/src/objectified_mcp/settings.py
@@ -43,7 +43,10 @@ class Settings(BaseSettings):
         default=2_097_152,
         ge=1024,
         le=100_000_000,
-        description="Max UTF-8 size of json-serialized OpenAPI from spec.get_openapi (413-style limit).",
+        description=(
+            "Max UTF-8 size of exported OpenAPI from spec.get_openapi (compact JSON) and "
+            "spec.export_yaml (YAML text); 413-style limit."
+        ),
     )
 
     @model_validator(mode="after")

--- a/objectified-mcp/src/objectified_mcp/spec_export_yaml_tool.py
+++ b/objectified-mcp/src/objectified_mcp/spec_export_yaml_tool.py
@@ -1,0 +1,36 @@
+"""MCP ``spec.export_yaml`` tool: full generated OpenAPI 3.1 as YAML (#3017)."""
+
+from __future__ import annotations
+
+import yaml
+from fastmcp.exceptions import ToolError
+from psycopg_pool import AsyncConnectionPool
+
+from objectified_mcp.mcp_auth import McpAuthContext
+from objectified_mcp.settings import get_settings
+from objectified_mcp.spec_get_openapi_tool import build_spec_get_openapi_response
+
+
+async def build_spec_export_yaml_response(
+    pool: AsyncConnectionPool,
+    *,
+    spec_id: str,
+    auth_ctx: McpAuthContext | None = None,
+) -> dict[str, str]:
+    """Return ``openapi_yaml`` text for ``spec_id``, or raise ``NotFoundError`` / ``ToolError``."""
+    spec = await build_spec_get_openapi_response(
+        pool,
+        spec_id=spec_id,
+        auth_ctx=auth_ctx,
+        apply_json_payload_cap=False,
+        private_access_audit_tool="spec.export_yaml",
+    )
+    text = yaml.dump(spec, sort_keys=False, default_flow_style=False)
+    settings = get_settings()
+    encoded = text.encode("utf-8")
+    if len(encoded) > settings.openapi_max_json_bytes:
+        raise ToolError(
+            f"OpenAPI YAML exceeds server limit ({settings.openapi_max_json_bytes} bytes); "
+            "this condition corresponds to HTTP 413 Payload Too Large."
+        )
+    return {"openapi_yaml": text}

--- a/objectified-mcp/src/objectified_mcp/spec_get_openapi_tool.py
+++ b/objectified-mcp/src/objectified_mcp/spec_get_openapi_tool.py
@@ -106,8 +106,15 @@ async def build_spec_get_openapi_response(
     *,
     spec_id: str,
     auth_ctx: McpAuthContext | None = None,
+    apply_json_payload_cap: bool = True,
+    private_access_audit_tool: str = "spec.get_openapi",
 ) -> dict[str, Any]:
-    """Return OpenAPI 3.1 document dict for ``spec_id``, or raise ``NotFoundError`` / ``ToolError``."""
+    """Return OpenAPI 3.1 document dict for ``spec_id``, or raise ``NotFoundError`` / ``ToolError``.
+
+    When ``apply_json_payload_cap`` is False, skip the compact JSON byte limit (used by YAML export,
+    which applies its own UTF-8 cap). ``private_access_audit_tool`` names the tool stored when a private
+    revision is returned to an authenticated caller.
+    """
     sid = _parse_spec_id(spec_id)
 
     if auth_ctx is not None and auth_ctx.scope.deny_all:
@@ -149,7 +156,7 @@ async def build_spec_get_openapi_response(
         schedule_mcp_private_access_audit(
             pool,
             key_id=auth_ctx.key_id,
-            tool="spec.get_openapi",
+            tool=private_access_audit_tool,
             spec_id=str(row["id"]),
         )
 
@@ -167,12 +174,13 @@ async def build_spec_get_openapi_response(
         server_rows=server_rows,
     )
 
-    settings = get_settings()
-    encoded = json.dumps(spec, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
-    if len(encoded) > settings.openapi_max_json_bytes:
-        raise ToolError(
-            f"OpenAPI document exceeds server limit ({settings.openapi_max_json_bytes} bytes); "
-            "this condition corresponds to HTTP 413 Payload Too Large."
-        )
+    if apply_json_payload_cap:
+        settings = get_settings()
+        encoded = json.dumps(spec, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+        if len(encoded) > settings.openapi_max_json_bytes:
+            raise ToolError(
+                f"OpenAPI document exceeds server limit ({settings.openapi_max_json_bytes} bytes); "
+                "this condition corresponds to HTTP 413 Payload Too Large."
+            )
 
     return spec

--- a/objectified-mcp/tests/test_spec_export_yaml_tool.py
+++ b/objectified-mcp/tests/test_spec_export_yaml_tool.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID, uuid4
+
+import pytest
+import yaml
+from fastmcp.exceptions import NotFoundError, ToolError
+from psycopg_pool import AsyncConnectionPool
+
+from objectified_mcp.mcp_auth import McpAuthContext
+from objectified_mcp.scope import Scope
+from objectified_mcp.spec_export_yaml_tool import build_spec_export_yaml_response
+
+
+def _openapi_row(*, spec_id: UUID | None = None, visibility: str = "public") -> dict[str, object]:
+    sid = spec_id or uuid4()
+    return {
+        "id": sid,
+        "tenant_slug": "acme",
+        "project_slug": "payments",
+        "version_label": "2.1.0",
+        "project_description": "Payments service",
+        "metadata": None,
+        "spec_visibility": visibility,
+    }
+
+
+def _mock_pool_with_row(row: dict[str, object] | None) -> MagicMock:
+    pool = MagicMock(spec=AsyncConnectionPool)
+    describe_cur = MagicMock()
+    describe_cur.execute = AsyncMock()
+    describe_cur.fetchone = AsyncMock(return_value=row)
+    describe_cm = AsyncMock()
+    describe_cm.__aenter__.return_value = describe_cur
+    describe_cm.__aexit__.return_value = None
+    conn = MagicMock()
+    conn.cursor = MagicMock(return_value=describe_cm)
+    conn_cm = AsyncMock()
+    conn_cm.__aenter__.return_value = conn
+    conn_cm.__aexit__.return_value = None
+    pool.connection = MagicMock(return_value=conn_cm)
+    return pool
+
+
+def test_build_spec_export_yaml_success_round_trips_json() -> None:
+    sid = uuid4()
+    row = _openapi_row(spec_id=sid)
+    sample_spec = {
+        "openapi": "3.1.0",
+        "info": {"title": "x", "version": "1"},
+        "paths": {},
+        "components": {"schemas": {}},
+    }
+
+    pool = _mock_pool_with_row(row)
+
+    async def fake_fetch(_conn: object, _revision_id: UUID) -> tuple:
+        return ([], {}, [], [], [])
+
+    with (
+        patch("objectified_mcp.spec_get_openapi_tool.fetch_openapi_generation_inputs_async", side_effect=fake_fetch),
+        patch("objectified_mcp.spec_get_openapi_tool.generate_openapi_spec", return_value=sample_spec),
+        patch("objectified_mcp.spec_export_yaml_tool.get_settings") as gs,
+    ):
+        gs.return_value.openapi_max_json_bytes = 1_000_000
+
+        async def run() -> dict[str, str]:
+            return await build_spec_export_yaml_response(pool, spec_id=str(sid))
+
+        out = asyncio.run(run())
+
+    assert "openapi_yaml" in out
+    parsed = yaml.safe_load(out["openapi_yaml"])
+    assert parsed == sample_spec
+    assert json.loads(json.dumps(parsed)) == sample_spec
+
+
+def test_build_spec_export_yaml_private_audited() -> None:
+    sid = uuid4()
+    row = _openapi_row(spec_id=sid, visibility="private")
+    auth = McpAuthContext(
+        key_id="00000000-0000-4000-8000-000000000099",
+        tenant_id=str(uuid4()),
+        label="k",
+        scope=Scope(),
+    )
+    sample_spec = {
+        "openapi": "3.1.0",
+        "info": {"title": "x", "version": "1"},
+        "paths": {},
+        "components": {"schemas": {}},
+    }
+
+    pool = _mock_pool_with_row(row)
+
+    async def fake_fetch(_conn: object, _revision_id: UUID) -> tuple:
+        return ([], {}, [], [], [])
+
+    with (
+        patch("objectified_mcp.spec_get_openapi_tool.fetch_openapi_generation_inputs_async", side_effect=fake_fetch),
+        patch("objectified_mcp.spec_get_openapi_tool.generate_openapi_spec", return_value=sample_spec),
+        patch("objectified_mcp.spec_export_yaml_tool.get_settings") as gs,
+        patch("objectified_mcp.spec_get_openapi_tool.schedule_mcp_private_access_audit") as audit,
+    ):
+        gs.return_value.openapi_max_json_bytes = 1_000_000
+
+        async def run() -> dict[str, str]:
+            return await build_spec_export_yaml_response(pool, spec_id=str(sid), auth_ctx=auth)
+
+        asyncio.run(run())
+
+    audit.assert_called_once()
+    assert audit.call_args.kwargs["tool"] == "spec.export_yaml"
+
+
+def test_build_spec_export_yaml_payload_too_large() -> None:
+    sid = uuid4()
+    row = _openapi_row(spec_id=sid)
+    huge = {"openapi": "3.1.0", "x": "y" * 500_000}
+
+    pool = _mock_pool_with_row(row)
+
+    async def fake_fetch(_conn: object, _revision_id: UUID) -> tuple:
+        return ([], {}, [], [], [])
+
+    with (
+        patch("objectified_mcp.spec_get_openapi_tool.fetch_openapi_generation_inputs_async", side_effect=fake_fetch),
+        patch("objectified_mcp.spec_get_openapi_tool.generate_openapi_spec", return_value=huge),
+        patch("objectified_mcp.spec_export_yaml_tool.get_settings") as gs,
+    ):
+        gs.return_value.openapi_max_json_bytes = 100
+
+        async def run() -> None:
+            await build_spec_export_yaml_response(pool, spec_id=str(sid))
+
+        with pytest.raises(ToolError, match="413"):
+            asyncio.run(run())
+
+
+def test_build_spec_export_yaml_not_found() -> None:
+    pool = _mock_pool_with_row(None)
+
+    async def run() -> None:
+        await build_spec_export_yaml_response(pool, spec_id=str(uuid4()))
+
+    with pytest.raises(NotFoundError, match="Unknown or non-public"):
+        asyncio.run(run())
+
+
+def test_spec_export_yaml_tool_registered_on_mcp() -> None:
+    from objectified_mcp.server import mcp
+
+    async def load() -> object:
+        return await mcp.get_tool("spec.export_yaml")
+
+    tool = asyncio.run(load())
+    assert tool is not None
+    assert tool.name == "spec.export_yaml"

--- a/objectified-mcp/tests/test_spec_get_openapi_tool.py
+++ b/objectified-mcp/tests/test_spec_get_openapi_tool.py
@@ -178,6 +178,61 @@ def test_build_spec_get_openapi_private_audited() -> None:
     assert audit.call_args.kwargs["tool"] == "spec.get_openapi"
 
 
+def test_build_spec_get_openapi_private_audited_custom_tool_name() -> None:
+    sid = uuid4()
+    row = _openapi_row(spec_id=sid, visibility="private")
+    auth = McpAuthContext(
+        key_id="00000000-0000-4000-8000-000000000099",
+        tenant_id=str(uuid4()),
+        label="k",
+        scope=Scope(),
+    )
+    sample_spec = {
+        "openapi": "3.1.0",
+        "info": {"title": "x", "version": "1"},
+        "paths": {},
+        "components": {"schemas": {}},
+    }
+
+    pool = MagicMock(spec=AsyncConnectionPool)
+    describe_cur = MagicMock()
+    describe_cur.execute = AsyncMock()
+    describe_cur.fetchone = AsyncMock(return_value=row)
+    describe_cm = AsyncMock()
+    describe_cm.__aenter__.return_value = describe_cur
+    describe_cm.__aexit__.return_value = None
+    conn = MagicMock()
+    conn.cursor = MagicMock(return_value=describe_cm)
+    conn_cm = AsyncMock()
+    conn_cm.__aenter__.return_value = conn
+    conn_cm.__aexit__.return_value = None
+    pool.connection = MagicMock(return_value=conn_cm)
+
+    async def fake_fetch(_conn: object, _revision_id: UUID) -> tuple:
+        return ([], {}, [], [], [])
+
+    with (
+        patch("objectified_mcp.spec_get_openapi_tool.fetch_openapi_generation_inputs_async", side_effect=fake_fetch),
+        patch("objectified_mcp.spec_get_openapi_tool.generate_openapi_spec", return_value=sample_spec),
+        patch("objectified_mcp.spec_get_openapi_tool.get_settings") as gs,
+        patch("objectified_mcp.spec_get_openapi_tool.schedule_mcp_private_access_audit") as audit,
+    ):
+        gs.return_value.openapi_max_json_bytes = 1_000_000
+
+        async def run() -> None:
+            await build_spec_get_openapi_response(
+                pool,
+                spec_id=str(sid),
+                auth_ctx=auth,
+                private_access_audit_tool="spec.export_yaml",
+            )
+
+        asyncio.run(run())
+
+    audit.assert_called_once()
+    assert audit.call_args.kwargs["tool"] == "spec.export_yaml"
+
+
 def test_build_spec_get_openapi_returns_valid_json_shape() -> None:
     sid = uuid4()
     row = _openapi_row(spec_id=sid)

--- a/objectified-mcp/uv.lock
+++ b/objectified-mcp/uv.lock
@@ -951,7 +951,7 @@ wheels = [
 
 [[package]]
 name = "objectified-mcp"
-version = "0.1.20"
+version = "0.1.21"
 source = { editable = "." }
 dependencies = [
     { name = "bcrypt" },
@@ -960,6 +960,7 @@ dependencies = [
     { name = "psycopg", extra = ["binary", "pool"] },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "pyyaml" },
     { name = "structlog" },
 ]
 
@@ -968,6 +969,7 @@ dev = [
     { name = "mypy" },
     { name = "pytest" },
     { name = "ruff" },
+    { name = "types-pyyaml" },
 ]
 
 [package.metadata]
@@ -978,6 +980,7 @@ requires-dist = [
     { name = "psycopg", extras = ["binary", "pool"], specifier = ">=3.2.0" },
     { name = "pydantic", specifier = ">=2.9.2" },
     { name = "pydantic-settings", specifier = ">=2.5.2" },
+    { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "structlog", specifier = ">=24.4.0" },
 ]
 
@@ -986,6 +989,7 @@ dev = [
     { name = "mypy", specifier = ">=1.13.0" },
     { name = "pytest", specifier = ">=8.0.0" },
     { name = "ruff", specifier = ">=0.8.0" },
+    { name = "types-pyyaml", specifier = ">=6.0.12" },
 ]
 
 [[package]]
@@ -1798,6 +1802,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ef/52/9ba0f43b686e7f3ddfeaa78ac3af750292662284b3661e91ad5494f21dbc/structlog-25.5.0.tar.gz", hash = "sha256:098522a3bebed9153d4570c6d0288abf80a031dfdb2048d59a49e9dc2190fc98", size = 1460830, upload-time = "2025-10-27T08:28:23.028Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a8/45/a132b9074aa18e799b891b91ad72133c98d8042c70f6240e4c5f9dabee2f/structlog-25.5.0-py3-none-any.whl", hash = "sha256:a8453e9b9e636ec59bd9e79bbd4a72f025981b3ba0f5837aebf48f02f37a7f9f", size = 72510, upload-time = "2025-10-27T08:28:21.535Z" },
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20260408"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/73/b759b1e413c31034cc01ecdfb96b38115d0ab4db55a752a3929f0cd449fd/types_pyyaml-6.0.12.20260408.tar.gz", hash = "sha256:92a73f2b8d7f39ef392a38131f76b970f8c66e4c42b3125ae872b7c93b556307", size = 17735, upload-time = "2026-04-08T04:30:50.974Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/f0/c391068b86abb708882c6d75a08cd7d25b2c7227dab527b3a3685a3c635b/types_pyyaml-6.0.12.20260408-py3-none-any.whl", hash = "sha256:fbc42037d12159d9c801ebfcc79ebd28335a7c13b08a4cfbc6916df78fee9384", size = 20339, upload-time = "2026-04-08T04:30:50.113Z" },
 ]
 
 [[package]]

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.25",
+  "version": "0.11.26",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -27,6 +27,7 @@ We continue to improve the platform based on your feedback with improvements and
 - Database table **`odb.mcp_access_audit`** records MCP API key **`key_id`**, tool name, **`spec_id`** (revision UUID), timestamp **`at`**, **`success`**, and optional **`error`** for traceability; **`spec.list`** and **`spec.describe`** enqueue **non-blocking** inserts after each **private** revision returned to an authenticated caller (#3013).
 - MCP tool **`spec.list_my_specs`** lists specs readable by the **current API key only** (same merged public/private semantics and pagination as authenticated **`spec.list`**); calls **without** a key are rejected (**`Depends(require_mcp_auth)`**); private rows are audited under tool name **`spec.list_my_specs`** (#3014).
 - MCP tool **`spec.get_openapi`** returns the generated **OpenAPI 3.1** document as JSON for a published revision UUID (same shape as REST **`GET /v1/schema/{tenant}/{project}/{version}`**): anonymous callers get **public** revisions only; with an MCP API key, **in-scope private** revisions are included; responses larger than **`OBJECTIFIED_MCP_OPENAPI_MAX_JSON_BYTES`** (default **2 MiB**) are rejected with an error described as **HTTP 413** (#3016).
+- MCP tool **`spec.export_yaml`** returns the same generated document as **`openapi_yaml`** YAML text (REST-aligned **`yaml.dump`** settings); visibility, auth, private access audit, and UTF-8 size cap match **`spec.get_openapi`** (#3017).
 
 ## Importing
 - Race condition fixed in 3.0.1 specification imports


### PR DESCRIPTION
## Summary
Adds MCP tool `spec.export_yaml`, returning the same generated OpenAPI 3.1 document as REST-aligned YAML (`yaml.dump(..., sort_keys=False, default_flow_style=False)`). Visibility, optional auth, and private revision audit mirror `spec.get_openapi`. UTF-8 YAML size is capped by the existing `OBJECTIFIED_MCP_OPENAPI_MAX_JSON_BYTES` setting (413-style error when exceeded).

## Changes
- `build_spec_get_openapi_response`: optional `apply_json_payload_cap` (skipped for YAML path) and `private_access_audit_tool` for correct audit tool names.
- New `spec_export_yaml_tool` + server registration.
- Tests for round-trip vs JSON, private audit, payload limit, registration.
- Docs: PLANNED_ROADMAP_MCP, WHATS_NEW; patch bumps `objectified-mcp` and `objectified-ui`.

## How to test
1. **Run** `yarn build` and `yarn test` from the repo root (passes locally).
2. **Start MCP** with DB configured; **invoke** `spec.export_yaml` with a **public revision UUID** (same as for `spec.get_openapi`).
3. **Parse** the returned `openapi_yaml` with a YAML loader and **compare** to `spec.get_openapi` for the same id — structures should match.

## Risk / notes
YAML serializations can exceed compact JSON length; the YAML path skips the JSON byte check and applies the cap to UTF-8 YAML only.

Closes #3017

Made with [Cursor](https://cursor.com)