### PR TITLE
Fix #530 - Property list with suggested types in AI class preview

### DIFF
--- a/docs/PLANNED_FEATURE_ROADMAP_AI.md
+++ b/docs/PLANNED_FEATURE_ROADMAP_AI.md
@@ -88,7 +88,7 @@ This outlines the planned features for integrating AI capabilities into Objectif
 - 📋 **Generation Output**:
     - ✅ Preview generated schema before creation (#528)
     - ✅ JSON Schema format display (#529)
-    - 📋 Property list with types
+    - ✅ Property list with types (#530)
     - 📋 Relationship suggestions
 - 📋 **Iterative Refinement**:
     - 📋 "Add a phone number field"
@@ -98,7 +98,6 @@ This outlines the planned features for integrating AI capabilities into Objectif
 
 | Ticket | Feature Description                                      |
 |--------|----------------------------------------------------------|
-| #530   | Property list with types on preview                      |
 | #531   | Relationship suggestions on preview                      |
 | #532   | Iterative refinement of generated schemas                |
 

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.51",
+  "version": "0.11.52",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -33,7 +33,7 @@ We continue to improve the platform based on your feedback with improvements and
 - Ollama chat cache keys include a fingerprint of the version’s class and property schemas when you use the Studio AI chatbot, so edits to OpenAPI/JSON Schema state do not reuse stale cached replies.
 - Studio AI chat **Preview changes** opens a modal with a formatted OpenAPI summary and JSON before **Apply import** runs the import action (cancel returns you to the chat with no import).
 - Assistant replies that include phrases such as **Create this class**, **Add these properties**, **Apply to current class**, or **Copy to clipboard** (with a JSON or YAML code block) show quick-action buttons: new class, open the selected class for editing, or copy the fenced payload.
-- **Create this class** opens a preview before continuing (#528); the preview shows class metadata and the generated schema as formatted **JSON Schema** (#529). Confirming opens Add Class in AI mode with that reply seeded. Create Class with AI uses the same preview via **Preview & create**.
+- **Create this class** opens a preview before continuing (#528); the preview shows class metadata and the generated schema as formatted **JSON Schema** (#529). Each property is summarized with a **suggested JSON Schema type** (including refs and arrays) (#530). Confirming opens Add Class in AI mode with that reply seeded. Create Class with AI uses the same preview via **Preview & create**.
 
 ---
 

--- a/objectified-ui/src/app/ade/studio/components/chatbot/AiClassCreatePreviewDialog.tsx
+++ b/objectified-ui/src/app/ade/studio/components/chatbot/AiClassCreatePreviewDialog.tsx
@@ -48,6 +48,12 @@ export function AiClassCreatePreviewDialog({
     [parsed],
   );
 
+  const hasPropertiesObject = React.useMemo(() => {
+    if (!parsed) return false;
+    const s = parsed.schema;
+    return s !== null && typeof s === 'object' && !Array.isArray(s) && 'properties' in (s as object);
+  }, [parsed]);
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
@@ -76,7 +82,9 @@ export function AiClassCreatePreviewDialog({
                 <dt className="font-medium text-gray-700 dark:text-gray-300">Properties (suggested types)</dt>
                 <dd className="mt-1">
                   {propsList.length === 0 ? (
-                    <span className="text-gray-500 dark:text-gray-500">No properties object</span>
+                    <span className="text-gray-500 dark:text-gray-500">
+                      {hasPropertiesObject ? 'No properties defined' : 'No properties object'}
+                    </span>
                   ) : (
                     <ul className="m-0 max-h-40 list-inside list-disc overflow-y-auto pl-1">
                       {propsList.map((p) => (

--- a/objectified-ui/src/app/ade/studio/components/chatbot/AiClassCreatePreviewDialog.tsx
+++ b/objectified-ui/src/app/ade/studio/components/chatbot/AiClassCreatePreviewDialog.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/app/components/ui/Dialog';
 import {
   parseClassDefinitionFromAssistantMarkdown,
+  summarizeJsonSchemaProperties,
   type ParsedAiClassDefinition,
 } from './assistant-action-detection';
 
@@ -20,24 +21,6 @@ export interface AiClassCreatePreviewDialogProps {
   assistantMarkdown: string | null;
   onOpenChange: (open: boolean) => void;
   onConfirmCreate: () => void;
-}
-
-function propertySummaries(schema: unknown): { name: string; detail: string }[] {
-  if (!schema || typeof schema !== 'object' || Array.isArray(schema)) return [];
-  const props = (schema as { properties?: unknown }).properties;
-  if (!props || typeof props !== 'object' || Array.isArray(props)) return [];
-  return Object.entries(props as Record<string, unknown>).map(([name, sub]) => {
-    let detail = '';
-    if (sub && typeof sub === 'object' && !Array.isArray(sub)) {
-      const o = sub as Record<string, unknown>;
-      const t = o.type;
-      detail = typeof t === 'string' ? t : Array.isArray(t) ? t.join(' | ') : '';
-      if (o.$ref && typeof o.$ref === 'string') {
-        detail = detail ? `${detail} (${o.$ref})` : o.$ref;
-      }
-    }
-    return { name, detail: detail || 'object' };
-  });
 }
 
 export function AiClassCreatePreviewDialog({
@@ -60,7 +43,10 @@ export function AiClassCreatePreviewDialog({
     }
   }, [parsed]);
 
-  const propsList = React.useMemo(() => (parsed ? propertySummaries(parsed.schema) : []), [parsed]);
+  const propsList = React.useMemo(
+    () => (parsed ? summarizeJsonSchemaProperties(parsed.schema) : []),
+    [parsed],
+  );
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -72,8 +58,8 @@ export function AiClassCreatePreviewDialog({
           <DialogHeader className="space-y-2 text-left">
             <DialogTitle>Preview class schema</DialogTitle>
             <DialogDescription className="text-left">
-              Review the class metadata and the formatted JSON Schema below before continuing. Cancel to return to the
-              chat with no changes.
+              Review the class metadata, the suggested type for each property, and the formatted JSON Schema below before
+              continuing. Cancel to return to the chat with no changes.
             </DialogDescription>
           </DialogHeader>
           {parsed ? (
@@ -87,16 +73,16 @@ export function AiClassCreatePreviewDialog({
                 <dd>{parsed.description?.trim() ? parsed.description : '—'}</dd>
               </div>
               <div className="sm:col-span-2">
-                <dt className="font-medium text-gray-700 dark:text-gray-300">Properties</dt>
+                <dt className="font-medium text-gray-700 dark:text-gray-300">Properties (suggested types)</dt>
                 <dd className="mt-1">
                   {propsList.length === 0 ? (
                     <span className="text-gray-500 dark:text-gray-500">No properties object</span>
                   ) : (
-                    <ul className="m-0 max-h-24 list-inside list-disc overflow-y-auto pl-1">
+                    <ul className="m-0 max-h-40 list-inside list-disc overflow-y-auto pl-1">
                       {propsList.map((p) => (
                         <li key={p.name}>
                           <span className="font-mono">{p.name}</span>
-                          {p.detail ? <span className="text-gray-500 dark:text-gray-500"> — {p.detail}</span> : null}
+                          <span className="text-gray-500 dark:text-gray-500"> — {p.suggestedType}</span>
                         </li>
                       ))}
                     </ul>

--- a/objectified-ui/src/app/ade/studio/components/chatbot/assistant-action-detection.ts
+++ b/objectified-ui/src/app/ade/studio/components/chatbot/assistant-action-detection.ts
@@ -55,7 +55,7 @@ function formatSuggestedJsonSchemaType(sub: unknown): string {
     if (t === 'array') {
       if (o.items === undefined) return 'array';
       const inner = formatSuggestedJsonSchemaType(o.items);
-      return inner === 'array' ? 'array' : `array<${inner}>`;
+      return `array<${inner}>`;
     }
     return t;
   }

--- a/objectified-ui/src/app/ade/studio/components/chatbot/assistant-action-detection.ts
+++ b/objectified-ui/src/app/ade/studio/components/chatbot/assistant-action-detection.ts
@@ -27,6 +27,64 @@ export interface ParsedAiClassDefinition {
   schema: unknown;
 }
 
+/** One row for UI previews: property name and a short suggested JSON Schema type label (#530). */
+export interface SchemaPropertySummaryRow {
+  name: string;
+  suggestedType: string;
+}
+
+function propertiesRecordFromSchema(schema: unknown): Record<string, unknown> | null {
+  if (!schema || typeof schema !== 'object' || Array.isArray(schema)) return null;
+  const raw = (schema as { properties?: unknown }).properties;
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null;
+  return raw as Record<string, unknown>;
+}
+
+function formatSuggestedJsonSchemaType(sub: unknown): string {
+  if (!sub || typeof sub !== 'object' || Array.isArray(sub)) return 'object';
+  const o = sub as Record<string, unknown>;
+
+  if (typeof o.$ref === 'string') {
+    const ref = o.$ref;
+    const leaf = ref.split('/').pop();
+    return leaf ? `ref (${leaf})` : ref;
+  }
+
+  const t = o.type;
+  if (typeof t === 'string') {
+    if (t === 'array') {
+      if (o.items === undefined) return 'array';
+      const inner = formatSuggestedJsonSchemaType(o.items);
+      return inner === 'array' ? 'array' : `array<${inner}>`;
+    }
+    return t;
+  }
+
+  if (Array.isArray(t)) {
+    return t.filter((x): x is string => typeof x === 'string').join(' | ') || 'mixed';
+  }
+
+  if (Array.isArray(o.oneOf)) return `oneOf(${o.oneOf.length})`;
+  if (Array.isArray(o.anyOf)) return `anyOf(${o.anyOf.length})`;
+  if (Array.isArray(o.allOf)) return `allOf(${o.allOf.length})`;
+  if (o.enum !== undefined) return 'enum';
+  if ('const' in o) return 'const';
+
+  return 'object';
+}
+
+/**
+ * Lists `schema.properties` keys with short type labels for preview UI (#530).
+ */
+export function summarizeJsonSchemaProperties(schema: unknown): SchemaPropertySummaryRow[] {
+  const props = propertiesRecordFromSchema(schema);
+  if (!props) return [];
+  return Object.entries(props).map(([name, sub]) => ({
+    name,
+    suggestedType: formatSuggestedJsonSchemaType(sub),
+  }));
+}
+
 export type DetectedChatQuickAction =
   | { kind: 'create_class' }
   | { kind: 'batch_add_properties' }

--- a/objectified-ui/src/app/api/ollama/chat/route.ts
+++ b/objectified-ui/src/app/api/ollama/chat/route.ts
@@ -38,11 +38,13 @@ function pickAssistantContent(data: Record<string, unknown>): string | undefined
   return typeof raw === 'string' && raw.length > 0 ? raw : undefined;
 }
 
-const CLASS_SKELETON_SYSTEM = `You are an expert at defining JSON Schema (OpenAPI 3.1) class/schema definitions. The user will describe a class they want to create. Your only job is to output a single JSON code block that defines that class.
+const CLASS_SKELETON_SYSTEM = `You are an expert at defining JSON Schema (OpenAPI 3.1) class/schema definitions. The user will describe a class they want to create.
 
 # Output format
 
-Respond with exactly one JSON code block in this shape:
+Optionally begin with a short markdown section titled **Suggested properties**: a bullet list where each line is \`- propertyName — type\` using plain-language JSON Schema types (e.g. \`- email — string\`, \`- age — integer\`, \`- orders — array of Order (ref)\`). This gives the user a scannable summary before the full schema.
+
+Then output exactly one JSON code block in this shape:
 \`\`\`json
 {
   "name": "ClassName",
@@ -59,11 +61,16 @@ Respond with exactly one JSON code block in this shape:
 
 - "name" must be PascalCase and contain only letters, numbers, and underscores (A-Za-z0-9_).
 - "schema" must be a valid JSON Schema object. It must include "type": "object" and a "properties" object (can be empty {} for a placeholder).
+- **Every property** under "schema.properties" must express its intended shape clearly:
+  - Scalar or inline object: include a JSON Schema \`type\` (and \`format\` when useful, e.g. date-time, email).
+  - Reference to another class: use \`"$ref": "#/components/schemas/ClassName"\` (no bare empty objects for named fields).
+  - Arrays: always include \`"type": "array"\` and a typed \`items\` schema (primitive, inline object, or \`$ref\`).
+  - Compositions (oneOf / anyOf / allOf): only when the user's request needs them; prefer simple typed properties otherwise.
 - You may use any JSON Schema / OpenAPI 3.1 schema features in "schema": properties, required, allOf, anyOf, oneOf, discriminator, additionalProperties, unevaluatedProperties, patternProperties, dependentSchemas, dependentRequired, deprecated, deprecationMessage, minProperties, maxProperties, examples, xml, $id, $anchor, $comment, externalDocs, if/then/else, and x-* extensions.
 - For $ref inside the schema, use format "#/components/schemas/ClassName" when referencing other classes.
 - Property names in "properties" should be camelCase. Include "description" (and optionally "summary") on the schema and on properties where helpful.
 - Keep the class a clear skeleton: include the structure the user asked for, but you do not need to exhaust every option. Prefer properties and required; add allOf/anyOf/oneOf/discriminator/additionalProperties etc. only when they fit the user's description.
-- Do not output any text outside the single JSON code block. No commentary before or after.`;
+- Apart from the optional **Suggested properties** section and the single JSON code block, do not add other commentary.`;
 
 function buildClassSkeletonSystem(options: {
   existingClassNames?: string[];

--- a/objectified-ui/tests/chatbot/assistant-action-detection.test.ts
+++ b/objectified-ui/tests/chatbot/assistant-action-detection.test.ts
@@ -143,4 +143,18 @@ describe('summarizeJsonSchemaProperties', () => {
     };
     expect(summarizeJsonSchemaProperties(schema)).toEqual([{ name: 'id', suggestedType: 'string | number' }]);
   });
+
+  it('preserves nested array type rather than collapsing to plain array', () => {
+    const schema = {
+      properties: {
+        matrix: { type: 'array', items: { type: 'array', items: { type: 'number' } } },
+        tags: { type: 'array', items: { type: 'array' } },
+      },
+    };
+    const rows = summarizeJsonSchemaProperties(schema);
+    expect(rows).toEqual([
+      { name: 'matrix', suggestedType: 'array<array<number>>' },
+      { name: 'tags', suggestedType: 'array<array>' },
+    ]);
+  });
 });

--- a/objectified-ui/tests/chatbot/assistant-action-detection.test.ts
+++ b/objectified-ui/tests/chatbot/assistant-action-detection.test.ts
@@ -2,6 +2,7 @@ import {
   detectChatQuickActions,
   extractFirstJsonOrYamlFenceBody,
   parseClassDefinitionFromAssistantMarkdown,
+  summarizeJsonSchemaProperties,
 } from '../../src/app/ade/studio/components/chatbot/assistant-action-detection';
 
 describe('extractFirstJsonOrYamlFenceBody', () => {
@@ -106,5 +107,40 @@ describe('parseClassDefinitionFromAssistantMarkdown', () => {
     const md = '```json\n' + payload + '```';
     const parsed = parseClassDefinitionFromAssistantMarkdown(md);
     expect(parsed?.name).toBe('Order');
+  });
+});
+
+describe('summarizeJsonSchemaProperties', () => {
+  it('returns empty when properties are missing', () => {
+    expect(summarizeJsonSchemaProperties(null)).toEqual([]);
+    expect(summarizeJsonSchemaProperties({ type: 'object' })).toEqual([]);
+  });
+
+  it('labels primitives, refs, arrays, and compositions', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        email: { type: 'string', format: 'email' },
+        userId: { $ref: '#/components/schemas/User' },
+        tags: { type: 'array', items: { type: 'string' } },
+        role: { oneOf: [{ type: 'string' }, { type: 'null' }] },
+      },
+    };
+    const rows = summarizeJsonSchemaProperties(schema);
+    expect(rows).toEqual([
+      { name: 'email', suggestedType: 'string' },
+      { name: 'userId', suggestedType: 'ref (User)' },
+      { name: 'tags', suggestedType: 'array<string>' },
+      { name: 'role', suggestedType: 'oneOf(2)' },
+    ]);
+  });
+
+  it('handles union type keyword arrays', () => {
+    const schema = {
+      properties: {
+        id: { type: ['string', 'number'] },
+      },
+    };
+    expect(summarizeJsonSchemaProperties(schema)).toEqual([{ name: 'id', suggestedType: 'string | number' }]);
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -2622,7 +2622,7 @@
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
       "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright": "1.59.1"
@@ -5520,7 +5520,6 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -5530,7 +5529,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -6683,7 +6682,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-react-compiler/-/babel-plugin-react-compiler-1.0.0.tgz",
       "integrity": "sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.26.0"
@@ -14639,7 +14638,7 @@
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
       "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.59.1"
@@ -14658,7 +14657,7 @@
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
       "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -14671,13 +14670,13 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -16382,7 +16381,6 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
       "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/tailwindcss-animate": {
@@ -17942,7 +17940,7 @@
       "version": "1.0.1"
     },
     "objectified-ui": {
-      "version": "0.11.50",
+      "version": "0.11.52",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -45,7 +45,7 @@
   resolved "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.5.tgz"
   integrity sha512-6uFXyCayocRbqhZOB+6XcuZbkMNimwfVGFji8CTZnCzOHVGvDqzvitu1re2AU5LROliz7eQPhB8CpAMvnx9EjA==
 
-"@babel/core@^7.23.9", "@babel/core@^7.24.4", "@babel/core@^7.27.4":
+"@babel/core@^7.0.0", "@babel/core@^7.0.0 || ^8.0.0-0", "@babel/core@^7.0.0-0", "@babel/core@^7.11.0 || ^8.0.0-0", "@babel/core@^7.11.0 || ^8.0.0-beta.1", "@babel/core@^7.23.9", "@babel/core@^7.24.4", "@babel/core@^7.27.4", "@babel/core@>=7.0.0-beta.0 <8":
   version "7.28.5"
   resolved "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz"
   integrity sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==
@@ -366,12 +366,12 @@
     "@csstools/color-helpers" "^5.1.0"
     "@csstools/css-calc" "^2.1.4"
 
-"@csstools/css-parser-algorithms@^3.0.4":
+"@csstools/css-parser-algorithms@^3.0.4", "@csstools/css-parser-algorithms@^3.0.5":
   version "3.0.5"
   resolved "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz"
   integrity sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==
 
-"@csstools/css-tokenizer@^3.0.3":
+"@csstools/css-tokenizer@^3.0.3", "@csstools/css-tokenizer@^3.0.4":
   version "3.0.4"
   resolved "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz"
   integrity sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==
@@ -383,7 +383,7 @@
   dependencies:
     tslib "^2.0.0"
 
-"@dnd-kit/core@^6.3.1":
+"@dnd-kit/core@^6.3.0", "@dnd-kit/core@^6.3.1":
   version "6.3.1"
   resolved "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz"
   integrity sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==
@@ -474,7 +474,7 @@
   resolved "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz"
   integrity sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==
 
-"@emotion/react@^11.14.0":
+"@emotion/react@^11.0.0-rc.0", "@emotion/react@^11.14.0":
   version "11.14.0"
   resolved "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz"
   integrity sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==
@@ -923,7 +923,7 @@
     jest-haste-map "30.3.0"
     slash "^3.0.0"
 
-"@jest/transform@30.3.0":
+"@jest/transform@^29.0.0 || ^30.0.0", "@jest/transform@30.3.0":
   version "30.3.0"
   resolved "https://registry.npmjs.org/@jest/transform/-/transform-30.3.0.tgz"
   integrity sha512-TLKY33fSLVd/lKB2YI1pH69ijyUblO/BQvCj566YvnwuzoTNr648iE0j22vRvVNk2HsPwByPxATg3MleS3gf5A==
@@ -943,7 +943,7 @@
     slash "^3.0.0"
     write-file-atomic "^5.0.1"
 
-"@jest/types@30.3.0":
+"@jest/types@^29.0.0 || ^30.0.0", "@jest/types@30.3.0":
   version "30.3.0"
   resolved "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz"
   integrity sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==
@@ -1092,7 +1092,7 @@
   resolved "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz"
   integrity sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==
 
-"@playwright/test@^1.59.1":
+"@playwright/test@^1.51.1", "@playwright/test@^1.59.1":
   version "1.59.1"
   resolved "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz"
   integrity sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==
@@ -1911,7 +1911,7 @@
     postcss "^8.5.6"
     tailwindcss "4.2.2"
 
-"@testing-library/dom@^10.4.1":
+"@testing-library/dom@^10.0.0", "@testing-library/dom@^10.4.1", "@testing-library/dom@>=7.21.4":
   version "10.4.1"
   resolved "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz"
   integrity sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==
@@ -2378,12 +2378,12 @@
   resolved "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz"
   integrity sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==
 
-"@types/react-dom@^19.2.3":
+"@types/react-dom@*", "@types/react-dom@^18.0.0 || ^19.0.0", "@types/react-dom@^19.2.3":
   version "19.2.3"
   resolved "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz"
   integrity sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==
 
-"@types/react@^19.2.14":
+"@types/react@*", "@types/react@^18.0.0 || ^19.0.0", "@types/react@^19.2.0", "@types/react@^19.2.14", "@types/react@>=16.8", "@types/react@>=18":
   version "19.2.14"
   resolved "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz"
   integrity sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==
@@ -2449,7 +2449,7 @@
     natural-compare "^1.4.0"
     ts-api-utils "^2.1.0"
 
-"@typescript-eslint/parser@8.46.2":
+"@typescript-eslint/parser@^8.46.2", "@typescript-eslint/parser@8.46.2":
   version "8.46.2"
   resolved "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.46.2.tgz"
   integrity sha512-BnOroVl1SgrPLywqxyqdJ4l3S2MsKVLDVxZvjI1Eoe8ev2r3kGDo+PcMihNmDE+6/KjkTubSJnmqGZZjQSBq/g==
@@ -2591,7 +2591,7 @@ acorn-walk@^8.1.1:
   dependencies:
     acorn "^8.11.0"
 
-acorn@^8.11.0, acorn@^8.15.0, acorn@^8.4.1:
+"acorn@^6.0.0 || ^7.0.0 || ^8.0.0", acorn@^8.11.0, acorn@^8.15.0, acorn@^8.4.1:
   version "8.15.0"
   resolved "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz"
   integrity sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==
@@ -2623,7 +2623,7 @@ ajv@^6.14.0:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ajv@^8.0.0, ajv@^8.18.0:
+ajv@^8.0.0, ajv@^8.18.0, ajv@^8.5.0:
   version "8.18.0"
   resolved "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz"
   integrity sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==
@@ -2834,7 +2834,7 @@ axobject-query@^4.1.0:
   resolved "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz"
   integrity sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==
 
-babel-jest@30.3.0:
+"babel-jest@^29.0.0 || ^30.0.0", babel-jest@30.3.0:
   version "30.3.0"
   resolved "https://registry.npmjs.org/babel-jest/-/babel-jest-30.3.0.tgz"
   integrity sha512-gRpauEU2KRrCox5Z296aeVHR4jQ98BCnu0IO332D/xpHNOsIH/bgSRk9k6GbKIbBw8vFeN6ctuu6tV8WOyVfYQ==
@@ -2874,7 +2874,7 @@ babel-plugin-macros@^3.1.0:
     cosmiconfig "^7.0.0"
     resolve "^1.19.0"
 
-babel-plugin-react-compiler@^1.0.0:
+babel-plugin-react-compiler@*, babel-plugin-react-compiler@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/babel-plugin-react-compiler/-/babel-plugin-react-compiler-1.0.0.tgz"
   integrity sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==
@@ -2967,7 +2967,7 @@ braces@^3.0.3:
   dependencies:
     fill-range "^7.1.1"
 
-browserslist@^4.24.0:
+browserslist@^4.24.0, "browserslist@>= 4.21.0":
   version "4.27.0"
   resolved "https://registry.npmjs.org/browserslist/-/browserslist-4.27.0.tgz"
   integrity sha512-AXVQwdhot1eqLihwasPElhX2tAZiBjWdJ9i/Zcj2S6QYIjkx62OKSfnobkriB81C3l4w0rVy3Nt4jaTBltYEpw==
@@ -3112,7 +3112,7 @@ chevrotain-allstar@~0.3.1:
   dependencies:
     lodash-es "^4.17.21"
 
-chevrotain@~11.1.1:
+chevrotain@^11.0.0, chevrotain@~11.1.1:
   version "11.1.2"
   resolved "https://registry.npmjs.org/chevrotain/-/chevrotain-11.1.2.tgz"
   integrity sha512-opLQzEVriiH1uUQ4Kctsd49bRoFDXGGSC4GUqj7pGyxM3RehRhvTlZJc1FL/Flew2p5uwxa1tUDWKzI4wNM8pg==
@@ -3325,7 +3325,7 @@ cytoscape-fcose@^2.2.0:
   dependencies:
     cose-base "^2.2.0"
 
-cytoscape@^3.33.1:
+cytoscape@^3.2.0, cytoscape@^3.33.1:
   version "3.33.1"
   resolved "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz"
   integrity sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==
@@ -4038,7 +4038,7 @@ eslint-module-utils@^2.12.1:
   dependencies:
     debug "^3.2.7"
 
-eslint-plugin-import@^2.32.0:
+eslint-plugin-import@*, eslint-plugin-import@^2.32.0:
   version "2.32.0"
   resolved "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz"
   integrity sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==
@@ -4137,7 +4137,7 @@ eslint-visitor-keys@^4.2.1:
   resolved "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz"
   integrity sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==
 
-eslint@^9.39.4:
+eslint@*, "eslint@^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9", "eslint@^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9", "eslint@^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7", "eslint@^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0", "eslint@^6.0.0 || ^7.0.0 || >=8.0.0", "eslint@^8.57.0 || ^9.0.0", eslint@^9.39.4, eslint@>=9.0.0:
   version "9.39.4"
   resolved "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz"
   integrity sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==
@@ -5412,7 +5412,7 @@ jest-resolve-dependencies@30.3.0:
     jest-regex-util "30.0.1"
     jest-snapshot "30.3.0"
 
-jest-resolve@30.3.0:
+jest-resolve@*, jest-resolve@30.3.0:
   version "30.3.0"
   resolved "https://registry.npmjs.org/jest-resolve/-/jest-resolve-30.3.0.tgz"
   integrity sha512-NRtTAHQlpd15F9rUR36jqwelbrDV/dY4vzNte3S2kxCKUJRYNd5/6nTSbYiak1VX5g8IoFF23Uj5TURkUW8O5g==
@@ -5509,7 +5509,7 @@ jest-snapshot@30.3.0:
     semver "^7.7.2"
     synckit "^0.11.8"
 
-jest-util@30.3.0:
+"jest-util@^29.0.0 || ^30.0.0", jest-util@30.3.0:
   version "30.3.0"
   resolved "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz"
   integrity sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==
@@ -5558,7 +5558,7 @@ jest-worker@30.3.0:
     merge-stream "^2.0.0"
     supports-color "^8.1.1"
 
-jest@^30.3.0:
+"jest@^29.0.0 || ^30.0.0", jest@^30.3.0:
   version "30.3.0"
   resolved "https://registry.npmjs.org/jest/-/jest-30.3.0.tgz"
   integrity sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==
@@ -5568,7 +5568,7 @@ jest@^30.3.0:
     import-local "^3.2.0"
     jest-cli "30.3.0"
 
-jiti@^2.6.1:
+jiti@*, jiti@^2.6.1:
   version "2.6.1"
   resolved "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz"
   integrity sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==
@@ -5606,7 +5606,7 @@ js-yaml@^4.1.1:
   dependencies:
     argparse "^2.0.1"
 
-jsdom@^26.1.0:
+jsdom@*, jsdom@^26.1.0:
   version "26.1.0"
   resolved "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz"
   integrity sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==
@@ -5632,7 +5632,7 @@ jsdom@^26.1.0:
     ws "^8.18.0"
     xml-name-validator "^5.0.0"
 
-jsep@^1.4.0:
+jsep@^0.4.0||^1.0.0, jsep@^1.4.0:
   version "1.4.0"
   resolved "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz"
   integrity sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==
@@ -6564,7 +6564,7 @@ mlly@^1.7.4, mlly@^1.8.0:
     pkg-types "^1.3.1"
     ufo "^1.6.1"
 
-monaco-editor@^0.55.1:
+monaco-editor@^0.55.1, "monaco-editor@>= 0.25.0 < 1":
   version "0.55.1"
   resolved "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz"
   integrity sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==
@@ -6622,7 +6622,7 @@ next-themes@^0.4.6:
   resolved "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz"
   integrity sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==
 
-next@^16.2.3:
+"next@^12.2.5 || ^13 || ^14 || ^15 || ^16", next@^16.2.3:
   version "16.2.4"
   resolved "https://registry.npmjs.org/next/-/next-16.2.4.tgz"
   integrity sha512-kPvz56wF5frc+FxlHI5qnklCzbq53HTwORaWBGdT0vNoKh1Aya9XC8aPauH4NJxqtzbWsS5mAbctm4cr+EkQ2Q==
@@ -6758,7 +6758,7 @@ object.values@^1.1.6, object.values@^1.2.1:
     es-object-atoms "^1.0.0"
 
 "objectified-ui@file:/home/runner/work/objectified-commercial/objectified-commercial/objectified-ui":
-  version "0.11.50"
+  version "0.11.52"
   resolved "file:objectified-ui"
   dependencies:
     "@dnd-kit/core" "^6.3.1"
@@ -7044,7 +7044,7 @@ pg-types@^2.2.0, pg-types@2.2.0:
     postgres-date "~1.0.4"
     postgres-interval "^1.1.0"
 
-pg@^8.20.0:
+pg@^8.20.0, pg@>=8.0:
   version "8.20.0"
   resolved "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz"
   integrity sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==
@@ -7073,6 +7073,11 @@ picomatch@^2.0.4, picomatch@^2.3.1:
   version "2.3.1"
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
+
+"picomatch@^3 || ^4":
+  version "4.0.3"
+  resolved "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz"
+  integrity sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==
 
 picomatch@^4.0.3:
   version "4.0.4"
@@ -7179,7 +7184,7 @@ preact-render-to-string@^5.1.19:
   dependencies:
     pretty-format "^3.8.0"
 
-preact@^10.6.3:
+preact@^10.6.3, preact@>=10:
   version "10.27.2"
   resolved "https://registry.npmjs.org/preact/-/preact-10.27.2.tgz"
   integrity sha512-5SYSgFKSyhCbk6SrXyMpqjb5+MQBgfvEKE/OC+PujcY34sOpqtr+0AZQtPYx5IA6VxynQ7rUPCtKzyovpj9Bpg==
@@ -7323,7 +7328,7 @@ raf@^3.4.1:
   dependencies:
     performance-now "^2.1.0"
 
-react-dom@^19.2.5:
+"react-dom@^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc", "react-dom@^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom@^17.0.2 || ^18 || ^19", "react-dom@^18 || ^19 || ^19.0.0-rc", "react-dom@^18.0.0 || ^19.0.0", "react-dom@^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react-dom@^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", react-dom@^19.2.5, react-dom@>=16.8.0, react-dom@>=17, "react-dom@16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc":
   version "19.2.5"
   resolved "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz"
   integrity sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==
@@ -7394,7 +7399,7 @@ react-style-singleton@^2.2.2, react-style-singleton@^2.2.3:
     get-nonce "^1.0.0"
     tslib "^2.0.0"
 
-react@^19.2.5:
+react@*, "react@^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react@^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc", "react@^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react@^16.x || ^17.x || ^18.x || ^19.0.0 || ^19.0.0-rc", "react@^17.0.2 || ^18 || ^19", "react@^18 || ^19 || ^19.0.0-rc", "react@^18.0.0 || ^19.0.0", "react@^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react@^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", react@^19.2.5, "react@>= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0", react@>=16.8, react@>=16.8.0, react@>=17, react@>=18, "react@16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc":
   version "19.2.5"
   resolved "https://registry.npmjs.org/react/-/react-19.2.5.tgz"
   integrity sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==
@@ -8126,7 +8131,7 @@ tailwindcss-animate@^1.0.7:
   resolved "https://registry.npmjs.org/tailwindcss-animate/-/tailwindcss-animate-1.0.7.tgz"
   integrity sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==
 
-tailwindcss@^4.2.2, tailwindcss@4.2.2:
+tailwindcss@^4.2.2, "tailwindcss@>=3.0.0 || insiders", tailwindcss@4.2.2:
   version "4.2.2"
   resolved "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz"
   integrity sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==
@@ -8238,7 +8243,7 @@ ts-jest@^29.4.9:
     type-fest "^4.41.0"
     yargs-parser "^21.1.1"
 
-ts-node@^10.9.2:
+ts-node@^10.9.2, ts-node@>=9.0.0:
   version "10.9.2"
   resolved "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz"
   integrity sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==
@@ -8349,7 +8354,7 @@ typescript-eslint@^8.46.0:
     "@typescript-eslint/typescript-estree" "8.46.2"
     "@typescript-eslint/utils" "8.46.2"
 
-typescript@^5.9.3:
+typescript@^5.9.3, typescript@>=2.7, typescript@>=3.3.1, "typescript@>=4.3 <7", typescript@>=4.8.4, "typescript@>=4.8.4 <6.0.0":
   version "5.9.3"
   resolved "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz"
   integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==


### PR DESCRIPTION
## What / why
- **Preview dialog** now derives a clearer **suggested type** per property from the parsed JSON Schema (primitives, `` leaf names, `array<…>`, `oneOf`/`anyOf`/`allOf` counts, union `type` arrays, `enum`/`const`).
- **Create Class with AI** (`class_skeleton`) system prompt now requires explicit `type` / `items` / `` per property and optionally allows a short **Suggested properties** bullet list before the JSON fence so the model can mirror human-readable types.

## How to test
1. Open **Studio** → **Add class** → **Create with AI** (or use chat **Create this class** → preview).
2. Ask for a class with several fields (strings, arrays, refs).
3. Open **Preview** and confirm **Properties (suggested types)** lists each name with a sensible type label.
4. Regenerate with Ollama and confirm new replies tend to include explicit `type` on each property and optional **Suggested properties** section.

## Risk / notes
- Type labels are **heuristic** for UI only; they do not change how classes are created from the JSON block.
- ESLint reports many pre-existing issues in `objectified-ui`; unchanged files were not touched.

Closes #530

Made with [Cursor](https://cursor.com)