### PR TITLE
Fix #256 - Bulk apply AI improvement documentation actions

### DIFF
--- a/docs/PLANNED_FEATURE_ROADMAP_AI.md
+++ b/docs/PLANNED_FEATURE_ROADMAP_AI.md
@@ -80,11 +80,7 @@ This outlines the planned features for integrating AI capabilities into Objectif
     - ✅ "Add pagination to 'GET /users' endpoint" (optional user focus + metrics)
 - ✅ Prioritized action items (quick wins first) (#254)
 - ✅ Estimated score impact for each fix (#255)
-- 📋 Bulk apply recommendations
-
-| Ticket | Feature Description                    |
-|--------|----------------------------------------|
-| #256   | Add bulk apply recommendations         |
+- ✅ Bulk apply recommendations (#256): structured class/property description fills from the AI dialog
 
 ### AI Schema Health Insights
 

--- a/objectified-ui/lib/ai-schema-improvement-suggestions.ts
+++ b/objectified-ui/lib/ai-schema-improvement-suggestions.ts
@@ -17,6 +17,20 @@ export type AiSchemaImprovementCategory =
 /** Relative implementation cost; quick wins are surfaced first (#254). */
 export type AiSchemaImprovementEffort = 'quick_win' | 'moderate' | 'substantial';
 
+/** Machine-executable documentation fills the Studio may apply in bulk (#256). */
+export type AiSchemaImprovementApplyAction =
+  | { type: 'set_class_description'; className: string; description: string }
+  | { type: 'set_property_description'; className: string; propertyName: string; description: string };
+
+/** Result of applying structured documentation actions in Studio (#256). */
+export type AiSchemaImprovementBulkApplyResult = {
+  applied: number;
+  skipped: number;
+  failures: string[];
+};
+
+const APPLY_DESCRIPTION_MAX_LEN = 8000;
+
 export type AiSchemaImprovementSuggestion = {
   title: string;
   detail: string;
@@ -27,6 +41,8 @@ export type AiSchemaImprovementSuggestion = {
    * Omitted when the model does not provide a usable estimate.
    */
   estimatedOverallScoreDelta?: number;
+  /** Optional structured apply payload when the model names exact canvas targets (#256). */
+  apply?: AiSchemaImprovementApplyAction;
 };
 
 export type AiSchemaImprovementSuggestionsPayload = {
@@ -76,6 +92,36 @@ function normalizeEffort(raw: unknown): AiSchemaImprovementEffort {
   if (key === 'substantial' || key === 'large' || key === 'major') return 'substantial';
   if (key === 'moderate' || key === 'medium') return 'moderate';
   return 'moderate';
+}
+
+function clampApplyDescription(text: string): string {
+  if (text.length <= APPLY_DESCRIPTION_MAX_LEN) return text;
+  return text.slice(0, APPLY_DESCRIPTION_MAX_LEN);
+}
+
+/** Parses and validates a model-supplied `apply` object; returns undefined if unusable. */
+export function normalizeAiSchemaImprovementApplyAction(raw: unknown): AiSchemaImprovementApplyAction | undefined {
+  if (!isPlainObject(raw)) return undefined;
+  const t = typeof raw.type === 'string' ? raw.type.trim() : '';
+  if (t === 'set_class_description') {
+    const className = typeof raw.className === 'string' ? raw.className.trim() : '';
+    const description = typeof raw.description === 'string' ? raw.description.trim() : '';
+    if (!className || !description) return undefined;
+    return { type: 'set_class_description', className, description: clampApplyDescription(description) };
+  }
+  if (t === 'set_property_description') {
+    const className = typeof raw.className === 'string' ? raw.className.trim() : '';
+    const propertyName = typeof raw.propertyName === 'string' ? raw.propertyName.trim() : '';
+    const description = typeof raw.description === 'string' ? raw.description.trim() : '';
+    if (!className || !propertyName || !description) return undefined;
+    return {
+      type: 'set_property_description',
+      className,
+      propertyName,
+      description: clampApplyDescription(description),
+    };
+  }
+  return undefined;
 }
 
 const SCORE_DELTA_MIN = -25;
@@ -141,12 +187,14 @@ export function parseAiSchemaImprovementSuggestionsResponse(markdown: string): A
     const detail = typeof item.detail === 'string' ? item.detail.trim() : '';
     if (!title || !detail) continue;
     const delta = normalizeEstimatedOverallScoreDelta(item.estimatedOverallScoreDelta);
+    const apply = normalizeAiSchemaImprovementApplyAction(item.apply);
     suggestions.push({
       title,
       detail,
       category: normalizeCategory(item.category),
       effort: normalizeEffort(item.effort),
       ...(delta !== undefined ? { estimatedOverallScoreDelta: delta } : {}),
+      ...(apply ? { apply } : {}),
     });
   }
 

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.71",
+  "version": "0.11.72",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -27,6 +27,7 @@ We continue to improve the platform based on your feedback with improvements and
 - Projects list includes a **Show deleted** switch; when on, soft-deleted projects appear with a **Deleted** badge and **Restore** or **permanent delete** in the row menu (#2981).
 
 ## Studio
+- **AI improvement suggestions** supports **bulk apply**: when the model returns structured **apply** targets (empty class or property descriptions), select rows and **Apply selected** to fill documentation on the canvas in one pass (#256).
 - **AI improvement suggestions** shows an optional **estimated overall score impact** (points on the 0–100 Studio composite) per row when the model supplies it; the metrics digest includes the **current overall score** so estimates stay grounded (#255).
 - **AI improvement suggestions** (Schema Metrics **lightbulb**) now labels each item with **effort** (quick win, standard, larger effort), **sorts quick wins to the top**, and adds an **Effort** line when you copy a row (#254).
 - **Schema Metrics** panel includes a **lightbulb** control that opens **AI improvement suggestions**: Ollama reads live canvas metrics (documentation %, naming compliance, complexity, samples of gaps) and returns a structured, copy-friendly list of actionable ideas (#253).

--- a/objectified-ui/src/app/ade/studio/editor/page.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/page.tsx
@@ -147,9 +147,14 @@ import {
 import {
   deleteClassWithSession,
   updateClassCanvasMetadataWithSession,
+  updateClassWithSession,
   getClassesWithPropertiesAndTagsWithSession,
   getClassWithPropertiesAndTagsWithSession
 } from '../../../../../lib/api/rest-client';
+import type {
+  AiSchemaImprovementApplyAction,
+  AiSchemaImprovementBulkApplyResult,
+} from '@lib/ai-schema-improvement-suggestions';
 import ClassNode from '../../../components/ade/studio/ClassNode';
 import EdgeWithWideHit from '../../../components/ade/studio/EdgeWithWideHit';
 import GroupNode, { GROUP_COLORS } from '../../../components/ade/studio/GroupNode';
@@ -2478,6 +2483,107 @@ const StudioContent = () => {
       console.error('Failed to update single class node:', error);
     }
   }, [setNodes, setEdges, selectedVersionId, updateNodeInternals]);
+
+  const handleBulkApplyAiSchemaImprovements = useCallback(
+    async (actions: AiSchemaImprovementApplyAction[]): Promise<AiSchemaImprovementBulkApplyResult> => {
+      const failures: string[] = [];
+      if (isReadOnly) {
+        return { applied: 0, skipped: actions.length, failures };
+      }
+      let applied = 0;
+      let skipped = 0;
+      const touched = new Set<string>();
+
+      for (const action of actions) {
+        const classNode = nodes.find(
+          (n) =>
+            n.type !== 'groupNode' &&
+            String((n.data as { name?: string })?.name ?? '').trim() === action.className
+        );
+        if (!classNode || classNode.type === 'groupNode') {
+          skipped++;
+          continue;
+        }
+        const classId = classNode.id;
+        const data = classNode.data as {
+          name?: string;
+          description?: string;
+          schema?: unknown;
+          properties?: Array<{ id?: string; name?: string; description?: string; data?: unknown }>;
+        };
+
+        if (action.type === 'set_class_description') {
+          if (String(data.description ?? '').trim()) {
+            skipped++;
+            continue;
+          }
+          const res = await updateClassWithSession(
+            classId,
+            String(data.name ?? action.className).trim(),
+            action.description,
+            data.schema ?? {}
+          );
+          if (res.success) {
+            applied++;
+            touched.add(classId);
+          } else {
+            failures.push(`${action.className}: ${res.error ?? 'update failed'}`);
+          }
+          continue;
+        }
+
+        const props = data.properties ?? [];
+        const prop = props.find((p) => String(p?.name ?? '').trim() === action.propertyName);
+        if (!prop?.id) {
+          skipped++;
+          continue;
+        }
+        if (String(prop.description ?? '').trim()) {
+          skipped++;
+          continue;
+        }
+        let propData: unknown = prop.data;
+        if (typeof propData === 'string') {
+          try {
+            propData = JSON.parse(propData);
+          } catch {
+            failures.push(`${action.className}.${action.propertyName}: invalid property JSON`);
+            continue;
+          }
+        }
+        const response = await fetch(`/api/classes/${classId}/properties/${prop.id}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            name: String(prop.name ?? action.propertyName).trim(),
+            description: action.description,
+            data: propData ?? {},
+          }),
+        });
+        let result: { success?: boolean; error?: string } = {};
+        try {
+          result = (await response.json()) as { success?: boolean; error?: string };
+        } catch {
+          result = {};
+        }
+        if (result.success) {
+          applied++;
+          touched.add(classId);
+        } else {
+          failures.push(
+            `${action.className}.${action.propertyName}: ${result.error ?? `HTTP ${response.status}`}`
+          );
+        }
+      }
+
+      for (const id of touched) {
+        await updateSingleClassNode(id);
+      }
+
+      return { applied, skipped, failures };
+    },
+    [isReadOnly, nodes, updateSingleClassNode]
+  );
 
 // Helper function to extract inline properties from a property schema
   const extractInlineProperties = (propData: any): { name: string; data: any; description?: string }[] => {
@@ -10617,6 +10723,8 @@ const StudioContent = () => {
             versionId={selectedVersionId || null}
             studioMetricsDigest={aiImprovementDigest}
             existingClassNames={aiImprovementClassNames}
+            readOnly={isReadOnly}
+            onBulkApplyDocumentation={handleBulkApplyAiSchemaImprovements}
           />
           <LayoutRevisionDiffDialog
             open={layoutDiffOpen}

--- a/objectified-ui/src/app/ade/studio/editor/page.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/page.tsx
@@ -2418,7 +2418,7 @@ const StudioContent = () => {
   }, [selectedVersionId, projects, versions, getNodes]);
 
   // Helper to update only a single class node without reloading the entire canvas
-  const updateSingleClassNode = useCallback(async (classId: string) => {
+  const updateSingleClassNode = useCallback(async (classId: string, options?: { skipEdgeRebuild?: boolean }) => {
     if (!classId) return;
 
     try {
@@ -2471,8 +2471,10 @@ const StudioContent = () => {
       });
 
       // Update edges that might be affected by property changes (e.g., new $ref properties)
-      // This is needed because adding a property with $ref creates new edges
-      if (selectedVersionId) {
+      // This is needed because adding a property with $ref creates new edges.
+      // Callers that refresh many nodes at once should pass skipEdgeRebuild: true and
+      // perform a single version-wide edge rebuild themselves after the loop.
+      if (!options?.skipEdgeRebuild && selectedVersionId) {
         const allClassesResult = await getClassesWithPropertiesAndTagsWithSession(selectedVersionId);
         if (allClassesResult.success && allClassesResult.classes) {
           const newEdges = createAllEdges(allClassesResult.classes);
@@ -2494,13 +2496,17 @@ const StudioContent = () => {
       let skipped = 0;
       const touched = new Set<string>();
 
+      // Build a name→node map once so each action lookup is O(1) instead of O(nodes).
+      const classNodeByName = new Map<string, typeof nodes[number]>();
+      for (const n of nodes) {
+        if (n.type === 'groupNode') continue;
+        const name = String((n.data as { name?: string })?.name ?? '').trim();
+        if (name) classNodeByName.set(name, n);
+      }
+
       for (const action of actions) {
-        const classNode = nodes.find(
-          (n) =>
-            n.type !== 'groupNode' &&
-            String((n.data as { name?: string })?.name ?? '').trim() === action.className
-        );
-        if (!classNode || classNode.type === 'groupNode') {
+        const classNode = classNodeByName.get(action.className);
+        if (!classNode) {
           skipped++;
           continue;
         }
@@ -2551,38 +2557,55 @@ const StudioContent = () => {
             continue;
           }
         }
-        const response = await fetch(`/api/classes/${classId}/properties/${prop.id}`, {
-          method: 'PUT',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            name: String(prop.name ?? action.propertyName).trim(),
-            description: action.description,
-            data: propData ?? {},
-          }),
-        });
-        let result: { success?: boolean; error?: string } = {};
+        // Wrap the property PUT in try/catch so a network error records a failure
+        // and allows the rest of the actions to continue.
         try {
-          result = (await response.json()) as { success?: boolean; error?: string };
-        } catch {
-          result = {};
-        }
-        if (result.success) {
-          applied++;
-          touched.add(classId);
-        } else {
+          const response = await fetch(`/api/classes/${classId}/properties/${prop.id}`, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              name: String(prop.name ?? action.propertyName).trim(),
+              description: action.description,
+              data: propData ?? {},
+            }),
+          });
+          let result: { success?: boolean; error?: string } = {};
+          try {
+            result = (await response.json()) as { success?: boolean; error?: string };
+          } catch {
+            result = {};
+          }
+          if (result.success) {
+            applied++;
+            touched.add(classId);
+          } else {
+            failures.push(
+              `${action.className}.${action.propertyName}: ${result.error ?? `HTTP ${response.status}`}`
+            );
+          }
+        } catch (err) {
           failures.push(
-            `${action.className}.${action.propertyName}: ${result.error ?? `HTTP ${response.status}`}`
+            `${action.className}.${action.propertyName}: ${err instanceof Error ? err.message : 'network error'}`
           );
         }
       }
 
+      // Refresh each touched node individually (skipping the edge rebuild), then
+      // perform a single version-wide edge rebuild once at the end. This avoids
+      // an O(N) full-graph fetch that would otherwise occur per touched node.
       for (const id of touched) {
-        await updateSingleClassNode(id);
+        await updateSingleClassNode(id, { skipEdgeRebuild: true });
+      }
+      if (touched.size > 0 && selectedVersionId) {
+        const allClassesResult = await getClassesWithPropertiesAndTagsWithSession(selectedVersionId);
+        if (allClassesResult.success && allClassesResult.classes) {
+          setEdges(createAllEdges(allClassesResult.classes));
+        }
       }
 
       return { applied, skipped, failures };
     },
-    [isReadOnly, nodes, updateSingleClassNode]
+    [isReadOnly, nodes, updateSingleClassNode, selectedVersionId, setEdges]
   );
 
 // Helper function to extract inline properties from a property schema

--- a/objectified-ui/src/app/api/ollama/chat/route.ts
+++ b/objectified-ui/src/app/api/ollama/chat/route.ts
@@ -279,7 +279,12 @@ Return **exactly one** markdown fenced JSON block and **nothing outside the fenc
       "detail": "Concrete explanation: what to change, where to look, and why it helps quality or maintainability.",
       "category": "documentation",
       "effort": "quick_win",
-      "estimatedOverallScoreDelta": 3
+      "estimatedOverallScoreDelta": 3,
+      "apply": {
+        "type": "set_class_description",
+        "className": "ExactPascalCaseClassFromDigest",
+        "description": "1–4 sentences; becomes the class description in Studio when the user bulk-applies."
+      }
     }
   ]
 }
@@ -299,6 +304,11 @@ Return **exactly one** markdown fenced JSON block and **nothing outside the fenc
 - Ground suggestions in the **digest numbers and named classes/properties** when present—do not invent entities that contradict the digest.
 - It is acceptable to mention **future** API design (pagination, error models, versioning) when metrics imply large graphs, hubs, or wide classes—even if paths are not listed.
 - Prefer distinct suggestions; do not repeat the same idea with different wording.
+- Optional **apply** per suggestion (#256): include **only** when the row is a **documentation** fix that can be automated as filling a **currently empty** Studio description, and you can copy **exact** \`className\` / \`propertyName\` identifiers from the digest lists of missing documentation (never invent names).
+  - **set_class_description**: \`{"type":"set_class_description","className":"<name>","description":"<text>"}\` — class must appear under classes missing description.
+  - **set_property_description**: \`{"type":"set_property_description","className":"<Class>","propertyName":"<prop>","description":"<text>"}\` — pair must match a \`ClassName.propertyName\` line under properties missing description.
+  - Omit **apply** for naming, structure, API design, or any suggestion that is not a straight empty-description fill.
+  - At most **one** **apply** object per suggestion; descriptions must stay concise (well under 8000 characters).
 - Do not output OpenAPI JSON, full schemas, or code blocks other than the single fenced JSON payload.`;
 
 function buildSchemaImprovementSuggestionsSystem(options: {

--- a/objectified-ui/src/app/components/ade/studio/AiSchemaImprovementSuggestionsDialog.tsx
+++ b/objectified-ui/src/app/components/ade/studio/AiSchemaImprovementSuggestionsDialog.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   Dialog,
   DialogContent,
@@ -14,6 +14,8 @@ import { Bot, Copy, Loader2, Square, Sparkles } from 'lucide-react';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../../ui/Tooltip';
 import {
   parseAiSchemaImprovementSuggestionsResponse,
+  type AiSchemaImprovementApplyAction,
+  type AiSchemaImprovementBulkApplyResult,
   type AiSchemaImprovementEffort,
   type AiSchemaImprovementSuggestionsPayload,
 } from '@lib/ai-schema-improvement-suggestions';
@@ -32,6 +34,13 @@ export interface AiSchemaImprovementSuggestionsDialogProps {
   /** Pre-built digest from Schema Metrics (required when generating). */
   studioMetricsDigest: string;
   existingClassNames: string[];
+  /** When true, bulk apply controls are disabled. */
+  readOnly?: boolean;
+  /**
+   * Applies selected structured documentation actions (#256).
+   * Parent persists via REST and refreshes affected class nodes.
+   */
+  onBulkApplyDocumentation?: (actions: AiSchemaImprovementApplyAction[]) => Promise<AiSchemaImprovementBulkApplyResult>;
 }
 
 const CATEGORY_LABEL: Record<string, string> = {
@@ -69,6 +78,8 @@ export function AiSchemaImprovementSuggestionsDialog({
   versionId,
   studioMetricsDigest,
   existingClassNames,
+  readOnly = false,
+  onBulkApplyDocumentation,
 }: AiSchemaImprovementSuggestionsDialogProps) {
   const [hint, setHint] = useState('');
   const [modelNames, setModelNames] = useState<string[]>([]);
@@ -78,6 +89,9 @@ export function AiSchemaImprovementSuggestionsDialog({
   const [parsed, setParsed] = useState<AiSchemaImprovementSuggestionsPayload | null>(null);
   const [parseError, setParseError] = useState<string | null>(null);
   const [copyIdx, setCopyIdx] = useState<number | null>(null);
+  const [selectedApplyIndices, setSelectedApplyIndices] = useState<Set<number>>(() => new Set());
+  const [applyBusy, setApplyBusy] = useState(false);
+  const [applyBanner, setApplyBanner] = useState<string | null>(null);
   const abortRef = React.useRef<AbortController | null>(null);
 
   useEffect(() => {
@@ -121,11 +135,77 @@ export function AiSchemaImprovementSuggestionsDialog({
       setParsed(null);
       setParseError(null);
       setCopyIdx(null);
+      setSelectedApplyIndices(new Set());
+      setApplyBanner(null);
+      setApplyBusy(false);
       setIsGenerating(false);
       abortRef.current?.abort();
       abortRef.current = null;
     }
   }, [open]);
+
+  useEffect(() => {
+    setSelectedApplyIndices(new Set());
+    setApplyBanner(null);
+  }, [parsed]);
+
+  const actionableIndices = useMemo(() => {
+    if (!parsed) return [];
+    const out: number[] = [];
+    parsed.suggestions.forEach((s, i) => {
+      if (s.apply) out.push(i);
+    });
+    return out;
+  }, [parsed]);
+
+  const selectedApplyCount = useMemo(() => {
+    let n = 0;
+    for (const i of selectedApplyIndices) {
+      if (parsed?.suggestions[i]?.apply) n += 1;
+    }
+    return n;
+  }, [parsed, selectedApplyIndices]);
+
+  const toggleApplySelect = useCallback((idx: number) => {
+    setSelectedApplyIndices((prev) => {
+      const next = new Set(prev);
+      if (next.has(idx)) next.delete(idx);
+      else next.add(idx);
+      return next;
+    });
+  }, []);
+
+  const selectAllActionable = useCallback(() => {
+    setSelectedApplyIndices(new Set(actionableIndices));
+  }, [actionableIndices]);
+
+  const clearApplySelection = useCallback(() => {
+    setSelectedApplyIndices(new Set());
+  }, []);
+
+  const handleBulkApply = useCallback(async () => {
+    if (!parsed || !onBulkApplyDocumentation || readOnly || applyBusy) return;
+    const ordered = [...selectedApplyIndices].sort((a, b) => a - b);
+    const actions: AiSchemaImprovementApplyAction[] = [];
+    for (const i of ordered) {
+      const a = parsed.suggestions[i]?.apply;
+      if (a) actions.push(a);
+    }
+    if (actions.length === 0) return;
+    setApplyBusy(true);
+    setApplyBanner(null);
+    try {
+      const r = await onBulkApplyDocumentation(actions);
+      const failNote = r.failures.length ? ` ${r.failures.slice(0, 2).join('; ')}` : '';
+      setApplyBanner(
+        `Applied ${r.applied}, skipped ${r.skipped}.${failNote}${r.failures.length > 2 ? ' …' : ''}`.trim(),
+      );
+    } catch (e) {
+      setApplyBanner(e instanceof Error ? e.message : 'Bulk apply failed.');
+    } finally {
+      setApplyBusy(false);
+    }
+  }, [parsed, onBulkApplyDocumentation, readOnly, applyBusy, selectedApplyIndices]);
 
   const handleStop = useCallback(() => {
     abortRef.current?.abort();
@@ -242,6 +322,7 @@ export function AiSchemaImprovementSuggestionsDialog({
           </DialogTitle>
           <p className="text-xs text-gray-500 dark:text-gray-400 font-normal pt-1">
             Uses live Schema Metrics and class names from the canvas. Quick wins are listed first; each row shows effort, optional estimated impact on the 0–100 overall schema quality score, and category.
+            When the model includes structured apply targets, you can bulk-fill empty class or property descriptions after review.
             Suggestions are advisory—review before changing your model.
           </p>
         </DialogHeader>
@@ -322,6 +403,67 @@ export function AiSchemaImprovementSuggestionsDialog({
                   {parsed.summary}
                 </p>
               ) : null}
+              {onBulkApplyDocumentation && (
+                <div className="flex flex-wrap items-center gap-2 text-xs">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    className="shrink-0"
+                    data-testid="ai-schema-improvement-select-all-apply"
+                    disabled={
+                      readOnly || isGenerating || applyBusy || actionableIndices.length === 0
+                    }
+                    onClick={selectAllActionable}
+                  >
+                    Select all with Studio actions
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    className="shrink-0"
+                    data-testid="ai-schema-improvement-clear-apply-selection"
+                    disabled={readOnly || isGenerating || applyBusy || selectedApplyCount === 0}
+                    onClick={clearApplySelection}
+                  >
+                    Clear selection
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="default"
+                    size="sm"
+                    className="shrink-0"
+                    data-testid="ai-schema-improvement-bulk-apply"
+                    disabled={
+                      readOnly ||
+                      isGenerating ||
+                      applyBusy ||
+                      selectedApplyCount === 0 ||
+                      !onBulkApplyDocumentation
+                    }
+                    onClick={() => void handleBulkApply()}
+                  >
+                    {applyBusy ? 'Applying…' : `Apply selected (${selectedApplyCount})`}
+                  </Button>
+                  {readOnly ? (
+                    <span className="text-amber-700 dark:text-amber-300">Read-only canvas</span>
+                  ) : null}
+                </div>
+              )}
+              {applyBanner ? (
+                <p
+                  className="text-xs text-gray-600 dark:text-gray-400 border border-gray-200 dark:border-gray-600 rounded-md px-2 py-1.5 bg-gray-50 dark:bg-gray-900/30"
+                  data-testid="ai-schema-improvement-apply-banner"
+                >
+                  {applyBanner}
+                </p>
+              ) : null}
+              {onBulkApplyDocumentation && parsed && actionableIndices.length === 0 ? (
+                <p className="text-xs text-gray-500 dark:text-gray-400">
+                  No rows include structured Studio apply targets; use Copy or regenerate with a docs-focused hint.
+                </p>
+              ) : null}
               <ul className="space-y-2" data-testid="ai-schema-improvement-list">
                 {parsed.suggestions.map((s, i) => (
                   <li
@@ -329,7 +471,20 @@ export function AiSchemaImprovementSuggestionsDialog({
                     className="rounded-lg border border-gray-200 dark:border-gray-600 p-3 bg-white dark:bg-gray-900/30"
                     data-testid={`ai-schema-improvement-item-${i}`}
                   >
-                    <div className="flex items-start justify-between gap-2">
+                    <div className="flex items-start gap-2">
+                      {s.apply && onBulkApplyDocumentation ? (
+                        <label className="flex items-start gap-2 pt-0.5 shrink-0 cursor-pointer">
+                          <input
+                            type="checkbox"
+                            className="mt-1 h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-900"
+                            data-testid={`ai-schema-improvement-apply-checkbox-${i}`}
+                            checked={selectedApplyIndices.has(i)}
+                            disabled={readOnly || isGenerating || applyBusy}
+                            onChange={() => toggleApplySelect(i)}
+                            aria-label={`Select apply for ${s.title}`}
+                          />
+                        </label>
+                      ) : null}
                       <div className="min-w-0 flex-1">
                         <div className="flex flex-wrap items-center gap-2 mb-1">
                           <span className="text-sm font-semibold text-gray-900 dark:text-gray-100">{s.title}</span>
@@ -361,6 +516,14 @@ export function AiSchemaImprovementSuggestionsDialog({
                           ) : null}
                         </div>
                         <p className="text-xs text-gray-600 dark:text-gray-400 whitespace-pre-wrap">{s.detail}</p>
+                        {s.apply ? (
+                          <p className="text-[10px] text-gray-500 dark:text-gray-400 mt-2 font-mono break-all">
+                            Studio apply:{' '}
+                            {s.apply.type === 'set_class_description'
+                              ? `class ${s.apply.className}`
+                              : `${s.apply.className}.${s.apply.propertyName}`}
+                          </p>
+                        ) : null}
                       </div>
                       <Button
                         type="button"

--- a/objectified-ui/tests/unit/ai-schema-improvement-suggestions.test.ts
+++ b/objectified-ui/tests/unit/ai-schema-improvement-suggestions.test.ts
@@ -1,4 +1,5 @@
 import {
+  normalizeAiSchemaImprovementApplyAction,
   normalizeEstimatedOverallScoreDelta,
   parseAiSchemaImprovementSuggestionsResponse,
 } from '../../lib/ai-schema-improvement-suggestions';
@@ -108,6 +109,56 @@ describe('parseAiSchemaImprovementSuggestionsResponse', () => {
 \`\`\``;
     const r = parseAiSchemaImprovementSuggestionsResponse(md);
     expect(r?.suggestions.map((s) => s.estimatedOverallScoreDelta)).toEqual([4, 25, -25]);
+  });
+
+  it('parses optional apply set_class_description', () => {
+    const md =
+      '```json\n{"thinking":"","summary":"","suggestions":[{"title":"Doc Order","detail":"Add text","category":"documentation","effort":"quick_win","estimatedOverallScoreDelta":2,"apply":{"type":"set_class_description","className":"Order","description":"Represents a customer order."}}]}\n```';
+    const r = parseAiSchemaImprovementSuggestionsResponse(md);
+    expect(r?.suggestions[0].apply).toEqual({
+      type: 'set_class_description',
+      className: 'Order',
+      description: 'Represents a customer order.',
+    });
+  });
+
+  it('parses optional apply set_property_description', () => {
+    const md =
+      '```json\n{"thinking":"","summary":"","suggestions":[{"title":"Prop","detail":"d","category":"documentation","effort":"quick_win","estimatedOverallScoreDelta":1,"apply":{"type":"set_property_description","className":"User","propertyName":"email","description":"Primary contact email."}}]}\n```';
+    const r = parseAiSchemaImprovementSuggestionsResponse(md);
+    expect(r?.suggestions[0].apply).toEqual({
+      type: 'set_property_description',
+      className: 'User',
+      propertyName: 'email',
+      description: 'Primary contact email.',
+    });
+  });
+
+  it('omits invalid apply payloads', () => {
+    const md =
+      '```json\n{"thinking":"","summary":"","suggestions":[{"title":"x","detail":"y","category":"documentation","effort":"quick_win","estimatedOverallScoreDelta":1,"apply":{"type":"unknown","className":"A","description":"b"}}]}\n```';
+    const r = parseAiSchemaImprovementSuggestionsResponse(md);
+    expect(r?.suggestions[0].apply).toBeUndefined();
+  });
+});
+
+describe('normalizeAiSchemaImprovementApplyAction', () => {
+  it('returns undefined for malformed payloads', () => {
+    expect(normalizeAiSchemaImprovementApplyAction(null)).toBeUndefined();
+    expect(normalizeAiSchemaImprovementApplyAction({ type: 'set_class_description' })).toBeUndefined();
+  });
+
+  it('clamps long descriptions', () => {
+    const long = 'x'.repeat(9000);
+    const a = normalizeAiSchemaImprovementApplyAction({
+      type: 'set_class_description',
+      className: 'Z',
+      description: long,
+    });
+    expect(a?.type).toBe('set_class_description');
+    if (a?.type === 'set_class_description') {
+      expect(a.description.length).toBe(8000);
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
Closes #256.

Adds **bulk apply** for AI schema improvement suggestions when the model returns optional structured **apply** payloads: **set_class_description** and **set_property_description** (empty targets only). The dialog exposes checkboxes, **Select all with Studio actions**, and **Apply selected**; the editor persists via existing class/property REST APIs and refreshes affected nodes.

## How to test
1. **Open Studio** on a version with classes/properties **missing descriptions** (Schema Metrics lists gaps).
2. **Open Schema Metrics** → **AI improvement suggestions** (lightbulb) and **Generate** with Ollama (optional hint asking for short descriptions to fill gaps).
3. If rows show **Studio apply:** and checkboxes, **select** the rows you want (or **Select all with Studio actions**).
4. **Apply selected** and confirm descriptions appear on the canvas; rows already documented or unknown names should be **skipped** (banner shows counts).

## Risk / notes
- Only **documentation** fills are automated; the model must emit valid **apply** JSON; malformed types are ignored at parse time.
- **Read-only** canvas disables apply controls.
- Root `yarn build` may fail locally if `uv` is missing for `objectified-mcp`; **objectified-ui** `yarn build` and `yarn test` pass.

## Issue
Closes #256

Made with [Cursor](https://cursor.com)