### PR TITLE
Fix #3028 - MCP CI: Postgres service for lint and tests

### DIFF
--- a/.github/workflows/objectified-mcp.yml
+++ b/.github/workflows/objectified-mcp.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [ main, develop ]
     paths:
+      - '.github/workflows/objectified-mcp.yml'
       - 'objectified-mcp/**'
       - 'objectified-rest/**'
       - 'docker-compose.yml'
@@ -12,6 +13,7 @@ on:
   pull_request:
     branches: [ main, develop ]
     paths:
+      - '.github/workflows/objectified-mcp.yml'
       - 'objectified-mcp/**'
       - 'objectified-rest/**'
       - 'docker-compose.yml'
@@ -23,6 +25,23 @@ jobs:
   test:
     name: Lint, type-check and test objectified-mcp
     runs-on: ubuntu-latest
+    env:
+      OBJECTIFIED_MCP_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/objectified_ci
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: objectified_ci
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d objectified_ci"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
 
     steps:
       - name: Checkout code

--- a/docs/PLANNED_ROADMAP_MCP.md
+++ b/docs/PLANNED_ROADMAP_MCP.md
@@ -133,7 +133,7 @@ process or via Docker.
 | 6.3 | ~~[#3025](../../issues/3025)~~ | ~~`.env.example` + config docs~~ (**completed**) | 1.2 |
 | 6.4 | ~~[#3026](../../issues/3026)~~ | ~~Local quickstart docs (`uv run`)~~ (**completed**) | 1.5, 1.6 |
 | 6.5 | ~~[#3027](../../issues/3027)~~ | ~~README (overview + tools reference)~~ (**completed**) | E3–E5 |
-| 6.6 | [#3028](../../issues/3028) | GitHub Actions CI (lint + tests) | 1.1 |
+| 6.6 | ~~[#3028](../../issues/3028)~~ | ~~GitHub Actions CI (lint + tests)~~ (**completed**) | 1.1 |
 
 ### Suggested parallelism
 

--- a/objectified-mcp/tests/test_ci_postgres_service.py
+++ b/objectified-mcp/tests/test_ci_postgres_service.py
@@ -1,0 +1,17 @@
+"""Verify CI provides a reachable Postgres (GitHub Actions service container)."""
+
+from __future__ import annotations
+
+import os
+
+import psycopg
+import pytest
+
+
+def test_ci_postgres_service_accepts_connections() -> None:
+    if os.environ.get("GITHUB_ACTIONS") != "true":
+        pytest.skip("Requires GitHub Actions Postgres service")
+    url = os.environ.get("OBJECTIFIED_MCP_DATABASE_URL")
+    assert url, "OBJECTIFIED_MCP_DATABASE_URL must be set when running in CI"
+    with psycopg.connect(url) as conn:
+        conn.execute("SELECT 1")

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.35",
+  "version": "0.11.36",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -6,6 +6,7 @@ We continue to improve the platform based on your feedback with improvements and
 
 ## MCP
 
+- **GitHub Actions** workflow **Objectified MCP** runs **ruff**, **mypy**, and **pytest** for **`objectified-mcp`** against an ephemeral **Postgres 16** service container on every relevant push and PR (#3028).
 - **`objectified-mcp/README.md`** — MCP package overview: architecture, transports, **tools** reference, auth, deployment, roadmap links; **local quickstart**: **`uv sync`**, **`.env`** (**`OBJECTIFIED_MCP_DATABASE_URL`**, **`OBJECTIFIED_MCP_INTERNAL_SECRET`**), **`uv run objectified-mcp serve --transport stdio`** or **`--transport http`**; optional Postgres+migrate via **`docker compose`** without the MCP image (#3027, #3026).
 - **`objectified-mcp/docs/CONFIGURATION.md`** documents every **`OBJECTIFIED_MCP_*`** variable (required vs optional, defaults, bounds); **`objectified-mcp/.env.example`** lists the same surface for copy/paste (#3025).
 - Root **`docker-compose.yml`** spins up **Postgres 16** (named volume **`objectified_postgres_data`**), a one-shot **`migrate`** image (**`objectified-db`** / schema-evolution-manager), and **`mcp`** (HTTP on **`8765`** by default); use **`docker compose up --build --wait`** from the repo root. Env overrides: **`docker-compose.env.example`** (#3024).


### PR DESCRIPTION
## Summary
Extends the existing **Objectified MCP** workflow so **ruff**, **mypy**, and **pytest** run with an ephemeral **Postgres 16** service container, matching MCP-6.6. Sets `OBJECTIFIED_MCP_DATABASE_URL` for the job and adds a CI-only smoke test that runs `SELECT 1` against that database.

Also triggers the workflow when `.github/workflows/objectified-mcp.yml` changes, and marks roadmap ticket 6.6 complete.

## How to test
- Open a PR that touches `objectified-mcp/**` or the workflow file and confirm the **Objectified MCP** check runs and passes.
- **Locally:** `cd objectified-mcp && uv run pytest` (Postgres smoke test skips unless `GITHUB_ACTIONS=true`).

## Risks / notes
- **Branch protection:** PRs are only blocked on red if the repo requires the **Objectified MCP** check in branch protection rules (configure in GitHub settings if not already).
- Existing pytest deprecation warnings from `websockets` / `uvicorn` in integration tests are unchanged.

Closes #3028

Made with [Cursor](https://cursor.com)