### PR TITLE
Fix #255 - Estimated score impact per AI improvement suggestion

### DIFF
--- a/docs/PLANNED_FEATURE_ROADMAP_AI.md
+++ b/docs/PLANNED_FEATURE_ROADMAP_AI.md
@@ -79,12 +79,11 @@ This outlines the planned features for integrating AI capabilities into Objectif
     - ✅ "Split 'User' class - it has 28 properties (recommended max: 15)"
     - ✅ "Add pagination to 'GET /users' endpoint" (optional user focus + metrics)
 - ✅ Prioritized action items (quick wins first) (#254)
-- 📋 Estimated score impact for each fix
+- ✅ Estimated score impact for each fix (#255)
 - 📋 Bulk apply recommendations
 
 | Ticket | Feature Description                    |
 |--------|----------------------------------------|
-| #255   | Estimated score impact for each fix    |
 | #256   | Add bulk apply recommendations         |
 
 ### AI Schema Health Insights

--- a/objectified-ui/lib/ai-schema-improvement-suggestions.ts
+++ b/objectified-ui/lib/ai-schema-improvement-suggestions.ts
@@ -22,6 +22,11 @@ export type AiSchemaImprovementSuggestion = {
   detail: string;
   category: AiSchemaImprovementCategory;
   effort: AiSchemaImprovementEffort;
+  /**
+   * Approximate points the Studio overall schema quality score (0–100) would gain if this fix were fully applied (#255).
+   * Omitted when the model does not provide a usable estimate.
+   */
+  estimatedOverallScoreDelta?: number;
 };
 
 export type AiSchemaImprovementSuggestionsPayload = {
@@ -73,6 +78,27 @@ function normalizeEffort(raw: unknown): AiSchemaImprovementEffort {
   return 'moderate';
 }
 
+const SCORE_DELTA_MIN = -25;
+const SCORE_DELTA_MAX = 25;
+
+/** Parses model-supplied overall-score delta; returns undefined if absent or unusable. */
+export function normalizeEstimatedOverallScoreDelta(raw: unknown): number | undefined {
+  if (raw === null || raw === undefined) return undefined;
+  let n: number;
+  if (typeof raw === 'number') {
+    n = raw;
+  } else if (typeof raw === 'string' && raw.trim().length > 0) {
+    const parsed = Number(raw.trim());
+    if (!Number.isFinite(parsed)) return undefined;
+    n = parsed;
+  } else {
+    return undefined;
+  }
+  const rounded = Math.round(n);
+  if (!Number.isFinite(rounded)) return undefined;
+  return Math.min(SCORE_DELTA_MAX, Math.max(SCORE_DELTA_MIN, rounded));
+}
+
 /** Sort key for display: lower comes first (quick wins at the top). */
 export function effortSortRank(effort: AiSchemaImprovementEffort): number {
   switch (effort) {
@@ -114,11 +140,13 @@ export function parseAiSchemaImprovementSuggestionsResponse(markdown: string): A
     const title = typeof item.title === 'string' ? item.title.trim() : '';
     const detail = typeof item.detail === 'string' ? item.detail.trim() : '';
     if (!title || !detail) continue;
+    const delta = normalizeEstimatedOverallScoreDelta(item.estimatedOverallScoreDelta);
     suggestions.push({
       title,
       detail,
       category: normalizeCategory(item.category),
       effort: normalizeEffort(item.effort),
+      ...(delta !== undefined ? { estimatedOverallScoreDelta: delta } : {}),
     });
   }
 

--- a/objectified-ui/lib/studio-metrics-digest-for-ai.ts
+++ b/objectified-ui/lib/studio-metrics-digest-for-ai.ts
@@ -16,7 +16,11 @@ function take<T>(arr: T[], n: number): T[] {
 /**
  * Human-readable block appended to the model system prompt.
  */
-export function buildStudioMetricsDigestForAi(metrics: SchemaMetricsResult): string {
+export function buildStudioMetricsDigestForAi(
+  metrics: SchemaMetricsResult,
+  /** Current Studio overall schema quality score (0–100); helps the model estimate per-fix deltas (#255). */
+  overallQualityScore?: number | null
+): string {
   const lines: string[] = [];
   lines.push('## Live schema metrics (Studio canvas)');
   lines.push(`- Classes: ${metrics.classCount}`);
@@ -28,6 +32,11 @@ export function buildStudioMetricsDigestForAi(metrics: SchemaMetricsResult): str
   lines.push(`- Naming compliance (PascalCase classes + camelCase props): ${metrics.namingCompliance.compliancePercentage}%`);
   lines.push(`- Circular dependency groups: ${metrics.circularDependencyCount}`);
   lines.push(`- Deepest dependency chain length: ${metrics.deepestChainLength}`);
+  if (typeof overallQualityScore === 'number' && Number.isFinite(overallQualityScore)) {
+    lines.push(
+      `- Overall schema quality score (0–100 composite: docs, naming, structural load, layout when available): ${Math.min(100, Math.max(0, Math.round(overallQualityScore)))}`,
+    );
+  }
 
   if (metrics.hubNames.length) {
     lines.push(`- Hub classes (sample): ${take(metrics.hubNames, MAX_NAMES).join(', ')}${metrics.hubNames.length > MAX_NAMES ? ' …' : ''}`);

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.70",
+  "version": "0.11.71",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -27,6 +27,7 @@ We continue to improve the platform based on your feedback with improvements and
 - Projects list includes a **Show deleted** switch; when on, soft-deleted projects appear with a **Deleted** badge and **Restore** or **permanent delete** in the row menu (#2981).
 
 ## Studio
+- **AI improvement suggestions** shows an optional **estimated overall score impact** (points on the 0–100 Studio composite) per row when the model supplies it; the metrics digest includes the **current overall score** so estimates stay grounded (#255).
 - **AI improvement suggestions** (Schema Metrics **lightbulb**) now labels each item with **effort** (quick win, standard, larger effort), **sorts quick wins to the top**, and adds an **Effort** line when you copy a row (#254).
 - **Schema Metrics** panel includes a **lightbulb** control that opens **AI improvement suggestions**: Ollama reads live canvas metrics (documentation %, naming compliance, complexity, samples of gaps) and returns a structured, copy-friendly list of actionable ideas (#253).
 - **Add Property** and **Edit Property** include **Analyze** on the Basics step (advanced Form view includes it in Basics): opens the same **AI property suggestions** dialog as the sidebar robot control (#276).

--- a/objectified-ui/src/app/ade/studio/editor/page.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/page.tsx
@@ -948,7 +948,10 @@ const StudioContent = () => {
 
   const handleOpenAiImprovementSuggestions = useCallback(() => {
     if (!schemaMetrics) return;
-    setAiImprovementDigest(buildStudioMetricsDigestForAi(schemaMetrics));
+    const classNodes = nodes.filter((n) => n.type !== 'groupNode');
+    const lq = classNodes.length === 0 ? null : computeLayoutQuality(nodes, edges);
+    const overallForDigest = computeOverallSchemaQualityScore(schemaMetrics, lq);
+    setAiImprovementDigest(buildStudioMetricsDigestForAi(schemaMetrics, overallForDigest));
     const allNames = nodes
       .filter((n) => n.type !== 'groupNode')
       .map((n) => String((n.data as { name?: string })?.name ?? '').trim())
@@ -956,7 +959,7 @@ const StudioContent = () => {
     const deduped = [...new Set(allNames)].sort();
     setAiImprovementClassNames(deduped.slice(0, CLASS_NAMES_CAP));
     setAiImprovementDialogOpen(true);
-  }, [schemaMetrics, nodes]);
+  }, [schemaMetrics, nodes, edges]);
 
   // #244: Version scoring panel — per-schema rows from the live canvas (same graph as metrics).
   // Only computed when the panel is open to avoid graph-traversal overhead during editing.

--- a/objectified-ui/src/app/api/ollama/chat/route.ts
+++ b/objectified-ui/src/app/api/ollama/chat/route.ts
@@ -278,7 +278,8 @@ Return **exactly one** markdown fenced JSON block and **nothing outside the fenc
       "title": "Short imperative headline the user can scan (max ~120 chars).",
       "detail": "Concrete explanation: what to change, where to look, and why it helps quality or maintainability.",
       "category": "documentation",
-      "effort": "quick_win"
+      "effort": "quick_win",
+      "estimatedOverallScoreDelta": 3
     }
   ]
 }
@@ -289,6 +290,7 @@ Return **exactly one** markdown fenced JSON block and **nothing outside the fenc
 - Emit **6–12** suggestions unless the digest is extremely small (then 3–5 is fine).
 - Every "title" and "detail" must be non-empty strings.
 - "category" must be one of: "documentation", "naming", "structure", "api", "performance", "other". Pick the best fit per row.
+- Every row MUST include **"estimatedOverallScoreDelta"**: an **integer** (typically **0–12**, occasionally higher for broad fixes) estimating how many **points** the Studio **overall schema quality score (0–100)** in the digest would **increase** if that suggestion were **fully applied**. Use **0** only when the effect on the composite would be negligible. When the digest includes the current overall score line, anchor estimates to that baseline and the listed doc %, naming %, and complexity. Do not exceed **25**; use negative values only if a fix could realistically lower the composite (rare).
 - Every row MUST include **"effort"**: one of \`"quick_win"\`, \`"moderate"\`, or \`"substantial"\`.
   - **quick_win**: small, localized edits (add missing descriptions, rename a few properties, tighten one validation) that a developer can often finish in minutes to an hour.
   - **moderate**: bounded refactors (split one busy class, normalize a small set of names, add a shared pattern across a few schemas).

--- a/objectified-ui/src/app/components/ade/studio/AiSchemaImprovementSuggestionsDialog.tsx
+++ b/objectified-ui/src/app/components/ade/studio/AiSchemaImprovementSuggestionsDialog.tsx
@@ -11,6 +11,7 @@ import {
 import { Button } from '../../ui/Button';
 import { Textarea } from '../../ui/Textarea';
 import { Bot, Copy, Loader2, Square, Sparkles } from 'lucide-react';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../../ui/Tooltip';
 import {
   parseAiSchemaImprovementSuggestionsResponse,
   type AiSchemaImprovementEffort,
@@ -219,9 +220,9 @@ export function AiSchemaImprovementSuggestionsDialog({
   ) => {
     const scoreLine =
       typeof estimatedDelta === 'number'
-        ? `Est. overall score impact: ${formatEstimatedScoreImpact(estimatedDelta)} (0–100 composite; model estimate)\n`
+        ? `\nEst. overall score impact: ${formatEstimatedScoreImpact(estimatedDelta)} (0–100 composite; model estimate)`
         : '';
-    const text = `${title}\nEffort: ${EFFORT_LABEL[effort]}\n${scoreLine}\n${detail}`;
+    const text = `${title}\nEffort: ${EFFORT_LABEL[effort]}${scoreLine}\n\n${detail}`;
     try {
       await navigator.clipboard.writeText(text);
       setCopyIdx(idx);
@@ -342,13 +343,21 @@ export function AiSchemaImprovementSuggestionsDialog({
                             {EFFORT_LABEL[s.effort]}
                           </span>
                           {typeof s.estimatedOverallScoreDelta === 'number' ? (
-                            <span
-                              className="text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded bg-sky-100 text-sky-900 dark:bg-sky-950 dark:text-sky-200 tabular-nums"
-                              title="Estimated change to the Studio overall schema quality score (0–100) if this fix were fully applied"
-                              data-testid={`ai-schema-improvement-score-${i}`}
-                            >
-                              {formatEstimatedScoreImpact(s.estimatedOverallScoreDelta)}
-                            </span>
+                            <TooltipProvider>
+                              <Tooltip>
+                                <TooltipTrigger asChild>
+                                  <span
+                                    className="text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded bg-sky-100 text-sky-900 dark:bg-sky-950 dark:text-sky-200 tabular-nums cursor-default"
+                                    data-testid={`ai-schema-improvement-score-${i}`}
+                                  >
+                                    {formatEstimatedScoreImpact(s.estimatedOverallScoreDelta)}
+                                  </span>
+                                </TooltipTrigger>
+                                <TooltipContent>
+                                  Estimated change to the Studio overall schema quality score (0–100) if this fix were fully applied
+                                </TooltipContent>
+                              </Tooltip>
+                            </TooltipProvider>
                           ) : null}
                         </div>
                         <p className="text-xs text-gray-600 dark:text-gray-400 whitespace-pre-wrap">{s.detail}</p>

--- a/objectified-ui/src/app/components/ade/studio/AiSchemaImprovementSuggestionsDialog.tsx
+++ b/objectified-ui/src/app/components/ade/studio/AiSchemaImprovementSuggestionsDialog.tsx
@@ -55,6 +55,11 @@ const EFFORT_BADGE_CLASS: Record<AiSchemaImprovementEffort, string> = {
   substantial: 'bg-amber-100 text-amber-900 dark:bg-amber-950 dark:text-amber-200',
 };
 
+function formatEstimatedScoreImpact(delta: number): string {
+  const sign = delta > 0 ? '+' : '';
+  return `${sign}${delta} pts`;
+}
+
 export function AiSchemaImprovementSuggestionsDialog({
   open,
   onClose,
@@ -205,8 +210,18 @@ export function AiSchemaImprovementSuggestionsDialog({
     }
   }, [hint, selectedModel, tenantId, projectId, versionId, studioMetricsDigest, existingClassNames]);
 
-  const handleCopyRow = async (idx: number, title: string, detail: string, effort: AiSchemaImprovementEffort) => {
-    const text = `${title}\nEffort: ${EFFORT_LABEL[effort]}\n\n${detail}`;
+  const handleCopyRow = async (
+    idx: number,
+    title: string,
+    detail: string,
+    effort: AiSchemaImprovementEffort,
+    estimatedDelta?: number
+  ) => {
+    const scoreLine =
+      typeof estimatedDelta === 'number'
+        ? `Est. overall score impact: ${formatEstimatedScoreImpact(estimatedDelta)} (0–100 composite; model estimate)\n`
+        : '';
+    const text = `${title}\nEffort: ${EFFORT_LABEL[effort]}\n${scoreLine}\n${detail}`;
     try {
       await navigator.clipboard.writeText(text);
       setCopyIdx(idx);
@@ -225,7 +240,7 @@ export function AiSchemaImprovementSuggestionsDialog({
             AI improvement suggestions
           </DialogTitle>
           <p className="text-xs text-gray-500 dark:text-gray-400 font-normal pt-1">
-            Uses live Schema Metrics and class names from the canvas. Quick wins are listed first; each row shows effort alongside category.
+            Uses live Schema Metrics and class names from the canvas. Quick wins are listed first; each row shows effort, optional estimated impact on the 0–100 overall schema quality score, and category.
             Suggestions are advisory—review before changing your model.
           </p>
         </DialogHeader>
@@ -326,6 +341,15 @@ export function AiSchemaImprovementSuggestionsDialog({
                           >
                             {EFFORT_LABEL[s.effort]}
                           </span>
+                          {typeof s.estimatedOverallScoreDelta === 'number' ? (
+                            <span
+                              className="text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded bg-sky-100 text-sky-900 dark:bg-sky-950 dark:text-sky-200 tabular-nums"
+                              title="Estimated change to the Studio overall schema quality score (0–100) if this fix were fully applied"
+                              data-testid={`ai-schema-improvement-score-${i}`}
+                            >
+                              {formatEstimatedScoreImpact(s.estimatedOverallScoreDelta)}
+                            </span>
+                          ) : null}
                         </div>
                         <p className="text-xs text-gray-600 dark:text-gray-400 whitespace-pre-wrap">{s.detail}</p>
                       </div>
@@ -335,7 +359,7 @@ export function AiSchemaImprovementSuggestionsDialog({
                         size="sm"
                         className="shrink-0"
                         data-testid={`ai-schema-improvement-copy-${i}`}
-                        onClick={() => void handleCopyRow(i, s.title, s.detail, s.effort)}
+                        onClick={() => void handleCopyRow(i, s.title, s.detail, s.effort, s.estimatedOverallScoreDelta)}
                       >
                         <Copy className="h-3.5 w-3.5 mr-1" />
                         {copyIdx === i ? 'Copied' : 'Copy'}

--- a/objectified-ui/tests/unit/ai-schema-improvement-suggestions.test.ts
+++ b/objectified-ui/tests/unit/ai-schema-improvement-suggestions.test.ts
@@ -1,14 +1,18 @@
-import { parseAiSchemaImprovementSuggestionsResponse } from '../../lib/ai-schema-improvement-suggestions';
+import {
+  normalizeEstimatedOverallScoreDelta,
+  parseAiSchemaImprovementSuggestionsResponse,
+} from '../../lib/ai-schema-improvement-suggestions';
 
 describe('parseAiSchemaImprovementSuggestionsResponse', () => {
   it('parses a valid fenced JSON payload', () => {
-    const md = `intro\n\n\`\`\`json\n{"thinking":"t","summary":"s","suggestions":[{"title":"Add docs","detail":"Fill descriptions","category":"documentation","effort":"quick_win"}]}\n\`\`\``;
+    const md = `intro\n\n\`\`\`json\n{"thinking":"t","summary":"s","suggestions":[{"title":"Add docs","detail":"Fill descriptions","category":"documentation","effort":"quick_win","estimatedOverallScoreDelta":3}]}\n\`\`\``;
     const p = parseAiSchemaImprovementSuggestionsResponse(md);
     expect(p).not.toBeNull();
     expect(p!.suggestions).toHaveLength(1);
     expect(p!.suggestions[0].title).toBe('Add docs');
     expect(p!.suggestions[0].category).toBe('documentation');
     expect(p!.suggestions[0].effort).toBe('quick_win');
+    expect(p!.suggestions[0].estimatedOverallScoreDelta).toBe(3);
   });
 
   it('uses last json fence when multiple exist', () => {
@@ -85,5 +89,32 @@ describe('parseAiSchemaImprovementSuggestionsResponse', () => {
 
   it('returns null when no json fence', () => {
     expect(parseAiSchemaImprovementSuggestionsResponse('no fence')).toBeNull();
+  });
+
+  it('omits estimatedOverallScoreDelta when not provided', () => {
+    const md =
+      '```json\n{"thinking":"","summary":"","suggestions":[{"title":"x","detail":"y","category":"documentation","effort":"quick_win"}]}\n```';
+    const r = parseAiSchemaImprovementSuggestionsResponse(md);
+    expect(r?.suggestions[0].estimatedOverallScoreDelta).toBeUndefined();
+  });
+
+  it('parses estimatedOverallScoreDelta from numeric strings and clamps', () => {
+    const md = `\`\`\`json
+{"thinking":"","summary":"","suggestions":[
+  {"title":"a","detail":"d","category":"documentation","effort":"quick_win","estimatedOverallScoreDelta":"4"},
+  {"title":"b","detail":"d","category":"documentation","effort":"quick_win","estimatedOverallScoreDelta":99},
+  {"title":"c","detail":"d","category":"documentation","effort":"quick_win","estimatedOverallScoreDelta":-40}
+]}
+\`\`\``;
+    const r = parseAiSchemaImprovementSuggestionsResponse(md);
+    expect(r?.suggestions.map((s) => s.estimatedOverallScoreDelta)).toEqual([4, 25, -25]);
+  });
+});
+
+describe('normalizeEstimatedOverallScoreDelta', () => {
+  it('returns undefined for non-finite input', () => {
+    expect(normalizeEstimatedOverallScoreDelta(undefined)).toBeUndefined();
+    expect(normalizeEstimatedOverallScoreDelta('')).toBeUndefined();
+    expect(normalizeEstimatedOverallScoreDelta('x')).toBeUndefined();
   });
 });

--- a/objectified-ui/tests/unit/studio-metrics-digest-for-ai.test.ts
+++ b/objectified-ui/tests/unit/studio-metrics-digest-for-ai.test.ts
@@ -45,4 +45,10 @@ describe('buildStudioMetricsDigestForAi', () => {
     expect(text).toContain('User_ID');
     expect(text).toContain('Hub classes');
   });
+
+  it('includes overall schema quality score when provided (#255)', () => {
+    const text = buildStudioMetricsDigestForAi(baseMetrics(), 72);
+    expect(text).toContain('Overall schema quality score');
+    expect(text).toContain('72');
+  });
 });


### PR DESCRIPTION
## What changed
- **Studio metrics digest** sent to Ollama now includes the current **overall schema quality score (0–100)** when improvement suggestions are generated, so the model can anchor estimates.
- **Ollama system prompt** (`schema_improvement_suggestions`) requires each JSON suggestion to include `estimatedOverallScoreDelta` (integer points on that composite if the fix were fully applied).
- **Parser** accepts the field, clamps to a safe range, and supports numeric strings; rows without a usable value omit the property (backward compatible).
- **AI improvement suggestions** dialog shows a **sky badge** (e.g. `+3 pts`) per row when present, documents it in the intro copy, and includes an **Est. overall score impact** line when copying a row.

## How to test
1. **Open Studio** with a project that has classes on the canvas.
2. **Open Schema Metrics** and use the **lightbulb** to open **AI improvement suggestions**.
3. **Pick a model**, optionally add focus text, and **Generate**.
4. Confirm each suggestion row can show **effort**, **category**, and when the model complies, **`+N pts`** (or negative) next to effort; hover the badge for the tooltip.
5. **Copy** a row and confirm the clipboard includes the estimated impact line when the badge was shown.

## Risk / notes
- Estimates are **LLM-generated**, not computed from the scoring engine; they are advisory.
- Root `yarn build` may still fail if `uv` is missing for `objectified-mcp`; **objectified-ui** `yarn build` and `yarn test` were run successfully.

Closes #255

Made with [Cursor](https://cursor.com)