### PR TITLE
Fix #266 - Ollama default model per tenant/project

### DIFF
--- a/docs/PLANNED_FEATURE_ROADMAP_AI.md
+++ b/docs/PLANNED_FEATURE_ROADMAP_AI.md
@@ -82,18 +82,13 @@ This outlines the planned features for integrating AI capabilities into Objectif
         - Custom fine-tuned models
     - Model switching per task type
     - Model performance comparison
-    - 📋 Default model per tenant/project
+    - ✅ Default model per tenant/project (#266)
 - **Resource Management**:
     - GPU memory monitoring
     - Request queuing for high load
     - Priority queues for different users
     - Rate limiting per user/tenant
     - Usage tracking and quotas
-
-| Ticket | Feature Description                     |
-|--------|-----------------------------------------|
-| #265   | Ollama model selection **(shipped)**    |
-| #266   | Ollama default model per tenant/project |
 
 **Ollama API Integration** 📋 PLANNED
 - 📋 **Streaming Responses**:

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.37",
+  "version": "0.11.38",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -21,6 +21,7 @@ We continue to improve the platform based on your feedback with improvements and
 
 ## Studio
 - AI chatbot lists Ollama models from your server and lets you pick which model answers each conversation (falls back to the offline assistant when Ollama is unavailable).
+- Studio chatbot remembers your preferred Ollama tag per project (and per tenant), with an optional control to set a tenant-wide default when you are inside a project.
 
 ---
 

--- a/objectified-ui/src/app/ade/studio/components/StudioAiChatbot.tsx
+++ b/objectified-ui/src/app/ade/studio/components/StudioAiChatbot.tsx
@@ -23,6 +23,10 @@
  * Ollama model listing and selection (#265): the conversation loads tags from
  * `/api/ollama/models` and sends each turn through `/api/ollama/chat` when a
  * model is available; otherwise the offline demo responder keeps the panel usable.
+ *
+ * Default model preferences (#266): when `tenantId` is passed with a project in
+ * `studioContext`, the user's model choice is stored per project (and can be
+ * promoted to the whole tenant via the chat toolbar).
  */
 
 import * as React from 'react';
@@ -72,6 +76,8 @@ export interface StudioAiChatbotProps {
    * project, version, classes, properties, and canvas selection.
    */
   studioContext?: ChatStudioContext;
+  /** Current tenant id from the session (#266) — enables per-tenant/project Ollama defaults. */
+  tenantId?: string | null;
 }
 
 /**
@@ -82,6 +88,7 @@ export function StudioAiChatbot({
   forceVisible,
   initialMode = 'closed',
   studioContext,
+  tenantId,
 }: StudioAiChatbotProps = {}) {
   const pathname = usePathname();
   const [mode, setMode] = React.useState<StudioAiChatbotMode>(initialMode);
@@ -127,6 +134,7 @@ export function StudioAiChatbot({
           onModeChange={setMode}
           onClose={close}
           studioContext={studioContext}
+          tenantId={tenantId}
         />
       )}
     </>
@@ -156,9 +164,10 @@ interface ChatbotPanelProps {
   onModeChange: (mode: StudioAiChatbotMode) => void;
   onClose: () => void;
   studioContext?: ChatStudioContext;
+  tenantId?: string | null;
 }
 
-function ChatbotPanel({ mode, onModeChange, onClose, studioContext }: ChatbotPanelProps) {
+function ChatbotPanel({ mode, onModeChange, onClose, studioContext, tenantId }: ChatbotPanelProps) {
   const isFullscreen = mode === 'fullscreen';
 
   const containerClasses = isFullscreen
@@ -226,6 +235,7 @@ function ChatbotPanel({ mode, onModeChange, onClose, studioContext }: ChatbotPan
         <ChatConversation
           onImportSpec={handleImportSpec}
           studioContext={studioContext}
+          tenantId={tenantId}
           ollamaTransport
         />
       </div>

--- a/objectified-ui/src/app/ade/studio/components/chatbot/ChatConversation.tsx
+++ b/objectified-ui/src/app/ade/studio/components/chatbot/ChatConversation.tsx
@@ -20,6 +20,7 @@ import {
 } from './conversation-store';
 import { createDemoChatResponder } from './demo-responder';
 import {
+  ollamaModelScopeKey,
   persistOllamaModelChoiceForScope,
   persistOllamaModelTenantDefault,
   resolvePreferredOllamaModel,
@@ -108,6 +109,20 @@ const PROMPT_SUGGESTIONS: readonly string[] = [
   'How would I model a multi-tenant audit log?',
 ];
 
+/**
+ * Safe accessor for `window.localStorage` that returns `null` instead of
+ * throwing when the storage is unavailable (e.g. `SecurityError` in
+ * privacy-restricted browser contexts). Preferences are best-effort.
+ */
+function safeLocalStorage(): Storage | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
 export function ChatConversation({
   onSendMessage,
   onImportSpec,
@@ -137,12 +152,13 @@ export function ChatConversation({
 
   const handleSelectOllamaModel = React.useCallback(
     (name: string) => {
-      setSelectedOllamaModel(name);
+      const normalized = name.trim();
+      setSelectedOllamaModel(normalized);
       persistOllamaModelChoiceForScope({
         tenantId: tenantId ?? null,
         projectId: studioContext?.project?.id ?? null,
-        modelName: name,
-        storage: typeof window !== 'undefined' ? window.localStorage : null,
+        modelName: normalized,
+        storage: safeLocalStorage(),
       });
     },
     [tenantId, studioContext?.project?.id],
@@ -152,7 +168,7 @@ export function ChatConversation({
     persistOllamaModelTenantDefault({
       tenantId: tenantId ?? null,
       modelName: selectedOllamaModel,
-      storage: typeof window !== 'undefined' ? window.localStorage : null,
+      storage: safeLocalStorage(),
     });
   }, [tenantId, selectedOllamaModel]);
 
@@ -167,8 +183,8 @@ export function ChatConversation({
 
     let cancelled = false;
     setModelsStatus('loading');
-    const ls = typeof window !== 'undefined' ? window.localStorage : null;
-    const scopeKeyNow = `${tenantId ?? ''}::${studioContext?.project?.id ?? ''}`;
+    const ls = safeLocalStorage();
+    const scopeKeyNow = ollamaModelScopeKey(tenantId, studioContext?.project?.id);
 
     function applyErrorState() {
       setOllamaModels([]);

--- a/objectified-ui/src/app/ade/studio/components/chatbot/ChatConversation.tsx
+++ b/objectified-ui/src/app/ade/studio/components/chatbot/ChatConversation.tsx
@@ -19,6 +19,11 @@ import {
   type StoredConversationScope,
 } from './conversation-store';
 import { createDemoChatResponder } from './demo-responder';
+import {
+  persistOllamaModelChoiceForScope,
+  persistOllamaModelTenantDefault,
+  resolvePreferredOllamaModel,
+} from './ollama-model-defaults';
 import { createOllamaChatResponder } from './ollama-chat-responder';
 import type { DetectedOpenApiSpec } from './openapi-detection';
 import type { ChatFeedback, ChatMessage, ChatSendFn } from './types';
@@ -43,6 +48,9 @@ import type { ChatFeedback, ChatMessage, ChatSendFn } from './types';
  *   - With `ollamaTransport` (#265), lists generative models from Ollama and
  *     sends turns through `/api/ollama/chat`; falls back to the demo when the
  *     server has no models or the list request fails.
+ *   - With `tenantId` + `studioContext.project` (#266), the chosen model is
+ *     remembered per project (and optionally per tenant) in localStorage so
+ *     each workspace reopens on its preferred tag when Ollama still exposes it.
  */
 export interface ChatConversationProps {
   /** Adapter invoked to produce assistant replies. Defaults to the demo responder. */
@@ -87,6 +95,11 @@ export interface ChatConversationProps {
    * Ollama chat route. Ignored when `onSendMessage` is provided.
    */
   ollamaTransport?: boolean;
+  /**
+   * Current tenant id from the signed-in session (#266). With `studioContext.project`,
+   * model choice is persisted per project; with tenant alone, per tenant.
+   */
+  tenantId?: string | null;
 }
 
 const PROMPT_SUGGESTIONS: readonly string[] = [
@@ -106,6 +119,7 @@ export function ChatConversation({
   confirmAction,
   onExportConversation,
   ollamaTransport = false,
+  tenantId,
 }: ChatConversationProps) {
   type OllamaModelRow = { name: string };
   type ModelsStatus = 'idle' | 'loading' | 'ready' | 'empty' | 'error';
@@ -116,12 +130,35 @@ export function ChatConversation({
     ollamaTransport ? 'loading' : 'idle',
   );
   const [modelsRetryToken, bumpModelsRetry] = React.useReducer((n: number) => n + 1, 0);
+  const ollamaModelScopeKeyRef = React.useRef<string | null>(null);
 
   const demoResponder = React.useMemo(() => createDemoChatResponder(), []);
   const ollamaResponder = React.useMemo(() => createOllamaChatResponder(), []);
 
+  const handleSelectOllamaModel = React.useCallback(
+    (name: string) => {
+      setSelectedOllamaModel(name);
+      persistOllamaModelChoiceForScope({
+        tenantId: tenantId ?? null,
+        projectId: studioContext?.project?.id ?? null,
+        modelName: name,
+        storage: typeof window !== 'undefined' ? window.localStorage : null,
+      });
+    },
+    [tenantId, studioContext?.project?.id],
+  );
+
+  const handlePersistTenantOllamaDefault = React.useCallback(() => {
+    persistOllamaModelTenantDefault({
+      tenantId: tenantId ?? null,
+      modelName: selectedOllamaModel,
+      storage: typeof window !== 'undefined' ? window.localStorage : null,
+    });
+  }, [tenantId, selectedOllamaModel]);
+
   React.useEffect(() => {
     if (!ollamaTransport) {
+      ollamaModelScopeKeyRef.current = null;
       setModelsStatus('idle');
       setOllamaModels([]);
       setSelectedOllamaModel('');
@@ -130,6 +167,8 @@ export function ChatConversation({
 
     let cancelled = false;
     setModelsStatus('loading');
+    const ls = typeof window !== 'undefined' ? window.localStorage : null;
+    const scopeKeyNow = `${tenantId ?? ''}::${studioContext?.project?.id ?? ''}`;
 
     function applyErrorState() {
       setOllamaModels([]);
@@ -155,8 +194,16 @@ export function ChatConversation({
           setOllamaModels(data.models);
           setSelectedOllamaModel((prev) => {
             const names = data.models!.map((m) => m.name);
-            if (prev && names.includes(prev)) return prev;
-            return data.models![0].name;
+            const prevScope = ollamaModelScopeKeyRef.current;
+            ollamaModelScopeKeyRef.current = scopeKeyNow;
+            const scopeUnchanged = prevScope === scopeKeyNow;
+            if (scopeUnchanged && prev && names.includes(prev)) return prev;
+            return resolvePreferredOllamaModel({
+              tenantId: tenantId ?? null,
+              projectId: studioContext?.project?.id ?? null,
+              availableModelNames: names,
+              storage: ls,
+            });
           });
           setModelsStatus('ready');
         } else {
@@ -173,7 +220,12 @@ export function ChatConversation({
     return () => {
       cancelled = true;
     };
-  }, [ollamaTransport, modelsRetryToken]);
+  }, [
+    ollamaTransport,
+    modelsRetryToken,
+    tenantId,
+    studioContext?.project?.id,
+  ]);
 
   const useLiveOllama =
     ollamaTransport && modelsStatus === 'ready' && ollamaModels.length > 0 && selectedOllamaModel.length > 0;
@@ -471,8 +523,10 @@ export function ChatConversation({
           status={ollamaTransport && modelsStatus === 'idle' ? 'loading' : modelsStatus}
           models={ollamaModels}
           selectedModel={selectedOllamaModel}
-          onSelectModel={setSelectedOllamaModel}
+          onSelectModel={handleSelectOllamaModel}
           onRetry={bumpModelsRetry}
+          showTenantDefaultButton={Boolean(tenantId && studioContext?.project?.id)}
+          onPersistTenantDefault={handlePersistTenantOllamaDefault}
         />
       )}
       <ChatToolbar
@@ -541,6 +595,8 @@ interface OllamaModelBarProps {
   selectedModel: string;
   onSelectModel: (name: string) => void;
   onRetry: () => void;
+  showTenantDefaultButton?: boolean;
+  onPersistTenantDefault?: () => void;
 }
 
 function OllamaModelBar({
@@ -549,6 +605,8 @@ function OllamaModelBar({
   selectedModel,
   onSelectModel,
   onRetry,
+  showTenantDefaultButton,
+  onPersistTenantDefault,
 }: OllamaModelBarProps) {
   if (status === 'idle') return null;
 
@@ -586,21 +644,34 @@ function OllamaModelBar({
         </span>
       )}
       {status === 'ready' && (
-        <label className="flex flex-wrap items-center gap-2 text-xs text-gray-700 dark:text-gray-300">
-          <span className="font-medium text-gray-600 dark:text-gray-400">Model</span>
-          <select
-            data-testid="studio-ai-chat-ollama-model-select"
-            className="max-w-[min(100%,18rem)] rounded-md border border-gray-300 bg-white px-2 py-1 font-mono text-xs text-gray-900 shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
-            value={selectedModel}
-            onChange={(e) => onSelectModel(e.target.value)}
-          >
-            {models.map((m) => (
-              <option key={m.name} value={m.name}>
-                {m.name}
-              </option>
-            ))}
-          </select>
-        </label>
+        <div className="flex flex-wrap items-center gap-2">
+          <label className="flex flex-wrap items-center gap-2 text-xs text-gray-700 dark:text-gray-300">
+            <span className="font-medium text-gray-600 dark:text-gray-400">Model</span>
+            <select
+              data-testid="studio-ai-chat-ollama-model-select"
+              className="max-w-[min(100%,18rem)] rounded-md border border-gray-300 bg-white px-2 py-1 font-mono text-xs text-gray-900 shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+              value={selectedModel}
+              onChange={(e) => onSelectModel(e.target.value)}
+            >
+              {models.map((m) => (
+                <option key={m.name} value={m.name}>
+                  {m.name}
+                </option>
+              ))}
+            </select>
+          </label>
+          {showTenantDefaultButton && onPersistTenantDefault && (
+            <button
+              type="button"
+              data-testid="studio-ai-chat-ollama-tenant-default"
+              title="Remember this model as the default for every project in this tenant (project-specific defaults still win when set)."
+              onClick={onPersistTenantDefault}
+              className="inline-flex h-7 items-center rounded-md border border-gray-300 bg-white px-2 text-xs font-medium text-gray-700 transition-colors hover:bg-gray-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
+            >
+              Tenant default
+            </button>
+          )}
+        </div>
       )}
     </div>
   );

--- a/objectified-ui/src/app/ade/studio/components/chatbot/index.ts
+++ b/objectified-ui/src/app/ade/studio/components/chatbot/index.ts
@@ -36,6 +36,15 @@ export type { ConversationHistoryPanelProps } from './ConversationHistoryPanel';
 export { createDemoChatResponder } from './demo-responder';
 export { createOllamaChatResponder } from './ollama-chat-responder';
 export {
+  CHAT_OLLAMA_MODEL_DEFAULTS_STORAGE_KEY,
+  persistOllamaModelChoiceForScope,
+  persistOllamaModelTenantDefault,
+  readOllamaModelDefaults,
+  resolvePreferredOllamaModel,
+  writeOllamaModelDefaults,
+} from './ollama-model-defaults';
+export type { OllamaModelDefaultsV1, StorageLike } from './ollama-model-defaults';
+export {
   detectOpenApiSpecs,
   hasOpenApiSpec,
 } from './openapi-detection';

--- a/objectified-ui/src/app/ade/studio/components/chatbot/ollama-model-defaults.ts
+++ b/objectified-ui/src/app/ade/studio/components/chatbot/ollama-model-defaults.ts
@@ -1,0 +1,144 @@
+/**
+ * Persisted default Ollama model tags for the Studio chatbot (#266).
+ *
+ * Preferences are stored in localStorage (best-effort). Project-level defaults
+ * override tenant-level defaults when both are set and the stored tag still
+ * exists in the live model list from `/api/ollama/models`.
+ */
+
+export const CHAT_OLLAMA_MODEL_DEFAULTS_STORAGE_KEY =
+  'objectified.studio.chatbot.ollamaModelDefaults.v1';
+
+export interface OllamaModelDefaultsV1 {
+  v: 1;
+  /** tenantId → model name */
+  byTenant: Record<string, string>;
+  /** `${tenantId}::${projectId}` → model name */
+  byProject: Record<string, string>;
+}
+
+export type StorageLike = Pick<Storage, 'getItem' | 'setItem'> | null;
+
+function emptyDefaults(): OllamaModelDefaultsV1 {
+  return { v: 1, byTenant: {}, byProject: {} };
+}
+
+function projectCompositeKey(tenantId: string, projectId: string): string {
+  return `${tenantId}::${projectId}`;
+}
+
+export function readOllamaModelDefaults(storage: StorageLike): OllamaModelDefaultsV1 {
+  if (!storage) return emptyDefaults();
+  try {
+    const raw = storage.getItem(CHAT_OLLAMA_MODEL_DEFAULTS_STORAGE_KEY);
+    if (!raw) return emptyDefaults();
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== 'object') return emptyDefaults();
+    const o = parsed as Record<string, unknown>;
+    if (o.v !== 1) return emptyDefaults();
+    const byTenant = o.byTenant;
+    const byProject = o.byProject;
+    return {
+      v: 1,
+      byTenant:
+        byTenant && typeof byTenant === 'object' && !Array.isArray(byTenant)
+          ? { ...(byTenant as Record<string, string>) }
+          : {},
+      byProject:
+        byProject && typeof byProject === 'object' && !Array.isArray(byProject)
+          ? { ...(byProject as Record<string, string>) }
+          : {},
+    };
+  } catch {
+    return emptyDefaults();
+  }
+}
+
+export function writeOllamaModelDefaults(
+  storage: StorageLike,
+  data: OllamaModelDefaultsV1,
+): void {
+  if (!storage) return;
+  try {
+    storage.setItem(CHAT_OLLAMA_MODEL_DEFAULTS_STORAGE_KEY, JSON.stringify(data));
+  } catch {
+    // Quota / privacy mode — preferences are best-effort.
+  }
+}
+
+/**
+ * Pick the initial model tag from saved defaults, falling back to the first
+ * available name when nothing matches.
+ */
+export function resolvePreferredOllamaModel(input: {
+  tenantId: string | null | undefined;
+  projectId: string | null | undefined;
+  availableModelNames: readonly string[];
+  storage: StorageLike;
+}): string {
+  const names = [...input.availableModelNames];
+  if (names.length === 0) return '';
+  const data = readOllamaModelDefaults(input.storage);
+  const tenantId = input.tenantId?.trim() || null;
+  const projectId = input.projectId?.trim() || null;
+
+  if (tenantId && projectId) {
+    const projectKey = projectCompositeKey(tenantId, projectId);
+    const projectModel = data.byProject[projectKey];
+    if (projectModel && names.includes(projectModel)) return projectModel;
+  }
+
+  if (tenantId) {
+    const tenantModel = data.byTenant[tenantId];
+    if (tenantModel && names.includes(tenantModel)) return tenantModel;
+  }
+
+  return names[0];
+}
+
+/**
+ * Save the user's current choice as the default for the active workspace.
+ * When both tenant and project are known, this updates the project default.
+ * With only a tenant, it updates the tenant default.
+ */
+export function persistOllamaModelChoiceForScope(input: {
+  tenantId: string | null | undefined;
+  projectId: string | null | undefined;
+  modelName: string;
+  storage: StorageLike;
+}): void {
+  if (!input.storage) return;
+  const tenantId = input.tenantId?.trim() || null;
+  const projectId = input.projectId?.trim() || null;
+  const modelName = input.modelName.trim();
+  if (!modelName) return;
+
+  const data = readOllamaModelDefaults(input.storage);
+  if (tenantId && projectId) {
+    data.byProject[projectCompositeKey(tenantId, projectId)] = modelName;
+  } else if (tenantId) {
+    data.byTenant[tenantId] = modelName;
+  } else {
+    return;
+  }
+  writeOllamaModelDefaults(input.storage, data);
+}
+
+/**
+ * Store the selected tag as the tenant-wide default (all projects), without
+ * clearing the per-project map entry.
+ */
+export function persistOllamaModelTenantDefault(input: {
+  tenantId: string | null | undefined;
+  modelName: string;
+  storage: StorageLike;
+}): void {
+  if (!input.storage) return;
+  const tenantId = input.tenantId?.trim() || null;
+  const modelName = input.modelName.trim();
+  if (!tenantId || !modelName) return;
+
+  const data = readOllamaModelDefaults(input.storage);
+  data.byTenant[tenantId] = modelName;
+  writeOllamaModelDefaults(input.storage, data);
+}

--- a/objectified-ui/src/app/ade/studio/components/chatbot/ollama-model-defaults.ts
+++ b/objectified-ui/src/app/ade/studio/components/chatbot/ollama-model-defaults.ts
@@ -27,6 +27,19 @@ function projectCompositeKey(tenantId: string, projectId: string): string {
   return `${tenantId}::${projectId}`;
 }
 
+/**
+ * Build the normalized scope key used to detect workspace changes and guard
+ * model re-selection. Both ids are trimmed and null-coalesced before
+ * combining, matching the same normalization applied during persistence and
+ * lookup so comparisons never mis-fire due to incidental whitespace.
+ */
+export function ollamaModelScopeKey(
+  tenantId: string | null | undefined,
+  projectId: string | null | undefined,
+): string {
+  return `${tenantId?.trim() ?? ''}::${projectId?.trim() ?? ''}`;
+}
+
 export function readOllamaModelDefaults(storage: StorageLike): OllamaModelDefaultsV1 {
   if (!storage) return emptyDefaults();
   try {

--- a/objectified-ui/src/app/ade/studio/layout.tsx
+++ b/objectified-ui/src/app/ade/studio/layout.tsx
@@ -648,7 +648,9 @@ function StudioLayoutContent({ children }: Readonly<{ children: React.ReactNode 
           studio layout level so the floating bubble and ⌘⇧A shortcut are available
           across the canvas and paths surfaces. Hidden in presentation mode to keep
           the canvas chrome-free. */}
-      {!canvasPresentationMode && <StudioAiChatbot studioContext={chatbotStudioContext} />}
+      {!canvasPresentationMode && (
+        <StudioAiChatbot studioContext={chatbotStudioContext} tenantId={currentTenantId} />
+      )}
 
       {/* Programmatic state of the canvas — pinned to the bottom of the studio layout.
           Hidden in presentation mode for chrome consistency with StudioHeader. */}

--- a/objectified-ui/tests/chatbot/ChatConversation.test.tsx
+++ b/objectified-ui/tests/chatbot/ChatConversation.test.tsx
@@ -20,13 +20,17 @@ import { act, fireEvent, render, screen, waitFor, within } from '@testing-librar
 import '@testing-library/jest-dom';
 
 import { ChatConversation } from '../../src/app/ade/studio/components/chatbot/ChatConversation';
-import type { ChatStudioContext } from '../../src/app/ade/studio/components/chatbot/chat-context';
+import {
+  EMPTY_CHAT_STUDIO_CONTEXT,
+  type ChatStudioContext,
+} from '../../src/app/ade/studio/components/chatbot/chat-context';
 import {
   createConversationStore,
   createMemoryConversationStorage,
   type ConversationStore,
   type StoredConversation,
 } from '../../src/app/ade/studio/components/chatbot/conversation-store';
+import { CHAT_OLLAMA_MODEL_DEFAULTS_STORAGE_KEY } from '../../src/app/ade/studio/components/chatbot/ollama-model-defaults';
 import type { ChatMessage, ChatSendFn } from '../../src/app/ade/studio/components/chatbot/types';
 
 function makeMemoryStore(initial: StoredConversation[] = []): ConversationStore {
@@ -800,6 +804,135 @@ describe('ChatConversation', () => {
 
       const select = screen.getByTestId('studio-ai-chat-ollama-model-select') as HTMLSelectElement;
       expect(select.value).toBe('studio-test:latest');
+    });
+
+    it('selects persisted project default over the first listed model (#266)', async () => {
+      window.localStorage.setItem(
+        CHAT_OLLAMA_MODEL_DEFAULTS_STORAGE_KEY,
+        JSON.stringify({
+          v: 1,
+          byTenant: {},
+          byProject: { 'tenant-a::project-b': 'saved:latest' },
+        }),
+      );
+
+      global.fetch = jest.fn().mockImplementation((input: RequestInfo | URL) => {
+        const url = typeof input === 'string' ? input : input instanceof Request ? input.url : String(input);
+        if (url.includes('/api/ollama/models')) {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              success: true,
+              models: [{ name: 'first:latest' }, { name: 'saved:latest' }],
+            }),
+          } as Response);
+        }
+        return Promise.reject(new Error(`unexpected fetch ${url}`));
+      });
+
+      render(
+        <ChatConversation
+          ollamaTransport
+          restoreLastConversation={false}
+          tenantId="tenant-a"
+          studioContext={{
+            ...EMPTY_CHAT_STUDIO_CONTEXT,
+            project: { id: 'project-b', name: 'PB' },
+          }}
+        />,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('studio-ai-chat-ollama-model-select')).toBeInTheDocument();
+      });
+
+      const select = screen.getByTestId('studio-ai-chat-ollama-model-select') as HTMLSelectElement;
+      expect(select.value).toBe('saved:latest');
+    });
+
+    it('writes project default to localStorage when the user changes the model (#266)', async () => {
+      window.localStorage.removeItem(CHAT_OLLAMA_MODEL_DEFAULTS_STORAGE_KEY);
+
+      global.fetch = jest.fn().mockImplementation((input: RequestInfo | URL) => {
+        const url = typeof input === 'string' ? input : input instanceof Request ? input.url : String(input);
+        if (url.includes('/api/ollama/models')) {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              success: true,
+              models: [{ name: 'a:latest' }, { name: 'b:latest' }],
+            }),
+          } as Response);
+        }
+        return Promise.reject(new Error(`unexpected fetch ${url}`));
+      });
+
+      render(
+        <ChatConversation
+          ollamaTransport
+          restoreLastConversation={false}
+          tenantId="tenant-x"
+          studioContext={{
+            ...EMPTY_CHAT_STUDIO_CONTEXT,
+            project: { id: 'project-y', name: 'PY' },
+          }}
+        />,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('studio-ai-chat-ollama-model-select')).toBeInTheDocument();
+      });
+
+      const select = screen.getByTestId('studio-ai-chat-ollama-model-select') as HTMLSelectElement;
+      fireEvent.change(select, { target: { value: 'b:latest' } });
+
+      const raw = window.localStorage.getItem(CHAT_OLLAMA_MODEL_DEFAULTS_STORAGE_KEY);
+      expect(raw).toBeTruthy();
+      const parsed = JSON.parse(raw!) as { byProject: Record<string, string> };
+      expect(parsed.byProject['tenant-x::project-y']).toBe('b:latest');
+    });
+
+    it('Tenant default button saves the tenant-wide preference (#266)', async () => {
+      window.localStorage.removeItem(CHAT_OLLAMA_MODEL_DEFAULTS_STORAGE_KEY);
+
+      global.fetch = jest.fn().mockImplementation((input: RequestInfo | URL) => {
+        const url = typeof input === 'string' ? input : input instanceof Request ? input.url : String(input);
+        if (url.includes('/api/ollama/models')) {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              success: true,
+              models: [{ name: 'a:latest' }, { name: 'b:latest' }],
+            }),
+          } as Response);
+        }
+        return Promise.reject(new Error(`unexpected fetch ${url}`));
+      });
+
+      render(
+        <ChatConversation
+          ollamaTransport
+          restoreLastConversation={false}
+          tenantId="tenant-x"
+          studioContext={{
+            ...EMPTY_CHAT_STUDIO_CONTEXT,
+            project: { id: 'project-y', name: 'PY' },
+          }}
+        />,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('studio-ai-chat-ollama-model-select')).toBeInTheDocument();
+      });
+
+      const select = screen.getByTestId('studio-ai-chat-ollama-model-select') as HTMLSelectElement;
+      fireEvent.change(select, { target: { value: 'b:latest' } });
+      fireEvent.click(screen.getByTestId('studio-ai-chat-ollama-tenant-default'));
+
+      const raw = window.localStorage.getItem(CHAT_OLLAMA_MODEL_DEFAULTS_STORAGE_KEY);
+      expect(raw).toBeTruthy();
+      const parsed = JSON.parse(raw!) as { byTenant: Record<string, string> };
+      expect(parsed.byTenant['tenant-x']).toBe('b:latest');
     });
 
     it('sends messages through the Ollama chat route when models are ready', async () => {

--- a/objectified-ui/tests/chatbot/ollama-model-defaults.test.ts
+++ b/objectified-ui/tests/chatbot/ollama-model-defaults.test.ts
@@ -1,0 +1,138 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import {
+  CHAT_OLLAMA_MODEL_DEFAULTS_STORAGE_KEY,
+  persistOllamaModelChoiceForScope,
+  persistOllamaModelTenantDefault,
+  readOllamaModelDefaults,
+  resolvePreferredOllamaModel,
+  writeOllamaModelDefaults,
+} from '../../src/app/ade/studio/components/chatbot/ollama-model-defaults';
+
+function createMemoryStorage(): Storage {
+  const m = new Map<string, string>();
+  return {
+    get length() {
+      return m.size;
+    },
+    clear() {
+      m.clear();
+    },
+    getItem(key: string) {
+      return m.get(key) ?? null;
+    },
+    key() {
+      return null;
+    },
+    removeItem(key: string) {
+      m.delete(key);
+    },
+    setItem(key: string, value: string) {
+      m.set(key, value);
+    },
+  } as Storage;
+}
+
+describe('ollama-model-defaults (#266)', () => {
+  it('resolvePreferredOllamaModel prefers project over tenant over first listed', () => {
+    const storage = createMemoryStorage();
+    writeOllamaModelDefaults(storage, {
+      v: 1,
+      byTenant: { t1: 'tenant-model:latest' },
+      byProject: { 't1::p1': 'project-model:latest' },
+    });
+
+    const names = ['first:latest', 'project-model:latest', 'tenant-model:latest'] as const;
+    expect(
+      resolvePreferredOllamaModel({
+        tenantId: 't1',
+        projectId: 'p1',
+        availableModelNames: names,
+        storage,
+      }),
+    ).toBe('project-model:latest');
+
+    expect(
+      resolvePreferredOllamaModel({
+        tenantId: 't1',
+        projectId: 'p2',
+        availableModelNames: names,
+        storage,
+      }),
+    ).toBe('tenant-model:latest');
+
+    expect(
+      resolvePreferredOllamaModel({
+        tenantId: 't2',
+        projectId: 'p1',
+        availableModelNames: names,
+        storage,
+      }),
+    ).toBe('first:latest');
+  });
+
+  it('ignores stored tags that are no longer installed', () => {
+    const storage = createMemoryStorage();
+    writeOllamaModelDefaults(storage, {
+      v: 1,
+      byTenant: {},
+      byProject: { 't1::p1': 'ghost:latest' },
+    });
+
+    expect(
+      resolvePreferredOllamaModel({
+        tenantId: 't1',
+        projectId: 'p1',
+        availableModelNames: ['only:latest'],
+        storage,
+      }),
+    ).toBe('only:latest');
+  });
+
+  it('persistOllamaModelChoiceForScope writes project composite key when both ids exist', () => {
+    const storage = createMemoryStorage();
+    persistOllamaModelChoiceForScope({
+      tenantId: 't1',
+      projectId: 'p1',
+      modelName: 'pick:latest',
+      storage,
+    });
+    const raw = storage.getItem(CHAT_OLLAMA_MODEL_DEFAULTS_STORAGE_KEY);
+    expect(raw).toBeTruthy();
+    const data = readOllamaModelDefaults(storage);
+    expect(data.byProject['t1::p1']).toBe('pick:latest');
+    expect(Object.keys(data.byTenant)).toHaveLength(0);
+  });
+
+  it('persistOllamaModelChoiceForScope writes tenant when project is missing', () => {
+    const storage = createMemoryStorage();
+    persistOllamaModelChoiceForScope({
+      tenantId: 't1',
+      projectId: null,
+      modelName: 'solo:latest',
+      storage,
+    });
+    const data = readOllamaModelDefaults(storage);
+    expect(data.byTenant.t1).toBe('solo:latest');
+  });
+
+  it('persistOllamaModelTenantDefault updates tenant map without removing project entries', () => {
+    const storage = createMemoryStorage();
+    persistOllamaModelChoiceForScope({
+      tenantId: 't1',
+      projectId: 'p1',
+      modelName: 'a:latest',
+      storage,
+    });
+    persistOllamaModelTenantDefault({
+      tenantId: 't1',
+      modelName: 'b:latest',
+      storage,
+    });
+    const data = readOllamaModelDefaults(storage);
+    expect(data.byProject['t1::p1']).toBe('a:latest');
+    expect(data.byTenant.t1).toBe('b:latest');
+  });
+});


### PR DESCRIPTION
## What changed
- Studio AI chatbot persists the selected Ollama model tag in `localStorage`, scoped by **tenant + project** (project entry wins when present).
- On load, the model list resolves **project default → tenant default → first available tag** so returning to a workspace restores the last choice when Ollama still exposes that tag.
- When a project is open, a **Tenant default** control saves the current tag as the tenant-wide fallback for projects without their own saved tag.

## How to test
1. **Sign in** with a tenant that has at least one project and **open the Studio** (editor or paths).
2. **Open the AI chatbot**, wait for Ollama models to load, and **pick a model** from the dropdown.
3. **Reload the page** or switch away and back — the same tag should be pre-selected for that project.
4. With a project open, click **Tenant default** — switch to another project with no saved preference; that tenant-wide tag should apply.

## Risks / notes
- Preferences are browser-local (`localStorage`), not synced across devices or users (same pattern as conversation history #261).
- Invalidated tags (model removed from Ollama) fall back to the first listed model.

Closes #266

Made with [Cursor](https://cursor.com)