### PR TITLE
Fix #523 - Show progress indicator in Studio AI chat

### DIFF
--- a/docs/PLANNED_FEATURE_ROADMAP_AI.md
+++ b/docs/PLANNED_FEATURE_ROADMAP_AI.md
@@ -95,7 +95,7 @@ This outlines the planned features for integrating AI capabilities into Objectif
     - ✅ Server-Sent Events (SSE) for streaming (#520)
     - ✅ Token-by-token usage display (#521)
     - ✅ Cancel generation mid-stream (#522)
-    - 📋 Progress indication
+    - ✅ Progress indication (#523)
 - 📋 **Caching**:
     - 📋 Cache common queries
     - 📋 Semantic similarity matching
@@ -108,7 +108,6 @@ This outlines the planned features for integrating AI capabilities into Objectif
 
 | Ticket | Feature Description                                 |
 |--------|-----------------------------------------------------|
-| #523   | Show progress indication during generation          |
 | #524   | Cache common queries to Ollama                      |
 | #525   | Semantic similarity matching for cache              |
 | #526   | Cache invalidation on schema changes                |

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.41",
+  "version": "0.11.42",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -25,6 +25,7 @@ We continue to improve the platform based on your feedback with improvements and
 - Studio AI chat streams Ollama replies over SSE so assistant text appears incrementally as the model generates.
 - Studio AI chat shows live token usage (estimated while streaming, then Ollama-reported counts when each reply finishes).
 - Studio AI chat includes **Stop** while a reply is generating so you can cancel mid-stream; partial text is kept when the model had already streamed content.
+- Studio AI chat shows an indeterminate progress bar while the assistant is generating a reply.
 
 ---
 

--- a/objectified-ui/src/app/ade/studio/components/chatbot/ChatBusyProgressIndicator.tsx
+++ b/objectified-ui/src/app/ade/studio/components/chatbot/ChatBusyProgressIndicator.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+/**
+ * Indeterminate progress bar while the assistant is generating (#523).
+ * Sits under the chat toolbar so generation is visible for the whole turn,
+ * including the gap before the first streamed token arrives.
+ */
+export function ChatBusyProgressIndicator() {
+  return (
+    <div
+      className="shrink-0 border-b border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-900"
+      data-testid="studio-ai-chat-generation-progress"
+    >
+      <div
+        role="progressbar"
+        aria-valuetext="Generating response"
+        className="relative h-1 w-full overflow-hidden bg-gray-200 dark:bg-gray-700"
+      >
+        <div
+          className="studio-chat-indeterminate-progress-fill absolute inset-y-0 left-0 w-[40%] rounded-full bg-indigo-500 dark:bg-indigo-400"
+          aria-hidden
+        />
+      </div>
+    </div>
+  );
+}

--- a/objectified-ui/src/app/ade/studio/components/chatbot/ChatBusyProgressIndicator.tsx
+++ b/objectified-ui/src/app/ade/studio/components/chatbot/ChatBusyProgressIndicator.tsx
@@ -13,6 +13,7 @@ export function ChatBusyProgressIndicator() {
     >
       <div
         role="progressbar"
+        aria-label="Chat response progress"
         aria-valuetext="Generating response"
         className="relative h-1 w-full overflow-hidden bg-gray-200 dark:bg-gray-700"
       >

--- a/objectified-ui/src/app/ade/studio/components/chatbot/ChatConversation.tsx
+++ b/objectified-ui/src/app/ade/studio/components/chatbot/ChatConversation.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import { Download, History, Loader2, Plus, RefreshCw, Sparkles, Trash2 } from 'lucide-react';
 
 import { ChatBubble } from './ChatBubble';
+import { ChatBusyProgressIndicator } from './ChatBusyProgressIndicator';
 import { ChatComposer } from './ChatComposer';
 import { ChatContextChip } from './ChatContextChip';
 import type { ChatStudioContext } from './chat-context';
@@ -52,6 +53,8 @@ import { isAbortError } from './abort-errors';
  *     server has no models or the list request fails.
  *   - With live Ollama (#521), a footer shows prompt/output token estimates while
  *     streaming and replaces them with measured counts when the model finishes.
+ *   - While a turn is in flight (#523), an indeterminate progress bar appears under
+ *     the toolbar so generation is obvious before and during streamed tokens.
  *   - The composer can **Stop** an in-flight turn (#522): `AbortSignal` is passed to
  *     the responder so streaming fetch/SSE readers unwind and partial text is kept.
  *   - With `tenantId` + `studioContext.project` (#266), the chosen model is
@@ -602,7 +605,11 @@ export function ChatConversation({
   const hasMessages = messages.length > 0;
 
   return (
-    <div className="flex h-full min-h-0 flex-col" data-testid="studio-ai-chat-conversation">
+    <div
+      className="flex h-full min-h-0 flex-col"
+      data-testid="studio-ai-chat-conversation"
+      aria-busy={view === 'chat' && isBusy}
+    >
       {ollamaTransport && view === 'chat' && (
         <OllamaModelBar
           status={ollamaTransport && modelsStatus === 'idle' ? 'loading' : modelsStatus}
@@ -623,6 +630,8 @@ export function ChatConversation({
         canClear={hasMessages}
         historyCount={storedConversations.length}
       />
+
+      {view === 'chat' && isBusy ? <ChatBusyProgressIndicator /> : null}
 
       {view === 'history' ? (
         <ConversationHistoryPanel

--- a/objectified-ui/src/app/api/ollama/chat/route.ts
+++ b/objectified-ui/src/app/api/ollama/chat/route.ts
@@ -3,7 +3,7 @@
  */
 
 import { NextRequest } from 'next/server';
-import { isAbortError } from '../../ade/studio/components/chatbot/abort-errors';
+import { isAbortError } from '../../../ade/studio/components/chatbot/abort-errors';
 
 const OLLAMA_BASE_URL = process.env.OLLAMA_BASE_URL || 'http://localhost:11434';
 

--- a/objectified-ui/src/app/globals.css
+++ b/objectified-ui/src/app/globals.css
@@ -381,3 +381,26 @@ button {
   opacity: 0.2;
 }
 
+/* Studio AI chat: indeterminate bar while assistant streams (#523) */
+@keyframes studio-chat-indeterminate-progress {
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(400%);
+  }
+}
+
+.studio-chat-indeterminate-progress-fill {
+  animation: studio-chat-indeterminate-progress 1.25s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .studio-chat-indeterminate-progress-fill {
+    animation: none;
+    width: 100%;
+    transform: none;
+    opacity: 0.55;
+  }
+}
+

--- a/objectified-ui/tests/chatbot/ChatConversation.test.tsx
+++ b/objectified-ui/tests/chatbot/ChatConversation.test.tsx
@@ -8,6 +8,7 @@
  *   - Regenerate re-uses the last user prompt and replaces the prior reply
  *   - Thumbs up/down feedback toggles
  *   - Composer is disabled while the assistant is working
+ *   - Indeterminate progress bar while the assistant is generating (#523)
  *   - The studio context snapshot rides on every send (#259)
  *   - Multi-turn follow-ups carry the full transcript and refine prior
  *     specs through the chat surface (#260)
@@ -153,6 +154,7 @@ describe('ChatConversation', () => {
 
     await waitFor(() => {
       expect(screen.getByTestId('studio-ai-chat-input')).toBeDisabled();
+      expect(screen.getByTestId('studio-ai-chat-generation-progress')).toBeInTheDocument();
     });
 
     await act(async () => {
@@ -160,6 +162,7 @@ describe('ChatConversation', () => {
     });
 
     expect(screen.getByTestId('studio-ai-chat-input')).not.toBeDisabled();
+    expect(screen.queryByTestId('studio-ai-chat-generation-progress')).not.toBeInTheDocument();
   });
 
   it('Stop aborts an in-flight responder turn and leaves a stopped message (#522)', async () => {


### PR DESCRIPTION
## Summary
Closes #523

While the assistant is generating a reply (`isBusy`), the Studio AI chat now shows an **indeterminate progress bar** directly under the chat toolbar so progress is visible from the first wait through streaming. The conversation root sets `aria-busy` for assistive tech; the bar uses `role="progressbar"` with `aria-valuetext="Generating response"`.

Also corrects the `/api/ollama/chat` import path to `abort-errors` (was one segment short), which was breaking `yarn build`.

## How to test
1. **Open Studio** with the AI chat panel (Ollama optional).
2. **Send a message** (or use the offline demo responder).
3. **Confirm** a thin indigo bar animates under the toolbar until the reply finishes.
4. **Enable reduced motion** in the OS and confirm the bar becomes a static dim strip (no sliding animation).

## Risks
Low — UI-only; history view unchanged.

## Copilot
Please request review from Copilot after merge if not auto-assigned.

Made with [Cursor](https://cursor.com)