### PR TITLE
Fix #3023 - Multi-stage Dockerfile for objectified-mcp

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+# Keeps `docker build -f objectified-mcp/Dockerfile .` contexts small and avoids copying local venvs.
+**/.venv
+.git

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,14 @@
 # Keeps `docker build -f objectified-mcp/Dockerfile .` contexts small and avoids copying local venvs.
 **/.venv
 .git
+**/node_modules
+**/dist
+**/.turbo
+**/__pycache__
+**/*.pyc
+**/*.pyo
+**/.pytest_cache
+**/.mypy_cache
+**/.ruff_cache
+**/coverage
+**/.coverage

--- a/docs/PLANNED_ROADMAP_MCP.md
+++ b/docs/PLANNED_ROADMAP_MCP.md
@@ -128,7 +128,7 @@ process or via Docker.
 
 | # | Issue | Title | Depends on |
 |---|-------|-------|------------|
-| 6.1 | [#3023](../../issues/3023) | Multi-stage Dockerfile | 1.1, 1.6 |
+| 6.1 | ~~[#3023](../../issues/3023)~~ | ~~Multi-stage Dockerfile~~ (**completed**) | 1.1, 1.6 |
 | 6.2 | [#3024](../../issues/3024) | `docker-compose.yml` (mcp + postgres) | 6.1, 2.1 |
 | 6.3 | [#3025](../../issues/3025) | `.env.example` + config docs | 1.2 |
 | 6.4 | [#3026](../../issues/3026) | Local quickstart docs (`uv run`) | 1.5, 1.6 |

--- a/objectified-mcp/Dockerfile
+++ b/objectified-mcp/Dockerfile
@@ -8,8 +8,11 @@
 FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim AS builder
 WORKDIR /build
 
-COPY objectified-rest /build/objectified-rest
-COPY objectified-mcp /build/objectified-mcp
+COPY objectified-rest/pyproject.toml /build/objectified-rest/pyproject.toml
+COPY objectified-rest/src /build/objectified-rest/src
+COPY objectified-mcp/pyproject.toml /build/objectified-mcp/pyproject.toml
+COPY objectified-mcp/uv.lock /build/objectified-mcp/uv.lock
+COPY objectified-mcp/src /build/objectified-mcp/src
 
 WORKDIR /build/objectified-mcp
 RUN --mount=type=cache,target=/root/.cache/uv \
@@ -39,4 +42,4 @@ EXPOSE 8765
 HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
     CMD python -c "import os, urllib.request; urllib.request.urlopen(f\"http://127.0.0.1:{os.environ.get('OBJECTIFIED_MCP_HTTP_PORT','8765')}/health\", timeout=4)"
 
-CMD ["objectified-mcp", "serve", "--transport", "http", "--host", "0.0.0.0"]
+CMD ["objectified-mcp", "serve", "--transport", "http"]

--- a/objectified-mcp/Dockerfile
+++ b/objectified-mcp/Dockerfile
@@ -1,0 +1,42 @@
+# syntax=docker/dockerfile:1
+
+# Multi-stage image for objectified-mcp (FastMCP streamable HTTP).
+#
+# Build from the repository root so the path dependency on objectified-rest is available:
+#   docker build -f objectified-mcp/Dockerfile .
+
+FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim AS builder
+WORKDIR /build
+
+COPY objectified-rest /build/objectified-rest
+COPY objectified-mcp /build/objectified-mcp
+
+WORKDIR /build/objectified-mcp
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-dev --compile-bytecode --no-editable
+
+FROM python:3.12-slim-bookworm AS runtime
+
+RUN useradd --create-home --uid 1000 --shell /usr/sbin/nologin mcp \
+    && mkdir -p /app \
+    && chown mcp:mcp /app
+
+WORKDIR /app
+
+COPY --from=builder --chown=mcp:mcp /build/objectified-mcp/.venv /app/.venv
+
+USER mcp
+
+ENV PATH="/app/.venv/bin:$PATH" \
+    PYTHONUNBUFFERED=1 \
+    VIRTUAL_ENV=/app/.venv
+
+ENV OBJECTIFIED_MCP_HTTP_HOST=0.0.0.0 \
+    OBJECTIFIED_MCP_HTTP_PORT=8765
+
+EXPOSE 8765
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
+    CMD python -c "import os, urllib.request; urllib.request.urlopen(f\"http://127.0.0.1:{os.environ.get('OBJECTIFIED_MCP_HTTP_PORT','8765')}/health\", timeout=4)"
+
+CMD ["objectified-mcp", "serve", "--transport", "http", "--host", "0.0.0.0"]

--- a/objectified-mcp/package.json
+++ b/objectified-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-mcp",
-  "version": "0.1.25",
+  "version": "0.1.26",
   "private": true,
   "description": "Yarn workspace anchor for the objectified-mcp Python package (uv + pyproject.toml).",
   "scripts": {

--- a/objectified-mcp/pyproject.toml
+++ b/objectified-mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "objectified-mcp"
-version = "0.1.25"
+version = "0.1.26"
 description = "Model Context Protocol server for Objectified (FastMCP)."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/objectified-mcp/src/objectified_mcp/__init__.py
+++ b/objectified-mcp/src/objectified_mcp/__init__.py
@@ -1,3 +1,3 @@
 """Objectified MCP server package."""
 
-__version__ = "0.1.25"
+__version__ = "0.1.26"

--- a/objectified-mcp/src/objectified_mcp/server.py
+++ b/objectified-mcp/src/objectified_mcp/server.py
@@ -9,6 +9,8 @@ import structlog
 from fastmcp import Context, FastMCP
 from fastmcp.dependencies import CurrentHeaders, Depends
 from fastmcp.server.lifespan import lifespan
+from starlette.requests import Request
+from starlette.responses import JSONResponse
 from structlog.contextvars import bound_contextvars
 
 from objectified_mcp.database_pool import MCP_DB_POOL_KEY, create_async_pool, get_db_pool, ping_pool
@@ -54,6 +56,12 @@ async def database_lifespan(server: Any) -> Any:
 
 mcp = FastMCP("Objectified", lifespan=database_lifespan)
 mcp.add_middleware(StashHttpBearerInToolContextMiddleware())
+
+
+@mcp.custom_route("/health", methods=["GET"])
+async def _http_health(_request: Request) -> JSONResponse:
+    """Liveness probe for load balancers and Docker HEALTHCHECK (HTTP 200; does not query Postgres)."""
+    return JSONResponse({"status": "ok"})
 
 
 @mcp.tool

--- a/objectified-mcp/tests/test_http_health_route.py
+++ b/objectified-mcp/tests/test_http_health_route.py
@@ -1,0 +1,33 @@
+"""HTTP ``/health`` custom route (Docker / load-balancer liveness)."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from starlette.middleware import Middleware as StarletteMiddleware
+from starlette.testclient import TestClient
+
+from objectified_mcp.http_credential_middleware import HttpCredentialExtractionMiddleware
+
+
+def test_health_returns_200_json(monkeypatch: pytest.MonkeyPatch, mock_pool: object) -> None:
+    monkeypatch.setenv("OBJECTIFIED_MCP_DATABASE_URL", "postgresql://localhost/db")
+    monkeypatch.setenv("OBJECTIFIED_MCP_INTERNAL_SECRET", "x" * 16)
+
+    from objectified_mcp.settings import get_settings
+
+    get_settings.cache_clear()
+
+    from objectified_mcp.server import mcp
+
+    with patch("objectified_mcp.server.create_async_pool", return_value=mock_pool):
+        app = mcp.http_app(
+            path="/mcp",
+            middleware=[StarletteMiddleware(HttpCredentialExtractionMiddleware)],
+        )
+        with TestClient(app) as client:
+            response = client.get("/health")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}

--- a/objectified-mcp/tests/test_http_health_route.py
+++ b/objectified-mcp/tests/test_http_health_route.py
@@ -19,15 +19,18 @@ def test_health_returns_200_json(monkeypatch: pytest.MonkeyPatch, mock_pool: obj
 
     get_settings.cache_clear()
 
-    from objectified_mcp.server import mcp
+    try:
+        from objectified_mcp.server import mcp
 
-    with patch("objectified_mcp.server.create_async_pool", return_value=mock_pool):
-        app = mcp.http_app(
-            path="/mcp",
-            middleware=[StarletteMiddleware(HttpCredentialExtractionMiddleware)],
-        )
-        with TestClient(app) as client:
-            response = client.get("/health")
+        with patch("objectified_mcp.server.create_async_pool", return_value=mock_pool):
+            app = mcp.http_app(
+                path="/mcp",
+                middleware=[StarletteMiddleware(HttpCredentialExtractionMiddleware)],
+            )
+            with TestClient(app) as client:
+                response = client.get("/health")
 
-    assert response.status_code == 200
-    assert response.json() == {"status": "ok"}
+        assert response.status_code == 200
+        assert response.json() == {"status": "ok"}
+    finally:
+        get_settings.cache_clear()

--- a/objectified-mcp/uv.lock
+++ b/objectified-mcp/uv.lock
@@ -951,7 +951,7 @@ wheels = [
 
 [[package]]
 name = "objectified-mcp"
-version = "0.1.25"
+version = "0.1.26"
 source = { editable = "." }
 dependencies = [
     { name = "bcrypt" },

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.30",
+  "version": "0.11.31",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -6,6 +6,7 @@ We continue to improve the platform based on your feedback with improvements and
 
 ## MCP
 
+- Multi-stage **`objectified-mcp/Dockerfile`** (uv builder + slim runtime, non-root user, **`GET /health`** liveness + **`HEALTHCHECK`**) — build from repo root: **`docker build -f objectified-mcp/Dockerfile .`** (#3023).
 - New `objectified-mcp` Python package (FastMCP, uv, ruff, mypy) as the foundation for the Model Context Protocol server.
 - MCP server loads typed configuration from the environment via pydantic-settings (`objectified-mcp serve`); **`objectified-mcp serve --transport stdio`** runs the FastMCP stdio transport for Claude Desktop and similar hosts; **`objectified-mcp serve --transport http`** exposes streamable HTTP at **`/mcp`** with configurable **`--host`** / **`--port`** (or env defaults); see `objectified-mcp/.env.example`.
 - MCP runtime opens a shared async Postgres pool (psycopg 3) at startup, exposes it to tools via lifespan context, runs a health probe (`SELECT 1`), and closes the pool cleanly on shutdown.


### PR DESCRIPTION
## Summary
Implements **MCP-6.1** (#3023): a reproducible multi-stage Docker image for `objectified-mcp` with a uv-based builder stage, `python:3.12-slim-bookworm` runtime, non-root user (`mcp` uid 1000), and an HTTP health probe.

Streamable HTTP alone does not expose a simple GET that returns **200** without SSE headers, so this adds **`GET /health`** (`{"status":"ok"}`) via FastMCP `custom_route` for load balancers and **Docker HEALTHCHECK**.

## How to test
1. From the **repository root**, run **`docker build -f objectified-mcp/Dockerfile .`**
2. Run the container with **`OBJECTIFIED_MCP_DATABASE_URL`** and **`OBJECTIFIED_MCP_INTERNAL_SECRET`** (≥16 chars) set (same as local `serve --transport http`).
3. **`curl -sf http://127.0.0.1:8765/health`** should return **200** and JSON **`{"status":"ok"}`**.
4. Confirm image size is under **250MB** (`docker image ls objectified-mcp:test`).

*(Docker CLI was not available in the agent environment; build/size verification should be run locally or in CI.)*

## Risk / notes
- New repo-root **`.dockerignore`** excludes **`**/.venv`** and **`.git`** for builds that use the repository root as context; other Dockerfiles that rely on copying `.git` from root would need adjustment (current component Dockerfiles use their own contexts).
- Runtime installs dependencies via **`uv sync --frozen --no-dev --no-editable`** so the image does not depend on editable path links into `objectified-rest` source after build.

Closes #3023

Made with [Cursor](https://cursor.com)