### PR TITLE
Fix #3024 - Docker Compose for MCP and Postgres 16

### DIFF
--- a/.github/workflows/objectified-mcp.yml
+++ b/.github/workflows/objectified-mcp.yml
@@ -6,11 +6,17 @@ on:
     paths:
       - 'objectified-mcp/**'
       - 'objectified-rest/**'
+      - 'docker-compose.yml'
+      - 'docker-compose.env.example'
+      - 'objectified-db/**'
   pull_request:
     branches: [ main, develop ]
     paths:
       - 'objectified-mcp/**'
       - 'objectified-rest/**'
+      - 'docker-compose.yml'
+      - 'docker-compose.env.example'
+      - 'objectified-db/**'
   workflow_dispatch:
 
 jobs:
@@ -21,6 +27,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Validate Docker Compose specification
+        run: docker compose config
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5

--- a/docker-compose.env.example
+++ b/docker-compose.env.example
@@ -1,0 +1,15 @@
+# Copy to `.env` in the repo root (same directory as docker-compose.yml) to override defaults.
+
+# Postgres (must match across postgres / migrate / mcp)
+# POSTGRES_USER=postgres
+# POSTGRES_PASSWORD=objectified_local_dev
+# POSTGRES_DB=objectified
+
+# Host port mapping (optional)
+# POSTGRES_PUBLISH_PORT=5432
+
+# MCP HTTP port on the host
+# OBJECTIFIED_MCP_HTTP_PORT=8765
+
+# Required by objectified-mcp at runtime (min 16 characters); compose supplies a dev default
+# OBJECTIFIED_MCP_INTERNAL_SECRET=replace-with-at-least-16-chars

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,68 @@
+# Local MCP stack: Postgres 16 (persistent volume), schema migrations, objectified-mcp (HTTP).
+# From repo root:
+#   docker compose up --build --wait
+#
+# Override secrets via environment or a `.env` file (see docker-compose.env.example).
+
+services:
+  postgres:
+    image: postgres:16-bookworm
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-objectified_local_dev}
+      POSTGRES_DB: ${POSTGRES_DB:-objectified}
+    volumes:
+      - objectified_postgres_data:/var/lib/postgresql/data
+    ports:
+      - "${POSTGRES_PUBLISH_PORT:-5432}:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U \"$$POSTGRES_USER\" -d \"$$POSTGRES_DB\""]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+      start_period: 15s
+    networks:
+      - objectified-mcp
+
+  migrate:
+    build:
+      context: ./objectified-db
+      dockerfile: Dockerfile
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-objectified_local_dev}
+      POSTGRES_HOST: postgres
+      POSTGRES_PORT: "5432"
+      POSTGRES_DB: ${POSTGRES_DB:-objectified}
+    depends_on:
+      postgres:
+        condition: service_healthy
+    restart: "no"
+    networks:
+      - objectified-mcp
+
+  mcp:
+    build:
+      context: .
+      dockerfile: objectified-mcp/Dockerfile
+    ports:
+      - "${OBJECTIFIED_MCP_HTTP_PORT:-8765}:8765"
+    environment:
+      OBJECTIFIED_MCP_DATABASE_URL: postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-objectified_local_dev}@postgres:5432/${POSTGRES_DB:-objectified}
+      OBJECTIFIED_MCP_INTERNAL_SECRET: ${OBJECTIFIED_MCP_INTERNAL_SECRET:-objectified-local-dev-secret-min-16}
+      OBJECTIFIED_MCP_HTTP_HOST: 0.0.0.0
+      OBJECTIFIED_MCP_HTTP_PORT: "8765"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
+    networks:
+      - objectified-mcp
+
+volumes:
+  objectified_postgres_data:
+
+networks:
+  objectified-mcp:
+    driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,12 +46,12 @@ services:
       context: .
       dockerfile: objectified-mcp/Dockerfile
     ports:
-      - "${OBJECTIFIED_MCP_HTTP_PORT:-8765}:8765"
+      - "${OBJECTIFIED_MCP_HTTP_PORT:-8765}:${OBJECTIFIED_MCP_HTTP_PORT:-8765}"
     environment:
       OBJECTIFIED_MCP_DATABASE_URL: postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-objectified_local_dev}@postgres:5432/${POSTGRES_DB:-objectified}
       OBJECTIFIED_MCP_INTERNAL_SECRET: ${OBJECTIFIED_MCP_INTERNAL_SECRET:-objectified-local-dev-secret-min-16}
       OBJECTIFIED_MCP_HTTP_HOST: 0.0.0.0
-      OBJECTIFIED_MCP_HTTP_PORT: "8765"
+      OBJECTIFIED_MCP_HTTP_PORT: ${OBJECTIFIED_MCP_HTTP_PORT:-8765}
     depends_on:
       postgres:
         condition: service_healthy

