### PR TITLE
Fix #253 - AI improvement suggestions from Schema Metrics

### DIFF
--- a/docs/PLANNED_FEATURE_ROADMAP_AI.md
+++ b/docs/PLANNED_FEATURE_ROADMAP_AI.md
@@ -73,18 +73,18 @@ This outlines the planned features for integrating AI capabilities into Objectif
 | #527   | Implementation of Guardrails for prompts/responses  |
 
 **Actionable Recommendations** 📋 PLANNED
-- 📋 AI-powered suggestions for improvement:
-    - 📋 "Add descriptions to 12 classes to improve docs score"
-    - 📋 "Rename 5 properties to follow camelCase convention"
-    - 📋 "Split 'User' class - it has 28 properties (recommended max: 15)"
-    - 📋 "Add pagination to 'GET /users' endpoint"
+- ✅ **AI-powered suggestions for improvement** (#253 — Schema Metrics **lightbulb** → Ollama structured list: docs, naming, structure, API, performance):
+    - ✅ "Add descriptions to 12 classes to improve docs score" (pattern; model uses live metrics)
+    - ✅ "Rename 5 properties to follow camelCase convention"
+    - ✅ "Split 'User' class - it has 28 properties (recommended max: 15)"
+    - ✅ "Add pagination to 'GET /users' endpoint" (optional user focus + metrics)
 - 📋 Prioritized action items (quick wins first)
 - 📋 Estimated score impact for each fix
 - 📋 Bulk apply recommendations
 
 | Ticket | Feature Description                    |
 |--------|----------------------------------------|
-| #253   | AI powered suggestions for improvement |
+| #253   | AI powered suggestions for improvement ✅ |
 | #254   | Prioritized action items               |
 | #255   | Estimated score impact for each fix    |
 | #256   | Add bulk apply recommendations         |

--- a/objectified-ui/lib/ai-schema-improvement-suggestions.ts
+++ b/objectified-ui/lib/ai-schema-improvement-suggestions.ts
@@ -3,6 +3,9 @@
  * Expects a single ```json ... ``` markdown block from that Ollama task.
  */
 
+/** Maximum number of class names included in an improvement-suggestions request. */
+export const CLASS_NAMES_CAP = 150;
+
 export type AiSchemaImprovementCategory =
   | 'documentation'
   | 'naming'

--- a/objectified-ui/lib/ai-schema-improvement-suggestions.ts
+++ b/objectified-ui/lib/ai-schema-improvement-suggestions.ts
@@ -1,0 +1,99 @@
+/**
+ * Parse structured AI responses for schema_improvement_suggestions (#253).
+ * Expects a single ```json ... ``` markdown block from that Ollama task.
+ */
+
+export type AiSchemaImprovementCategory =
+  | 'documentation'
+  | 'naming'
+  | 'structure'
+  | 'api'
+  | 'performance'
+  | 'other';
+
+export type AiSchemaImprovementSuggestion = {
+  title: string;
+  detail: string;
+  category: AiSchemaImprovementCategory;
+};
+
+export type AiSchemaImprovementSuggestionsPayload = {
+  thinking: string;
+  summary: string;
+  suggestions: AiSchemaImprovementSuggestion[];
+};
+
+function extractLastJsonCodeBlock(text: string): string | null {
+  const re = /```(?:json)?\s*([\s\S]*?)```/gi;
+  let last: string | null = null;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(text)) !== null) {
+    last = m[1].trim();
+  }
+  return last;
+}
+
+function isNonEmptyString(v: unknown): v is string {
+  return typeof v === 'string' && v.trim().length > 0;
+}
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return v !== null && typeof v === 'object' && !Array.isArray(v);
+}
+
+const CATEGORIES: ReadonlySet<string> = new Set([
+  'documentation',
+  'naming',
+  'structure',
+  'api',
+  'performance',
+  'other',
+]);
+
+function normalizeCategory(raw: unknown): AiSchemaImprovementCategory {
+  if (typeof raw === 'string' && CATEGORIES.has(raw.trim())) {
+    return raw.trim() as AiSchemaImprovementCategory;
+  }
+  return 'other';
+}
+
+/**
+ * Returns null if the response does not contain valid structured suggestions.
+ */
+export function parseAiSchemaImprovementSuggestionsResponse(markdown: string): AiSchemaImprovementSuggestionsPayload | null {
+  const raw = extractLastJsonCodeBlock(markdown.trim());
+  if (!raw) return null;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+
+  if (!isPlainObject(parsed)) return null;
+
+  const thinking = isNonEmptyString(parsed.thinking) ? parsed.thinking.trim() : '';
+  const summary = isNonEmptyString(parsed.summary) ? parsed.summary.trim() : '';
+  const suggestionsRaw = parsed.suggestions;
+
+  if (!Array.isArray(suggestionsRaw) || suggestionsRaw.length === 0) return null;
+
+  const suggestions: AiSchemaImprovementSuggestion[] = [];
+
+  for (const item of suggestionsRaw) {
+    if (!isPlainObject(item)) continue;
+    const title = typeof item.title === 'string' ? item.title.trim() : '';
+    const detail = typeof item.detail === 'string' ? item.detail.trim() : '';
+    if (!title || !detail) continue;
+    suggestions.push({
+      title,
+      detail,
+      category: normalizeCategory(item.category),
+    });
+  }
+
+  if (suggestions.length === 0) return null;
+
+  return { thinking, summary, suggestions };
+}

