### PR TITLE
Fix #2983 - Sortable Versions timeline table

### DIFF
--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.73",
+  "version": "0.11.74",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -24,6 +24,7 @@ We continue to improve the platform based on your feedback with improvements and
 ## Export
 
 ## Dashboard
+- **Versions** timeline table (**version**, **revision / changelog**, **status**, **created by**, **created**) is **sortable** from the column headers: click to sort ascending, click again to toggle descending (#2983).
 - **Projects** table columns (**name**, **description**, **quality trend**, **status**, **creator**, **created**, **updated**) are **sortable** from the header: click to sort ascending, click again to toggle descending (#2982).
 - Projects list includes a **Show deleted** switch; when on, soft-deleted projects appear with a **Deleted** badge and **Restore** or **permanent delete** in the row menu (#2981).
 

--- a/objectified-ui/src/app/ade/dashboard/versions/page.tsx
+++ b/objectified-ui/src/app/ade/dashboard/versions/page.tsx
@@ -3,8 +3,37 @@
 import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useSession } from 'next-auth/react';
-import { useEffect, useState, useRef, useMemo, useCallback } from 'react';
-import { Edit2, Trash2, Package, AlertCircle, Lock, Unlock, CheckCircle, Eye, Copy, MoreVertical, Network, Snowflake, GitBranch, GitMerge, Tag, GitFork, Shield, Sun, LayoutGrid, Undo2, ScrollText, ListOrdered, GitCompareArrows, FileText, ChevronRight } from 'lucide-react';
+import { useEffect, useState, useRef, useMemo, useCallback, type ReactNode } from 'react';
+import {
+  Edit2,
+  Trash2,
+  Package,
+  AlertCircle,
+  Lock,
+  Unlock,
+  CheckCircle,
+  Eye,
+  Copy,
+  MoreVertical,
+  Network,
+  Snowflake,
+  GitBranch,
+  GitMerge,
+  Tag,
+  GitFork,
+  Shield,
+  Sun,
+  LayoutGrid,
+  Undo2,
+  ScrollText,
+  ListOrdered,
+  GitCompareArrows,
+  FileText,
+  ChevronRight,
+  ArrowUp,
+  ArrowDown,
+  ArrowUpDown,
+} from 'lucide-react';
 import dynamic from 'next/dynamic';
 import {
   Dialog,
@@ -96,6 +125,11 @@ import {
   dashboardTrHoverClass,
 } from '@/app/components/ade/dashboard/dashboardScreenClasses';
 import { FEATURE_GITLIKE } from '@lib/feature-flags';
+import {
+  sortVersionsDashboardRows,
+  type VersionsDashboardSortColumn,
+  type VersionsDashboardSortDirection,
+} from '@/app/utils/versions-dashboard-sort';
 
 /** Radix Select cannot use empty string as a value; maps to no successor in metadata. */
 const SUCCESSOR_SELECT_NONE = '__none__';
@@ -265,6 +299,54 @@ interface VersionTagRow {
   created_by?: string | null;
 }
 
+function VersionsSortTh({
+  column,
+  sortColumn,
+  sortDirection,
+  onSortClick,
+  className,
+  testId,
+  ariaLabel,
+  children,
+}: {
+  column: VersionsDashboardSortColumn;
+  sortColumn: VersionsDashboardSortColumn;
+  sortDirection: VersionsDashboardSortDirection;
+  onSortClick: (c: VersionsDashboardSortColumn) => void;
+  className: string;
+  testId: string;
+  ariaLabel: string;
+  children: ReactNode;
+}) {
+  const active = sortColumn === column;
+  return (
+    <th
+      scope="col"
+      className={className}
+      aria-sort={active ? (sortDirection === 'asc' ? 'ascending' : 'descending') : 'none'}
+    >
+      <button
+        type="button"
+        className="inline-flex w-full max-w-full items-center gap-1.5 rounded-md px-2 py-1 text-left text-xs font-medium uppercase tracking-wider text-gray-600 hover:bg-gray-100 hover:text-gray-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-white"
+        onClick={() => onSortClick(column)}
+        data-testid={testId}
+        aria-label={ariaLabel}
+      >
+        <span className="inline-flex min-w-0 flex-1 items-center gap-1.5 truncate">{children}</span>
+        {active ? (
+          sortDirection === 'asc' ? (
+            <ArrowUp className="h-3.5 w-3.5 shrink-0 text-indigo-600 dark:text-indigo-400" aria-hidden />
+          ) : (
+            <ArrowDown className="h-3.5 w-3.5 shrink-0 text-indigo-600 dark:text-indigo-400" aria-hidden />
+          )
+        ) : (
+          <ArrowUpDown className="h-3.5 w-3.5 shrink-0 opacity-40" aria-hidden />
+        )}
+      </button>
+    </th>
+  );
+}
+
 const Versions = () => {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -411,6 +493,10 @@ const Versions = () => {
   const [historyAuthorCreatorId, setHistoryAuthorCreatorId] = useState('');
   const [historyDateFrom, setHistoryDateFrom] = useState('');
   const [historyDateTo, setHistoryDateTo] = useState('');
+  const [versionsTableSortColumn, setVersionsTableSortColumn] =
+    useState<VersionsDashboardSortColumn>('created');
+  const [versionsTableSortDirection, setVersionsTableSortDirection] =
+    useState<VersionsDashboardSortDirection>('desc');
   const [lifecycleFilter, setLifecycleFilter] = useState<string>('');
   const [editLifecycle, setEditLifecycle] = useState<string>('stable');
   const [editDeprecationMessage, setEditDeprecationMessage] = useState('');
@@ -1892,6 +1978,27 @@ const Versions = () => {
     );
   }, [tagFilteredVersions, historySearchQ, historyAuthorCreatorId, historyDateFrom, historyDateTo]);
 
+  const tableDisplayVersions = useMemo(
+    () =>
+      sortVersionsDashboardRows(
+        displayVersions,
+        versionsTableSortColumn,
+        versionsTableSortDirection
+      ),
+    [displayVersions, versionsTableSortColumn, versionsTableSortDirection]
+  );
+
+  const handleVersionsTableSortClick = useCallback((column: VersionsDashboardSortColumn) => {
+    setVersionsTableSortColumn((prevCol) => {
+      if (prevCol === column) {
+        setVersionsTableSortDirection((d) => (d === 'asc' ? 'desc' : 'asc'));
+        return prevCol;
+      }
+      setVersionsTableSortDirection('asc');
+      return column;
+    });
+  }, []);
+
   const historyTimelineFiltersActive =
     historySearchQ.trim() !== '' || !!historyAuthorCreatorId || !!historyDateFrom || !!historyDateTo;
 
@@ -3057,12 +3164,64 @@ const Versions = () => {
           <table className="min-w-full">
             <thead className={dashboardTableTheadClass}>
               <tr>
-                <th className={dashboardThClass}>Version</th>
-                <th className={dashboardThClass}>Revision / changelog</th>
-                <th className={dashboardThClass}>Status</th>
-                <th className={dashboardThClass}>Created By</th>
-                <th className={dashboardThClass}>Created</th>
-                <th className={dashboardThRightClass}>Actions</th>
+                <VersionsSortTh
+                  column="version"
+                  sortColumn={versionsTableSortColumn}
+                  sortDirection={versionsTableSortDirection}
+                  onSortClick={handleVersionsTableSortClick}
+                  className={dashboardThClass}
+                  testId="versions-sort-version"
+                  ariaLabel="Sort by version"
+                >
+                  Version
+                </VersionsSortTh>
+                <VersionsSortTh
+                  column="revision"
+                  sortColumn={versionsTableSortColumn}
+                  sortDirection={versionsTableSortDirection}
+                  onSortClick={handleVersionsTableSortClick}
+                  className={dashboardThClass}
+                  testId="versions-sort-revision"
+                  ariaLabel="Sort by revision and changelog"
+                >
+                  Revision / changelog
+                </VersionsSortTh>
+                <VersionsSortTh
+                  column="status"
+                  sortColumn={versionsTableSortColumn}
+                  sortDirection={versionsTableSortDirection}
+                  onSortClick={handleVersionsTableSortClick}
+                  className={dashboardThClass}
+                  testId="versions-sort-status"
+                  ariaLabel="Sort by status"
+                >
+                  Status
+                </VersionsSortTh>
+                <VersionsSortTh
+                  column="creator"
+                  sortColumn={versionsTableSortColumn}
+                  sortDirection={versionsTableSortDirection}
+                  onSortClick={handleVersionsTableSortClick}
+                  className={dashboardThClass}
+                  testId="versions-sort-creator"
+                  ariaLabel="Sort by created by"
+                >
+                  Created By
+                </VersionsSortTh>
+                <VersionsSortTh
+                  column="created"
+                  sortColumn={versionsTableSortColumn}
+                  sortDirection={versionsTableSortDirection}
+                  onSortClick={handleVersionsTableSortClick}
+                  className={dashboardThClass}
+                  testId="versions-sort-created"
+                  ariaLabel="Sort by created date"
+                >
+                  Created
+                </VersionsSortTh>
+                <th scope="col" className={dashboardThRightClass} aria-sort="none">
+                  Actions
+                </th>
               </tr>
             </thead>
             <tbody className={dashboardTbodyClass}>
@@ -3089,7 +3248,7 @@ const Versions = () => {
                     </Button>
                   </td>
                 </tr>
-              ) : displayVersions.length === 0 ? (
+              ) : tableDisplayVersions.length === 0 ? (
                 <tr key="versions-empty-timeline">
                   <td colSpan={6} className="px-6 py-12 text-center text-sm text-gray-600 dark:text-gray-300">
                     <p className="mx-auto max-w-md">
@@ -3104,7 +3263,7 @@ const Versions = () => {
                   </td>
                 </tr>
               ) : (
-                displayVersions.map((version) => (
+                tableDisplayVersions.map((version) => (
                 <tr key={version.id} className={dashboardTrHoverClass}>
                   <td className="px-6 py-4 whitespace-nowrap">
                     <div className="flex items-center gap-2 flex-wrap">

--- a/objectified-ui/src/app/utils/versions-dashboard-sort.ts
+++ b/objectified-ui/src/app/utils/versions-dashboard-sort.ts
@@ -1,0 +1,123 @@
+/**
+ * Client-side sort for the project Versions timeline table (#2983).
+ */
+
+export type VersionsDashboardSortColumn =
+  | 'version'
+  | 'revision'
+  | 'status'
+  | 'creator'
+  | 'created';
+
+export type VersionsDashboardSortDirection = 'asc' | 'desc';
+
+/** Minimal revision row shape used by the sorter. */
+export type VersionSortRow = {
+  id: string;
+  version_id: string;
+  shortMessage: string | null;
+  changelog: string | null;
+  message?: string | null;
+  published: boolean;
+  enabled: boolean;
+  lifecycle?: string;
+  creator_name: string;
+  creator_email: string;
+  created_at: string;
+};
+
+function compareStringsCaseInsensitive(a: string, b: string, dir: 1 | -1): number {
+  const ac = a.trim().toLowerCase();
+  const bc = b.trim().toLowerCase();
+  if (ac === bc) return 0;
+  return ac < bc ? -dir : dir;
+}
+
+function revisionSortText(v: VersionSortRow): string {
+  return [v.shortMessage, v.message, v.changelog]
+    .filter((x): x is string => typeof x === 'string' && x.length > 0)
+    .join('\n')
+    .trim();
+}
+
+/** Draft+enabled=0 … published+disabled=3 for a stable status ordering. */
+function statusComposite(v: VersionSortRow): number {
+  let k = 0;
+  if (v.published) k += 2;
+  if (!v.enabled) k += 1;
+  return k * 10 + lifecycleRank(v.lifecycle);
+}
+
+function lifecycleRank(lc: string | undefined): number {
+  const v = (lc ?? 'stable').toLowerCase();
+  if (v === 'beta') return 1;
+  if (v === 'deprecated') return 2;
+  if (v === 'archived') return 3;
+  return 0;
+}
+
+function compareVersionIds(a: string, b: string, dir: 1 | -1): number {
+  const ac = a.trim();
+  const bc = b.trim();
+  if (ac === bc) return 0;
+  const c = ac.localeCompare(bc, undefined, { numeric: true, sensitivity: 'base' });
+  if (c === 0) return 0;
+  return c < 0 ? -dir : dir;
+}
+
+export function compareVersionsDashboardRows(
+  a: VersionSortRow,
+  b: VersionSortRow,
+  column: VersionsDashboardSortColumn,
+  direction: VersionsDashboardSortDirection
+): number {
+  const dir: 1 | -1 = direction === 'asc' ? 1 : -1;
+
+  switch (column) {
+    case 'version': {
+      const c = compareVersionIds(a.version_id, b.version_id, dir);
+      if (c !== 0) return c;
+      return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+    }
+    case 'revision': {
+      const c = compareStringsCaseInsensitive(revisionSortText(a), revisionSortText(b), dir);
+      if (c !== 0) return c;
+      return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+    }
+    case 'status': {
+      const ka = statusComposite(a);
+      const kb = statusComposite(b);
+      if (ka !== kb) return ka < kb ? -dir : dir;
+      return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+    }
+    case 'creator': {
+      const c = compareStringsCaseInsensitive(a.creator_name ?? '', b.creator_name ?? '', dir);
+      if (c !== 0) return c;
+      const e = compareStringsCaseInsensitive(a.creator_email ?? '', b.creator_email ?? '', dir);
+      if (e !== 0) return e;
+      return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+    }
+    case 'created': {
+      const ta = Date.parse(a.created_at);
+      const tb = Date.parse(b.created_at);
+      const aOk = Number.isFinite(ta);
+      const bOk = Number.isFinite(tb);
+      if (!aOk && !bOk) return a.id.localeCompare(b.id);
+      if (!aOk) return 1;
+      if (!bOk) return -1;
+      if (ta !== tb) return ta < tb ? -dir : dir;
+      return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+    }
+    default:
+      return 0;
+  }
+}
+
+export function sortVersionsDashboardRows<T extends VersionSortRow>(
+  rows: readonly T[],
+  column: VersionsDashboardSortColumn | null,
+  direction: VersionsDashboardSortDirection
+): T[] {
+  if (!column) return [...rows];
+  return [...rows].sort((a, b) => compareVersionsDashboardRows(a, b, column, direction));
+}

--- a/objectified-ui/tests/unit/versions-dashboard-sort.test.ts
+++ b/objectified-ui/tests/unit/versions-dashboard-sort.test.ts
@@ -1,0 +1,77 @@
+import {
+  compareVersionsDashboardRows,
+  sortVersionsDashboardRows,
+  type VersionSortRow,
+} from '@/app/utils/versions-dashboard-sort';
+
+const base = (over: Partial<VersionSortRow>): VersionSortRow => ({
+  id: over.id ?? 'rev-1',
+  version_id: over.version_id ?? '1.0.0',
+  shortMessage: over.shortMessage ?? null,
+  changelog: over.changelog ?? null,
+  message: over.message ?? null,
+  published: over.published ?? false,
+  enabled: over.enabled ?? true,
+  lifecycle: over.lifecycle,
+  creator_name: over.creator_name ?? 'Alice',
+  creator_email: over.creator_email ?? 'a@x.com',
+  created_at: over.created_at ?? '2024-01-02T00:00:00.000Z',
+});
+
+describe('compareVersionsDashboardRows', () => {
+  it('sorts by version_id with numeric-aware ordering', () => {
+    const a = base({ id: 'a', version_id: '1.10.0' });
+    const b = base({ id: 'b', version_id: '1.2.0' });
+    expect(compareVersionsDashboardRows(a, b, 'version', 'asc')).toBeGreaterThan(0);
+    expect(compareVersionsDashboardRows(b, a, 'version', 'asc')).toBeLessThan(0);
+  });
+
+  it('sorts revision column using shortMessage, message, and changelog', () => {
+    const z = base({ id: '1', shortMessage: 'zebra', message: null, changelog: null });
+    const apple = base({ id: '2', shortMessage: 'apple', message: 'body', changelog: null });
+    expect(compareVersionsDashboardRows(z, apple, 'revision', 'asc')).toBeGreaterThan(0);
+    const withChg = base({ id: '3', shortMessage: null, message: null, changelog: 'notes' });
+    const empty = base({ id: '4', shortMessage: null, message: null, changelog: null });
+    expect(compareVersionsDashboardRows(empty, withChg, 'revision', 'asc')).toBeLessThan(0);
+    expect(compareVersionsDashboardRows(withChg, empty, 'revision', 'asc')).toBeGreaterThan(0);
+  });
+
+  it('sorts status by draft/published and enabled before lifecycle detail', () => {
+    const draftOn = base({ id: 'd', published: false, enabled: true, lifecycle: 'stable' });
+    const pubOn = base({ id: 'p', published: true, enabled: true, lifecycle: 'stable' });
+    expect(compareVersionsDashboardRows(draftOn, pubOn, 'status', 'asc')).toBeLessThan(0);
+    const disabled = base({ id: 'x', published: false, enabled: false });
+    expect(compareVersionsDashboardRows(draftOn, disabled, 'status', 'asc')).toBeLessThan(0);
+  });
+
+  it('sorts by creator then email', () => {
+    const a = base({ id: '1', creator_name: 'Bob', creator_email: 'b@z.com' });
+    const b = base({ id: '2', creator_name: 'Bob', creator_email: 'a@z.com' });
+    expect(compareVersionsDashboardRows(a, b, 'creator', 'asc')).toBeGreaterThan(0);
+  });
+
+  it('sorts by created_at', () => {
+    const older = base({ id: 'o', created_at: '2020-01-01T00:00:00.000Z' });
+    const newer = base({ id: 'n', created_at: '2021-01-01T00:00:00.000Z' });
+    expect(compareVersionsDashboardRows(older, newer, 'created', 'asc')).toBeLessThan(0);
+    expect(compareVersionsDashboardRows(older, newer, 'created', 'desc')).toBeGreaterThan(0);
+  });
+});
+
+describe('sortVersionsDashboardRows', () => {
+  it('returns a copy preserving order when column is null', () => {
+    const rows = [base({ id: '2', version_id: '2.0.0' }), base({ id: '1', version_id: '1.0.0' })];
+    const out = sortVersionsDashboardRows(rows, null, 'asc');
+    expect(out).not.toBe(rows);
+    expect(out.map((r) => r.id)).toEqual(['2', '1']);
+  });
+
+  it('sorts full list by version ascending', () => {
+    const rows = [
+      base({ id: 'b', version_id: '10.0.0' }),
+      base({ id: 'a', version_id: '2.0.0' }),
+    ];
+    const out = sortVersionsDashboardRows(rows, 'version', 'asc');
+    expect(out.map((r) => r.id)).toEqual(['a', 'b']);
+  });
+});


### PR DESCRIPTION
## What changed
- Made the project **Versions** dashboard timeline table sortable by **Version**, **Revision / changelog**, **Status**, **Created by**, and **Created** (same header-button pattern as the Projects dashboard, #2982).
- Default sort remains **Created · descending** so the list matches the API (`ORDER BY created_at DESC`) until the user picks another column.
- Added `versions-dashboard-sort` helper and unit tests.

## How to test
1. **Sign in** and open **Dashboard → Versions**.
2. **Select a project** that has at least two revisions.
3. **Click** each sortable column header; confirm **ascending/descending** toggles on repeat clicks and the row order updates.
4. Optional: use **timeline filters** (search, author, dates); sorting should apply to the filtered rows only.

## Risk / notes
- Low risk: client-only reorder; history graph still uses the unsorted filtered list so DAG semantics are unchanged.
- Repo root `yarn build` may require `uv` for `objectified-mcp`; **objectified-ui** `yarn build` and targeted Jest passed locally.

Closes #2983

Made with [Cursor](https://cursor.com)