### PR TITLE
Fix #267 - Schema generation from plain-language descriptions

### DIFF
--- a/docs/PLANNED_FEATURE_ROADMAP_AI.md
+++ b/docs/PLANNED_FEATURE_ROADMAP_AI.md
@@ -76,7 +76,7 @@ This outlines the planned features for integrating AI capabilities into Objectif
 
 **Schema Generation from Description** 📋 PLANNED
 - 📋 **Input Methods**:
-    - 📋 Free-form text description
+    - ✅ Free-form text description (#267 — Studio AI chat: offline demo + Ollama system prompt)
     - 📋 Structured prompts with templates
     - 📋 Voice input (speech-to-text)
     - 📋 Paste requirements document
@@ -98,7 +98,6 @@ This outlines the planned features for integrating AI capabilities into Objectif
 
 | Ticket | Feature Description                                      |
 |--------|----------------------------------------------------------|
-| #267   | Adds the ability to generate a schema from a description |
 | #268   | Adds example prompts                                     |
 | #528   | Preview generated schema before creation                 |
 | #529   | JSON Schema format display on preview                    |

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.47",
+  "version": "0.11.48",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -20,6 +20,7 @@ We continue to improve the platform based on your feedback with improvements and
 ## Export
 
 ## Studio
+- Studio AI chat treats plain-language domain descriptions (and similar phrasing) as requests to draft OpenAPI `components/schemas`, including when Ollama is connected (#267).
 - AI chatbot lists Ollama models from your server and lets you pick which model answers each conversation (falls back to the offline assistant when Ollama is unavailable).
 - Studio chatbot remembers your preferred Ollama tag per project (and per tenant), with an optional control to set a tenant-wide default when you are inside a project.
 - Studio AI chat streams Ollama replies over SSE so assistant text appears incrementally as the model generates.
@@ -46,5 +47,5 @@ We'd love to hear your thoughts! Your feedback helps us make Objectified better.
 
 **Thank you for using Objectified!**
 
-*Last updated: May 3, 2026*
+*Last updated: May 4, 2026*
 

--- a/objectified-ui/src/app/ade/studio/components/chatbot/ChatConversation.tsx
+++ b/objectified-ui/src/app/ade/studio/components/chatbot/ChatConversation.tsx
@@ -120,9 +120,9 @@ export interface ChatConversationProps {
 }
 
 const PROMPT_SUGGESTIONS: readonly string[] = [
+  'I need an e-commerce order with line items, shipping address, and payment info',
   'Sketch a User class with email, password hash, and roles',
   'Generate an OpenAPI spec for a small catalog API',
-  'How would I model a multi-tenant audit log?',
 ];
 
 /**

--- a/objectified-ui/src/app/ade/studio/components/chatbot/demo-responder.ts
+++ b/objectified-ui/src/app/ade/studio/components/chatbot/demo-responder.ts
@@ -41,6 +41,7 @@ import {
   type ChatRefinementOp,
 } from './conversation-history';
 import type { ChatSendFn } from './types';
+import { userPromptRequestsSchemaFromDescription } from './schema-from-description-intent';
 
 const SPEC_DEMO_PROMPTS = ['openapi', 'spec', 'schema', 'api'];
 
@@ -71,7 +72,8 @@ export const createDemoChatResponder = (): ChatSendFn => async ({
 
   const wantsSpec =
     history.intent === 'comparison' ||
-    SPEC_DEMO_PROMPTS.some((needle) => lower.includes(needle));
+    SPEC_DEMO_PROMPTS.some((needle) => lower.includes(needle)) ||
+    userPromptRequestsSchemaFromDescription(prompt);
 
   if (wantsSpec) {
     const spec = buildSampleSpec(studioContext, history);

--- a/objectified-ui/src/app/ade/studio/components/chatbot/schema-from-description-intent.ts
+++ b/objectified-ui/src/app/ade/studio/components/chatbot/schema-from-description-intent.ts
@@ -1,0 +1,46 @@
+/**
+ * Detect Studio chat prompts that ask for schema output from a plain-language
+ * description (#267), without requiring words like "OpenAPI" or "spec".
+ */
+
+const SPEC_HINT_NEEDLES = ['openapi', 'spec', 'schema', 'api'] as const;
+
+const DESCRIPTION_INTENT_PATTERNS: ReadonlyArray<RegExp> = [
+  /\b(create|build|design|sketch|model|define|map out)\s+(a|an|the|my|our)\b/i,
+  /\b(i|we)\s+(need|want)\s+(a|an|the|my|our|to\s+model|to\s+design|to\s+build)\b/i,
+  /\b(class|classes|entity|entities)\s+(with|for|named|called|that|having)\b/i,
+  /\b(data|domain|object)\s+model\b/i,
+  /\b(user\s+stor(y|ies)|requirements(\s+document)?|requirements?\s+for)\b/i,
+  /\bpaste(d)?\s+(the\s+)?requirements\b/i,
+];
+
+const SMALL_TALK_PREFIX =
+  /^(hi|hello|hey|thanks|thank you|ok|okay|bye|good morning|good afternoon)\b/i;
+
+const MODELING_VOCAB =
+  /\b(class|classes|entity|entities|schema|schemas|model|models|field|fields|property|properties|type|types|object|objects|record|records|table|tables|attribute|attributes)\b/i;
+
+const MIN_CHARS = 16;
+const MIN_CHARS_WITHOUT_MODELING_TERMS = 28;
+
+/**
+ * True when the user is likely asking for generated OpenAPI components/schemas
+ * from a written description (possibly multi-sentence or pasted).
+ */
+export function userPromptRequestsSchemaFromDescription(prompt: string): boolean {
+  const trimmed = prompt.trim();
+  if (trimmed.length < MIN_CHARS) return false;
+
+  const lower = trimmed.toLowerCase();
+  if (SPEC_HINT_NEEDLES.some((n) => lower.includes(n))) return true;
+
+  if (SMALL_TALK_PREFIX.test(trimmed) && trimmed.length < 100) return false;
+
+  if (!DESCRIPTION_INTENT_PATTERNS.some((re) => re.test(trimmed))) return false;
+
+  if (trimmed.length < MIN_CHARS_WITHOUT_MODELING_TERMS && !MODELING_VOCAB.test(trimmed)) {
+    return false;
+  }
+
+  return true;
+}

--- a/objectified-ui/src/app/ade/studio/components/chatbot/schema-from-description-intent.ts
+++ b/objectified-ui/src/app/ade/studio/components/chatbot/schema-from-description-intent.ts
@@ -14,8 +14,26 @@ const DESCRIPTION_INTENT_PATTERNS: ReadonlyArray<RegExp> = [
   /\bpaste(d)?\s+(the\s+)?requirements\b/i,
 ];
 
+// Words that must NOT appear as the first "entity" after "I need/want" to avoid
+// matching support phrases like "I need help and advice".
+const ENTITY_LIST_EXCLUSIONS =
+  /help|assistance|support|info|information|advice|guidance|clarification|you|someone|anything|something|more|some|just/;
+
+// Matches "I need users, roles, and permissions" or "We want posts and comments":
+// subject ("I"/"we") + verb ("need"/"want") + first entity (not a support/meta word)
+// + at least one more entity connected by comma or "and".
+const ENTITY_LIST_PATTERNS: ReadonlyArray<RegExp> = [
+  new RegExp(
+    `\\b(i|we)\\s+(need|want)\\s+(?!(${ENTITY_LIST_EXCLUSIONS.source})\\b)\\w+(?:\\s*,\\s*\\w+|\\s+and\\s+\\w+)`,
+    'i',
+  ),
+];
+
 const SMALL_TALK_PREFIX =
   /^(hi|hello|hey|thanks|thank you|ok|okay|bye|good morning|good afternoon)\b/i;
+
+// Punctuation/whitespace that separates a greeting from the rest of the prompt.
+const LEADING_PUNCTUATION = /^[\s,;!.]+/;
 
 const MODELING_VOCAB =
   /\b(class|classes|entity|entities|schema|schemas|model|models|field|fields|property|properties|type|types|object|objects|record|records|table|tables|attribute|attributes)\b/i;
@@ -34,11 +52,22 @@ export function userPromptRequestsSchemaFromDescription(prompt: string): boolean
   const lower = trimmed.toLowerCase();
   if (SPEC_HINT_NEEDLES.some((n) => lower.includes(n))) return true;
 
-  if (SMALL_TALK_PREFIX.test(trimmed) && trimmed.length < 100) return false;
+  // Strip leading greeting/social phrase so "Hi, I need a blog platform…" is evaluated
+  // on its meaningful tail rather than being rejected as small-talk.
+  const content = SMALL_TALK_PREFIX.test(trimmed)
+    ? trimmed.replace(SMALL_TALK_PREFIX, '').replace(LEADING_PUNCTUATION, '')
+    : trimmed;
 
-  if (!DESCRIPTION_INTENT_PATTERNS.some((re) => re.test(trimmed))) return false;
+  // Pure greeting with no following domain content.
+  if (content.length < MIN_CHARS) return false;
 
-  if (trimmed.length < MIN_CHARS_WITHOUT_MODELING_TERMS && !MODELING_VOCAB.test(trimmed)) {
+  // Entity-list patterns are specific enough to signal a schema request without
+  // requiring explicit modeling vocabulary (e.g. "I need users, roles, and permissions").
+  if (ENTITY_LIST_PATTERNS.some((re) => re.test(content))) return true;
+
+  if (!DESCRIPTION_INTENT_PATTERNS.some((re) => re.test(content))) return false;
+
+  if (content.length < MIN_CHARS_WITHOUT_MODELING_TERMS && !MODELING_VOCAB.test(content)) {
     return false;
   }
 

--- a/objectified-ui/src/app/api/ollama/chat/route.ts
+++ b/objectified-ui/src/app/api/ollama/chat/route.ts
@@ -147,6 +147,7 @@ export async function POST(request: NextRequest) {
 
 # Rules
 
+- When the user describes a domain, product, entities, or pasted requirements in plain language — even if they never say "OpenAPI" or "schema" — treat that as a request to produce or extend \`#/components/schemas\` accordingly (unless they clearly want non-schema advice only).
 - Always generate valid OpenAPI 3.1.0 specifications
 - When generating a complete specification, wrap it in a JSON code block: \`\`\`json\n{spec}\n\`\`\`
 - Include proper info section with title, version, description, license, contact details

--- a/objectified-ui/tests/chatbot/demo-responder.test.ts
+++ b/objectified-ui/tests/chatbot/demo-responder.test.ts
@@ -47,6 +47,18 @@ describe('createDemoChatResponder', () => {
     expect(detectOpenApiSpecs(reply)).toHaveLength(1);
   });
 
+  it('returns an OpenAPI spec for a plain-language description without spec keywords (#267)', async () => {
+    const reply = await responder({
+      messages: [],
+      prompt:
+        'I need a blog platform with posts, authors, and comments where each comment references a post',
+      isRegenerate: false,
+    });
+    expect(reply).toMatch(/```json/);
+    expect(detectOpenApiSpecs(reply)).toHaveLength(1);
+    expect(reply).toMatch(/Import OpenAPI spec/);
+  });
+
   it('returns a generic onboarding reply for unrelated prompts', async () => {
     const reply = await responder({
       messages: [],

--- a/objectified-ui/tests/chatbot/schema-from-description-intent.test.ts
+++ b/objectified-ui/tests/chatbot/schema-from-description-intent.test.ts
@@ -1,0 +1,39 @@
+import { userPromptRequestsSchemaFromDescription } from '../../src/app/ade/studio/components/chatbot/schema-from-description-intent';
+
+describe('userPromptRequestsSchemaFromDescription (#267)', () => {
+  it('is true for plain-language domain descriptions without spec keywords', () => {
+    expect(
+      userPromptRequestsSchemaFromDescription(
+        'I need a simple todo list with tasks that have titles, due dates, and completion flags',
+      ),
+    ).toBe(true);
+    expect(
+      userPromptRequestsSchemaFromDescription(
+        'We want to model patients, appointments, and providers for a small clinic',
+      ),
+    ).toBe(true);
+  });
+
+  it('still treats explicit spec/schema vocabulary as a generation request', () => {
+    expect(userPromptRequestsSchemaFromDescription('draft an openapi blob')).toBe(true);
+    expect(userPromptRequestsSchemaFromDescription('show me the schema')).toBe(true);
+  });
+
+  it('is false for small talk and unrelated short prompts', () => {
+    expect(userPromptRequestsSchemaFromDescription('tell me a joke')).toBe(false);
+    expect(userPromptRequestsSchemaFromDescription('thanks for your help')).toBe(false);
+    expect(userPromptRequestsSchemaFromDescription('hello')).toBe(false);
+  });
+
+  it('is false for vague “create” lines without modeling vocabulary', () => {
+    expect(userPromptRequestsSchemaFromDescription('create something cool')).toBe(false);
+  });
+
+  it('is true for pasted-requirements phrasing', () => {
+    expect(
+      userPromptRequestsSchemaFromDescription(
+        'Here are the requirements: users must authenticate with email and belong to organizations',
+      ),
+    ).toBe(true);
+  });
+});

--- a/objectified-ui/tests/chatbot/schema-from-description-intent.test.ts
+++ b/objectified-ui/tests/chatbot/schema-from-description-intent.test.ts
@@ -25,7 +25,7 @@ describe('userPromptRequestsSchemaFromDescription (#267)', () => {
     expect(userPromptRequestsSchemaFromDescription('hello')).toBe(false);
   });
 
-  it('is false for vague “create” lines without modeling vocabulary', () => {
+  it('is false for vague "create" lines without modeling vocabulary', () => {
     expect(userPromptRequestsSchemaFromDescription('create something cool')).toBe(false);
   });
 
@@ -35,5 +35,38 @@ describe('userPromptRequestsSchemaFromDescription (#267)', () => {
         'Here are the requirements: users must authenticate with email and belong to organizations',
       ),
     ).toBe(true);
+  });
+
+  it('is true for polite prompts that lead into a modeling request', () => {
+    // Greeting prefix should not suppress detection when the tail is a schema request.
+    expect(
+      userPromptRequestsSchemaFromDescription(
+        'Hi, I need a blog platform with posts and comments',
+      ),
+    ).toBe(true);
+    expect(
+      userPromptRequestsSchemaFromDescription(
+        'Hello, we want to model a library system with books and members',
+      ),
+    ).toBe(true);
+  });
+
+  it('is true for direct noun lists after "I need" / "we want" without an article', () => {
+    // The entity-list pattern should catch these even without modeling vocabulary.
+    expect(
+      userPromptRequestsSchemaFromDescription('I need users, roles, and permissions'),
+    ).toBe(true);
+    expect(
+      userPromptRequestsSchemaFromDescription('We want posts and comments'),
+    ).toBe(true);
+    expect(
+      userPromptRequestsSchemaFromDescription('I need products, orders, and customers'),
+    ).toBe(true);
+  });
+
+  it('is false when "I need/want" is followed by support or meta words', () => {
+    // Common non-entity words after need/want should not trigger schema generation.
+    expect(userPromptRequestsSchemaFromDescription('I need help and support')).toBe(false);
+    expect(userPromptRequestsSchemaFromDescription('I need more information')).toBe(false);
   });
 });


### PR DESCRIPTION
## What / why
Studio AI chat now treats common plain-language modeling prompts (e.g. “I need…”, “we want to model…”, pasted requirements) as requests to draft OpenAPI `components/schemas`, not only when the user says “OpenAPI” or “schema”. The offline demo uses a small intent helper; the live Ollama route’s default system prompt states the same expectation.

## How to test
1. **Open Studio** editor/paths with the AI chatbot available (no Ollama needed for the offline path).
2. **Send** a prompt like: `I need a blog platform with posts, authors, and comments` (no “OpenAPI” wording).
3. **Confirm** the assistant returns a ```json``` OpenAPI block and **Import OpenAPI spec** / preview affordances appear as before.
4. **Optional:** With Ollama enabled, send the same style of prompt and confirm the model still returns a valid OpenAPI document.

## Risk / notes
- Intent detection is heuristic; unrelated long prompts that match phrasing patterns could yield a spec (users can ignore or refine).
- Root `yarn lint` in objectified-ui reports many pre-existing issues across tests; unchanged by this PR.

Closes #267

Made with [Cursor](https://cursor.com)