### PR TITLE
Fix #254 - Prioritized AI improvement suggestions (quick wins first)

### DIFF
--- a/docs/PLANNED_FEATURE_ROADMAP_AI.md
+++ b/docs/PLANNED_FEATURE_ROADMAP_AI.md
@@ -78,13 +78,12 @@ This outlines the planned features for integrating AI capabilities into Objectif
     - ✅ "Rename 5 properties to follow camelCase convention"
     - ✅ "Split 'User' class - it has 28 properties (recommended max: 15)"
     - ✅ "Add pagination to 'GET /users' endpoint" (optional user focus + metrics)
-- 📋 Prioritized action items (quick wins first)
+- ✅ Prioritized action items (quick wins first) (#254)
 - 📋 Estimated score impact for each fix
 - 📋 Bulk apply recommendations
 
 | Ticket | Feature Description                    |
 |--------|----------------------------------------|
-| #254   | Prioritized action items               |
 | #255   | Estimated score impact for each fix    |
 | #256   | Add bulk apply recommendations         |
 

--- a/objectified-ui/lib/ai-schema-improvement-suggestions.ts
+++ b/objectified-ui/lib/ai-schema-improvement-suggestions.ts
@@ -14,10 +14,14 @@ export type AiSchemaImprovementCategory =
   | 'performance'
   | 'other';
 
+/** Relative implementation cost; quick wins are surfaced first (#254). */
+export type AiSchemaImprovementEffort = 'quick_win' | 'moderate' | 'substantial';
+
 export type AiSchemaImprovementSuggestion = {
   title: string;
   detail: string;
   category: AiSchemaImprovementCategory;
+  effort: AiSchemaImprovementEffort;
 };
 
 export type AiSchemaImprovementSuggestionsPayload = {
@@ -60,6 +64,27 @@ function normalizeCategory(raw: unknown): AiSchemaImprovementCategory {
   return 'other';
 }
 
+function normalizeEffort(raw: unknown): AiSchemaImprovementEffort {
+  if (typeof raw !== 'string') return 'moderate';
+  const key = raw.trim().toLowerCase().replace(/-/g, '_');
+  if (key === 'quick_win' || key === 'quickwin') return 'quick_win';
+  if (key === 'substantial' || key === 'large' || key === 'major') return 'substantial';
+  if (key === 'moderate' || key === 'medium') return 'moderate';
+  return 'moderate';
+}
+
+/** Sort key for display: lower comes first (quick wins at the top). */
+export function effortSortRank(effort: AiSchemaImprovementEffort): number {
+  switch (effort) {
+    case 'quick_win':
+      return 0;
+    case 'moderate':
+      return 1;
+    case 'substantial':
+      return 2;
+  }
+}
+
 /**
  * Returns null if the response does not contain valid structured suggestions.
  */
@@ -93,10 +118,20 @@ export function parseAiSchemaImprovementSuggestionsResponse(markdown: string): A
       title,
       detail,
       category: normalizeCategory(item.category),
+      effort: normalizeEffort(item.effort),
     });
   }
 
   if (suggestions.length === 0) return null;
 
-  return { thinking, summary, suggestions };
+  const ordered = suggestions
+    .map((s, originalIndex) => ({ s, originalIndex }))
+    .sort((a, b) => {
+      const dr = effortSortRank(a.s.effort) - effortSortRank(b.s.effort);
+      if (dr !== 0) return dr;
+      return a.originalIndex - b.originalIndex;
+    })
+    .map(({ s }) => s);
+
+  return { thinking, summary, suggestions: ordered };
 }

