### PR TITLE
Fix #270 - Add property suggestion dropdown

### DIFF
--- a/docs/PLANNED_FEATURE_ROADMAP_AI.md
+++ b/docs/PLANNED_FEATURE_ROADMAP_AI.md
@@ -86,7 +86,7 @@ This outlines the planned features for integrating AI capabilities into Objectif
     - 📋 Related properties based on existing ones
     - 📋 Industry-standard properties (FHIR for healthcare, etc.)
 - 📋 **Suggestion UI**:
-    - 📋 Property suggestion dropdown
+    - ✅ Property suggestion dropdown (#270)
     - 📋 Bulk accept/reject
     - 📋 Customize before adding
     - 📋 "Add all suggested" button
@@ -95,7 +95,6 @@ This outlines the planned features for integrating AI capabilities into Objectif
 | Ticket | Feature Description                                |
 |--------|----------------------------------------------------|
 | #269   | Adds the ability to suggest properties based on AI |
-| #270   | Adds a property suggestion dropdown                |
 | #271   | Adds bulk accept/reject for property suggestions   |
 | #272   | Adds customization before adding                   |
 | #273   | Adds explanations for each suggestion              |

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.61",
+  "version": "0.11.62",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -28,7 +28,7 @@ We continue to improve the platform based on your feedback with improvements and
 
 ## Studio
 - **Add Property** includes **Suggest types with AI** (when Ollama is configured): enter a property name, ask for alternatives (formats, refs, domain hints such as FHIR), then **Apply to form** to load a chosen JSON Schema (#269).
-- Properties sidebar includes an **AI suggest properties** control (robot): describe what you need, review thinking and summary around the suggestion chips, inspect each proposal, then **Open in Add Property** to create it (#609).
+- Properties sidebar includes an **AI suggest properties** control (robot): describe what you need, review thinking and summary, **pick a suggestion from the dropdown**, inspect the detail panel, then **Open in Add Property** to create it (#609, #270).
 - Studio AI chat schema refinements infer JSON Schema type and common constraints from well-known property names (`email`, `createdAt`, `age`, `price`, `isActive`) when you add a field without specifying a type; the class-skeleton Ollama prompt uses the same conventions (#277).
 - Chat refinement inference now adds typical validation hints from names—string lengths, numeric bounds, regex patterns, and marking `id` as required when added without a type (#278).
 - Studio AI assistant (live Ollama and offline demo) appends an **Improvement suggestions** section after OpenAPI sketches—actionable bullets such as pagination, `allOf` inheritance, discriminators, splitting large schemas, and standard error shapes (#495).

--- a/objectified-ui/src/app/components/ade/studio/AiPropertySuggestionsDialog.tsx
+++ b/objectified-ui/src/app/components/ade/studio/AiPropertySuggestionsDialog.tsx
@@ -330,28 +330,29 @@ export function AiPropertySuggestionsDialog({
           )}
 
           {parsed && parsed.suggestions.length > 0 && (
-            <section aria-label="Suggested properties">
-              <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
-                Suggested properties
-              </h3>
-              <ul className="flex flex-wrap gap-2" data-testid="ai-property-suggestions-list">
+            <section aria-label="Suggested properties" className="space-y-2">
+              <label
+                htmlFor="ai-prop-suggest-pick"
+                className="block text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400"
+              >
+                Suggested property
+              </label>
+              <select
+                id="ai-prop-suggest-pick"
+                data-testid="ai-property-suggestions-list"
+                value={selectedIdx !== null ? String(selectedIdx) : ''}
+                onChange={(e) => {
+                  const raw = e.target.value;
+                  setSelectedIdx(raw === '' ? null : Number.parseInt(raw, 10));
+                }}
+                className="w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100 sm:max-w-xl"
+              >
                 {parsed.suggestions.map((s, i) => (
-                  <li key={`${s.name}-${i}`}>
-                    <button
-                      type="button"
-                      data-testid={`ai-property-suggestions-item-${i}`}
-                      onClick={() => setSelectedIdx(i)}
-                      className={`rounded-full border px-3 py-1.5 text-sm font-medium transition-colors ${
-                        selectedIdx === i
-                          ? 'border-violet-500 bg-violet-500/15 text-violet-800 dark:text-violet-200'
-                          : 'border-slate-200 bg-white text-slate-700 hover:border-violet-300 hover:bg-violet-50 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-200 dark:hover:border-violet-500 dark:hover:bg-violet-950/40'
-                      }`}
-                    >
-                      {s.summary || s.name}
-                    </button>
-                  </li>
+                  <option key={`${s.name}-${i}`} value={String(i)} data-testid={`ai-property-suggestions-item-${i}`}>
+                    {s.summary?.trim() ? s.summary : s.name}
+                  </option>
                 ))}
-              </ul>
+              </select>
             </section>
           )}
 


### PR DESCRIPTION
## Summary
Replaces the chip-style suggestion picker in **Suggest properties with AI** with a native **dropdown** (`<select>`) so users can choose among model proposals in a compact, familiar control. The detail panel and **Open in Add Property** flow are unchanged.

## How to test
1. **Start Ollama** with at least one model.
2. In Studio, open the properties sidebar and **click the robot (AI suggest properties)**.
3. Enter a prompt, **pick a model**, **Generate suggestions**.
4. **Use the Suggested property dropdown** to switch between rows and confirm the detail panel updates.
5. **Open in Add Property** and confirm the seed loads in Add Property.

## Risk / notes
Low risk: presentation-only change; same `data-testid` hooks (`ai-property-suggestions-list`, `ai-property-suggestions-item-*`) preserved on the select and options.

Closes #270

Made with [Cursor](https://cursor.com)