### PR TITLE
Fix #269 - AI-suggested property types in Add Property

### DIFF
--- a/objectified-ui/lib/ai-property-suggestions.ts
+++ b/objectified-ui/lib/ai-property-suggestions.ts
@@ -1,6 +1,7 @@
 /**
- * Parse structured AI responses for reusable property suggestions (#609).
- * Expects a single ```json ... ``` markdown block from the property_suggestions Ollama task.
+ * Parse structured AI responses for reusable property suggestions (#609) and
+ * property_type_suggestions (alternative schemas for one name, #269).
+ * Expects a single ```json ... ``` markdown block from those Ollama tasks.
  */
 
 export type AiPropertySuggestion = {
@@ -35,10 +36,18 @@ function isPlainObject(v: unknown): v is Record<string, unknown> {
   return v !== null && typeof v === 'object' && !Array.isArray(v);
 }
 
+export type ParseAiPropertySuggestionsOptions = {
+  /** When set, every suggestion uses this name (fixes model drift for type-only tasks). */
+  canonicalPropertyName?: string;
+};
+
 /**
  * Returns null if the response does not contain valid structured suggestions.
  */
-export function parseAiPropertySuggestionsResponse(markdown: string): AiPropertySuggestionsPayload | null {
+export function parseAiPropertySuggestionsResponse(
+  markdown: string,
+  options?: ParseAiPropertySuggestionsOptions,
+): AiPropertySuggestionsPayload | null {
   const raw = extractLastJsonCodeBlock(markdown.trim());
   if (!raw) return null;
 
@@ -59,10 +68,16 @@ export function parseAiPropertySuggestionsResponse(markdown: string): AiProperty
 
   const suggestions: AiPropertySuggestion[] = [];
 
+  const canonical = options?.canonicalPropertyName?.trim() || '';
+
   for (const item of suggestionsRaw) {
     if (!isPlainObject(item)) continue;
-    const name = typeof item.name === 'string' ? item.name.trim() : '';
-    if (!name) continue;
+    let name = typeof item.name === 'string' ? item.name.trim() : '';
+    if (canonical) {
+      name = canonical;
+    } else if (!name) {
+      continue;
+    }
     const schema = item.schema;
     if (!isPlainObject(schema)) continue;
 

--- a/objectified-ui/lib/ollama-chat-sse.ts
+++ b/objectified-ui/lib/ollama-chat-sse.ts
@@ -1,0 +1,45 @@
+/**
+ * Accumulate assistant text from an Ollama-compatible SSE response (data: JSON lines).
+ */
+
+export async function accumulateOllamaSse(
+  response: Response,
+  signal: AbortSignal | undefined,
+  onDelta?: (accumulated: string) => void,
+): Promise<string> {
+  const reader = response.body?.getReader();
+  if (!reader) return '';
+
+  const decoder = new TextDecoder();
+  let buffer = '';
+  let accumulated = '';
+
+  while (true) {
+    if (signal?.aborted) {
+      await reader.cancel().catch(() => {});
+      break;
+    }
+    const { done, value } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    const lines = buffer.split('\n');
+    buffer = lines.pop() || '';
+
+    for (const line of lines) {
+      if (!line.trim() || !line.startsWith('data: ')) continue;
+      const data = line.slice(6);
+      if (data === '[DONE]') continue;
+      try {
+        const event = JSON.parse(data) as { content?: string };
+        if (event.content) {
+          accumulated += event.content;
+          onDelta?.(accumulated);
+        }
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+
+  return accumulated;
+}

--- a/objectified-ui/lib/property-item-utils.ts
+++ b/objectified-ui/lib/property-item-utils.ts
@@ -1,0 +1,24 @@
+import type { PropertyItem } from '@/app/components/ade/studio/StudioSideNav';
+
+/**
+ * Converts a PropertyItem into the reduced shape expected by the Ollama API's
+ * `existing_properties` payload field (id and name stripped, description normalised).
+ */
+export function propertyItemToExistingApiShape(p: PropertyItem): {
+  name: string;
+  description: string | null;
+  data: Record<string, unknown>;
+} {
+  const rec = p as unknown as Record<string, unknown>;
+  const name = rec.name;
+  const description = rec.description;
+  const data = { ...rec };
+  delete data.id;
+  delete data.name;
+  delete data.description;
+  return {
+    name: typeof name === 'string' ? name : String(name ?? ''),
+    description: description != null && String(description).trim() ? String(description) : null,
+    data,
+  };
+}

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.60",
+  "version": "0.11.61",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -27,6 +27,7 @@ We continue to improve the platform based on your feedback with improvements and
 - Projects list includes a **Show deleted** switch; when on, soft-deleted projects appear with a **Deleted** badge and **Restore** or **permanent delete** in the row menu (#2981).
 
 ## Studio
+- **Add Property** includes **Suggest types with AI** (when Ollama is configured): enter a property name, ask for alternatives (formats, refs, domain hints such as FHIR), then **Apply to form** to load a chosen JSON Schema (#269).
 - Properties sidebar includes an **AI suggest properties** control (robot): describe what you need, review thinking and summary around the suggestion chips, inspect each proposal, then **Open in Add Property** to create it (#609).
 - Studio AI chat schema refinements infer JSON Schema type and common constraints from well-known property names (`email`, `createdAt`, `age`, `price`, `isActive`) when you add a field without specifying a type; the class-skeleton Ollama prompt uses the same conventions (#277).
 - Chat refinement inference now adds typical validation hints from names—string lengths, numeric bounds, regex patterns, and marking `id` as required when added without a type (#278).

--- a/objectified-ui/src/app/ade/studio/layout.tsx
+++ b/objectified-ui/src/app/ade/studio/layout.tsx
@@ -633,10 +633,10 @@ function StudioLayoutContent({ children }: Readonly<{ children: React.ReactNode 
             open: true,
             mode: 'add',
             selectedProperty: {
+              ...payload.schema,
               id: '__ai_seed__',
               name: payload.name,
               description: payload.description ?? undefined,
-              ...payload.schema,
             } as PropertyItem,
           });
         }}

--- a/objectified-ui/src/app/ade/studio/layout.tsx
+++ b/objectified-ui/src/app/ade/studio/layout.tsx
@@ -458,6 +458,12 @@ function StudioLayoutContent({ children }: Readonly<{ children: React.ReactNode 
   // Snapshot of the studio workspace assembled for the AI chatbot (#259).
   // Recomputed only when its inputs change so the chatbot doesn't re-render
   // on unrelated layout state churn.
+  const selectedClassNameForPropertyAi = React.useMemo(() => {
+    const idSet = new Set(selectedCanvasNodeIds);
+    const hit = classes.find((c) => idSet.has(c.id));
+    return hit?.name?.trim() || null;
+  }, [classes, selectedCanvasNodeIds]);
+
   const chatbotStudioContext = React.useMemo<ChatStudioContext>(() => {
     const chatProperties: ChatStudioProperty[] = properties.map((prop) => {
       const propAny = prop as unknown as Record<string, unknown>;
@@ -609,6 +615,31 @@ function StudioLayoutContent({ children }: Readonly<{ children: React.ReactNode 
         property={propertyDialog.selectedProperty}
         onSubmit={handlePropertySubmit}
         availableClasses={classes.map(c => c.name)}
+        propertyAiContext={
+          currentTenantId && selectedProjectId
+            ? {
+                tenantId: currentTenantId,
+                projectId: selectedProjectId,
+                versionId: selectedVersionId,
+                existingClasses: classes.map((c) => c.name),
+                existingProperties: properties,
+                studioContext: chatbotStudioContext,
+                contextClassName: selectedClassNameForPropertyAi,
+              }
+            : undefined
+        }
+        onApplyAiTypeSchema={(payload) => {
+          setPropertyDialog({
+            open: true,
+            mode: 'add',
+            selectedProperty: {
+              id: '__ai_seed__',
+              name: payload.name,
+              description: payload.description ?? undefined,
+              ...payload.schema,
+            } as PropertyItem,
+          });
+        }}
       />
 
       {selectedProjectId && (

--- a/objectified-ui/src/app/api/ollama/chat/route.ts
+++ b/objectified-ui/src/app/api/ollama/chat/route.ts
@@ -156,6 +156,43 @@ Return exactly one markdown fenced JSON block and nothing else — no preamble, 
 - Use "$ref": "#/components/schemas/ClassName" only when that class appears in **Existing classes** below; otherwise use inline types.
 - Prefer practical constraints: string + format, bounded numbers, enums as JSON arrays, arrays with typed \`items\`, etc.
 - Do not reuse names from **Existing project properties** unless the user explicitly wants a variant — then pick a clearly distinct camelCase name.
+- When the user names a domain (healthcare, finance, IoT, etc.), you may align names and formats with common industry vocabularies (for example FHIR-style elements in healthcare) while still emitting valid JSON Schema the Studio property library can store.
+- Consider archetypal class fields (e.g. User → email, password hash, displayName), standard cross-cutting fields (id, createdAt, updatedAt), and properties that complement **Existing project properties** when the user asks for a coherent set.
+- "thinking" at the root is your overall reasoning; each suggestion's "thinking" is specific to that row.`;
+
+const PROPERTY_TYPE_SUGGESTIONS_SYSTEM = `You help API designers pick JSON Schema shapes for ONE reusable property in an OpenAPI 3.1 property library.
+
+The user has already chosen a property name (and may describe a class or domain). You return several **alternative schemas** for that same name so they can compare types, formats, references, and constraints.
+
+# Output format
+
+Return exactly one markdown fenced JSON block and nothing else — no preamble, no commentary outside the fence:
+
+\`\`\`json
+{
+  "thinking": "2–5 sentences: how you interpreted the property name, class context, and existing project properties.",
+  "summary": "2–4 sentences: how the alternatives differ and when to pick each.",
+  "suggestions": [
+    {
+      "name": "sameAsTargetPropertyName",
+      "description": "Optional human-readable line for the library.",
+      "schema": { },
+      "thinking": "1–3 sentences: why this schema fits.",
+      "summary": "Very short label (e.g. UUID string)"
+    }
+  ]
+}
+\`\`\`
+
+# Rules
+
+- "suggestions" must contain at least 2 items and usually 3–8 **distinct schema shapes** (not duplicate JSON).
+- Every suggestion's "name" MUST match the **Target property name** given in the system context (identical spelling).
+- Each "schema" must be a valid JSON Schema object for a single reusable property (the shape stored as property \`data\` in Studio — not wrapped in an outer "properties" object).
+- Prefer a spread of practical alternatives: primitives with strong formats, bounded numbers, enums, arrays with typed \`items\`, or \`"$ref": "#/components/schemas/ClassName"\` when that class appears in **Existing classes**.
+- Include at least one "boring but robust" option (e.g. plain string or ISO-8601 date-time) when other options are domain-specific.
+- When the domain suggests it (e.g. healthcare), one alternative may mirror a well-known industry pattern (FHIR logical types) using standard JSON Schema — do not invent non-JSON-Schema keywords.
+- Use **Existing project properties** to propose complementary or related shapes (e.g. foreign-key style refs, parallel timestamp fields) when relevant.
 - "thinking" at the root is your overall reasoning; each suggestion's "thinking" is specific to that row.`;
 
 function buildPropertySuggestionsSystem(options: {
@@ -182,6 +219,40 @@ function buildPropertySuggestionsSystem(options: {
   return PROPERTY_SUGGESTIONS_SYSTEM + extra;
 }
 
+function buildPropertyTypeSuggestionsSystem(options: {
+  existingClassNames?: string[];
+  existingProperties?: Array<{ name: string; description?: string | null; data?: Record<string, unknown> }>;
+  targetPropertyName?: string;
+  targetClassName?: string;
+}): string {
+  let s = PROPERTY_TYPE_SUGGESTIONS_SYSTEM;
+  const tp = typeof options.targetPropertyName === 'string' ? options.targetPropertyName.trim() : '';
+  if (tp) {
+    s += `\n\n# Target property name (mandatory)\nEvery suggestion's "name" field must be exactly: ${tp}\n`;
+  }
+  const tc = typeof options.targetClassName === 'string' ? options.targetClassName.trim() : '';
+  if (tc) {
+    s += `\n\n# Class or domain context\n${tc}\n`;
+  }
+  if (options.existingClassNames?.length) {
+    s += `\n\n# Existing classes (reference only with $ref: "#/components/schemas/ClassName")\n${options.existingClassNames.join(', ')}`;
+  }
+  if (options.existingProperties?.length) {
+    s += `\n\n# Existing project properties\n`;
+    options.existingProperties.forEach((p) => {
+      const d = p.data;
+      const typeStr =
+        typeof d?.type === 'string'
+          ? d.type
+          : d && typeof d === 'object' && '$ref' in d && d.$ref
+            ? '$ref'
+            : 'object';
+      s += `- ${p.name}: ${typeStr}${p.description ? ` — ${String(p.description).slice(0, 80)}` : ''}\n`;
+    });
+  }
+  return s;
+}
+
 export async function POST(request: NextRequest) {
   try {
     const {
@@ -194,6 +265,8 @@ export async function POST(request: NextRequest) {
       currentTableName,
       versionId,
       schemaContextFingerprint,
+      targetPropertyName,
+      targetClassName,
     } = await request.json();
 
     if (typeof model !== 'string' || !model.trim() || !messages || !Array.isArray(messages)) {
@@ -206,6 +279,8 @@ export async function POST(request: NextRequest) {
     const isClassSkeleton = task === 'class_skeleton';
     const isDataQuery = task === 'data_query';
     const isPropertySuggestions = task === 'property_suggestions';
+    const isPropertyTypeSuggestions = task === 'property_type_suggestions';
+    const usesPropertyLibraryContext = isClassSkeleton || isPropertySuggestions || isPropertyTypeSuggestions;
 
     // Create a system message to guide the LLM
     const systemContent = isClassSkeleton
@@ -223,7 +298,14 @@ export async function POST(request: NextRequest) {
               existingClassNames: Array.isArray(existingClassNames) ? existingClassNames : undefined,
               existingProperties: Array.isArray(existingProperties) ? existingProperties : undefined,
             })
-          : `You are an expert API designer and OpenAPI specification generator. Your task is to help users create OpenAPI 3.1.0 specifications based on their natural language descriptions.
+          : isPropertyTypeSuggestions
+            ? buildPropertyTypeSuggestionsSystem({
+                existingClassNames: Array.isArray(existingClassNames) ? existingClassNames : undefined,
+                existingProperties: Array.isArray(existingProperties) ? existingProperties : undefined,
+                targetPropertyName: typeof targetPropertyName === 'string' ? targetPropertyName : undefined,
+                targetClassName: typeof targetClassName === 'string' ? targetClassName : undefined,
+              })
+            : `You are an expert API designer and OpenAPI specification generator. Your task is to help users create OpenAPI 3.1.0 specifications based on their natural language descriptions.
 
 # Rules
 
@@ -292,8 +374,8 @@ Do not repeat the full JSON spec outside the code block. Do not add other sectio
     const cacheKey = ollamaChatCacheKey({
       model: typeof model === 'string' ? model : '',
       task: typeof task === 'string' ? task : undefined,
-      existingClassNames: isClassSkeleton || isPropertySuggestions ? existingClassNames : undefined,
-      existingProperties: isClassSkeleton || isPropertySuggestions ? existingProperties : undefined,
+      existingClassNames: usesPropertyLibraryContext ? existingClassNames : undefined,
+      existingProperties: usesPropertyLibraryContext ? existingProperties : undefined,
       tableNames: isDataQuery ? tableNames : undefined,
       currentTableName: isDataQuery ? currentTableName : undefined,
       versionId: typeof versionId === 'string' ? versionId : undefined,
@@ -304,8 +386,8 @@ Do not repeat the full JSON spec outside the code block. Do not add other sectio
     const semanticContextKey = ollamaChatSemanticContextKey({
       model: typeof model === 'string' ? model : '',
       task: typeof task === 'string' ? task : undefined,
-      existingClassNames: isClassSkeleton || isPropertySuggestions ? existingClassNames : undefined,
-      existingProperties: isClassSkeleton || isPropertySuggestions ? existingProperties : undefined,
+      existingClassNames: usesPropertyLibraryContext ? existingClassNames : undefined,
+      existingProperties: usesPropertyLibraryContext ? existingProperties : undefined,
       tableNames: isDataQuery ? tableNames : undefined,
       currentTableName: isDataQuery ? currentTableName : undefined,
       versionId: typeof versionId === 'string' ? versionId : undefined,

--- a/objectified-ui/src/app/components/ade/studio/AiPropertySuggestionsDialog.tsx
+++ b/objectified-ui/src/app/components/ade/studio/AiPropertySuggestionsDialog.tsx
@@ -25,25 +25,7 @@ import {
   persistOllamaModelChoiceForScope,
 } from '@/app/ade/studio/components/chatbot/ollama-model-defaults';
 import { accumulateOllamaSse } from '@lib/ollama-chat-sse';
-
-export function propertyItemToExistingApiShape(p: PropertyItem): {
-  name: string;
-  description: string | null;
-  data: Record<string, unknown>;
-} {
-  const rec = p as unknown as Record<string, unknown>;
-  const name = rec.name;
-  const description = rec.description;
-  const data = { ...rec };
-  delete data.id;
-  delete data.name;
-  delete data.description;
-  return {
-    name: typeof name === 'string' ? name : String(name ?? ''),
-    description: description != null && String(description).trim() ? String(description) : null,
-    data,
-  };
-}
+import { propertyItemToExistingApiShape } from '@lib/property-item-utils';
 
 function suggestionToSeedProperty(s: AiPropertySuggestion): PropertyItem {
   return {

--- a/objectified-ui/src/app/components/ade/studio/AiPropertyTypeSuggestionsDialog.tsx
+++ b/objectified-ui/src/app/components/ade/studio/AiPropertyTypeSuggestionsDialog.tsx
@@ -25,58 +25,37 @@ import {
   persistOllamaModelChoiceForScope,
 } from '@/app/ade/studio/components/chatbot/ollama-model-defaults';
 import { accumulateOllamaSse } from '@lib/ollama-chat-sse';
+import { propertyItemToExistingApiShape } from './AiPropertySuggestionsDialog';
 
-export function propertyItemToExistingApiShape(p: PropertyItem): {
-  name: string;
-  description: string | null;
-  data: Record<string, unknown>;
-} {
-  const rec = p as unknown as Record<string, unknown>;
-  const name = rec.name;
-  const description = rec.description;
-  const data = { ...rec };
-  delete data.id;
-  delete data.name;
-  delete data.description;
-  return {
-    name: typeof name === 'string' ? name : String(name ?? ''),
-    description: description != null && String(description).trim() ? String(description) : null,
-    data,
-  };
-}
-
-function suggestionToSeedProperty(s: AiPropertySuggestion): PropertyItem {
-  return {
-    ...(s.schema as Record<string, unknown>),
-    id: '__ai_seed__',
-    name: s.name,
-    description: s.description,
-  } as PropertyItem;
-}
-
-export interface AiPropertySuggestionsDialogProps {
+export interface AiPropertyTypeSuggestionsDialogProps {
   open: boolean;
   onClose: () => void;
   tenantId: string | null | undefined;
   projectId: string;
   versionId: string | null | undefined;
+  targetPropertyName: string;
+  targetPropertyDescription?: string;
+  contextClassName?: string | null;
   existingClasses: string[];
   existingProperties: PropertyItem[];
   studioContext: ChatStudioContext;
-  onCreatePropertyFromSuggestion: (seed: PropertyItem) => void;
+  onApplyTypeSuggestion: (suggestion: AiPropertySuggestion) => void;
 }
 
-export function AiPropertySuggestionsDialog({
+export function AiPropertyTypeSuggestionsDialog({
   open,
   onClose,
   tenantId,
   projectId,
   versionId,
+  targetPropertyName,
+  targetPropertyDescription,
+  contextClassName,
   existingClasses,
   existingProperties,
   studioContext,
-  onCreatePropertyFromSuggestion,
-}: AiPropertySuggestionsDialogProps) {
+  onApplyTypeSuggestion,
+}: AiPropertyTypeSuggestionsDialogProps) {
   const [prompt, setPrompt] = useState('');
   const [modelNames, setModelNames] = useState<string[]>([]);
   const [selectedModel, setSelectedModel] = useState('');
@@ -141,8 +120,8 @@ export function AiPropertySuggestionsDialog({
   };
 
   const handleGenerate = useCallback(async () => {
-    const trimmed = prompt.trim();
-    if (!trimmed || !selectedModel.trim()) return;
+    const propName = targetPropertyName.trim();
+    if (!propName || !selectedModel.trim()) return;
 
     persistOllamaModelChoiceForScope({
       tenantId,
@@ -171,6 +150,17 @@ export function AiPropertySuggestionsDialog({
     }
 
     const existingPropsPayload = existingProperties.map(propertyItemToExistingApiShape);
+    const trimmedPrompt = prompt.trim();
+    const desc = (targetPropertyDescription || '').trim();
+
+    const userContent = [
+      `Target property: ${propName}`,
+      contextClassName?.trim() ? `Class or domain context: ${contextClassName.trim()}` : null,
+      desc ? `Current description in the form: ${desc}` : null,
+      `User instructions:\n${trimmedPrompt || 'Infer strong type options from the property name and project context.'}`,
+    ]
+      .filter(Boolean)
+      .join('\n\n');
 
     try {
       const response = await fetch('/api/ollama/chat', {
@@ -179,10 +169,12 @@ export function AiPropertySuggestionsDialog({
         signal: ac.signal,
         body: JSON.stringify({
           model: selectedModel.trim(),
-          task: 'property_suggestions',
-          messages: [{ role: 'user', content: trimmed }],
+          task: 'property_type_suggestions',
+          messages: [{ role: 'user', content: userContent }],
           existingClassNames: existingClasses,
           existingProperties: existingPropsPayload,
+          targetPropertyName: propName,
+          ...(contextClassName?.trim() ? { targetClassName: contextClassName.trim() } : {}),
           ...(typeof versionId === 'string' && versionId ? { versionId } : {}),
           ...(schemaContextFingerprint ? { schemaContextFingerprint } : {}),
         }),
@@ -198,14 +190,17 @@ export function AiPropertySuggestionsDialog({
 
       if (ac.signal.aborted) return;
 
-      const structured = parseAiPropertySuggestionsResponse(full);
-      if (structured) {
+      const structured = parseAiPropertySuggestionsResponse(full, { canonicalPropertyName: propName });
+      if (structured && structured.suggestions.length >= 2) {
         setParsed(structured);
         setParseError(null);
         setSelectedIdx(0);
+      } else if (structured && structured.suggestions.length === 1) {
+        setParseError('The model returned only one type option. Try again and ask for multiple alternatives.');
+        setParsed(null);
       } else {
         setParseError(
-          'The model response could not be read as structured suggestions. Try again, or ask for fewer properties at once.',
+          'The model response could not be read as structured type suggestions. Try again with a shorter hint.',
         );
       }
     } catch (e) {
@@ -224,6 +219,9 @@ export function AiPropertySuggestionsDialog({
     tenantId,
     projectId,
     versionId,
+    targetPropertyName,
+    targetPropertyDescription,
+    contextClassName,
     existingClasses,
     existingProperties,
     studioContext,
@@ -251,24 +249,27 @@ export function AiPropertySuggestionsDialog({
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2 text-lg">
             <Bot className="h-5 w-5 text-violet-600 dark:text-violet-400" aria-hidden />
-            Suggest properties with AI
+            Suggest property types with AI
           </DialogTitle>
         </DialogHeader>
 
         <div className="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto px-1 py-2">
           <p className="text-sm text-slate-600 dark:text-slate-400">
-            Describe the kinds of reusable properties you want for this project (for example accounting fields,
-            user profile traits, or IoT telemetry). The model proposes JSON Schema snippets you can open in Add
-            Property.
+            For property{' '}
+            <span className="font-mono font-semibold text-slate-800 dark:text-slate-200">
+              {targetPropertyName.trim() || '—'}
+            </span>
+            , the model proposes alternative JSON Schema shapes (primitives with formats, refs to existing classes,
+            arrays, enums, or domain-oriented options). Pick one to fill the Add Property form.
           </p>
 
           <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
-            <label htmlFor="ai-prop-suggest-model" className="sr-only">
+            <label htmlFor="ai-type-suggest-model" className="sr-only">
               Ollama model
             </label>
             <select
-              id="ai-prop-suggest-model"
-              data-testid="ai-property-suggestions-model"
+              id="ai-type-suggest-model"
+              data-testid="ai-property-type-suggestions-model"
               value={selectedModel}
               onChange={(e) => setSelectedModel(e.target.value)}
               disabled={modelNames.length === 0 || isGenerating}
@@ -287,15 +288,18 @@ export function AiPropertySuggestionsDialog({
           </div>
 
           <div>
-            <label htmlFor="ai-prop-suggest-prompt" className="mb-1 block text-xs font-medium text-slate-700 dark:text-slate-300">
-              What should we create?
+            <label
+              htmlFor="ai-type-suggest-prompt"
+              className="mb-1 block text-xs font-medium text-slate-700 dark:text-slate-300"
+            >
+              What should the types optimize for?
             </label>
             <Textarea
-              id="ai-prop-suggest-prompt"
-              data-testid="ai-property-suggestions-prompt"
+              id="ai-type-suggest-prompt"
+              data-testid="ai-property-type-suggestions-prompt"
               value={prompt}
               onChange={(e) => setPrompt(e.target.value)}
-              placeholder="e.g. Standard fields for a subscription billing entity"
+              placeholder="e.g. FHIR Patient identifiers, strict validation, or compatibility with existing emailAddress property"
               disabled={isGenerating}
               rows={3}
               className="resize-y text-sm"
@@ -305,9 +309,9 @@ export function AiPropertySuggestionsDialog({
           <div className="flex flex-wrap gap-2">
             <Button
               type="button"
-              data-testid="ai-property-suggestions-generate"
+              data-testid="ai-property-type-suggestions-generate"
               onClick={() => void handleGenerate()}
-              disabled={isGenerating || !prompt.trim() || !selectedModel.trim()}
+              disabled={isGenerating || !targetPropertyName.trim() || !selectedModel.trim()}
               className="bg-gradient-to-r from-violet-600 to-indigo-600 text-white hover:from-violet-500 hover:to-indigo-500"
             >
               {isGenerating ? (
@@ -316,11 +320,11 @@ export function AiPropertySuggestionsDialog({
                   Generating…
                 </>
               ) : (
-                'Generate suggestions'
+                'Suggest types'
               )}
             </Button>
             {isGenerating && (
-              <Button type="button" variant="outline" onClick={handleStop} data-testid="ai-property-suggestions-stop">
+              <Button type="button" variant="outline" onClick={handleStop} data-testid="ai-property-type-suggestions-stop">
                 <Square className="mr-2 h-3.5 w-3.5 fill-current" aria-hidden />
                 Stop
               </Button>
@@ -339,7 +343,7 @@ export function AiPropertySuggestionsDialog({
                 Thinking
               </h3>
               <div
-                data-testid="ai-property-suggestions-thinking"
+                data-testid="ai-property-type-suggestions-thinking"
                 className="max-h-36 overflow-y-auto rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-800 dark:border-slate-600 dark:bg-slate-900/60 dark:text-slate-200"
               >
                 {thinkingBody}
@@ -348,16 +352,16 @@ export function AiPropertySuggestionsDialog({
           )}
 
           {parsed && parsed.suggestions.length > 0 && (
-            <section aria-label="Suggested properties">
+            <section aria-label="Suggested types">
               <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
-                Suggested properties
+                Type alternatives
               </h3>
-              <ul className="flex flex-wrap gap-2" data-testid="ai-property-suggestions-list">
+              <ul className="flex flex-wrap gap-2" data-testid="ai-property-type-suggestions-list">
                 {parsed.suggestions.map((s, i) => (
-                  <li key={`${s.name}-${i}`}>
+                  <li key={`${s.summary || s.name}-${i}`}>
                     <button
                       type="button"
-                      data-testid={`ai-property-suggestions-item-${i}`}
+                      data-testid={`ai-property-type-suggestions-item-${i}`}
                       onClick={() => setSelectedIdx(i)}
                       className={`rounded-full border px-3 py-1.5 text-sm font-medium transition-colors ${
                         selectedIdx === i
@@ -365,7 +369,7 @@ export function AiPropertySuggestionsDialog({
                           : 'border-slate-200 bg-white text-slate-700 hover:border-violet-300 hover:bg-violet-50 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-200 dark:hover:border-violet-500 dark:hover:bg-violet-950/40'
                       }`}
                     >
-                      {s.summary || s.name}
+                      {s.summary?.trim() ? s.summary : `Alternative ${i + 1}`}
                     </button>
                   </li>
                 ))}
@@ -374,23 +378,12 @@ export function AiPropertySuggestionsDialog({
           )}
 
           {selectedSuggestion && (
-            <section aria-label="Selected suggestion detail" className="space-y-2 rounded-lg border border-slate-200 p-3 dark:border-slate-600">
+            <section aria-label="Selected type detail" className="space-y-2 rounded-lg border border-slate-200 p-3 dark:border-slate-600">
               <div>
                 <h3 className="mb-1 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
-                  Property thinking
+                  Why this type
                 </h3>
-                <p className="text-sm text-slate-700 dark:text-slate-300">
-                  {selectedSuggestion.thinking || '—'}
-                </p>
-              </div>
-              <div>
-                <h3 className="mb-1 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
-                  Name &amp; description
-                </h3>
-                <p className="font-mono text-sm font-semibold text-slate-900 dark:text-slate-100">{selectedSuggestion.name}</p>
-                {selectedSuggestion.description && (
-                  <p className="mt-1 text-sm text-slate-600 dark:text-slate-400">{selectedSuggestion.description}</p>
-                )}
+                <p className="text-sm text-slate-700 dark:text-slate-300">{selectedSuggestion.thinking || '—'}</p>
               </div>
               <div>
                 <h3 className="mb-1 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
@@ -402,14 +395,14 @@ export function AiPropertySuggestionsDialog({
               </div>
               <Button
                 type="button"
-                data-testid="ai-property-suggestions-open-add"
+                data-testid="ai-property-type-suggestions-apply"
                 onClick={() => {
-                  onCreatePropertyFromSuggestion(suggestionToSeedProperty(selectedSuggestion));
+                  onApplyTypeSuggestion(selectedSuggestion);
                   onClose();
                 }}
                 className="w-full bg-gradient-to-r from-indigo-600 to-purple-600 text-white hover:from-indigo-500 hover:to-purple-500 sm:w-auto"
               >
-                Open in Add Property
+                Apply to form
               </Button>
             </section>
           )}
@@ -420,7 +413,7 @@ export function AiPropertySuggestionsDialog({
                 Summary
               </h3>
               <div
-                data-testid="ai-property-suggestions-summary"
+                data-testid="ai-property-type-suggestions-summary"
                 className="rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 dark:border-slate-600 dark:bg-slate-900/40 dark:text-slate-200"
               >
                 {summaryBelow}

--- a/objectified-ui/src/app/components/ade/studio/AiPropertyTypeSuggestionsDialog.tsx
+++ b/objectified-ui/src/app/components/ade/studio/AiPropertyTypeSuggestionsDialog.tsx
@@ -25,7 +25,7 @@ import {
   persistOllamaModelChoiceForScope,
 } from '@/app/ade/studio/components/chatbot/ollama-model-defaults';
 import { accumulateOllamaSse } from '@lib/ollama-chat-sse';
-import { propertyItemToExistingApiShape } from './AiPropertySuggestionsDialog';
+import { propertyItemToExistingApiShape } from '@lib/property-item-utils';
 
 export interface AiPropertyTypeSuggestionsDialogProps {
   open: boolean;

--- a/objectified-ui/src/app/components/ade/studio/PropertyDialog.tsx
+++ b/objectified-ui/src/app/components/ade/studio/PropertyDialog.tsx
@@ -27,7 +27,12 @@ import {
   Sparkles,
   ListChecks,
   BookOpenText,
+  Wand2,
 } from 'lucide-react';
+import type { ChatStudioContext } from '@/app/ade/studio/components/chatbot/chat-context';
+import { AiPropertyTypeSuggestionsDialog } from './AiPropertyTypeSuggestionsDialog';
+import type { AiPropertySuggestion } from '@lib/ai-property-suggestions';
+import type { PropertyItem as LibraryPropertyItem } from './StudioSideNav';
 import {
   FormSection,
   FormFieldGroup,
@@ -95,6 +100,16 @@ export interface PropertyItem {
   items?: any; // Schema for items beyond prefix positions
 }
 
+export interface PropertyDialogAiContext {
+  tenantId: string | null | undefined;
+  projectId: string;
+  versionId: string | null | undefined;
+  existingClasses: string[];
+  existingProperties: LibraryPropertyItem[];
+  studioContext: ChatStudioContext;
+  contextClassName?: string | null;
+}
+
 interface PropertyDialogProps {
   open: boolean;
   onClose: () => void;
@@ -107,6 +122,13 @@ interface PropertyDialogProps {
   }) => Promise<void>;
   // Available class names for schema references
   availableClasses?: string[];
+  /** When set, Add Property shows AI type suggestions (Ollama). */
+  propertyAiContext?: PropertyDialogAiContext;
+  onApplyAiTypeSchema?: (payload: {
+    name: string;
+    description: string | null;
+    schema: Record<string, unknown>;
+  }) => void;
 }
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -127,6 +149,7 @@ interface BasicsSectionProps {
   setFormData: React.Dispatch<React.SetStateAction<PropertyFormData>>;
   primitiveAvailable: boolean;
   setPrimitiveDialogOpen: (next: boolean) => void;
+  addModeAiTypeSuggest?: { onOpen: () => void } | null;
   changed?: boolean;
   eyebrow?: string;
 }
@@ -143,6 +166,7 @@ const BasicsSection: React.FC<BasicsSectionProps> = ({
   setFormData,
   primitiveAvailable,
   setPrimitiveDialogOpen,
+  addModeAiTypeSuggest,
   changed,
   eyebrow = 'Basics',
 }) => (
@@ -203,6 +227,35 @@ const BasicsSection: React.FC<BasicsSectionProps> = ({
         </Select>
       </FormFieldGroup>
     </FormGrid>
+
+    {mode === 'add' && addModeAiTypeSuggest && (
+      <div className="rounded-xl border border-violet-200 bg-violet-50/60 p-4 dark:border-violet-900/50 dark:bg-violet-950/30">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="flex items-start gap-3">
+            <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-violet-100 text-violet-600 dark:bg-violet-900/40 dark:text-violet-300">
+              <Wand2 className="h-4 w-4" aria-hidden />
+            </span>
+            <div className="min-w-0">
+              <h4 className="text-sm font-semibold text-slate-900 dark:text-slate-100">Suggest types with AI</h4>
+              <p className="mt-0.5 text-xs leading-5 text-slate-500 dark:text-slate-400">
+                Get several JSON Schema options for this property name (formats, refs, arrays). Requires Ollama.
+              </p>
+            </div>
+          </div>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            data-testid="property-dialog-ai-type-suggest"
+            disabled={!propertyName.trim()}
+            onClick={addModeAiTypeSuggest.onOpen}
+            className="shrink-0 border-violet-300 text-violet-800 hover:bg-violet-100 dark:border-violet-700 dark:text-violet-200 dark:hover:bg-violet-950/50"
+          >
+            Suggest types…
+          </Button>
+        </div>
+      </div>
+    )}
 
     <FormFieldGroup
       label="Title"
@@ -489,13 +542,15 @@ const DocsSection: React.FC<DocsSectionProps> = ({ formData, setFormData, change
 );
 
 export const PropertyDialog: React.FC<PropertyDialogProps> = ({
-                                                                open,
-                                                                onClose,
-                                                                mode,
-                                                                property,
-                                                                onSubmit,
-                                                                availableClasses = [],
-                                                              }) => {
+  open,
+  onClose,
+  mode,
+  property,
+  onSubmit,
+  availableClasses = [],
+  propertyAiContext,
+  onApplyAiTypeSchema,
+}) => {
   const isDark = useDarkMode();
 
   const [tabMode, setTabMode] = useState<'form' | 'json'>('form');
@@ -507,6 +562,7 @@ export const PropertyDialog: React.FC<PropertyDialogProps> = ({
   const [propertyError, setPropertyError] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [primitiveDialogOpen, setPrimitiveDialogOpen] = useState(false);
+  const [aiTypeSuggestOpen, setAiTypeSuggestOpen] = useState(false);
 
   // Use shared form data structure
   const [formData, setFormData] = useState<PropertyFormData>({});
@@ -1576,7 +1632,22 @@ export const PropertyDialog: React.FC<PropertyDialogProps> = ({
     setCurrentStepIndex((i) => Math.max(i - 1, 0));
   };
 
+  const addModeAiTypeSuggest =
+    mode === 'add' && propertyAiContext && onApplyAiTypeSchema
+      ? { onOpen: () => setAiTypeSuggestOpen(true) }
+      : null;
+
+  const handleApplyAiTypeSuggestion = (s: AiPropertySuggestion) => {
+    if (!onApplyAiTypeSchema) return;
+    onApplyAiTypeSchema({
+      name: propertyName.trim(),
+      description: (formData.description || '').trim() || null,
+      schema: s.schema as Record<string, unknown>,
+    });
+  };
+
   return (
+    <>
     <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()} modal={true}>
       <DialogContent
         className="max-w-6xl h-[90vh] max-h-[900px] p-0 flex flex-col overflow-hidden"
@@ -1645,6 +1716,7 @@ export const PropertyDialog: React.FC<PropertyDialogProps> = ({
                         setFormData={setFormData}
                         primitiveAvailable={primitiveAvailable}
                         setPrimitiveDialogOpen={setPrimitiveDialogOpen}
+                        addModeAiTypeSuggest={addModeAiTypeSuggest}
                         changed={changedBasics}
                         eyebrow="Step 1 of 5"
                       />
@@ -1724,6 +1796,7 @@ export const PropertyDialog: React.FC<PropertyDialogProps> = ({
                       setFormData={setFormData}
                       primitiveAvailable={primitiveAvailable}
                       setPrimitiveDialogOpen={setPrimitiveDialogOpen}
+                      addModeAiTypeSuggest={addModeAiTypeSuggest}
                       changed={changedBasics}
                     />
                     <FlagsSection formData={formData} setFormData={setFormData} changed={changedFlags} />
@@ -1795,6 +1868,24 @@ export const PropertyDialog: React.FC<PropertyDialogProps> = ({
         )}
       </DialogContent>
     </Dialog>
+
+    {propertyAiContext && onApplyAiTypeSchema && (
+      <AiPropertyTypeSuggestionsDialog
+        open={aiTypeSuggestOpen}
+        onClose={() => setAiTypeSuggestOpen(false)}
+        tenantId={propertyAiContext.tenantId}
+        projectId={propertyAiContext.projectId}
+        versionId={propertyAiContext.versionId}
+        targetPropertyName={propertyName}
+        targetPropertyDescription={formData.description}
+        contextClassName={propertyAiContext.contextClassName}
+        existingClasses={propertyAiContext.existingClasses}
+        existingProperties={propertyAiContext.existingProperties}
+        studioContext={propertyAiContext.studioContext}
+        onApplyTypeSuggestion={handleApplyAiTypeSuggestion}
+      />
+    )}
+    </>
   );
 };
 

--- a/objectified-ui/src/app/components/ade/studio/PropertyDialog.tsx
+++ b/objectified-ui/src/app/components/ade/studio/PropertyDialog.tsx
@@ -569,6 +569,13 @@ export const PropertyDialog: React.FC<PropertyDialogProps> = ({
 
   const advancedScrollRef = useRef<HTMLDivElement>(null);
 
+  // Reset nested dialog state when the parent PropertyDialog closes.
+  useEffect(() => {
+    if (!open) {
+      setAiTypeSuggestOpen(false);
+    }
+  }, [open]);
+
   // Load property data when dialog opens in edit mode, or when adding with an AI/template seed (#609).
   useEffect(() => {
     if (open && property && (mode === 'edit' || mode === 'add')) {

--- a/objectified-ui/tests/unit/ai-property-suggestions.test.ts
+++ b/objectified-ui/tests/unit/ai-property-suggestions.test.ts
@@ -33,4 +33,11 @@ describe('parseAiPropertySuggestionsResponse', () => {
       expect.objectContaining({ name: 'ok', schema: { type: 'integer' } }),
     ]);
   });
+
+  it('canonicalPropertyName overrides suggestion names', () => {
+    const md =
+      '```json\n{"thinking":"","summary":"","suggestions":[{"name":"wrong","schema":{"type":"string"}},{"name":"x","schema":{"type":"integer"}}]}\n```';
+    const r = parseAiPropertySuggestionsResponse(md, { canonicalPropertyName: 'patientId' });
+    expect(r?.suggestions.map((s) => s.name)).toEqual(['patientId', 'patientId']);
+  });
 });


### PR DESCRIPTION
## What changed
- Added Ollama task `property_type_suggestions` with a dedicated system prompt so the model returns **multiple JSON Schema alternatives** for a **single** property name (formats, refs, arrays, domain hints such as FHIR when relevant).
- New **Suggest types with AI** flow in **Add Property** (Basics): opens a dialog, streams the response, lists type chips, and **Apply to form** hydrates the dialog from the chosen schema (same pattern as existing AI property seeds).
- Studio layout passes project/version, class names, property library list, chatbot studio context, and the **name of the class selected on the canvas** (when any) so suggestions stay grounded.
- Extended the existing `property_suggestions` system text with guidance on archetypal fields, audit ids, related properties, and industry vocabularies.
- Factored SSE accumulation into `lib/ollama-chat-sse.ts` for reuse; `parseAiPropertySuggestionsResponse` accepts optional `canonicalPropertyName` for the type task.

## How to test
1. Run Ollama with a chat model installed.
2. Open Studio with a project and version; optionally **select a class on the canvas**.
3. **Open Add Property**, enter a property name (e.g. `birthDate` or `patientId`).
4. In Basics, click **Suggest types…**, pick a model, add optional hints, click **Suggest types**.
5. **Select a chip** and click **Apply to form** — verify type, array flag, format/constraints, and JSON preview update.

## Risks / notes
- Requires Ollama (same as existing AI property suggestions). The UI expects **at least two** alternatives; a single suggestion shows a retry message.
- Model quality varies; `canonicalPropertyName` keeps the applied name aligned with the form even if the model mis-sets `name` on a row.

Closes #269

Made with [Cursor](https://cursor.com)