### PR TITLE
Fix #3025 - MCP .env.example and configuration docs

### DIFF
--- a/docker-compose.env.example
+++ b/docker-compose.env.example
@@ -8,8 +8,15 @@
 # Host port mapping (optional)
 # POSTGRES_PUBLISH_PORT=5432
 
-# MCP HTTP port on the host
+# MCP HTTP port on the host (must match in-container OBJECTIFIED_MCP_HTTP_PORT)
 # OBJECTIFIED_MCP_HTTP_PORT=8765
 
 # Required by objectified-mcp at runtime (min 16 characters); compose supplies a dev default
 # OBJECTIFIED_MCP_INTERNAL_SECRET=replace-with-at-least-16-chars
+
+# Optional objectified-mcp overrides (defaults documented in objectified-mcp/docs/CONFIGURATION.md)
+# OBJECTIFIED_MCP_LOG_LEVEL=INFO
+# OBJECTIFIED_MCP_DATABASE_POOL_MIN_SIZE=1
+# OBJECTIFIED_MCP_DATABASE_POOL_MAX_SIZE=10
+# OBJECTIFIED_MCP_DATABASE_POOL_TIMEOUT=30
+# OBJECTIFIED_MCP_OPENAPI_MAX_JSON_BYTES=2097152

--- a/docs/PLANNED_ROADMAP_MCP.md
+++ b/docs/PLANNED_ROADMAP_MCP.md
@@ -130,7 +130,7 @@ process or via Docker.
 |---|-------|-------|------------|
 | 6.1 | ~~[#3023](../../issues/3023)~~ | ~~Multi-stage Dockerfile~~ (**completed**) | 1.1, 1.6 |
 | 6.2 | ~~[#3024](../../issues/3024)~~ | ~~`docker-compose.yml` (mcp + postgres)~~ (**completed**) | 6.1, 2.1 |
-| 6.3 | [#3025](../../issues/3025) | `.env.example` + config docs | 1.2 |
+| 6.3 | ~~[#3025](../../issues/3025)~~ | ~~`.env.example` + config docs~~ (**completed**) | 1.2 |
 | 6.4 | [#3026](../../issues/3026) | Local quickstart docs (`uv run`) | 1.5, 1.6 |
 | 6.5 | [#3027](../../issues/3027) | README (overview + tools reference) | E3–E5 |
 | 6.6 | [#3028](../../issues/3028) | GitHub Actions CI (lint + tests) | 1.1 |

--- a/objectified-mcp/.env.example
+++ b/objectified-mcp/.env.example
@@ -1,15 +1,35 @@
-# Required for `objectified-mcp serve`
+# objectified-mcp environment (prefix OBJECTIFIED_MCP_)
+# Copy to ".env" in your working directory. Schema matches objectified_mcp.settings.Settings.
+
+# -----------------------------------------------------------------------------
+# Required (no defaults — process fails fast at startup if missing or invalid)
+# -----------------------------------------------------------------------------
+# PostgreSQL connection URI for the Objectified database.
 OBJECTIFIED_MCP_DATABASE_URL=postgresql://user:password@localhost:5432/objectified
+# Secret for internal signing (HMAC, etc.). Minimum 16 characters.
 OBJECTIFIED_MCP_INTERNAL_SECRET=replace-with-at-least-16-chars
 
-# Optional (defaults shown)
-# OBJECTIFIED_MCP_DATABASE_POOL_MIN_SIZE=1
-# OBJECTIFIED_MCP_DATABASE_POOL_MAX_SIZE=10
-# OBJECTIFIED_MCP_DATABASE_POOL_TIMEOUT=30
+# -----------------------------------------------------------------------------
+# Optional — defaults shown below match Settings in settings.py
+# -----------------------------------------------------------------------------
+# Root log level (DEBUG | INFO | WARNING | ERROR | CRITICAL).
 # OBJECTIFIED_MCP_LOG_LEVEL=INFO
+
+# Default transport in settings: stdio | http. The CLI still needs an explicit
+#   uv run objectified-mcp serve --transport stdio
+#   uv run objectified-mcp serve --transport http
+# when you want to run the server (omit both to validate env only).
 # OBJECTIFIED_MCP_TRANSPORT=stdio
-# For `objectified-mcp serve --transport http` (MCP at http://HOST:PORT/mcp):
+
+# HTTP bind address and port when using --transport http (or Docker CMD).
 # OBJECTIFIED_MCP_HTTP_HOST=127.0.0.1
 # OBJECTIFIED_MCP_HTTP_PORT=8765
-# Max UTF-8 size of JSON-serialized OpenAPI from spec.get_openapi (413-style rejection):
+
+# Async connection pool (psycopg_pool). Max must be >= min.
+# OBJECTIFIED_MCP_DATABASE_POOL_MIN_SIZE=1
+# OBJECTIFIED_MCP_DATABASE_POOL_MAX_SIZE=10
+# Seconds to wait for a connection from the pool.
+# OBJECTIFIED_MCP_DATABASE_POOL_TIMEOUT=30
+
+# Max UTF-8 size for OpenAPI JSON/YAML exports (413-style limit).
 # OBJECTIFIED_MCP_OPENAPI_MAX_JSON_BYTES=2097152

--- a/objectified-mcp/README.md
+++ b/objectified-mcp/README.md
@@ -12,6 +12,8 @@ uv run objectified-mcp --help
 
 ## Configuration
 
+Full reference (every variable, default, required flag, and validation bounds) is in **[docs/CONFIGURATION.md](docs/CONFIGURATION.md)**—it mirrors **`objectified_mcp.settings.Settings`**.
+
 Copy [.env.example](.env.example) to `.env` and set at least **`OBJECTIFIED_MCP_DATABASE_URL`** and **`OBJECTIFIED_MCP_INTERNAL_SECRET`** (minimum 16 characters). **`uv run objectified-mcp serve`** validates configuration and exits; **`uv run objectified-mcp serve --transport stdio`** runs the FastMCP stdio transport for local hosts (Claude Desktop, mcp-inspector). **`uv run objectified-mcp serve --transport http`** runs streamable HTTP (MCP endpoint **`/mcp`**); bind address and port come from **`OBJECTIFIED_MCP_HTTP_HOST`** / **`OBJECTIFIED_MCP_HTTP_PORT`** or **`--host`** / **`--port`**. Stop with Ctrl+C or **`SIGTERM`** for graceful uvicorn shutdown.
 
 ### Docker Compose (Postgres + migrations + MCP)

--- a/objectified-mcp/docs/CONFIGURATION.md
+++ b/objectified-mcp/docs/CONFIGURATION.md
@@ -1,0 +1,23 @@
+# objectified-mcp configuration
+
+Runtime configuration is loaded from the environment by [`Settings`](../src/objectified_mcp/settings.py) (pydantic-settings). All variables use the prefix **`OBJECTIFIED_MCP_`**. An optional **`.env`** file in the current working directory is read when present (`env_file=".env"`).
+
+## Variable reference
+
+| Environment variable | Required | Default | Valid range / notes |
+|---------------------|----------|---------|---------------------|
+| **`OBJECTIFIED_MCP_DATABASE_URL`** | Yes | — | PostgreSQL URL (`postgres://` or `postgresql://`). Field: `database_url`. |
+| **`OBJECTIFIED_MCP_INTERNAL_SECRET`** | Yes | — | Minimum **16** characters. Used for internal signing material (e.g. HMAC). Field: `internal_secret` (secret value). |
+| **`OBJECTIFIED_MCP_LOG_LEVEL`** | No | `INFO` | One of: `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL` (case-insensitive; normalized to uppercase). |
+| **`OBJECTIFIED_MCP_TRANSPORT`** | No | `stdio` | `stdio` or `http`. Stored on `Settings`; **`objectified-mcp serve` still requires `--transport stdio` or `--transport http` to run a transport**—without those flags the CLI validates configuration and exits. |
+| **`OBJECTIFIED_MCP_HTTP_HOST`** | No | `127.0.0.1` | Non-empty bind address when using HTTP transport (CLI `--host` overrides). |
+| **`OBJECTIFIED_MCP_HTTP_PORT`** | No | `8765` | Integer **1–65535** (CLI `--port` overrides). |
+| **`OBJECTIFIED_MCP_DATABASE_POOL_MIN_SIZE`** | No | `1` | Integer **1–256**. |
+| **`OBJECTIFIED_MCP_DATABASE_POOL_MAX_SIZE`** | No | `10` | Integer **1–256**; must be **≥** `DATABASE_POOL_MIN_SIZE`. |
+| **`OBJECTIFIED_MCP_DATABASE_POOL_TIMEOUT`** | No | `30` | Seconds to wait for a pool connection; **> 0** and **≤ 600**. |
+| **`OBJECTIFIED_MCP_OPENAPI_MAX_JSON_BYTES`** | No | `2097152` | Max UTF-8 size for exported OpenAPI JSON/YAML payloads (**1024–100_000_000**). |
+
+## Related files
+
+- **[`../.env.example`](../.env.example)** — copy/paste template for local development.
+- **Repository root [`docker-compose.env.example`](../../docker-compose.env.example)** — overrides for **`docker compose`** (Postgres + MCP port + secret).

--- a/objectified-mcp/pyproject.toml
+++ b/objectified-mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "objectified-mcp"
-version = "0.1.26"
+version = "0.1.27"
 description = "Model Context Protocol server for Objectified (FastMCP)."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/objectified-mcp/src/objectified_mcp/__init__.py
+++ b/objectified-mcp/src/objectified_mcp/__init__.py
@@ -1,3 +1,3 @@
 """Objectified MCP server package."""
 
-__version__ = "0.1.26"
+__version__ = "0.1.27"

--- a/objectified-mcp/uv.lock
+++ b/objectified-mcp/uv.lock
@@ -951,7 +951,7 @@ wheels = [
 
 [[package]]
 name = "objectified-mcp"
-version = "0.1.26"
+version = "0.1.27"
 source = { editable = "." }
 dependencies = [
     { name = "bcrypt" },

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.32",
+  "version": "0.11.33",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -6,6 +6,7 @@ We continue to improve the platform based on your feedback with improvements and
 
 ## MCP
 
+- **`objectified-mcp/docs/CONFIGURATION.md`** documents every **`OBJECTIFIED_MCP_*`** variable (required vs optional, defaults, bounds); **`objectified-mcp/.env.example`** lists the same surface for copy/paste (#3025).
 - Root **`docker-compose.yml`** spins up **Postgres 16** (named volume **`objectified_postgres_data`**), a one-shot **`migrate`** image (**`objectified-db`** / schema-evolution-manager), and **`mcp`** (HTTP on **`8765`** by default); use **`docker compose up --build --wait`** from the repo root. Env overrides: **`docker-compose.env.example`** (#3024).
 - Multi-stage **`objectified-mcp/Dockerfile`** (uv builder + slim runtime, non-root user, **`GET /health`** liveness + **`HEALTHCHECK`**) — build from repo root: **`docker build -f objectified-mcp/Dockerfile .`** (#3023).
 - New `objectified-mcp` Python package (FastMCP, uv, ruff, mypy) as the foundation for the Model Context Protocol server.


### PR DESCRIPTION
## What changed
- Added **`objectified-mcp/docs/CONFIGURATION.md`** with a table of every `OBJECTIFIED_MCP_*` variable aligned to `Settings`: required vs optional, defaults, and validation bounds.
- Expanded **`objectified-mcp/.env.example`** so every setting is listed with purpose and default-aligned commented examples.
- Linked the reference from **`objectified-mcp/README.md`** and extended root **`docker-compose.env.example`** with optional MCP overrides pointing at the doc.
- Marked roadmap ticket 6.3 complete in **`docs/PLANNED_ROADMAP_MCP.md`**, noted the work in **`objectified-ui/public/WHATS_NEW.md`**, and bumped **`objectified-mcp`** to **0.1.27** (plus **`objectified-ui`** patch for WHATS_NEW).

## How to test
1. Open **`objectified-mcp/docs/CONFIGURATION.md`** and confirm each row matches **`objectified_mcp/settings.py`**.
2. Compare **`objectified-mcp/.env.example`** to `Settings` fields (same names under `OBJECTIFIED_MCP_` prefix).
3. No runtime behavior changes; **`yarn build`** and **`yarn test`** were run successfully from the repo root.

## Risk / notes
Documentation-only plus patch version bumps; low risk.

Closes #3025

Made with [Cursor](https://cursor.com)