### PR TITLE
Fix #519 - Preview OpenAPI import from AI chat

### DIFF
--- a/docs/PLANNED_FEATURE_ROADMAP_AI.md
+++ b/docs/PLANNED_FEATURE_ROADMAP_AI.md
@@ -57,13 +57,12 @@ This outlines the planned features for integrating AI capabilities into Objectif
     - 📋 "Apply to current class" → Modify selected class
     - "Generate path for this" → Create CRUD endpoints
     - 📋 "Copy to clipboard" → Copy generated JSON/YAML
-- 📋 Preview changes before applying
+- ✅ Preview changes before applying (#519)
 - Undo AI-generated changes
 
 | Ticket | Feature Description             |
 |--------|---------------------------------|
 | #518   | Quick Actions from Chat         |
-| #519   | Preview changes before applying |
 
 ### Ollama Integration
 

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.45",
+  "version": "0.11.46",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -29,6 +29,7 @@ We continue to improve the platform based on your feedback with improvements and
 - Identical Ollama chat requests are served from an in-memory exact-match cache when a prior reply completed successfully, reducing load on your model server (disable with `OLLAMA_CHAT_CACHE_DISABLED`).
 - When a request is not an exact key match, the chat route can still reuse a prior reply if the same model/task/context applies and Ollama returns a similar enough embedding for the message payload (cosine threshold, default 0.92); disable with `OLLAMA_CHAT_CACHE_SEMANTIC_DISABLED` or tune with `OLLAMA_CHAT_CACHE_SEMANTIC_THRESHOLD` (uses the same Ollama embed endpoint as snapshot vectorization).
 - Ollama chat cache keys include a fingerprint of the version’s class and property schemas when you use the Studio AI chatbot, so edits to OpenAPI/JSON Schema state do not reuse stale cached replies.
+- Studio AI chat **Preview changes** opens a modal with a formatted OpenAPI summary and JSON before **Apply import** runs the import action (cancel returns you to the chat with no import).
 
 ---
 

--- a/objectified-ui/src/app/ade/studio/components/StudioAiChatbot.tsx
+++ b/objectified-ui/src/app/ade/studio/components/StudioAiChatbot.tsx
@@ -177,8 +177,8 @@ function ChatbotPanel({ mode, onModeChange, onClose, studioContext, tenantId }: 
   const toggleFullscreen = () =>
     onModeChange(isFullscreen ? 'slide' : 'fullscreen');
 
-  // Until project-aware import lands in a follow-up, surface the detected
-  // spec via a toast so reviewers see the affordance fire end-to-end.
+  // Import is previewed in the chat shell (#519) before this runs; until
+  // project-aware import lands in a follow-up, surface the detected spec via a toast.
   const handleImportSpec = React.useCallback((spec: DetectedOpenApiSpec) => {
     const title = (spec.spec.info as { title?: string } | undefined)?.title ?? 'OpenAPI spec';
     toast.success(`Ready to import: ${title}`, {

--- a/objectified-ui/src/app/ade/studio/components/chatbot/AiImportPreviewDialog.tsx
+++ b/objectified-ui/src/app/ade/studio/components/chatbot/AiImportPreviewDialog.tsx
@@ -1,0 +1,143 @@
+'use client';
+
+import * as React from 'react';
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/app/components/ui/Dialog';
+import type { DetectedOpenApiSpec } from './openapi-detection';
+
+export interface AiImportPreviewDialogProps {
+  open: boolean;
+  spec: DetectedOpenApiSpec | null;
+  onOpenChange: (open: boolean) => void;
+  onConfirmApply: () => void;
+}
+
+function summarizeOpenApi(spec: Record<string, unknown>) {
+  const info =
+    spec.info && typeof spec.info === 'object' && !Array.isArray(spec.info)
+      ? (spec.info as Record<string, unknown>)
+      : null;
+  const title = typeof info?.title === 'string' ? info.title : 'Untitled';
+  const infoVersion = typeof info?.version === 'string' ? info.version : null;
+  const openapi =
+    typeof spec.openapi === 'string'
+      ? spec.openapi
+      : typeof spec.swagger === 'string'
+        ? `Swagger ${spec.swagger}`
+        : null;
+  let pathCount = 0;
+  if (spec.paths && typeof spec.paths === 'object' && !Array.isArray(spec.paths)) {
+    pathCount = Object.keys(spec.paths as Record<string, unknown>).length;
+  }
+  let schemaCount = 0;
+  const components = spec.components;
+  if (components && typeof components === 'object' && !Array.isArray(components)) {
+    const schemas = (components as Record<string, unknown>).schemas;
+    if (schemas && typeof schemas === 'object' && !Array.isArray(schemas)) {
+      schemaCount = Object.keys(schemas as Record<string, unknown>).length;
+    }
+  }
+  return { title, infoVersion, openapi, pathCount, schemaCount };
+}
+
+export function AiImportPreviewDialog({
+  open,
+  spec,
+  onOpenChange,
+  onConfirmApply,
+}: AiImportPreviewDialogProps) {
+  const pretty = React.useMemo(() => {
+    if (!spec) return '';
+    try {
+      return JSON.stringify(spec.spec, null, 2);
+    } catch {
+      return spec.raw;
+    }
+  }, [spec]);
+
+  const summary = React.useMemo(() => (spec ? summarizeOpenApi(spec.spec) : null), [spec]);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        data-testid="studio-ai-chat-import-preview-dialog"
+        className="flex max-h-[90vh] max-w-3xl flex-col gap-0 overflow-hidden p-0 sm:max-w-3xl"
+      >
+        <div className="border-b border-gray-200 px-6 py-4 dark:border-gray-700">
+          <DialogHeader className="space-y-2 text-left">
+            <DialogTitle>Preview import</DialogTitle>
+            <DialogDescription className="text-left">
+              Review this OpenAPI document before it is applied. Cancel to return to the chat with no
+              changes.
+            </DialogDescription>
+          </DialogHeader>
+          {summary && (
+            <dl className="mt-3 grid gap-1 text-xs text-gray-600 dark:text-gray-400 sm:grid-cols-2">
+              <div className="flex flex-wrap gap-x-2">
+                <dt className="font-medium text-gray-700 dark:text-gray-300">API title</dt>
+                <dd>{summary.title}</dd>
+              </div>
+              {summary.openapi && (
+                <div className="flex flex-wrap gap-x-2">
+                  <dt className="font-medium text-gray-700 dark:text-gray-300">Document</dt>
+                  <dd>{summary.openapi}</dd>
+                </div>
+              )}
+              {summary.infoVersion && (
+                <div className="flex flex-wrap gap-x-2">
+                  <dt className="font-medium text-gray-700 dark:text-gray-300">Version</dt>
+                  <dd>{summary.infoVersion}</dd>
+                </div>
+              )}
+              <div className="flex flex-wrap gap-x-2">
+                <dt className="font-medium text-gray-700 dark:text-gray-300">Paths</dt>
+                <dd>{summary.pathCount}</dd>
+              </div>
+              <div className="flex flex-wrap gap-x-2">
+                <dt className="font-medium text-gray-700 dark:text-gray-300">Component schemas</dt>
+                <dd>{summary.schemaCount}</dd>
+              </div>
+            </dl>
+          )}
+        </div>
+
+        <div className="min-h-0 flex-1 overflow-y-auto px-6 py-3">
+          <pre
+            className="max-h-[min(50vh,28rem)] overflow-auto rounded-lg border border-gray-200 bg-gray-50 p-3 text-xs leading-relaxed text-gray-900 dark:border-gray-600 dark:bg-gray-950 dark:text-gray-100"
+            data-testid="studio-ai-chat-import-preview-json"
+          >
+            {pretty}
+          </pre>
+        </div>
+
+        <DialogFooter className="border-t border-gray-200 bg-gray-50 px-6 py-4 dark:border-gray-700 dark:bg-gray-900/80 sm:justify-end">
+          <button
+            type="button"
+            data-testid="studio-ai-chat-import-preview-cancel"
+            className="inline-flex h-9 items-center justify-center rounded-md border border-gray-300 bg-white px-4 text-sm font-medium text-gray-700 shadow-sm transition-colors hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
+            onClick={() => onOpenChange(false)}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            data-testid="studio-ai-chat-import-preview-apply"
+            className="inline-flex h-9 items-center justify-center rounded-md border border-transparent bg-indigo-600 px-4 text-sm font-medium text-white shadow-sm transition-colors hover:bg-indigo-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 dark:focus-visible:ring-indigo-500"
+            onClick={() => {
+              onConfirmApply();
+            }}
+          >
+            Apply import
+          </button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/objectified-ui/src/app/ade/studio/components/chatbot/ChatBubble.tsx
+++ b/objectified-ui/src/app/ade/studio/components/chatbot/ChatBubble.tsx
@@ -28,8 +28,8 @@ export interface ChatBubbleProps {
   isLatestAssistant?: boolean;
   onRegenerate?: () => void;
   onFeedback?: (feedback: ChatFeedback) => void;
-  /** When the user previews an import from a ```json``` OpenAPI block (apply is confirmed in the shell). */
-  onImportSpec?: (spec: DetectedOpenApiSpec) => void;
+  /** When the user clicks "Preview changes" on a ```json``` OpenAPI block (opens the preview dialog in the shell). */
+  onRequestImportSpecPreview?: (spec: DetectedOpenApiSpec) => void;
 }
 
 export function ChatBubble({
@@ -37,7 +37,7 @@ export function ChatBubble({
   isLatestAssistant = false,
   onRegenerate,
   onFeedback,
-  onImportSpec,
+  onRequestImportSpecPreview,
 }: ChatBubbleProps) {
   const isUser = message.role === 'user';
   const specs = React.useMemo(
@@ -80,7 +80,7 @@ export function ChatBubble({
             specs={specs}
             onRegenerate={onRegenerate}
             onFeedback={onFeedback}
-            onImportSpec={onImportSpec}
+            onRequestImportSpecPreview={onRequestImportSpecPreview}
           />
         )}
       </div>
@@ -112,7 +112,7 @@ interface AssistantActionsProps {
   specs: DetectedOpenApiSpec[];
   onRegenerate?: () => void;
   onFeedback?: (feedback: ChatFeedback) => void;
-  onImportSpec?: (spec: DetectedOpenApiSpec) => void;
+  onRequestImportSpecPreview?: (spec: DetectedOpenApiSpec) => void;
 }
 
 function AssistantActions({
@@ -121,7 +121,7 @@ function AssistantActions({
   specs,
   onRegenerate,
   onFeedback,
-  onImportSpec,
+  onRequestImportSpecPreview,
 }: AssistantActionsProps) {
   const feedback = message.feedback;
   return (
@@ -152,12 +152,12 @@ function AssistantActions({
           />
         </>
       )}
-      {onImportSpec &&
+      {onRequestImportSpecPreview &&
         specs.map((spec, index) => (
           <button
             key={`spec-${index}`}
             type="button"
-            onClick={() => onImportSpec(spec)}
+            onClick={() => onRequestImportSpecPreview(spec)}
             data-testid={`studio-ai-chat-import-spec-${index}`}
             className="ml-auto inline-flex items-center gap-1.5 rounded-md border border-indigo-200 bg-indigo-50 px-2 py-1 text-xs font-medium text-indigo-700 transition-colors hover:bg-indigo-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 dark:border-indigo-700 dark:bg-indigo-900/40 dark:text-indigo-200 dark:hover:bg-indigo-900/60"
           >

--- a/objectified-ui/src/app/ade/studio/components/chatbot/ChatBubble.tsx
+++ b/objectified-ui/src/app/ade/studio/components/chatbot/ChatBubble.tsx
@@ -20,7 +20,7 @@ import type { ChatFeedback, ChatMessage } from './types';
  *     component, with the chat-specific `<ChatCodeBlock>` for fences
  *   - assistant messages expose Regenerate and thumbs up/down feedback
  *   - assistant messages with a recognizably-OpenAPI ```json``` block expose
- *     a one-click Import button
+ *     a **Preview changes** button (#519) that opens the import preview flow in the shell
  */
 export interface ChatBubbleProps {
   message: ChatMessage;
@@ -28,7 +28,7 @@ export interface ChatBubbleProps {
   isLatestAssistant?: boolean;
   onRegenerate?: () => void;
   onFeedback?: (feedback: ChatFeedback) => void;
-  /** Receives the raw JSON of the spec the user chose to import. */
+  /** When the user previews an import from a ```json``` OpenAPI block (apply is confirmed in the shell). */
   onImportSpec?: (spec: DetectedOpenApiSpec) => void;
 }
 
@@ -162,7 +162,7 @@ function AssistantActions({
             className="ml-auto inline-flex items-center gap-1.5 rounded-md border border-indigo-200 bg-indigo-50 px-2 py-1 text-xs font-medium text-indigo-700 transition-colors hover:bg-indigo-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 dark:border-indigo-700 dark:bg-indigo-900/40 dark:text-indigo-200 dark:hover:bg-indigo-900/60"
           >
             <Download className="h-3.5 w-3.5" />
-            {specs.length > 1 ? `Import spec ${index + 1}` : 'Import OpenAPI spec'}
+            {specs.length > 1 ? `Preview changes (${index + 1})` : 'Preview changes'}
           </button>
         ))}
     </div>

--- a/objectified-ui/src/app/ade/studio/components/chatbot/ChatConversation.tsx
+++ b/objectified-ui/src/app/ade/studio/components/chatbot/ChatConversation.tsx
@@ -27,6 +27,7 @@ import {
   resolvePreferredOllamaModel,
 } from './ollama-model-defaults';
 import { createOllamaChatResponder } from './ollama-chat-responder';
+import { AiImportPreviewDialog } from './AiImportPreviewDialog';
 import type { DetectedOpenApiSpec } from './openapi-detection';
 import type { ChatFeedback, ChatMessage, ChatSendFn, ChatStreamAccumulatedMeta } from './types';
 import { isAbortError } from './abort-errors';
@@ -55,6 +56,8 @@ import { isAbortError } from './abort-errors';
  *     streaming and replaces them with measured counts when the model finishes.
  *   - While a turn is in flight (#523), an indeterminate progress bar appears under
  *     the toolbar so generation is obvious before and during streamed tokens.
+ *   - OpenAPI import from chat (#519): **Preview changes** opens a modal with a formatted
+ *     spec and summary; **Apply import** invokes `onImportSpec` so nothing applies without confirmation.
  *   - The composer can **Stop** an in-flight turn (#522): `AbortSignal` is passed to
  *     the responder so streaming fetch/SSE readers unwind and partial text is kept.
  *   - With `tenantId` + `studioContext.project` (#266), the chosen model is
@@ -64,7 +67,7 @@ import { isAbortError } from './abort-errors';
 export interface ChatConversationProps {
   /** Adapter invoked to produce assistant replies. Defaults to the demo responder. */
   onSendMessage?: ChatSendFn;
-  /** Called when the user clicks "Import OpenAPI spec" on a message. */
+  /** Called after the user confirms **Apply import** in the OpenAPI preview dialog (#519). */
   onImportSpec?: (spec: DetectedOpenApiSpec) => void;
   /** Optional starter messages — useful for tests and previews. */
   initialMessages?: ChatMessage[];
@@ -154,6 +157,7 @@ export function ChatConversation({
   );
   const [modelsRetryToken, bumpModelsRetry] = React.useReducer((n: number) => n + 1, 0);
   const ollamaModelScopeKeyRef = React.useRef<string | null>(null);
+  const [openapiImportPreview, setOpenapiImportPreview] = React.useState<DetectedOpenApiSpec | null>(null);
 
   const demoResponder = React.useMemo(() => createDemoChatResponder(), []);
   const ollamaResponder = React.useMemo(() => createOllamaChatResponder(), []);
@@ -490,6 +494,21 @@ export function ChatConversation({
     []
   );
 
+  const handleOpenApiImportPreviewRequest = React.useCallback((detected: DetectedOpenApiSpec) => {
+    setOpenapiImportPreview(detected);
+  }, []);
+
+  const handleConfirmOpenApiImportApply = React.useCallback(() => {
+    if (openapiImportPreview && onImportSpec) {
+      onImportSpec(openapiImportPreview);
+    }
+    setOpenapiImportPreview(null);
+  }, [openapiImportPreview, onImportSpec]);
+
+  const handleOpenApiImportPreviewDialogChange = React.useCallback((next: boolean) => {
+    if (!next) setOpenapiImportPreview(null);
+  }, []);
+
   const askConfirm = React.useCallback(
     (message: string) => {
       const fn = confirmAction ?? defaultConfirm;
@@ -660,7 +679,7 @@ export function ChatConversation({
                     isLatestAssistant={message.id === lastAssistantId}
                     onRegenerate={message.id === lastAssistantId ? handleRegenerate : undefined}
                     onFeedback={(feedback) => handleFeedback(message.id, feedback)}
-                    onImportSpec={onImportSpec}
+                    onImportSpec={onImportSpec ? handleOpenApiImportPreviewRequest : undefined}
                   />
                 ))}
                 <div ref={messagesEndRef} aria-hidden />
@@ -679,6 +698,15 @@ export function ChatConversation({
           <ChatComposer onSend={handleSend} isBusy={isBusy} onStop={handleStopStreaming} />
         </>
       )}
+
+      {onImportSpec ? (
+        <AiImportPreviewDialog
+          open={openapiImportPreview !== null}
+          spec={openapiImportPreview}
+          onOpenChange={handleOpenApiImportPreviewDialogChange}
+          onConfirmApply={handleConfirmOpenApiImportApply}
+        />
+      ) : null}
     </div>
   );
 }

--- a/objectified-ui/src/app/ade/studio/components/chatbot/ChatConversation.tsx
+++ b/objectified-ui/src/app/ade/studio/components/chatbot/ChatConversation.tsx
@@ -494,19 +494,27 @@ export function ChatConversation({
     []
   );
 
+  const isApplyingSpecRef = React.useRef(false);
+
   const handleOpenApiImportPreviewRequest = React.useCallback((detected: DetectedOpenApiSpec) => {
+    isApplyingSpecRef.current = false;
     setOpenapiImportPreview(detected);
   }, []);
 
   const handleConfirmOpenApiImportApply = React.useCallback(() => {
-    if (openapiImportPreview && onImportSpec) {
-      onImportSpec(openapiImportPreview);
+    if (openapiImportPreview && onImportSpec && !isApplyingSpecRef.current) {
+      isApplyingSpecRef.current = true;
+      const specToApply = openapiImportPreview;
+      setOpenapiImportPreview(null);
+      onImportSpec(specToApply);
     }
-    setOpenapiImportPreview(null);
   }, [openapiImportPreview, onImportSpec]);
 
   const handleOpenApiImportPreviewDialogChange = React.useCallback((next: boolean) => {
-    if (!next) setOpenapiImportPreview(null);
+    if (!next) {
+      isApplyingSpecRef.current = false;
+      setOpenapiImportPreview(null);
+    }
   }, []);
 
   const askConfirm = React.useCallback(
@@ -679,7 +687,7 @@ export function ChatConversation({
                     isLatestAssistant={message.id === lastAssistantId}
                     onRegenerate={message.id === lastAssistantId ? handleRegenerate : undefined}
                     onFeedback={(feedback) => handleFeedback(message.id, feedback)}
-                    onImportSpec={onImportSpec ? handleOpenApiImportPreviewRequest : undefined}
+                    onRequestImportSpecPreview={onImportSpec ? handleOpenApiImportPreviewRequest : undefined}
                   />
                 ))}
                 <div ref={messagesEndRef} aria-hidden />

--- a/objectified-ui/tests/chatbot/ChatBubble.test.tsx
+++ b/objectified-ui/tests/chatbot/ChatBubble.test.tsx
@@ -99,25 +99,25 @@ describe('ChatBubble', () => {
   });
 
   it('renders an Import button when the message contains an OpenAPI spec', () => {
-    const onImportSpec = jest.fn();
-    render(<ChatBubble message={specMessage} onImportSpec={onImportSpec} />);
+    const onRequestImportSpecPreview = jest.fn();
+    render(<ChatBubble message={specMessage} onRequestImportSpecPreview={onRequestImportSpecPreview} />);
     const importButton = screen.getByTestId('studio-ai-chat-import-spec-0');
     expect(importButton).toHaveTextContent(/Preview changes/i);
     fireEvent.click(importButton);
-    expect(onImportSpec).toHaveBeenCalledTimes(1);
-    expect(onImportSpec.mock.calls[0][0].version).toBe('3.1.0');
+    expect(onRequestImportSpecPreview).toHaveBeenCalledTimes(1);
+    expect(onRequestImportSpecPreview.mock.calls[0][0].version).toBe('3.1.0');
   });
 
-  it('does not render an Import button when onImportSpec is not provided', () => {
+  it('does not render an Import button when onRequestImportSpecPreview is not provided', () => {
     render(<ChatBubble message={specMessage} />);
     expect(screen.queryByTestId('studio-ai-chat-import-spec-0')).not.toBeInTheDocument();
   });
 
   it('does not render an Import button on user messages or assistant text without a spec', () => {
-    const { rerender } = render(<ChatBubble message={userMessage} onImportSpec={() => undefined} />);
+    const { rerender } = render(<ChatBubble message={userMessage} onRequestImportSpecPreview={() => undefined} />);
     expect(screen.queryByTestId('studio-ai-chat-import-spec-0')).not.toBeInTheDocument();
 
-    rerender(<ChatBubble message={assistantMessage} onImportSpec={() => undefined} />);
+    rerender(<ChatBubble message={assistantMessage} onRequestImportSpecPreview={() => undefined} />);
     expect(screen.queryByTestId('studio-ai-chat-import-spec-0')).not.toBeInTheDocument();
   });
 });

--- a/objectified-ui/tests/chatbot/ChatBubble.test.tsx
+++ b/objectified-ui/tests/chatbot/ChatBubble.test.tsx
@@ -102,7 +102,7 @@ describe('ChatBubble', () => {
     const onImportSpec = jest.fn();
     render(<ChatBubble message={specMessage} onImportSpec={onImportSpec} />);
     const importButton = screen.getByTestId('studio-ai-chat-import-spec-0');
-    expect(importButton).toHaveTextContent(/Import OpenAPI spec/i);
+    expect(importButton).toHaveTextContent(/Preview changes/i);
     fireEvent.click(importButton);
     expect(onImportSpec).toHaveBeenCalledTimes(1);
     expect(onImportSpec.mock.calls[0][0].version).toBe('3.1.0');

--- a/objectified-ui/tests/chatbot/ChatConversation.test.tsx
+++ b/objectified-ui/tests/chatbot/ChatConversation.test.tsx
@@ -729,8 +729,41 @@ describe('ChatConversation', () => {
 
     const importButton = await screen.findByTestId('studio-ai-chat-import-spec-0');
     fireEvent.click(importButton);
+    expect(screen.getByTestId('studio-ai-chat-import-preview-dialog')).toBeInTheDocument();
+    expect(onImportSpec).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByTestId('studio-ai-chat-import-preview-apply'));
     expect(onImportSpec).toHaveBeenCalledTimes(1);
     expect(onImportSpec.mock.calls[0][0].version).toBe('3.1.0');
+  });
+
+  it('closes the OpenAPI import preview without applying when Cancel is used (#519)', async () => {
+    const onImportSpec = jest.fn();
+    const responder: ChatSendFn = () =>
+      Promise.resolve(
+        [
+          'Spec ready:',
+          '',
+          '```json',
+          JSON.stringify({
+            openapi: '3.1.0',
+            info: { title: 'Sample', version: '0.1.0' },
+            components: { schemas: {} },
+          }),
+          '```',
+        ].join('\n')
+      );
+
+    render(<ChatConversation onSendMessage={responder} onImportSpec={onImportSpec} />);
+    fireEvent.change(screen.getByTestId('studio-ai-chat-input'), { target: { value: 'spec' } });
+    fireEvent.click(screen.getByTestId('studio-ai-chat-send'));
+
+    const importButton = await screen.findByTestId('studio-ai-chat-import-spec-0');
+    fireEvent.click(importButton);
+    fireEvent.click(screen.getByTestId('studio-ai-chat-import-preview-cancel'));
+
+    expect(onImportSpec).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('studio-ai-chat-import-preview-dialog')).not.toBeInTheDocument();
   });
 
   it('updates the pending bubble incrementally via onStreamAccumulated and commits the final reply (#520)', async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17940,7 +17940,7 @@
       "version": "1.0.1"
     },
     "objectified-ui": {
-      "version": "0.11.45",
+      "version": "0.11.46",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6758,7 +6758,7 @@ object.values@^1.1.6, object.values@^1.2.1:
     es-object-atoms "^1.0.0"
 
 "objectified-ui@file:/home/runner/work/objectified-commercial/objectified-commercial/objectified-ui":
-  version "0.11.45"
+  version "0.11.46"
   resolved "file:objectified-ui"
   dependencies:
     "@dnd-kit/core" "^6.3.1"


### PR DESCRIPTION
## What changed
- OpenAPI blocks in assistant replies now use a **Preview changes** action that opens a modal (summary + formatted JSON) instead of applying immediately.
- **Apply import** runs the existing `onImportSpec` handler (studio still shows the success toast until project-aware import lands). **Cancel** closes with no callback.

## How to test
1. **Open** the Studio AI chat on editor or paths.
2. **Send** a prompt that returns a ```json``` OpenAPI document (or use a canned reply in tests).
3. **Click** **Preview changes** on the assistant message.
4. **Confirm** the modal shows title, document version, path/schema counts, and JSON.
5. **Click** **Apply import** and verify the toast / downstream behavior; repeat and **Cancel** to ensure nothing fires.

## Risk / notes
- Modal uses Radix `Dialog` (z-index above the chat panel). Large specs scroll inside the preview pane.

Closes #519

Made with [Cursor](https://cursor.com)