### PR TITLE
Fix #609 - AI property creation suggestions in Studio sidebar

### DIFF
--- a/docs/PLANNED_FEATURE_ROADMAP_AI.md
+++ b/docs/PLANNED_FEATURE_ROADMAP_AI.md
@@ -122,15 +122,12 @@ This outlines the planned features for integrating AI capabilities into Objectif
 
 ### AI Properties Insights
 
-**Property Creation Suggestions** 📋 PLANNED
+**Property Creation Suggestions** — ✅ **#609 delivered** (Studio Properties sidebar: AI suggestions dialog with thinking/summary, pick a suggestion, open in Add Property). Further items below remain roadmap.
+
 - 📋 Common property sets for specific class types
 - 📋 Industry-standard property recommendations
 - 📋 Context-aware property suggestions based on existing schema
 - 📋 Property naming convention analysis
-
-| Ticket | Feature Description              |
-|--------|----------------------------------|
-| #609   | AI Property Creation Suggestions |
 
 ### AI Schema Health Insights
 

--- a/objectified-ui/lib/ai-property-suggestions.ts
+++ b/objectified-ui/lib/ai-property-suggestions.ts
@@ -1,0 +1,94 @@
+/**
+ * Parse structured AI responses for reusable property suggestions (#609).
+ * Expects a single ```json ... ``` markdown block from the property_suggestions Ollama task.
+ */
+
+export type AiPropertySuggestion = {
+  name: string;
+  description?: string;
+  schema: Record<string, unknown>;
+  thinking?: string;
+  summary?: string;
+};
+
+export type AiPropertySuggestionsPayload = {
+  thinking: string;
+  summary: string;
+  suggestions: AiPropertySuggestion[];
+};
+
+function extractLastJsonCodeBlock(text: string): string | null {
+  const re = /```(?:json)?\s*([\s\S]*?)```/gi;
+  let last: string | null = null;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(text)) !== null) {
+    last = m[1].trim();
+  }
+  return last;
+}
+
+function isNonEmptyString(v: unknown): v is string {
+  return typeof v === 'string' && v.trim().length > 0;
+}
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return v !== null && typeof v === 'object' && !Array.isArray(v);
+}
+
+/**
+ * Returns null if the response does not contain valid structured suggestions.
+ */
+export function parseAiPropertySuggestionsResponse(markdown: string): AiPropertySuggestionsPayload | null {
+  const raw = extractLastJsonCodeBlock(markdown.trim());
+  if (!raw) return null;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+
+  if (!isPlainObject(parsed)) return null;
+
+  const thinking = isNonEmptyString(parsed.thinking) ? parsed.thinking.trim() : '';
+  const summary = isNonEmptyString(parsed.summary) ? parsed.summary.trim() : '';
+  const suggestionsRaw = parsed.suggestions;
+
+  if (!Array.isArray(suggestionsRaw) || suggestionsRaw.length === 0) return null;
+
+  const suggestions: AiPropertySuggestion[] = [];
+
+  for (const item of suggestionsRaw) {
+    if (!isPlainObject(item)) continue;
+    const name = typeof item.name === 'string' ? item.name.trim() : '';
+    if (!name) continue;
+    const schema = item.schema;
+    if (!isPlainObject(schema)) continue;
+
+    const description =
+      typeof item.description === 'string' && item.description.trim()
+        ? item.description.trim()
+        : undefined;
+    const st =
+      typeof item.thinking === 'string' && item.thinking.trim() ? item.thinking.trim() : undefined;
+    const su =
+      typeof item.summary === 'string' && item.summary.trim() ? item.summary.trim() : undefined;
+
+    suggestions.push({
+      name,
+      description,
+      schema,
+      thinking: st,
+      summary: su,
+    });
+  }
+
+  if (suggestions.length === 0) return null;
+
+  return {
+    thinking,
+    summary,
+    suggestions,
+  };
+}

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.57",
+  "version": "0.11.58",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -20,6 +20,7 @@ We continue to improve the platform based on your feedback with improvements and
 ## Export
 
 ## Studio
