### PR TITLE
Fix #3019 - MCP tool spec.describe_operation

### DIFF
--- a/docs/PLANNED_ROADMAP_MCP.md
+++ b/docs/PLANNED_ROADMAP_MCP.md
@@ -120,7 +120,7 @@ process or via Docker.
 | 5.1 | ~~[#3016](../../issues/3016)~~ | ~~Tool `spec.get_openapi` (JSON)~~ (**completed**) | 3.1, 4.1 |
 | 5.2 | ~~[#3017](../../issues/3017)~~ | ~~Tool `spec.export_yaml`~~ (**completed**) | 5.1 |
 | 5.3 | ~~[#3018](../../issues/3018)~~ | ~~Tool `spec.list_operations`~~ (**completed**) | 5.1 |
-| 5.4 | [#3019](../../issues/3019) | Tool `spec.describe_operation` | 5.3 |
+| 5.4 | ~~[#3019](../../issues/3019)~~ | ~~Tool `spec.describe_operation`~~ (**completed**) | 5.3 |
 | 5.5 | [#3020](../../issues/3020) | Tool `spec.list_components` | 5.1 |
 | 5.6 | [#3021](../../issues/3021) | Tool `spec.describe_component` | 5.5 |
 

--- a/objectified-mcp/pyproject.toml
+++ b/objectified-mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "objectified-mcp"
-version = "0.1.22"
+version = "0.1.23"
 description = "Model Context Protocol server for Objectified (FastMCP)."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/objectified-mcp/src/objectified_mcp/__init__.py
+++ b/objectified-mcp/src/objectified_mcp/__init__.py
@@ -1,3 +1,3 @@
 """Objectified MCP server package."""
 
-__version__ = "0.1.22"
+__version__ = "0.1.23"

--- a/objectified-mcp/src/objectified_mcp/server.py
+++ b/objectified-mcp/src/objectified_mcp/server.py
@@ -17,6 +17,7 @@ from objectified_mcp.logging_config import configure_logging
 from objectified_mcp.mcp_auth import McpAuthContext, require_mcp_auth, resolve_optional_mcp_auth
 from objectified_mcp.ping_tool import build_ping_response
 from objectified_mcp.settings import get_settings
+from objectified_mcp.spec_describe_operation_tool import build_spec_describe_operation_response
 from objectified_mcp.spec_describe_tool import build_spec_describe_response
 from objectified_mcp.spec_export_yaml_tool import build_spec_export_yaml_response
 from objectified_mcp.spec_get_openapi_tool import build_spec_get_openapi_response
@@ -201,6 +202,34 @@ async def spec_list_operations(
     pool = get_db_pool(ctx)
     auth_ctx = await resolve_optional_mcp_auth(ctx, pool, headers=headers)
     return await build_spec_list_operations_response(pool, spec_id=spec_id, auth_ctx=auth_ctx)
+
+
+@mcp.tool(
+    name="spec.describe_operation",
+    description=(
+        "Return OpenAPI fragments for one HTTP operation on a published spec revision: ``parameters`` "
+        "(path-item + operation merge, operation wins same name/in), ``requestBody``, ``responses``, "
+        "and ``security`` (operation override or document default). Internal ``#/…`` ``$ref`` values "
+        "are expanded; external refs are left as-is. Same visibility and auth rules as "
+        "spec.get_openapi (#3019). Raises not-found for inaccessible revisions or unknown path/method."
+    ),
+)
+async def spec_describe_operation(
+    ctx: Context,
+    spec_id: str,
+    path: str,
+    method: str,
+    headers: dict[str, str] = CurrentHeaders(),
+) -> dict[str, Any]:
+    pool = get_db_pool(ctx)
+    auth_ctx = await resolve_optional_mcp_auth(ctx, pool, headers=headers)
+    return await build_spec_describe_operation_response(
+        pool,
+        spec_id=spec_id,
+        path=path,
+        method=method,
+        auth_ctx=auth_ctx,
+    )
 
 
 @mcp.tool(

--- a/objectified-mcp/src/objectified_mcp/spec_describe_operation_tool.py
+++ b/objectified-mcp/src/objectified_mcp/spec_describe_operation_tool.py
@@ -1,0 +1,156 @@
+"""MCP ``spec.describe_operation`` tool: operation fragments with resolved refs (#3019)."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+from fastmcp.exceptions import NotFoundError
+from psycopg_pool import AsyncConnectionPool
+
+from objectified_mcp.mcp_auth import McpAuthContext
+from objectified_mcp.spec_get_openapi_tool import build_spec_get_openapi_response
+
+_HTTP_METHODS = frozenset({"get", "put", "post", "delete", "options", "head", "patch", "trace"})
+
+
+def _json_pointer_follow(root: dict[str, Any], pointer: str) -> Any | None:
+    """Resolve an OpenAPI internal fragment pointer ``#/a/b`` against ``root``."""
+    if not pointer.startswith("#/"):
+        return None
+    node: Any = root
+    for raw in pointer[2:].split("/"):
+        key = raw.replace("~1", "/").replace("~0", "~")
+        if isinstance(node, dict):
+            node = node.get(key)
+        elif isinstance(node, list):
+            try:
+                idx = int(key)
+            except ValueError:
+                return None
+            if idx < 0 or idx >= len(node):
+                return None
+            node = node[idx]
+        else:
+            return None
+    return node
+
+
+def resolve_openapi_refs(root: dict[str, Any], node: Any, stack: frozenset[str]) -> Any:
+    """Recursively resolve document-internal ``#/…`` ``$ref`` values; leave external refs unchanged."""
+    if isinstance(node, dict):
+        ref = node.get("$ref")
+        if isinstance(ref, str) and ref.startswith("#/"):
+            if ref in stack:
+                return {"$ref": ref}
+            target = _json_pointer_follow(root, ref)
+            if target is None:
+                return deepcopy(node)
+            return resolve_openapi_refs(root, deepcopy(target), frozenset({*stack, ref}))
+        return {k: resolve_openapi_refs(root, v, stack) for k, v in node.items()}
+    if isinstance(node, list):
+        return [resolve_openapi_refs(root, item, stack) for item in node]
+    return node
+
+
+def _follow_path_item_ref(spec: dict[str, Any], raw: Any, stack: frozenset[str]) -> dict[str, Any] | None:
+    """Expand path-item reference chain (``$ref`` only); return a path-item dict or None."""
+    cur: Any = raw
+    while isinstance(cur, dict) and "$ref" in cur:
+        ref = cur.get("$ref")
+        if not isinstance(ref, str) or not ref.startswith("#/"):
+            return None
+        if ref in stack:
+            return None
+        nxt = _json_pointer_follow(spec, ref)
+        if not isinstance(nxt, dict):
+            return None
+        cur = nxt
+        stack = frozenset({*stack, ref})
+    return cur if isinstance(cur, dict) else None
+
+
+def merge_path_and_operation_parameters(path_item: dict[str, Any], operation: dict[str, Any]) -> list[Any]:
+    """Merge OpenAPI path-item and operation ``parameters`` (operation wins same ``name`` + ``in``)."""
+    pp = path_item.get("parameters")
+    op = operation.get("parameters")
+    path_list = pp if isinstance(pp, list) else []
+    op_list = op if isinstance(op, list) else []
+    combined: list[Any] = [*path_list, *op_list]
+
+    seen: dict[tuple[str, str], int] = {}
+    out: list[Any] = []
+    for p in combined:
+        if not isinstance(p, dict):
+            out.append(p)
+            continue
+        name, inn = p.get("name"), p.get("in")
+        if isinstance(name, str) and isinstance(inn, str):
+            key = (name, inn)
+            if key in seen:
+                out[seen[key]] = p
+            else:
+                seen[key] = len(out)
+                out.append(p)
+        else:
+            out.append(p)
+    return out
+
+
+def extract_operation_detail(spec: dict[str, Any], path: str, method: str) -> dict[str, Any] | None:
+    """Return merged parameters, requestBody, responses, and security for ``path`` / ``method``, or None."""
+    m = method.strip().lower()
+    if m not in _HTTP_METHODS:
+        return None
+
+    paths_raw = spec.get("paths")
+    if not isinstance(paths_raw, dict):
+        return None
+
+    path_item = _follow_path_item_ref(spec, paths_raw.get(path), frozenset())
+    if path_item is None:
+        return None
+
+    op_raw = path_item.get(m)
+    operation = resolve_openapi_refs(spec, op_raw, frozenset())
+    if not isinstance(operation, dict):
+        return None
+
+    parameters = merge_path_and_operation_parameters(path_item, operation)
+    parameters_resolved = resolve_openapi_refs(spec, parameters, frozenset())
+
+    request_body = operation.get("requestBody")
+    responses = operation.get("responses")
+    if "security" in operation:
+        sec_raw = operation.get("security")
+    else:
+        sec_raw = spec.get("security")
+
+    return {
+        "parameters": parameters_resolved,
+        "requestBody": resolve_openapi_refs(spec, request_body, frozenset()) if request_body is not None else None,
+        "responses": resolve_openapi_refs(spec, responses, frozenset()) if responses is not None else None,
+        "security": resolve_openapi_refs(spec, sec_raw, frozenset()) if sec_raw is not None else None,
+    }
+
+
+async def build_spec_describe_operation_response(
+    pool: AsyncConnectionPool,
+    *,
+    spec_id: str,
+    path: str,
+    method: str,
+    auth_ctx: McpAuthContext | None = None,
+) -> dict[str, Any]:
+    """Return operation fragments for ``spec_id`` / ``path`` / ``method``, or raise ``NotFoundError``."""
+    spec = await build_spec_get_openapi_response(
+        pool,
+        spec_id=spec_id,
+        auth_ctx=auth_ctx,
+        apply_json_payload_cap=False,
+        private_access_audit_tool="spec.describe_operation",
+    )
+    detail = extract_operation_detail(spec, path=str(path), method=str(method))
+    if detail is None:
+        raise NotFoundError("Unknown path or method for this spec.")
+    return detail

--- a/objectified-mcp/src/objectified_mcp/spec_describe_operation_tool.py
+++ b/objectified-mcp/src/objectified_mcp/spec_describe_operation_tool.py
@@ -37,7 +37,11 @@ def _json_pointer_follow(root: dict[str, Any], pointer: str) -> Any | None:
 
 
 def resolve_openapi_refs(root: dict[str, Any], node: Any, stack: frozenset[str]) -> Any:
-    """Recursively resolve document-internal ``#/…`` ``$ref`` values; leave external refs unchanged."""
+    """Recursively resolve document-internal ``#/…`` ``$ref`` values; leave external refs unchanged.
+
+    Sibling fields alongside a ``$ref`` (valid in OAS 3.1 / JSON Schema) are merged into the resolved
+    target, with the sibling values taking precedence over same-named target fields.
+    """
     if isinstance(node, dict):
         ref = node.get("$ref")
         if isinstance(ref, str) and ref.startswith("#/"):
@@ -46,7 +50,16 @@ def resolve_openapi_refs(root: dict[str, Any], node: Any, stack: frozenset[str])
             target = _json_pointer_follow(root, ref)
             if target is None:
                 return deepcopy(node)
-            return resolve_openapi_refs(root, deepcopy(target), frozenset({*stack, ref}))
+            new_stack = frozenset({*stack, ref})
+            resolved = resolve_openapi_refs(root, deepcopy(target), new_stack)
+            siblings = {
+                k: resolve_openapi_refs(root, deepcopy(v), new_stack)
+                for k, v in node.items()
+                if k != "$ref"
+            }
+            if siblings and isinstance(resolved, dict):
+                return {**resolved, **siblings}
+            return resolved
         return {k: resolve_openapi_refs(root, v, stack) for k, v in node.items()}
     if isinstance(node, list):
         return [resolve_openapi_refs(root, item, stack) for item in node]
@@ -116,7 +129,17 @@ def extract_operation_detail(spec: dict[str, Any], path: str, method: str) -> di
     if not isinstance(operation, dict):
         return None
 
-    parameters = merge_path_and_operation_parameters(path_item, operation)
+    # Expand $ref values in path-item parameters before the (name, in) dedup merge so that
+    # operation-level parameters correctly override path-level $ref parameters.
+    path_item_params_raw = path_item.get("parameters")
+    path_item_params_expanded = resolve_openapi_refs(
+        spec,
+        path_item_params_raw if isinstance(path_item_params_raw, list) else [],
+        frozenset(),
+    )
+    path_item_for_merge = {**path_item, "parameters": path_item_params_expanded}
+    parameters = merge_path_and_operation_parameters(path_item_for_merge, operation)
+    # operation params inside `operation` are already resolved; re-running is a harmless no-op.
     parameters_resolved = resolve_openapi_refs(spec, parameters, frozenset())
 
     request_body = operation.get("requestBody")

--- a/objectified-mcp/tests/test_spec_describe_operation_tool.py
+++ b/objectified-mcp/tests/test_spec_describe_operation_tool.py
@@ -18,6 +18,34 @@ from objectified_mcp.spec_describe_operation_tool import (
 )
 
 
+def test_extract_operation_detail_op_param_overrides_path_ref_param() -> None:
+    """Operation-level parameter must override a path-level $ref parameter with the same (name, in)."""
+    spec: dict[str, object] = {
+        "openapi": "3.1.0",
+        "paths": {
+            "/items": {
+                "parameters": [{"$ref": "#/components/parameters/Limit"}],
+                "get": {
+                    "parameters": [{"name": "limit", "in": "query", "schema": {"type": "integer"}, "description": "op-level"}],
+                    "responses": {"200": {"description": "ok"}},
+                },
+            }
+        },
+        "components": {
+            "parameters": {
+                "Limit": {"name": "limit", "in": "query", "schema": {"type": "string"}, "description": "path-level"},
+            }
+        },
+    }
+    detail = extract_operation_detail(spec, "/items", "get")
+    assert detail is not None
+    params = detail["parameters"]
+    # Only one parameter after dedup — operation-level wins
+    assert len(params) == 1
+    assert params[0]["description"] == "op-level"
+    assert params[0]["schema"]["type"] == "integer"
+
+
 def test_merge_path_and_operation_parameters_operation_wins() -> None:
     path_item = {
         "parameters": [
@@ -45,6 +73,25 @@ def test_resolve_openapi_refs_internal_expands() -> None:
     out = resolve_openapi_refs(spec, spec["paths"]["/x"]["get"], frozenset())
     assert isinstance(out, dict)
     assert out["responses"] == {"description": "fine"}
+
+
+def test_resolve_openapi_refs_preserves_siblings_alongside_ref() -> None:
+    """Sibling fields on a $ref object must be merged into the resolved target (OAS 3.1 / JSON Schema)."""
+    spec: dict[str, object] = {
+        "components": {
+            "schemas": {
+                "BaseUser": {"type": "object", "properties": {"id": {"type": "string"}}},
+            }
+        }
+    }
+    node = {"$ref": "#/components/schemas/BaseUser", "description": "override", "nullable": True}
+    out = resolve_openapi_refs(spec, node, frozenset())
+    assert isinstance(out, dict)
+    # Base schema fields are kept
+    assert out["type"] == "object"
+    # Sibling fields are merged and take precedence
+    assert out["description"] == "override"
+    assert out["nullable"] is True
 
 
 def test_resolve_openapi_refs_leaves_external_ref() -> None:
@@ -285,6 +332,49 @@ def test_build_spec_describe_operation_private_audited() -> None:
 
     audit.assert_called_once()
     assert audit.call_args.kwargs["tool"] == "spec.describe_operation"
+
+
+def test_build_spec_describe_operation_allows_oversize_openapi_payload() -> None:
+    """describe_operation bypasses the JSON byte cap so large specs don't raise ToolError (apply_json_payload_cap=False)."""
+    sid = uuid4()
+    row = _openapi_row(spec_id=sid)
+    huge = {
+        "openapi": "3.1.0",
+        "paths": {"/ping": {"get": {"responses": {"200": {"description": "pong"}}}}},
+        # Padding large enough to exceed the 100-byte cap set below, mimicking a real oversized spec.
+        "x-padding": "z" * 500_000,
+    }
+
+    pool = MagicMock(spec=AsyncConnectionPool)
+    describe_cur = MagicMock()
+    describe_cur.execute = AsyncMock()
+    describe_cur.fetchone = AsyncMock(return_value=row)
+    describe_cm = AsyncMock()
+    describe_cm.__aenter__.return_value = describe_cur
+    describe_cm.__aexit__.return_value = None
+    conn = MagicMock()
+    conn.cursor = MagicMock(return_value=describe_cm)
+    conn_cm = AsyncMock()
+    conn_cm.__aenter__.return_value = conn
+    conn_cm.__aexit__.return_value = None
+    pool.connection = MagicMock(return_value=conn_cm)
+
+    async def fake_fetch(_conn: object, _revision_id: UUID) -> tuple:
+        return ([], {}, [], [], [])
+
+    with (
+        patch("objectified_mcp.spec_get_openapi_tool.fetch_openapi_generation_inputs_async", side_effect=fake_fetch),
+        patch("objectified_mcp.spec_get_openapi_tool.generate_openapi_spec", return_value=huge),
+        patch("objectified_mcp.spec_get_openapi_tool.get_settings") as gs,
+    ):
+        gs.return_value.openapi_max_json_bytes = 100  # tiny cap that would block spec.get_openapi
+
+        async def run() -> dict[str, object]:
+            return await build_spec_describe_operation_response(pool, spec_id=str(sid), path="/ping", method="get")
+
+        out = asyncio.run(run())
+
+    assert out["responses"] == {"200": {"description": "pong"}}
 
 
 def test_spec_describe_operation_tool_registered_on_mcp() -> None:

--- a/objectified-mcp/tests/test_spec_describe_operation_tool.py
+++ b/objectified-mcp/tests/test_spec_describe_operation_tool.py
@@ -1,0 +1,298 @@
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID, uuid4
+
+import pytest
+from fastmcp.exceptions import NotFoundError
+from psycopg_pool import AsyncConnectionPool
+
+from objectified_mcp.mcp_auth import McpAuthContext
+from objectified_mcp.scope import Scope
+from objectified_mcp.spec_describe_operation_tool import (
+    build_spec_describe_operation_response,
+    extract_operation_detail,
+    merge_path_and_operation_parameters,
+    resolve_openapi_refs,
+)
+
+
+def test_merge_path_and_operation_parameters_operation_wins() -> None:
+    path_item = {
+        "parameters": [
+            {"name": "a", "in": "query", "schema": {"type": "string"}},
+            {"name": "shared", "in": "header", "schema": {"type": "string"}},
+        ]
+    }
+    operation = {
+        "parameters": [
+            {"name": "shared", "in": "header", "schema": {"type": "integer"}},
+            {"name": "b", "in": "path", "schema": {"type": "string"}},
+        ]
+    }
+    merged = merge_path_and_operation_parameters(path_item, operation)
+    assert [p["name"] for p in merged if isinstance(p, dict)] == ["a", "shared", "b"]
+    hdr = next(p for p in merged if isinstance(p, dict) and p.get("name") == "shared")
+    assert hdr["schema"]["type"] == "integer"
+
+
+def test_resolve_openapi_refs_internal_expands() -> None:
+    spec: dict[str, object] = {
+        "paths": {"/x": {"get": {"responses": {"$ref": "#/components/responses/Ok"}}}},
+        "components": {"responses": {"Ok": {"description": "fine"}}},
+    }
+    out = resolve_openapi_refs(spec, spec["paths"]["/x"]["get"], frozenset())
+    assert isinstance(out, dict)
+    assert out["responses"] == {"description": "fine"}
+
+
+def test_resolve_openapi_refs_leaves_external_ref() -> None:
+    spec: dict[str, object] = {}
+    node = {"$ref": "https://example.com/other.json#/Foo"}
+    assert resolve_openapi_refs(spec, node, frozenset()) == node
+
+
+def test_resolve_openapi_refs_circular() -> None:
+    spec: dict[str, object] = {
+        "components": {
+            "schemas": {
+                "A": {"type": "object", "properties": {"b": {"$ref": "#/components/schemas/B"}}},
+                "B": {"type": "object", "properties": {"a": {"$ref": "#/components/schemas/A"}}},
+            }
+        }
+    }
+    out = resolve_openapi_refs(spec, {"$ref": "#/components/schemas/A"}, frozenset())
+    assert isinstance(out, dict)
+    assert out["type"] == "object"
+    b = out["properties"]["b"]
+    assert isinstance(b, dict)
+    a_back = b["properties"]["a"]
+    assert a_back == {"$ref": "#/components/schemas/A"}
+
+
+def test_extract_operation_detail_resolves_components() -> None:
+    spec: dict[str, object] = {
+        "openapi": "3.1.0",
+        "security": [{"ApiKeyAuth": []}],
+        "paths": {
+            "/users": {
+                "parameters": [{"$ref": "#/components/parameters/Limit"}],
+                "post": {
+                    "parameters": [{"name": "id", "in": "path", "schema": {"type": "string"}}],
+                    "requestBody": {"$ref": "#/components/requestBodies/UserBody"},
+                    "responses": {"200": {"$ref": "#/components/responses/Ok"}},
+                    "security": [{"OAuth2": ["write"]}],
+                },
+            }
+        },
+        "components": {
+            "parameters": {
+                "Limit": {"name": "limit", "in": "query", "schema": {"type": "integer"}},
+            },
+            "requestBodies": {
+                "UserBody": {
+                    "required": True,
+                    "content": {"application/json": {"schema": {"$ref": "#/components/schemas/User"}}},
+                }
+            },
+            "schemas": {"User": {"type": "object", "properties": {"id": {"type": "string"}}}},
+            "responses": {"Ok": {"description": "ok"}},
+        },
+    }
+    detail = extract_operation_detail(spec, "/users", "post")
+    assert detail is not None
+    params = detail["parameters"]
+    assert len(params) == 2
+    lim = next(p for p in params if p["name"] == "limit")
+    assert lim["in"] == "query"
+    assert detail["requestBody"]["required"] is True
+    assert detail["requestBody"]["content"]["application/json"]["schema"]["type"] == "object"
+    assert detail["responses"] == {"200": {"description": "ok"}}
+    assert detail["security"] == [{"OAuth2": ["write"]}]
+
+
+def test_extract_operation_detail_inherits_security() -> None:
+    spec: dict[str, object] = {
+        "openapi": "3.1.0",
+        "security": [{"ApiKeyAuth": []}],
+        "paths": {"/x": {"get": {"responses": {"200": {"description": "ok"}}}}},
+    }
+    detail = extract_operation_detail(spec, "/x", "get")
+    assert detail is not None
+    assert detail["security"] == [{"ApiKeyAuth": []}]
+
+
+def test_extract_operation_detail_path_item_ref() -> None:
+    spec: dict[str, object] = {
+        "openapi": "3.1.0",
+        "paths": {
+            "/shared": {"$ref": "#/paths/~1items"},
+            "/items": {"get": {"summary": "x"}},
+        },
+    }
+    detail = extract_operation_detail(spec, "/shared", "get")
+    assert detail is not None
+    assert detail["parameters"] == []
+    assert detail["responses"] is None
+    assert detail["requestBody"] is None
+
+
+def test_extract_operation_detail_unknown_path() -> None:
+    spec: dict[str, object] = {"openapi": "3.1.0", "paths": {"/a": {"get": {}}}}
+    assert extract_operation_detail(spec, "/missing", "get") is None
+
+
+def test_extract_operation_detail_unknown_method() -> None:
+    spec: dict[str, object] = {"openapi": "3.1.0", "paths": {"/a": {"get": {}}}}
+    assert extract_operation_detail(spec, "/a", "post") is None
+
+
+def test_extract_operation_detail_method_case_insensitive() -> None:
+    spec: dict[str, object] = {
+        "openapi": "3.1.0",
+        "paths": {"/a": {"get": {"responses": {"204": {"description": "n"}}}}},
+    }
+    assert extract_operation_detail(spec, "/a", "GET") is not None
+
+
+def _openapi_row(*, spec_id: UUID | None = None, visibility: str = "public") -> dict[str, object]:
+    sid = spec_id or uuid4()
+    return {
+        "id": sid,
+        "tenant_slug": "acme",
+        "project_slug": "payments",
+        "version_label": "2.1.0",
+        "project_description": "Payments service",
+        "metadata": None,
+        "spec_visibility": visibility,
+    }
+
+
+def test_build_spec_describe_operation_success() -> None:
+    sid = uuid4()
+    row = _openapi_row(spec_id=sid)
+    sample_spec: dict[str, object] = {
+        "openapi": "3.1.0",
+        "paths": {"/ping": {"get": {"responses": {"200": {"description": "pong"}}}}},
+    }
+
+    pool = MagicMock(spec=AsyncConnectionPool)
+    describe_cur = MagicMock()
+    describe_cur.execute = AsyncMock()
+    describe_cur.fetchone = AsyncMock(return_value=row)
+    describe_cm = AsyncMock()
+    describe_cm.__aenter__.return_value = describe_cur
+    describe_cm.__aexit__.return_value = None
+    conn = MagicMock()
+    conn.cursor = MagicMock(return_value=describe_cm)
+    conn_cm = AsyncMock()
+    conn_cm.__aenter__.return_value = conn
+    conn_cm.__aexit__.return_value = None
+    pool.connection = MagicMock(return_value=conn_cm)
+
+    async def fake_fetch(_conn: object, _revision_id: UUID) -> tuple:
+        return ([], {}, [], [], [])
+
+    with (
+        patch("objectified_mcp.spec_get_openapi_tool.fetch_openapi_generation_inputs_async", side_effect=fake_fetch),
+        patch("objectified_mcp.spec_get_openapi_tool.generate_openapi_spec", return_value=sample_spec),
+    ):
+
+        async def run() -> dict[str, object]:
+            return await build_spec_describe_operation_response(pool, spec_id=str(sid), path="/ping", method="get")
+
+        out = asyncio.run(run())
+
+    assert out["responses"] == {"200": {"description": "pong"}}
+
+
+def test_build_spec_describe_operation_unknown_operation() -> None:
+    sid = uuid4()
+    row = _openapi_row(spec_id=sid)
+    sample_spec: dict[str, object] = {"openapi": "3.1.0", "paths": {"/ping": {"get": {}}}}
+
+    pool = MagicMock(spec=AsyncConnectionPool)
+    describe_cur = MagicMock()
+    describe_cur.execute = AsyncMock()
+    describe_cur.fetchone = AsyncMock(return_value=row)
+    describe_cm = AsyncMock()
+    describe_cm.__aenter__.return_value = describe_cur
+    describe_cm.__aexit__.return_value = None
+    conn = MagicMock()
+    conn.cursor = MagicMock(return_value=describe_cm)
+    conn_cm = AsyncMock()
+    conn_cm.__aenter__.return_value = conn
+    conn_cm.__aexit__.return_value = None
+    pool.connection = MagicMock(return_value=conn_cm)
+
+    async def fake_fetch(_conn: object, _revision_id: UUID) -> tuple:
+        return ([], {}, [], [], [])
+
+    with (
+        patch("objectified_mcp.spec_get_openapi_tool.fetch_openapi_generation_inputs_async", side_effect=fake_fetch),
+        patch("objectified_mcp.spec_get_openapi_tool.generate_openapi_spec", return_value=sample_spec),
+    ):
+
+        async def run() -> None:
+            await build_spec_describe_operation_response(pool, spec_id=str(sid), path="/ping", method="post")
+
+        with pytest.raises(NotFoundError, match="Unknown path or method"):
+            asyncio.run(run())
+
+
+def test_build_spec_describe_operation_private_audited() -> None:
+    sid = uuid4()
+    row = _openapi_row(spec_id=sid, visibility="private")
+    auth = McpAuthContext(
+        key_id="00000000-0000-4000-8000-000000000099",
+        tenant_id=str(uuid4()),
+        label="k",
+        scope=Scope(),
+    )
+    sample_spec: dict[str, object] = {
+        "openapi": "3.1.0",
+        "paths": {"/x": {"get": {"responses": {"200": {"description": "ok"}}}}},
+    }
+
+    pool = MagicMock(spec=AsyncConnectionPool)
+    describe_cur = MagicMock()
+    describe_cur.execute = AsyncMock()
+    describe_cur.fetchone = AsyncMock(return_value=row)
+    describe_cm = AsyncMock()
+    describe_cm.__aenter__.return_value = describe_cur
+    describe_cm.__aexit__.return_value = None
+    conn = MagicMock()
+    conn.cursor = MagicMock(return_value=describe_cm)
+    conn_cm = AsyncMock()
+    conn_cm.__aenter__.return_value = conn
+    conn_cm.__aexit__.return_value = None
+    pool.connection = MagicMock(return_value=conn_cm)
+
+    async def fake_fetch(_conn: object, _revision_id: UUID) -> tuple:
+        return ([], {}, [], [], [])
+
+    with (
+        patch("objectified_mcp.spec_get_openapi_tool.fetch_openapi_generation_inputs_async", side_effect=fake_fetch),
+        patch("objectified_mcp.spec_get_openapi_tool.generate_openapi_spec", return_value=sample_spec),
+        patch("objectified_mcp.spec_get_openapi_tool.schedule_mcp_private_access_audit") as audit,
+    ):
+
+        async def run() -> None:
+            await build_spec_describe_operation_response(pool, spec_id=str(sid), path="/x", method="get", auth_ctx=auth)
+
+        asyncio.run(run())
+
+    audit.assert_called_once()
+    assert audit.call_args.kwargs["tool"] == "spec.describe_operation"
+
+
+def test_spec_describe_operation_tool_registered_on_mcp() -> None:
+    from objectified_mcp.server import mcp
+
+    async def load() -> object:
+        return await mcp.get_tool("spec.describe_operation")
+
+    tool = asyncio.run(load())
+    assert tool is not None
+    assert tool.name == "spec.describe_operation"

--- a/objectified-mcp/uv.lock
+++ b/objectified-mcp/uv.lock
@@ -951,7 +951,7 @@ wheels = [
 
 [[package]]
 name = "objectified-mcp"
-version = "0.1.22"
+version = "0.1.23"
 source = { editable = "." }
 dependencies = [
     { name = "bcrypt" },

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.27",
+  "version": "0.11.28",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -29,6 +29,7 @@ We continue to improve the platform based on your feedback with improvements and
 - MCP tool **`spec.get_openapi`** returns the generated **OpenAPI 3.1** document as JSON for a published revision UUID (same shape as REST **`GET /v1/schema/{tenant}/{project}/{version}`**): anonymous callers get **public** revisions only; with an MCP API key, **in-scope private** revisions are included; responses larger than **`OBJECTIFIED_MCP_OPENAPI_MAX_JSON_BYTES`** (default **2 MiB**) are rejected with an error described as **HTTP 413** (#3016).
 - MCP tool **`spec.export_yaml`** returns the same generated document as **`openapi_yaml`** YAML text (REST-aligned **`yaml.dump`** settings); visibility, auth, private access audit, and UTF-8 size cap match **`spec.get_openapi`** (#3017).
 - MCP tool **`spec.list_operations`** returns a compact **`[{path, method, operation_id, summary, tags}, …]`** index for a revision UUID (sorted by path then method), with the same visibility and auth rules as **`spec.get_openapi`**, without returning the full OpenAPI document; private reads are audited as **`spec.list_operations`** (#3018).
+- MCP tool **`spec.describe_operation`** returns **`parameters`** (merged path + operation), **`requestBody`**, **`responses`**, and **`security`** for a revision UUID and **`path`** / **`method`**; internal **`#/…`** **`$ref`** values are expanded; unknown paths or methods are **not-found**; visibility, auth, and private audit match **`spec.get_openapi`** (#3019).
 
 ## Importing
 - Race condition fixed in 3.0.1 specification imports


### PR DESCRIPTION
## What changed
Adds MCP tool `spec.describe_operation` that returns OpenAPI operation fragments for a published revision UUID plus `path` and `method`: merged `parameters`, `requestBody`, `responses`, and effective `security` (operation override or document default). Internal `#/…` `$ref` values are expanded recursively; external refs are left unchanged. Circular references collapse back to a `$ref` object. Same DB visibility, optional MCP auth, private access audit, and oversized-document bypass as `spec.list_operations` / `spec.get_openapi` (`apply_json_payload_cap=False`). Unknown path or HTTP method raises not-found.

## How to test
- From repo root: **`yarn build`** and **`yarn test`** (or **`cd objectified-mcp && uv run pytest`**).
- Call **`spec.describe_operation`** with a valid **`spec_id`** from **`spec.list_operations`**, a **`path`** and **`method`** from that index; confirm **`parameters`**, **`requestBody`**, **`responses`**, **`security`** match the full OpenAPI for that operation with refs expanded.
- Use a wrong **`path`** or **`method`** and expect **not-found**.

## Risk / notes
Resolved fragments can still be large for schemas with deep expansion; no separate byte cap beyond skipping the full-document JSON cap when loading the spec.

Closes #3019

Made with [Cursor](https://cursor.com)