### PR TITLE
Fix #275 - AI property suggestions trigger conditions

### DIFF
--- a/docs/PLANNED_FEATURE_ROADMAP_AI.md
+++ b/docs/PLANNED_FEATURE_ROADMAP_AI.md
@@ -75,11 +75,11 @@ This outlines the planned features for integrating AI capabilities into Objectif
 ### AI-Powered Property Suggestions
 
 **Smart Property Recommendations** 📋 PLANNED
-- 📋 **Trigger Conditions**:
-    - 📋 When creating a new class
-    - 📋 When class name is entered
-    - 📋 On-demand via chat or button
-    - 📋 After adding first few properties
+- ✅ **Trigger Conditions** (#275):
+    - ✅ When creating a new class
+    - ✅ When class name is entered
+    - ✅ On-demand via chat or button
+    - ✅ After adding first few properties
 - 📋 **Suggestion Types**:
     - 📋 Common properties for class type (e.g., "User" → email, password, name)
     - 📋 Missing standard properties (e.g., id, createdAt, updatedAt)
@@ -91,10 +91,10 @@ This outlines the planned features for integrating AI capabilities into Objectif
     - ✅ Customize before adding (#272)
     - ✅ "Add all suggested" button (#274)
     - ✅ Explanation for each suggestion (#273)
+    - ✅ Trigger conditions for opening the dialog (#275)
 
 | Ticket | Feature Description                                |
 |--------|----------------------------------------------------|
-| #275   | Adds trigger conditions for the Suggestion UI      |
 | #276   | Adds analyze button for properties analysis        |
 
 **Actionable Recommendations** 📋 PLANNED

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.66",
+  "version": "0.11.67",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -27,6 +27,7 @@ We continue to improve the platform based on your feedback with improvements and
 - Projects list includes a **Show deleted** switch; when on, soft-deleted projects appear with a **Deleted** badge and **Restore** or **permanent delete** in the row menu (#2981).
 
 ## Studio
+- The **AI property suggestions** dialog opens when you start **Add Class** (or **Create this class** from chat), when the new **class name** reaches two characters, after saving your **first** or **third** property in a single-property add (not during bulk **Add all suggested**), from **AI suggest properties** in the sidebar, or when chat includes **Open AI property suggestions** (#275).
 - **Suggest properties with AI** names the bulk queue action **Add all suggested** (clearer next to **Open in Add Property**) (#274).
 - **AI suggest properties** and **Suggest types with AI** list each row with a short **explanation** (model `thinking`, optional `explanation` / `rationale`, or description fallback) so you can scan rationales before opening the detail panel (#273).
 - **Add Property** includes **Suggest types with AI** (when Ollama is configured): enter a property name, ask for alternatives (formats, refs, domain hints such as FHIR), **edit the schema JSON** if you want tweaks, then **Apply to form** to load it (#269, #272).

--- a/objectified-ui/src/app/ade/studio/components/chatbot/ChatBubble.tsx
+++ b/objectified-ui/src/app/ade/studio/components/chatbot/ChatBubble.tsx
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import type { Components } from 'react-markdown';
-import { Bot, ClipboardCopy, Download, ListPlus, Pencil, Plus, RefreshCw, ThumbsDown, ThumbsUp, User } from 'lucide-react';
+import { Bot, ClipboardCopy, Download, ListChecks, ListPlus, Pencil, Plus, RefreshCw, ThumbsDown, ThumbsUp, User } from 'lucide-react';
 import { toast } from 'sonner';
 
 import { Markdown } from '@/app/components/ui/Markdown';
@@ -263,6 +263,11 @@ function QuickActionButton({
       label: 'Apply to current class',
       icon: <Pencil className="h-3.5 w-3.5" />,
       testId: 'studio-ai-chat-quick-apply-class',
+    },
+    open_property_suggestions: {
+      label: 'Open AI property suggestions',
+      icon: <ListChecks className="h-3.5 w-3.5" />,
+      testId: 'studio-ai-chat-quick-open-property-suggestions',
     },
   };
 

--- a/objectified-ui/src/app/ade/studio/components/chatbot/assistant-action-detection.ts
+++ b/objectified-ui/src/app/ade/studio/components/chatbot/assistant-action-detection.ts
@@ -8,7 +8,11 @@
  * ```yaml```/```yml``` fence when no JSON/JSONC fence exists.
  */
 
-export type StudioChatWorkspaceActionKind = 'create_class' | 'batch_add_properties' | 'apply_current_class';
+export type StudioChatWorkspaceActionKind =
+  | 'create_class'
+  | 'batch_add_properties'
+  | 'apply_current_class'
+  | 'open_property_suggestions';
 
 export interface StudioChatWorkspaceAction {
   kind: StudioChatWorkspaceActionKind;
@@ -154,6 +158,7 @@ export type DetectedChatQuickAction =
   | { kind: 'create_class' }
   | { kind: 'batch_add_properties' }
   | { kind: 'apply_current_class' }
+  | { kind: 'open_property_suggestions' }
   | { kind: 'copy_generated_payload'; payload: string };
 
 /** Marks Studio chat user turns that carry a class draft + refinement instructions (#532). */
@@ -276,6 +281,9 @@ export function detectChatQuickActions(markdown: string): DetectedChatQuickActio
   }
   if (phrasePresent(markdown, 'apply to current class')) {
     push({ kind: 'apply_current_class' });
+  }
+  if (phrasePresent(markdown, 'open ai property suggestions')) {
+    push({ kind: 'open_property_suggestions' });
   }
   if (phrasePresent(markdown, 'copy to clipboard')) {
     const payload = extractFirstJsonOrYamlFenceBody(markdown);

--- a/objectified-ui/src/app/ade/studio/layout.tsx
+++ b/objectified-ui/src/app/ade/studio/layout.tsx
@@ -208,6 +208,9 @@ function StudioLayoutContent({ children }: Readonly<{ children: React.ReactNode 
   const handleClassAdd = async () => {
     if (!(await checkVersionSelected()) || !(await checkNotReadOnly('add classes'))) return;
     setClassDialog({ open: true, selectedClass: null, aiAssistantSeedMarkdown: null });
+    if ((await checkProjectSelected()) && (await checkNotReadOnly('add properties'))) {
+      setAiPropertySuggestionsOpen(true);
+    }
   };
 
   const handleClassEdit = async (classItem: ClassItem) => {
@@ -235,34 +238,6 @@ function StudioLayoutContent({ children }: Readonly<{ children: React.ReactNode 
     setClassTemplateDialog({ open: true });
   };
 
-  const handleChatWorkspaceAction = React.useCallback(
-    async (action: StudioChatWorkspaceAction) => {
-      if (action.kind === 'create_class') {
-        if (!(await checkVersionSelected()) || !(await checkNotReadOnly('add classes'))) return;
-        const seed = action.assistantMarkdown?.trim();
-        setClassDialog({
-          open: true,
-          selectedClass: null,
-          aiAssistantSeedMarkdown: seed || null,
-        });
-        return;
-      }
-      if (action.kind === 'batch_add_properties' || action.kind === 'apply_current_class') {
-        const idSet = new Set(selectedCanvasNodeIds);
-        const selectedClass = classes.find((c) => idSet.has(c.id));
-        if (!selectedClass) {
-          await alertDialog({
-            message: 'Select a class on the canvas first so Studio knows which class to open.',
-            variant: 'warning',
-          });
-          return;
-        }
-        await handleClassEdit(selectedClass);
-      }
-    },
-    [checkVersionSelected, checkNotReadOnly, handleClassEdit, selectedCanvasNodeIds, classes, alertDialog],
-  );
-
   // Property handlers
   const handlePropertyAdd = async () => {
     if (!(await checkProjectSelected()) || !(await checkNotReadOnly('add properties'))) return;
@@ -278,6 +253,50 @@ function StudioLayoutContent({ children }: Readonly<{ children: React.ReactNode 
     if (!(await checkProjectSelected()) || !(await checkNotReadOnly('add properties'))) return;
     setAiPropertySuggestionsOpen(true);
   };
+
+  const handleChatWorkspaceAction = React.useCallback(
+    async (action: StudioChatWorkspaceAction) => {
+      if (action.kind === 'create_class') {
+        if (!(await checkVersionSelected()) || !(await checkNotReadOnly('add classes'))) return;
+        const seed = action.assistantMarkdown?.trim();
+        setClassDialog({
+          open: true,
+          selectedClass: null,
+          aiAssistantSeedMarkdown: seed || null,
+        });
+        if ((await checkProjectSelected()) && (await checkNotReadOnly('add properties'))) {
+          setAiPropertySuggestionsOpen(true);
+        }
+        return;
+      }
+      if (action.kind === 'batch_add_properties' || action.kind === 'apply_current_class') {
+        const idSet = new Set(selectedCanvasNodeIds);
+        const selectedClass = classes.find((c) => idSet.has(c.id));
+        if (!selectedClass) {
+          await alertDialog({
+            message: 'Select a class on the canvas first so Studio knows which class to open.',
+            variant: 'warning',
+          });
+          return;
+        }
+        await handleClassEdit(selectedClass);
+        return;
+      }
+      if (action.kind === 'open_property_suggestions') {
+        await handlePropertyAiSuggest();
+      }
+    },
+    [
+      checkVersionSelected,
+      checkNotReadOnly,
+      checkProjectSelected,
+      handleClassEdit,
+      handlePropertyAiSuggest,
+      selectedCanvasNodeIds,
+      classes,
+      alertDialog,
+    ],
+  );
 
   const handlePropertyEdit = async (propertyItem: PropertyItem) => {
     if (!(await checkProjectSelected()) || !(await checkNotReadOnly('edit properties'))) return;
@@ -338,6 +357,13 @@ function StudioLayoutContent({ children }: Readonly<{ children: React.ReactNode 
         setPropertyDialog({ open: false, mode: 'add', selectedProperty: null, pendingBulkSeeds: null });
       }
       setRefreshKey(prev => prev + 1);
+
+      if (mode === 'add' && (!pendingBulkSeeds || pendingBulkSeeds.length === 0)) {
+        const newCount = properties.length + 1;
+        if (newCount === 1 || newCount === 3) {
+          void handlePropertyAiSuggest();
+        }
+      }
     } catch (error) {
       console.error('Error saving property:', error);
       throw error;
@@ -600,6 +626,9 @@ function StudioLayoutContent({ children }: Readonly<{ children: React.ReactNode 
         onAiAssistantSeedConsumed={() =>
           setClassDialog((d) => ({ ...d, aiAssistantSeedMarkdown: null }))
         }
+        onClassNameEnteredForPropertySuggestions={() => {
+          void handlePropertyAiSuggest();
+        }}
         nodes={classNodes}
         isReadOnly={isReadOnly}
         onSave={() => {

--- a/objectified-ui/src/app/ade/studio/layout.tsx
+++ b/objectified-ui/src/app/ade/studio/layout.tsx
@@ -351,14 +351,14 @@ function StudioLayoutContent({ children }: Readonly<{ children: React.ReactNode 
           open: true,
           mode: 'add',
           selectedProperty: next,
-          pendingBulkSeeds: rest.length > 0 ? rest : null,
+          pendingBulkSeeds: rest,
         });
       } else {
         setPropertyDialog({ open: false, mode: 'add', selectedProperty: null, pendingBulkSeeds: null });
       }
       setRefreshKey(prev => prev + 1);
 
-      if (mode === 'add' && (!pendingBulkSeeds || pendingBulkSeeds.length === 0)) {
+      if (mode === 'add' && pendingBulkSeeds === null) {
         const newCount = properties.length + 1;
         if (newCount === 1 || newCount === 3) {
           void handlePropertyAiSuggest();
@@ -711,7 +711,7 @@ function StudioLayoutContent({ children }: Readonly<{ children: React.ReactNode 
               open: true,
               mode: 'add',
               selectedProperty: first,
-              pendingBulkSeeds: rest.length > 0 ? rest : null,
+              pendingBulkSeeds: rest,
             });
           }}
         />

--- a/objectified-ui/src/app/components/ade/studio/ClassEditDialog.tsx
+++ b/objectified-ui/src/app/components/ade/studio/ClassEditDialog.tsx
@@ -238,6 +238,8 @@ interface ClassEditDialogProps {
   /** When opening Add Class from chat (#528), seed AI mode with this assistant markdown. */
   aiAssistantSeedMarkdown?: string | null;
   onAiAssistantSeedConsumed?: () => void;
+  /** Fires once per Add Class session when the class name reaches 2+ characters (#275). */
+  onClassNameEnteredForPropertySuggestions?: () => void;
 }
 
 const ClassEditDialog = ({
@@ -253,6 +255,7 @@ const ClassEditDialog = ({
   projectMetadata,
   aiAssistantSeedMarkdown = null,
   onAiAssistantSeedConsumed,
+  onClassNameEnteredForPropertySuggestions,
 }: ClassEditDialogProps) => {
   const isDark = useDarkMode();
 
@@ -298,6 +301,7 @@ const ClassEditDialog = ({
   const [newDependentSchemaProperty, setNewDependentSchemaProperty] = useState('');
   const aiMessagesEndRef = useRef<HTMLDivElement>(null);
   const aiAbortControllerRef = useRef<AbortController | null>(null);
+  const classNamePropertySuggestGateRef = useRef(false);
 
   // Form state
   const [formData, setFormData] = useState({
@@ -766,6 +770,19 @@ const ClassEditDialog = ({
     setAiMessages([{ role: 'assistant', content: md }]);
     onAiAssistantSeedConsumed?.();
   }, [open, editingClassData, aiAssistantSeedMarkdown, onAiAssistantSeedConsumed]);
+
+  useEffect(() => {
+    if (!open) {
+      classNamePropertySuggestGateRef.current = false;
+      return;
+    }
+    if (editingClassData || isReadOnly || !onClassNameEnteredForPropertySuggestions) return;
+    const t = formData.name.trim();
+    if (t.length >= 2 && !classNamePropertySuggestGateRef.current) {
+      classNamePropertySuggestGateRef.current = true;
+      onClassNameEnteredForPropertySuggestions();
+    }
+  }, [open, editingClassData, isReadOnly, formData.name, onClassNameEnteredForPropertySuggestions]);
 
   useEffect(() => {
     aiMessagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });

--- a/objectified-ui/tests/chatbot/assistant-action-detection.test.ts
+++ b/objectified-ui/tests/chatbot/assistant-action-detection.test.ts
@@ -65,6 +65,11 @@ describe('detectChatQuickActions', () => {
     const kinds = detectChatQuickActions(md).map((a) => a.kind);
     expect(kinds.filter((k) => k === 'create_class').length).toBe(1);
   });
+
+  it('detects open ai property suggestions CTA (#275)', () => {
+    const md = 'Here are ideas.\n\n**Open AI property suggestions**';
+    expect(detectChatQuickActions(md).some((a) => a.kind === 'open_property_suggestions')).toBe(true);
+  });
 });
 
 describe('parseClassDefinitionFromAssistantMarkdown', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2622,7 +2622,7 @@
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
       "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright": "1.59.1"
@@ -5520,6 +5520,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -5529,7 +5530,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -6682,7 +6683,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-react-compiler/-/babel-plugin-react-compiler-1.0.0.tgz",
       "integrity": "sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.26.0"
@@ -14638,7 +14639,7 @@
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
       "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.59.1"
@@ -14657,7 +14658,7 @@
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
       "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -14670,13 +14671,13 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -16381,6 +16382,7 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
       "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/tailwindcss-animate": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17940,7 +17940,7 @@
       "version": "1.0.1"
     },
     "objectified-ui": {
-      "version": "0.11.65",
+      "version": "0.11.67",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6758,7 +6758,7 @@ object.values@^1.1.6, object.values@^1.2.1:
     es-object-atoms "^1.0.0"
 
 "objectified-ui@file:/home/runner/work/objectified-commercial/objectified-commercial/objectified-ui":
-  version "0.11.66"
+  version "0.11.67"
   resolved "file:objectified-ui"
   dependencies:
     "@dnd-kit/core" "^6.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -45,7 +45,7 @@
   resolved "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.5.tgz"
   integrity sha512-6uFXyCayocRbqhZOB+6XcuZbkMNimwfVGFji8CTZnCzOHVGvDqzvitu1re2AU5LROliz7eQPhB8CpAMvnx9EjA==
 
-"@babel/core@^7.0.0", "@babel/core@^7.0.0 || ^8.0.0-0", "@babel/core@^7.0.0-0", "@babel/core@^7.11.0 || ^8.0.0-0", "@babel/core@^7.11.0 || ^8.0.0-beta.1", "@babel/core@^7.23.9", "@babel/core@^7.24.4", "@babel/core@^7.27.4", "@babel/core@>=7.0.0-beta.0 <8":
+"@babel/core@^7.23.9", "@babel/core@^7.24.4", "@babel/core@^7.27.4":
   version "7.28.5"
   resolved "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz"
   integrity sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==
@@ -366,12 +366,12 @@
     "@csstools/color-helpers" "^5.1.0"
     "@csstools/css-calc" "^2.1.4"
 
-"@csstools/css-parser-algorithms@^3.0.4", "@csstools/css-parser-algorithms@^3.0.5":
+"@csstools/css-parser-algorithms@^3.0.4":
   version "3.0.5"
   resolved "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz"
   integrity sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==
 
-"@csstools/css-tokenizer@^3.0.3", "@csstools/css-tokenizer@^3.0.4":
+"@csstools/css-tokenizer@^3.0.3":
   version "3.0.4"
   resolved "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz"
   integrity sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==
@@ -383,7 +383,7 @@
   dependencies:
     tslib "^2.0.0"
 
-"@dnd-kit/core@^6.3.0", "@dnd-kit/core@^6.3.1":
+"@dnd-kit/core@^6.3.1":
   version "6.3.1"
   resolved "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz"
   integrity sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==
@@ -474,7 +474,7 @@
   resolved "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz"
   integrity sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==
 
-"@emotion/react@^11.0.0-rc.0", "@emotion/react@^11.14.0":
+"@emotion/react@^11.14.0":
   version "11.14.0"
   resolved "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz"
   integrity sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==
@@ -923,7 +923,7 @@
     jest-haste-map "30.3.0"
     slash "^3.0.0"
 
-"@jest/transform@^29.0.0 || ^30.0.0", "@jest/transform@30.3.0":
+"@jest/transform@30.3.0":
   version "30.3.0"
   resolved "https://registry.npmjs.org/@jest/transform/-/transform-30.3.0.tgz"
   integrity sha512-TLKY33fSLVd/lKB2YI1pH69ijyUblO/BQvCj566YvnwuzoTNr648iE0j22vRvVNk2HsPwByPxATg3MleS3gf5A==
@@ -943,7 +943,7 @@
     slash "^3.0.0"
     write-file-atomic "^5.0.1"
 
-"@jest/types@^29.0.0 || ^30.0.0", "@jest/types@30.3.0":
+"@jest/types@30.3.0":
   version "30.3.0"
   resolved "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz"
   integrity sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==
@@ -1092,7 +1092,7 @@
   resolved "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz"
   integrity sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==
 
-"@playwright/test@^1.51.1", "@playwright/test@^1.59.1":
+"@playwright/test@^1.59.1":
   version "1.59.1"
   resolved "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz"
   integrity sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==
@@ -1911,7 +1911,7 @@
     postcss "^8.5.6"
     tailwindcss "4.2.2"
 
-"@testing-library/dom@^10.0.0", "@testing-library/dom@^10.4.1", "@testing-library/dom@>=7.21.4":
+"@testing-library/dom@^10.4.1":
   version "10.4.1"
   resolved "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz"
   integrity sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==
@@ -2378,12 +2378,12 @@
   resolved "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz"
   integrity sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==
 
-"@types/react-dom@*", "@types/react-dom@^18.0.0 || ^19.0.0", "@types/react-dom@^19.2.3":
+"@types/react-dom@^19.2.3":
   version "19.2.3"
   resolved "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz"
   integrity sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==
 
-"@types/react@*", "@types/react@^18.0.0 || ^19.0.0", "@types/react@^19.2.0", "@types/react@^19.2.14", "@types/react@>=16.8", "@types/react@>=18":
+"@types/react@^19.2.14":
   version "19.2.14"
   resolved "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz"
   integrity sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==
@@ -2449,7 +2449,7 @@
     natural-compare "^1.4.0"
     ts-api-utils "^2.1.0"
 
-"@typescript-eslint/parser@^8.46.2", "@typescript-eslint/parser@8.46.2":
+"@typescript-eslint/parser@8.46.2":
   version "8.46.2"
   resolved "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.46.2.tgz"
   integrity sha512-BnOroVl1SgrPLywqxyqdJ4l3S2MsKVLDVxZvjI1Eoe8ev2r3kGDo+PcMihNmDE+6/KjkTubSJnmqGZZjQSBq/g==
@@ -2591,7 +2591,7 @@ acorn-walk@^8.1.1:
   dependencies:
     acorn "^8.11.0"
 
-"acorn@^6.0.0 || ^7.0.0 || ^8.0.0", acorn@^8.11.0, acorn@^8.15.0, acorn@^8.4.1:
+acorn@^8.11.0, acorn@^8.15.0, acorn@^8.4.1:
   version "8.15.0"
   resolved "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz"
   integrity sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==
@@ -2623,7 +2623,7 @@ ajv@^6.14.0:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ajv@^8.0.0, ajv@^8.18.0, ajv@^8.5.0:
+ajv@^8.0.0, ajv@^8.18.0:
   version "8.18.0"
   resolved "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz"
   integrity sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==
@@ -2834,7 +2834,7 @@ axobject-query@^4.1.0:
   resolved "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz"
   integrity sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==
 
-"babel-jest@^29.0.0 || ^30.0.0", babel-jest@30.3.0:
+babel-jest@30.3.0:
   version "30.3.0"
   resolved "https://registry.npmjs.org/babel-jest/-/babel-jest-30.3.0.tgz"
   integrity sha512-gRpauEU2KRrCox5Z296aeVHR4jQ98BCnu0IO332D/xpHNOsIH/bgSRk9k6GbKIbBw8vFeN6ctuu6tV8WOyVfYQ==
@@ -2874,7 +2874,7 @@ babel-plugin-macros@^3.1.0:
     cosmiconfig "^7.0.0"
     resolve "^1.19.0"
 
-babel-plugin-react-compiler@*, babel-plugin-react-compiler@^1.0.0:
+babel-plugin-react-compiler@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/babel-plugin-react-compiler/-/babel-plugin-react-compiler-1.0.0.tgz"
   integrity sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==
@@ -2967,7 +2967,7 @@ braces@^3.0.3:
   dependencies:
     fill-range "^7.1.1"
 
-browserslist@^4.24.0, "browserslist@>= 4.21.0":
+browserslist@^4.24.0:
   version "4.27.0"
   resolved "https://registry.npmjs.org/browserslist/-/browserslist-4.27.0.tgz"
   integrity sha512-AXVQwdhot1eqLihwasPElhX2tAZiBjWdJ9i/Zcj2S6QYIjkx62OKSfnobkriB81C3l4w0rVy3Nt4jaTBltYEpw==
@@ -3112,7 +3112,7 @@ chevrotain-allstar@~0.3.1:
   dependencies:
     lodash-es "^4.17.21"
 
-chevrotain@^11.0.0, chevrotain@~11.1.1:
+chevrotain@~11.1.1:
   version "11.1.2"
   resolved "https://registry.npmjs.org/chevrotain/-/chevrotain-11.1.2.tgz"
   integrity sha512-opLQzEVriiH1uUQ4Kctsd49bRoFDXGGSC4GUqj7pGyxM3RehRhvTlZJc1FL/Flew2p5uwxa1tUDWKzI4wNM8pg==
@@ -3325,7 +3325,7 @@ cytoscape-fcose@^2.2.0:
   dependencies:
     cose-base "^2.2.0"
 
-cytoscape@^3.2.0, cytoscape@^3.33.1:
+cytoscape@^3.33.1:
   version "3.33.1"
   resolved "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz"
   integrity sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==
@@ -4038,7 +4038,7 @@ eslint-module-utils@^2.12.1:
   dependencies:
     debug "^3.2.7"
 
-eslint-plugin-import@*, eslint-plugin-import@^2.32.0:
+eslint-plugin-import@^2.32.0:
   version "2.32.0"
   resolved "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz"
   integrity sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==
@@ -4137,7 +4137,7 @@ eslint-visitor-keys@^4.2.1:
   resolved "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz"
   integrity sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==
 
-eslint@*, "eslint@^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9", "eslint@^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9", "eslint@^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7", "eslint@^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0", "eslint@^6.0.0 || ^7.0.0 || >=8.0.0", "eslint@^8.57.0 || ^9.0.0", eslint@^9.39.4, eslint@>=9.0.0:
+eslint@^9.39.4:
   version "9.39.4"
   resolved "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz"
   integrity sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==
@@ -5412,7 +5412,7 @@ jest-resolve-dependencies@30.3.0:
     jest-regex-util "30.0.1"
     jest-snapshot "30.3.0"
 
-jest-resolve@*, jest-resolve@30.3.0:
+jest-resolve@30.3.0:
   version "30.3.0"
   resolved "https://registry.npmjs.org/jest-resolve/-/jest-resolve-30.3.0.tgz"
   integrity sha512-NRtTAHQlpd15F9rUR36jqwelbrDV/dY4vzNte3S2kxCKUJRYNd5/6nTSbYiak1VX5g8IoFF23Uj5TURkUW8O5g==
@@ -5509,7 +5509,7 @@ jest-snapshot@30.3.0:
     semver "^7.7.2"
     synckit "^0.11.8"
 
-"jest-util@^29.0.0 || ^30.0.0", jest-util@30.3.0:
+jest-util@30.3.0:
   version "30.3.0"
   resolved "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz"
   integrity sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==
@@ -5558,7 +5558,7 @@ jest-worker@30.3.0:
     merge-stream "^2.0.0"
     supports-color "^8.1.1"
 
-"jest@^29.0.0 || ^30.0.0", jest@^30.3.0:
+jest@^30.3.0:
   version "30.3.0"
   resolved "https://registry.npmjs.org/jest/-/jest-30.3.0.tgz"
   integrity sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==
@@ -5568,7 +5568,7 @@ jest-worker@30.3.0:
     import-local "^3.2.0"
     jest-cli "30.3.0"
 
-jiti@*, jiti@^2.6.1:
+jiti@^2.6.1:
   version "2.6.1"
   resolved "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz"
   integrity sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==
@@ -5606,7 +5606,7 @@ js-yaml@^4.1.1:
   dependencies:
     argparse "^2.0.1"
 
-jsdom@*, jsdom@^26.1.0:
+jsdom@^26.1.0:
   version "26.1.0"
   resolved "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz"
   integrity sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==
@@ -5632,7 +5632,7 @@ jsdom@*, jsdom@^26.1.0:
     ws "^8.18.0"
     xml-name-validator "^5.0.0"
 
-jsep@^0.4.0||^1.0.0, jsep@^1.4.0:
+jsep@^1.4.0:
   version "1.4.0"
   resolved "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz"
   integrity sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==
@@ -6564,7 +6564,7 @@ mlly@^1.7.4, mlly@^1.8.0:
     pkg-types "^1.3.1"
     ufo "^1.6.1"
 
-monaco-editor@^0.55.1, "monaco-editor@>= 0.25.0 < 1":
+monaco-editor@^0.55.1:
   version "0.55.1"
   resolved "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz"
   integrity sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==
@@ -6622,7 +6622,7 @@ next-themes@^0.4.6:
   resolved "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz"
   integrity sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==
 
-"next@^12.2.5 || ^13 || ^14 || ^15 || ^16", next@^16.2.3:
+next@^16.2.3:
   version "16.2.4"
   resolved "https://registry.npmjs.org/next/-/next-16.2.4.tgz"
   integrity sha512-kPvz56wF5frc+FxlHI5qnklCzbq53HTwORaWBGdT0vNoKh1Aya9XC8aPauH4NJxqtzbWsS5mAbctm4cr+EkQ2Q==
@@ -7044,7 +7044,7 @@ pg-types@^2.2.0, pg-types@2.2.0:
     postgres-date "~1.0.4"
     postgres-interval "^1.1.0"
 
-pg@^8.20.0, pg@>=8.0:
+pg@^8.20.0:
   version "8.20.0"
   resolved "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz"
   integrity sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==
@@ -7073,11 +7073,6 @@ picomatch@^2.0.4, picomatch@^2.3.1:
   version "2.3.1"
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
-
-"picomatch@^3 || ^4":
-  version "4.0.3"
-  resolved "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz"
-  integrity sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==
 
 picomatch@^4.0.3:
   version "4.0.4"
@@ -7184,7 +7179,7 @@ preact-render-to-string@^5.1.19:
   dependencies:
     pretty-format "^3.8.0"
 
-preact@^10.6.3, preact@>=10:
+preact@^10.6.3:
   version "10.27.2"
   resolved "https://registry.npmjs.org/preact/-/preact-10.27.2.tgz"
   integrity sha512-5SYSgFKSyhCbk6SrXyMpqjb5+MQBgfvEKE/OC+PujcY34sOpqtr+0AZQtPYx5IA6VxynQ7rUPCtKzyovpj9Bpg==
@@ -7328,7 +7323,7 @@ raf@^3.4.1:
   dependencies:
     performance-now "^2.1.0"
 
-"react-dom@^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc", "react-dom@^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom@^17.0.2 || ^18 || ^19", "react-dom@^18 || ^19 || ^19.0.0-rc", "react-dom@^18.0.0 || ^19.0.0", "react-dom@^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react-dom@^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", react-dom@^19.2.5, react-dom@>=16.8.0, react-dom@>=17, "react-dom@16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc":
+react-dom@^19.2.5:
   version "19.2.5"
   resolved "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz"
   integrity sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==
@@ -7399,7 +7394,7 @@ react-style-singleton@^2.2.2, react-style-singleton@^2.2.3:
     get-nonce "^1.0.0"
     tslib "^2.0.0"
 
-react@*, "react@^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react@^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc", "react@^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react@^16.x || ^17.x || ^18.x || ^19.0.0 || ^19.0.0-rc", "react@^17.0.2 || ^18 || ^19", "react@^18 || ^19 || ^19.0.0-rc", "react@^18.0.0 || ^19.0.0", "react@^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react@^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", react@^19.2.5, "react@>= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0", react@>=16.8, react@>=16.8.0, react@>=17, react@>=18, "react@16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc":
+react@^19.2.5:
   version "19.2.5"
   resolved "https://registry.npmjs.org/react/-/react-19.2.5.tgz"
   integrity sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==
@@ -8131,7 +8126,7 @@ tailwindcss-animate@^1.0.7:
   resolved "https://registry.npmjs.org/tailwindcss-animate/-/tailwindcss-animate-1.0.7.tgz"
   integrity sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==
 
-tailwindcss@^4.2.2, "tailwindcss@>=3.0.0 || insiders", tailwindcss@4.2.2:
+tailwindcss@^4.2.2, tailwindcss@4.2.2:
   version "4.2.2"
   resolved "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz"
   integrity sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==
@@ -8243,7 +8238,7 @@ ts-jest@^29.4.9:
     type-fest "^4.41.0"
     yargs-parser "^21.1.1"
 
-ts-node@^10.9.2, ts-node@>=9.0.0:
+ts-node@^10.9.2:
   version "10.9.2"
   resolved "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz"
   integrity sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==
@@ -8354,7 +8349,7 @@ typescript-eslint@^8.46.0:
     "@typescript-eslint/typescript-estree" "8.46.2"
     "@typescript-eslint/utils" "8.46.2"
 
-typescript@^5.9.3, typescript@>=2.7, typescript@>=3.3.1, "typescript@>=4.3 <7", typescript@>=4.8.4, "typescript@>=4.8.4 <6.0.0":
+typescript@^5.9.3:
   version "5.9.3"
   resolved "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz"
   integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==


### PR DESCRIPTION
## What changed
Studio now opens the **AI property suggestions** dialog in these situations (in addition to the existing **AI suggest properties** sidebar control):

- **Add Class** (sidebar): after the Add Class dialog opens, when project/version permissions allow property work.
- **Create this class** from Studio AI chat: same as above so chat-driven class creation matches sidebar behavior.
- **Class name** on a new class: once the trimmed name reaches **2 characters**, a single callback opens the dialog for that Add Class session.
- **First or third property** saved via a normal **Add Property** flow (not while stepping through **Add all suggested** bulk seeds).
- **Chat quick action**: when the assistant message includes the phrase **Open AI property suggestions** (case-insensitive, markdown bold supported like other CTAs).

## How to test
1. **Open Studio** with a project and unpublished version selected.
2. **Click Add Class**: confirm the property suggestions dialog appears (may stack above the class dialog); dismiss it and continue editing the class.
3. **Close and reopen Add Class**, type a **class name** of at least two characters: the suggestions dialog should open once for that session.
4. In **Studio AI chat**, use an assistant reply containing **Open AI property suggestions** and click the green quick action.
5. **Add Property** twice (or until you have three properties) with single saves: after the **first** and **third** successful saves, the suggestions dialog should open (not between bulk **Add all suggested** steps).

## Risk / notes
- Multiple triggers can open the dialog in succession during onboarding (e.g. Add Class + name effect); users can dismiss the overlay as before.
- Chat models must include the exact phrase **Open AI property suggestions** for the new quick action to appear (same pattern as **Create this class**).

Closes #275

Made with [Cursor](https://cursor.com)