### PR TITLE
Fix #495 - Add actionable improvement suggestions to Studio AI chat

### DIFF
--- a/docs/PLANNED_FEATURES.md
+++ b/docs/PLANNED_FEATURES.md
@@ -257,7 +257,7 @@ Implement in this order so each step stays testable. **Issue → roadmap ID** fo
 | C.7 | **Quick actions + apply:** actions from chat, preview before apply | **#518** (done), **#519** |
 | C.8 | **NL → schema:** description → schema, examples, preview surface | **#267**, **#268** (done), **#528–#532** (done) |
 | C.9 | **Property assist:** suggestions, dropdown, bulk, triggers, analysis | **#269–#276**, **#277**, **#278** |
-| C.10 | **Higher insights (post-MVP polish):** improvement suggestions, docs generation, layout hints, etc. | **#253–#256**, **#495**, **#609–#623** (schedule after core chat works) |
+| C.10 | **Higher insights (post-MVP polish):** improvement suggestions, docs generation, layout hints, etc. | **#253–#256**, **#609–#623** (schedule after core chat works) |
 
 ### C.2 Codebase alignment
 

--- a/docs/PLANNED_FEATURE_ROADMAP_AI.md
+++ b/docs/PLANNED_FEATURE_ROADMAP_AI.md
@@ -123,16 +123,12 @@ This outlines the planned features for integrating AI capabilities into Objectif
 
 ### AI Schema Review & Improvement
 