+- Properties sidebar includes an **AI suggest properties** control (robot): describe what you need, review thinking and summary around the suggestion chips, inspect each proposal, then **Open in Add Property** to create it (#609).
 - Studio AI chat schema refinements infer JSON Schema type and common constraints from well-known property names (`email`, `createdAt`, `age`, `price`, `isActive`) when you add a field without specifying a type; the class-skeleton Ollama prompt uses the same conventions (#277).
 - Chat refinement inference now adds typical validation hints from names—string lengths, numeric bounds, regex patterns, and marking `id` as required when added without a type (#278).
 - Studio AI assistant (live Ollama and offline demo) appends an **Improvement suggestions** section after OpenAPI sketches—actionable bullets such as pagination, `allOf` inheritance, discriminators, splitting large schemas, and standard error shapes (#495).

--- a/objectified-ui/src/app/ade/studio/layout.tsx
+++ b/objectified-ui/src/app/ade/studio/layout.tsx
@@ -16,6 +16,7 @@ import PropertyDialog from '@/app/components/ade/studio/PropertyDialog';
 import ClassEditDialog from '@/app/components/ade/studio/ClassEditDialog';
 import ClassImportDialog from '@/app/components/ade/studio/ClassImportDialog';
 import PropertyTemplateBrowserDialog from '@/app/components/ade/studio/PropertyTemplateBrowserDialog';
+import { AiPropertySuggestionsDialog } from '@/app/components/ade/studio/AiPropertySuggestionsDialog';
 import ClassTemplateBrowserDialog from '@/app/components/ade/studio/ClassTemplateBrowserDialog';
 import TagManager from '@/app/components/ade/studio/TagManager';
 import { getClassesForVersion, getTagsForProject } from '../../../../lib/db/helper';
@@ -106,6 +107,7 @@ function StudioLayoutContent({ children }: Readonly<{ children: React.ReactNode 
   const [classImportDialog, setClassImportDialog] = useState({ open: false });
   const [propertyDialog, setPropertyDialog] = useState({ open: false, mode: 'add' as 'add' | 'edit', selectedProperty: null as PropertyItem | null });
   const [propertyTemplateDialog, setPropertyTemplateDialog] = useState({ open: false });
+  const [aiPropertySuggestionsOpen, setAiPropertySuggestionsOpen] = useState(false);
   const [classTemplateDialog, setClassTemplateDialog] = useState({ open: false });
   const [deleteDialog, setDeleteDialog] = useState({ open: false, target: null as { type: 'class' | 'property'; id: string } | null });
   const [tagManagerOpen, setTagManagerOpen] = useState(false);
@@ -266,6 +268,11 @@ function StudioLayoutContent({ children }: Readonly<{ children: React.ReactNode 
     setPropertyTemplateDialog({ open: true });
   };
 
+  const handlePropertyAiSuggest = async () => {
+    if (!(await checkProjectSelected()) || !(await checkNotReadOnly('add properties'))) return;
+    setAiPropertySuggestionsOpen(true);
+  };
+
   const handlePropertyEdit = async (propertyItem: PropertyItem) => {
     if (!(await checkProjectSelected()) || !(await checkNotReadOnly('edit properties'))) return;
     setPropertyDialog({ open: true, mode: 'edit', selectedProperty: propertyItem });
@@ -363,7 +370,11 @@ function StudioLayoutContent({ children }: Readonly<{ children: React.ReactNode 
       toggleClassVisibilityFn?.(classId, visible);
       triggerCanvasRefresh();
     },
-    onPropertyAdd: handlePropertyAdd, onPropertyEdit: handlePropertyEdit, onPropertyDelete: handlePropertyDelete, onPropertyTemplates: handlePropertyTemplates,
+    onPropertyAdd: handlePropertyAdd,
+    onPropertyEdit: handlePropertyEdit,
+    onPropertyDelete: handlePropertyDelete,
+    onPropertyTemplates: handlePropertyTemplates,
+    onPropertyAiSuggest: handlePropertyAiSuggest,
     onPropertySelect: (propertyItem) => console.log('Property selected:', propertyItem),
     onGroupAdd: () => {
       if (createGroupFn) {
@@ -599,6 +610,22 @@ function StudioLayoutContent({ children }: Readonly<{ children: React.ReactNode 
         onSubmit={handlePropertySubmit}
         availableClasses={classes.map(c => c.name)}
       />
+
+      {selectedProjectId && (
+        <AiPropertySuggestionsDialog
+          open={aiPropertySuggestionsOpen}
+          onClose={() => setAiPropertySuggestionsOpen(false)}
+          tenantId={currentTenantId}
+          projectId={selectedProjectId}
+          versionId={selectedVersionId}
+          existingClasses={classes.map((c) => c.name)}
+          existingProperties={properties}
+          studioContext={chatbotStudioContext}
+          onCreatePropertyFromSuggestion={(seed) => {
+            setPropertyDialog({ open: true, mode: 'add', selectedProperty: seed });
+          }}
+        />
+      )}
 
       {/* Property Template Browser Dialog */}
       <PropertyTemplateBrowserDialog

--- a/objectified-ui/src/app/api/ollama/chat/route.ts
+++ b/objectified-ui/src/app/api/ollama/chat/route.ts
@@ -126,6 +126,62 @@ function buildDataQuerySystem(options: { tableNames?: string[]; currentTableName
   return s;
 }
 
+const PROPERTY_SUGGESTIONS_SYSTEM = `You help API designers propose reusable JSON Schema property definitions for a project's property library (OpenAPI 3.1).
+
+# Output format
+
+Return exactly one markdown fenced JSON block and nothing else — no preamble, no commentary outside the fence:
+
+\`\`\`json
+{
+  "thinking": "2–5 sentences: how you interpreted the request and how you chose the suggestions.",
+  "summary": "2–4 sentences: overview of the suggestion set and how the user might adopt them in Studio.",
+  "suggestions": [
+    {
+      "name": "camelCasePropertyName",
+      "description": "Human-readable description for the property library.",
+      "schema": { },
+      "thinking": "1–3 sentences: why this property fits the user's ask.",
+      "summary": "Very short label (e.g. primary email)"
+    }
+  ]
+}
+\`\`\`
+
+# Rules
+
+- "suggestions" must contain at least one item; for broad asks prefer roughly 3–8 distinct properties.
+- Each "name" must be camelCase and unique within "suggestions".
+- Each "schema" must be a valid JSON Schema object describing a single reusable property (the shape stored as property \`data\` in Studio — not wrapped in an outer "properties" object).
+- Use "$ref": "#/components/schemas/ClassName" only when that class appears in **Existing classes** below; otherwise use inline types.
+- Prefer practical constraints: string + format, bounded numbers, enums as JSON arrays, arrays with typed \`items\`, etc.
+- Do not reuse names from **Existing project properties** unless the user explicitly wants a variant — then pick a clearly distinct camelCase name.
+- "thinking" at the root is your overall reasoning; each suggestion's "thinking" is specific to that row.`;
+
+function buildPropertySuggestionsSystem(options: {
+  existingClassNames?: string[];
+  existingProperties?: Array<{ name: string; description?: string | null; data?: Record<string, unknown> }>;
+}): string {
+  let extra = '';
+  if (options.existingClassNames?.length) {
+    extra += `\n\n# Existing classes (reference only with $ref: "#/components/schemas/ClassName")\n${options.existingClassNames.join(', ')}`;
+  }
+  if (options.existingProperties?.length) {
+    extra += `\n\n# Existing project properties (avoid duplicate names unless the user asks for variants)\n`;
+    options.existingProperties.forEach((p) => {
+      const d = p.data;
+      const typeStr =
+        typeof d?.type === 'string'
+          ? d.type
+          : d && typeof d === 'object' && '$ref' in d && d.$ref
+            ? '$ref'
+            : 'object';
+      extra += `- ${p.name}: ${typeStr}${p.description ? ` — ${String(p.description).slice(0, 80)}` : ''}\n`;
+    });
+  }
+  return PROPERTY_SUGGESTIONS_SYSTEM + extra;
+}
+
 export async function POST(request: NextRequest) {
   try {
     const {
@@ -149,6 +205,7 @@ export async function POST(request: NextRequest) {
 
     const isClassSkeleton = task === 'class_skeleton';
     const isDataQuery = task === 'data_query';
+    const isPropertySuggestions = task === 'property_suggestions';
 
     // Create a system message to guide the LLM
     const systemContent = isClassSkeleton
@@ -161,7 +218,12 @@ export async function POST(request: NextRequest) {
             tableNames: Array.isArray(tableNames) ? tableNames : undefined,
             currentTableName: typeof currentTableName === 'string' ? currentTableName : undefined,
           })
-        : `You are an expert API designer and OpenAPI specification generator. Your task is to help users create OpenAPI 3.1.0 specifications based on their natural language descriptions.
+        : isPropertySuggestions
+          ? buildPropertySuggestionsSystem({
+              existingClassNames: Array.isArray(existingClassNames) ? existingClassNames : undefined,
+              existingProperties: Array.isArray(existingProperties) ? existingProperties : undefined,
+            })
+          : `You are an expert API designer and OpenAPI specification generator. Your task is to help users create OpenAPI 3.1.0 specifications based on their natural language descriptions.
 
 # Rules
 
@@ -230,8 +292,8 @@ Do not repeat the full JSON spec outside the code block. Do not add other sectio
     const cacheKey = ollamaChatCacheKey({
       model: typeof model === 'string' ? model : '',
       task: typeof task === 'string' ? task : undefined,
-      existingClassNames: isClassSkeleton ? existingClassNames : undefined,
-      existingProperties: isClassSkeleton ? existingProperties : undefined,
+      existingClassNames: isClassSkeleton || isPropertySuggestions ? existingClassNames : undefined,
+      existingProperties: isClassSkeleton || isPropertySuggestions ? existingProperties : undefined,
       tableNames: isDataQuery ? tableNames : undefined,
       currentTableName: isDataQuery ? currentTableName : undefined,
       versionId: typeof versionId === 'string' ? versionId : undefined,
@@ -242,8 +304,8 @@ Do not repeat the full JSON spec outside the code block. Do not add other sectio
     const semanticContextKey = ollamaChatSemanticContextKey({
       model: typeof model === 'string' ? model : '',
       task: typeof task === 'string' ? task : undefined,
-      existingClassNames: isClassSkeleton ? existingClassNames : undefined,
-      existingProperties: isClassSkeleton ? existingProperties : undefined,
+      existingClassNames: isClassSkeleton || isPropertySuggestions ? existingClassNames : undefined,
+      existingProperties: isClassSkeleton || isPropertySuggestions ? existingProperties : undefined,
       tableNames: isDataQuery ? tableNames : undefined,
       currentTableName: isDataQuery ? currentTableName : undefined,
       versionId: typeof versionId === 'string' ? versionId : undefined,

--- a/objectified-ui/src/app/components/ade/studio/AiPropertySuggestionsDialog.tsx
+++ b/objectified-ui/src/app/components/ade/studio/AiPropertySuggestionsDialog.tsx
@@ -46,10 +46,10 @@ export function propertyItemToExistingApiShape(p: PropertyItem): {
 
 function suggestionToSeedProperty(s: AiPropertySuggestion): PropertyItem {
   return {
+    ...(s.schema as Record<string, unknown>),
     id: '__ai_seed__',
     name: s.name,
     description: s.description,
-    ...(s.schema as Record<string, unknown>),
   } as PropertyItem;
 }
 
@@ -236,6 +236,8 @@ export function AiPropertySuggestionsDialog({
 
       const full = await accumulateOllamaSse(response, ac.signal, (acc) => setStreamText(acc));
       setStreamText(full);
+
+      if (ac.signal.aborted) return;
 
       const structured = parseAiPropertySuggestionsResponse(full);
       if (structured) {

--- a/objectified-ui/src/app/components/ade/studio/AiPropertySuggestionsDialog.tsx
+++ b/objectified-ui/src/app/components/ade/studio/AiPropertySuggestionsDialog.tsx
@@ -1,0 +1,479 @@
+'use client';
+
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '../../ui/Dialog';
+import { Button } from '../../ui/Button';
+import { Textarea } from '../../ui/Textarea';
+import { Bot, Loader2, Square } from 'lucide-react';
+import type { PropertyItem } from './StudioSideNav';
+import {
+  parseAiPropertySuggestionsResponse,
+  type AiPropertySuggestion,
+  type AiPropertySuggestionsPayload,
+} from '@lib/ai-property-suggestions';
+import { computeStudioSchemaFingerprint } from '@lib/studio-schema-fingerprint';
+import type { ChatStudioContext } from '@/app/ade/studio/components/chatbot/chat-context';
+import { isChatStudioContextEmpty } from '@/app/ade/studio/components/chatbot/chat-context';
+import {
+  resolvePreferredOllamaModel,
+  persistOllamaModelChoiceForScope,
+} from '@/app/ade/studio/components/chatbot/ollama-model-defaults';
+
+export function propertyItemToExistingApiShape(p: PropertyItem): {
+  name: string;
+  description: string | null;
+  data: Record<string, unknown>;
+} {
+  const rec = p as unknown as Record<string, unknown>;
+  const name = rec.name;
+  const description = rec.description;
+  const data = { ...rec };
+  delete data.id;
+  delete data.name;
+  delete data.description;
+  return {
+    name: typeof name === 'string' ? name : String(name ?? ''),
+    description: description != null && String(description).trim() ? String(description) : null,
+    data,
+  };
+}
+
+function suggestionToSeedProperty(s: AiPropertySuggestion): PropertyItem {
+  return {
+    id: '__ai_seed__',
+    name: s.name,
+    description: s.description,
+    ...(s.schema as Record<string, unknown>),
+  } as PropertyItem;
+}
+
+async function accumulateOllamaSse(
+  response: Response,
+  signal: AbortSignal | undefined,
+  onDelta?: (accumulated: string) => void,
+): Promise<string> {
+  const reader = response.body?.getReader();
+  if (!reader) return '';
+
+  const decoder = new TextDecoder();
+  let buffer = '';
+  let accumulated = '';
+
+  while (true) {
+    if (signal?.aborted) {
+      await reader.cancel().catch(() => {});
+      break;
+    }
+    const { done, value } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    const lines = buffer.split('\n');
+    buffer = lines.pop() || '';
+
+    for (const line of lines) {
+      if (!line.trim() || !line.startsWith('data: ')) continue;
+      const data = line.slice(6);
+      if (data === '[DONE]') continue;
+      try {
+        const event = JSON.parse(data) as { content?: string };
+        if (event.content) {
+          accumulated += event.content;
+          onDelta?.(accumulated);
+        }
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+
+  return accumulated;
+}
+
+export interface AiPropertySuggestionsDialogProps {
+  open: boolean;
+  onClose: () => void;
+  tenantId: string | null | undefined;
+  projectId: string;
+  versionId: string | null | undefined;
+  existingClasses: string[];
+  existingProperties: PropertyItem[];
+  studioContext: ChatStudioContext;
+  onCreatePropertyFromSuggestion: (seed: PropertyItem) => void;
+}
+
+export function AiPropertySuggestionsDialog({
+  open,
+  onClose,
+  tenantId,
+  projectId,
+  versionId,
+  existingClasses,
+  existingProperties,
+  studioContext,
+  onCreatePropertyFromSuggestion,
+}: AiPropertySuggestionsDialogProps) {
+  const [prompt, setPrompt] = useState('');
+  const [modelNames, setModelNames] = useState<string[]>([]);
+  const [selectedModel, setSelectedModel] = useState('');
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [streamText, setStreamText] = useState('');
+  const [parsed, setParsed] = useState<AiPropertySuggestionsPayload | null>(null);
+  const [parseError, setParseError] = useState<string | null>(null);
+  const [selectedIdx, setSelectedIdx] = useState<number | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch('/api/ollama/models');
+        const json = (await res.json()) as { success?: boolean; models?: { name?: string }[] };
+        const list = res.ok && json.success && Array.isArray(json.models) ? json.models : undefined;
+        const names = Array.isArray(list)
+          ? list.map((m) => m?.name).filter((n): n is string => typeof n === 'string' && n.trim().length > 0)
+          : [];
+        if (cancelled) return;
+        setModelNames(names);
+        const preferred = resolvePreferredOllamaModel({
+          tenantId,
+          projectId,
+          availableModelNames: names,
+          storage: typeof window !== 'undefined' ? window.localStorage : null,
+        });
+        setSelectedModel(preferred);
+      } catch {
+        if (!cancelled) {
+          setModelNames([]);
+          setSelectedModel('');
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [open, tenantId, projectId]);
+
+  useEffect(() => {
+    if (!open) {
+      setPrompt('');
+      setStreamText('');
+      setParsed(null);
+      setParseError(null);
+      setSelectedIdx(null);
+      setIsGenerating(false);
+      abortRef.current?.abort();
+      abortRef.current = null;
+    }
+  }, [open]);
+
+  const handleStop = () => {
+    abortRef.current?.abort();
+    abortRef.current = null;
+    setIsGenerating(false);
+  };
+
+  const handleGenerate = useCallback(async () => {
+    const trimmed = prompt.trim();
+    if (!trimmed || !selectedModel.trim()) return;
+
+    persistOllamaModelChoiceForScope({
+      tenantId,
+      projectId,
+      modelName: selectedModel,
+      storage: typeof window !== 'undefined' ? window.localStorage : null,
+    });
+
+    abortRef.current?.abort();
+    const ac = new AbortController();
+    abortRef.current = ac;
+
+    setIsGenerating(true);
+    setStreamText('');
+    setParsed(null);
+    setParseError(null);
+    setSelectedIdx(null);
+
+    let schemaContextFingerprint: string | undefined;
+    if (studioContext && !isChatStudioContextEmpty(studioContext)) {
+      try {
+        schemaContextFingerprint = await computeStudioSchemaFingerprint(studioContext);
+      } catch {
+        /* optional */
+      }
+    }
+
+    const existingPropsPayload = existingProperties.map(propertyItemToExistingApiShape);
+
+    try {
+      const response = await fetch('/api/ollama/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        signal: ac.signal,
+        body: JSON.stringify({
+          model: selectedModel.trim(),
+          task: 'property_suggestions',
+          messages: [{ role: 'user', content: trimmed }],
+          existingClassNames: existingClasses,
+          existingProperties: existingPropsPayload,
+          ...(typeof versionId === 'string' && versionId ? { versionId } : {}),
+          ...(schemaContextFingerprint ? { schemaContextFingerprint } : {}),
+        }),
+      });
+
+      if (!response.ok) {
+        const t = await response.text().catch(() => '');
+        throw new Error(t || `Request failed (${response.status})`);
+      }
+
+      const full = await accumulateOllamaSse(response, ac.signal, (acc) => setStreamText(acc));
+      setStreamText(full);
+
+      const structured = parseAiPropertySuggestionsResponse(full);
+      if (structured) {
+        setParsed(structured);
+        setParseError(null);
+        setSelectedIdx(0);
+      } else {
+        setParseError(
+          'The model response could not be read as structured suggestions. Try again, or ask for fewer properties at once.',
+        );
+      }
+    } catch (e) {
+      if (ac.signal.aborted) {
+        setParseError(null);
+      } else {
+        setParseError(e instanceof Error ? e.message : 'Something went wrong.');
+      }
+    } finally {
+      setIsGenerating(false);
+      abortRef.current = null;
+    }
+  }, [
+    prompt,
+    selectedModel,
+    tenantId,
+    projectId,
+    versionId,
+    existingClasses,
+    existingProperties,
+    studioContext,
+  ]);
+
+  const selectedSuggestion: AiPropertySuggestion | null =
+    parsed && selectedIdx !== null && parsed.suggestions[selectedIdx] ? parsed.suggestions[selectedIdx] : null;
+
+  const thinkingBody = isGenerating
+    ? streamText || '…'
+    : parsed
+      ? (parsed.thinking?.trim() ? parsed.thinking : '—')
+      : streamText;
+
+  const showThinkingSection = isGenerating || parsed !== null || (!!streamText && streamText.length > 0);
+
+  const summaryBelow = parsed?.summary?.trim() ? parsed.summary : '';
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
+      <DialogContent
+        className="max-h-[90vh] flex flex-col gap-0 overflow-hidden sm:max-w-2xl"
+        aria-describedby={undefined}
+      >
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2 text-lg">
+            <Bot className="h-5 w-5 text-violet-600 dark:text-violet-400" aria-hidden />
+            Suggest properties with AI
+          </DialogTitle>
+        </DialogHeader>
+
+        <div className="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto px-1 py-2">
+          <p className="text-sm text-slate-600 dark:text-slate-400">
+            Describe the kinds of reusable properties you want for this project (for example accounting fields,
+            user profile traits, or IoT telemetry). The model proposes JSON Schema snippets you can open in Add
+            Property.
+          </p>
+
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+            <label htmlFor="ai-prop-suggest-model" className="sr-only">
+              Ollama model
+            </label>
+            <select
+              id="ai-prop-suggest-model"
+              data-testid="ai-property-suggestions-model"
+              value={selectedModel}
+              onChange={(e) => setSelectedModel(e.target.value)}
+              disabled={modelNames.length === 0 || isGenerating}
+              className="w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm dark:border-slate-600 dark:bg-slate-900 sm:max-w-xs"
+            >
+              {modelNames.length === 0 ? (
+                <option value="">No models — start Ollama</option>
+              ) : (
+                modelNames.map((name) => (
+                  <option key={name} value={name}>
+                    {name}
+                  </option>
+                ))
+              )}
+            </select>
+          </div>
+
+          <div>
+            <label htmlFor="ai-prop-suggest-prompt" className="mb-1 block text-xs font-medium text-slate-700 dark:text-slate-300">
+              What should we create?
+            </label>
+            <Textarea
+              id="ai-prop-suggest-prompt"
+              data-testid="ai-property-suggestions-prompt"
+              value={prompt}
+              onChange={(e) => setPrompt(e.target.value)}
+              placeholder="e.g. Standard fields for a subscription billing entity"
+              disabled={isGenerating}
+              rows={3}
+              className="resize-y text-sm"
+            />
+          </div>
+
+          <div className="flex flex-wrap gap-2">
+            <Button
+              type="button"
+              data-testid="ai-property-suggestions-generate"
+              onClick={() => void handleGenerate()}
+              disabled={isGenerating || !prompt.trim() || !selectedModel.trim()}
+              className="bg-gradient-to-r from-violet-600 to-indigo-600 text-white hover:from-violet-500 hover:to-indigo-500"
+            >
+              {isGenerating ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden />
+                  Generating…
+                </>
+              ) : (
+                'Generate suggestions'
+              )}
+            </Button>
+            {isGenerating && (
+              <Button type="button" variant="outline" onClick={handleStop} data-testid="ai-property-suggestions-stop">
+                <Square className="mr-2 h-3.5 w-3.5 fill-current" aria-hidden />
+                Stop
+              </Button>
+            )}
+          </div>
+
+          {parseError && (
+            <p className="rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-900 dark:border-amber-900/50 dark:bg-amber-950/40 dark:text-amber-100">
+              {parseError}
+            </p>
+          )}
+
+          {showThinkingSection && (
+            <section aria-label="Thinking">
+              <h3 className="mb-1 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                Thinking
+              </h3>
+              <div
+                data-testid="ai-property-suggestions-thinking"
+                className="max-h-36 overflow-y-auto rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-800 dark:border-slate-600 dark:bg-slate-900/60 dark:text-slate-200"
+              >
+                {thinkingBody}
+              </div>
+            </section>
+          )}
+
+          {parsed && parsed.suggestions.length > 0 && (
+            <section aria-label="Suggested properties">
+              <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                Suggested properties
+              </h3>
+              <ul className="flex flex-wrap gap-2" data-testid="ai-property-suggestions-list">
+                {parsed.suggestions.map((s, i) => (
+                  <li key={`${s.name}-${i}`}>
+                    <button
+                      type="button"
+                      data-testid={`ai-property-suggestions-item-${i}`}
+                      onClick={() => setSelectedIdx(i)}
+                      className={`rounded-full border px-3 py-1.5 text-sm font-medium transition-colors ${
+                        selectedIdx === i
+                          ? 'border-violet-500 bg-violet-500/15 text-violet-800 dark:text-violet-200'
+                          : 'border-slate-200 bg-white text-slate-700 hover:border-violet-300 hover:bg-violet-50 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-200 dark:hover:border-violet-500 dark:hover:bg-violet-950/40'
+                      }`}
+                    >
+                      {s.summary || s.name}
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          )}
+
+          {selectedSuggestion && (
+            <section aria-label="Selected suggestion detail" className="space-y-2 rounded-lg border border-slate-200 p-3 dark:border-slate-600">
+              <div>
+                <h3 className="mb-1 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                  Property thinking
+                </h3>
+                <p className="text-sm text-slate-700 dark:text-slate-300">
+                  {selectedSuggestion.thinking || '—'}
+                </p>
+              </div>
+              <div>
+                <h3 className="mb-1 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                  Name &amp; description
+                </h3>
+                <p className="font-mono text-sm font-semibold text-slate-900 dark:text-slate-100">{selectedSuggestion.name}</p>
+                {selectedSuggestion.description && (
+                  <p className="mt-1 text-sm text-slate-600 dark:text-slate-400">{selectedSuggestion.description}</p>
+                )}
+              </div>
+              <div>
+                <h3 className="mb-1 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                  Schema (JSON)
+                </h3>
+                <pre className="max-h-40 overflow-auto rounded-md bg-slate-950 px-3 py-2 text-xs text-slate-100">
+                  {JSON.stringify(selectedSuggestion.schema, null, 2)}
+                </pre>
+              </div>
+              <Button
+                type="button"
+                data-testid="ai-property-suggestions-open-add"
+                onClick={() => {
+                  onCreatePropertyFromSuggestion(suggestionToSeedProperty(selectedSuggestion));
+                  onClose();
+                }}
+                className="w-full bg-gradient-to-r from-indigo-600 to-purple-600 text-white hover:from-indigo-500 hover:to-purple-500 sm:w-auto"
+              >
+                Open in Add Property
+              </Button>
+            </section>
+          )}
+
+          {summaryBelow && (
+            <section aria-label="Summary">
+              <h3 className="mb-1 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                Summary
+              </h3>
+              <div
+                data-testid="ai-property-suggestions-summary"
+                className="rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 dark:border-slate-600 dark:bg-slate-900/40 dark:text-slate-200"
+              >
+                {summaryBelow}
+              </div>
+            </section>
+          )}
+        </div>
+
+        <DialogFooter className="border-t border-slate-200 pt-3 dark:border-slate-700">
+          <Button type="button" variant="outline" onClick={onClose}>
+            Close
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/objectified-ui/src/app/components/ade/studio/PropertyDialog.tsx
+++ b/objectified-ui/src/app/components/ade/studio/PropertyDialog.tsx
@@ -513,9 +513,9 @@ export const PropertyDialog: React.FC<PropertyDialogProps> = ({
 
   const advancedScrollRef = useRef<HTMLDivElement>(null);
 
-  // Load property data when dialog opens in edit mode
+  // Load property data when dialog opens in edit mode, or when adding with an AI/template seed (#609).
   useEffect(() => {
-    if (open && property && mode === 'edit') {
+    if (open && property && (mode === 'edit' || mode === 'add')) {
       setPropertyName(property.name);
 
       // Check if property type is an array (for nullable detection)

--- a/objectified-ui/src/app/components/ade/studio/StudioSideNav.tsx
+++ b/objectified-ui/src/app/components/ade/studio/StudioSideNav.tsx
@@ -3,7 +3,7 @@
 
 import React, { useState } from 'react';
 import * as Tabs from '@radix-ui/react-tabs';
-import { Search, Plus, Pencil, Trash2, FileX, Upload, Library, ChevronDown, ChevronUp, ChevronRight, Eye, EyeOff, Boxes, ListTree, Layers } from 'lucide-react';
+import { Search, Plus, Pencil, Trash2, FileX, Upload, Library, ChevronDown, ChevronUp, ChevronRight, Eye, EyeOff, Boxes, ListTree, Layers, Bot } from 'lucide-react';
 import { getPropertiesForClass } from '../../../../../lib/db/helper';
 import { useDarkMode } from '@/app/hooks/useDarkMode';
 import SidebarDensityToggle from '@/app/components/sidebar/SidebarDensityToggle';
@@ -67,6 +67,8 @@ export interface StudioSideNavCallbacks {
   onPropertyDelete?: (propertyId: string) => void;
   onPropertySelect?: (propertyItem: PropertyItem) => void;
   onPropertyTemplates?: () => void;
+  /** Open AI-assisted property suggestions (#609) */
+  onPropertyAiSuggest?: () => void;
 
   // Groups callbacks
   onGroupAdd?: () => void;
@@ -868,6 +870,23 @@ const StudioSideNav: React.FC<StudioSideNavProps> = ({
                   className="w-8 h-8 rounded-full flex items-center justify-center shadow-sm transition-all hover:-translate-y-0.5 hover:scale-105 disabled:opacity-50 disabled:pointer-events-none disabled:transform-none bg-gradient-to-br from-emerald-500 to-emerald-600 text-white hover:shadow-emerald-500/40"
                 >
                   <Library className="w-4 h-4" />
+                </button>
+                <button
+                  type="button"
+                  data-testid="studio-sidebar-ai-property-suggestions"
+                  onClick={() => callbacks.onPropertyAiSuggest?.()}
+                  disabled={!selectedProjectId || isReadOnly}
+                  aria-label="Suggest properties with AI"
+                  title={
+                    !selectedProjectId
+                      ? 'Select a project first'
+                      : isReadOnly
+                        ? 'Cannot edit published version'
+                        : 'Suggest reusable properties with AI'
+                  }
+                  className="w-8 h-8 rounded-full flex items-center justify-center shadow-sm transition-all hover:-translate-y-0.5 hover:scale-105 disabled:opacity-50 disabled:pointer-events-none disabled:transform-none bg-gradient-to-br from-violet-500 to-purple-600 text-white hover:shadow-violet-500/40"
+                >
+                  <Bot className="w-4 h-4" aria-hidden />
                 </button>
                 <button
                   type="button"

--- a/objectified-ui/tests/unit/ai-property-suggestions.test.ts
+++ b/objectified-ui/tests/unit/ai-property-suggestions.test.ts
@@ -1,0 +1,36 @@
+import {
+  parseAiPropertySuggestionsResponse,
+  type AiPropertySuggestionsPayload,
+} from '../../lib/ai-property-suggestions';
+
+describe('parseAiPropertySuggestionsResponse', () => {
+  it('parses the last fenced json block', () => {
+    const md = `ignored\n\n\`\`\`json\n{"thinking":"overall","summary":"wrap","suggestions":[{"name":"emailAddress","description":"Primary","schema":{"type":"string","format":"email"},"thinking":"common id","summary":"email"}]}\n\`\`\``;
+    const r = parseAiPropertySuggestionsResponse(md);
+    expect(r).not.toBeNull();
+    const p = r as AiPropertySuggestionsPayload;
+    expect(p.thinking).toBe('overall');
+    expect(p.summary).toBe('wrap');
+    expect(p.suggestions).toHaveLength(1);
+    expect(p.suggestions[0].name).toBe('emailAddress');
+    expect(p.suggestions[0].schema).toEqual({ type: 'string', format: 'email' });
+  });
+
+  it('returns null without a json fence', () => {
+    expect(parseAiPropertySuggestionsResponse('plain text')).toBeNull();
+  });
+
+  it('returns null when suggestions empty', () => {
+    const md = "```json\n{\"thinking\":\"x\",\"summary\":\"y\",\"suggestions\":[]}\n```";
+    expect(parseAiPropertySuggestionsResponse(md)).toBeNull();
+  });
+
+  it('skips suggestion rows missing name or schema object', () => {
+    const md =
+      "```json\n{\"thinking\":\"\",\"summary\":\"\",\"suggestions\":[{\"name\":\"\",\"schema\":{\"type\":\"string\"}},{\"name\":\"ok\",\"schema\":{\"type\":\"integer\"}}]}\n```";
+    const r = parseAiPropertySuggestionsResponse(md);
+    expect(r?.suggestions).toEqual([
+      expect.objectContaining({ name: 'ok', schema: { type: 'integer' } }),
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a **robot** control in the Properties sidebar footer (next to templates and add). It opens a dialog where you describe reusable properties; the app calls `/api/ollama/chat` with `task: property_suggestions` and shows **Thinking** (streaming), clickable suggestion chips, per-suggestion **thinking** plus schema JSON, an overall **Summary**, and **Open in Add Property** to prefill the Add Property dialog.
- Extends the Ollama chat route with a dedicated system prompt and includes existing classes/properties in cache keys (same pattern as `class_skeleton`).
- **PropertyDialog** loads full form state when **add** mode is opened with a seed property (AI suggestion payload).

## How to test
1. **Open Studio**, select a **project** on an editable version.
2. Sidebar → **Properties** → **click the violet robot** (`data-testid="studio-sidebar-ai-property-suggestions"`).
3. Choose an **Ollama model**, enter a prompt, **Generate suggestions**.
4. Confirm **Thinking** updates during generation; after completion, use suggestion chips and inspect detail.
5. **Open in Add Property** and verify fields/schema are prefilled.

## Risks / notes
- Needs Ollama reachable from the UI API with at least one non-embedding model.
- Parsing requires one fenced ```json``` block in the model output; otherwise an inline error is shown.

Closes #609

Made with [Cursor](https://cursor.com)