--- a/objectified-ui/lib/ai-schema-improvement-suggestions.ts
+++ b/objectified-ui/lib/ai-schema-improvement-suggestions.ts
@@ -66,7 +66,7 @@ function normalizeCategory(raw: unknown): AiSchemaImprovementCategory {
 
 function normalizeEffort(raw: unknown): AiSchemaImprovementEffort {
   if (typeof raw !== 'string') return 'moderate';
-  const key = raw.trim().toLowerCase().replace(/-/g, '_');
+  const key = raw.trim().toLowerCase().replace(/[\s-]+/g, '_');
   if (key === 'quick_win' || key === 'quickwin') return 'quick_win';
   if (key === 'substantial' || key === 'large' || key === 'major') return 'substantial';
   if (key === 'moderate' || key === 'medium') return 'moderate';

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.69",
+  "version": "0.11.70",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -27,6 +27,7 @@ We continue to improve the platform based on your feedback with improvements and
 - Projects list includes a **Show deleted** switch; when on, soft-deleted projects appear with a **Deleted** badge and **Restore** or **permanent delete** in the row menu (#2981).
 
 ## Studio
+- **AI improvement suggestions** (Schema Metrics **lightbulb**) now labels each item with **effort** (quick win, standard, larger effort), **sorts quick wins to the top**, and adds an **Effort** line when you copy a row (#254).
 - **Schema Metrics** panel includes a **lightbulb** control that opens **AI improvement suggestions**: Ollama reads live canvas metrics (documentation %, naming compliance, complexity, samples of gaps) and returns a structured, copy-friendly list of actionable ideas (#253).
 - **Add Property** and **Edit Property** include **Analyze** on the Basics step (advanced Form view includes it in Basics): opens the same **AI property suggestions** dialog as the sidebar robot control (#276).
 - The **AI property suggestions** dialog opens when you start **Add Class** (or **Create this class** from chat), when the new **class name** reaches two characters, after saving your **first** or **third** property in a single-property add (not during bulk **Add all suggested**), from **AI suggest properties** in the sidebar, or when chat includes **Open AI property suggestions** (#275).

--- a/objectified-ui/src/app/api/ollama/chat/route.ts
+++ b/objectified-ui/src/app/api/ollama/chat/route.ts
@@ -277,7 +277,8 @@ Return **exactly one** markdown fenced JSON block and **nothing outside the fenc
     {
       "title": "Short imperative headline the user can scan (max ~120 chars).",
       "detail": "Concrete explanation: what to change, where to look, and why it helps quality or maintainability.",
-      "category": "documentation"
+      "category": "documentation",
+      "effort": "quick_win"
     }
   ]
 }
@@ -288,6 +289,11 @@ Return **exactly one** markdown fenced JSON block and **nothing outside the fenc
 - Emit **6–12** suggestions unless the digest is extremely small (then 3–5 is fine).
 - Every "title" and "detail" must be non-empty strings.
 - "category" must be one of: "documentation", "naming", "structure", "api", "performance", "other". Pick the best fit per row.
+- Every row MUST include **"effort"**: one of \`"quick_win"\`, \`"moderate"\`, or \`"substantial"\`.
+  - **quick_win**: small, localized edits (add missing descriptions, rename a few properties, tighten one validation) that a developer can often finish in minutes to an hour.
+  - **moderate**: bounded refactors (split one busy class, normalize a small set of names, add a shared pattern across a few schemas).
+  - **substantial**: broader design or cross-cutting work (large decompositions, API-wide pagination strategy, dependency reshaping).
+- Order the **suggestions** array with **all quick_win items first**, then moderate, then substantial—so the JSON list itself reads as a prioritized backlog.
 - Ground suggestions in the **digest numbers and named classes/properties** when present—do not invent entities that contradict the digest.
 - It is acceptable to mention **future** API design (pagination, error models, versioning) when metrics imply large graphs, hubs, or wide classes—even if paths are not listed.
 - Prefer distinct suggestions; do not repeat the same idea with different wording.

--- a/objectified-ui/src/app/components/ade/studio/AiSchemaImprovementSuggestionsDialog.tsx
+++ b/objectified-ui/src/app/components/ade/studio/AiSchemaImprovementSuggestionsDialog.tsx
@@ -13,6 +13,7 @@ import { Textarea } from '../../ui/Textarea';
 import { Bot, Copy, Loader2, Square, Sparkles } from 'lucide-react';
 import {
   parseAiSchemaImprovementSuggestionsResponse,
+  type AiSchemaImprovementEffort,
   type AiSchemaImprovementSuggestionsPayload,
 } from '@lib/ai-schema-improvement-suggestions';
 import {
@@ -39,6 +40,19 @@ const CATEGORY_LABEL: Record<string, string> = {
   api: 'API',
   performance: 'Performance',
   other: 'Other',
+};
+
+const EFFORT_LABEL: Record<AiSchemaImprovementEffort, string> = {
+  quick_win: 'Quick win',
+  moderate: 'Standard',
+  substantial: 'Larger effort',
+};
+
+const EFFORT_BADGE_CLASS: Record<AiSchemaImprovementEffort, string> = {
+  quick_win:
+    'bg-emerald-100 text-emerald-900 dark:bg-emerald-950 dark:text-emerald-200',
+  moderate: 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300',
+  substantial: 'bg-amber-100 text-amber-900 dark:bg-amber-950 dark:text-amber-200',
 };
 
 export function AiSchemaImprovementSuggestionsDialog({
@@ -191,8 +205,8 @@ export function AiSchemaImprovementSuggestionsDialog({
     }
   }, [hint, selectedModel, tenantId, projectId, versionId, studioMetricsDigest, existingClassNames]);
 
-  const handleCopyRow = async (idx: number, title: string, detail: string) => {
-    const text = `${title}\n\n${detail}`;
+  const handleCopyRow = async (idx: number, title: string, detail: string, effort: AiSchemaImprovementEffort) => {
+    const text = `${title}\nEffort: ${EFFORT_LABEL[effort]}\n\n${detail}`;
     try {
       await navigator.clipboard.writeText(text);
       setCopyIdx(idx);
@@ -211,7 +225,8 @@ export function AiSchemaImprovementSuggestionsDialog({
             AI improvement suggestions
           </DialogTitle>
           <p className="text-xs text-gray-500 dark:text-gray-400 font-normal pt-1">
-            Uses live Schema Metrics and class names from the canvas. Suggestions are advisory—review before changing your model.
+            Uses live Schema Metrics and class names from the canvas. Quick wins are listed first; each row shows effort alongside category.
+            Suggestions are advisory—review before changing your model.
           </p>
         </DialogHeader>
 
@@ -305,6 +320,12 @@ export function AiSchemaImprovementSuggestionsDialog({
                           <span className="text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded bg-indigo-100 text-indigo-800 dark:bg-indigo-950 dark:text-indigo-200">
                             {CATEGORY_LABEL[s.category] ?? s.category}
                           </span>
+                          <span
+                            className={`text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded ${EFFORT_BADGE_CLASS[s.effort]}`}
+                            data-testid={`ai-schema-improvement-effort-${i}`}
+                          >
+                            {EFFORT_LABEL[s.effort]}
+                          </span>
                         </div>
                         <p className="text-xs text-gray-600 dark:text-gray-400 whitespace-pre-wrap">{s.detail}</p>
                       </div>
@@ -314,7 +335,7 @@ export function AiSchemaImprovementSuggestionsDialog({
                         size="sm"
                         className="shrink-0"
                         data-testid={`ai-schema-improvement-copy-${i}`}
-                        onClick={() => void handleCopyRow(i, s.title, s.detail)}
+                        onClick={() => void handleCopyRow(i, s.title, s.detail, s.effort)}
                       >
                         <Copy className="h-3.5 w-3.5 mr-1" />
                         {copyIdx === i ? 'Copied' : 'Copy'}

--- a/objectified-ui/tests/unit/ai-schema-improvement-suggestions.test.ts
+++ b/objectified-ui/tests/unit/ai-schema-improvement-suggestions.test.ts
@@ -2,17 +2,18 @@ import { parseAiSchemaImprovementSuggestionsResponse } from '../../lib/ai-schema
 
 describe('parseAiSchemaImprovementSuggestionsResponse', () => {
   it('parses a valid fenced JSON payload', () => {
-    const md = `intro\n\n\`\`\`json\n{"thinking":"t","summary":"s","suggestions":[{"title":"Add docs","detail":"Fill descriptions","category":"documentation"}]}\n\`\`\``;
+    const md = `intro\n\n\`\`\`json\n{"thinking":"t","summary":"s","suggestions":[{"title":"Add docs","detail":"Fill descriptions","category":"documentation","effort":"quick_win"}]}\n\`\`\``;
     const p = parseAiSchemaImprovementSuggestionsResponse(md);
     expect(p).not.toBeNull();
     expect(p!.suggestions).toHaveLength(1);
     expect(p!.suggestions[0].title).toBe('Add docs');
     expect(p!.suggestions[0].category).toBe('documentation');
+    expect(p!.suggestions[0].effort).toBe('quick_win');
   });
 
   it('uses last json fence when multiple exist', () => {
     const md =
-      '```json\n{"thinking":"","summary":"","suggestions":[{"title":"a","detail":"d","category":"other"}]}\n```\n\n```json\n{"thinking":"","summary":"","suggestions":[{"title":"b","detail":"d2","category":"naming"}]}\n```';
+      '```json\n{"thinking":"","summary":"","suggestions":[{"title":"a","detail":"d","category":"other","effort":"moderate"}]}\n```\n\n```json\n{"thinking":"","summary":"","suggestions":[{"title":"b","detail":"d2","category":"naming","effort":"moderate"}]}\n```';
     const p = parseAiSchemaImprovementSuggestionsResponse(md);
     expect(p?.suggestions[0].title).toBe('b');
   });
@@ -26,7 +27,7 @@ describe('parseAiSchemaImprovementSuggestionsResponse', () => {
     const md =
       "```json\n{\"thinking\":\"\",\"summary\":\"\",\"suggestions\":[{\"title\":\"\",\"detail\":\"x\",\"category\":\"other\"},{\"title\":\"ok\",\"detail\":\"\",\"category\":\"other\"},{\"title\":\"good\",\"detail\":\"body\",\"category\":\"api\"}]}\n```";
     const r = parseAiSchemaImprovementSuggestionsResponse(md);
-    expect(r?.suggestions).toEqual([{ title: 'good', detail: 'body', category: 'api' }]);
+    expect(r?.suggestions).toEqual([{ title: 'good', detail: 'body', category: 'api', effort: 'moderate' }]);
   });
 
   it('normalizes unknown category to other', () => {
@@ -34,6 +35,38 @@ describe('parseAiSchemaImprovementSuggestionsResponse', () => {
       '```json\n{"thinking":"","summary":"","suggestions":[{"title":"x","detail":"y","category":"not-a-real-category"}]}\n```';
     const r = parseAiSchemaImprovementSuggestionsResponse(md);
     expect(r?.suggestions[0].category).toBe('other');
+  });
+
+  it('defaults missing effort to moderate', () => {
+    const md =
+      '```json\n{"thinking":"","summary":"","suggestions":[{"title":"x","detail":"y","category":"documentation"}]}\n```';
+    const r = parseAiSchemaImprovementSuggestionsResponse(md);
+    expect(r?.suggestions[0].effort).toBe('moderate');
+  });
+
+  it('sorts suggestions so quick_win rows come first (stable within tier)', () => {
+    const md = `\`\`\`json
+{"thinking":"","summary":"","suggestions":[
+  {"title":"big","detail":"d","category":"structure","effort":"substantial"},
+  {"title":"fast","detail":"d","category":"documentation","effort":"quick_win"},
+  {"title":"mid","detail":"d","category":"naming","effort":"moderate"},
+  {"title":"also fast","detail":"d","category":"documentation","effort":"quick_win"}
+]}
+\`\`\``;
+    const r = parseAiSchemaImprovementSuggestionsResponse(md);
+    expect(r?.suggestions.map((s) => s.title)).toEqual(['fast', 'also fast', 'mid', 'big']);
+  });
+
+  it('normalizes effort aliases', () => {
+    const md = `\`\`\`json
+{"thinking":"","summary":"","suggestions":[
+  {"title":"a","detail":"d","category":"other","effort":"Quick-Win"},
+  {"title":"b","detail":"d","category":"other","effort":"LARGE"}
+]}
+\`\`\``;
+    const r = parseAiSchemaImprovementSuggestionsResponse(md);
+    expect(r?.suggestions[0].effort).toBe('quick_win');
+    expect(r?.suggestions[1].effort).toBe('substantial');
   });
 
   it('returns null when no json fence', () => {

--- a/objectified-ui/tests/unit/ai-schema-improvement-suggestions.test.ts
+++ b/objectified-ui/tests/unit/ai-schema-improvement-suggestions.test.ts
@@ -69,6 +69,20 @@ describe('parseAiSchemaImprovementSuggestionsResponse', () => {
     expect(r?.suggestions[1].effort).toBe('substantial');
   });
 
+  it('normalizes spaced effort variants (e.g. "quick win" with a space)', () => {
+    const md = `\`\`\`json
+{"thinking":"","summary":"","suggestions":[
+  {"title":"a","detail":"d","category":"other","effort":"quick win"},
+  {"title":"b","detail":"d","category":"other","effort":"Quick Win"},
+  {"title":"c","detail":"d","category":"other","effort":"QUICK WIN"}
+]}
+\`\`\``;
+    const r = parseAiSchemaImprovementSuggestionsResponse(md);
+    expect(r?.suggestions[0].effort).toBe('quick_win');
+    expect(r?.suggestions[1].effort).toBe('quick_win');
+    expect(r?.suggestions[2].effort).toBe('quick_win');
+  });
+
   it('returns null when no json fence', () => {
     expect(parseAiSchemaImprovementSuggestionsResponse('no fence')).toBeNull();
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -2622,7 +2622,7 @@
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
       "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright": "1.59.1"
@@ -5520,7 +5520,6 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -5530,7 +5529,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -6683,7 +6682,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-react-compiler/-/babel-plugin-react-compiler-1.0.0.tgz",
       "integrity": "sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.26.0"
@@ -14639,7 +14638,7 @@
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
       "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.59.1"
@@ -14658,7 +14657,7 @@
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
       "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -14671,7 +14670,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -16382,7 +16380,6 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
       "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/tailwindcss-animate": {
@@ -17942,7 +17939,7 @@
       "version": "1.0.1"
     },
     "objectified-ui": {
-      "version": "0.11.67",
+      "version": "0.11.70",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",


### PR DESCRIPTION
## What changed
- Schema improvement suggestions (`schema_improvement_suggestions`) now require an **effort** field from the model: `quick_win`, `moderate`, or `substantial`, with prompt guidance so quick wins are small localized fixes and substantial items are cross-cutting work.
- The parser normalizes aliases, defaults missing effort to `moderate`, and **stable-sorts** so **quick wins always appear first** in Studio.
- The AI improvement suggestions dialog shows an **effort** badge next to category, explains ordering in the subtitle, and includes **Effort:** in copied text.

## How to test
1. Open Studio with Schema Metrics available and Ollama configured.
2. **Open** Schema Metrics → **AI improvement suggestions** (lightbulb).
3. **Pick a model**, optionally add a focus note, **Generate**.
4. Confirm suggestions list **Quick win** rows **above** Standard / Larger effort when the model returns mixed efforts (parser also reorders if the model sends JSON out of order).
5. **Copy** a row and confirm the clipboard includes an **Effort:** line.

## Risk / notes
- Older cached Ollama responses without `effort` still parse (treated as `moderate`); only display order changes vs models that already emitted quick_win first.

Closes #254

Made with [Cursor](https://cursor.com)