-**Improvement Suggestions** 📋 PLANNED
-- 📋 "Consider adding pagination to this list endpoint"
-- 📋 "This schema could benefit from inheritance using allOf"
-- 📋 "Add a discriminator for this polymorphic type"
-- 📋 "Consider breaking this large schema into smaller components"
-- 📋 "Add error responses for common failure scenarios"
-
-| Ticket | Feature Description             |
-|--------|---------------------------------|
-| #495   | Adds AI improvement suggestions |
+**Improvement Suggestions** ✅ (#495 — Studio chat / Ollama system prompt + offline demo)
+- ✅ "Consider adding pagination to this list endpoint"
+- ✅ "This schema could benefit from inheritance using allOf"
+- ✅ "Add a discriminator for this polymorphic type"
+- ✅ "Consider breaking this large schema into smaller components"
+- ✅ "Add error responses for common failure scenarios"
 
 **Actionable Recommendations** 📋 PLANNED
 - 📋 AI-powered suggestions for improvement:

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.54",
+  "version": "0.11.55",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -20,6 +20,7 @@ We continue to improve the platform based on your feedback with improvements and
 ## Export
 
 ## Studio
+- Studio AI assistant (live Ollama and offline demo) appends an **Improvement suggestions** section after OpenAPI sketches—actionable bullets such as pagination, `allOf` inheritance, discriminators, splitting large schemas, and standard error shapes (#495).
 - Studio AI chat empty state offers example prompts for schema and API generation (#268).
 - Studio AI chat treats plain-language domain descriptions (and similar phrasing) as requests to draft OpenAPI `components/schemas`, including when Ollama is connected (#267).
 - AI chatbot lists Ollama models from your server and lets you pick which model answers each conversation (falls back to the offline assistant when Ollama is unavailable).

--- a/objectified-ui/src/app/ade/studio/components/chatbot/demo-responder.ts
+++ b/objectified-ui/src/app/ade/studio/components/chatbot/demo-responder.ts
@@ -19,6 +19,10 @@
  * **Create this class**, **Add these properties**, **Apply to current class**,
  * and **Copy to clipboard** without running a live model.
  *
+ * #495: spec and class-draft replies include **Improvement suggestions** so the
+ * offline demo matches live-model guidance (pagination, allOf, discriminator,
+ * component splits, error-response notes).
+ *
  * #260 layers in multi-turn awareness. Each call asks
  * `summarizeConversationHistory` to classify the prompt against the prior
  * transcript and we branch on the result:
@@ -100,7 +104,8 @@ export const createDemoChatResponder = (): ChatSendFn => async ({
       JSON.stringify(spec, null, 2),
       '```',
       '',
-      'A few things to consider next:',
+      '**Improvement suggestions**',
+      '',
       ...suggestions,
     );
     appendStudioChatQuickActionDemo(lines, { includeYamlSample: false });
@@ -187,6 +192,12 @@ function buildDemoClassDraftRefinementReply(input: {
     ),
     '```',
     '',
+    '**Improvement suggestions**',
+    '',
+    '- Consider extracting repeated audit fields (`createdAt`, `updatedAt`) into a shared base schema composed with `allOf`.',
+    '- If this type participates in a polymorphic union, add a `discriminator` when variants need stable identification.',
+    '- When the property list grows, split cross-cutting groups into `$ref` components under `components/schemas`.',
+    '',
     '**Create this class**',
     '',
     'Ask for another change in the preview dialog or here in chat.',
@@ -211,7 +222,7 @@ function applyDemoHeuristicClassRefinement(
       : {};
   schema.properties = props;
 
-  let required: string[] = Array.isArray(schema.required)
+  const required: string[] = Array.isArray(schema.required)
     ? [...schema.required].filter((x): x is string => typeof x === 'string')
     : [];
 
@@ -304,6 +315,12 @@ function buildRefinementReply({
     JSON.stringify(refined, null, 2),
     '```',
     '',
+    '**Improvement suggestions**',
+    '',
+    '- Consider adding pagination (cursor or offset/limit) when this resource is exposed as a collection endpoint.',
+    '- Consider standard error response bodies (validation, not found) when you document operations alongside these schemas.',
+    '- If several schemas share the same embedded shape, model the shared part once with `allOf` and `$ref`.',
+    '',
     'Need another change? Ask me to add, remove, rename, or require a property and I\'ll keep iterating.',
   );
   appendStudioChatQuickActionDemo(lines, { includeYamlSample: false });
@@ -374,18 +391,23 @@ function describeGrounding(ctx: ChatStudioContext | undefined): string | null {
 
 function buildContextAwareSuggestions(ctx: ChatStudioContext | undefined): string[] {
   const suggestions = [
-    '- Tighten property descriptions for documentation scoring',
-    '- Add `examples` arrays where missing',
-    '- Decide whether to expose this through a path operation in a follow-up',
+    '- Consider adding pagination to list endpoints that return many rows from this model.',
+    '- Consider breaking large schemas into smaller `components/schemas` fragments composed with `$ref` when one object mixes unrelated concerns.',
+    '- Add shared validation or metadata fields via `allOf` referencing a common base schema when multiple types repeat the same shape.',
+    '- Add a `discriminator` when you model polymorphic payloads with `oneOf` / `anyOf`.',
+    '- Plan explicit error response schemas (validation, conflict, not found) when you add path operations later.',
+    '- Tighten descriptions and add `examples` arrays where documentation tooling expects them.',
   ];
   if (!ctx || isChatStudioContextEmpty(ctx)) return suggestions;
   const selected = getSelectedClasses(ctx);
   if (selected.length > 0) {
     const names = selected.slice(0, 3).map((cls) => `\`${cls.name}\``).join(', ');
-    suggestions.unshift(`- Cross-check the new schema against your selected ${selected.length === 1 ? 'class' : 'classes'} (${names})`);
+    suggestions.unshift(`- Cross-check the new schema against your selected ${selected.length === 1 ? 'class' : 'classes'} (${names}) before importing.`);
   } else if (ctx.classes.length > 0) {
     const sample = ctx.classes.slice(0, 3).map((cls) => `\`${cls.name}\``).join(', ');
-    suggestions.unshift(`- Reuse the names already in this version when possible (e.g. ${sample})`);
+    suggestions.unshift(
+      `- Reuse schema names already in this version when wiring \`$ref\` (e.g. ${sample}).`,
+    );
   }
   return suggestions;
 }

--- a/objectified-ui/src/app/api/ollama/chat/route.ts
+++ b/objectified-ui/src/app/api/ollama/chat/route.ts
@@ -61,7 +61,7 @@ Then output exactly one JSON code block in this shape:
 }
 \`\`\`
 
-After that JSON block, add a markdown section titled exactly **Improvement suggestions** with 2–4 bullets: actionable schema/API notes for this class (e.g. \`allOf\` for shared bases, \`discriminator\` with \`oneOf\`, splitting large objects into referenced components, pagination or error-response considerations when list/query APIs are added later). Keep bullets specific to what you generated.
+After that JSON block, add a markdown section titled exactly **Improvement suggestions** with 2–5 bullets: actionable schema/API notes for this class (e.g. \`allOf\` for shared bases, \`discriminator\` with \`oneOf\`, splitting large objects into referenced components, pagination or error-response considerations when list/query APIs are added later). Keep bullets specific to what you generated.
 
 # Rules
 
@@ -76,7 +76,7 @@ After that JSON block, add a markdown section titled exactly **Improvement sugge
 - For $ref inside the schema, use format "#/components/schemas/ClassName" when referencing other classes.
 - Property names in "properties" should be camelCase. Include "description" (and optionally "summary") on the schema and on properties where helpful.
 - Keep the class a clear skeleton: include the structure the user asked for, but you do not need to exhaust every option. Prefer properties and required; add allOf/anyOf/oneOf/discriminator/additionalProperties etc. only when they fit the user's description.
-- Apart from the optional **Suggested properties**, **Suggested relationships**, and **Improvement suggestions** sections and the single JSON code block, do not add other commentary.
+- Apart from the optional **Suggested properties** and **Suggested relationships** sections, the single JSON code block, and the required **Improvement suggestions** section, do not add other commentary.
 
 # Iterative refinement
 

--- a/objectified-ui/src/app/api/ollama/chat/route.ts
+++ b/objectified-ui/src/app/api/ollama/chat/route.ts
@@ -61,6 +61,8 @@ Then output exactly one JSON code block in this shape:
 }
 \`\`\`
 
+After that JSON block, add a markdown section titled exactly **Improvement suggestions** with 2–4 bullets: actionable schema/API notes for this class (e.g. \`allOf\` for shared bases, \`discriminator\` with \`oneOf\`, splitting large objects into referenced components, pagination or error-response considerations when list/query APIs are added later). Keep bullets specific to what you generated.
+
 # Rules
 
 - "name" must be PascalCase and contain only letters, numbers, and underscores (A-Za-z0-9_).
@@ -74,7 +76,7 @@ Then output exactly one JSON code block in this shape:
 - For $ref inside the schema, use format "#/components/schemas/ClassName" when referencing other classes.
 - Property names in "properties" should be camelCase. Include "description" (and optionally "summary") on the schema and on properties where helpful.
 - Keep the class a clear skeleton: include the structure the user asked for, but you do not need to exhaust every option. Prefer properties and required; add allOf/anyOf/oneOf/discriminator/additionalProperties etc. only when they fit the user's description.
-- Apart from the optional **Suggested properties** and **Suggested relationships** sections and the single JSON code block, do not add other commentary.
+- Apart from the optional **Suggested properties**, **Suggested relationships**, and **Improvement suggestions** sections and the single JSON code block, do not add other commentary.
 
 # Iterative refinement
 
@@ -167,9 +169,8 @@ export async function POST(request: NextRequest) {
 - When generating a complete specification, wrap it in a JSON code block: \`\`\`json\n{spec}\n\`\`\`
 - Include proper info section with title, version, description, license, contact details
 - Add servers section with at least one server URL (localhost is fine), and tags section with relevant tags
-- Generate only schemas. Do not generate paths.
+- Generate only schemas. Do not generate paths or path items inside the JSON document.
 - Use components/schemas for all schema definitions
-- Include appropriate HTTP methods and response codes
 - Always generate descriptions and summaries to all properties and schemas
 - Encourage using $ref for schema references when properties are reused
 - Avoid duplicating properties: use $ref instead
@@ -177,10 +178,10 @@ export async function POST(request: NextRequest) {
 - **CORRECT: { "$ref": "#/components/schemas/User" }**
 - When you need to reference a class/schema, use: "#/components/schemas/ClassName"
 - Use advanced schema features like patternProperties, discriminators, conditional rules, and allOf/oneOf/anyOf where applicable
-- Be conversational and explain your design decisions
+- Keep prose concise; put brief rationale into **Improvement suggestions** bullets where it helps
 - Support incremental improvements to existing specs
 - Do not generate clips of schemas in the response: The output should be the final schema
-- Do not make up rules or paths that are not possible in OpenAPI 3.1.0
+- Do not make up rules or constructs that are not possible in OpenAPI 3.1.0
 
 # Generation instructions
 
@@ -203,8 +204,19 @@ export async function POST(request: NextRequest) {
 - All classes must include examples
 - Examples must be provided in an "examples" array
 
-Make adjustments to the schema as needed based on user feedback and requests for changes.  Provide no additional feedback,
-commentary, or thinking output.`;
+Make adjustments to the schema as needed based on user feedback and requests for changes.
+
+# Improvement suggestions (#495)
+
+Immediately after the JSON code block, add a markdown section titled exactly **Improvement suggestions** with a bullet list of 2–5 short, actionable items tailored to the schemas you produced and the user's domain. Each bullet should read like a concrete next step (not generic platitudes). Draw from these patterns when they apply; rephrase for context:
+
+- Consider adding pagination to list or collection endpoints when this API exposes large result sets (e.g. cursor or offset/limit).
+- Consider modeling shared fields once with \`allOf\` when several schemas repeat the same base shape (inheritance / composition).
+- Consider adding a \`discriminator\` when polymorphic types use \`oneOf\`/\`anyOf\` and variants need stable identification.
+- Consider splitting an oversized schema into smaller \`#/components/schemas\` pieces composed with \`$ref\` when one object mixes unrelated concerns.
+- Consider standard error responses (validation, not found, conflict, etc.) when operations are documented later.
+
+Do not repeat the full JSON spec outside the code block. Do not add other sections beyond the spec JSON and **Improvement suggestions**, unless the user explicitly asks for a different layout.`;
 
     const systemMessage = {
       role: 'system',

--- a/objectified-ui/tests/chatbot/demo-responder.test.ts
+++ b/objectified-ui/tests/chatbot/demo-responder.test.ts
@@ -49,6 +49,8 @@ describe('createDemoChatResponder', () => {
     });
     expect(reply).toMatch(/```json/);
     expect(detectOpenApiSpecs(reply)).toHaveLength(1);
+    expect(reply).toMatch(/\*\*Improvement suggestions\*\*/);
+    expect(reply).toMatch(/pagination/i);
   });
 
   it('returns an OpenAPI spec for a plain-language description without spec keywords (#267)', async () => {
@@ -98,6 +100,7 @@ describe('createDemoChatResponder', () => {
       isRegenerate: false,
     });
     expect(reply).toContain('phoneNumber');
+    expect(reply).toMatch(/\*\*Improvement suggestions\*\*/);
     const out = parseClassDefinitionFromAssistantMarkdown(reply);
     expect(out).not.toBeNull();
     const props = (out!.schema as { properties?: Record<string, unknown> }).properties ?? {};
@@ -207,6 +210,7 @@ describe('createDemoChatResponder', () => {
       });
       expect(refinement).toMatch(/Updated the previous schema/);
       expect(refinement).toMatch(/added `phone`/);
+      expect(refinement).toMatch(/\*\*Improvement suggestions\*\*/);
       const refinedSpecs = detectOpenApiSpecs(refinement);
       expect(refinedSpecs).toHaveLength(1);
       const refinedSchema = (refinedSpecs[0].spec as {


### PR DESCRIPTION
## Summary
Adds an **Improvement suggestions** section to Studio AI outputs: the default Ollama system prompt (schemas-only chat + class-skeleton task) now asks the model for 2–5 actionable bullets after the JSON (pagination, `allOf`, discriminators, splitting large schemas, standard errors). The offline demo responder mirrors the same heading and example bullets for designers without a model.

## How to test
- **Open Studio AI chat** with Ollama enabled: ask for an OpenAPI sketch and confirm the reply ends with **Improvement suggestions** tailored to the topic.
- **Disable Ollama / use offline demo**: ask for an OpenAPI spec and confirm **Improvement suggestions** appears after the JSON; refine a spec in multi-turn and confirm refinements include the section too.
- **Create Class with AI / refinement path**: trigger a class draft refinement and confirm **Improvement suggestions** appears below the JSON block.

## Risk / notes
- Changes model instructions only (plus demo copy); cache keys still derive from user messages, so behavior shifts are intentional on cache miss.
- Slightly longer assistant replies by design.

Closes #495

Made with [Cursor](https://cursor.com)