### PR TITLE
Fix #268 - Add example prompts to Studio AI generation

### DIFF
--- a/docs/PLANNED_FEATURES.md
+++ b/docs/PLANNED_FEATURES.md
@@ -255,7 +255,7 @@ Implement in this order so each step stays testable. **Issue → roadmap ID** fo
 | C.5 | **Chat shell:** placement, design guidelines | **#257**, **#258** |
 | C.6 | **Conversation + context:** context awareness, multi-turn, history actions | **#259**, **#260**, **#261** |
 | C.7 | **Quick actions + apply:** actions from chat, preview before apply | **#518** (done), **#519** |
-| C.8 | **NL → schema:** description → schema, examples, preview surface | **#267**, **#268**, **#528–#532** |
+| C.8 | **NL → schema:** description → schema, examples, preview surface | **#267**, **#268** (done), **#528–#532** |
 | C.9 | **Property assist:** suggestions, dropdown, bulk, triggers, analysis | **#269–#276**, **#277**, **#278** |
 | C.10 | **Higher insights (post-MVP polish):** improvement suggestions, docs generation, layout hints, etc. | **#253–#256**, **#495**, **#609–#623** (schedule after core chat works) |
 

--- a/docs/PLANNED_FEATURE_ROADMAP_AI.md
+++ b/docs/PLANNED_FEATURE_ROADMAP_AI.md
@@ -80,11 +80,11 @@ This outlines the planned features for integrating AI capabilities into Objectif
     - 📋 Structured prompts with templates
     - 📋 Voice input (speech-to-text)
     - 📋 Paste requirements document
-- 📋 **Example Prompts**:
-    - 📋 "Create a User class with email, password hash, created date, and roles array"
-    - 📋 "I need an e-commerce order with line items, shipping address, and payment info"
-    - 📋 "Generate a blog post schema with author reference, tags, and comments"
-    - 📋 "Create a REST API for managing a todo list application"
+- ✅ **Example Prompts** (#268):
+    - ✅ "Create a User class with email, password hash, created date, and roles array"
+    - ✅ "I need an e-commerce order with line items, shipping address, and payment info"
+    - ✅ "Generate a blog post schema with author reference, tags, and comments"
+    - ✅ "Create a REST API for managing a todo list application"
 - 📋 **Generation Output**:
     - 📋 Preview generated schema before creation
     - 📋 JSON Schema format display
@@ -98,7 +98,6 @@ This outlines the planned features for integrating AI capabilities into Objectif
 
 | Ticket | Feature Description                                      |
 |--------|----------------------------------------------------------|
-| #268   | Adds example prompts                                     |
 | #528   | Preview generated schema before creation                 |
 | #529   | JSON Schema format display on preview                    |
 | #530   | Property list with types on preview                      |

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.48",
+  "version": "0.11.49",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -20,6 +20,7 @@ We continue to improve the platform based on your feedback with improvements and
 ## Export
 
 ## Studio
+- Studio AI chat empty state offers example prompts for schema and API generation (#268).
 - Studio AI chat treats plain-language domain descriptions (and similar phrasing) as requests to draft OpenAPI `components/schemas`, including when Ollama is connected (#267).
 - AI chatbot lists Ollama models from your server and lets you pick which model answers each conversation (falls back to the offline assistant when Ollama is unavailable).
 - Studio chatbot remembers your preferred Ollama tag per project (and per tenant), with an optional control to set a tenant-wide default when you are inside a project.

--- a/objectified-ui/src/app/ade/studio/components/chatbot/ChatConversation.tsx
+++ b/objectified-ui/src/app/ade/studio/components/chatbot/ChatConversation.tsx
@@ -120,9 +120,10 @@ export interface ChatConversationProps {
 }
 
 const PROMPT_SUGGESTIONS: readonly string[] = [
+  'Create a User class with email, password hash, created date, and roles array',
   'I need an e-commerce order with line items, shipping address, and payment info',
-  'Sketch a User class with email, password hash, and roles',
-  'Generate an OpenAPI spec for a small catalog API',
+  'Generate a blog post schema with author reference, tags, and comments',
+  'Create a REST API for managing a todo list application',
 ];
 
 /**

--- a/objectified-ui/tests/chatbot/ChatConversation.test.tsx
+++ b/objectified-ui/tests/chatbot/ChatConversation.test.tsx
@@ -120,6 +120,17 @@ describe('ChatConversation', () => {
     expect(suggestions.length).toBeGreaterThanOrEqual(3);
   });
 
+  it('shows the four NL→schema example prompts on the empty state (#268)', () => {
+    render(<ChatConversation />);
+    const labels = screen.getAllByTestId('studio-ai-chat-suggestion').map((el) => el.textContent?.trim() ?? '');
+    expect(labels).toEqual([
+      'Create a User class with email, password hash, created date, and roles array',
+      'I need an e-commerce order with line items, shipping address, and payment info',
+      'Generate a blog post schema with author reference, tags, and comments',
+      'Create a REST API for managing a todo list application',
+    ]);
+  });
+
   it('clicking a suggestion seeds the conversation as a user message', async () => {
     const { responder, calls, resolveWith } = createDeferredResponder();
     render(<ChatConversation onSendMessage={responder} />);


### PR DESCRIPTION
## What changed
- Replaced Studio AI chat empty-state `PROMPT_SUGGESTIONS` with the four NL→schema example prompts from the issue (User, e-commerce order, blog post schema, todo REST API).
- Added a Jest case that locks the visible suggestion list to those strings.
- Marked #268 done in `docs/PLANNED_FEATURE_ROADMAP_AI.md`, noted in `docs/PLANNED_FEATURES.md`, `public/WHATS_NEW.md`, and bumped `objectified-ui` patch version.

## How to test
1. **Open Studio** on a canvas route and **open the AI assistant** (launcher / Ctrl+Shift+A).
2. **Start a new chat** or clear history so the empty state appears.
3. Confirm **four suggestion buttons** match the issue copy; **click one** and confirm it sends as the user message.

## Risk / notes
- Copy-only + roadmap housekeeping; low risk. Full-repo `yarn workspace objectified-ui lint` currently reports many pre-existing issues; `yarn build` and `yarn test` from repo root passed.

Closes #268

Made with [Cursor](https://cursor.com)