### PR TITLE
Fix #3027 - MCP README (overview + tools + roadmap links)

### DIFF
--- a/docs/PLANNED_ROADMAP_MCP.md
+++ b/docs/PLANNED_ROADMAP_MCP.md
@@ -132,7 +132,7 @@ process or via Docker.
 | 6.2 | ~~[#3024](../../issues/3024)~~ | ~~`docker-compose.yml` (mcp + postgres)~~ (**completed**) | 6.1, 2.1 |
 | 6.3 | ~~[#3025](../../issues/3025)~~ | ~~`.env.example` + config docs~~ (**completed**) | 1.2 |
 | 6.4 | ~~[#3026](../../issues/3026)~~ | ~~Local quickstart docs (`uv run`)~~ (**completed**) | 1.5, 1.6 |
-| 6.5 | [#3027](../../issues/3027) | README (overview + tools reference) | E3–E5 |
+| 6.5 | ~~[#3027](../../issues/3027)~~ | ~~README (overview + tools reference)~~ (**completed**) | E3–E5 |
 | 6.6 | [#3028](../../issues/3028) | GitHub Actions CI (lint + tests) | 1.1 |
 
 ### Suggested parallelism

--- a/objectified-mcp/README.md
+++ b/objectified-mcp/README.md
@@ -1,30 +1,100 @@
 # objectified-mcp
 
-Python **FastMCP** service for exposing Objectified OpenAPI specifications over the Model Context Protocol.
+Python [**FastMCP**](https://github.com/jlowin/fastmcp) service that exposes Objectified **published OpenAPI** specifications to MCP hosts (IDEs, Claude Desktop, automation, etc.) over **stdio** or **streamable HTTP**. The server is **read-only** for the MVP: it lists, searches, and returns documents and fragments from **PostgreSQL** using SQL views and scoped API keys—no Redis or other infrastructure.
 
-## Local quickstart (uv, no MCP container)
+---
 
-Use **[uv](https://docs.astral.sh/uv/)** with **Python ≥ 3.11**. Environment variables are loaded from **`.env`** in your **current working directory**—run commands from **`objectified-mcp/`** after **`cd`**.
+## Architecture
 
-### Database
+MCP hosts talk to a single async Python process. That process keeps one shared **`psycopg`** async connection pool for all tools; authentication and visibility rules are enforced in SQL and Python helpers (`scope` ∩ revision visibility).
 
-The server needs PostgreSQL with the Objectified schema applied. Startup fails if the connection pool cannot open; a failed initial `SELECT 1` probe only logs a warning and the server continues.
-
-**Option A — Docker from the repository root** (Postgres + migrations only; does not start the MCP image):
-
-```bash
-docker compose up -d postgres && docker compose run --rm migrate
+```
+┌────────────┐   stdio / streamable HTTP   ┌─────────────────────────┐
+│  MCP host  │ ──────────────────────────▶ │   objectified-mcp       │
+│ (Claude,   │                             │   FastMCP service       │
+│  IDE, …)   │ ◀────────────────────────── │   (Python, async)       │
+└────────────┘                             └────────────┬────────────┘
+                                                        │ psycopg async pool
+                                                        ▼
+                                            ┌─────────────────────────┐
+                                            │       Postgres          │
+                                            │  (Objectified schema +  │
+                                            │   mcp_api_keys,         │
+                                            │   mcp_access_audit,     │
+                                            │   mcp_v_public_specs)   │
+                                            └─────────────────────────┘
 ```
 
-With default **`docker-compose.yml`** credentials, set **`OBJECTIFIED_MCP_DATABASE_URL`** to:
+- **Datastore:** Postgres only (Objectified migrations applied). Pool opens at startup; failed `SELECT 1` probe logs a warning but the server still runs.
+- **Public catalog:** Anonymous callers use SQL views over **published, public** revisions (e.g. `odb.mcp_v_public_specs`).
+- **Private revisions:** Valid **MCP API keys** (hashed in `odb.mcp_api_keys`) unlock **in-scope** private published revisions for the key’s tenant; see [Authentication](#authentication).
+- **Observability:** Structured JSON logs on stderr (`structlog`). HTTP exposes **`GET /health`** (liveness, no DB).
 
-`postgresql://postgres:objectified_local_dev@localhost:5432/objectified`
+Canonical planning doc: [**Planned Roadmap — MCP Server**](../docs/PLANNED_ROADMAP_MCP.md).
 
-**Option B — Your own cluster** — use any migrated database URI in **`OBJECTIFIED_MCP_DATABASE_URL`**.
+---
 
-### Install, env, and run
+## Transports
 
-After the database is ready:
+| Transport | Entry | Notes |
+|-----------|--------|--------|
+| **stdio** | `uv run objectified-mcp serve --transport stdio` | For local hosts (Claude Desktop, MCP Inspector). Credentials for tools can be passed via `tools/call` **`_meta`** (see [Authentication](#authentication)). |
+| **Streamable HTTP** | `uv run objectified-mcp serve --transport http` | MCP endpoint at **`http://<host>:<port>/mcp`** (bind with **`OBJECTIFIED_MCP_HTTP_HOST`** / **`OBJECTIFIED_MCP_HTTP_PORT`** or **`--host`** / **`--port`**). Bearer tokens are read from **`Authorization`** per request. |
+
+Running **`uv run objectified-mcp serve`** without **`--transport`** loads settings and exits—useful to validate **`.env`**.
+
+---
+
+## MCP tools
+
+| Tool | Summary |
+|------|---------|
+| **`ping`** | Service id, package version, UTC timestamp, Postgres reachability (`db_ok` / `db_error`). |
+| **`spec.list`** | Cursor-paginated list of published specs. Anonymous: public catalog only. With **`Authorization: Bearer`**, merges in-scope public rows and in-scope **private** revisions for the key’s tenant. Optional **`tenant_id`** / **`project_id`**, **`limit`** (default 50, max 100), **`cursor`** / **`next_cursor`**. |
+| **`spec.list_my_specs`** | Same response shape as **`spec.list`**, but **requires** a valid API key; rejects anonymous callers. Optional audit logging for private reads. |
+| **`spec.describe`** | Metadata for one revision UUID (`id`, `title`, `version`, `description`, `owner`, `tags`, `updated_at`). Anonymous: public only; with Bearer, includes in-scope private revisions. |
+| **`spec.search`** | Keyword search over **public** specs (title, description, tags). Requires non-empty **`q`**; ranked results; cursor pagination. |
+| **`spec.list_tags`** | Distinct public tag names with counts; sorted by count; short **in-memory** cache (60s). |
+| **`spec.get_openapi`** | Full generated OpenAPI **JSON** for a revision UUID (same visibility rules as describe). Size capped by **`OBJECTIFIED_MCP_OPENAPI_MAX_JSON_BYTES`**. |
+| **`spec.export_yaml`** | Same as **`spec.get_openapi`** but **YAML** text field; same cap semantics. |
+| **`spec.list_operations`** | Compact index of HTTP operations (`path`, `method`, `operation_id`, summary, tags). |
+| **`spec.describe_operation`** | Fragments for one operation: `parameters`, `requestBody`, `responses`, `security`; internal `$ref` expanded. |
+| **`spec.list_components`** | Component keys grouped by kind (`schemas`, `parameters`, `responses`, `securitySchemes`). |
+| **`spec.describe_component`** | Single component definition by **`kind`** + **`name`**; internal `$ref` expanded. |
+
+Tool implementations live in `src/objectified_mcp/server.py` and sibling `*_tool.py` modules.
+
+---
+
+## Authentication
+
+- **HTTP:** **`Authorization: Bearer <secret>`** is parsed by ASGI middleware and attached to tool context. Missing or non-Bearer → **anonymous** for optional-auth tools.
+- **stdio:** Hosts may supply secrets via **`tools/call`** **`params._meta`** (`authorization`, `objectified_authorization`, `objectified_api_key`, or `api_key`) as documented in `mcp_auth.py`.
+- **Storage:** Keys live in **`odb.mcp_api_keys`**; secrets are verified with **SHA-256 then bcrypt**. Scope is JSON (`tenants`, `projects` UUID lists) parsed into **`Scope`**; **`spec.list_my_specs`** uses **`Depends(require_mcp_auth)`**.
+- **Scopes:** **`Scope.allows(tenant_id, project_id)`** combines with revision visibility (`authorize_spec` / SQL predicates). Details: [API key read scope](#api-key-read-scope) below and [**CONFIGURATION.md**](docs/CONFIGURATION.md).
+
+---
+
+## Deployment
+
+### Local (uv)
+
+Use **[uv](https://docs.astral.sh/uv/)** with **Python ≥ 3.11**. Env files are read from **`.env`** in the **current working directory**—run from **`objectified-mcp/`**.
+
+**Database**
+
+- **Option A — Docker from repo root** (Postgres + migrations only):
+
+  ```bash
+  docker compose up -d postgres && docker compose run --rm migrate
+  ```
+
+  With default compose credentials, set **`OBJECTIFIED_MCP_DATABASE_URL`** to  
+  `postgresql://postgres:objectified_local_dev@localhost:5432/objectified`
+
+- **Option B:** Any Postgres URI that already has Objectified migrations applied.
+
+**Install and run**
 
 ```bash
 cd objectified-mcp
@@ -32,36 +102,125 @@ uv sync
 cp .env.example .env
 ```
 
-Edit **`.env`**: set **`OBJECTIFIED_MCP_DATABASE_URL`** and **`OBJECTIFIED_MCP_INTERNAL_SECRET`** (minimum **16** characters). Every **`OBJECTIFIED_MCP_*`** variable is documented in **[docs/CONFIGURATION.md](docs/CONFIGURATION.md)**.
-
-**Stdio** (Claude Desktop, MCP Inspector):
+Edit **`.env`**: **`OBJECTIFIED_MCP_DATABASE_URL`**, **`OBJECTIFIED_MCP_INTERNAL_SECRET`** (minimum **16** characters). All **`OBJECTIFIED_MCP_*`** variables are documented in **[docs/CONFIGURATION.md](docs/CONFIGURATION.md)**.
 
 ```bash
 uv run objectified-mcp serve --transport stdio
-```
-
-**HTTP** (streamable MCP at **`http://<host>:<port>/mcp`**; bind **`OBJECTIFIED_MCP_HTTP_HOST`** / **`OBJECTIFIED_MCP_HTTP_PORT`** or **`--host`** / **`--port`**):
-
-```bash
+# or
 uv run objectified-mcp serve --transport http
 ```
 
-**`uv run objectified-mcp serve`** without **`--transport`** loads settings and exits—use that to verify **`.env`** after edits. Stop a running server with **Ctrl+C** or **`SIGTERM`** (HTTP uses graceful uvicorn shutdown).
+Stop with **Ctrl+C** or **`SIGTERM`** (HTTP shuts down gracefully).
+
+### Docker Compose (Postgres + migrations + MCP image)
+
+From the **repository root**, **`docker compose up --build --wait`** starts Postgres 16 (persistent volume), runs **`migrate`** once, then the MCP service on port **`8765`** by default. Overrides: [**`docker-compose.env.example`**](../docker-compose.env.example).
+
+### Container image
+
+Multi-stage **`Dockerfile`** in this directory: build from repo root with  
+**`docker build -f objectified-mcp/Dockerfile .`**. Includes non-root user, **`GET /health`**, and **`HEALTHCHECK`**.
+
+---
 
 ## Configuration
 
-Full reference (defaults, bounds, required flags) is **[docs/CONFIGURATION.md](docs/CONFIGURATION.md)**—it mirrors **`objectified_mcp.settings.Settings`**.
+Full reference: **[docs/CONFIGURATION.md](docs/CONFIGURATION.md)** (defaults, bounds, required variables)—aligned with **`objectified_mcp.settings.Settings`**.
 
-### Docker Compose (Postgres + migrations + MCP)
-
-From the **repository root**, **`docker compose up --build --wait`** starts Postgres 16 with a persistent volume, applies **`objectified-db`** migrations once, then runs the MCP image on **`8765`** (override with **`OBJECTIFIED_MCP_HTTP_PORT`**). Optional env overrides are documented in [**`docker-compose.env.example`**](../docker-compose.env.example) at the repo root.
-
-When the MCP runtime starts, it opens a shared **`psycopg_pool.AsyncConnectionPool`**, runs **`SELECT 1`** against it, exposes the pool on FastMCP lifespan context under **`db_pool`**, and **`await pool.close()`** in **`finally`** so shutdown (including EOF on stdio or task cancellation) tears down connections cleanly. Pool sizing is controlled with **`OBJECTIFIED_MCP_DATABASE_POOL_MIN_SIZE`**, **`OBJECTIFIED_MCP_DATABASE_POOL_MAX_SIZE`**, and **`OBJECTIFIED_MCP_DATABASE_POOL_TIMEOUT`** (seconds to wait for a connection).
+---
 
 ## API key read scope
 
-`odb.mcp_api_keys.scope_json` stores **`{"tenants": [...], "projects": [...]}`** (UUID strings). The Python type is **`objectified_mcp.scope.Scope`**: empty **`tenants`** means any tenant; empty **`projects`** means any project within the tenant constraint; **`Scope.allows(tenant_id, project_id)`** returns whether a read is permitted. Parse DB payloads with **`parse_scope_json`**.
+`odb.mcp_api_keys.scope_json` stores **`{"tenants": [...], "projects": [...]}`** (UUID strings). The Python type is **`objectified_mcp.scope.Scope`**: empty **`tenants`** means any tenant; empty **`projects`** means any project within the tenant constraint; **`Scope.allows(tenant_id, project_id)`** gates reads. Parse payloads with **`parse_scope_json`**.
+
+---
 
 ## Logging
 
-Logs go to **stderr** as **JSON** (via **structlog**), one object per line. Each line includes **`timestamp`** (UTC ISO-8601), **`level`**, **`event`**, **`request_id`**, and **`tool_name`** (use **`structlog.contextvars.bound_contextvars`** around MCP tool handlers so tool calls carry the RPC id and tool name). Root verbosity is set with **`OBJECTIFIED_MCP_LOG_LEVEL`** (`DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`).
+Logs go to **stderr** as one JSON object per line (**structlog**): **`timestamp`** (UTC ISO-8601), **`level`**, **`event`**, **`request_id`**, **`tool_name`**. Verbosity: **`OBJECTIFIED_MCP_LOG_LEVEL`** (`DEBUG` … `CRITICAL`).
+
+---
+
+## Roadmap documentation
+
+Links below are relative to this directory (`objectified-mcp/`).
+
+### MCP planning
+
+- [Planned Roadmap — MCP Server (FastMCP + Postgres)](../docs/PLANNED_ROADMAP_MCP.md)
+- [Model Context Protocol (MCP) Server Roadmap](../docs/PLANNED_FEATURE_ROADMAP_MCP.md)
+- [Planned Feature Roadmap — AI](../docs/PLANNED_FEATURE_ROADMAP_AI.md)
+
+### Product hubs
+
+- [Current Roadmap](../docs/CURRENT_ROADMAP.md)
+- [Feature Roadmap](../docs/FEATURE_ROADMAP.md)
+- [Roadmap offerings inventory](../docs/ROADMAP_OFFERINGS_INVENTORY.md)
+- [Planned features](../docs/PLANNED_FEATURES.md)
+
+### Finished / archived roadmap
+
+- [Planned Feature Roadmap — Versioning (finished)](../docs/finished/PLANNED_FEATURE_ROADMAP_VERSIONING.md)
+
+### Package-specific
+
+- [objectified-ui — Planned Feature Roadmap — Paths](../objectified-ui/docs/PLANNED_FEATURE_ROADMAP_PATHS.md)
+- [objectified-browse — Feature Roadmap](../objectified-browse/FEATURE_ROADMAP.md)
+
+### Future themed roadmaps (`docs/`)
+
+- [Future — Academy](../docs/FUTURE_FEATURE_ROADMAP_ACADEMY.md)
+- [Future — AI](../docs/FUTURE_FEATURE_ROADMAP_AI.md)
+- [Future — Analytics](../docs/FUTURE_FEATURE_ROADMAP_ANALYTICS.md)
+- [Future — API keys](../docs/FUTURE_FEATURE_ROADMAP_API_KEYS.md)
+- [Future — Architect](../docs/FUTURE_FEATURE_ROADMAP_ARCHITECT.md)
+- [Future — Automation](../docs/FUTURE_FEATURE_ROADMAP_AUTOMATION.md)
+- [Future — Browser](../docs/FUTURE_FEATURE_ROADMAP_BROWSER.md)
+- [Future — Canvas](../docs/FUTURE_FEATURE_ROADMAP_CANVAS.md)
+- [Future — Code generation](../docs/FUTURE_FEATURE_ROADMAP_CODE_GENERATION.md)
+- [Future — Collaboration](../docs/FUTURE_FEATURE_ROADMAP_COLLABORATION.md)
+- [Future — Connect](../docs/FUTURE_FEATURE_ROADMAP_CONNECT.md)
+- [Future — Contracts](../docs/FUTURE_FEATURE_ROADMAP_CONTRACTS.md)
+- [Future — Copilot](../docs/FUTURE_FEATURE_ROADMAP_COPILOT.md)
+- [Future — Dashboard](../docs/FUTURE_FEATURE_ROADMAP_DASHBOARD.md)
+- [Future — Database](../docs/FUTURE_FEATURE_ROADMAP_DATABASE.md)
+- [Future — Data transform](../docs/FUTURE_FEATURE_ROADMAP_DATA_TRANSFORM.md)
+- [Future — Detective](../docs/FUTURE_FEATURE_ROADMAP_DETECTIVE.md)
+- [Future — DevEx](../docs/FUTURE_FEATURE_ROADMAP_DEVEX.md)
+- [Future — Diff](../docs/FUTURE_FEATURE_ROADMAP_DIFF.md)
+- [Future — Enterprise hub](../docs/FUTURE_FEATURE_ROADMAP_ENTERPRISE_HUB.md)
+- [Future — Gateway](../docs/FUTURE_FEATURE_ROADMAP_GATEWAY.md)
+- [Future — Git-like](../docs/FUTURE_FEATURE_ROADMAP_GITLIKE.md)
+- [Future — Git-like improvements](../docs/FUTURE_FEATURE_ROADMAP_GITLIKE_IMPROVEMENTS.md)
+- [Future — Governance](../docs/FUTURE_FEATURE_ROADMAP_GOVERNANCE.md)
+- [Future — Import](../docs/FUTURE_FEATURE_ROADMAP_IMPORT.md)
+- [Future — Insights](../docs/FUTURE_FEATURE_ROADMAP_INSIGHTS.md)
+- [Future — Integrations](../docs/FUTURE_FEATURE_ROADMAP_INTEGRATIONS.md)
+- [Future — Linting](../docs/FUTURE_FEATURE_ROADMAP_LINTING.md)
+- [Future — Localization](../docs/FUTURE_FEATURE_ROADMAP_LOCALIZATION.md)
+- [Future — Mock server](../docs/FUTURE_FEATURE_ROADMAP_MOCK_SERVER.md)
+- [Future — Monetization](../docs/FUTURE_FEATURE_ROADMAP_MONETIZATION.md)
+- [Future — Monitoring](../docs/FUTURE_FEATURE_ROADMAP_MONITORING.md)
+- [Future — Mobile SDK](../docs/FUTURE_FEATURE_ROADMAP_MOBILE_SDK.md)
+- [Future — Multi-protocol](../docs/FUTURE_FEATURE_ROADMAP_MULTI_PROTOCOL.md)
+- [Future — Nginx](../docs/FUTURE_FEATURE_ROADMAP_NGINX.md)
+- [Future — Offline](../docs/FUTURE_FEATURE_ROADMAP_OFFLINE.md)
+- [Future — Package manager](../docs/FUTURE_FEATURE_ROADMAP_PACKAGE_MANAGER.md)
+- [Future — Paths first](../docs/FUTURE_FEATURE_ROADMAP_PATHS_FIRST.md)
+- [Future — Paths second](../docs/FUTURE_FEATURE_ROADMAP_PATHS_SECOND.md)
+- [Future — Playground](../docs/FUTURE_FEATURE_ROADMAP_PLAYGROUND.md)
+- [Future — Portal](../docs/FUTURE_FEATURE_ROADMAP_PORTAL.md)
+- [Future — Predict](../docs/FUTURE_FEATURE_ROADMAP_PREDICT.md)
+- [Future — Profile](../docs/FUTURE_FEATURE_ROADMAP_PROFILE.md)
+- [Future — Roles](../docs/FUTURE_FEATURE_ROADMAP_ROLES.md)
+- [Future — Schema showcase](../docs/FUTURE_FEATURE_ROADMAP_SCHEMA_SHOWCASE.md)
+- [Future — Security](../docs/FUTURE_FEATURE_ROADMAP_SECURITY.md)
+- [Future — Shield](../docs/FUTURE_FEATURE_ROADMAP_SHIELD.md)
+- [Future — Sync](../docs/FUTURE_FEATURE_ROADMAP_SYNC.md)
+- [Future — Template marketplace](../docs/FUTURE_FEATURE_ROADMAP_TEMPLATE_MARKETPLACE.md)
+- [Future — Templates](../docs/FUTURE_FEATURE_ROADMAP_TEMPLATES.md)
+- [Future — Tenancy](../docs/FUTURE_FEATURE_ROADMAP_TENANCY.md)
+- [Future — Test lab](../docs/FUTURE_FEATURE_ROADMAP_TEST_LAB.md)
+- [Future — Testing](../docs/FUTURE_FEATURE_ROADMAP_TESTING.md)
+- [Future — UI](../docs/FUTURE_FEATURE_ROADMAP_UI.md)
+- [Future — Validation](../docs/FUTURE_FEATURE_ROADMAP_VALIDATION.md)

--- a/objectified-mcp/pyproject.toml
+++ b/objectified-mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "objectified-mcp"
-version = "0.1.27"
+version = "0.1.28"
 description = "Model Context Protocol server for Objectified (FastMCP)."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/objectified-mcp/src/objectified_mcp/__init__.py
+++ b/objectified-mcp/src/objectified_mcp/__init__.py
@@ -1,3 +1,3 @@
 """Objectified MCP server package."""
 
-__version__ = "0.1.27"
+__version__ = "0.1.28"

--- a/objectified-mcp/uv.lock
+++ b/objectified-mcp/uv.lock
@@ -951,7 +951,7 @@ wheels = [
 
 [[package]]
 name = "objectified-mcp"
-version = "0.1.27"
+version = "0.1.28"
 source = { editable = "." }
 dependencies = [
     { name = "bcrypt" },

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.34",
+  "version": "0.11.35",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -6,7 +6,7 @@ We continue to improve the platform based on your feedback with improvements and
 
 ## MCP
 
-- **`objectified-mcp/README.md`** local quickstart: **`uv sync`**, **`.env`** (**`OBJECTIFIED_MCP_DATABASE_URL`**, **`OBJECTIFIED_MCP_INTERNAL_SECRET`**), **`uv run objectified-mcp serve --transport stdio`** or **`--transport http`**; optional Postgres+migrate via **`docker compose`** without the MCP image (#3026).
+- **`objectified-mcp/README.md`** — MCP package overview: architecture, transports, **tools** reference, auth, deployment, roadmap links; **local quickstart**: **`uv sync`**, **`.env`** (**`OBJECTIFIED_MCP_DATABASE_URL`**, **`OBJECTIFIED_MCP_INTERNAL_SECRET`**), **`uv run objectified-mcp serve --transport stdio`** or **`--transport http`**; optional Postgres+migrate via **`docker compose`** without the MCP image (#3027, #3026).
 - **`objectified-mcp/docs/CONFIGURATION.md`** documents every **`OBJECTIFIED_MCP_*`** variable (required vs optional, defaults, bounds); **`objectified-mcp/.env.example`** lists the same surface for copy/paste (#3025).
 - Root **`docker-compose.yml`** spins up **Postgres 16** (named volume **`objectified_postgres_data`**), a one-shot **`migrate`** image (**`objectified-db`** / schema-evolution-manager), and **`mcp`** (HTTP on **`8765`** by default); use **`docker compose up --build --wait`** from the repo root. Env overrides: **`docker-compose.env.example`** (#3024).
 - Multi-stage **`objectified-mcp/Dockerfile`** (uv builder + slim runtime, non-root user, **`GET /health`** liveness + **`HEALTHCHECK`**) — build from repo root: **`docker build -f objectified-mcp/Dockerfile .`** (#3023).


### PR DESCRIPTION
## What was done and why

Issue **MCP-6.5** asked for a proper entry-point README for `objectified-mcp`: architecture, transports, tools reference, auth, deployment, and links to roadmap documentation.

- Expanded [`objectified-mcp/README.md`](https://github.com/KenSuenobu/objectified-commercial/blob/ticket-3027/objectified-mcp/README.md) with an architecture diagram (aligned with [`docs/PLANNED_ROADMAP_MCP.md`](https://github.com/KenSuenobu/objectified-commercial/blob/main/docs/PLANNED_ROADMAP_MCP.md)), transport comparison, full MCP **tools** table, authentication summary, consolidated deployment (`uv`, Docker Compose, image), configuration pointer, scope/logging sections, and a **Roadmap documentation** section linking every `*ROADMAP*` markdown file in the repo (plus related hubs).
- Marked ticket **6.5** complete in [`docs/PLANNED_ROADMAP_MCP.md`](https://github.com/KenSuenobu/objectified-commercial/blob/main/docs/PLANNED_ROADMAP_MCP.md).
- Bumped `objectified-mcp` patch version to **0.1.28** (`pyproject.toml`, `__init__.py`, lockfile) and noted the README in [`objectified-ui/public/WHATS_NEW.md`](https://github.com/KenSuenobu/objectified-commercial/blob/main/objectified-ui/public/WHATS_NEW.md); bumped `objectified-ui` patch per release-notes convention.

## How to test it

1. Open [`objectified-mcp/README.md`](https://github.com/KenSuenobu/objectified-commercial/blob/ticket-3027/objectified-mcp/README.md) on GitHub or locally and confirm sections render (tables, code fence diagram, relative links from `objectified-mcp/`).
2. **Click several roadmap links** (e.g. `../docs/PLANNED_ROADMAP_MCP.md`) from the rendered tree view to ensure paths resolve.
3. Run **`yarn build`** and **`yarn test`** from the repo root (already passing in CI prep).

## Risk / notes

- Documentation-only functional change; low risk.
- Roadmap list includes `docs/PLANNED_FEATURES.md` as a product hub (not strictly `*ROADMAP*` in the filename) for discoverability alongside [`FEATURE_ROADMAP.md`](https://github.com/KenSuenobu/objectified-commercial/blob/main/docs/FEATURE_ROADMAP.md).

Closes #3027

Made with [Cursor](https://cursor.com)