### PR TITLE
Fix #3018 - MCP tool spec.list_operations

### DIFF
--- a/docs/PLANNED_ROADMAP_MCP.md
+++ b/docs/PLANNED_ROADMAP_MCP.md
@@ -119,7 +119,7 @@ process or via Docker.
 |---|-------|-------|------------|
 | 5.1 | ~~[#3016](../../issues/3016)~~ | ~~Tool `spec.get_openapi` (JSON)~~ (**completed**) | 3.1, 4.1 |
 | 5.2 | ~~[#3017](../../issues/3017)~~ | ~~Tool `spec.export_yaml`~~ (**completed**) | 5.1 |
-| 5.3 | [#3018](../../issues/3018) | Tool `spec.list_operations` | 5.1 |
+| 5.3 | ~~[#3018](../../issues/3018)~~ | ~~Tool `spec.list_operations`~~ (**completed**) | 5.1 |
 | 5.4 | [#3019](../../issues/3019) | Tool `spec.describe_operation` | 5.3 |
 | 5.5 | [#3020](../../issues/3020) | Tool `spec.list_components` | 5.1 |
 | 5.6 | [#3021](../../issues/3021) | Tool `spec.describe_component` | 5.5 |

--- a/objectified-mcp/pyproject.toml
+++ b/objectified-mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "objectified-mcp"
-version = "0.1.21"
+version = "0.1.22"
 description = "Model Context Protocol server for Objectified (FastMCP)."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/objectified-mcp/src/objectified_mcp/__init__.py
+++ b/objectified-mcp/src/objectified_mcp/__init__.py
@@ -1,3 +1,3 @@
 """Objectified MCP server package."""
 
-__version__ = "0.1.21"
+__version__ = "0.1.22"

--- a/objectified-mcp/src/objectified_mcp/server.py
+++ b/objectified-mcp/src/objectified_mcp/server.py
@@ -20,6 +20,7 @@ from objectified_mcp.settings import get_settings
 from objectified_mcp.spec_describe_tool import build_spec_describe_response
 from objectified_mcp.spec_export_yaml_tool import build_spec_export_yaml_response
 from objectified_mcp.spec_get_openapi_tool import build_spec_get_openapi_response
+from objectified_mcp.spec_list_operations_tool import build_spec_list_operations_response
 from objectified_mcp.spec_list_tags_tool import build_spec_list_tags_response
 from objectified_mcp.spec_list_tool import build_spec_list_response
 from objectified_mcp.spec_search_tool import build_spec_search_response
@@ -180,6 +181,26 @@ async def spec_export_yaml(
     pool = get_db_pool(ctx)
     auth_ctx = await resolve_optional_mcp_auth(ctx, pool, headers=headers)
     return await build_spec_export_yaml_response(pool, spec_id=spec_id, auth_ctx=auth_ctx)
+
+
+@mcp.tool(
+    name="spec.list_operations",
+    description=(
+        "Return a compact index of HTTP operations for a published spec revision by id (UUID): "
+        "each item has path, method, operation_id, summary, and tags. Sorted by path then method. "
+        "Same visibility and auth rules as spec.get_openapi: anonymous callers see public revisions only; "
+        "with Authorization: Bearer <MCP API key>, in-scope private published revisions are included (#3018). "
+        "Does not return the full OpenAPI document."
+    ),
+)
+async def spec_list_operations(
+    ctx: Context,
+    spec_id: str,
+    headers: dict[str, str] = CurrentHeaders(),
+) -> list[dict[str, Any]]:
+    pool = get_db_pool(ctx)
+    auth_ctx = await resolve_optional_mcp_auth(ctx, pool, headers=headers)
+    return await build_spec_list_operations_response(pool, spec_id=spec_id, auth_ctx=auth_ctx)
 
 
 @mcp.tool(

--- a/objectified-mcp/src/objectified_mcp/spec_list_operations_tool.py
+++ b/objectified-mcp/src/objectified_mcp/spec_list_operations_tool.py
@@ -1,0 +1,67 @@
+"""MCP ``spec.list_operations`` tool: operation index without full OpenAPI doc (#3018)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from psycopg_pool import AsyncConnectionPool
+
+from objectified_mcp.mcp_auth import McpAuthContext
+from objectified_mcp.spec_get_openapi_tool import build_spec_get_openapi_response
+
+# OpenAPI 3.x path item operation keys (exclude summary/description/parameters/servers/$ref).
+_HTTP_METHODS = frozenset({"get", "put", "post", "delete", "options", "head", "patch", "trace"})
+
+
+def sorted_operations_from_openapi(spec: dict[str, Any]) -> list[dict[str, Any]]:
+    """Build ``[{path, method, operation_id, summary, tags}, …]`` sorted by path then method."""
+    paths_raw = spec.get("paths")
+    paths: dict[str, Any] = paths_raw if isinstance(paths_raw, dict) else {}
+    rows: list[dict[str, Any]] = []
+
+    for path_str in sorted(paths.keys()):
+        item = paths[path_str]
+        if not isinstance(item, dict):
+            continue
+        for method in sorted(k for k in item if k in _HTTP_METHODS):
+            op = item[method]
+            if not isinstance(op, dict):
+                continue
+            oid = op.get("operationId")
+            summary = op.get("summary")
+            tags_raw = op.get("tags")
+            if tags_raw is None:
+                tags: list[str] = []
+            elif isinstance(tags_raw, list):
+                tags = [str(t) for t in tags_raw]
+            else:
+                tags = []
+
+            rows.append(
+                {
+                    "path": path_str,
+                    "method": method,
+                    "operation_id": str(oid) if oid is not None else None,
+                    "summary": str(summary) if summary is not None else None,
+                    "tags": tags,
+                }
+            )
+
+    return rows
+
+
+async def build_spec_list_operations_response(
+    pool: AsyncConnectionPool,
+    *,
+    spec_id: str,
+    auth_ctx: McpAuthContext | None = None,
+) -> list[dict[str, Any]]:
+    """Return sorted operation rows for ``spec_id``, or raise like ``spec.get_openapi``."""
+    spec = await build_spec_get_openapi_response(
+        pool,
+        spec_id=spec_id,
+        auth_ctx=auth_ctx,
+        apply_json_payload_cap=False,
+        private_access_audit_tool="spec.list_operations",
+    )
+    return sorted_operations_from_openapi(spec)

--- a/objectified-mcp/tests/test_spec_list_operations_tool.py
+++ b/objectified-mcp/tests/test_spec_list_operations_tool.py
@@ -1,0 +1,253 @@
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID, uuid4
+
+import pytest
+from fastmcp.exceptions import NotFoundError
+from psycopg_pool import AsyncConnectionPool
+
+from objectified_mcp.mcp_auth import McpAuthContext
+from objectified_mcp.scope import Scope
+from objectified_mcp.spec_list_operations_tool import (
+    build_spec_list_operations_response,
+    sorted_operations_from_openapi,
+)
+
+
+def _spec_alpha() -> dict[str, object]:
+    """Paths out of order; methods out of order on same path."""
+    return {
+        "openapi": "3.1.0",
+        "paths": {
+            "/users": {
+                "post": {"operationId": "createUser", "summary": "Create", "tags": ["users"]},
+                "get": {"operationId": "listUsers", "summary": "List", "tags": ["users"]},
+            },
+            "/items/{id}": {
+                "get": {"operationId": "getItem", "summary": None, "tags": ["items", "read"]},
+                "delete": {"tags": ["items"]},
+            },
+        },
+    }
+
+
+def _spec_beta() -> dict[str, object]:
+    """Another shape: parameters only on path item, trace method, missing operationId."""
+    return {
+        "openapi": "3.1.0",
+        "paths": {
+            "/v1/ping": {
+                "parameters": [{"name": "x", "in": "header"}],
+                "trace": {"summary": "probe"},
+                "get": {"operationId": "pingGet"},
+            },
+        },
+    }
+
+
+def test_sorted_operations_from_openapi_spec_alpha_order() -> None:
+    rows = sorted_operations_from_openapi(_spec_alpha())
+    assert [r["path"] for r in rows] == ["/items/{id}", "/items/{id}", "/users", "/users"]
+    assert [r["method"] for r in rows] == ["delete", "get", "get", "post"]
+    assert rows[0] == {
+        "path": "/items/{id}",
+        "method": "delete",
+        "operation_id": None,
+        "summary": None,
+        "tags": ["items"],
+    }
+    assert rows[1]["operation_id"] == "getItem"
+    assert rows[2]["operation_id"] == "listUsers"
+    assert rows[3]["operation_id"] == "createUser"
+
+
+def test_sorted_operations_from_openapi_spec_beta_skips_parameters() -> None:
+    rows = sorted_operations_from_openapi(_spec_beta())
+    assert len(rows) == 2
+    assert rows[0] == {
+        "path": "/v1/ping",
+        "method": "get",
+        "operation_id": "pingGet",
+        "summary": None,
+        "tags": [],
+    }
+    assert rows[1] == {
+        "path": "/v1/ping",
+        "method": "trace",
+        "operation_id": None,
+        "summary": "probe",
+        "tags": [],
+    }
+
+
+def test_sorted_operations_empty_and_malformed_paths() -> None:
+    assert sorted_operations_from_openapi({}) == []
+    assert sorted_operations_from_openapi({"paths": None}) == []
+    assert sorted_operations_from_openapi({"paths": "/not-a-dict"}) == []
+    assert sorted_operations_from_openapi({"paths": {"/x": "bad"}}) == []
+
+
+def _openapi_row(*, spec_id: UUID | None = None, visibility: str = "public") -> dict[str, object]:
+    sid = spec_id or uuid4()
+    return {
+        "id": sid,
+        "tenant_slug": "acme",
+        "project_slug": "payments",
+        "version_label": "2.1.0",
+        "project_description": "Payments service",
+        "metadata": None,
+        "spec_visibility": visibility,
+    }
+
+
+def test_build_spec_list_operations_success() -> None:
+    sid = uuid4()
+    row = _openapi_row(spec_id=sid)
+    sample_spec = _spec_alpha()
+
+    pool = MagicMock(spec=AsyncConnectionPool)
+    describe_cur = MagicMock()
+    describe_cur.execute = AsyncMock()
+    describe_cur.fetchone = AsyncMock(return_value=row)
+    describe_cm = AsyncMock()
+    describe_cm.__aenter__.return_value = describe_cur
+    describe_cm.__aexit__.return_value = None
+    conn = MagicMock()
+    conn.cursor = MagicMock(return_value=describe_cm)
+    conn_cm = AsyncMock()
+    conn_cm.__aenter__.return_value = conn
+    conn_cm.__aexit__.return_value = None
+    pool.connection = MagicMock(return_value=conn_cm)
+
+    async def fake_fetch(_conn: object, _revision_id: UUID) -> tuple:
+        return ([], {}, [], [], [])
+
+    with (
+        patch("objectified_mcp.spec_get_openapi_tool.fetch_openapi_generation_inputs_async", side_effect=fake_fetch),
+        patch("objectified_mcp.spec_get_openapi_tool.generate_openapi_spec", return_value=sample_spec),
+    ):
+
+        async def run() -> list[dict[str, object]]:
+            return await build_spec_list_operations_response(pool, spec_id=str(sid))
+
+        out = asyncio.run(run())
+
+    assert len(out) == 4
+    assert out[0]["method"] == "delete"
+
+
+def test_build_spec_list_operations_not_found() -> None:
+    pool = MagicMock(spec=AsyncConnectionPool)
+    describe_cur = MagicMock()
+    describe_cur.execute = AsyncMock()
+    describe_cur.fetchone = AsyncMock(return_value=None)
+    describe_cm = AsyncMock()
+    describe_cm.__aenter__.return_value = describe_cur
+    describe_cm.__aexit__.return_value = None
+    conn = MagicMock()
+    conn.cursor = MagicMock(return_value=describe_cm)
+    conn_cm = AsyncMock()
+    conn_cm.__aenter__.return_value = conn
+    conn_cm.__aexit__.return_value = None
+    pool.connection = MagicMock(return_value=conn_cm)
+
+    async def run() -> None:
+        await build_spec_list_operations_response(pool, spec_id=str(uuid4()))
+
+    with pytest.raises(NotFoundError, match="Unknown or non-public"):
+        asyncio.run(run())
+
+
+def test_build_spec_list_operations_private_audited() -> None:
+    sid = uuid4()
+    row = _openapi_row(spec_id=sid, visibility="private")
+    auth = McpAuthContext(
+        key_id="00000000-0000-4000-8000-000000000099",
+        tenant_id=str(uuid4()),
+        label="k",
+        scope=Scope(),
+    )
+
+    pool = MagicMock(spec=AsyncConnectionPool)
+    describe_cur = MagicMock()
+    describe_cur.execute = AsyncMock()
+    describe_cur.fetchone = AsyncMock(return_value=row)
+    describe_cm = AsyncMock()
+    describe_cm.__aenter__.return_value = describe_cur
+    describe_cm.__aexit__.return_value = None
+    conn = MagicMock()
+    conn.cursor = MagicMock(return_value=describe_cm)
+    conn_cm = AsyncMock()
+    conn_cm.__aenter__.return_value = conn
+    conn_cm.__aexit__.return_value = None
+    pool.connection = MagicMock(return_value=conn_cm)
+
+    async def fake_fetch(_conn: object, _revision_id: UUID) -> tuple:
+        return ([], {}, [], [], [])
+
+    with (
+        patch("objectified_mcp.spec_get_openapi_tool.fetch_openapi_generation_inputs_async", side_effect=fake_fetch),
+        patch("objectified_mcp.spec_get_openapi_tool.generate_openapi_spec", return_value=_spec_beta()),
+        patch("objectified_mcp.spec_get_openapi_tool.schedule_mcp_private_access_audit") as audit,
+    ):
+
+        async def run() -> None:
+            await build_spec_list_operations_response(pool, spec_id=str(sid), auth_ctx=auth)
+
+        asyncio.run(run())
+
+    audit.assert_called_once()
+    assert audit.call_args.kwargs["tool"] == "spec.list_operations"
+
+
+def test_build_spec_list_operations_allows_oversize_openapi_payload() -> None:
+    """Operation index skips JSON byte cap that would block spec.get_openapi."""
+    sid = uuid4()
+    row = _openapi_row(spec_id=sid)
+    huge = {"openapi": "3.1.0", "paths": {"/x": {"get": {"operationId": "x"}}}, "x": "y" * 500_000}
+
+    pool = MagicMock(spec=AsyncConnectionPool)
+    describe_cur = MagicMock()
+    describe_cur.execute = AsyncMock()
+    describe_cur.fetchone = AsyncMock(return_value=row)
+    describe_cm = AsyncMock()
+    describe_cm.__aenter__.return_value = describe_cur
+    describe_cm.__aexit__.return_value = None
+    conn = MagicMock()
+    conn.cursor = MagicMock(return_value=describe_cm)
+    conn_cm = AsyncMock()
+    conn_cm.__aenter__.return_value = conn
+    conn_cm.__aexit__.return_value = None
+    pool.connection = MagicMock(return_value=conn_cm)
+
+    async def fake_fetch(_conn: object, _revision_id: UUID) -> tuple:
+        return ([], {}, [], [], [])
+
+    with (
+        patch("objectified_mcp.spec_get_openapi_tool.fetch_openapi_generation_inputs_async", side_effect=fake_fetch),
+        patch("objectified_mcp.spec_get_openapi_tool.generate_openapi_spec", return_value=huge),
+        patch("objectified_mcp.spec_get_openapi_tool.get_settings") as gs,
+    ):
+        gs.return_value.openapi_max_json_bytes = 100
+
+        async def run() -> list[dict[str, object]]:
+            return await build_spec_list_operations_response(pool, spec_id=str(sid))
+
+        out = asyncio.run(run())
+
+    assert out == [
+        {"path": "/x", "method": "get", "operation_id": "x", "summary": None, "tags": []},
+    ]
+
+
+def test_spec_list_operations_tool_registered_on_mcp() -> None:
+    from objectified_mcp.server import mcp
+
+    async def load() -> object:
+        return await mcp.get_tool("spec.list_operations")
+
+    tool = asyncio.run(load())
+    assert tool is not None
+    assert tool.name == "spec.list_operations"

--- a/objectified-mcp/uv.lock
+++ b/objectified-mcp/uv.lock
@@ -951,7 +951,7 @@ wheels = [
 
 [[package]]
 name = "objectified-mcp"
-version = "0.1.21"
+version = "0.1.22"
 source = { editable = "." }
 dependencies = [
     { name = "bcrypt" },

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.26",
+  "version": "0.11.27",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -28,6 +28,7 @@ We continue to improve the platform based on your feedback with improvements and
 - MCP tool **`spec.list_my_specs`** lists specs readable by the **current API key only** (same merged public/private semantics and pagination as authenticated **`spec.list`**); calls **without** a key are rejected (**`Depends(require_mcp_auth)`**); private rows are audited under tool name **`spec.list_my_specs`** (#3014).
 - MCP tool **`spec.get_openapi`** returns the generated **OpenAPI 3.1** document as JSON for a published revision UUID (same shape as REST **`GET /v1/schema/{tenant}/{project}/{version}`**): anonymous callers get **public** revisions only; with an MCP API key, **in-scope private** revisions are included; responses larger than **`OBJECTIFIED_MCP_OPENAPI_MAX_JSON_BYTES`** (default **2 MiB**) are rejected with an error described as **HTTP 413** (#3016).
 - MCP tool **`spec.export_yaml`** returns the same generated document as **`openapi_yaml`** YAML text (REST-aligned **`yaml.dump`** settings); visibility, auth, private access audit, and UTF-8 size cap match **`spec.get_openapi`** (#3017).
+- MCP tool **`spec.list_operations`** returns a compact **`[{path, method, operation_id, summary, tags}, …]`** index for a revision UUID (sorted by path then method), with the same visibility and auth rules as **`spec.get_openapi`**, without returning the full OpenAPI document; private reads are audited as **`spec.list_operations`** (#3018).
 
 ## Importing
 - Race condition fixed in 3.0.1 specification imports


### PR DESCRIPTION
## What changed
Adds MCP tool `spec.list_operations` that returns a compact operation index for a published revision UUID: `[{path, method, operation_id, summary, tags}, …]`, sorted by path then HTTP method. Implementation reuses `build_spec_get_openapi_response` with `apply_json_payload_cap=False` so callers get an index without transferring the full OpenAPI document and without failing the JSON byte cap that applies to `spec.get_openapi`. Visibility, optional auth, and private access audit semantics match `spec.get_openapi` (audit tool name `spec.list_operations`).

## How to test
- **Run** `yarn build` and `yarn test` from the repo root (passes locally).
- **Call** `spec.list_operations` with a known public revision UUID over MCP (stdio or HTTP): confirm the list matches paths/methods in `spec.get_openapi` for the same id and order is stable across calls.

## Risk / notes
Still generates the full OpenAPI in memory server-side (same as export/index use cases); only the wire payload is small.

Closes #3018

Made with [Cursor](https://cursor.com)