### PR TITLE
Fix #529 - JSON Schema format display in AI class previews

### DIFF
--- a/docs/PLANNED_FEATURE_ROADMAP_AI.md
+++ b/docs/PLANNED_FEATURE_ROADMAP_AI.md
@@ -87,7 +87,7 @@ This outlines the planned features for integrating AI capabilities into Objectif
     - ✅ "Create a REST API for managing a todo list application"
 - 📋 **Generation Output**:
     - ✅ Preview generated schema before creation (#528)
-    - 📋 JSON Schema format display
+    - ✅ JSON Schema format display (#529)
     - 📋 Property list with types
     - 📋 Relationship suggestions
 - 📋 **Iterative Refinement**:
@@ -98,7 +98,6 @@ This outlines the planned features for integrating AI capabilities into Objectif
 
 | Ticket | Feature Description                                      |
 |--------|----------------------------------------------------------|
-| #529   | JSON Schema format display on preview                    |
 | #530   | Property list with types on preview                      |
 | #531   | Relationship suggestions on preview                      |
 | #532   | Iterative refinement of generated schemas                |

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.50",
+  "version": "0.11.51",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -33,7 +33,7 @@ We continue to improve the platform based on your feedback with improvements and
 - Ollama chat cache keys include a fingerprint of the version’s class and property schemas when you use the Studio AI chatbot, so edits to OpenAPI/JSON Schema state do not reuse stale cached replies.
 - Studio AI chat **Preview changes** opens a modal with a formatted OpenAPI summary and JSON before **Apply import** runs the import action (cancel returns you to the chat with no import).
 - Assistant replies that include phrases such as **Create this class**, **Add these properties**, **Apply to current class**, or **Copy to clipboard** (with a JSON or YAML code block) show quick-action buttons: new class, open the selected class for editing, or copy the fenced payload.
-- **Create this class** opens a preview of class metadata and the formatted JSON Schema body before continuing; confirming opens Add Class in AI mode with that reply seeded (#528). Create Class with AI uses the same preview step via **Preview & create** (#529).
+- **Create this class** opens a preview before continuing (#528); the preview shows class metadata and the generated schema as formatted **JSON Schema** (#529). Confirming opens Add Class in AI mode with that reply seeded. Create Class with AI uses the same preview via **Preview & create**.
 
 ---
 

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -33,7 +33,7 @@ We continue to improve the platform based on your feedback with improvements and
 - Ollama chat cache keys include a fingerprint of the version’s class and property schemas when you use the Studio AI chatbot, so edits to OpenAPI/JSON Schema state do not reuse stale cached replies.
 - Studio AI chat **Preview changes** opens a modal with a formatted OpenAPI summary and JSON before **Apply import** runs the import action (cancel returns you to the chat with no import).
 - Assistant replies that include phrases such as **Create this class**, **Add these properties**, **Apply to current class**, or **Copy to clipboard** (with a JSON or YAML code block) show quick-action buttons: new class, open the selected class for editing, or copy the fenced payload.
-- **Create this class** opens a preview of the parsed JSON Schema (name, description, property list, and raw JSON) before continuing; confirming opens Add Class in AI mode with that reply seeded (#528). Create Class with AI uses the same preview step via **Preview & create**.
+- **Create this class** opens a preview of class metadata and the formatted JSON Schema body before continuing; confirming opens Add Class in AI mode with that reply seeded (#528). Create Class with AI uses the same preview step via **Preview & create** (#529).
 
 ---
 

--- a/objectified-ui/src/app/ade/studio/components/chatbot/AiClassCreatePreviewDialog.tsx
+++ b/objectified-ui/src/app/ade/studio/components/chatbot/AiClassCreatePreviewDialog.tsx
@@ -51,10 +51,10 @@ export function AiClassCreatePreviewDialog({
     return parseClassDefinitionFromAssistantMarkdown(assistantMarkdown);
   }, [assistantMarkdown]);
 
-  const pretty = React.useMemo(() => {
+  const schemaJson = React.useMemo(() => {
     if (!parsed) return '';
     try {
-      return JSON.stringify({ name: parsed.name, description: parsed.description, schema: parsed.schema }, null, 2);
+      return JSON.stringify(parsed.schema, null, 2);
     } catch {
       return '';
     }
@@ -72,7 +72,8 @@ export function AiClassCreatePreviewDialog({
           <DialogHeader className="space-y-2 text-left">
             <DialogTitle>Preview class schema</DialogTitle>
             <DialogDescription className="text-left">
-              Review the generated JSON Schema before continuing. Cancel to return to the chat with no changes.
+              Review the class metadata and the formatted JSON Schema below before continuing. Cancel to return to the
+              chat with no changes.
             </DialogDescription>
           </DialogHeader>
           {parsed ? (
@@ -112,12 +113,17 @@ export function AiClassCreatePreviewDialog({
         </div>
 
         <div className="min-h-0 flex-1 overflow-y-auto px-6 py-3">
-          <pre
-            className="max-h-[min(50vh,28rem)] overflow-auto rounded-lg border border-gray-200 bg-gray-50 p-3 text-xs leading-relaxed text-gray-900 dark:border-gray-600 dark:bg-gray-950 dark:text-gray-100"
-            data-testid="studio-ai-chat-class-create-preview-json"
-          >
-            {pretty || assistantMarkdown || '—'}
-          </pre>
+          <div className="overflow-hidden rounded-lg border border-gray-200 dark:border-gray-600">
+            <div className="border-b border-gray-200 bg-gray-100 px-3 py-1.5 dark:border-gray-700 dark:bg-gray-900">
+              <span className="text-xs font-mono text-gray-700 dark:text-gray-300">JSON Schema</span>
+            </div>
+            <pre
+              className="max-h-[min(50vh,28rem)] overflow-auto bg-gray-50 p-3 text-xs leading-relaxed text-gray-900 dark:bg-gray-950 dark:text-gray-100"
+              data-testid="studio-ai-chat-class-create-preview-json"
+            >
+              {schemaJson || assistantMarkdown || '—'}
+            </pre>
+          </div>
         </div>
 
         <DialogFooter className="border-t border-gray-200 bg-gray-50 px-6 py-4 dark:border-gray-700 dark:bg-gray-900/80 sm:justify-end">

--- a/objectified-ui/src/app/ade/studio/components/chatbot/AiClassCreatePreviewDialog.tsx
+++ b/objectified-ui/src/app/ade/studio/components/chatbot/AiClassCreatePreviewDialog.tsx
@@ -115,7 +115,9 @@ export function AiClassCreatePreviewDialog({
         <div className="min-h-0 flex-1 overflow-y-auto px-6 py-3">
           <div className="overflow-hidden rounded-lg border border-gray-200 dark:border-gray-600">
             <div className="border-b border-gray-200 bg-gray-100 px-3 py-1.5 dark:border-gray-700 dark:bg-gray-900">
-              <span className="text-xs font-mono text-gray-700 dark:text-gray-300">JSON Schema</span>
+              <span className="text-xs font-mono text-gray-700 dark:text-gray-300">
+                {schemaJson ? 'JSON Schema' : 'Assistant response'}
+              </span>
             </div>
             <pre
               className="max-h-[min(50vh,28rem)] overflow-auto bg-gray-50 p-3 text-xs leading-relaxed text-gray-900 dark:bg-gray-950 dark:text-gray-100"

--- a/objectified-ui/src/app/components/ade/studio/ClassEditDialog.tsx
+++ b/objectified-ui/src/app/components/ade/studio/ClassEditDialog.tsx
@@ -1663,11 +1663,23 @@ const ClassEditDialog = ({
                         {message.role === 'assistant' && hasClassDef && classDef ? (
                           <div className="rounded-lg overflow-hidden border border-gray-300 dark:border-gray-600">
                             <div className="bg-gray-800 dark:bg-gray-900 px-3 py-1.5 border-b border-gray-700">
-                              <span className="text-xs font-mono text-gray-300">JSON</span>
+                              <span className="text-xs font-mono text-gray-300">JSON Schema</span>
+                            </div>
+                            <div className="bg-gray-900 dark:bg-black px-4 py-2 border-b border-gray-800 space-y-1 text-xs">
+                              <div>
+                                <span className="text-gray-500 dark:text-gray-500">Class name</span>{' '}
+                                <span className="font-mono text-gray-200">{classDef.name}</span>
+                              </div>
+                              <div>
+                                <span className="text-gray-500 dark:text-gray-500">Description</span>{' '}
+                                <span className="text-gray-300">
+                                  {classDef.description?.trim() ? classDef.description : '—'}
+                                </span>
+                              </div>
                             </div>
                             <pre className="bg-gray-900 dark:bg-black p-4 overflow-x-auto m-0 text-left">
                               <code className="text-sm font-mono text-green-400 dark:text-green-300 whitespace-pre">
-                                {JSON.stringify({ name: classDef.name, description: classDef.description, schema: classDef.schema }, null, 2)}
+                                {JSON.stringify(classDef.schema, null, 2)}
                               </code>
                             </pre>
                           </div>

--- a/objectified-ui/tests/chatbot/ChatConversation.test.tsx
+++ b/objectified-ui/tests/chatbot/ChatConversation.test.tsx
@@ -806,6 +806,11 @@ describe('ChatConversation', () => {
     expect(screen.getByTestId('studio-ai-chat-class-create-preview-dialog')).toBeInTheDocument();
     expect(onChatWorkspaceAction).not.toHaveBeenCalled();
 
+    const previewSchema = screen.getByTestId('studio-ai-chat-class-create-preview-json');
+    expect(previewSchema.textContent).toContain('"type": "object"');
+    expect(previewSchema.textContent).toContain('"id"');
+    expect(previewSchema.textContent).not.toMatch(/"name"\s*:\s*"Widget"/);
+
     fireEvent.click(screen.getByTestId('studio-ai-chat-class-create-preview-confirm'));
     expect(onChatWorkspaceAction).toHaveBeenCalledTimes(1);
     expect(onChatWorkspaceAction.mock.calls[0][0]).toMatchObject({


### PR DESCRIPTION
## Summary
- **Issue:** [#529](https://github.com/KenSuenobu/objectified-commercial/issues/529) — show generated class output as formatted **JSON Schema** in previews instead of a single JSON blob mixing `name`, `description`, and `schema`.
- **Studio AI chat (`AiClassCreatePreviewDialog`):** The scrollable preview is labeled **JSON Schema** and pretty-prints only `parsed.schema`; class name, description, and property summary stay in the header.
- **Create Class with AI (`ClassEditDialog`):** Same separation — metadata rows above the code block, **JSON Schema** label, `JSON.stringify(schema, null, 2)` in the pre.
- **Docs:** `docs/PLANNED_FEATURE_ROADMAP_AI.md` marks #529 complete and removes the ticket row; `WHATS_NEW.md` and `objectified-ui` patch bump **0.11.51**.

## How to test
1. **Studio → AI chat:** Get an assistant reply with **Create this class** and a ```json``` block (`name`, `description`, `schema`). **Click Create this class.** In the modal, confirm the lower pane shows a **JSON Schema** bar and indented schema only (no top-level `"name"` for the class).
2. **Add Class → Create Class with AI:** After a reply parses as a class definition, confirm the bubble shows **Class name** / **Description** above the green monospace block, header **JSON Schema**, and the block matches the schema object only.

## Risk / notes
- Low risk: display-only; create flow still uses the full assistant markdown / parsed payload unchanged.
- Repo root `yarn` failed locally against the checked-in lockfile (workspace resolution error); verification used `next build` / root `turbo` before lockfile revert and `jest` via `node_modules/.bin/jest`. CI should run the normal pipeline.

Closes #529

Made with [Cursor](https://cursor.com)