### PR TITLE
Fix #3026 - Local quickstart docs (uv run)

### DIFF
--- a/docs/PLANNED_ROADMAP_MCP.md
+++ b/docs/PLANNED_ROADMAP_MCP.md
@@ -131,7 +131,7 @@ process or via Docker.
 | 6.1 | ~~[#3023](../../issues/3023)~~ | ~~Multi-stage Dockerfile~~ (**completed**) | 1.1, 1.6 |
 | 6.2 | ~~[#3024](../../issues/3024)~~ | ~~`docker-compose.yml` (mcp + postgres)~~ (**completed**) | 6.1, 2.1 |
 | 6.3 | ~~[#3025](../../issues/3025)~~ | ~~`.env.example` + config docs~~ (**completed**) | 1.2 |
-| 6.4 | [#3026](../../issues/3026) | Local quickstart docs (`uv run`) | 1.5, 1.6 |
+| 6.4 | ~~[#3026](../../issues/3026)~~ | ~~Local quickstart docs (`uv run`)~~ (**completed**) | 1.5, 1.6 |
 | 6.5 | [#3027](../../issues/3027) | README (overview + tools reference) | E3–E5 |
 | 6.6 | [#3028](../../issues/3028) | GitHub Actions CI (lint + tests) | 1.1 |
 

--- a/objectified-mcp/README.md
+++ b/objectified-mcp/README.md
@@ -8,7 +8,7 @@ Use **[uv](https://docs.astral.sh/uv/)** with **Python ≥ 3.11**. Environment v
 
 ### Database
 
-The server needs PostgreSQL with the Objectified schema applied; startup fails if the pool cannot connect.
+The server needs PostgreSQL with the Objectified schema applied. Startup fails if the connection pool cannot open; a failed initial `SELECT 1` probe only logs a warning and the server continues.
 
 **Option A — Docker from the repository root** (Postgres + migrations only; does not start the MCP image):
 
@@ -22,7 +22,7 @@ With default **`docker-compose.yml`** credentials, set **`OBJECTIFIED_MCP_DATABA
 
 **Option B — Your own cluster** — use any migrated database URI in **`OBJECTIFIED_MCP_DATABASE_URL`**.
 
-### Install, env, and run (five commands)
+### Install, env, and run
 
 After the database is ready:
 

--- a/objectified-mcp/README.md
+++ b/objectified-mcp/README.md
@@ -2,19 +2,55 @@
 
 Python **FastMCP** service for exposing Objectified OpenAPI specifications over the Model Context Protocol.
 
-Local development uses **[uv](https://docs.astral.sh/uv/)**:
+## Local quickstart (uv, no MCP container)
+
+Use **[uv](https://docs.astral.sh/uv/)** with **Python ≥ 3.11**. Environment variables are loaded from **`.env`** in your **current working directory**—run commands from **`objectified-mcp/`** after **`cd`**.
+
+### Database
+
+The server needs PostgreSQL with the Objectified schema applied; startup fails if the pool cannot connect.
+
+**Option A — Docker from the repository root** (Postgres + migrations only; does not start the MCP image):
+
+```bash
+docker compose up -d postgres && docker compose run --rm migrate
+```
+
+With default **`docker-compose.yml`** credentials, set **`OBJECTIFIED_MCP_DATABASE_URL`** to:
+
+`postgresql://postgres:objectified_local_dev@localhost:5432/objectified`
+
+**Option B — Your own cluster** — use any migrated database URI in **`OBJECTIFIED_MCP_DATABASE_URL`**.
+
+### Install, env, and run (five commands)
+
+After the database is ready:
 
 ```bash
 cd objectified-mcp
 uv sync
-uv run objectified-mcp --help
+cp .env.example .env
 ```
+
+Edit **`.env`**: set **`OBJECTIFIED_MCP_DATABASE_URL`** and **`OBJECTIFIED_MCP_INTERNAL_SECRET`** (minimum **16** characters). Every **`OBJECTIFIED_MCP_*`** variable is documented in **[docs/CONFIGURATION.md](docs/CONFIGURATION.md)**.
+
+**Stdio** (Claude Desktop, MCP Inspector):
+
+```bash
+uv run objectified-mcp serve --transport stdio
+```
+
+**HTTP** (streamable MCP at **`http://<host>:<port>/mcp`**; bind **`OBJECTIFIED_MCP_HTTP_HOST`** / **`OBJECTIFIED_MCP_HTTP_PORT`** or **`--host`** / **`--port`**):
+
+```bash
+uv run objectified-mcp serve --transport http
+```
+
+**`uv run objectified-mcp serve`** without **`--transport`** loads settings and exits—use that to verify **`.env`** after edits. Stop a running server with **Ctrl+C** or **`SIGTERM`** (HTTP uses graceful uvicorn shutdown).
 
 ## Configuration
 
-Full reference (every variable, default, required flag, and validation bounds) is in **[docs/CONFIGURATION.md](docs/CONFIGURATION.md)**—it mirrors **`objectified_mcp.settings.Settings`**.
-
-Copy [.env.example](.env.example) to `.env` and set at least **`OBJECTIFIED_MCP_DATABASE_URL`** and **`OBJECTIFIED_MCP_INTERNAL_SECRET`** (minimum 16 characters). **`uv run objectified-mcp serve`** validates configuration and exits; **`uv run objectified-mcp serve --transport stdio`** runs the FastMCP stdio transport for local hosts (Claude Desktop, mcp-inspector). **`uv run objectified-mcp serve --transport http`** runs streamable HTTP (MCP endpoint **`/mcp`**); bind address and port come from **`OBJECTIFIED_MCP_HTTP_HOST`** / **`OBJECTIFIED_MCP_HTTP_PORT`** or **`--host`** / **`--port`**. Stop with Ctrl+C or **`SIGTERM`** for graceful uvicorn shutdown.
+Full reference (defaults, bounds, required flags) is **[docs/CONFIGURATION.md](docs/CONFIGURATION.md)**—it mirrors **`objectified_mcp.settings.Settings`**.
 
 ### Docker Compose (Postgres + migrations + MCP)
 

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.33",
+  "version": "0.11.34",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -6,6 +6,7 @@ We continue to improve the platform based on your feedback with improvements and
 
 ## MCP
 
+- **`objectified-mcp/README.md`** local quickstart: **`uv sync`**, **`.env`** (**`OBJECTIFIED_MCP_DATABASE_URL`**, **`OBJECTIFIED_MCP_INTERNAL_SECRET`**), **`uv run objectified-mcp serve --transport stdio`** or **`--transport http`**; optional Postgres+migrate via **`docker compose`** without the MCP image (#3026).
 - **`objectified-mcp/docs/CONFIGURATION.md`** documents every **`OBJECTIFIED_MCP_*`** variable (required vs optional, defaults, bounds); **`objectified-mcp/.env.example`** lists the same surface for copy/paste (#3025).
 - Root **`docker-compose.yml`** spins up **Postgres 16** (named volume **`objectified_postgres_data`**), a one-shot **`migrate`** image (**`objectified-db`** / schema-evolution-manager), and **`mcp`** (HTTP on **`8765`** by default); use **`docker compose up --build --wait`** from the repo root. Env overrides: **`docker-compose.env.example`** (#3024).
 - Multi-stage **`objectified-mcp/Dockerfile`** (uv builder + slim runtime, non-root user, **`GET /health`** liveness + **`HEALTHCHECK`**) — build from repo root: **`docker build -f objectified-mcp/Dockerfile .`** (#3023).


### PR DESCRIPTION
## Summary
Adds a **Local quickstart** section to `objectified-mcp/README.md` for running the MCP server with **uv** (no MCP Docker image): Postgres + migrations via compose, `uv sync`, `.env` setup, and **stdio** vs **HTTP** transports.

## How to test
1. From repo root: **`docker compose up -d postgres && docker compose run --rm migrate`**
2. **`cd objectified-mcp`**, **`uv sync`**, **`cp .env.example .env`**, set URL + secret in **`.env`**
3. **`uv run objectified-mcp serve --transport http`** (or **`--transport stdio`**)

## Risk / notes
Documentation-only; roadmap + WHATS_NEW + UI patch version per repo conventions.

Closes #3026

Made with [Cursor](https://cursor.com)