### PR TITLE
Fix #610 - Cognitive complexity score per class

### DIFF
--- a/docs/PLANNED_FEATURE_ROADMAP_AI.md
+++ b/docs/PLANNED_FEATURE_ROADMAP_AI.md
@@ -85,7 +85,7 @@ This outlines the planned features for integrating AI capabilities into Objectif
 ### AI Schema Health Insights
 
 **Schema Complexity Analysis** 📋 PLANNED
-- 📋 Cognitive complexity score per class
+- ✅ Cognitive complexity score per class (#610)
 - 📋 Dependency graph complexity
 - 📋 Cyclomatic complexity for conditional schemas
 - 📋 Maintainability index
@@ -93,7 +93,6 @@ This outlines the planned features for integrating AI capabilities into Objectif
 
 | Ticket | Feature Description                           |
 |--------|-----------------------------------------------|
-| #610   | AI Schema Complexity Analysis                 |
 | #611   | Dependency Graph Complexity                   |
 | #612   | Cyclomatic Complexity for Conditional Schemas |
 | #613   | Maintainability Index                         |

--- a/objectified-ui/lib/studio-metrics-digest-for-ai.ts
+++ b/objectified-ui/lib/studio-metrics-digest-for-ai.ts
@@ -8,6 +8,7 @@ import type { SchemaMetricsResult } from '@/app/utils/schema-metrics';
 const MAX_NAMES = 48;
 const MAX_PROP_ROWS = 60;
 const MAX_DEP_ROWS = 24;
+const MAX_COGNITIVE_ROWS = 40;
 
 function take<T>(arr: T[], n: number): T[] {
   return arr.length <= n ? arr : arr.slice(0, n);
@@ -87,6 +88,19 @@ export function buildStudioMetricsDigestForAi(
     lines.push('- Heaviest classes by degree (sample):');
     for (const row of take(sorted, MAX_DEP_ROWS)) {
       lines.push(`  - ${row.className}: in ${row.inDegree}, out ${row.outDegree}, betweenness ${row.betweenness.toFixed(3)}`);
+    }
+  }
+
+  if (metrics.cognitiveComplexityPerClass?.length) {
+    const sorted = [...metrics.cognitiveComplexityPerClass].sort((a, b) => b.score - a.score || a.className.localeCompare(b.className));
+    lines.push('- Per-class cognitive complexity (#610; props + weighted refs; higher = harder to reason about):');
+    for (const row of take(sorted, MAX_COGNITIVE_ROWS)) {
+      lines.push(
+        `  - ${row.className}: ${row.score} (props +${row.propertyContribution}, refs +${row.referenceContribution})`,
+      );
+    }
+    if (sorted.length > MAX_COGNITIVE_ROWS) {
+      lines.push(`  … and ${sorted.length - MAX_COGNITIVE_ROWS} more classes`);
     }
   }
 

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.75",
+  "version": "0.11.76",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -30,6 +30,7 @@ We continue to improve the platform based on your feedback with improvements and
 - Projects list includes a **Show deleted** switch; when on, soft-deleted projects appear with a **Deleted** badge and **Restore** or **permanent delete** in the row menu (#2981).
 
 ## Studio
+- **Schema Metrics** includes **cognitive complexity per class** (props plus weighted outgoing dependency edges; anyOf/oneOf count double) and feeds the same scores into the **AI improvement suggestions** metrics digest (#610).
 - **AI improvement suggestions** supports **bulk apply**: when the model returns structured **apply** targets (empty class or property descriptions), select rows and **Apply selected** to fill documentation on the canvas in one pass (#256).
 - **AI improvement suggestions** shows an optional **estimated overall score impact** (points on the 0–100 Studio composite) per row when the model supplies it; the metrics digest includes the **current overall score** so estimates stay grounded (#255).
 - **AI improvement suggestions** (Schema Metrics **lightbulb**) now labels each item with **effort** (quick win, standard, larger effort), **sorts quick wins to the top**, and adds an **Effort** line when you copy a row (#254).

--- a/objectified-ui/src/app/ade/studio/components/SchemaMetricsPanel.tsx
+++ b/objectified-ui/src/app/ade/studio/components/SchemaMetricsPanel.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import * as React from 'react';
-import { BarChart3, ChevronDown, ChevronUp, X, Link2, Unlink, GitBranch, RefreshCw, Layout, Gauge, Lightbulb, LayoutGrid, Box, Layers, FileText, Type, Network, FileDown } from 'lucide-react';
+import { BarChart3, ChevronDown, ChevronUp, X, Link2, Unlink, GitBranch, RefreshCw, Layout, Gauge, Lightbulb, LayoutGrid, Box, Layers, FileText, Type, Network, FileDown, Brain } from 'lucide-react';
 import * as Tooltip from '@radix-ui/react-tooltip';
 import * as Popover from '@radix-ui/react-popover';
 import { cn } from '../../../../../lib/utils';
@@ -85,6 +85,7 @@ export default function SchemaMetricsPanel({
     propertiesMissingDocumentation,
     namingCompliance,
     dependencyMetricsPerClass = [],
+    cognitiveComplexityPerClass = [],
   } = metrics;
 
   const docsScoreTier = getNumericScoreTier(documentationCompletionPercentage);
@@ -675,6 +676,45 @@ export default function SchemaMetricsPanel({
                           <td className="py-1 px-2 text-right tabular-nums text-gray-600 dark:text-gray-400">
                             {row.betweenness.toFixed(2)}
                           </td>
+                        </tr>
+                      ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          )}
+
+          {/* #610: Cognitive complexity per class (for humans + AI digest) */}
+          {cognitiveComplexityPerClass.length > 0 && (
+            <div>
+              <div className="flex items-center gap-1.5 text-[10px] text-gray-500 dark:text-gray-400 uppercase tracking-wider mb-1.5">
+                <Brain className="w-3 h-3" />
+                Cognitive complexity per class
+              </div>
+              <p className="text-[11px] text-gray-500 dark:text-gray-400 mb-2">
+                Props + weighted outgoing refs (anyOf/oneOf count double). Higher scores mean more to hold in mind when reading the model.
+              </p>
+              <div className="rounded-lg border border-gray-200 dark:border-gray-600 overflow-hidden max-h-48 overflow-y-auto">
+                <table className="w-full text-[11px] border-collapse">
+                  <thead className="sticky top-0 bg-gray-50 dark:bg-gray-700/80 text-left">
+                    <tr>
+                      <th className="py-1.5 px-2 font-medium text-gray-600 dark:text-gray-400">Class</th>
+                      <th className="py-1.5 px-2 font-medium text-gray-600 dark:text-gray-400 text-right w-14">Score</th>
+                      <th className="py-1.5 px-2 font-medium text-gray-600 dark:text-gray-400 text-right w-12">Props</th>
+                      <th className="py-1.5 px-2 font-medium text-gray-600 dark:text-gray-400 text-right w-12">Refs</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {[...cognitiveComplexityPerClass]
+                      .sort((a, b) => b.score - a.score || a.className.localeCompare(b.className))
+                      .map((row, i) => (
+                        <tr key={row.classId} className={i % 2 === 0 ? 'bg-white dark:bg-gray-800/50' : 'bg-gray-50/80 dark:bg-gray-700/30'}>
+                          <td className="py-1 px-2 truncate max-w-[100px] text-gray-800 dark:text-gray-200 font-medium" title={row.className}>
+                            {row.className}
+                          </td>
+                          <td className="py-1 px-2 text-right tabular-nums font-medium text-gray-800 dark:text-gray-200">{row.score}</td>
+                          <td className="py-1 px-2 text-right tabular-nums text-gray-600 dark:text-gray-400">{row.propertyContribution}</td>
+                          <td className="py-1 px-2 text-right tabular-nums text-gray-600 dark:text-gray-400">{row.referenceContribution}</td>
                         </tr>
                       ))}
                   </tbody>

--- a/objectified-ui/src/app/api/ollama/chat/route.ts
+++ b/objectified-ui/src/app/api/ollama/chat/route.ts
@@ -258,7 +258,7 @@ function buildPropertyTypeSuggestionsSystem(options: {
 
 const SCHEMA_IMPROVEMENT_SUGGESTIONS_SYSTEM = `You are a senior API and JSON Schema reviewer helping a team improve an OpenAPI 3.1–oriented data model in Objectified Studio.
 
-You receive **measured canvas metrics** (class counts, documentation coverage, naming compliance, dependency complexity, samples of gaps). Your job is to propose **prioritized, actionable improvements** that a human can follow—similar in tone to:
+You receive **measured canvas metrics** (class counts, documentation coverage, naming compliance, aggregate dependency complexity, **per-class cognitive complexity** scores, samples of gaps). Your job is to propose **prioritized, actionable improvements** that a human can follow—similar in tone to:
 
 - "Add descriptions to N classes to improve docs score"
 - "Rename M properties to follow camelCase convention"
@@ -295,7 +295,7 @@ Return **exactly one** markdown fenced JSON block and **nothing outside the fenc
 - Emit **6–12** suggestions unless the digest is extremely small (then 3–5 is fine).
 - Every "title" and "detail" must be non-empty strings.
 - "category" must be one of: "documentation", "naming", "structure", "api", "performance", "other". Pick the best fit per row.
-- Every row MUST include **"estimatedOverallScoreDelta"**: an **integer** (typically **0–12**, occasionally higher for broad fixes) estimating how many **points** the Studio **overall schema quality score (0–100)** in the digest would **increase** if that suggestion were **fully applied**. Use **0** only when the effect on the composite would be negligible. When the digest includes the current overall score line, anchor estimates to that baseline and the listed doc %, naming %, and complexity. Do not exceed **25**; use negative values only if a fix could realistically lower the composite (rare).
+- Every row MUST include **"estimatedOverallScoreDelta"**: an **integer** (typically **0–12**, occasionally higher for broad fixes) estimating how many **points** the Studio **overall schema quality score (0–100)** in the digest would **increase** if that suggestion were **fully applied**. Use **0** only when the effect on the composite would be negligible. When the digest includes the current overall score line, anchor estimates to that baseline and the listed doc %, naming %, complexity, and **per-class cognitive complexity** lines. Do not exceed **25**; use negative values only if a fix could realistically lower the composite (rare).
 - Every row MUST include **"effort"**: one of \`"quick_win"\`, \`"moderate"\`, or \`"substantial"\`.
   - **quick_win**: small, localized edits (add missing descriptions, rename a few properties, tighten one validation) that a developer can often finish in minutes to an hour.
   - **moderate**: bounded refactors (split one busy class, normalize a small set of names, add a shared pattern across a few schemas).

--- a/objectified-ui/src/app/utils/export-schema-score-report-pdf.ts
+++ b/objectified-ui/src/app/utils/export-schema-score-report-pdf.ts
@@ -176,6 +176,23 @@ function addMetricsBody(
     }
   }
 
+  if (m.cognitiveComplexityPerClass.length > 0) {
+    section(ctx, 'Cognitive complexity per class (#610)');
+    const sorted = [...m.cognitiveComplexityPerClass].sort((a, b) => b.score - a.score || a.className.localeCompare(b.className));
+    const cap = Math.min(sorted.length, 60);
+    const hdr = 'Class | Score | Props | Refs';
+    const body = sorted
+      .slice(0, cap)
+      .map(
+        (r) =>
+          `${r.className} | ${r.score} | ${r.propertyContribution} | ${r.referenceContribution}`,
+      );
+    paragraph(ctx, [hdr, ...body].join('\n'));
+    if (sorted.length > cap) {
+      paragraph(ctx, `+ ${sorted.length - cap} more rows in Studio.`);
+    }
+  }
+
   if (layoutQuality) {
     section(ctx, 'Layout quality');
     paragraph(

--- a/objectified-ui/src/app/utils/schema-metrics.ts
+++ b/objectified-ui/src/app/utils/schema-metrics.ts
@@ -48,6 +48,12 @@ export interface SchemaMetricsResult {
   namingCompliance: NamingComplianceResult;
   /** #553: Per-class dependency metrics (in-degree, out-degree, betweenness) on dependency graph */
   dependencyMetricsPerClass: DependencyClassMetricsEntry[];
+  /**
+   * #610: Per-class cognitive complexity for the schema model (AI digest + Studio).
+   * Score = property count + weighted sum of outgoing dependency edges (simple refs +1;
+   * class-level or property-level allOf +1; anyOf/oneOf +2 as disjunctive load).
+   */
+  cognitiveComplexityPerClass: CognitiveComplexityPerClassEntry[];
 }
 
 /** #553: One row of dependency metrics for a class (in-degree, out-degree, betweenness). */
@@ -57,6 +63,15 @@ export interface DependencyClassMetricsEntry {
   inDegree: number;
   outDegree: number;
   betweenness: number;
+}
+
+/** #610: Cognitive-style load for one class (unbounded integer; higher = more to reason about). */
+export interface CognitiveComplexityPerClassEntry {
+  classId: string;
+  className: string;
+  score: number;
+  propertyContribution: number;
+  referenceContribution: number;
 }
 
 /** Naming convention counts and compliance percentage (#558) */
@@ -178,6 +193,41 @@ function getDegreePerNode(nodes: Node[], edges: Edge[]): Map<string, number> {
 function isDependencyEdge(e: Edge): boolean {
   const id = e.id ?? '';
   return /^(prop-|allOf-|anyOf-|oneOf-)/.test(id);
+}
+
+/**
+ * #610: Incremental weight for one outgoing dependency edge toward cognitive complexity.
+ * Matches Studio / metrics graph edge id conventions from {@link buildGraphForSchemaMetrics}.
+ */
+function cognitiveWeightForDependencyEdge(e: Edge): number {
+  const id = e.id ?? '';
+  if (id.startsWith('anyOf-') || id.startsWith('oneOf-')) return 2;
+  if (id.startsWith('allOf-')) return 1;
+  if (/^prop-(anyOf|oneOf)-/.test(id)) return 2;
+  if (/^prop-allOf-/.test(id)) return 1;
+  if (id.startsWith('prop-')) return 1;
+  return 0;
+}
+
+function computeCognitiveComplexityPerClass(classNodes: Node[], dependencyEdges: Edge[]): CognitiveComplexityPerClassEntry[] {
+  const refLoadBySource = new Map<string, number>();
+  for (const e of dependencyEdges) {
+    if (!isDependencyEdge(e)) continue;
+    const w = cognitiveWeightForDependencyEdge(e);
+    if (w <= 0) continue;
+    refLoadBySource.set(e.source, (refLoadBySource.get(e.source) ?? 0) + w);
+  }
+  return classNodes.map((n) => {
+    const propertyContribution = getPropertyCount(n);
+    const referenceContribution = refLoadBySource.get(n.id) ?? 0;
+    return {
+      classId: n.id,
+      className: getNodeName(n),
+      score: propertyContribution + referenceContribution,
+      propertyContribution,
+      referenceContribution,
+    };
+  });
 }
 
 /**
@@ -474,6 +524,8 @@ export function computeSchemaMetrics(nodes: Node[], edges: Edge[]): SchemaMetric
     betweenness: betweennessMap.get(n.id) ?? 0,
   }));
 
+  const cognitiveComplexityPerClass = computeCognitiveComplexityPerClass(classNodes, dependencyEdges);
+
   return {
     classCount,
     totalProperties,
@@ -495,6 +547,7 @@ export function computeSchemaMetrics(nodes: Node[], edges: Edge[]): SchemaMetric
     propertiesMissingDocumentation: docResult.propertiesMissing,
     namingCompliance,
     dependencyMetricsPerClass,
+    cognitiveComplexityPerClass,
   };
 }
 

--- a/objectified-ui/tests/schema-graph-from-classes.test.ts
+++ b/objectified-ui/tests/schema-graph-from-classes.test.ts
@@ -44,5 +44,8 @@ describe('schema-graph-from-classes / computeSchemaMetricsFromClasses', () => {
     expect(m.relationshipCount).toBeGreaterThan(0);
     expect(m.complexityScore).toBeGreaterThanOrEqual(0);
     expect(m.complexityScore).toBeLessThanOrEqual(100);
+    const byName = Object.fromEntries(m.cognitiveComplexityPerClass.map((c) => [c.className, c]));
+    expect(byName.Post?.score).toBe(2);
+    expect(byName.User?.score).toBe(0);
   });
 });

--- a/objectified-ui/tests/unit/cognitive-complexity-per-class.test.ts
+++ b/objectified-ui/tests/unit/cognitive-complexity-per-class.test.ts
@@ -1,0 +1,76 @@
+import { buildGraphForSchemaMetrics } from '@/app/utils/schema-graph-from-classes';
+import { computeSchemaMetrics, computeSchemaMetricsFromClasses } from '@/app/utils/schema-metrics';
+
+describe('cognitive complexity per class (#610)', () => {
+  it('sums properties and simple outgoing ref edges', () => {
+    const classes = [
+      { id: 'a', name: 'User', properties: [], schema: {} },
+      {
+        id: 'b',
+        name: 'Post',
+        properties: [
+          {
+            id: 'p1',
+            name: 'author',
+            data: JSON.stringify({ $ref: '#/components/schemas/User' }),
+          },
+        ],
+        schema: {},
+      },
+    ];
+    const m = computeSchemaMetricsFromClasses(classes);
+    const byName = Object.fromEntries(m.cognitiveComplexityPerClass.map((c) => [c.className, c]));
+    expect(byName.User).toMatchObject({ score: 0, propertyContribution: 0, referenceContribution: 0 });
+    expect(byName.Post).toMatchObject({ score: 2, propertyContribution: 1, referenceContribution: 1 });
+  });
+
+  it('weights property-level anyOf refs higher than a single $ref', () => {
+    const classes = [
+      { id: 'u', name: 'User', properties: [], schema: {} },
+      { id: 'p', name: 'Pet', properties: [], schema: {} },
+      {
+        id: 'o',
+        name: 'OwnerRef',
+        properties: [
+          {
+            id: 'p1',
+            name: 'subject',
+            data: JSON.stringify({
+              anyOf: [{ $ref: '#/components/schemas/User' }, { $ref: '#/components/schemas/Pet' }],
+            }),
+          },
+        ],
+        schema: {},
+      },
+    ];
+    const m = computeSchemaMetricsFromClasses(classes);
+    const row = m.cognitiveComplexityPerClass.find((c) => c.className === 'OwnerRef');
+    expect(row).toBeDefined();
+    expect(row).toMatchObject({
+      propertyContribution: 1,
+      referenceContribution: 4,
+      score: 5,
+    });
+  });
+
+  it('uses weight 2 for class-level oneOf edges from built graph', () => {
+    const classes = [
+      {
+        id: 'a',
+        name: 'Shape',
+        properties: [],
+        schema: {
+          oneOf: [{ $ref: '#/components/schemas/Circle' }, { $ref: '#/components/schemas/Square' }],
+        },
+      },
+      { id: 'b', name: 'Circle', properties: [], schema: {} },
+      { id: 'c', name: 'Square', properties: [], schema: {} },
+    ];
+    const { nodes, edges } = buildGraphForSchemaMetrics(classes);
+    const m = computeSchemaMetrics(nodes, edges);
+    const shape = m.cognitiveComplexityPerClass.find((r) => r.className === 'Shape');
+    expect(shape).toBeDefined();
+    expect(shape!.referenceContribution).toBe(4);
+    expect(shape!.score).toBe(4);
+  });
+});

--- a/objectified-ui/tests/unit/export-schema-score-report-pdf.test.ts
+++ b/objectified-ui/tests/unit/export-schema-score-report-pdf.test.ts
@@ -71,6 +71,7 @@ function makeMinimalMetrics(overrides: Partial<SchemaMetricsResult> = {}): Schem
       propertiesNonCamel: [],
     },
     dependencyMetricsPerClass: [],
+    cognitiveComplexityPerClass: [],
     ...overrides,
   };
 }
@@ -143,6 +144,18 @@ describe('downloadSchemaScoreReportPdf', () => {
       downloadSchemaScoreReportPdf({ metrics, projectName: 'P', versionLabel: 'v1' })
     ).not.toThrow();
     expect(mockSave).toHaveBeenCalledTimes(1);
+  });
+
+  it('includes cognitive complexity section when rows are present', () => {
+    const metrics = makeMinimalMetrics({
+      cognitiveComplexityPerClass: [
+        { classId: 'c1', className: 'Heavy', score: 15, propertyContribution: 12, referenceContribution: 3 },
+      ],
+    });
+    downloadSchemaScoreReportPdf({ metrics, projectName: 'P', versionLabel: 'v1' });
+    const joined = (mockText.mock.calls as Array<[string, ...unknown[]]>).map((c) => String(c[0])).join('\n');
+    expect(joined).toContain('Cognitive complexity per class');
+    expect(joined).toContain('Heavy | 15 | 12 | 3');
   });
 
   it('does not throw with dependency metrics and layout quality', () => {

--- a/objectified-ui/tests/unit/overall-schema-quality.test.ts
+++ b/objectified-ui/tests/unit/overall-schema-quality.test.ts
@@ -30,6 +30,7 @@ function makeMinimalMetrics(overrides: Partial<SchemaMetricsResult> = {}): Schem
       propertiesNonCamel: [],
     },
     dependencyMetricsPerClass: [],
+    cognitiveComplexityPerClass: [],
     ...overrides,
   };
 }

--- a/objectified-ui/tests/unit/schema-version-score-compare.test.ts
+++ b/objectified-ui/tests/unit/schema-version-score-compare.test.ts
@@ -33,6 +33,7 @@ function makeMinimalMetrics(overrides: Partial<SchemaMetricsResult> = {}): Schem
       propertiesNonCamel: [],
     },
     dependencyMetricsPerClass: [],
+    cognitiveComplexityPerClass: [],
     ...overrides,
   };
 }

--- a/objectified-ui/tests/unit/studio-metrics-digest-for-ai.test.ts
+++ b/objectified-ui/tests/unit/studio-metrics-digest-for-ai.test.ts
@@ -31,6 +31,9 @@ function baseMetrics(over: Partial<SchemaMetricsResult> = {}): SchemaMetricsResu
     dependencyMetricsPerClass: [
       { classId: '1', className: 'User', inDegree: 0, outDegree: 2, betweenness: 0.1 },
     ],
+    cognitiveComplexityPerClass: [
+      { classId: '1', className: 'User', score: 7, propertyContribution: 5, referenceContribution: 2 },
+    ],
     ...over,
   };
 }
@@ -44,6 +47,8 @@ describe('buildStudioMetricsDigestForAi', () => {
     expect(text).toContain('User.email');
     expect(text).toContain('User_ID');
     expect(text).toContain('Hub classes');
+    expect(text).toContain('Per-class cognitive complexity');
+    expect(text).toContain('User: 7 (props +5, refs +2)');
   });
 
   it('includes overall schema quality score when provided (#255)', () => {


### PR DESCRIPTION
## What
Adds a **per-class cognitive complexity** score derived from the live schema graph: each class gets `propertyContribution` (count of properties) plus `referenceContribution` (weighted sum of outgoing dependency edges). Simple `$ref` / `allOf` edges add **1**; `anyOf` / `oneOf` (disjunctive shapes) add **2** per edge so the model matches how hard the type is to reason about.

Surfaces the data in **Schema Metrics** (sortable table), the **studio metrics digest** for **AI improvement suggestions**, the **Ollama** improvement prompt (so the model anchors on the new lines), and **PDF score export**. `SchemaMetricsResult` now includes `cognitiveComplexityPerClass`.

## How to test
1. **Open Studio** with a version that has classes and some `$ref` / composition edges.
2. **Open Schema Metrics** and scroll to **Cognitive complexity per class** — confirm scores match intuition (e.g. a class with `anyOf` refs scores higher than a plain single `$ref`).
3. **Click the lightbulb** (AI improvement suggestions) and confirm the digest includes a **Per-class cognitive complexity** block with `props +N, refs +M` breakdown.
4. **Export PDF** from Schema Metrics and confirm the new section appears when metrics are non-empty.

## Risk / notes
- Scores are **heuristic** (edge-id conventions from `buildGraphForSchemaMetrics` / editor); custom edges outside those patterns may contribute **0** reference weight until aligned.
- Monorepo `yarn build` at root may require `uv` for `objectified-mcp`; **objectified-ui** `yarn build` and `yarn test` were run successfully.

Fixes KenSuenobu/objectified#610

Made with [Cursor](https://cursor.com)