### PR TITLE
Fix #520 - Use SSE streaming in Studio AI chat

### DIFF
--- a/docs/PLANNED_FEATURE_ROADMAP_AI.md
+++ b/docs/PLANNED_FEATURE_ROADMAP_AI.md
@@ -92,7 +92,7 @@ This outlines the planned features for integrating AI capabilities into Objectif
 
 **Ollama API Integration** 📋 PLANNED
 - 📋 **Streaming Responses**:
-    - 📋 Server-Sent Events (SSE) for streaming
+    - ✅ Server-Sent Events (SSE) for streaming (#520)
     - 📋 Token-by-token display
     - 📋 Cancel generation mid-stream
     - 📋 Progress indication
@@ -108,7 +108,6 @@ This outlines the planned features for integrating AI capabilities into Objectif
 
 | Ticket | Feature Description                                 |
 |--------|-----------------------------------------------------|
-| #520   | Streaming responses from Ollama                     |
 | #521   | Token-by-token usage display                        |
 | #522   | Cancel generation mid-stream                        |
 | #523   | Show progress indication during generation          |

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.38",
+  "version": "0.11.39",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -22,6 +22,7 @@ We continue to improve the platform based on your feedback with improvements and
 ## Studio
 - AI chatbot lists Ollama models from your server and lets you pick which model answers each conversation (falls back to the offline assistant when Ollama is unavailable).
 - Studio chatbot remembers your preferred Ollama tag per project (and per tenant), with an optional control to set a tenant-wide default when you are inside a project.
+- Studio AI chat streams Ollama replies over SSE so assistant text appears incrementally as the model generates.
 
 ---
 

--- a/objectified-ui/src/app/ade/studio/components/chatbot/ChatConversation.tsx
+++ b/objectified-ui/src/app/ade/studio/components/chatbot/ChatConversation.tsx
@@ -367,6 +367,14 @@ export function ChatConversation({
           isRegenerate,
           studioContext: studioContextRef.current,
           ollamaModel: useLiveOllama ? selectedOllamaModel : undefined,
+          onStreamDelta: (accumulated) => {
+            if (requestIdRef.current !== requestId) return;
+            setMessages((current) =>
+              current.map((message) =>
+                message.id === pendingId ? { ...message, content: accumulated, pending: true } : message,
+              ),
+            );
+          },
         });
       } catch (error) {
         console.error('Chat assistant failed to respond', error);

--- a/objectified-ui/src/app/ade/studio/components/chatbot/ChatConversation.tsx
+++ b/objectified-ui/src/app/ade/studio/components/chatbot/ChatConversation.tsx
@@ -308,9 +308,13 @@ export function ChatConversation({
     }
   }, [restoreLastConversation, initialMessages, scope, store]);
 
+  // Only scroll to the bottom when new messages are appended (length increases).
+  // Skipping content-only updates (streaming chunks) prevents the scroll animation
+  // from restarting on every token and fighting the user's own scrolling.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   React.useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth', block: 'end' });
-  }, [messages]);
+  }, [messages.length]);
 
   // Auto-persist whenever the transcript settles (no pending turns).
   // Guard: only run when the change was user-originated (send / regenerate),
