### PR TITLE
Fix #273 - Per-suggestion explanations in AI suggestion UIs

### DIFF
--- a/docs/PLANNED_FEATURE_ROADMAP_AI.md
+++ b/docs/PLANNED_FEATURE_ROADMAP_AI.md
@@ -90,11 +90,10 @@ This outlines the planned features for integrating AI capabilities into Objectif
     - ✅ Bulk accept/reject (#271)
     - ✅ Customize before adding (#272)
     - 📋 "Add all suggested" button
-    - 📋 Explanation for each suggestion
+    - ✅ Explanation for each suggestion (#273)
 
 | Ticket | Feature Description                                |
 |--------|----------------------------------------------------|
-| #273   | Adds explanations for each suggestion              |
 | #274   | Adds "Add all suggested" button                    |
 | #275   | Adds trigger conditions for the Suggestion UI      |
 | #276   | Adds analyze button for properties analysis        |

--- a/objectified-ui/lib/ai-property-suggestions.ts
+++ b/objectified-ui/lib/ai-property-suggestions.ts
@@ -8,6 +8,8 @@ export type AiPropertySuggestion = {
   name: string;
   description?: string;
   schema: Record<string, unknown>;
+  /** Optional user-facing rationale (parsed from `explanation` or `rationale` in JSON). */
+  explanation?: string;
   thinking?: string;
   summary?: string;
 };
@@ -40,6 +42,17 @@ export type ParseAiPropertySuggestionsOptions = {
   /** When set, every suggestion uses this name (fixes model drift for type-only tasks). */
   canonicalPropertyName?: string;
 };
+
+/** Text shown next to each suggestion in the Studio list (dedicated explanation, then model rationale, then description). */
+export function suggestionPublicExplanation(s: AiPropertySuggestion): string | undefined {
+  const e = s.explanation?.trim();
+  if (e) return e;
+  const t = s.thinking?.trim();
+  if (t) return t;
+  const d = s.description?.trim();
+  if (d) return d;
+  return undefined;
+}
 
 /**
  * Returns null if the response does not contain valid structured suggestions.
@@ -85,6 +98,12 @@ export function parseAiPropertySuggestionsResponse(
       typeof item.description === 'string' && item.description.trim()
         ? item.description.trim()
         : undefined;
+    const expl =
+      typeof item.explanation === 'string' && item.explanation.trim()
+        ? item.explanation.trim()
+        : typeof item.rationale === 'string' && item.rationale.trim()
+          ? item.rationale.trim()
+          : undefined;
     const st =
       typeof item.thinking === 'string' && item.thinking.trim() ? item.thinking.trim() : undefined;
     const su =
@@ -94,6 +113,7 @@ export function parseAiPropertySuggestionsResponse(
       name,
       description,
       schema,
+      ...(expl ? { explanation: expl } : {}),
       thinking: st,
       summary: su,
     });

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.64",
+  "version": "0.11.65",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -27,6 +27,7 @@ We continue to improve the platform based on your feedback with improvements and
 - Projects list includes a **Show deleted** switch; when on, soft-deleted projects appear with a **Deleted** badge and **Restore** or **permanent delete** in the row menu (#2981).
 
 ## Studio
+- **AI suggest properties** and **Suggest types with AI** list each row with a short **explanation** (model `thinking`, optional `explanation` / `rationale`, or description fallback) so you can scan rationales before opening the detail panel (#273).
 - **Add Property** includes **Suggest types with AI** (when Ollama is configured): enter a property name, ask for alternatives (formats, refs, domain hints such as FHIR), **edit the schema JSON** if you want tweaks, then **Apply to form** to load it (#269, #272).
 - Properties sidebar includes an **AI suggest properties** control (robot): describe what you need, review thinking and summary, **pick a suggestion from the list**, use **Accept all** or **Reject all** (or reject individual rows), **edit name, description, and schema** in the detail panel, then **Open in Add Property** or **Accept all** to step through Add Property for each remaining suggestion (#609, #270, #271, #272).
 - Studio AI chat schema refinements infer JSON Schema type and common constraints from well-known property names (`email`, `createdAt`, `age`, `price`, `isActive`) when you add a field without specifying a type; the class-skeleton Ollama prompt uses the same conventions (#277).

--- a/objectified-ui/src/app/api/ollama/chat/route.ts
+++ b/objectified-ui/src/app/api/ollama/chat/route.ts
@@ -141,7 +141,7 @@ Return exactly one markdown fenced JSON block and nothing else — no preamble, 
       "name": "camelCasePropertyName",
       "description": "Human-readable description for the property library.",
       "schema": { },
-      "thinking": "1–3 sentences: why this property fits the user's ask.",
+      "thinking": "1–3 sentences: user-facing rationale for this row (Studio shows it beside the label in the suggestion list).",
       "summary": "Very short label (e.g. primary email)"
     }
   ]
@@ -158,7 +158,8 @@ Return exactly one markdown fenced JSON block and nothing else — no preamble, 
 - Do not reuse names from **Existing project properties** unless the user explicitly wants a variant — then pick a clearly distinct camelCase name.
 - When the user names a domain (healthcare, finance, IoT, etc.), you may align names and formats with common industry vocabularies (for example FHIR-style elements in healthcare) while still emitting valid JSON Schema the Studio property library can store.
 - Consider archetypal class fields (e.g. User → email, password hash, displayName), standard cross-cutting fields (id, createdAt, updatedAt), and properties that complement **Existing project properties** when the user asks for a coherent set.
-- "thinking" at the root is your overall reasoning; each suggestion's "thinking" is specific to that row.`;
+- "thinking" at the root is your overall reasoning; each suggestion's "thinking" is specific to that row and appears beside that suggestion in the Studio list (keep it concise).
+- You may add "explanation" or "rationale" on a suggestion instead of or in addition to "thinking"; if present, the UI prefers that string as the list subtitle.`;
 
 const PROPERTY_TYPE_SUGGESTIONS_SYSTEM = `You help API designers pick JSON Schema shapes for ONE reusable property in an OpenAPI 3.1 property library.
 
@@ -177,7 +178,7 @@ Return exactly one markdown fenced JSON block and nothing else — no preamble, 
       "name": "sameAsTargetPropertyName",
       "description": "Optional human-readable line for the library.",
       "schema": { },
-      "thinking": "1–3 sentences: why this schema fits.",
+      "thinking": "1–3 sentences: user-facing rationale for this alternative (Studio shows it beside the label in the list).",
       "summary": "Very short label (e.g. UUID string)"
     }
   ]
@@ -193,7 +194,8 @@ Return exactly one markdown fenced JSON block and nothing else — no preamble, 
 - Include at least one "boring but robust" option (e.g. plain string or ISO-8601 date-time) when other options are domain-specific.
 - When the domain suggests it (e.g. healthcare), one alternative may mirror a well-known industry pattern (FHIR logical types) using standard JSON Schema — do not invent non-JSON-Schema keywords.
 - Use **Existing project properties** to propose complementary or related shapes (e.g. foreign-key style refs, parallel timestamp fields) when relevant.
-- "thinking" at the root is your overall reasoning; each suggestion's "thinking" is specific to that row.`;
+- "thinking" at the root is your overall reasoning; each suggestion's "thinking" is specific to that row and appears beside that alternative in the Studio list (keep it concise).
+- You may add "explanation" or "rationale" on a suggestion instead of or in addition to "thinking"; if present, the UI prefers that string as the list subtitle.`;
 
 function buildPropertySuggestionsSystem(options: {
   existingClassNames?: string[];

--- a/objectified-ui/src/app/components/ade/studio/AiPropertySuggestionsDialog.tsx
+++ b/objectified-ui/src/app/components/ade/studio/AiPropertySuggestionsDialog.tsx
@@ -540,7 +540,7 @@ export function AiPropertySuggestionsDialog({
             <section aria-label="Selected suggestion detail" className="space-y-2 rounded-lg border border-slate-200 p-3 dark:border-slate-600">
               <div>
                 <h3 className="mb-1 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
-                  Property thinking
+                  Why this property
                 </h3>
                 <p className="text-sm text-slate-700 dark:text-slate-300">
                   {suggestionPublicExplanation(selectedSuggestion) || '—'}

--- a/objectified-ui/src/app/components/ade/studio/AiPropertySuggestionsDialog.tsx
+++ b/objectified-ui/src/app/components/ade/studio/AiPropertySuggestionsDialog.tsx
@@ -15,6 +15,7 @@ import { Bot, Loader2, Square, ListChecks, Ban, Trash2 } from 'lucide-react';
 import type { PropertyItem } from './StudioSideNav';
 import {
   parseAiPropertySuggestionsResponse,
+  suggestionPublicExplanation,
   type AiPropertySuggestion,
   type AiPropertySuggestionsPayload,
 } from '@lib/ai-property-suggestions';
@@ -485,6 +486,7 @@ export function AiPropertySuggestionsDialog({
                 <ul data-testid="ai-property-suggestions-list" className="max-h-48 space-y-1.5 overflow-y-auto sm:max-w-xl">
                   {activeSuggestionRows.map(({ suggestion: s, origIdx }) => {
                     const label = s.summary?.trim() ? s.summary : s.name;
+                    const explanation = suggestionPublicExplanation(s);
                     const isSelected = selectedIdx === origIdx;
                     return (
                       <li
@@ -504,6 +506,14 @@ export function AiPropertySuggestionsDialog({
                           <span className="font-medium">{label}</span>
                           {s.name && s.summary?.trim() ? (
                             <span className="mt-0.5 block font-mono text-xs text-slate-500 dark:text-slate-400">{s.name}</span>
+                          ) : null}
+                          {explanation ? (
+                            <span
+                              className="mt-1 block text-xs leading-snug text-slate-600 line-clamp-4 dark:text-slate-400"
+                              data-testid={`ai-property-suggestions-item-explanation-${origIdx}`}
+                            >
+                              {explanation}
+                            </span>
                           ) : null}
                         </button>
                         <Button
@@ -533,7 +543,7 @@ export function AiPropertySuggestionsDialog({
                   Property thinking
                 </h3>
                 <p className="text-sm text-slate-700 dark:text-slate-300">
-                  {selectedSuggestion.thinking || '—'}
+                  {suggestionPublicExplanation(selectedSuggestion) || '—'}
                 </p>
               </div>
               <div>

--- a/objectified-ui/src/app/components/ade/studio/AiPropertyTypeSuggestionsDialog.tsx
+++ b/objectified-ui/src/app/components/ade/studio/AiPropertyTypeSuggestionsDialog.tsx
@@ -14,6 +14,7 @@ import { Bot, Loader2, Square } from 'lucide-react';
 import type { PropertyItem } from './StudioSideNav';
 import {
   parseAiPropertySuggestionsResponse,
+  suggestionPublicExplanation,
   type AiPropertySuggestion,
   type AiPropertySuggestionsPayload,
 } from '@lib/ai-property-suggestions';
@@ -382,23 +383,42 @@ export function AiPropertyTypeSuggestionsDialog({
               <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
                 Type alternatives
               </h3>
-              <ul className="flex flex-wrap gap-2" data-testid="ai-property-type-suggestions-list">
-                {parsed.suggestions.map((s, i) => (
-                  <li key={`${s.summary || s.name}-${i}`}>
-                    <button
-                      type="button"
-                      data-testid={`ai-property-type-suggestions-item-${i}`}
-                      onClick={() => setSelectedIdx(i)}
-                      className={`rounded-full border px-3 py-1.5 text-sm font-medium transition-colors ${
-                        selectedIdx === i
-                          ? 'border-violet-500 bg-violet-500/15 text-violet-800 dark:text-violet-200'
-                          : 'border-slate-200 bg-white text-slate-700 hover:border-violet-300 hover:bg-violet-50 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-200 dark:hover:border-violet-500 dark:hover:bg-violet-950/40'
+              <ul
+                data-testid="ai-property-type-suggestions-list"
+                className="max-h-48 space-y-1.5 overflow-y-auto sm:max-w-xl"
+              >
+                {parsed.suggestions.map((s, i) => {
+                  const title = s.summary?.trim() ? s.summary : `Alternative ${i + 1}`;
+                  const explanation = suggestionPublicExplanation(s);
+                  const isSelected = selectedIdx === i;
+                  return (
+                    <li
+                      key={`${s.summary || s.name}-${i}`}
+                      className={`flex items-stretch gap-1 rounded-lg border transition-colors ${
+                        isSelected
+                          ? 'border-violet-500 bg-violet-500/10 ring-2 ring-violet-500/30 dark:border-violet-500 dark:bg-violet-950/30'
+                          : 'border-slate-200 bg-white dark:border-slate-600 dark:bg-slate-900'
                       }`}
                     >
-                      {s.summary?.trim() ? s.summary : `Alternative ${i + 1}`}
-                    </button>
-                  </li>
-                ))}
+                      <button
+                        type="button"
+                        data-testid={`ai-property-type-suggestions-item-${i}`}
+                        onClick={() => setSelectedIdx(i)}
+                        className="min-w-0 flex-1 px-3 py-2 text-left text-sm text-slate-900 hover:bg-slate-50 dark:text-slate-100 dark:hover:bg-slate-800/80"
+                      >
+                        <span className="font-medium">{title}</span>
+                        {explanation ? (
+                          <span
+                            className="mt-1 block text-xs leading-snug text-slate-600 line-clamp-4 dark:text-slate-400"
+                            data-testid={`ai-property-type-suggestions-item-explanation-${i}`}
+                          >
+                            {explanation}
+                          </span>
+                        ) : null}
+                      </button>
+                    </li>
+                  );
+                })}
               </ul>
             </section>
           )}
@@ -409,7 +429,9 @@ export function AiPropertyTypeSuggestionsDialog({
                 <h3 className="mb-1 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
                   Why this type
                 </h3>
-                <p className="text-sm text-slate-700 dark:text-slate-300">{selectedSuggestion.thinking || '—'}</p>
+                <p className="text-sm text-slate-700 dark:text-slate-300">
+                  {suggestionPublicExplanation(selectedSuggestion) || '—'}
+                </p>
               </div>
               <div>
                 <h3 className="mb-1 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">

--- a/objectified-ui/tests/unit/ai-property-suggestions.test.ts
+++ b/objectified-ui/tests/unit/ai-property-suggestions.test.ts
@@ -1,5 +1,6 @@
 import {
   parseAiPropertySuggestionsResponse,
+  suggestionPublicExplanation,
   type AiPropertySuggestionsPayload,
 } from '../../lib/ai-property-suggestions';
 
@@ -39,5 +40,50 @@ describe('parseAiPropertySuggestionsResponse', () => {
       '```json\n{"thinking":"","summary":"","suggestions":[{"name":"wrong","schema":{"type":"string"}},{"name":"x","schema":{"type":"integer"}}]}\n```';
     const r = parseAiPropertySuggestionsResponse(md, { canonicalPropertyName: 'patientId' });
     expect(r?.suggestions.map((s) => s.name)).toEqual(['patientId', 'patientId']);
+  });
+
+  it('parses per-suggestion explanation and rationale', () => {
+    const md = `\`\`\`json
+{"thinking":"","summary":"","suggestions":[
+  {"name":"a","schema":{"type":"string"},"explanation":"From explanation"},
+  {"name":"b","schema":{"type":"integer"},"rationale":"From rationale"},
+  {"name":"c","schema":{"type":"number"},"thinking":"From thinking"}
+]}
+\`\`\``;
+    const r = parseAiPropertySuggestionsResponse(md);
+    expect(r?.suggestions[0].explanation).toBe('From explanation');
+    expect(r?.suggestions[1].explanation).toBe('From rationale');
+    expect(r?.suggestions[2].explanation).toBeUndefined();
+    expect(r?.suggestions[2].thinking).toBe('From thinking');
+  });
+});
+
+describe('suggestionPublicExplanation', () => {
+  it('prefers explanation, then thinking, then description', () => {
+    expect(
+      suggestionPublicExplanation({
+        name: 'x',
+        schema: {},
+        explanation: 'E',
+        thinking: 'T',
+        description: 'D',
+      }),
+    ).toBe('E');
+    expect(
+      suggestionPublicExplanation({
+        name: 'x',
+        schema: {},
+        thinking: 'T',
+        description: 'D',
+      }),
+    ).toBe('T');
+    expect(
+      suggestionPublicExplanation({
+        name: 'x',
+        schema: {},
+        description: 'D',
+      }),
+    ).toBe('D');
+    expect(suggestionPublicExplanation({ name: 'x', schema: {} })).toBeUndefined();
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -17940,7 +17940,7 @@
       "version": "1.0.1"
     },
     "objectified-ui": {
-      "version": "0.11.64",
+      "version": "0.11.65",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6758,7 +6758,7 @@ object.values@^1.1.6, object.values@^1.2.1:
     es-object-atoms "^1.0.0"
 
 "objectified-ui@file:/home/runner/work/objectified-commercial/objectified-commercial/objectified-ui":
-  version "0.11.64"
+  version "0.11.65"
   resolved "file:objectified-ui"
   dependencies:
     "@dnd-kit/core" "^6.3.1"


### PR DESCRIPTION
## What changed
- **Suggest properties with AI** and **Suggest types with AI** now show a short explanation under each suggestion in the list (model `thinking`, optional JSON fields `explanation` / `rationale`, or `description` as a fallback) so users can scan rationales before selecting a row.
- Added `suggestionPublicExplanation()` in `lib/ai-property-suggestions.ts` and parse `explanation` / `rationale` from structured responses.
- Ollama system prompts for `property_suggestions` and `property_type_suggestions` note that per-row thinking is shown in the Studio list.
- Tests, roadmap, `public/WHATS_NEW.md`, and UI patch version bump.

## How to test
1. **Start Ollama** with a chat model and open Studio on a version.
2. Open **AI suggest properties** (robot control), enter a prompt, **Generate suggestions** — confirm each list row shows a subtitle when the model returns per-suggestion `thinking` (or description).
3. In **Add Property**, use **Suggest types with AI**, generate alternatives — confirm each alternative row shows an explanation, not only after selection.
4. Run `npx jest objectified-ui/tests/unit/ai-property-suggestions.test.ts` (or full UI test suite).

## Risk / notes
- Low UI-only risk; list layout for type alternatives changed from pills to stacked rows for readability with explanations.

Closes #273

Made with [Cursor](https://cursor.com)