### PR TITLE
Fix #271 - Bulk accept/reject for AI property suggestions

### DIFF
--- a/docs/PLANNED_FEATURE_ROADMAP_AI.md
+++ b/docs/PLANNED_FEATURE_ROADMAP_AI.md
@@ -87,7 +87,7 @@ This outlines the planned features for integrating AI capabilities into Objectif
     - 📋 Industry-standard properties (FHIR for healthcare, etc.)
 - 📋 **Suggestion UI**:
     - ✅ Property suggestion dropdown (#270)
-    - 📋 Bulk accept/reject
+    - ✅ Bulk accept/reject (#271)
     - 📋 Customize before adding
     - 📋 "Add all suggested" button
     - 📋 Explanation for each suggestion
@@ -95,7 +95,7 @@ This outlines the planned features for integrating AI capabilities into Objectif
 | Ticket | Feature Description                                |
 |--------|----------------------------------------------------|
 | #269   | Adds the ability to suggest properties based on AI |
-| #271   | Adds bulk accept/reject for property suggestions   |
+| #271   | Adds bulk accept/reject for property suggestions ✅ |
 | #272   | Adds customization before adding                   |
 | #273   | Adds explanations for each suggestion              |
 | #274   | Adds "Add all suggested" button                    |

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.62",
+  "version": "0.11.63",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -28,7 +28,7 @@ We continue to improve the platform based on your feedback with improvements and
 
 ## Studio
 - **Add Property** includes **Suggest types with AI** (when Ollama is configured): enter a property name, ask for alternatives (formats, refs, domain hints such as FHIR), then **Apply to form** to load a chosen JSON Schema (#269).
-- Properties sidebar includes an **AI suggest properties** control (robot): describe what you need, review thinking and summary, **pick a suggestion from the dropdown**, inspect the detail panel, then **Open in Add Property** to create it (#609, #270).
+- Properties sidebar includes an **AI suggest properties** control (robot): describe what you need, review thinking and summary, **pick a suggestion from the list**, use **Accept all** or **Reject all** (or reject individual rows), inspect the detail panel, then **Open in Add Property** to create one—or accept all to step through Add Property for each remaining suggestion (#609, #270, #271).
 - Studio AI chat schema refinements infer JSON Schema type and common constraints from well-known property names (`email`, `createdAt`, `age`, `price`, `isActive`) when you add a field without specifying a type; the class-skeleton Ollama prompt uses the same conventions (#277).
 - Chat refinement inference now adds typical validation hints from names—string lengths, numeric bounds, regex patterns, and marking `id` as required when added without a type (#278).
 - Studio AI assistant (live Ollama and offline demo) appends an **Improvement suggestions** section after OpenAPI sketches—actionable bullets such as pagination, `allOf` inheritance, discriminators, splitting large schemas, and standard error shapes (#495).

--- a/objectified-ui/src/app/ade/studio/layout.tsx
+++ b/objectified-ui/src/app/ade/studio/layout.tsx
@@ -292,9 +292,12 @@ function StudioLayoutContent({ children }: Readonly<{ children: React.ReactNode 
   const handlePropertySubmit = async (propertyData: { name: string; description: string | null; data: any }) => {
     if (!selectedProjectId) throw new Error('No project selected');
 
+    // Capture dialog state synchronously before any awaits to avoid stale closure.
+    const { mode, selectedProperty, pendingBulkSeeds } = propertyDialog;
+
     try {
       let response;
-      if (propertyDialog.mode === 'add') {
+      if (mode === 'add') {
         response = await fetch(`/api/properties/${selectedProjectId}`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
@@ -304,8 +307,8 @@ function StudioLayoutContent({ children }: Readonly<{ children: React.ReactNode 
             data: propertyData.data,
           }),
         });
-      } else if (propertyDialog.selectedProperty) {
-        response = await fetch(`/api/properties/${selectedProjectId}/${propertyDialog.selectedProperty.id}`, {
+      } else if (selectedProperty) {
+        response = await fetch(`/api/properties/${selectedProjectId}/${selectedProperty.id}`, {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
@@ -323,7 +326,6 @@ function StudioLayoutContent({ children }: Readonly<{ children: React.ReactNode 
         throw new Error(result.error || 'Failed to save property');
       }
 
-      const { mode, pendingBulkSeeds } = propertyDialog;
       if (mode === 'add' && pendingBulkSeeds && pendingBulkSeeds.length > 0) {
         const [next, ...rest] = pendingBulkSeeds;
         setPropertyDialog({

--- a/objectified-ui/src/app/ade/studio/layout.tsx
+++ b/objectified-ui/src/app/ade/studio/layout.tsx
@@ -105,7 +105,13 @@ function StudioLayoutContent({ children }: Readonly<{ children: React.ReactNode 
     aiAssistantSeedMarkdown: null as string | null,
   });
   const [classImportDialog, setClassImportDialog] = useState({ open: false });
-  const [propertyDialog, setPropertyDialog] = useState({ open: false, mode: 'add' as 'add' | 'edit', selectedProperty: null as PropertyItem | null });
+  const [propertyDialog, setPropertyDialog] = useState({
+    open: false,
+    mode: 'add' as 'add' | 'edit',
+    selectedProperty: null as PropertyItem | null,
+    /** After bulk-accept from AI property suggestions (#271), each save opens the next seed. */
+    pendingBulkSeeds: null as PropertyItem[] | null,
+  });
   const [propertyTemplateDialog, setPropertyTemplateDialog] = useState({ open: false });
   const [aiPropertySuggestionsOpen, setAiPropertySuggestionsOpen] = useState(false);
   const [classTemplateDialog, setClassTemplateDialog] = useState({ open: false });
@@ -260,7 +266,7 @@ function StudioLayoutContent({ children }: Readonly<{ children: React.ReactNode 
   // Property handlers
   const handlePropertyAdd = async () => {
     if (!(await checkProjectSelected()) || !(await checkNotReadOnly('add properties'))) return;
-    setPropertyDialog({ open: true, mode: 'add', selectedProperty: null });
+    setPropertyDialog({ open: true, mode: 'add', selectedProperty: null, pendingBulkSeeds: null });
   };
 
   const handlePropertyTemplates = async () => {
@@ -275,7 +281,7 @@ function StudioLayoutContent({ children }: Readonly<{ children: React.ReactNode 
 
   const handlePropertyEdit = async (propertyItem: PropertyItem) => {
     if (!(await checkProjectSelected()) || !(await checkNotReadOnly('edit properties'))) return;
-    setPropertyDialog({ open: true, mode: 'edit', selectedProperty: propertyItem });
+    setPropertyDialog({ open: true, mode: 'edit', selectedProperty: propertyItem, pendingBulkSeeds: null });
   };
 
   const handlePropertyDelete = async (propertyId: string) => {
@@ -317,7 +323,18 @@ function StudioLayoutContent({ children }: Readonly<{ children: React.ReactNode 
         throw new Error(result.error || 'Failed to save property');
       }
 
-      setPropertyDialog({ open: false, mode: 'add', selectedProperty: null });
+      const { mode, pendingBulkSeeds } = propertyDialog;
+      if (mode === 'add' && pendingBulkSeeds && pendingBulkSeeds.length > 0) {
+        const [next, ...rest] = pendingBulkSeeds;
+        setPropertyDialog({
+          open: true,
+          mode: 'add',
+          selectedProperty: next,
+          pendingBulkSeeds: rest.length > 0 ? rest : null,
+        });
+      } else {
+        setPropertyDialog({ open: false, mode: 'add', selectedProperty: null, pendingBulkSeeds: null });
+      }
       setRefreshKey(prev => prev + 1);
     } catch (error) {
       console.error('Error saving property:', error);
@@ -610,7 +627,7 @@ function StudioLayoutContent({ children }: Readonly<{ children: React.ReactNode 
       {/* Property Dialog */}
       <PropertyDialog
         open={propertyDialog.open}
-        onClose={() => setPropertyDialog({ open: false, mode: 'add', selectedProperty: null })}
+        onClose={() => setPropertyDialog({ open: false, mode: 'add', selectedProperty: null, pendingBulkSeeds: null })}
         mode={propertyDialog.mode}
         property={propertyDialog.selectedProperty}
         onSubmit={handlePropertySubmit}
@@ -632,6 +649,7 @@ function StudioLayoutContent({ children }: Readonly<{ children: React.ReactNode 
           setPropertyDialog({
             open: true,
             mode: 'add',
+            pendingBulkSeeds: null,
             selectedProperty: {
               ...payload.schema,
               id: '__ai_seed__',
@@ -653,7 +671,17 @@ function StudioLayoutContent({ children }: Readonly<{ children: React.ReactNode 
           existingProperties={properties}
           studioContext={chatbotStudioContext}
           onCreatePropertyFromSuggestion={(seed) => {
-            setPropertyDialog({ open: true, mode: 'add', selectedProperty: seed });
+            setPropertyDialog({ open: true, mode: 'add', selectedProperty: seed, pendingBulkSeeds: null });
+          }}
+          onAcceptAllPropertySuggestions={(seeds) => {
+            if (seeds.length === 0) return;
+            const [first, ...rest] = seeds;
+            setPropertyDialog({
+              open: true,
+              mode: 'add',
+              selectedProperty: first,
+              pendingBulkSeeds: rest.length > 0 ? rest : null,
+            });
           }}
         />
       )}

--- a/objectified-ui/src/app/components/ade/studio/AiPropertySuggestionsDialog.tsx
+++ b/objectified-ui/src/app/components/ade/studio/AiPropertySuggestionsDialog.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   Dialog,
   DialogContent,
@@ -10,7 +10,7 @@ import {
 } from '../../ui/Dialog';
 import { Button } from '../../ui/Button';
 import { Textarea } from '../../ui/Textarea';
-import { Bot, Loader2, Square } from 'lucide-react';
+import { Bot, Loader2, Square, ListChecks, Ban, Trash2 } from 'lucide-react';
 import type { PropertyItem } from './StudioSideNav';
 import {
   parseAiPropertySuggestionsResponse,
@@ -46,6 +46,8 @@ export interface AiPropertySuggestionsDialogProps {
   existingProperties: PropertyItem[];
   studioContext: ChatStudioContext;
   onCreatePropertyFromSuggestion: (seed: PropertyItem) => void;
+  /** Opens Add Property for each remaining suggestion in order after each save (#271). */
+  onAcceptAllPropertySuggestions: (seeds: PropertyItem[]) => void;
 }
 
 export function AiPropertySuggestionsDialog({
@@ -58,6 +60,7 @@ export function AiPropertySuggestionsDialog({
   existingProperties,
   studioContext,
   onCreatePropertyFromSuggestion,
+  onAcceptAllPropertySuggestions,
 }: AiPropertySuggestionsDialogProps) {
   const [prompt, setPrompt] = useState('');
   const [modelNames, setModelNames] = useState<string[]>([]);
@@ -67,6 +70,7 @@ export function AiPropertySuggestionsDialog({
   const [parsed, setParsed] = useState<AiPropertySuggestionsPayload | null>(null);
   const [parseError, setParseError] = useState<string | null>(null);
   const [selectedIdx, setSelectedIdx] = useState<number | null>(null);
+  const [rejectedIndices, setRejectedIndices] = useState<Set<number>>(() => new Set());
   const abortRef = useRef<AbortController | null>(null);
 
   useEffect(() => {
@@ -110,6 +114,7 @@ export function AiPropertySuggestionsDialog({
       setParsed(null);
       setParseError(null);
       setSelectedIdx(null);
+      setRejectedIndices(new Set());
       setIsGenerating(false);
       abortRef.current?.abort();
       abortRef.current = null;
@@ -142,6 +147,7 @@ export function AiPropertySuggestionsDialog({
     setParsed(null);
     setParseError(null);
     setSelectedIdx(null);
+    setRejectedIndices(new Set());
 
     let schemaContextFingerprint: string | undefined;
     if (studioContext && !isChatStudioContextEmpty(studioContext)) {
@@ -211,8 +217,51 @@ export function AiPropertySuggestionsDialog({
     studioContext,
   ]);
 
+  useEffect(() => {
+    if (selectedIdx === null || !parsed) return;
+    if (!rejectedIndices.has(selectedIdx)) return;
+    const first = parsed.suggestions.findIndex((_, i) => !rejectedIndices.has(i));
+    setSelectedIdx(first >= 0 ? first : null);
+  }, [rejectedIndices, selectedIdx, parsed]);
+
+  const activeSuggestionRows = useMemo(() => {
+    if (!parsed) return [];
+    return parsed.suggestions
+      .map((s, origIdx) => ({ suggestion: s, origIdx }))
+      .filter(({ origIdx }) => !rejectedIndices.has(origIdx));
+  }, [parsed, rejectedIndices]);
+
+  const handleRejectOne = (origIdx: number) => {
+    setRejectedIndices((prev) => {
+      const next = new Set(prev);
+      next.add(origIdx);
+      return next;
+    });
+  };
+
+  const handleRejectAll = () => {
+    if (!parsed?.suggestions.length) return;
+    setRejectedIndices(new Set(parsed.suggestions.map((_, i) => i)));
+  };
+
+  const handleAcceptAll = () => {
+    if (!parsed) return;
+    const seeds = parsed.suggestions
+      .map((s, i) => ({ s, i }))
+      .filter(({ i }) => !rejectedIndices.has(i))
+      .map(({ s }) => suggestionToSeedProperty(s));
+    if (seeds.length === 0) return;
+    onAcceptAllPropertySuggestions(seeds);
+    onClose();
+  };
+
   const selectedSuggestion: AiPropertySuggestion | null =
-    parsed && selectedIdx !== null && parsed.suggestions[selectedIdx] ? parsed.suggestions[selectedIdx] : null;
+    parsed &&
+    selectedIdx !== null &&
+    !rejectedIndices.has(selectedIdx) &&
+    parsed.suggestions[selectedIdx]
+      ? parsed.suggestions[selectedIdx]
+      : null;
 
   const thinkingBody = isGenerating
     ? streamText || '…'
@@ -331,28 +380,86 @@ export function AiPropertySuggestionsDialog({
 
           {parsed && parsed.suggestions.length > 0 && (
             <section aria-label="Suggested properties" className="space-y-2">
-              <label
-                htmlFor="ai-prop-suggest-pick"
-                className="block text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400"
-              >
-                Suggested property
-              </label>
-              <select
-                id="ai-prop-suggest-pick"
-                data-testid="ai-property-suggestions-list"
-                value={selectedIdx !== null ? String(selectedIdx) : ''}
-                onChange={(e) => {
-                  const raw = e.target.value;
-                  setSelectedIdx(raw === '' ? null : Number.parseInt(raw, 10));
-                }}
-                className="w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100 sm:max-w-xl"
-              >
-                {parsed.suggestions.map((s, i) => (
-                  <option key={`${s.name}-${i}`} value={String(i)} data-testid={`ai-property-suggestions-item-${i}`}>
-                    {s.summary?.trim() ? s.summary : s.name}
-                  </option>
-                ))}
-              </select>
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <h3 className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                  Suggested properties
+                </h3>
+                <div className="flex flex-wrap items-center gap-2">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    data-testid="ai-property-suggestions-accept-all"
+                    disabled={activeSuggestionRows.length === 0}
+                    onClick={handleAcceptAll}
+                    className="border-emerald-300 text-emerald-800 hover:bg-emerald-50 dark:border-emerald-700 dark:text-emerald-200 dark:hover:bg-emerald-950/40"
+                  >
+                    <ListChecks className="h-4 w-4" aria-hidden />
+                    Accept all
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    data-testid="ai-property-suggestions-reject-all"
+                    disabled={activeSuggestionRows.length === 0}
+                    onClick={handleRejectAll}
+                    className="border-rose-300 text-rose-800 hover:bg-rose-50 dark:border-rose-700 dark:text-rose-200 dark:hover:bg-rose-950/40"
+                  >
+                    <Ban className="h-4 w-4" aria-hidden />
+                    Reject all
+                  </Button>
+                </div>
+              </div>
+              {activeSuggestionRows.length === 0 ? (
+                <p
+                  data-testid="ai-property-suggestions-list-empty"
+                  className="rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-600 dark:border-slate-600 dark:bg-slate-900/50 dark:text-slate-400"
+                >
+                  No suggestions left to review. Generate again or close.
+                </p>
+              ) : (
+                <ul data-testid="ai-property-suggestions-list" className="max-h-48 space-y-1.5 overflow-y-auto sm:max-w-xl">
+                  {activeSuggestionRows.map(({ suggestion: s, origIdx }) => {
+                    const label = s.summary?.trim() ? s.summary : s.name;
+                    const isSelected = selectedIdx === origIdx;
+                    return (
+                      <li
+                        key={origIdx}
+                        className={`flex items-stretch gap-1 rounded-lg border transition-colors ${
+                          isSelected
+                            ? 'border-violet-500 bg-violet-500/10 ring-2 ring-violet-500/30 dark:border-violet-500 dark:bg-violet-950/30'
+                            : 'border-slate-200 bg-white dark:border-slate-600 dark:bg-slate-900'
+                        }`}
+                      >
+                        <button
+                          type="button"
+                          data-testid={`ai-property-suggestions-item-${origIdx}`}
+                          onClick={() => setSelectedIdx(origIdx)}
+                          className="min-w-0 flex-1 px-3 py-2 text-left text-sm text-slate-900 hover:bg-slate-50 dark:text-slate-100 dark:hover:bg-slate-800/80"
+                        >
+                          <span className="font-medium">{label}</span>
+                          {s.name && s.summary?.trim() ? (
+                            <span className="mt-0.5 block font-mono text-xs text-slate-500 dark:text-slate-400">{s.name}</span>
+                          ) : null}
+                        </button>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          data-testid={`ai-property-suggestions-reject-${origIdx}`}
+                          onClick={() => handleRejectOne(origIdx)}
+                          className="shrink-0 rounded-none rounded-r-lg text-slate-500 hover:bg-rose-50 hover:text-rose-700 dark:hover:bg-rose-950/50 dark:hover:text-rose-300"
+                          aria-label={`Reject suggestion ${s.name}`}
+                          title="Reject this suggestion"
+                        >
+                          <Trash2 className="h-4 w-4" aria-hidden />
+                        </Button>
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
             </section>
           )}
 

--- a/objectified-ui/src/app/components/ade/studio/PropertyDialog.tsx
+++ b/objectified-ui/src/app/components/ade/studio/PropertyDialog.tsx
@@ -1561,8 +1561,8 @@ export const PropertyDialog: React.FC<PropertyDialogProps> = ({
         description: formData.description || null,
         data: dataObject,
       });
-
-      onClose();
+      // The parent onSubmit is responsible for closing or advancing the dialog
+      // (e.g. stepping through pendingBulkSeeds). Do not call onClose() here.
     } catch (error) {
       console.error('Error submitting property:', error);
       setPropertyError(error instanceof Error ? error.message : 'An error occurred while saving the property');


### PR DESCRIPTION
## Summary
Implements bulk **Accept all** and **Reject all** for the AI **Suggest properties** dialog, plus per-row reject. **Accept all** opens Add Property for each remaining suggestion in sequence after each successful save (queued in Studio layout).

## How to test
1. **Open Studio** with a project and unpublished version.
2. **Open** sidebar **AI suggest properties** (robot control).
3. **Pick an Ollama model**, enter a prompt, **Generate suggestions**.
4. Confirm the **suggestion list** shows **Accept all**, **Reject all**, and a **reject (trash)** control per row.
5. **Reject all**: list should show the empty-state message.
6. Generate again, **reject one row**: only that row disappears; selection moves to another suggestion.
7. **Accept all**: AI dialog should close; **Add Property** should open with the first seed; after **Add Property** succeeds, the dialog should reopen with the next seed until the queue is empty.

## Risk / notes
- Bulk accept relies on the existing property POST path; if the user **closes** Add Property without saving, remaining queued seeds are discarded (same as closing any dialog).

Closes #271

Made with [Cursor](https://cursor.com)