### PR TITLE
Fix #276 - Analyze button on property form for AI suggestions

### DIFF
--- a/docs/PLANNED_FEATURE_ROADMAP_AI.md
+++ b/docs/PLANNED_FEATURE_ROADMAP_AI.md
@@ -79,6 +79,7 @@ This outlines the planned features for integrating AI capabilities into Objectif
     - ✅ When creating a new class
     - ✅ When class name is entered
     - ✅ On-demand via chat or button
+    - ✅ **Analyze** on Add / Edit Property form (#276)
     - ✅ After adding first few properties
 - 📋 **Suggestion Types**:
     - 📋 Common properties for class type (e.g., "User" → email, password, name)
@@ -92,10 +93,6 @@ This outlines the planned features for integrating AI capabilities into Objectif
     - ✅ "Add all suggested" button (#274)
     - ✅ Explanation for each suggestion (#273)
     - ✅ Trigger conditions for opening the dialog (#275)
-
-| Ticket | Feature Description                                |
-|--------|----------------------------------------------------|
-| #276   | Adds analyze button for properties analysis        |
 
 **Actionable Recommendations** 📋 PLANNED
 - 📋 AI-powered suggestions for improvement:

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.67",
+  "version": "0.11.68",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -27,6 +27,7 @@ We continue to improve the platform based on your feedback with improvements and
 - Projects list includes a **Show deleted** switch; when on, soft-deleted projects appear with a **Deleted** badge and **Restore** or **permanent delete** in the row menu (#2981).
 
 ## Studio
+- **Add Property** and **Edit Property** include **Analyze** on the Basics step (advanced Form view includes it in Basics): opens the same **AI property suggestions** dialog as the sidebar robot control (#276).
 - The **AI property suggestions** dialog opens when you start **Add Class** (or **Create this class** from chat), when the new **class name** reaches two characters, after saving your **first** or **third** property in a single-property add (not during bulk **Add all suggested**), from **AI suggest properties** in the sidebar, or when chat includes **Open AI property suggestions** (#275).
 - **Suggest properties with AI** names the bulk queue action **Add all suggested** (clearer next to **Open in Add Property**) (#274).
 - **AI suggest properties** and **Suggest types with AI** list each row with a short **explanation** (model `thinking`, optional `explanation` / `rationale`, or description fallback) so you can scan rationales before opening the detail panel (#273).

--- a/objectified-ui/src/app/ade/studio/layout.tsx
+++ b/objectified-ui/src/app/ade/studio/layout.tsx
@@ -689,6 +689,13 @@ function StudioLayoutContent({ children }: Readonly<{ children: React.ReactNode 
             } as PropertyItem,
           });
         }}
+        onOpenAiPropertySuggestions={
+          !isReadOnly && selectedProjectId
+            ? () => {
+                void handlePropertyAiSuggest();
+              }
+            : undefined
+        }
       />
 
       {selectedProjectId && (

--- a/objectified-ui/src/app/components/ade/studio/PropertyDialog.tsx
+++ b/objectified-ui/src/app/components/ade/studio/PropertyDialog.tsx
@@ -28,6 +28,7 @@ import {
   ListChecks,
   BookOpenText,
   Wand2,
+  Bot,
 } from 'lucide-react';
 import type { ChatStudioContext } from '@/app/ade/studio/components/chatbot/chat-context';
 import { AiPropertyTypeSuggestionsDialog } from './AiPropertyTypeSuggestionsDialog';
@@ -129,6 +130,8 @@ interface PropertyDialogProps {
     description: string | null;
     schema: Record<string, unknown>;
   }) => void;
+  /** Opens the AI property suggestions dialog (same as sidebar / chat; #276). */
+  onOpenAiPropertySuggestions?: () => void;
 }
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -150,6 +153,7 @@ interface BasicsSectionProps {
   primitiveAvailable: boolean;
   setPrimitiveDialogOpen: (next: boolean) => void;
   addModeAiTypeSuggest?: { onOpen: () => void } | null;
+  onOpenAiPropertySuggestions?: () => void;
   changed?: boolean;
   eyebrow?: string;
 }
@@ -167,6 +171,7 @@ const BasicsSection: React.FC<BasicsSectionProps> = ({
   primitiveAvailable,
   setPrimitiveDialogOpen,
   addModeAiTypeSuggest,
+  onOpenAiPropertySuggestions,
   changed,
   eyebrow = 'Basics',
 }) => (
@@ -227,6 +232,34 @@ const BasicsSection: React.FC<BasicsSectionProps> = ({
         </Select>
       </FormFieldGroup>
     </FormGrid>
+
+    {onOpenAiPropertySuggestions && (
+      <div className="rounded-xl border border-emerald-200 bg-emerald-50/60 p-4 dark:border-emerald-900/50 dark:bg-emerald-950/30">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="flex items-start gap-3">
+            <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-emerald-100 text-emerald-600 dark:bg-emerald-900/40 dark:text-emerald-300">
+              <Bot className="h-4 w-4" aria-hidden />
+            </span>
+            <div className="min-w-0">
+              <h4 className="text-sm font-semibold text-slate-900 dark:text-slate-100">AI property suggestions</h4>
+              <p className="mt-0.5 text-xs leading-5 text-slate-500 dark:text-slate-400">
+                Brainstorm reusable property names and schemas from a short prompt. Uses the same flow as the properties sidebar. Requires Ollama when connected.
+              </p>
+            </div>
+          </div>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            data-testid="property-dialog-analyze-ai-properties"
+            onClick={onOpenAiPropertySuggestions}
+            className="shrink-0 border-emerald-300 text-emerald-800 hover:bg-emerald-100 dark:border-emerald-700 dark:text-emerald-200 dark:hover:bg-emerald-950/50"
+          >
+            Analyze
+          </Button>
+        </div>
+      </div>
+    )}
 
     {mode === 'add' && addModeAiTypeSuggest && (
       <div className="rounded-xl border border-violet-200 bg-violet-50/60 p-4 dark:border-violet-900/50 dark:bg-violet-950/30">
@@ -550,6 +583,7 @@ export const PropertyDialog: React.FC<PropertyDialogProps> = ({
   availableClasses = [],
   propertyAiContext,
   onApplyAiTypeSchema,
+  onOpenAiPropertySuggestions,
 }) => {
   const isDark = useDarkMode();
 
@@ -1724,6 +1758,7 @@ export const PropertyDialog: React.FC<PropertyDialogProps> = ({
                         primitiveAvailable={primitiveAvailable}
                         setPrimitiveDialogOpen={setPrimitiveDialogOpen}
                         addModeAiTypeSuggest={addModeAiTypeSuggest}
+                        onOpenAiPropertySuggestions={onOpenAiPropertySuggestions}
                         changed={changedBasics}
                         eyebrow="Step 1 of 5"
                       />
@@ -1804,6 +1839,7 @@ export const PropertyDialog: React.FC<PropertyDialogProps> = ({
                       primitiveAvailable={primitiveAvailable}
                       setPrimitiveDialogOpen={setPrimitiveDialogOpen}
                       addModeAiTypeSuggest={addModeAiTypeSuggest}
+                      onOpenAiPropertySuggestions={onOpenAiPropertySuggestions}
                       changed={changedBasics}
                     />
                     <FlagsSection formData={formData} setFormData={setFormData} changed={changedFlags} />

--- a/objectified-ui/tests/unit/PropertyDialog-analyze.test.tsx
+++ b/objectified-ui/tests/unit/PropertyDialog-analyze.test.tsx
@@ -1,0 +1,60 @@
+/**
+ * Add Property / Edit Property — **Analyze** opens AI property suggestions (#276).
+ */
+
+jest.mock('@monaco-editor/react', () => ({
+  __esModule: true,
+  default: function MockMonaco() {
+    return null;
+  },
+}));
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import PropertyDialog from '../../src/app/components/ade/studio/PropertyDialog';
+
+(global as { ResizeObserver?: typeof ResizeObserver }).ResizeObserver = class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+} as unknown as typeof ResizeObserver;
+
+describe('PropertyDialog Analyze (#276)', () => {
+  it('calls onOpenAiPropertySuggestions when Analyze is clicked', async () => {
+    const user = userEvent.setup();
+    const onOpenAiPropertySuggestions = jest.fn();
+
+    render(
+      <PropertyDialog
+        open
+        onClose={jest.fn()}
+        mode="add"
+        property={null}
+        onSubmit={jest.fn().mockResolvedValue(undefined)}
+        onOpenAiPropertySuggestions={onOpenAiPropertySuggestions}
+      />,
+    );
+
+    await user.click(screen.getByTestId('property-dialog-analyze-ai-properties'));
+    expect(onOpenAiPropertySuggestions).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not render Analyze when onOpenAiPropertySuggestions is omitted', () => {
+    render(
+      <PropertyDialog
+        open
+        onClose={jest.fn()}
+        mode="edit"
+        property={{
+          id: 'p1',
+          name: 'email',
+          type: 'string',
+        }}
+        onSubmit={jest.fn().mockResolvedValue(undefined)}
+      />,
+    );
+
+    expect(screen.queryByTestId('property-dialog-analyze-ai-properties')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## What changed
- Added an **Analyze** control to the property dialog Basics section (guided step 1 and advanced Form view). It calls the same handler as **AI suggest properties** in the sidebar, opening `AiPropertySuggestionsDialog`.
- Wired from Studio layout when the version is writable and a project is selected (hidden in read-only).

## How to test
1. Open Studio with an **unpublished** version and a project.
2. **Open Add Property** or **Edit** an existing property.
3. On **Basics** (or step 1 in guided mode), **click Analyze**.
4. Confirm the **AI property suggestions** dialog opens; generate or close as usual.

## Risk / notes
- The property dialog can stack above the suggestions dialog; closing suggestions returns to the property form. No API changes.

Closes #276

Made with [Cursor](https://cursor.com)