--- a/objectified-ui/lib/studio-metrics-digest-for-ai.ts
+++ b/objectified-ui/lib/studio-metrics-digest-for-ai.ts
@@ -1,0 +1,87 @@
+/**
+ * Compact digest of Schema Metrics for Ollama improvement-suggestions (#253).
+ * Caps list sizes so large canvases stay within prompt budget.
+ */
+
+import type { SchemaMetricsResult } from '@/app/utils/schema-metrics';
+
+const MAX_NAMES = 48;
+const MAX_PROP_ROWS = 60;
+const MAX_DEP_ROWS = 24;
+
+function take<T>(arr: T[], n: number): T[] {
+  return arr.length <= n ? arr : arr.slice(0, n);
+}
+
+/**
+ * Human-readable block appended to the model system prompt.
+ */
+export function buildStudioMetricsDigestForAi(metrics: SchemaMetricsResult): string {
+  const lines: string[] = [];
+  lines.push('## Live schema metrics (Studio canvas)');
+  lines.push(`- Classes: ${metrics.classCount}`);
+  lines.push(`- Total properties: ${metrics.totalProperties}`);
+  lines.push(`- Avg properties per class: ${metrics.averagePropertiesPerClass.toFixed(1)}`);
+  lines.push(`- Relationship edges: ${metrics.relationshipCount}`);
+  lines.push(`- Complexity score: ${metrics.complexityScore} (${metrics.complexityLabel})`);
+  lines.push(`- Documentation completion: ${metrics.documentationCompletionPercentage}%`);
+  lines.push(`- Naming compliance (PascalCase classes + camelCase props): ${metrics.namingCompliance.compliancePercentage}%`);
+  lines.push(`- Circular dependency groups: ${metrics.circularDependencyCount}`);
+  lines.push(`- Deepest dependency chain length: ${metrics.deepestChainLength}`);
+
+  if (metrics.hubNames.length) {
+    lines.push(`- Hub classes (sample): ${take(metrics.hubNames, MAX_NAMES).join(', ')}${metrics.hubNames.length > MAX_NAMES ? ' …' : ''}`);
+  }
+  if (metrics.isolatedNames.length) {
+    lines.push(`- Isolated classes (sample): ${take(metrics.isolatedNames, MAX_NAMES).join(', ')}${metrics.isolatedNames.length > MAX_NAMES ? ' …' : ''}`);
+  }
+  if (metrics.circularSampleNames.length) {
+    lines.push(
+      `- Classes in cycles (sample): ${take(metrics.circularSampleNames, MAX_NAMES).join(', ')}${metrics.circularSampleNames.length > MAX_NAMES ? ' …' : ''}`,
+    );
+  }
+
+  if (metrics.classesMissingDocumentation.length) {
+    const c = take(metrics.classesMissingDocumentation, MAX_NAMES);
+    lines.push(
+      `- Classes missing description (${metrics.classesMissingDocumentation.length}): ${c.join(', ')}${metrics.classesMissingDocumentation.length > MAX_NAMES ? ' …' : ''}`,
+    );
+  }
+  if (metrics.propertiesMissingDocumentation.length) {
+    lines.push('- Properties missing description (sample):');
+    for (const row of take(metrics.propertiesMissingDocumentation, MAX_PROP_ROWS)) {
+      lines.push(`  - ${row.className}.${row.propertyName}`);
+    }
+    if (metrics.propertiesMissingDocumentation.length > MAX_PROP_ROWS) {
+      lines.push(`  … and ${metrics.propertiesMissingDocumentation.length - MAX_PROP_ROWS} more`);
+    }
+  }
+
+  if (metrics.namingCompliance.classesNonPascal.length) {
+    const c = take(metrics.namingCompliance.classesNonPascal, MAX_NAMES);
+    lines.push(
+      `- Class names not PascalCase (${metrics.namingCompliance.classesNonPascal.length}): ${c.join(', ')}${metrics.namingCompliance.classesNonPascal.length > MAX_NAMES ? ' …' : ''}`,
+    );
+  }
+  if (metrics.namingCompliance.propertiesNonCamel.length) {
+    lines.push('- Properties not camelCase (sample):');
+    for (const row of take(metrics.namingCompliance.propertiesNonCamel, MAX_PROP_ROWS)) {
+      lines.push(`  - ${row.className}.${row.propertyName}`);
+    }
+    if (metrics.namingCompliance.propertiesNonCamel.length > MAX_PROP_ROWS) {
+      lines.push(`  … and ${metrics.namingCompliance.propertiesNonCamel.length - MAX_PROP_ROWS} more`);
+    }
+  }
+
+  if (metrics.dependencyMetricsPerClass?.length) {
+    const sorted = [...metrics.dependencyMetricsPerClass].sort((a, b) => b.outDegree + b.inDegree - (a.outDegree + a.inDegree));
+    lines.push('- Heaviest classes by degree (sample):');
+    for (const row of take(sorted, MAX_DEP_ROWS)) {
+      lines.push(`  - ${row.className}: in ${row.inDegree}, out ${row.outDegree}, betweenness ${row.betweenness.toFixed(3)}`);
+    }
+  }
+
+  lines.push('');
+  lines.push('Use these numbers and names to make suggestions concrete (quote class/property names when relevant).');
+  return lines.join('\n');
+}

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.68",
+  "version": "0.11.69",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -27,6 +27,7 @@ We continue to improve the platform based on your feedback with improvements and
 - Projects list includes a **Show deleted** switch; when on, soft-deleted projects appear with a **Deleted** badge and **Restore** or **permanent delete** in the row menu (#2981).
 
 ## Studio
+- **Schema Metrics** panel includes a **lightbulb** control that opens **AI improvement suggestions**: Ollama reads live canvas metrics (documentation %, naming compliance, complexity, samples of gaps) and returns a structured, copy-friendly list of actionable ideas (#253).
 - **Add Property** and **Edit Property** include **Analyze** on the Basics step (advanced Form view includes it in Basics): opens the same **AI property suggestions** dialog as the sidebar robot control (#276).
 - The **AI property suggestions** dialog opens when you start **Add Class** (or **Create this class** from chat), when the new **class name** reaches two characters, after saving your **first** or **third** property in a single-property add (not during bulk **Add all suggested**), from **AI suggest properties** in the sidebar, or when chat includes **Open AI property suggestions** (#275).
 - **Suggest properties with AI** names the bulk queue action **Add all suggested** (clearer next to **Open in Add Property**) (#274).

--- a/objectified-ui/src/app/ade/studio/components/SchemaMetricsPanel.tsx
+++ b/objectified-ui/src/app/ade/studio/components/SchemaMetricsPanel.tsx
@@ -24,6 +24,8 @@ interface SchemaMetricsPanelProps {
   versionLabel?: string;
   /** Called when user triggers an action (e.g. apply layout) */
   onSuggestionAction?: (suggestion: CanvasSuggestion) => void;
+  /** Opens AI improvement suggestions from live metrics (#253). */
+  onOpenAiImprovementSuggestions?: () => void;
   onClose?: () => void;
   isMinimized?: boolean;
   onMinimizeToggle?: () => void;
@@ -37,6 +39,7 @@ export default function SchemaMetricsPanel({
   projectName,
   versionLabel,
   onSuggestionAction,
+  onOpenAiImprovementSuggestions,
   onClose,
   isMinimized = false,
   onMinimizeToggle,
@@ -115,6 +118,18 @@ export default function SchemaMetricsPanel({
             <span className="text-sm font-semibold text-gray-800 dark:text-gray-200">Schema Metrics</span>
           </div>
           <div className="flex items-center gap-1">
+            {onOpenAiImprovementSuggestions && (
+              <button
+                type="button"
+                onClick={onOpenAiImprovementSuggestions}
+                className="p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-700 text-amber-600 dark:text-amber-400"
+                title="AI improvement suggestions from these metrics"
+                aria-label="AI improvement suggestions from these metrics"
+                data-testid="schema-metrics-ai-improvements"
+              >
+                <Lightbulb className="w-4 h-4" />
+              </button>
+            )}
             <button
               type="button"
               onClick={() =>

--- a/objectified-ui/src/app/ade/studio/editor/page.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/page.tsx
@@ -217,6 +217,8 @@ import { LayoutRevisionDiffDialog } from './components/LayoutRevisionDiffDialog'
 import DraggablePanel from '../components/DraggablePanel';
 import MemoryProfiler from '../components/MemoryProfiler';
 import SchemaMetricsPanel from '../components/SchemaMetricsPanel';
+import { AiSchemaImprovementSuggestionsDialog } from '../../../components/ade/studio/AiSchemaImprovementSuggestionsDialog';
+import { buildStudioMetricsDigestForAi } from '@lib/studio-metrics-digest-for-ai';
 import SchemaTimelinePanel from '../components/SchemaTimelinePanel';
 import SchemaVersionScoringPanel from '../components/SchemaVersionScoringPanel';
 import {
@@ -875,6 +877,9 @@ const StudioContent = () => {
   const [memoryProfilerMinimized, setMemoryProfilerMinimized] = useState(false);
   const [schemaMetricsOpen, setSchemaMetricsOpen] = useState(false);
   const [schemaMetricsMinimized, setSchemaMetricsMinimized] = useState(false);
+  const [aiImprovementDialogOpen, setAiImprovementDialogOpen] = useState(false);
+  const [aiImprovementDigest, setAiImprovementDigest] = useState('');
+  const [aiImprovementClassNames, setAiImprovementClassNames] = useState<string[]>([]);
   const [schemaTimelineOpen, setSchemaTimelineOpen] = useState(false);
   const [schemaTimelineMinimized, setSchemaTimelineMinimized] = useState(false);
   const [schemaVersionScoringOpen, setSchemaVersionScoringOpen] = useState(false);
@@ -939,6 +944,18 @@ const StudioContent = () => {
     if (classNodes.length === 0) return null;
     return computeSchemaMetrics(nodes, edges);
   }, [nodes, edges]);
+
+  const handleOpenAiImprovementSuggestions = useCallback(() => {
+    if (!schemaMetrics) return;
+    setAiImprovementDigest(buildStudioMetricsDigestForAi(schemaMetrics));
+    setAiImprovementClassNames(
+      nodes
+        .filter((n) => n.type !== 'groupNode')
+        .map((n) => String((n.data as { name?: string })?.name ?? '').trim())
+        .filter(Boolean),
+    );
+    setAiImprovementDialogOpen(true);
+  }, [schemaMetrics, nodes]);
 
   // #244: Version scoring panel — per-schema rows from the live canvas (same graph as metrics).
   // Only computed when the panel is open to avoid graph-traversal overhead during editing.
@@ -10513,6 +10530,7 @@ const StudioContent = () => {
                   projectName={selectedProject?.name}
                   versionLabel={selectedVersion?.version_id}
                   onSuggestionAction={handleSuggestionAction}
+                  onOpenAiImprovementSuggestions={handleOpenAiImprovementSuggestions}
                   onClose={() => setSchemaMetricsOpen(false)}
                   isMinimized={schemaMetricsMinimized}
                   onMinimizeToggle={() => setSchemaMetricsMinimized(!schemaMetricsMinimized)}
@@ -10586,6 +10604,15 @@ const StudioContent = () => {
             open={quickSnapshotCompareOpen}
             onOpenChange={setQuickSnapshotCompareOpen}
             snapshots={quickLayoutSnapshots}
+          />
+          <AiSchemaImprovementSuggestionsDialog
+            open={aiImprovementDialogOpen}
+            onClose={() => setAiImprovementDialogOpen(false)}
+            tenantId={currentTenantId}
+            projectId={selectedProjectId}
+            versionId={selectedVersionId || null}
+            studioMetricsDigest={aiImprovementDigest}
+            existingClassNames={aiImprovementClassNames}
           />
           <LayoutRevisionDiffDialog
             open={layoutDiffOpen}

--- a/objectified-ui/src/app/ade/studio/editor/page.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/page.tsx
@@ -219,6 +219,7 @@ import MemoryProfiler from '../components/MemoryProfiler';
 import SchemaMetricsPanel from '../components/SchemaMetricsPanel';
 import { AiSchemaImprovementSuggestionsDialog } from '../../../components/ade/studio/AiSchemaImprovementSuggestionsDialog';
 import { buildStudioMetricsDigestForAi } from '@lib/studio-metrics-digest-for-ai';
+import { CLASS_NAMES_CAP } from '@lib/ai-schema-improvement-suggestions';
 import SchemaTimelinePanel from '../components/SchemaTimelinePanel';
 import SchemaVersionScoringPanel from '../components/SchemaVersionScoringPanel';
 import {
@@ -953,7 +954,7 @@ const StudioContent = () => {
       .map((n) => String((n.data as { name?: string })?.name ?? '').trim())
       .filter(Boolean);
     const deduped = [...new Set(allNames)].sort();
-    setAiImprovementClassNames(deduped.slice(0, 150));
+    setAiImprovementClassNames(deduped.slice(0, CLASS_NAMES_CAP));
     setAiImprovementDialogOpen(true);
   }, [schemaMetrics, nodes]);
 

--- a/objectified-ui/src/app/ade/studio/editor/page.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/page.tsx
@@ -948,12 +948,12 @@ const StudioContent = () => {
   const handleOpenAiImprovementSuggestions = useCallback(() => {
     if (!schemaMetrics) return;
     setAiImprovementDigest(buildStudioMetricsDigestForAi(schemaMetrics));
-    setAiImprovementClassNames(
-      nodes
-        .filter((n) => n.type !== 'groupNode')
-        .map((n) => String((n.data as { name?: string })?.name ?? '').trim())
-        .filter(Boolean),
-    );
+    const allNames = nodes
+      .filter((n) => n.type !== 'groupNode')
+      .map((n) => String((n.data as { name?: string })?.name ?? '').trim())
+      .filter(Boolean);
+    const deduped = [...new Set(allNames)].sort();
+    setAiImprovementClassNames(deduped.slice(0, 150));
     setAiImprovementDialogOpen(true);
   }, [schemaMetrics, nodes]);
 

--- a/objectified-ui/src/app/api/ollama/chat/query-cache.ts
+++ b/objectified-ui/src/app/api/ollama/chat/query-cache.ts
@@ -64,6 +64,8 @@ export type OllamaChatCacheKeyInput = {
   versionId?: string;
   /** Client SHA-256 of full class/property schemas so cache invalidates when OpenAPI state changes (#526). */
   schemaContextFingerprint?: unknown;
+  /** Studio metrics digest for schema_improvement_suggestions (#253). */
+  studioMetricsDigest?: unknown;
   messages: unknown;
 };
 
@@ -76,6 +78,10 @@ export function normalizeSchemaContextFingerprint(value: unknown): string | null
 /** Hash of request fields excluding messages — semantic hits require this to match exactly. */
 export function ollamaChatSemanticContextKey(input: Omit<OllamaChatCacheKeyInput, 'messages'>): string {
   const fp = normalizeSchemaContextFingerprint(input.schemaContextFingerprint);
+  const digest =
+    typeof input.studioMetricsDigest === 'string' && input.studioMetricsDigest.trim()
+      ? input.studioMetricsDigest.trim().slice(0, 64_000)
+      : null;
   const payload = stableStringify({
     model: input.model.trim(),
     task: input.task ?? null,
@@ -85,6 +91,7 @@ export function ollamaChatSemanticContextKey(input: Omit<OllamaChatCacheKeyInput
     currentTableName: input.currentTableName ?? null,
     versionId: input.versionId ?? null,
     schemaContextFingerprint: fp,
+    studioMetricsDigest: digest,
   });
   return createHash('sha256').update(payload, 'utf8').digest('hex');
 }
@@ -112,6 +119,10 @@ export function cosineSimilarity(a: number[], b: number[]): number {
 
 export function ollamaChatCacheKey(input: OllamaChatCacheKeyInput): string {
   const fp = normalizeSchemaContextFingerprint(input.schemaContextFingerprint);
+  const digest =
+    typeof input.studioMetricsDigest === 'string' && input.studioMetricsDigest.trim()
+      ? input.studioMetricsDigest.trim().slice(0, 64_000)
+      : null;
   const payload = stableStringify({
     model: input.model.trim(),
     task: input.task ?? null,
@@ -121,6 +132,7 @@ export function ollamaChatCacheKey(input: OllamaChatCacheKeyInput): string {
     currentTableName: input.currentTableName ?? null,
     versionId: input.versionId ?? null,
     schemaContextFingerprint: fp,
+    studioMetricsDigest: digest,
     messages: input.messages,
   });
   return createHash('sha256').update(payload, 'utf8').digest('hex');

--- a/objectified-ui/src/app/api/ollama/chat/route.ts
+++ b/objectified-ui/src/app/api/ollama/chat/route.ts
@@ -292,6 +292,8 @@ Return **exactly one** markdown fenced JSON block and **nothing outside the fenc
 - Prefer distinct suggestions; do not repeat the same idea with different wording.
 - Do not output OpenAPI JSON, full schemas, or code blocks other than the single fenced JSON payload.`;
 
+const CLASS_NAMES_CAP = 150;
+
 function buildSchemaImprovementSuggestionsSystem(options: {
   studioMetricsDigest: string;
   existingClassNames?: string[];
@@ -299,7 +301,11 @@ function buildSchemaImprovementSuggestionsSystem(options: {
   let s = SCHEMA_IMPROVEMENT_SUGGESTIONS_SYSTEM;
   s += `\n\n# Studio metrics digest\n\n${options.studioMetricsDigest.trim()}`;
   if (options.existingClassNames?.length) {
-    s += `\n\n# Class names on canvas (PascalCase expected)\n${options.existingClassNames.join(', ')}`;
+    const deduped = [...new Set(options.existingClassNames)].sort();
+    const capped = deduped.slice(0, CLASS_NAMES_CAP);
+    const overflow = deduped.length - capped.length;
+    const suffix = overflow > 0 ? `, … and ${overflow} more` : '';
+    s += `\n\n# Class names on canvas (PascalCase expected)\n${capped.join(', ')}${suffix}`;
   }
   return s;
 }

--- a/objectified-ui/src/app/api/ollama/chat/route.ts
+++ b/objectified-ui/src/app/api/ollama/chat/route.ts
@@ -255,6 +255,55 @@ function buildPropertyTypeSuggestionsSystem(options: {
   return s;
 }
 
+const SCHEMA_IMPROVEMENT_SUGGESTIONS_SYSTEM = `You are a senior API and JSON Schema reviewer helping a team improve an OpenAPI 3.1–oriented data model in Objectified Studio.
+
+You receive **measured canvas metrics** (class counts, documentation coverage, naming compliance, dependency complexity, samples of gaps). Your job is to propose **prioritized, actionable improvements** that a human can follow—similar in tone to:
+
+- "Add descriptions to N classes to improve docs score"
+- "Rename M properties to follow camelCase convention"
+- "Split 'X' class — it has many properties (recommend decomposition when a class mixes unrelated concerns)"
+- "Add pagination to 'GET /…' list endpoints" (when the user or digest implies large collections / list APIs)
+
+# Output format
+
+Return **exactly one** markdown fenced JSON block and **nothing outside the fence** (no preamble, no trailing commentary):
+
+\`\`\`json
+{
+  "thinking": "2–5 sentences: how you read the metrics and what you prioritized.",
+  "summary": "2–4 sentences: overall themes in your suggestion set.",
+  "suggestions": [
+    {
+      "title": "Short imperative headline the user can scan (max ~120 chars).",
+      "detail": "Concrete explanation: what to change, where to look, and why it helps quality or maintainability.",
+      "category": "documentation"
+    }
+  ]
+}
+\`\`\`
+
+# Rules
+
+- Emit **6–12** suggestions unless the digest is extremely small (then 3–5 is fine).
+- Every "title" and "detail" must be non-empty strings.
+- "category" must be one of: "documentation", "naming", "structure", "api", "performance", "other". Pick the best fit per row.
+- Ground suggestions in the **digest numbers and named classes/properties** when present—do not invent entities that contradict the digest.
+- It is acceptable to mention **future** API design (pagination, error models, versioning) when metrics imply large graphs, hubs, or wide classes—even if paths are not listed.
+- Prefer distinct suggestions; do not repeat the same idea with different wording.
+- Do not output OpenAPI JSON, full schemas, or code blocks other than the single fenced JSON payload.`;
+
+function buildSchemaImprovementSuggestionsSystem(options: {
+  studioMetricsDigest: string;
+  existingClassNames?: string[];
+}): string {
+  let s = SCHEMA_IMPROVEMENT_SUGGESTIONS_SYSTEM;
+  s += `\n\n# Studio metrics digest\n\n${options.studioMetricsDigest.trim()}`;
+  if (options.existingClassNames?.length) {
+    s += `\n\n# Class names on canvas (PascalCase expected)\n${options.existingClassNames.join(', ')}`;
+  }
+  return s;
+}
+
 export async function POST(request: NextRequest) {
   try {
     const {
@@ -267,6 +316,7 @@ export async function POST(request: NextRequest) {
       currentTableName,
       versionId,
       schemaContextFingerprint,
+      studioMetricsDigest,
       targetPropertyName,
       targetClassName,
     } = await request.json();
@@ -282,7 +332,20 @@ export async function POST(request: NextRequest) {
     const isDataQuery = task === 'data_query';
     const isPropertySuggestions = task === 'property_suggestions';
     const isPropertyTypeSuggestions = task === 'property_type_suggestions';
+    const isSchemaImprovementSuggestions = task === 'schema_improvement_suggestions';
     const usesPropertyLibraryContext = isClassSkeleton || isPropertySuggestions || isPropertyTypeSuggestions;
+
+    const digestStr =
+      typeof studioMetricsDigest === 'string' && studioMetricsDigest.trim().length > 0
+        ? studioMetricsDigest.trim().slice(0, 64_000)
+        : '';
+
+    if (isSchemaImprovementSuggestions && !digestStr) {
+      return new Response(
+        JSON.stringify({ error: 'Invalid request: studioMetricsDigest is required for schema_improvement_suggestions' }),
+        { status: 400, headers: { 'Content-Type': 'application/json' } },
+      );
+    }
 
     // Create a system message to guide the LLM
     const systemContent = isClassSkeleton
@@ -307,6 +370,13 @@ export async function POST(request: NextRequest) {
                 targetPropertyName: typeof targetPropertyName === 'string' ? targetPropertyName : undefined,
                 targetClassName: typeof targetClassName === 'string' ? targetClassName : undefined,
               })
+            : isSchemaImprovementSuggestions
+              ? buildSchemaImprovementSuggestionsSystem({
+                  studioMetricsDigest: digestStr,
+                  existingClassNames: Array.isArray(existingClassNames)
+                    ? existingClassNames.filter((n: unknown): n is string => typeof n === 'string' && n.trim().length > 0)
+                    : undefined,
+                })
             : `You are an expert API designer and OpenAPI specification generator. Your task is to help users create OpenAPI 3.1.0 specifications based on their natural language descriptions.
 
 # Rules
@@ -373,27 +443,32 @@ Do not repeat the full JSON spec outside the code block. Do not add other sectio
     // Prepare messages with system prompt
     const fullMessages = [systemMessage, ...messages];
 
+    const improvementClassNames =
+      isSchemaImprovementSuggestions && Array.isArray(existingClassNames) ? existingClassNames : undefined;
+
     const cacheKey = ollamaChatCacheKey({
       model: typeof model === 'string' ? model : '',
       task: typeof task === 'string' ? task : undefined,
-      existingClassNames: usesPropertyLibraryContext ? existingClassNames : undefined,
+      existingClassNames: usesPropertyLibraryContext ? existingClassNames : improvementClassNames,
       existingProperties: usesPropertyLibraryContext ? existingProperties : undefined,
       tableNames: isDataQuery ? tableNames : undefined,
       currentTableName: isDataQuery ? currentTableName : undefined,
       versionId: typeof versionId === 'string' ? versionId : undefined,
       schemaContextFingerprint,
+      studioMetricsDigest: isSchemaImprovementSuggestions ? digestStr : undefined,
       messages,
     });
 
     const semanticContextKey = ollamaChatSemanticContextKey({
       model: typeof model === 'string' ? model : '',
       task: typeof task === 'string' ? task : undefined,
-      existingClassNames: usesPropertyLibraryContext ? existingClassNames : undefined,
+      existingClassNames: usesPropertyLibraryContext ? existingClassNames : improvementClassNames,
       existingProperties: usesPropertyLibraryContext ? existingProperties : undefined,
       tableNames: isDataQuery ? tableNames : undefined,
       currentTableName: isDataQuery ? currentTableName : undefined,
       versionId: typeof versionId === 'string' ? versionId : undefined,
       schemaContextFingerprint,
+      studioMetricsDigest: isSchemaImprovementSuggestions ? digestStr : undefined,
     });
 
     const cached = getCachedOllamaChatResponse(cacheKey);

--- a/objectified-ui/src/app/api/ollama/chat/route.ts
+++ b/objectified-ui/src/app/api/ollama/chat/route.ts
@@ -16,6 +16,7 @@ import {
   ollamaSemanticCacheThreshold,
   setCachedOllamaChatResponse,
 } from './query-cache';
+import { CLASS_NAMES_CAP } from '@lib/ai-schema-improvement-suggestions';
 
 const OLLAMA_BASE_URL = process.env.OLLAMA_BASE_URL || 'http://localhost:11434';
 
@@ -291,8 +292,6 @@ Return **exactly one** markdown fenced JSON block and **nothing outside the fenc
 - It is acceptable to mention **future** API design (pagination, error models, versioning) when metrics imply large graphs, hubs, or wide classes—even if paths are not listed.
 - Prefer distinct suggestions; do not repeat the same idea with different wording.
 - Do not output OpenAPI JSON, full schemas, or code blocks other than the single fenced JSON payload.`;
-
-const CLASS_NAMES_CAP = 150;
 
 function buildSchemaImprovementSuggestionsSystem(options: {
   studioMetricsDigest: string;

--- a/objectified-ui/src/app/components/ade/studio/AiSchemaImprovementSuggestionsDialog.tsx
+++ b/objectified-ui/src/app/components/ade/studio/AiSchemaImprovementSuggestionsDialog.tsx
@@ -1,0 +1,347 @@
+'use client';
+
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '../../ui/Dialog';
+import { Button } from '../../ui/Button';
+import { Textarea } from '../../ui/Textarea';
+import { Bot, Copy, Loader2, Square, Sparkles } from 'lucide-react';
+import {
+  parseAiSchemaImprovementSuggestionsResponse,
+  type AiSchemaImprovementSuggestionsPayload,
+} from '@lib/ai-schema-improvement-suggestions';
+import {
+  resolvePreferredOllamaModel,
+  persistOllamaModelChoiceForScope,
+} from '@/app/ade/studio/components/chatbot/ollama-model-defaults';
+import { accumulateOllamaSse } from '@lib/ollama-chat-sse';
+
+export interface AiSchemaImprovementSuggestionsDialogProps {
+  open: boolean;
+  onClose: () => void;
+  tenantId: string | null | undefined;
+  projectId: string;
+  versionId: string | null | undefined;
+  /** Pre-built digest from Schema Metrics (required when generating). */
+  studioMetricsDigest: string;
+  existingClassNames: string[];
+}
+
+const CATEGORY_LABEL: Record<string, string> = {
+  documentation: 'Docs',
+  naming: 'Naming',
+  structure: 'Structure',
+  api: 'API',
+  performance: 'Performance',
+  other: 'Other',
+};
+
+export function AiSchemaImprovementSuggestionsDialog({
+  open,
+  onClose,
+  tenantId,
+  projectId,
+  versionId,
+  studioMetricsDigest,
+  existingClassNames,
+}: AiSchemaImprovementSuggestionsDialogProps) {
+  const [hint, setHint] = useState('');
+  const [modelNames, setModelNames] = useState<string[]>([]);
+  const [selectedModel, setSelectedModel] = useState('');
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [streamText, setStreamText] = useState('');
+  const [parsed, setParsed] = useState<AiSchemaImprovementSuggestionsPayload | null>(null);
+  const [parseError, setParseError] = useState<string | null>(null);
+  const [copyIdx, setCopyIdx] = useState<number | null>(null);
+  const abortRef = React.useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch('/api/ollama/models');
+        const json = (await res.json()) as { success?: boolean; models?: { name?: string }[] };
+        const list = res.ok && json.success && Array.isArray(json.models) ? json.models : undefined;
+        const names = Array.isArray(list)
+          ? list.map((m) => m?.name).filter((n): n is string => typeof n === 'string' && n.trim().length > 0)
+          : [];
+        if (cancelled) return;
+        setModelNames(names);
+        const preferred = resolvePreferredOllamaModel({
+          tenantId,
+          projectId,
+          availableModelNames: names,
+          storage: typeof window !== 'undefined' ? window.localStorage : null,
+        });
+        setSelectedModel(preferred);
+      } catch {
+        if (!cancelled) {
+          setModelNames([]);
+          setSelectedModel('');
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [open, tenantId, projectId]);
+
+  useEffect(() => {
+    if (!open) {
+      setHint('');
+      setStreamText('');
+      setParsed(null);
+      setParseError(null);
+      setCopyIdx(null);
+      setIsGenerating(false);
+      abortRef.current?.abort();
+      abortRef.current = null;
+    }
+  }, [open]);
+
+  const handleStop = useCallback(() => {
+    abortRef.current?.abort();
+    abortRef.current = null;
+    setIsGenerating(false);
+  }, []);
+
+  const handleGenerate = useCallback(async () => {
+    const trimmedHint = hint.trim();
+    if (!selectedModel.trim()) {
+      setParseError('Pick an Ollama model first.');
+      return;
+    }
+    if (!studioMetricsDigest.trim()) {
+      setParseError('Schema metrics are not available.');
+      return;
+    }
+
+    persistOllamaModelChoiceForScope({
+      tenantId,
+      projectId,
+      modelName: selectedModel,
+      storage: typeof window !== 'undefined' ? window.localStorage : null,
+    });
+
+    abortRef.current?.abort();
+    const ac = new AbortController();
+    abortRef.current = ac;
+
+    setIsGenerating(true);
+    setStreamText('');
+    setParsed(null);
+    setParseError(null);
+
+    const userLines = [
+      'Based on the Studio metrics digest in your system context, propose improvement suggestions as specified.',
+      trimmedHint ? `Additional focus from the user: ${trimmedHint}` : '',
+    ].filter(Boolean);
+
+    try {
+      const response = await fetch('/api/ollama/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        signal: ac.signal,
+        body: JSON.stringify({
+          model: selectedModel.trim(),
+          task: 'schema_improvement_suggestions',
+          messages: [{ role: 'user', content: userLines.join('\n\n') }],
+          existingClassNames,
+          studioMetricsDigest: studioMetricsDigest.trim(),
+          ...(typeof versionId === 'string' && versionId ? { versionId } : {}),
+        }),
+      });
+
+      if (!response.ok) {
+        const t = await response.text().catch(() => '');
+        throw new Error(t || `Request failed (${response.status})`);
+      }
+
+      const full = await accumulateOllamaSse(response, ac.signal, (acc) => setStreamText(acc));
+      setStreamText(full);
+
+      if (ac.signal.aborted) return;
+
+      const structured = parseAiSchemaImprovementSuggestionsResponse(full);
+      if (structured) {
+        setParsed(structured);
+        setParseError(null);
+      } else {
+        setParseError(
+          'The model response could not be read as structured suggestions. Try again, or shorten the optional focus note.',
+        );
+      }
+    } catch (e) {
+      if (ac.signal.aborted) {
+        setParseError(null);
+      } else {
+        setParseError(e instanceof Error ? e.message : 'Something went wrong.');
+      }
+    } finally {
+      setIsGenerating(false);
+      abortRef.current = null;
+    }
+  }, [hint, selectedModel, tenantId, projectId, versionId, studioMetricsDigest, existingClassNames]);
+
+  const handleCopyRow = async (idx: number, title: string, detail: string) => {
+    const text = `${title}\n\n${detail}`;
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopyIdx(idx);
+      window.setTimeout(() => setCopyIdx((c) => (c === idx ? null : c)), 2000);
+    } catch {
+      setParseError('Could not copy to clipboard.');
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
+      <DialogContent className="max-w-lg max-h-[90vh] flex flex-col gap-0 p-0 overflow-hidden sm:max-w-lg">
+        <DialogHeader className="px-4 pt-4 pb-2 border-b border-gray-200 dark:border-gray-700 shrink-0">
+          <DialogTitle className="flex items-center gap-2 text-base">
+            <Sparkles className="h-4 w-4 text-amber-500 shrink-0" aria-hidden />
+            AI improvement suggestions
+          </DialogTitle>
+          <p className="text-xs text-gray-500 dark:text-gray-400 font-normal pt-1">
+            Uses live Schema Metrics and class names from the canvas. Suggestions are advisory—review before changing your model.
+          </p>
+        </DialogHeader>
+
+        <div className="flex-1 min-h-0 overflow-y-auto px-4 py-3 space-y-3">
+          <div className="flex flex-wrap items-end gap-2">
+            <label className="flex flex-col gap-1 text-xs font-medium text-gray-700 dark:text-gray-300 min-w-[12rem] flex-1">
+              Model
+              <select
+                data-testid="ai-schema-improvement-model"
+                className="h-9 w-full rounded-md border border-gray-200 bg-white px-2 text-sm dark:border-gray-600 dark:bg-gray-900"
+                value={selectedModel}
+                onChange={(e) => setSelectedModel(e.target.value)}
+                disabled={isGenerating || modelNames.length === 0}
+              >
+                {modelNames.length === 0 ? (
+                  <option value="">No models</option>
+                ) : (
+                  modelNames.map((name) => (
+                    <option key={name} value={name}>
+                      {name}
+                    </option>
+                  ))
+                )}
+              </select>
+            </label>
+            <Button
+              type="button"
+              variant="default"
+              className="shrink-0"
+              data-testid="ai-schema-improvement-generate"
+              disabled={isGenerating || !selectedModel.trim() || modelNames.length === 0}
+              onClick={() => void handleGenerate()}
+            >
+              {isGenerating ? (
+                <>
+                  <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                  Generating…
+                </>
+              ) : (
+                <>
+                  <Bot className="h-4 w-4 mr-2" />
+                  Generate
+                </>
+              )}
+            </Button>
+            {isGenerating && (
+              <Button type="button" variant="outline" data-testid="ai-schema-improvement-stop" onClick={handleStop}>
+                <Square className="h-4 w-4 mr-2" />
+                Stop
+              </Button>
+            )}
+          </div>
+
+          <label className="flex flex-col gap-1 text-xs font-medium text-gray-700 dark:text-gray-300">
+            Optional focus (paths, product area, constraints)
+            <Textarea
+              data-testid="ai-schema-improvement-hint"
+              value={hint}
+              onChange={(e) => setHint(e.target.value)}
+              rows={3}
+              disabled={isGenerating}
+              placeholder="e.g. We expose GET /orders and GET /users list endpoints—comment on pagination."
+              className="text-sm resize-y min-h-[4rem]"
+            />
+          </label>
+
+          {parseError && (
+            <p className="text-sm text-red-600 dark:text-red-400" data-testid="ai-schema-improvement-error">
+              {parseError}
+            </p>
+          )}
+
+          {parsed && (
+            <div className="space-y-2">
+              {parsed.summary ? (
+                <p className="text-sm text-gray-700 dark:text-gray-300 border border-gray-200 dark:border-gray-600 rounded-md p-2 bg-gray-50 dark:bg-gray-900/40">
+                  {parsed.summary}
+                </p>
+              ) : null}
+              <ul className="space-y-2" data-testid="ai-schema-improvement-list">
+                {parsed.suggestions.map((s, i) => (
+                  <li
+                    key={`${i}-${s.title}`}
+                    className="rounded-lg border border-gray-200 dark:border-gray-600 p-3 bg-white dark:bg-gray-900/30"
+                    data-testid={`ai-schema-improvement-item-${i}`}
+                  >
+                    <div className="flex items-start justify-between gap-2">
+                      <div className="min-w-0 flex-1">
+                        <div className="flex flex-wrap items-center gap-2 mb-1">
+                          <span className="text-sm font-semibold text-gray-900 dark:text-gray-100">{s.title}</span>
+                          <span className="text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded bg-indigo-100 text-indigo-800 dark:bg-indigo-950 dark:text-indigo-200">
+                            {CATEGORY_LABEL[s.category] ?? s.category}
+                          </span>
+                        </div>
+                        <p className="text-xs text-gray-600 dark:text-gray-400 whitespace-pre-wrap">{s.detail}</p>
+                      </div>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        className="shrink-0"
+                        data-testid={`ai-schema-improvement-copy-${i}`}
+                        onClick={() => void handleCopyRow(i, s.title, s.detail)}
+                      >
+                        <Copy className="h-3.5 w-3.5 mr-1" />
+                        {copyIdx === i ? 'Copied' : 'Copy'}
+                      </Button>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {isGenerating && streamText && !parsed && (
+            <pre
+              className="text-xs text-gray-500 dark:text-gray-400 whitespace-pre-wrap max-h-40 overflow-y-auto rounded border border-gray-100 dark:border-gray-700 p-2 bg-gray-50 dark:bg-gray-900/20"
+              data-testid="ai-schema-improvement-stream"
+            >
+              {streamText}
+            </pre>
+          )}
+        </div>
+
+        <DialogFooter className="px-4 py-3 border-t border-gray-200 dark:border-gray-700 shrink-0">
+          <Button type="button" variant="outline" onClick={onClose}>
+            Close
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/objectified-ui/src/app/components/ade/studio/AiSchemaImprovementSuggestionsDialog.tsx
+++ b/objectified-ui/src/app/components/ade/studio/AiSchemaImprovementSuggestionsDialog.tsx
@@ -187,7 +187,7 @@ export function AiSchemaImprovementSuggestionsDialog({
       }
     } finally {
       setIsGenerating(false);
-      abortRef.current = null;
+      if (abortRef.current === ac) abortRef.current = null;
     }
   }, [hint, selectedModel, tenantId, projectId, versionId, studioMetricsDigest, existingClassNames]);
 

--- a/objectified-ui/tests/api/ollama-query-cache.test.ts
+++ b/objectified-ui/tests/api/ollama-query-cache.test.ts
@@ -58,6 +58,17 @@ describe('ollamaChatCacheKey', () => {
     expect(k1).not.toBe(k2);
     expect(k1).not.toBe(kNone);
   });
+
+  it('changes when studioMetricsDigest differs (#253)', () => {
+    const base = {
+      model: 'm',
+      task: 'schema_improvement_suggestions',
+      messages: [{ role: 'user', content: 'go' }],
+    };
+    const a = ollamaChatCacheKey({ ...base, studioMetricsDigest: 'digest-a' });
+    const b = ollamaChatCacheKey({ ...base, studioMetricsDigest: 'digest-b' });
+    expect(a).not.toBe(b);
+  });
 });
 
 describe('normalizeSchemaContextFingerprint', () => {
@@ -154,6 +165,13 @@ describe('ollamaChatSemanticContextKey', () => {
     const base = { model: 'm', task: undefined };
     const a = ollamaChatSemanticContextKey({ ...base, schemaContextFingerprint: 'f1' });
     const b = ollamaChatSemanticContextKey({ ...base, schemaContextFingerprint: 'f2' });
+    expect(a).not.toBe(b);
+  });
+
+  it('changes when studioMetricsDigest differs (#253)', () => {
+    const base = { model: 'm', task: 'schema_improvement_suggestions' };
+    const a = ollamaChatSemanticContextKey({ ...base, studioMetricsDigest: 'x' });
+    const b = ollamaChatSemanticContextKey({ ...base, studioMetricsDigest: 'y' });
     expect(a).not.toBe(b);
   });
 });

--- a/objectified-ui/tests/unit/ai-schema-improvement-suggestions.test.ts
+++ b/objectified-ui/tests/unit/ai-schema-improvement-suggestions.test.ts
@@ -1,0 +1,42 @@
+import { parseAiSchemaImprovementSuggestionsResponse } from '../../lib/ai-schema-improvement-suggestions';
+
+describe('parseAiSchemaImprovementSuggestionsResponse', () => {
+  it('parses a valid fenced JSON payload', () => {
+    const md = `intro\n\n\`\`\`json\n{"thinking":"t","summary":"s","suggestions":[{"title":"Add docs","detail":"Fill descriptions","category":"documentation"}]}\n\`\`\``;
+    const p = parseAiSchemaImprovementSuggestionsResponse(md);
+    expect(p).not.toBeNull();
+    expect(p!.suggestions).toHaveLength(1);
+    expect(p!.suggestions[0].title).toBe('Add docs');
+    expect(p!.suggestions[0].category).toBe('documentation');
+  });
+
+  it('uses last json fence when multiple exist', () => {
+    const md =
+      '```json\n{"thinking":"","summary":"","suggestions":[{"title":"a","detail":"d","category":"other"}]}\n```\n\n```json\n{"thinking":"","summary":"","suggestions":[{"title":"b","detail":"d2","category":"naming"}]}\n```';
+    const p = parseAiSchemaImprovementSuggestionsResponse(md);
+    expect(p?.suggestions[0].title).toBe('b');
+  });
+
+  it('returns null when suggestions empty', () => {
+    const md = "```json\n{\"thinking\":\"x\",\"summary\":\"y\",\"suggestions\":[]}\n```";
+    expect(parseAiSchemaImprovementSuggestionsResponse(md)).toBeNull();
+  });
+
+  it('skips rows missing title or detail', () => {
+    const md =
+      "```json\n{\"thinking\":\"\",\"summary\":\"\",\"suggestions\":[{\"title\":\"\",\"detail\":\"x\",\"category\":\"other\"},{\"title\":\"ok\",\"detail\":\"\",\"category\":\"other\"},{\"title\":\"good\",\"detail\":\"body\",\"category\":\"api\"}]}\n```";
+    const r = parseAiSchemaImprovementSuggestionsResponse(md);
+    expect(r?.suggestions).toEqual([{ title: 'good', detail: 'body', category: 'api' }]);
+  });
+
+  it('normalizes unknown category to other', () => {
+    const md =
+      '```json\n{"thinking":"","summary":"","suggestions":[{"title":"x","detail":"y","category":"not-a-real-category"}]}\n```';
+    const r = parseAiSchemaImprovementSuggestionsResponse(md);
+    expect(r?.suggestions[0].category).toBe('other');
+  });
+
+  it('returns null when no json fence', () => {
+    expect(parseAiSchemaImprovementSuggestionsResponse('no fence')).toBeNull();
+  });
+});

--- a/objectified-ui/tests/unit/studio-metrics-digest-for-ai.test.ts
+++ b/objectified-ui/tests/unit/studio-metrics-digest-for-ai.test.ts
@@ -1,0 +1,48 @@
+import { buildStudioMetricsDigestForAi } from '../../lib/studio-metrics-digest-for-ai';
+import type { SchemaMetricsResult } from '@/app/utils/schema-metrics';
+
+function baseMetrics(over: Partial<SchemaMetricsResult> = {}): SchemaMetricsResult {
+  return {
+    classCount: 2,
+    totalProperties: 5,
+    averagePropertiesPerClass: 2.5,
+    relationshipCount: 1,
+    hubClassIds: [],
+    hubNames: ['User'],
+    isolatedClassIds: [],
+    isolatedNames: [],
+    deepestChainLength: 2,
+    circularDependencyCount: 0,
+    circularSampleNames: [],
+    circularDependencyNodeIds: [],
+    complexityScore: 40,
+    complexityLabel: 'Medium',
+    complexityBreakdown: [],
+    documentationCompletionPercentage: 50,
+    classesMissingDocumentation: ['Order'],
+    propertiesMissingDocumentation: [{ className: 'User', propertyName: 'email' }],
+    namingCompliance: {
+      classes: { pascal: 2, camel: 0, snake: 0, other: 0, total: 2 },
+      properties: { pascal: 0, camel: 4, snake: 1, other: 0, total: 5 },
+      compliancePercentage: 80,
+      classesNonPascal: [],
+      propertiesNonCamel: [{ className: 'User', propertyName: 'User_ID' }],
+    },
+    dependencyMetricsPerClass: [
+      { classId: '1', className: 'User', inDegree: 0, outDegree: 2, betweenness: 0.1 },
+    ],
+    ...over,
+  };
+}
+
+describe('buildStudioMetricsDigestForAi', () => {
+  it('includes headline stats and gap samples', () => {
+    const text = buildStudioMetricsDigestForAi(baseMetrics());
+    expect(text).toContain('Classes: 2');
+    expect(text).toContain('Documentation completion: 50%');
+    expect(text).toContain('Order');
+    expect(text).toContain('User.email');
+    expect(text).toContain('User_ID');
+    expect(text).toContain('Hub classes');
+  });
+});


### PR DESCRIPTION
## What changed
Implements **#253** (AI-powered suggestions for improvement) in Studio:

- New Ollama task `schema_improvement_suggestions` on `/api/ollama/chat` with a structured JSON contract (title, detail, category).
- **Schema Metrics** panel **lightbulb** opens a dialog that sends a capped **metrics digest** plus canvas class names; optional user **focus** text for API/path context.
- Ollama query cache / semantic context include `studioMetricsDigest` so responses do not bleed across different metric snapshots.
- Parser + digest builder + unit tests; `objectified-ui` patch **0.11.69**; `WHATS_NEW.md` and `PLANNED_FEATURE_ROADMAP_AI.md` updated.

## How to test
1. **Configure Ollama** (`OLLAMA_BASE_URL`) and ensure models load in Studio.
2. Open **Studio** → **editor** with a version that has classes on the canvas.
3. Open **Schema Metrics** (bar chart panel).
4. **Click the lightbulb** next to PDF export.
5. **Pick a model**, optionally add focus text, **Generate** — expect a list with categories and **Copy** per row.

## Risk / notes
- Suggestions are **advisory** only (no auto-apply); bulk apply remains future work (#256).
- Root `yarn build` failed here only because `uv` is missing for `objectified-mcp`; **objectified-ui** `yarn build` and targeted Jest suites passed.

Closes #253

Made with [Cursor](https://cursor.com)