--- a/docs/PLANNED_ROADMAP_MCP.md
+++ b/docs/PLANNED_ROADMAP_MCP.md
@@ -129,7 +129,7 @@ process or via Docker.
 | # | Issue | Title | Depends on |
 |---|-------|-------|------------|
 | 6.1 | ~~[#3023](../../issues/3023)~~ | ~~Multi-stage Dockerfile~~ (**completed**) | 1.1, 1.6 |
-| 6.2 | [#3024](../../issues/3024) | `docker-compose.yml` (mcp + postgres) | 6.1, 2.1 |
+| 6.2 | ~~[#3024](../../issues/3024)~~ | ~~`docker-compose.yml` (mcp + postgres)~~ (**completed**) | 6.1, 2.1 |
 | 6.3 | [#3025](../../issues/3025) | `.env.example` + config docs | 1.2 |
 | 6.4 | [#3026](../../issues/3026) | Local quickstart docs (`uv run`) | 1.5, 1.6 |
 | 6.5 | [#3027](../../issues/3027) | README (overview + tools reference) | E3–E5 |

--- a/objectified-db/Dockerfile
+++ b/objectified-db/Dockerfile
@@ -26,5 +26,5 @@ ENV PATH="/opt/sem/bin:${PATH}"
 WORKDIR /app
 COPY scripts/ /app/scripts/
 
-# Run sem-apply with URL from POSTGRES_USER, POSTGRES_PASSWORD, POSTGRES_HOST, POSTGRES_PORT
-ENTRYPOINT ["/bin/sh", "-c", "sem-apply --url \"postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/\""]
+# Run sem-apply with URL from POSTGRES_* (database name defaults to objectified)
+ENTRYPOINT ["/bin/sh", "-c", "sem-apply --url \"postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB:-objectified}\""]

--- a/objectified-mcp/README.md
+++ b/objectified-mcp/README.md
@@ -14,6 +14,10 @@ uv run objectified-mcp --help
 
 Copy [.env.example](.env.example) to `.env` and set at least **`OBJECTIFIED_MCP_DATABASE_URL`** and **`OBJECTIFIED_MCP_INTERNAL_SECRET`** (minimum 16 characters). **`uv run objectified-mcp serve`** validates configuration and exits; **`uv run objectified-mcp serve --transport stdio`** runs the FastMCP stdio transport for local hosts (Claude Desktop, mcp-inspector). **`uv run objectified-mcp serve --transport http`** runs streamable HTTP (MCP endpoint **`/mcp`**); bind address and port come from **`OBJECTIFIED_MCP_HTTP_HOST`** / **`OBJECTIFIED_MCP_HTTP_PORT`** or **`--host`** / **`--port`**. Stop with Ctrl+C or **`SIGTERM`** for graceful uvicorn shutdown.
 
+### Docker Compose (Postgres + migrations + MCP)
+
+From the **repository root**, **`docker compose up --build --wait`** starts Postgres 16 with a persistent volume, applies **`objectified-db`** migrations once, then runs the MCP image on **`8765`** (override with **`OBJECTIFIED_MCP_HTTP_PORT`**). Optional env overrides are documented in [**`docker-compose.env.example`**](../docker-compose.env.example) at the repo root.
+
 When the MCP runtime starts, it opens a shared **`psycopg_pool.AsyncConnectionPool`**, runs **`SELECT 1`** against it, exposes the pool on FastMCP lifespan context under **`db_pool`**, and **`await pool.close()`** in **`finally`** so shutdown (including EOF on stdio or task cancellation) tears down connections cleanly. Pool sizing is controlled with **`OBJECTIFIED_MCP_DATABASE_POOL_MIN_SIZE`**, **`OBJECTIFIED_MCP_DATABASE_POOL_MAX_SIZE`**, and **`OBJECTIFIED_MCP_DATABASE_POOL_TIMEOUT`** (seconds to wait for a connection).
 
 ## API key read scope

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.31",
+  "version": "0.11.32",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -6,6 +6,7 @@ We continue to improve the platform based on your feedback with improvements and
 
 ## MCP
 
+- Root **`docker-compose.yml`** spins up **Postgres 16** (named volume **`objectified_postgres_data`**), a one-shot **`migrate`** image (**`objectified-db`** / schema-evolution-manager), and **`mcp`** (HTTP on **`8765`** by default); use **`docker compose up --build --wait`** from the repo root. Env overrides: **`docker-compose.env.example`** (#3024).
 - Multi-stage **`objectified-mcp/Dockerfile`** (uv builder + slim runtime, non-root user, **`GET /health`** liveness + **`HEALTHCHECK`**) — build from repo root: **`docker build -f objectified-mcp/Dockerfile .`** (#3023).
 - New `objectified-mcp` Python package (FastMCP, uv, ruff, mypy) as the foundation for the Model Context Protocol server.
 - MCP server loads typed configuration from the environment via pydantic-settings (`objectified-mcp serve`); **`objectified-mcp serve --transport stdio`** runs the FastMCP stdio transport for Claude Desktop and similar hosts; **`objectified-mcp serve --transport http`** exposes streamable HTTP at **`/mcp`** with configurable **`--host`** / **`--port`** (or env defaults); see `objectified-mcp/.env.example`.


### PR DESCRIPTION
## Summary
Adds a root `docker-compose.yml` that brings up Postgres 16 with a persistent named volume, runs `objectified-db` migrations once via schema-evolution-manager, then starts the multi-stage MCP image on HTTP (default port **8765**). Updates the migration image entrypoint so `sem-apply` targets `${POSTGRES_DB:-objectified}` instead of an unnamed database.

## How to test
1. From the repo root: **`docker compose up --build --wait`**
2. **`curl -sf http://localhost:8765/health`** (or open in a browser)
3. Optionally override secrets via **`.env`** using **`docker-compose.env.example`** as a template

## Risk / notes
- Default Postgres password and MCP internal secret are suitable for local dev only; override for any shared environment.
- If `POSTGRES_PASSWORD` contains URL-reserved characters, set `OBJECTIFIED_MCP_DATABASE_URL` explicitly in compose or use a password-safe for URLs.

Closes #3024

Made with [Cursor](https://cursor.com)