@@ -367,7 +371,7 @@ export function ChatConversation({
           isRegenerate,
           studioContext: studioContextRef.current,
           ollamaModel: useLiveOllama ? selectedOllamaModel : undefined,
-          onStreamDelta: (accumulated) => {
+          onStreamAccumulated: (accumulated) => {
             if (requestIdRef.current !== requestId) return;
             setMessages((current) =>
               current.map((message) =>

--- a/objectified-ui/src/app/ade/studio/components/chatbot/ollama-chat-responder.ts
+++ b/objectified-ui/src/app/ade/studio/components/chatbot/ollama-chat-responder.ts
@@ -3,7 +3,7 @@
  *
  * Posts to `/api/ollama/chat` with the model from context, maps the transcript
  * to Ollama message shape, injects Studio context into the latest user turn,
- * and reads the SSE stream. When `onStreamDelta` is set on the context (#520),
+ * and reads the SSE stream. When `onStreamAccumulated` is set on the context (#520),
  * each chunk is forwarded so the UI can render incrementally; the returned
  * string is still the full accumulated markdown.
  */
@@ -36,7 +36,7 @@ export function createOllamaChatResponder(): ChatSendFn {
       throw new Error(detail || `Chat request failed (${response.status})`);
     }
 
-    const text = await accumulateOllamaSseFromResponse(response, ctx.onStreamDelta);
+    const text = await accumulateOllamaSseFromResponse(response, ctx.onStreamAccumulated);
     return text.trim().length > 0 ? text : 'The model returned an empty reply.';
   };
 }

--- a/objectified-ui/src/app/ade/studio/components/chatbot/ollama-chat-responder.ts
+++ b/objectified-ui/src/app/ade/studio/components/chatbot/ollama-chat-responder.ts
@@ -3,7 +3,9 @@
  *
  * Posts to `/api/ollama/chat` with the model from context, maps the transcript
  * to Ollama message shape, injects Studio context into the latest user turn,
- * and accumulates the SSE stream into a single markdown string.
+ * and reads the SSE stream. When `onStreamDelta` is set on the context (#520),
+ * each chunk is forwarded so the UI can render incrementally; the returned
+ * string is still the full accumulated markdown.
  */
 
 import { injectChatContext } from './chat-context';
@@ -34,7 +36,7 @@ export function createOllamaChatResponder(): ChatSendFn {
       throw new Error(detail || `Chat request failed (${response.status})`);
     }
 
-    const text = await accumulateOllamaSseFromResponse(response);
+    const text = await accumulateOllamaSseFromResponse(response, ctx.onStreamDelta);
     return text.trim().length > 0 ? text : 'The model returned an empty reply.';
   };
 }
@@ -64,7 +66,10 @@ function buildOllamaChatMessages(
   return out;
 }
 
-async function accumulateOllamaSseFromResponse(response: Response): Promise<string> {
+async function accumulateOllamaSseFromResponse(
+  response: Response,
+  onDelta?: (accumulatedMarkdown: string) => void,
+): Promise<string> {
   const reader = response.body?.getReader();
   if (!reader) return '';
 
@@ -86,7 +91,10 @@ async function accumulateOllamaSseFromResponse(response: Response): Promise<stri
       if (data === '[DONE]') continue;
       try {
         const event = JSON.parse(data) as { content?: string };
-        if (event.content) accumulated += event.content;
+        if (event.content) {
+          accumulated += event.content;
+          onDelta?.(accumulated);
+        }
       } catch {
         /* ignore malformed SSE lines */
       }

--- a/objectified-ui/src/app/ade/studio/components/chatbot/types.ts
+++ b/objectified-ui/src/app/ade/studio/components/chatbot/types.ts
@@ -43,11 +43,17 @@ export interface ChatSendContext {
    * Ollama model tag (e.g. `qwen2.5:latest`) when using `createOllamaChatResponder` (#265).
    */
   ollamaModel?: string;
+  /**
+   * Called as streamed assistant text grows (e.g. Ollama SSE). The shell passes this so the
+   * pending bubble updates live; responders that do not stream can ignore it (#520).
+   */
+  onStreamDelta?: (accumulatedMarkdown: string) => void;
 }
 
 /**
  * Adapter the chat shell calls when the user submits or regenerates. Returns
- * the assistant's full markdown reply. Implementations may stream internally;
- * the shell only renders the resolved value.
+ * the assistant's full markdown reply. When the shell supplies `onStreamDelta`,
+ * streaming responders should invoke it as content arrives; the shell still uses
+ * the resolved return value as the final assistant text.
  */
 export type ChatSendFn = (ctx: ChatSendContext) => Promise<string>;

--- a/objectified-ui/src/app/ade/studio/components/chatbot/types.ts
+++ b/objectified-ui/src/app/ade/studio/components/chatbot/types.ts
@@ -44,15 +44,16 @@ export interface ChatSendContext {
    */
   ollamaModel?: string;
   /**
-   * Called as streamed assistant text grows (e.g. Ollama SSE). The shell passes this so the
-   * pending bubble updates live; responders that do not stream can ignore it (#520).
+   * Called as streamed assistant text grows (e.g. Ollama SSE). Receives the full
+   * accumulated markdown seen so far — NOT the latest delta chunk. The shell passes
+   * this so the pending bubble updates live; responders that do not stream can ignore it (#520).
    */
-  onStreamDelta?: (accumulatedMarkdown: string) => void;
+  onStreamAccumulated?: (accumulatedMarkdown: string) => void;
 }
 
 /**
  * Adapter the chat shell calls when the user submits or regenerates. Returns
- * the assistant's full markdown reply. When the shell supplies `onStreamDelta`,
+ * the assistant's full markdown reply. When the shell supplies `onStreamAccumulated`,
  * streaming responders should invoke it as content arrives; the shell still uses
  * the resolved return value as the final assistant text.
  */

--- a/objectified-ui/tests/chatbot/ChatConversation.test.tsx
+++ b/objectified-ui/tests/chatbot/ChatConversation.test.tsx
@@ -682,6 +682,58 @@ describe('ChatConversation', () => {
     expect(onImportSpec.mock.calls[0][0].version).toBe('3.1.0');
   });
 
+  it('updates the pending bubble incrementally via onStreamAccumulated and commits the final reply (#520)', async () => {
+    let capturedStreamAccumulated: ((text: string) => void) | undefined;
+    let pendingResolve: ((text: string) => void) | null = null;
+
+    const streamingResponder: ChatSendFn = ({ onStreamAccumulated }) => {
+      capturedStreamAccumulated = onStreamAccumulated;
+      return new Promise<string>((resolve) => {
+        pendingResolve = resolve;
+      });
+    };
+
+    render(<ChatConversation onSendMessage={streamingResponder} />);
+
+    fireEvent.change(screen.getByTestId('studio-ai-chat-input'), { target: { value: 'stream me' } });
+    fireEvent.click(screen.getByTestId('studio-ai-chat-send'));
+
+    // Pending bubble appears with the typing indicator (empty content)
+    await waitFor(() => {
+      expect(screen.getByTestId('studio-ai-chat-typing')).toBeInTheDocument();
+    });
+
+    // First streamed chunk — typing indicator gives way to partial content
+    await act(async () => {
+      capturedStreamAccumulated?.('Hello');
+    });
+    expect(screen.queryByTestId('studio-ai-chat-typing')).not.toBeInTheDocument();
+    const bubbleAfterFirstChunk = screen
+      .getAllByTestId('studio-ai-chat-bubble')
+      .find((b) => b.getAttribute('data-role') === 'assistant')!;
+    expect(bubbleAfterFirstChunk).toHaveTextContent('Hello');
+
+    // Second chunk replaces the accumulated text (not double-appended)
+    await act(async () => {
+      capturedStreamAccumulated?.('Hello world');
+    });
+    const bubbleAfterSecondChunk = screen
+      .getAllByTestId('studio-ai-chat-bubble')
+      .find((b) => b.getAttribute('data-role') === 'assistant')!;
+    expect(bubbleAfterSecondChunk).toHaveTextContent('Hello world');
+    expect(bubbleAfterSecondChunk).not.toHaveTextContent('Hello Hello world');
+
+    // Responder resolves — pending state clears and assistant actions appear
+    await act(async () => {
+      pendingResolve?.('Hello world!');
+    });
+    await waitFor(() => {
+      expect(screen.queryByTestId('studio-ai-chat-typing')).not.toBeInTheDocument();
+    });
+    expect(screen.getByText('Hello world!')).toBeInTheDocument();
+    expect(screen.getByTestId('studio-ai-chat-regenerate')).toBeInTheDocument();
+  });
+
   describe('Ollama transport (#265)', () => {
     const originalFetch = global.fetch;
 

--- a/objectified-ui/tests/chatbot/ollama-chat-responder.test.ts
+++ b/objectified-ui/tests/chatbot/ollama-chat-responder.test.ts
@@ -76,7 +76,7 @@ describe('createOllamaChatResponder', () => {
     expect(body.messages).toEqual([{ role: 'user', content: 'Hi' }]);
   });
 
-  it('invokes onStreamDelta with accumulated text for each content chunk', async () => {
+  it('invokes onStreamAccumulated with accumulated text for each content chunk', async () => {
     const deltas: string[] = [];
     global.fetch = jest.fn().mockResolvedValue(
       mockSseResponse([
@@ -93,7 +93,7 @@ describe('createOllamaChatResponder', () => {
       prompt: 'Hi',
       isRegenerate: false,
       ollamaModel: 'qwen2.5:latest',
-      onStreamDelta: (acc) => deltas.push(acc),
+      onStreamAccumulated: (acc) => deltas.push(acc),
     });
 
     expect(out).toBe('Hello world');

--- a/objectified-ui/tests/chatbot/ollama-chat-responder.test.ts
+++ b/objectified-ui/tests/chatbot/ollama-chat-responder.test.ts
@@ -76,6 +76,30 @@ describe('createOllamaChatResponder', () => {
     expect(body.messages).toEqual([{ role: 'user', content: 'Hi' }]);
   });
 
+  it('invokes onStreamDelta with accumulated text for each content chunk', async () => {
+    const deltas: string[] = [];
+    global.fetch = jest.fn().mockResolvedValue(
+      mockSseResponse([
+        'data: {"content":"Hello","done":false}\n\n',
+        'data: {"content":" world","done":false}\n\n',
+        'data: [DONE]\n\n',
+      ]),
+    );
+
+    const responder = createOllamaChatResponder();
+    const messages: ChatMessage[] = [{ id: 'u1', role: 'user', content: 'Hi' }];
+    const out = await responder({
+      messages,
+      prompt: 'Hi',
+      isRegenerate: false,
+      ollamaModel: 'qwen2.5:latest',
+      onStreamDelta: (acc) => deltas.push(acc),
+    });
+
+    expect(out).toBe('Hello world');
+    expect(deltas).toEqual(['Hello', 'Hello world']);
+  });
+
   it('injects studio context into the latest user message only', async () => {
     global.fetch = jest.fn().mockResolvedValue(
       mockSseResponse(['data: {"content":"ok","done":true}\n\n', 'data: [DONE]\n\n']),


### PR DESCRIPTION
## What changed
Studio AI chat (`ChatConversation` + Ollama responder) now updates the pending assistant bubble as each SSE chunk arrives from `/api/ollama/chat`, instead of waiting for the full response. Added optional `onStreamDelta` on `ChatSendContext` so any `ChatSendFn` can stream the same way.

## How to test
1. **Run Ollama** locally with at least one chat model pulled.
2. **Open Studio** with the AI chatbot, ensure **models load** and pick a model.
3. **Send a prompt** that yields a multi-token reply and confirm assistant **text grows incrementally** (not only after the full completion).

## Risk / notes
Low scope: demo responder unchanged; custom `onSendMessage` hooks receive `onStreamDelta` and may ignore it. Root `yarn lint` reports many pre-existing issues; changed files pass targeted ESLint.

Fixes KenSuenobu/objectified#520

Made with [Cursor](https://cursor.com)