### PR TITLE
Fix #611 - Dependency graph complexity in schema metrics

### DIFF
--- a/docs/PLANNED_FEATURE_ROADMAP_AI.md
+++ b/docs/PLANNED_FEATURE_ROADMAP_AI.md
@@ -86,14 +86,13 @@ This outlines the planned features for integrating AI capabilities into Objectif
 
 **Schema Complexity Analysis** 📋 PLANNED
 - ✅ Cognitive complexity score per class (#610)
-- 📋 Dependency graph complexity
+- ✅ Dependency graph complexity (#611)
 - 📋 Cyclomatic complexity for conditional schemas
 - 📋 Maintainability index
 - 📋 Technical debt metrics
 
 | Ticket | Feature Description                           |
 |--------|-----------------------------------------------|
-| #611   | Dependency Graph Complexity                   |
 | #612   | Cyclomatic Complexity for Conditional Schemas |
 | #613   | Maintainability Index                         |
 | #614   | Technical Debt Metrics                        |

--- a/objectified-ui/lib/studio-metrics-digest-for-ai.ts
+++ b/objectified-ui/lib/studio-metrics-digest-for-ai.ts
@@ -33,6 +33,10 @@ export function buildStudioMetricsDigestForAi(
   lines.push(`- Naming compliance (PascalCase classes + camelCase props): ${metrics.namingCompliance.compliancePercentage}%`);
   lines.push(`- Circular dependency groups: ${metrics.circularDependencyCount}`);
   lines.push(`- Deepest dependency chain length: ${metrics.deepestChainLength}`);
+  const dg = metrics.dependencyGraphComplexity;
+  lines.push(
+    `- Dependency graph complexity (#611): ${dg.score}/100 (${dg.scoreLabel}) — ${dg.edgeCount} dependency-only edges, deepest chain ${dg.deepestChainSteps} step(s), ${dg.circularGroupCount} cycle group(s) on refs/composition graph`,
+  );
   if (typeof overallQualityScore === 'number' && Number.isFinite(overallQualityScore)) {
     lines.push(
       `- Overall schema quality score (0–100 composite: docs, naming, structural load, layout when available): ${Math.min(100, Math.max(0, Math.round(overallQualityScore)))}`,

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.76",
+  "version": "0.11.77",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -30,6 +30,7 @@ We continue to improve the platform based on your feedback with improvements and
 - Projects list includes a **Show deleted** switch; when on, soft-deleted projects appear with a **Deleted** badge and **Restore** or **permanent delete** in the row menu (#2981).
 
 ## Studio
+- **Schema Metrics** adds **dependency graph complexity** (0–100 on property references and class-level allOf/anyOf/oneOf only): headline score with factor breakdown in the panel, **AI metrics digest**, and **PDF score report** (#611).
 - **Schema Metrics** includes **cognitive complexity per class** (props plus weighted outgoing dependency edges; anyOf/oneOf count double) and feeds the same scores into the **AI improvement suggestions** metrics digest (#610).
 - **AI improvement suggestions** supports **bulk apply**: when the model returns structured **apply** targets (empty class or property descriptions), select rows and **Apply selected** to fill documentation on the canvas in one pass (#256).
 - **AI improvement suggestions** shows an optional **estimated overall score impact** (points on the 0–100 Studio composite) per row when the model supplies it; the metrics digest includes the **current overall score** so estimates stay grounded (#255).

--- a/objectified-ui/src/app/ade/studio/components/SchemaMetricsPanel.tsx
+++ b/objectified-ui/src/app/ade/studio/components/SchemaMetricsPanel.tsx
@@ -86,6 +86,7 @@ export default function SchemaMetricsPanel({
     namingCompliance,
     dependencyMetricsPerClass = [],
     cognitiveComplexityPerClass = [],
+    dependencyGraphComplexity,
   } = metrics;
 
   const docsScoreTier = getNumericScoreTier(documentationCompletionPercentage);
@@ -641,6 +642,99 @@ export default function SchemaMetricsPanel({
                 {circularSampleNames.length > 3 ? '…' : ''}
               </p>
             )}
+          </div>
+
+          {/* #611: Dependency-only graph complexity (score + factor breakdown) */}
+          <div>
+            <Popover.Root>
+              <Popover.Trigger asChild>
+                <button
+                  type="button"
+                  className="w-full rounded-lg bg-gray-50 dark:bg-gray-700/40 dark:border dark:border-gray-600/40 px-2.5 py-2 text-left cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-600/40 focus:outline-none focus:ring-2 focus:ring-indigo-400 focus:ring-offset-2 focus:ring-offset-white dark:focus:ring-offset-gray-800"
+                  aria-label="Dependency graph complexity; click for breakdown"
+                  title="Property references and class composition edges only — click for breakdown"
+                >
+                  <div className="flex items-center justify-between gap-2">
+                    <div className="flex items-center gap-1.5 min-w-0">
+                      <Network className="w-4 h-4 text-indigo-500 shrink-0" aria-hidden />
+                      <span className="text-[10px] text-gray-500 dark:text-gray-400 uppercase tracking-wider truncate">
+                        Dependency graph complexity
+                      </span>
+                    </div>
+                    <div className="flex items-center gap-2 shrink-0">
+                      <span className="text-lg font-bold text-gray-800 dark:text-gray-200 tabular-nums">
+                        {dependencyGraphComplexity.score}
+                      </span>
+                      <span
+                        className={cn(
+                          'text-xs font-medium px-1.5 py-0.5 rounded',
+                          dependencyGraphComplexity.scoreLabel === 'Low' &&
+                            'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-300',
+                          dependencyGraphComplexity.scoreLabel === 'Medium' &&
+                            'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300',
+                          dependencyGraphComplexity.scoreLabel === 'High' &&
+                            'bg-rose-100 text-rose-800 dark:bg-rose-900/40 dark:text-rose-300',
+                        )}
+                      >
+                        {dependencyGraphComplexity.scoreLabel}
+                      </span>
+                    </div>
+                  </div>
+                  <p className="text-[10px] text-gray-500 dark:text-gray-400 mt-1 leading-snug">
+                    {dependencyGraphComplexity.edgeCount} dependency edge
+                    {dependencyGraphComplexity.edgeCount !== 1 ? 's' : ''} · deepest chain{' '}
+                    {dependencyGraphComplexity.deepestChainSteps} step
+                    {dependencyGraphComplexity.deepestChainSteps !== 1 ? 's' : ''} ·{' '}
+                    {dependencyGraphComplexity.circularGroupCount} cycle group
+                    {dependencyGraphComplexity.circularGroupCount !== 1 ? 's' : ''}
+                  </p>
+                  <p className="text-[10px] text-gray-400 dark:text-gray-500 mt-0.5">Click for factor breakdown</p>
+                </button>
+              </Popover.Trigger>
+              <Popover.Portal>
+                <Popover.Content
+                  className="z-[10000] w-72 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-lg p-3 focus:outline-none"
+                  sideOffset={6}
+                  align="start"
+                >
+                  <div className="text-xs font-semibold text-gray-800 dark:text-gray-200 mb-2">
+                    Why this dependency graph score?
+                  </div>
+                  <p className="text-[11px] text-gray-500 dark:text-gray-400 mb-3">
+                    Uses only property references and class-level allOf, anyOf, and oneOf links—the same
+                    dependency edges as the per-class table below. Layout-only canvas edges are excluded.
+                  </p>
+                  <table className="w-full text-[11px] text-left border-collapse">
+                    <thead>
+                      <tr className="border-b border-gray-200 dark:border-gray-600">
+                        <th className="py-1 pr-2 font-medium text-gray-600 dark:text-gray-400">Factor</th>
+                        <th className="py-1 pr-2 font-medium text-gray-600 dark:text-gray-400 text-right">Value</th>
+                        <th className="py-1 pr-2 font-medium text-gray-600 dark:text-gray-400 text-right">× weight</th>
+                        <th className="py-1 font-medium text-gray-600 dark:text-gray-400 text-right">Points</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {dependencyGraphComplexity.breakdown.map((row, i) => (
+                        <tr key={i} className="border-b border-gray-100 dark:border-gray-700/80">
+                          <td className="py-1 pr-2 text-gray-700 dark:text-gray-300">{row.label}</td>
+                          <td className="py-1 pr-2 text-right tabular-nums text-gray-700 dark:text-gray-300">{row.value}</td>
+                          <td className="py-1 pr-2 text-right tabular-nums text-gray-500 dark:text-gray-400">{row.weight}</td>
+                          <td className="py-1 text-right tabular-nums font-medium text-gray-800 dark:text-gray-200">
+                            {row.contribution.toFixed(1)}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                  <div className="mt-2 pt-2 border-t border-gray-200 dark:border-gray-600 flex justify-between text-[11px]">
+                    <span className="text-gray-500 dark:text-gray-400">Raw sum → capped</span>
+                    <span className="font-semibold text-gray-800 dark:text-gray-200 tabular-nums">
+                      {dependencyGraphComplexity.score}/100
+                    </span>
+                  </div>
+                </Popover.Content>
+              </Popover.Portal>
+            </Popover.Root>
           </div>
 
           {/* #553: Dependency metrics per class (in-degree, out-degree, betweenness) */}

--- a/objectified-ui/src/app/api/ollama/chat/route.ts
+++ b/objectified-ui/src/app/api/ollama/chat/route.ts
@@ -258,7 +258,7 @@ function buildPropertyTypeSuggestionsSystem(options: {
 
 const SCHEMA_IMPROVEMENT_SUGGESTIONS_SYSTEM = `You are a senior API and JSON Schema reviewer helping a team improve an OpenAPI 3.1–oriented data model in Objectified Studio.
 
-You receive **measured canvas metrics** (class counts, documentation coverage, naming compliance, aggregate dependency complexity, **per-class cognitive complexity** scores, samples of gaps). Your job is to propose **prioritized, actionable improvements** that a human can follow—similar in tone to:
+You receive **measured canvas metrics** (class counts, documentation coverage, naming compliance, aggregate schema complexity, **dependency graph complexity** on refs/composition, **per-class cognitive complexity** scores, samples of gaps). Your job is to propose **prioritized, actionable improvements** that a human can follow—similar in tone to:
 
 - "Add descriptions to N classes to improve docs score"
 - "Rename M properties to follow camelCase convention"
@@ -295,7 +295,7 @@ Return **exactly one** markdown fenced JSON block and **nothing outside the fenc
 - Emit **6–12** suggestions unless the digest is extremely small (then 3–5 is fine).
 - Every "title" and "detail" must be non-empty strings.
 - "category" must be one of: "documentation", "naming", "structure", "api", "performance", "other". Pick the best fit per row.
-- Every row MUST include **"estimatedOverallScoreDelta"**: an **integer** (typically **0–12**, occasionally higher for broad fixes) estimating how many **points** the Studio **overall schema quality score (0–100)** in the digest would **increase** if that suggestion were **fully applied**. Use **0** only when the effect on the composite would be negligible. When the digest includes the current overall score line, anchor estimates to that baseline and the listed doc %, naming %, complexity, and **per-class cognitive complexity** lines. Do not exceed **25**; use negative values only if a fix could realistically lower the composite (rare).
+- Every row MUST include **"estimatedOverallScoreDelta"**: an **integer** (typically **0–12**, occasionally higher for broad fixes) estimating how many **points** the Studio **overall schema quality score (0–100)** in the digest would **increase** if that suggestion were **fully applied**. Use **0** only when the effect on the composite would be negligible. When the digest includes the current overall score line, anchor estimates to that baseline and the listed doc %, naming %, complexity, **dependency graph complexity (#611)**, and **per-class cognitive complexity** lines. Do not exceed **25**; use negative values only if a fix could realistically lower the composite (rare).
 - Every row MUST include **"effort"**: one of \`"quick_win"\`, \`"moderate"\`, or \`"substantial"\`.
   - **quick_win**: small, localized edits (add missing descriptions, rename a few properties, tighten one validation) that a developer can often finish in minutes to an hour.
   - **moderate**: bounded refactors (split one busy class, normalize a small set of names, add a shared pattern across a few schemas).

--- a/objectified-ui/src/app/utils/export-schema-score-report-pdf.ts
+++ b/objectified-ui/src/app/utils/export-schema-score-report-pdf.ts
@@ -78,6 +78,7 @@ function addMetricsBody(
       `Average properties per class: ${m.averagePropertiesPerClass.toFixed(1)}`,
       `Relationships: ${m.relationshipCount}`,
       `Schema complexity: ${m.complexityScore}/100 (${m.complexityLabel})`,
+      `Dependency graph complexity (#611): ${m.dependencyGraphComplexity.score}/100 (${m.dependencyGraphComplexity.scoreLabel}) — ${m.dependencyGraphComplexity.edgeCount} dependency-only edges, deepest ref chain ${m.dependencyGraphComplexity.deepestChainSteps} step(s), ${m.dependencyGraphComplexity.circularGroupCount} cycle group(s)`,
       `Documentation coverage: ${m.documentationCompletionPercentage}%`,
       `Naming compliance: ${m.namingCompliance.compliancePercentage}%`,
     ].join('\n')
@@ -159,6 +160,23 @@ function addMetricsBody(
       `Circular dependencies: ${m.circularDependencyCount}${m.circularSampleNames.length ? ` (e.g. ${m.circularSampleNames.slice(0, 5).join(', ')})` : ''}`,
     ].join('\n')
   );
+
+  section(ctx, 'Dependency graph complexity (#611)');
+  const dg = m.dependencyGraphComplexity;
+  paragraph(
+    ctx,
+    [
+      `Score: ${dg.score}/100 (${dg.scoreLabel})`,
+      `Dependency-only edges: ${dg.edgeCount}`,
+      `Deepest ref chain (dependency graph): ${dg.deepestChainSteps} step(s)`,
+      `Cycle groups on dependency graph: ${dg.circularGroupCount}`,
+    ].join('\n')
+  );
+  const dgRows: string[] = ['Factor | Value | Weight | Points'];
+  for (const row of dg.breakdown) {
+    dgRows.push(`${row.label} | ${row.value} | ${row.weight} | ${row.contribution.toFixed(1)}`);
+  }
+  paragraph(ctx, dgRows.join('\n'));
 
   if (m.dependencyMetricsPerClass.length > 0) {
     section(ctx, 'Dependency metrics per class');

--- a/objectified-ui/src/app/utils/schema-metrics.ts
+++ b/objectified-ui/src/app/utils/schema-metrics.ts
@@ -54,6 +54,8 @@ export interface SchemaMetricsResult {
    * class-level or property-level allOf +1; anyOf/oneOf +2 as disjunctive load).
    */
   cognitiveComplexityPerClass: CognitiveComplexityPerClassEntry[];
+  /** #611: Dependency-only graph complexity (score + drivers). */
+  dependencyGraphComplexity: DependencyGraphComplexityReport;
 }
 
 /** #553: One row of dependency metrics for a class (in-degree, out-degree, betweenness). */
@@ -72,6 +74,24 @@ export interface CognitiveComplexityPerClassEntry {
   score: number;
   propertyContribution: number;
   referenceContribution: number;
+}
+
+/**
+ * #611: Aggregate complexity of the dependency-only subgraph ($ref + class allOf/anyOf/oneOf),
+ * distinct from the full-canvas relationship count used in the main schema complexity score.
+ */
+export interface DependencyGraphComplexityReport {
+  /** Studio dependency edges (property $ref + class composition edges). */
+  edgeCount: number;
+  /** Longest path in the dependency digraph (number of edges). */
+  deepestChainSteps: number;
+  /** Cycle groups (non-trivial SCCs) using only dependency edges. */
+  circularGroupCount: number;
+  /** 0–100 composite from edges, depth, and cycles on that subgraph. */
+  score: number;
+  scoreLabel: 'Low' | 'Medium' | 'High';
+  /** Factor table for Studio popover and PDF export. */
+  breakdown: ComplexityBreakdownItem[];
 }
 
 /** Naming convention counts and compliance percentage (#558) */
@@ -525,6 +545,7 @@ export function computeSchemaMetrics(nodes: Node[], edges: Edge[]): SchemaMetric
   }));
 
   const cognitiveComplexityPerClass = computeCognitiveComplexityPerClass(classNodes, dependencyEdges);
+  const dependencyGraphComplexity = computeDependencyGraphComplexityReport(nodeIds, dependencyEdges);
 
   return {
     classCount,
@@ -548,6 +569,7 @@ export function computeSchemaMetrics(nodes: Node[], edges: Edge[]): SchemaMetric
     namingCompliance,
     dependencyMetricsPerClass,
     cognitiveComplexityPerClass,
+    dependencyGraphComplexity,
   };
 }
 
@@ -747,6 +769,58 @@ export function computeComplexityScoreFromAggregates(metrics: AggregateComplexit
   const complexityLabel: 'Low' | 'Medium' | 'High' =
     complexityScore <= 33 ? 'Low' : complexityScore <= 66 ? 'Medium' : 'High';
   return { complexityScore, complexityLabel, complexityBreakdown: breakdown };
+}
+
+/**
+ * #611: Score how tangled the dependency-only graph is (refs + composition), using the same
+ * weight scale as the structural slice of {@link computeComplexityScoreFromAggregates}
+ * (edges × 1.2, deepest chain × 4, cycles × 6), capped to 0–100.
+ */
+export function computeDependencyGraphComplexityReport(
+  nodeIds: Set<string>,
+  dependencyEdges: Edge[]
+): DependencyGraphComplexityReport {
+  const edgeCount = dependencyEdges.length;
+  const depAdj = buildDirectedAdjacency(dependencyEdges);
+  const deepestChainSteps =
+    nodeIds.size === 0 ? 0 : computeDeepestChain(depAdj, nodeIds);
+  const { count: circularGroupCount } = countCircularDependencies(depAdj, nodeIds);
+
+  const wEdge = 1.2;
+  const wDepth = 4;
+  const wCycle = 6;
+  const breakdown: ComplexityBreakdownItem[] = [
+    {
+      label: 'Dependency edges',
+      value: edgeCount,
+      weight: wEdge,
+      contribution: edgeCount * wEdge,
+    },
+    {
+      label: 'Deepest ref chain (steps)',
+      value: deepestChainSteps,
+      weight: wDepth,
+      contribution: deepestChainSteps * wDepth,
+    },
+    {
+      label: 'Circular groups (deps)',
+      value: circularGroupCount,
+      weight: wCycle,
+      contribution: circularGroupCount * wCycle,
+    },
+  ];
+  const raw = breakdown.reduce((sum, b) => sum + b.contribution, 0);
+  const score = Math.min(100, Math.max(0, Math.round(raw)));
+  const scoreLabel: 'Low' | 'Medium' | 'High' =
+    score <= 33 ? 'Low' : score <= 66 ? 'Medium' : 'High';
+  return {
+    edgeCount,
+    deepestChainSteps,
+    circularGroupCount,
+    score,
+    scoreLabel,
+    breakdown,
+  };
 }
 
 /** One class (schema) row for version scoring breakdown (#250). */

--- a/objectified-ui/tests/schema-graph-from-classes.test.ts
+++ b/objectified-ui/tests/schema-graph-from-classes.test.ts
@@ -44,6 +44,8 @@ describe('schema-graph-from-classes / computeSchemaMetricsFromClasses', () => {
     expect(m.relationshipCount).toBeGreaterThan(0);
     expect(m.complexityScore).toBeGreaterThanOrEqual(0);
     expect(m.complexityScore).toBeLessThanOrEqual(100);
+    expect(m.dependencyGraphComplexity.edgeCount).toBeGreaterThanOrEqual(1);
+    expect(m.dependencyGraphComplexity.deepestChainSteps).toBe(1);
     const byName = Object.fromEntries(m.cognitiveComplexityPerClass.map((c) => [c.className, c]));
     expect(byName.Post?.score).toBe(2);
     expect(byName.User?.score).toBe(0);

--- a/objectified-ui/tests/unit/dependency-graph-complexity.test.ts
+++ b/objectified-ui/tests/unit/dependency-graph-complexity.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from '@jest/globals';
+import { buildGraphForSchemaMetrics } from '@/app/utils/schema-graph-from-classes';
+import {
+  computeDependencyGraphComplexityReport,
+  computeSchemaMetricsFromClasses,
+} from '@/app/utils/schema-metrics';
+
+describe('dependency graph complexity (#611)', () => {
+  it('exposes a 0–100 score and drivers on the dependency-only subgraph', () => {
+    const classes = [
+      { id: 'a', name: 'User', properties: [], schema: {} },
+      {
+        id: 'b',
+        name: 'Post',
+        properties: [
+          {
+            id: 'p1',
+            name: 'author',
+            data: JSON.stringify({ $ref: '#/components/schemas/User' }),
+          },
+        ],
+        schema: {},
+      },
+    ];
+    const m = computeSchemaMetricsFromClasses(classes);
+    const dg = m.dependencyGraphComplexity;
+    expect(dg.edgeCount).toBeGreaterThanOrEqual(1);
+    expect(dg.deepestChainSteps).toBe(1);
+    expect(dg.circularGroupCount).toBe(0);
+    expect(dg.score).toBeGreaterThanOrEqual(0);
+    expect(dg.score).toBeLessThanOrEqual(100);
+    expect(['Low', 'Medium', 'High']).toContain(dg.scoreLabel);
+    expect(dg.breakdown).toHaveLength(3);
+    expect(dg.breakdown.map((b) => b.label)).toEqual([
+      'Dependency edges',
+      'Deepest ref chain (steps)',
+      'Circular groups (deps)',
+    ]);
+  });
+
+  it('counts cycle groups on dependency edges', () => {
+    const classes = [
+      {
+        id: 'a',
+        name: 'A',
+        properties: [
+          {
+            id: 'p1',
+            name: 'toB',
+            data: JSON.stringify({ $ref: '#/components/schemas/B' }),
+          },
+        ],
+        schema: {},
+      },
+      {
+        id: 'b',
+        name: 'B',
+        properties: [
+          {
+            id: 'p2',
+            name: 'toA',
+            data: JSON.stringify({ $ref: '#/components/schemas/A' }),
+          },
+        ],
+        schema: {},
+      },
+    ];
+    const m = computeSchemaMetricsFromClasses(classes);
+    expect(m.dependencyGraphComplexity.circularGroupCount).toBeGreaterThanOrEqual(1);
+    expect(m.dependencyGraphComplexity.edgeCount).toBeGreaterThanOrEqual(2);
+  });
+
+  it('computeDependencyGraphComplexityReport handles an empty node set', () => {
+    const { edges } = buildGraphForSchemaMetrics([]);
+    const dg = computeDependencyGraphComplexityReport(new Set(), edges);
+    expect(dg.edgeCount).toBe(0);
+    expect(dg.deepestChainSteps).toBe(0);
+    expect(dg.score).toBe(0);
+    expect(dg.scoreLabel).toBe('Low');
+  });
+});

--- a/objectified-ui/tests/unit/export-schema-score-report-pdf.test.ts
+++ b/objectified-ui/tests/unit/export-schema-score-report-pdf.test.ts
@@ -72,6 +72,18 @@ function makeMinimalMetrics(overrides: Partial<SchemaMetricsResult> = {}): Schem
     },
     dependencyMetricsPerClass: [],
     cognitiveComplexityPerClass: [],
+    dependencyGraphComplexity: {
+      edgeCount: 0,
+      deepestChainSteps: 0,
+      circularGroupCount: 0,
+      score: 0,
+      scoreLabel: 'Low',
+      breakdown: [
+        { label: 'Dependency edges', value: 0, weight: 1.2, contribution: 0 },
+        { label: 'Deepest ref chain (steps)', value: 0, weight: 4, contribution: 0 },
+        { label: 'Circular groups (deps)', value: 0, weight: 6, contribution: 0 },
+      ],
+    },
     ...overrides,
   };
 }
@@ -156,6 +168,13 @@ describe('downloadSchemaScoreReportPdf', () => {
     const joined = (mockText.mock.calls as Array<[string, ...unknown[]]>).map((c) => String(c[0])).join('\n');
     expect(joined).toContain('Cognitive complexity per class');
     expect(joined).toContain('Heavy | 15 | 12 | 3');
+  });
+
+  it('includes dependency graph complexity section (#611)', () => {
+    downloadSchemaScoreReportPdf({ metrics: makeMinimalMetrics(), projectName: 'P', versionLabel: 'v1' });
+    const joined = (mockText.mock.calls as Array<[string, ...unknown[]]>).map((c) => String(c[0])).join('\n');
+    expect(joined).toContain('Dependency graph complexity (#611)');
+    expect(joined).toContain('Dependency-only edges: 0');
   });
 
   it('does not throw with dependency metrics and layout quality', () => {

--- a/objectified-ui/tests/unit/overall-schema-quality.test.ts
+++ b/objectified-ui/tests/unit/overall-schema-quality.test.ts
@@ -31,6 +31,18 @@ function makeMinimalMetrics(overrides: Partial<SchemaMetricsResult> = {}): Schem
     },
     dependencyMetricsPerClass: [],
     cognitiveComplexityPerClass: [],
+    dependencyGraphComplexity: {
+      edgeCount: 0,
+      deepestChainSteps: 0,
+      circularGroupCount: 0,
+      score: 0,
+      scoreLabel: 'Low',
+      breakdown: [
+        { label: 'Dependency edges', value: 0, weight: 1.2, contribution: 0 },
+        { label: 'Deepest ref chain (steps)', value: 0, weight: 4, contribution: 0 },
+        { label: 'Circular groups (deps)', value: 0, weight: 6, contribution: 0 },
+      ],
+    },
     ...overrides,
   };
 }

--- a/objectified-ui/tests/unit/schema-version-score-compare.test.ts
+++ b/objectified-ui/tests/unit/schema-version-score-compare.test.ts
@@ -34,6 +34,18 @@ function makeMinimalMetrics(overrides: Partial<SchemaMetricsResult> = {}): Schem
     },
     dependencyMetricsPerClass: [],
     cognitiveComplexityPerClass: [],
+    dependencyGraphComplexity: {
+      edgeCount: 0,
+      deepestChainSteps: 0,
+      circularGroupCount: 0,
+      score: 0,
+      scoreLabel: 'Low',
+      breakdown: [
+        { label: 'Dependency edges', value: 0, weight: 1.2, contribution: 0 },
+        { label: 'Deepest ref chain (steps)', value: 0, weight: 4, contribution: 0 },
+        { label: 'Circular groups (deps)', value: 0, weight: 6, contribution: 0 },
+      ],
+    },
     ...overrides,
   };
 }

--- a/objectified-ui/tests/unit/studio-metrics-digest-for-ai.test.ts
+++ b/objectified-ui/tests/unit/studio-metrics-digest-for-ai.test.ts
@@ -34,6 +34,18 @@ function baseMetrics(over: Partial<SchemaMetricsResult> = {}): SchemaMetricsResu
     cognitiveComplexityPerClass: [
       { classId: '1', className: 'User', score: 7, propertyContribution: 5, referenceContribution: 2 },
     ],
+    dependencyGraphComplexity: {
+      edgeCount: 2,
+      deepestChainSteps: 1,
+      circularGroupCount: 0,
+      score: 6,
+      scoreLabel: 'Low',
+      breakdown: [
+        { label: 'Dependency edges', value: 2, weight: 1.2, contribution: 2.4 },
+        { label: 'Deepest ref chain (steps)', value: 1, weight: 4, contribution: 4 },
+        { label: 'Circular groups (deps)', value: 0, weight: 6, contribution: 0 },
+      ],
+    },
     ...over,
   };
 }
@@ -49,6 +61,8 @@ describe('buildStudioMetricsDigestForAi', () => {
     expect(text).toContain('Hub classes');
     expect(text).toContain('Per-class cognitive complexity');
     expect(text).toContain('User: 7 (props +5, refs +2)');
+    expect(text).toContain('Dependency graph complexity (#611)');
+    expect(text).toContain('6/100');
   });
 
   it('includes overall schema quality score when provided (#255)', () => {


### PR DESCRIPTION
## Summary
Adds **dependency graph complexity** (#611): a 0–100 composite score and factor breakdown computed only on studio **dependency edges** (property references and class-level allOf/anyOf/oneOf), separate from the full-canvas relationship count in the main schema complexity score.

## Changes
- `SchemaMetricsResult.dependencyGraphComplexity` with edge count, deepest chain on the dependency digraph, cycle groups (SCCs), capped score, label, and breakdown (`schema-metrics.ts`).
- **Schema Metrics** panel: new section with popover breakdown (`SchemaMetricsPanel.tsx`).
- **AI metrics digest** and Ollama improvement-suggestions prompt mention the new line (`studio-metrics-digest-for-ai.ts`, `ollama/chat/route.ts`).
- **PDF score report**: summary line plus dedicated section (`export-schema-score-report-pdf.ts`).
- Tests, roadmap note, `WHATS_NEW.md`, patch bump `objectified-ui` to 0.11.77.

## How to test
1. **Open Studio** with a project version that has classes and at least one property `$ref` or composition edge.
2. **Open Schema Metrics** (bar chart) and scroll to **Dependency graph complexity** — confirm score, edge/chain/cycle counts, and **click** for the factor table.
3. **Export PDF** from Schema Metrics — confirm **Dependency graph complexity (#611)** section and summary line.
4. **AI improvement suggestions** (lightbulb) — confirm the digest in the request includes the dependency graph complexity line (e.g. via network tab or server logs if available).

## Risk / notes
- Score weights mirror the structural slice of the existing aggregate complexity model (edges ×1.2, depth ×4, cycles ×6); tuning may be desired later.
- Main schema complexity score is unchanged; this is an additional report dimension.

Closes #611

Made with [Cursor](https://cursor.com)