### PR TITLE
Fix #3132 - Published private spec links reuse saved API key

### DIFF
--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.74",
+  "version": "0.11.75",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -24,6 +24,7 @@ We continue to improve the platform based on your feedback with improvements and
 ## Export
 
 ## Dashboard
+- **Published Versions**: opening a **private** revision’s OpenAPI, Swagger UI, Arazzo, or JSON Schema link **reuses an API key saved in this browser** for the current tenant when present, so you are not prompted every time; otherwise the key dialog appears, with optional **remember** and a **clear saved key** control (#3132).
 - **Versions** timeline table (**version**, **revision / changelog**, **status**, **created by**, **created**) is **sortable** from the column headers: click to sort ascending, click again to toggle descending (#2983).
 - **Projects** table columns (**name**, **description**, **quality trend**, **status**, **creator**, **created**, **updated**) are **sortable** from the header: click to sort ascending, click again to toggle descending (#2982).
 - Projects list includes a **Show deleted** switch; when on, soft-deleted projects appear with a **Deleted** badge and **Restore** or **permanent delete** in the row menu (#2981).

--- a/objectified-ui/src/app/ade/dashboard/published/page.tsx
+++ b/objectified-ui/src/app/ade/dashboard/published/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useSession } from 'next-auth/react';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useMemo } from 'react';
 import { Eye, Lock, Globe, Copy, ExternalLink, Search, FileText, MoreVertical, ChevronLeft } from 'lucide-react';
 import { getPublishedVersionsForTenant, updateVersionVisibility, getApiKeysForTenant } from '../../../../../lib/db/helper';
 import {
@@ -13,6 +13,7 @@ import {
   DialogDescription,
 } from '../../../components/ui/Dialog';
 import { Button } from '../../../components/ui/Button';
+import { Checkbox } from '../../../components/ui/Checkbox';
 import { Input } from '../../../components/ui/Input';
 import { Label } from '../../../components/ui/Label';
 import { Badge } from '../../../components/ui/Badge';
@@ -34,6 +35,11 @@ import {
   dashboardTbodyClass,
   dashboardTrHoverClass,
 } from '@/app/components/ade/dashboard/dashboardScreenClasses';
+import {
+  clearStoredPreviewApiKey,
+  getStoredPreviewApiKey,
+  setStoredPreviewApiKey,
+} from '@/app/utils/preview-api-key-storage';
 
 interface PublishedVersion {
   id: string;
@@ -142,51 +148,79 @@ const PublishedVersions = () => {
 
   const [apiKeyDialog, setApiKeyDialog] = useState<{ version: PublishedVersion; action: 'open' | 'arazzo' | 'json' | 'swagger' } | null>(null);
   const [apiKeyInput, setApiKeyInput] = useState('');
+  const [rememberApiKey, setRememberApiKey] = useState(true);
+  /** Bumps when localStorage preview key changes so saved-key UI re-reads storage. */
+  const [previewKeyStorageVersion, setPreviewKeyStorageVersion] = useState(0);
+
+  const hasSavedPreviewApiKey = useMemo(() => {
+    void previewKeyStorageVersion;
+    return Boolean(currentTenantId && getStoredPreviewApiKey(currentTenantId));
+  }, [currentTenantId, previewKeyStorageVersion]);
 
   const openViewWithKey = (version: PublishedVersion, action: 'open' | 'arazzo' | 'json' | 'swagger', apiKey: string | undefined) => {
     const url = action === 'open' ? getFullAccessUrl(version) : action === 'arazzo' ? getArazzoUrl(version) : action === 'json' ? getJsonUrl(version) : getSwaggerUrl(version);
     window.open(withApiKey(url, apiKey), '_blank');
   };
 
+  const openPrivateWithOptionalStoredKey = (version: PublishedVersion, action: 'open' | 'arazzo' | 'json' | 'swagger') => {
+    const stored = getStoredPreviewApiKey(currentTenantId);
+    if (stored) {
+      openViewWithKey(version, action, stored);
+      return;
+    }
+    setApiKeyInput('');
+    setRememberApiKey(true);
+    setApiKeyDialog({ version, action });
+  };
+
   const handleOpenUrl = (version: PublishedVersion) => {
     if (version.visibility === 'private') {
-      setApiKeyInput('');
-      setApiKeyDialog({ version, action: 'open' });
+      openPrivateWithOptionalStoredKey(version, 'open');
       return;
     }
     window.open(getFullAccessUrl(version), '_blank');
   };
   const handleOpenSwagger = (version: PublishedVersion) => {
     if (version.visibility === 'private') {
-      setApiKeyInput('');
-      setApiKeyDialog({ version, action: 'swagger' });
+      openPrivateWithOptionalStoredKey(version, 'swagger');
       return;
     }
     window.open(getSwaggerUrl(version), '_blank');
   };
   const handleOpenArazzo = (version: PublishedVersion) => {
     if (version.visibility === 'private') {
-      setApiKeyInput('');
-      setApiKeyDialog({ version, action: 'arazzo' });
+      openPrivateWithOptionalStoredKey(version, 'arazzo');
       return;
     }
     window.open(getArazzoUrl(version), '_blank');
   };
   const handleOpenJson = (version: PublishedVersion) => {
     if (version.visibility === 'private') {
-      setApiKeyInput('');
-      setApiKeyDialog({ version, action: 'json' });
+      openPrivateWithOptionalStoredKey(version, 'json');
       return;
     }
     window.open(getJsonUrl(version), '_blank');
   };
   const handleApiKeyDialogOpen = () => {
     if (!apiKeyDialog) return;
-    openViewWithKey(apiKeyDialog.version, apiKeyDialog.action, apiKeyInput);
+    const trimmed = apiKeyInput.trim();
+    if (!trimmed) return;
+    openViewWithKey(apiKeyDialog.version, apiKeyDialog.action, trimmed);
+    if (rememberApiKey && currentTenantId) {
+      setStoredPreviewApiKey(currentTenantId, trimmed);
+      setPreviewKeyStorageVersion((n) => n + 1);
+    }
     setApiKeyDialog(null);
     setApiKeyInput('');
     setOpenVersionDropdown(null);
     setOpenViewSubmenu(null);
+  };
+
+  const handleClearSavedPreviewApiKey = () => {
+    if (!currentTenantId) return;
+    clearStoredPreviewApiKey(currentTenantId);
+    setPreviewKeyStorageVersion((n) => n + 1);
+    toast.success('Saved API key removed from this browser.');
   };
 
   const handleToggleVisibility = async (version: PublishedVersion) => {
@@ -565,7 +599,16 @@ const PublishedVersions = () => {
           <DialogHeader>
             <DialogTitle>API key required</DialogTitle>
             <DialogDescription>
-              This version is private. Enter your API key to open with authentication. You can create or copy a key from the API Keys page.
+              This version is private. Enter your tenant API key so the opened URL includes authentication (query{' '}
+              <code className="text-xs">api_key</code>). Create or manage keys on the{' '}
+              <a
+                href="/ade/dashboard/api-keys"
+                className="font-medium text-indigo-600 underline dark:text-indigo-400"
+              >
+                API Keys
+              </a>{' '}
+              page. If you choose &quot;Remember this key&quot; below, private OpenAPI, Swagger UI, Arazzo, and JSON
+              Schema links skip this prompt next time on this device.
             </DialogDescription>
           </DialogHeader>
           <div className="space-y-4 py-4">
@@ -581,12 +624,37 @@ const PublishedVersions = () => {
                 placeholder="sk_..."
               />
             </div>
+            <div className="flex items-start gap-3">
+              <Checkbox
+                id="remember-tenant-api-key"
+                checked={rememberApiKey}
+                onCheckedChange={(v) => setRememberApiKey(v === true)}
+                className="mt-0.5"
+              />
+              <Label htmlFor="remember-tenant-api-key" className="cursor-pointer text-sm font-normal leading-snug text-gray-700 dark:text-gray-300">
+                Remember this key on this browser for the current tenant (local storage only).
+              </Label>
+            </div>
           </div>
-          <DialogFooter>
-            <Button variant="outline" onClick={() => setApiKeyDialog(null)}>Cancel</Button>
-            <Button onClick={handleApiKeyDialogOpen} disabled={!apiKeyInput.trim()}>
-              Open with key
-            </Button>
+          <DialogFooter className="flex flex-col gap-3 sm:flex-col sm:space-x-0">
+            {hasSavedPreviewApiKey ? (
+              <Button
+                type="button"
+                variant="outline"
+                className="w-full sm:w-auto self-start border-amber-200 text-amber-900 hover:bg-amber-50 dark:border-amber-800 dark:text-amber-100 dark:hover:bg-amber-950/40"
+                onClick={handleClearSavedPreviewApiKey}
+              >
+                Clear saved key from this browser
+              </Button>
+            ) : null}
+            <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+              <Button variant="outline" onClick={() => setApiKeyDialog(null)}>
+                Cancel
+              </Button>
+              <Button onClick={handleApiKeyDialogOpen} disabled={!apiKeyInput.trim()}>
+                Open with key
+              </Button>
+            </div>
           </DialogFooter>
         </DialogContent>
       </Dialog>

--- a/objectified-ui/src/app/utils/preview-api-key-storage.ts
+++ b/objectified-ui/src/app/utils/preview-api-key-storage.ts
@@ -1,0 +1,45 @@
+/**
+ * Persists a tenant-scoped API key on the device so the Published Versions dashboard
+ * can open private schema / Swagger / Arazzo / JSON URLs without prompting every time.
+ * Values live only in localStorage (never sent except as auth on REST requests the user opens).
+ */
+
+const STORAGE_PREFIX = 'objectified.previewApiKey.v1:';
+
+export function previewApiKeyStorageKey(tenantId: string): string {
+  return `${STORAGE_PREFIX}${tenantId}`;
+}
+
+export function getStoredPreviewApiKey(tenantId: string | null | undefined): string | null {
+  if (!tenantId || typeof window === 'undefined') return null;
+  try {
+    const v = localStorage.getItem(previewApiKeyStorageKey(tenantId));
+    const t = v?.trim();
+    return t ? t : null;
+  } catch {
+    return null;
+  }
+}
+
+export function setStoredPreviewApiKey(tenantId: string, apiKey: string): void {
+  if (typeof window === 'undefined') return;
+  const t = apiKey.trim();
+  if (!t) {
+    clearStoredPreviewApiKey(tenantId);
+    return;
+  }
+  try {
+    localStorage.setItem(previewApiKeyStorageKey(tenantId), t);
+  } catch {
+    /* quota / private mode */
+  }
+}
+
+export function clearStoredPreviewApiKey(tenantId: string | null | undefined): void {
+  if (!tenantId || typeof window === 'undefined') return;
+  try {
+    localStorage.removeItem(previewApiKeyStorageKey(tenantId));
+  } catch {
+    /* ignore */
+  }
+}

--- a/objectified-ui/tests/unit/preview-api-key-storage.test.ts
+++ b/objectified-ui/tests/unit/preview-api-key-storage.test.ts
@@ -1,0 +1,40 @@
+import {
+  clearStoredPreviewApiKey,
+  getStoredPreviewApiKey,
+  previewApiKeyStorageKey,
+  setStoredPreviewApiKey,
+} from '../../src/app/utils/preview-api-key-storage';
+
+describe('preview-api-key-storage', () => {
+  const tenant = 'tenant-uuid-1';
+
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('uses a stable storage key per tenant', () => {
+    expect(previewApiKeyStorageKey(tenant)).toContain(tenant);
+  });
+
+  it('round-trips a trimmed key', () => {
+    setStoredPreviewApiKey(tenant, '  sk_test_abc  ');
+    expect(getStoredPreviewApiKey(tenant)).toBe('sk_test_abc');
+  });
+
+  it('returns null for empty or whitespace-only writes', () => {
+    setStoredPreviewApiKey(tenant, '   ');
+    expect(getStoredPreviewApiKey(tenant)).toBeNull();
+  });
+
+  it('clearStoredPreviewApiKey removes the entry', () => {
+    setStoredPreviewApiKey(tenant, 'sk_x');
+    clearStoredPreviewApiKey(tenant);
+    expect(getStoredPreviewApiKey(tenant)).toBeNull();
+  });
+
+  it('getStoredPreviewApiKey returns null when tenant is missing', () => {
+    setStoredPreviewApiKey(tenant, 'sk_x');
+    expect(getStoredPreviewApiKey(null)).toBeNull();
+    expect(getStoredPreviewApiKey(undefined)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
Private published OpenAPI / Swagger UI / Arazzo / JSON Schema actions on **Published Versions** now **open immediately** when a tenant API key is already saved in **localStorage** for the current tenant. Otherwise the existing key dialog appears, with optional **remember this key**, a link to **API Keys**, and **clear saved key** for this browser.

## How to test
1. **Sign in** and select a tenant that has a **private** published revision (with at least one enabled API key, or paste any valid key).
2. Open **Dashboard → Published Versions**.
3. Use **Actions → View → OpenAPI** (or **Swagger UI**): complete the API key dialog with **Remember this key** checked, then **Open with key**.
4. Repeat the same action: the spec should **open in a new tab without the dialog** (URL includes `api_key=`).
5. Open the dialog again (e.g. after revoking the saved key flow): use **Clear saved key from this browser**, then confirm the next private open **prompts** again.

## Risk / notes
- Keys are stored **only in the browser** (per-tenant). Users on shared machines should avoid “remember” or clear after use.

Fixes #3132

Made with [Cursor](https://cursor.com)