### PR TITLE
Fix #613 - Add maintainability index

### DIFF
--- a/docs/PLANNED_FEATURE_ROADMAP_AI.md
+++ b/docs/PLANNED_FEATURE_ROADMAP_AI.md
@@ -88,12 +88,11 @@ This outlines the planned features for integrating AI capabilities into Objectif
 - ✅ Cognitive complexity score per class (#610)
 - ✅ Dependency graph complexity (#611)
 - ✅ Cyclomatic complexity for conditional schemas (#612)
-- 📋 Maintainability index
+- ✅ Maintainability index (#613)
 - 📋 Technical debt metrics
 
 | Ticket | Feature Description                           |
 |--------|-----------------------------------------------|
-| #613   | Maintainability Index                         |
 | #614   | Technical Debt Metrics                        |
 
 **Best Practice Suggestions** 📋 PLANNED

--- a/objectified-ui/lib/studio-metrics-digest-for-ai.ts
+++ b/objectified-ui/lib/studio-metrics-digest-for-ai.ts
@@ -40,6 +40,10 @@ export function buildStudioMetricsDigestForAi(
   lines.push(
     `- Dependency graph complexity (#611): ${dg.score}/100 (${dg.scoreLabel}) — ${dg.edgeCount} dependency-only edges, deepest chain ${dg.deepestChainSteps} step(s), ${dg.circularGroupCount} cycle group(s) on refs/composition graph`,
   );
+  const mi = metrics.maintainabilityIndex;
+  lines.push(
+    `- Maintainability index (#613): ${mi.score}/100 (${mi.scoreLabel}) — composite from documentation, naming, inverted schema/dependency complexity, mean cognitive load per class, and class-size pressure`,
+  );
   if (typeof overallQualityScore === 'number' && Number.isFinite(overallQualityScore)) {
     lines.push(
       `- Overall schema quality score (0–100 composite: docs, naming, structural load, layout when available): ${Math.min(100, Math.max(0, Math.round(overallQualityScore)))}`,

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.78",
+  "version": "0.11.79",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -30,6 +30,7 @@ We continue to improve the platform based on your feedback with improvements and
 - Projects list includes a **Show deleted** switch; when on, soft-deleted projects appear with a **Deleted** badge and **Restore** or **permanent delete** in the row menu (#2981).
 
 ## Studio
+- **Schema Metrics** adds a **maintainability index** (0–100, higher = easier to evolve): composite from documentation, naming, inverted schema and dependency-graph complexity, mean cognitive load, and class-size pressure—with a factor breakdown in the panel, **AI metrics digest**, **version score compare**, and **PDF score report** (#613).
 - **Schema Metrics** counts **conditional schema cyclomatic** (#612): if/then/else decision points are summed from class and property JSON Schemas, fed into the **aggregate complexity** breakdown, **per-class cognitive** score (new If column), **AI metrics digest**, **version score compare**, and **PDF score report**.
 - **Schema Metrics** adds **dependency graph complexity** (0–100 on property references and class-level allOf/anyOf/oneOf only): headline score with factor breakdown in the panel, **AI metrics digest**, and **PDF score report** (#611).
 - **Schema Metrics** includes **cognitive complexity per class** (props plus weighted outgoing dependency edges; anyOf/oneOf count double) and feeds the same scores into the **AI improvement suggestions** metrics digest (#610).

--- a/objectified-ui/src/app/ade/studio/components/SchemaMetricsPanel.tsx
+++ b/objectified-ui/src/app/ade/studio/components/SchemaMetricsPanel.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import * as React from 'react';
-import { BarChart3, ChevronDown, ChevronUp, X, Link2, Unlink, GitBranch, RefreshCw, Layout, Gauge, Lightbulb, LayoutGrid, Box, Layers, FileText, Type, Network, FileDown, Brain } from 'lucide-react';
+import { BarChart3, ChevronDown, ChevronUp, X, Link2, Unlink, GitBranch, RefreshCw, Layout, Gauge, Lightbulb, LayoutGrid, Box, Layers, FileText, Type, Network, FileDown, Brain, Sprout } from 'lucide-react';
 import * as Tooltip from '@radix-ui/react-tooltip';
 import * as Popover from '@radix-ui/react-popover';
 import { cn } from '../../../../../lib/utils';
@@ -87,6 +87,7 @@ export default function SchemaMetricsPanel({
     dependencyMetricsPerClass = [],
     cognitiveComplexityPerClass = [],
     dependencyGraphComplexity,
+    maintainabilityIndex,
   } = metrics;
 
   const docsScoreTier = getNumericScoreTier(documentationCompletionPercentage);
@@ -730,6 +731,99 @@ export default function SchemaMetricsPanel({
                     <span className="text-gray-500 dark:text-gray-400">Raw sum → capped</span>
                     <span className="font-semibold text-gray-800 dark:text-gray-200 tabular-nums">
                       {dependencyGraphComplexity.score}/100
+                    </span>
+                  </div>
+                </Popover.Content>
+              </Popover.Portal>
+            </Popover.Root>
+          </div>
+
+          {/* #613: Maintainability index (higher = easier to evolve) */}
+          <div>
+            <Popover.Root>
+              <Popover.Trigger asChild>
+                <button
+                  type="button"
+                  className="w-full rounded-lg bg-gray-50 dark:bg-gray-700/40 dark:border dark:border-gray-600/40 px-2.5 py-2 text-left cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-600/40 focus:outline-none focus:ring-2 focus:ring-indigo-400 focus:ring-offset-2 focus:ring-offset-white dark:focus:ring-offset-gray-800"
+                  aria-label="Maintainability index; click for breakdown"
+                  title="Composite from docs, naming, inverted structural complexity, cognitive load, and class size"
+                >
+                  <div className="flex items-center justify-between gap-2">
+                    <div className="flex items-center gap-1.5 min-w-0">
+                      <Sprout className="w-4 h-4 text-emerald-600 dark:text-emerald-400 shrink-0" aria-hidden />
+                      <span className="text-[10px] text-gray-500 dark:text-gray-400 uppercase tracking-wider truncate">
+                        Maintainability index
+                      </span>
+                    </div>
+                    <div className="flex items-center gap-2 shrink-0">
+                      <span className="text-lg font-bold text-gray-800 dark:text-gray-200 tabular-nums">
+                        {maintainabilityIndex.score}
+                      </span>
+                      <span
+                        className={cn(
+                          'text-xs font-medium px-1.5 py-0.5 rounded',
+                          maintainabilityIndex.scoreLabel === 'High' &&
+                            'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-300',
+                          maintainabilityIndex.scoreLabel === 'Medium' &&
+                            'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300',
+                          maintainabilityIndex.scoreLabel === 'Low' &&
+                            'bg-rose-100 text-rose-800 dark:bg-rose-900/40 dark:text-rose-300',
+                        )}
+                      >
+                        {maintainabilityIndex.scoreLabel}
+                      </span>
+                    </div>
+                  </div>
+                  <p className="text-[10px] text-gray-500 dark:text-gray-400 mt-1 leading-snug">
+                    Higher scores mean easier long-term evolution (docs + naming + simplicity, minus load penalties).
+                  </p>
+                  <p className="text-[10px] text-gray-400 dark:text-gray-500 mt-0.5">Click for factor breakdown</p>
+                </button>
+              </Popover.Trigger>
+              <Popover.Portal>
+                <Popover.Content
+                  className="z-[10000] w-72 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-lg p-3 focus:outline-none"
+                  sideOffset={6}
+                  align="start"
+                >
+                  <div className="text-xs font-semibold text-gray-800 dark:text-gray-200 mb-2">
+                    Why this maintainability score? (#613)
+                  </div>
+                  <p className="text-[11px] text-gray-500 dark:text-gray-400 mb-3">
+                    Weighted blend of documentation and naming quality, inverted aggregate schema complexity and
+                    dependency-graph tangling, minus mean per-class cognitive complexity and a penalty when average
+                    properties per class exceed 14.
+                  </p>
+                  <table className="w-full text-[11px] text-left border-collapse">
+                    <thead>
+                      <tr className="border-b border-gray-200 dark:border-gray-600">
+                        <th className="py-1 pr-2 font-medium text-gray-600 dark:text-gray-400">Factor</th>
+                        <th className="py-1 pr-2 font-medium text-gray-600 dark:text-gray-400 text-right">Value</th>
+                        <th className="py-1 pr-2 font-medium text-gray-600 dark:text-gray-400 text-right">× weight</th>
+                        <th className="py-1 font-medium text-gray-600 dark:text-gray-400 text-right">Points</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {maintainabilityIndex.breakdown.map((row, i) => (
+                        <tr key={i} className="border-b border-gray-100 dark:border-gray-700/80">
+                          <td className="py-1 pr-2 text-gray-700 dark:text-gray-300">{row.label}</td>
+                          <td className="py-1 pr-2 text-right tabular-nums text-gray-700 dark:text-gray-300">
+                            {row.value}
+                          </td>
+                          <td className="py-1 pr-2 text-right tabular-nums text-gray-500 dark:text-gray-400">
+                            {row.weight}
+                          </td>
+                          <td className="py-1 text-right tabular-nums font-medium text-gray-800 dark:text-gray-200">
+                            {row.contribution.toFixed(1)}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                  <div className="mt-2 pt-2 border-t border-gray-200 dark:border-gray-600 flex justify-between text-[11px]">
+                    <span className="text-gray-500 dark:text-gray-400">Composite → capped 0–100</span>
+                    <span className="font-semibold text-gray-800 dark:text-gray-200 tabular-nums">
+                      {maintainabilityIndex.score}/100
                     </span>
                   </div>
                 </Popover.Content>

--- a/objectified-ui/src/app/api/ollama/chat/route.ts
+++ b/objectified-ui/src/app/api/ollama/chat/route.ts
@@ -258,7 +258,7 @@ function buildPropertyTypeSuggestionsSystem(options: {
 
 const SCHEMA_IMPROVEMENT_SUGGESTIONS_SYSTEM = `You are a senior API and JSON Schema reviewer helping a team improve an OpenAPI 3.1–oriented data model in Objectified Studio.
 
-You receive **measured canvas metrics** (class counts, documentation coverage, naming compliance, aggregate schema complexity, **conditional schema cyclomatic** (#612) from if/then/else, **dependency graph complexity** on refs/composition, **per-class cognitive complexity** scores, samples of gaps). Your job is to propose **prioritized, actionable improvements** that a human can follow—similar in tone to:
+You receive **measured canvas metrics** (class counts, documentation coverage, naming compliance, aggregate schema complexity, **conditional schema cyclomatic** (#612) from if/then/else, **dependency graph complexity** on refs/composition, **per-class cognitive complexity** scores, **maintainability index** (#613; higher = easier to evolve), samples of gaps). Your job is to propose **prioritized, actionable improvements** that a human can follow—similar in tone to:
 
 - "Add descriptions to N classes to improve docs score"
 - "Rename M properties to follow camelCase convention"
@@ -295,7 +295,7 @@ Return **exactly one** markdown fenced JSON block and **nothing outside the fenc
 - Emit **6–12** suggestions unless the digest is extremely small (then 3–5 is fine).
 - Every "title" and "detail" must be non-empty strings.
 - "category" must be one of: "documentation", "naming", "structure", "api", "performance", "other". Pick the best fit per row.
-- Every row MUST include **"estimatedOverallScoreDelta"**: an **integer** (typically **0–12**, occasionally higher for broad fixes) estimating how many **points** the Studio **overall schema quality score (0–100)** in the digest would **increase** if that suggestion were **fully applied**. Use **0** only when the effect on the composite would be negligible. When the digest includes the current overall score line, anchor estimates to that baseline and the listed doc %, naming %, complexity, **conditional schema cyclomatic (#612)**, **dependency graph complexity (#611)**, and **per-class cognitive complexity** lines. Do not exceed **25**; use negative values only if a fix could realistically lower the composite (rare).
+- Every row MUST include **"estimatedOverallScoreDelta"**: an **integer** (typically **0–12**, occasionally higher for broad fixes) estimating how many **points** the Studio **overall schema quality score (0–100)** in the digest would **increase** if that suggestion were **fully applied**. Use **0** only when the effect on the composite would be negligible. When the digest includes the current overall score line, anchor estimates to that baseline and the listed doc %, naming %, complexity, **conditional schema cyclomatic (#612)**, **dependency graph complexity (#611)**, **maintainability index (#613)**, and **per-class cognitive complexity** lines. Do not exceed **25**; use negative values only if a fix could realistically lower the composite (rare).
 - Every row MUST include **"effort"**: one of \`"quick_win"\`, \`"moderate"\`, or \`"substantial"\`.
   - **quick_win**: small, localized edits (add missing descriptions, rename a few properties, tighten one validation) that a developer can often finish in minutes to an hour.
   - **moderate**: bounded refactors (split one busy class, normalize a small set of names, add a shared pattern across a few schemas).

--- a/objectified-ui/src/app/utils/export-schema-score-report-pdf.ts
+++ b/objectified-ui/src/app/utils/export-schema-score-report-pdf.ts
@@ -80,6 +80,7 @@ function addMetricsBody(
       `Schema complexity: ${m.complexityScore}/100 (${m.complexityLabel})`,
       `Conditional schema cyclomatic (#612): ${m.conditionalSchemaCyclomaticTotal} (aggregate if/then/else decision points across class and property schemas)`,
       `Dependency graph complexity (#611): ${m.dependencyGraphComplexity.score}/100 (${m.dependencyGraphComplexity.scoreLabel}) — ${m.dependencyGraphComplexity.edgeCount} dependency-only edges, deepest ref chain ${m.dependencyGraphComplexity.deepestChainSteps} step(s), ${m.dependencyGraphComplexity.circularGroupCount} cycle group(s)`,
+      `Maintainability index (#613): ${m.maintainabilityIndex.score}/100 (${m.maintainabilityIndex.scoreLabel})`,
       `Documentation coverage: ${m.documentationCompletionPercentage}%`,
       `Naming compliance: ${m.namingCompliance.compliancePercentage}%`,
     ].join('\n')
@@ -178,6 +179,21 @@ function addMetricsBody(
     dgRows.push(`${row.label} | ${row.value} | ${row.weight} | ${row.contribution.toFixed(1)}`);
   }
   paragraph(ctx, dgRows.join('\n'));
+
+  section(ctx, 'Maintainability index (#613)');
+  const mi = m.maintainabilityIndex;
+  paragraph(
+    ctx,
+    [
+      `Score: ${mi.score}/100 (${mi.scoreLabel}; higher = easier to evolve)`,
+      'Blend: documentation and naming quality, inverted aggregate schema complexity and dependency-graph tangling, minus mean cognitive load and oversized-class penalties.',
+    ].join('\n')
+  );
+  const miRows: string[] = ['Factor | Value | Weight | Points'];
+  for (const row of mi.breakdown) {
+    miRows.push(`${row.label} | ${row.value} | ${row.weight} | ${row.contribution.toFixed(1)}`);
+  }
+  paragraph(ctx, miRows.join('\n'));
 
   if (m.dependencyMetricsPerClass.length > 0) {
     section(ctx, 'Dependency metrics per class');

--- a/objectified-ui/src/app/utils/schema-metrics.ts
+++ b/objectified-ui/src/app/utils/schema-metrics.ts
@@ -61,6 +61,8 @@ export interface SchemaMetricsResult {
   cognitiveComplexityPerClass: CognitiveComplexityPerClassEntry[];
   /** #611: Dependency-only graph complexity (score + drivers). */
   dependencyGraphComplexity: DependencyGraphComplexityReport;
+  /** #613: Composite maintainability (higher = easier to evolve). */
+  maintainabilityIndex: MaintainabilityIndexReport;
 }
 
 /** #553: One row of dependency metrics for a class (in-degree, out-degree, betweenness). */
@@ -99,6 +101,93 @@ export interface DependencyGraphComplexityReport {
   scoreLabel: 'Low' | 'Medium' | 'High';
   /** Factor table for Studio popover and PDF export. */
   breakdown: ComplexityBreakdownItem[];
+}
+
+/**
+ * #613: Composite maintainability 0–100 (higher = easier to evolve the schema).
+ * Blends documentation and naming with inverted structural complexity (#556, #611), with light
+ * penalties for mean per-class cognitive load (#610) and wide classes (avg properties/class).
+ */
+export interface MaintainabilityIndexReport {
+  score: number;
+  /** Low = harder to maintain; High = easier to maintain. */
+  scoreLabel: 'Low' | 'Medium' | 'High';
+  breakdown: ComplexityBreakdownItem[];
+}
+
+export function computeMaintainabilityIndexReport(input: {
+  documentationCompletionPercentage: number;
+  namingCompliancePercentage: number;
+  complexityScore: number;
+  dependencyGraphScore: number;
+  cognitiveComplexityPerClass: CognitiveComplexityPerClassEntry[];
+  averagePropertiesPerClass: number;
+  classCount: number;
+}): MaintainabilityIndexReport {
+  const wDoc = 0.32;
+  const wNam = 0.28;
+  const wInvC = 0.2;
+  const wInvD = 0.2;
+
+  const docs = Math.min(100, Math.max(0, input.documentationCompletionPercentage));
+  const nam = Math.min(100, Math.max(0, input.namingCompliancePercentage));
+  const invC = Math.min(100, Math.max(0, 100 - input.complexityScore));
+  const invD = Math.min(100, Math.max(0, 100 - input.dependencyGraphScore));
+
+  const breakdown: ComplexityBreakdownItem[] = [
+    { label: 'Documentation', value: docs, weight: wDoc, contribution: docs * wDoc },
+    { label: 'Naming consistency', value: nam, weight: wNam, contribution: nam * wNam },
+    {
+      label: 'Simplicity vs schema complexity',
+      value: invC,
+      weight: wInvC,
+      contribution: invC * wInvC,
+    },
+    {
+      label: 'Simplicity vs dependency graph',
+      value: invD,
+      weight: wInvD,
+      contribution: invD * wInvD,
+    },
+  ];
+
+  let base = breakdown.reduce((sum, b) => sum + b.contribution, 0);
+
+  const meanCog =
+    input.classCount > 0
+      ? input.cognitiveComplexityPerClass.reduce((sum, r) => sum + r.score, 0) / input.classCount
+      : 0;
+  const cognitivePenalty = Math.min(14, meanCog * 0.4);
+  if (cognitivePenalty > 0) {
+    const mc = Math.round(meanCog * 10) / 10;
+    breakdown.push({
+      label: 'Cognitive load penalty (mean per class)',
+      value: mc,
+      weight: 1,
+      contribution: -cognitivePenalty,
+    });
+    base -= cognitivePenalty;
+  }
+
+  const sizeExcess =
+    input.classCount > 0 ? Math.max(0, input.averagePropertiesPerClass - 14) : 0;
+  const sizePenalty = Math.min(10, sizeExcess * 0.55);
+  if (sizePenalty > 0) {
+    const ap = Math.round(input.averagePropertiesPerClass * 10) / 10;
+    breakdown.push({
+      label: 'Class size penalty (avg properties/class > 14)',
+      value: ap,
+      weight: 1,
+      contribution: -sizePenalty,
+    });
+    base -= sizePenalty;
+  }
+
+  const score = Math.min(100, Math.max(0, Math.round(base)));
+  const scoreLabel: 'Low' | 'Medium' | 'High' =
+    score >= 67 ? 'High' : score >= 34 ? 'Medium' : 'Low';
+
+  return { score, scoreLabel, breakdown };
 }
 
 /** Naming convention counts and compliance percentage (#558) */
@@ -627,6 +716,16 @@ export function computeSchemaMetrics(nodes: Node[], edges: Edge[]): SchemaMetric
   const cognitiveComplexityPerClass = computeCognitiveComplexityPerClass(classNodes, dependencyEdges);
   const dependencyGraphComplexity = computeDependencyGraphComplexityReport(nodeIds, dependencyEdges);
 
+  const maintainabilityIndex = computeMaintainabilityIndexReport({
+    documentationCompletionPercentage: docResult.percentage,
+    namingCompliancePercentage: namingCompliance.compliancePercentage,
+    complexityScore,
+    dependencyGraphScore: dependencyGraphComplexity.score,
+    cognitiveComplexityPerClass,
+    averagePropertiesPerClass,
+    classCount,
+  });
+
   return {
     classCount,
     totalProperties,
@@ -651,6 +750,7 @@ export function computeSchemaMetrics(nodes: Node[], edges: Edge[]): SchemaMetric
     dependencyMetricsPerClass,
     cognitiveComplexityPerClass,
     dependencyGraphComplexity,
+    maintainabilityIndex,
   };
 }
 

--- a/objectified-ui/src/app/utils/schema-version-score-compare.ts
+++ b/objectified-ui/src/app/utils/schema-version-score-compare.ts
@@ -88,6 +88,13 @@ export function buildSchemaScoreCompareRows(
     fmtInt,
     toneLowerIsBetter
   );
+  push(
+    'Maintainability index (#613)',
+    a.maintainabilityIndex.score,
+    b.maintainabilityIndex.score,
+    fmtInt,
+    toneHigherIsBetter
+  );
 
   return rows;
 }

--- a/objectified-ui/tests/schema-graph-from-classes.test.ts
+++ b/objectified-ui/tests/schema-graph-from-classes.test.ts
@@ -49,5 +49,7 @@ describe('schema-graph-from-classes / computeSchemaMetricsFromClasses', () => {
     const byName = Object.fromEntries(m.cognitiveComplexityPerClass.map((c) => [c.className, c]));
     expect(byName.Post?.score).toBe(2);
     expect(byName.User?.score).toBe(0);
+    expect(m.maintainabilityIndex.score).toBeGreaterThanOrEqual(0);
+    expect(m.maintainabilityIndex.score).toBeLessThanOrEqual(100);
   });
 });

--- a/objectified-ui/tests/unit/export-schema-score-report-pdf.test.ts
+++ b/objectified-ui/tests/unit/export-schema-score-report-pdf.test.ts
@@ -1,5 +1,5 @@
 import { jest, describe, it, expect, beforeEach } from '@jest/globals';
-import type { SchemaMetricsResult } from '@/app/utils/schema-metrics';
+import { computeMaintainabilityIndexReport, type SchemaMetricsResult } from '@/app/utils/schema-metrics';
 
 // ── jsPDF mock ────────────────────────────────────────────────────────────────
 
@@ -42,7 +42,7 @@ import {
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 function makeMinimalMetrics(overrides: Partial<SchemaMetricsResult> = {}): SchemaMetricsResult {
-  return {
+  const merged: SchemaMetricsResult = {
     classCount: 3,
     totalProperties: 9,
     averagePropertiesPerClass: 3,
@@ -87,6 +87,18 @@ function makeMinimalMetrics(overrides: Partial<SchemaMetricsResult> = {}): Schem
     },
     ...overrides,
   };
+  merged.maintainabilityIndex =
+    overrides.maintainabilityIndex ??
+    computeMaintainabilityIndexReport({
+      documentationCompletionPercentage: merged.documentationCompletionPercentage,
+      namingCompliancePercentage: merged.namingCompliance.compliancePercentage,
+      complexityScore: merged.complexityScore,
+      dependencyGraphScore: merged.dependencyGraphComplexity.score,
+      cognitiveComplexityPerClass: merged.cognitiveComplexityPerClass,
+      averagePropertiesPerClass: merged.averagePropertiesPerClass,
+      classCount: merged.classCount,
+    });
+  return merged;
 }
 
 // ── sanitizeFilenameSegment ───────────────────────────────────────────────────
@@ -193,6 +205,14 @@ describe('downloadSchemaScoreReportPdf', () => {
     const joined = (mockText.mock.calls as Array<[string, ...unknown[]]>).map((c) => String(c[0])).join('\n');
     expect(joined).toContain('Dependency graph complexity (#611)');
     expect(joined).toContain('Dependency-only edges: 0');
+  });
+
+  it('includes maintainability index section (#613)', () => {
+    downloadSchemaScoreReportPdf({ metrics: makeMinimalMetrics(), projectName: 'P', versionLabel: 'v1' });
+    const joined = (mockText.mock.calls as Array<[string, ...unknown[]]>).map((c) => String(c[0])).join('\n');
+    expect(joined).toContain('Maintainability index (#613)');
+    expect(joined).toContain('easier to evolve');
+    expect(joined).toContain('Simplicity vs schema complexity');
   });
 
   it('does not throw with dependency metrics and layout quality', () => {

--- a/objectified-ui/tests/unit/maintainability-index.test.ts
+++ b/objectified-ui/tests/unit/maintainability-index.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from '@jest/globals';
+import {
+  computeMaintainabilityIndexReport,
+  computeSchemaMetricsFromClasses,
+} from '@/app/utils/schema-metrics';
+
+describe('maintainability index (#613)', () => {
+  it('scores 0–100 with High label when docs, naming, and simplicity are strong', () => {
+    const r = computeMaintainabilityIndexReport({
+      documentationCompletionPercentage: 100,
+      namingCompliancePercentage: 100,
+      complexityScore: 0,
+      dependencyGraphScore: 0,
+      cognitiveComplexityPerClass: [],
+      averagePropertiesPerClass: 3,
+      classCount: 2,
+    });
+    expect(r.score).toBe(100);
+    expect(r.scoreLabel).toBe('High');
+    expect(r.breakdown.some((b) => b.label === 'Documentation')).toBe(true);
+  });
+
+  it('applies cognitive and class-size penalties when drivers are poor', () => {
+    const r = computeMaintainabilityIndexReport({
+      documentationCompletionPercentage: 0,
+      namingCompliancePercentage: 0,
+      complexityScore: 100,
+      dependencyGraphScore: 100,
+      cognitiveComplexityPerClass: [
+        {
+          classId: 'a',
+          className: 'A',
+          score: 40,
+          propertyContribution: 20,
+          referenceContribution: 20,
+          conditionalSchemaCyclomaticContribution: 0,
+        },
+      ],
+      averagePropertiesPerClass: 30,
+      classCount: 1,
+    });
+    expect(r.score).toBeGreaterThanOrEqual(0);
+    expect(r.score).toBeLessThanOrEqual(100);
+    expect(r.scoreLabel).toBe('Low');
+    expect(r.breakdown.some((b) => b.label.includes('Cognitive load penalty'))).toBe(true);
+    expect(r.breakdown.some((b) => b.label.includes('Class size penalty'))).toBe(true);
+  });
+
+  it('is present on computeSchemaMetricsFromClasses output', () => {
+    const classes = [{ id: 'a', name: 'User', properties: [], schema: {} }];
+    const m = computeSchemaMetricsFromClasses(classes);
+    expect(m.maintainabilityIndex.score).toBeGreaterThanOrEqual(0);
+    expect(m.maintainabilityIndex.score).toBeLessThanOrEqual(100);
+    expect(['Low', 'Medium', 'High']).toContain(m.maintainabilityIndex.scoreLabel);
+  });
+});

--- a/objectified-ui/tests/unit/overall-schema-quality.test.ts
+++ b/objectified-ui/tests/unit/overall-schema-quality.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect } from '@jest/globals';
-import type { SchemaMetricsResult } from '@/app/utils/schema-metrics';
+import { computeMaintainabilityIndexReport, type SchemaMetricsResult } from '@/app/utils/schema-metrics';
 import { computeOverallSchemaQualityScore, computeOverallSchemaQualityDetail } from '@/app/utils/overall-schema-quality';
 
 function makeMinimalMetrics(overrides: Partial<SchemaMetricsResult> = {}): SchemaMetricsResult {
-  return {
+  const merged: SchemaMetricsResult = {
     classCount: 3,
     totalProperties: 9,
     averagePropertiesPerClass: 3,
@@ -46,6 +46,18 @@ function makeMinimalMetrics(overrides: Partial<SchemaMetricsResult> = {}): Schem
     },
     ...overrides,
   };
+  merged.maintainabilityIndex =
+    overrides.maintainabilityIndex ??
+    computeMaintainabilityIndexReport({
+      documentationCompletionPercentage: merged.documentationCompletionPercentage,
+      namingCompliancePercentage: merged.namingCompliance.compliancePercentage,
+      complexityScore: merged.complexityScore,
+      dependencyGraphScore: merged.dependencyGraphComplexity.score,
+      cognitiveComplexityPerClass: merged.cognitiveComplexityPerClass,
+      averagePropertiesPerClass: merged.averagePropertiesPerClass,
+      classCount: merged.classCount,
+    });
+  return merged;
 }
 
 describe('computeOverallSchemaQualityScore (#245)', () => {

--- a/objectified-ui/tests/unit/schema-version-score-compare.test.ts
+++ b/objectified-ui/tests/unit/schema-version-score-compare.test.ts
@@ -1,12 +1,12 @@
 import { describe, it, expect } from '@jest/globals';
-import type { SchemaMetricsResult } from '@/app/utils/schema-metrics';
+import { computeMaintainabilityIndexReport, type SchemaMetricsResult } from '@/app/utils/schema-metrics';
 import {
   formatScoreDelta,
   buildSchemaScoreCompareRows,
 } from '@/app/utils/schema-version-score-compare';
 
 function makeMinimalMetrics(overrides: Partial<SchemaMetricsResult> = {}): SchemaMetricsResult {
-  return {
+  const merged: SchemaMetricsResult = {
     classCount: 3,
     totalProperties: 9,
     averagePropertiesPerClass: 3,
@@ -49,6 +49,18 @@ function makeMinimalMetrics(overrides: Partial<SchemaMetricsResult> = {}): Schem
     },
     ...overrides,
   };
+  merged.maintainabilityIndex =
+    overrides.maintainabilityIndex ??
+    computeMaintainabilityIndexReport({
+      documentationCompletionPercentage: merged.documentationCompletionPercentage,
+      namingCompliancePercentage: merged.namingCompliance.compliancePercentage,
+      complexityScore: merged.complexityScore,
+      dependencyGraphScore: merged.dependencyGraphComplexity.score,
+      cognitiveComplexityPerClass: merged.cognitiveComplexityPerClass,
+      averagePropertiesPerClass: merged.averagePropertiesPerClass,
+      classCount: merged.classCount,
+    });
+  return merged;
 }
 
 describe('formatScoreDelta', () => {
@@ -109,6 +121,15 @@ describe('buildSchemaScoreCompareRows', () => {
     const rows = buildSchemaScoreCompareRows(older, newer);
     const row = rows.find((r) => r.label === 'Conditional schema cyclomatic');
     expect(row?.delta).toBe('-3');
+    expect(row?.deltaTone).toBe('positive');
+  });
+
+  it('labels higher maintainability index as positive (#613)', () => {
+    const older = makeMinimalMetrics({ maintainabilityIndex: { score: 40, scoreLabel: 'Medium', breakdown: [] } });
+    const newer = makeMinimalMetrics({ maintainabilityIndex: { score: 55, scoreLabel: 'Medium', breakdown: [] } });
+    const rows = buildSchemaScoreCompareRows(older, newer);
+    const row = rows.find((r) => r.label === 'Maintainability index (#613)');
+    expect(row?.delta).toBe('+15');
     expect(row?.deltaTone).toBe('positive');
   });
 });

--- a/objectified-ui/tests/unit/studio-metrics-digest-for-ai.test.ts
+++ b/objectified-ui/tests/unit/studio-metrics-digest-for-ai.test.ts
@@ -1,8 +1,8 @@
 import { buildStudioMetricsDigestForAi } from '../../lib/studio-metrics-digest-for-ai';
-import type { SchemaMetricsResult } from '@/app/utils/schema-metrics';
+import { computeMaintainabilityIndexReport, type SchemaMetricsResult } from '@/app/utils/schema-metrics';
 
 function baseMetrics(over: Partial<SchemaMetricsResult> = {}): SchemaMetricsResult {
-  return {
+  const merged: SchemaMetricsResult = {
     classCount: 2,
     totalProperties: 5,
     averagePropertiesPerClass: 2.5,
@@ -56,6 +56,18 @@ function baseMetrics(over: Partial<SchemaMetricsResult> = {}): SchemaMetricsResu
     },
     ...over,
   };
+  merged.maintainabilityIndex =
+    over.maintainabilityIndex ??
+    computeMaintainabilityIndexReport({
+      documentationCompletionPercentage: merged.documentationCompletionPercentage,
+      namingCompliancePercentage: merged.namingCompliance.compliancePercentage,
+      complexityScore: merged.complexityScore,
+      dependencyGraphScore: merged.dependencyGraphComplexity.score,
+      cognitiveComplexityPerClass: merged.cognitiveComplexityPerClass,
+      averagePropertiesPerClass: merged.averagePropertiesPerClass,
+      classCount: merged.classCount,
+    });
+  return merged;
 }
 
 describe('buildStudioMetricsDigestForAi', () => {
@@ -72,6 +84,8 @@ describe('buildStudioMetricsDigestForAi', () => {
     expect(text).toContain('Conditional schema cyclomatic (#612): 0');
     expect(text).toContain('Dependency graph complexity (#611)');
     expect(text).toContain('6/100');
+    expect(text).toContain('Maintainability index (#613)');
+    expect(text).toMatch(/Maintainability index \(#613\): \d+\/100/);
   });
 
   it('includes overall schema quality score when provided (#255)', () => {


### PR DESCRIPTION
## Summary
Adds a **maintainability index** (0–100, higher = easier to evolve) to schema health insights: weighted blend of documentation and naming quality, inverted aggregate schema complexity and dependency-graph complexity (#611), minus penalties for mean per-class cognitive complexity (#610) and heavy average properties-per-class.

## What changed
- `schema-metrics`: `MaintainabilityIndexReport`, `computeMaintainabilityIndexReport`, wired into `computeSchemaMetrics` / `computeSchemaMetricsFromClasses`
- **Schema Metrics** panel: new card with factor breakdown popover (#613)
- **AI digest** (`studio-metrics-digest-for-ai`), **PDF export**, **version score compare** rows, and **Ollama improvement-suggestions** system prompt mention the new metric
- Tests: unit coverage + fixture helpers updated for required `SchemaMetricsResult` field
- `docs/PLANNED_FEATURE_ROADMAP_AI.md`, `public/WHATS_NEW.md`, patch version bump

## How to test
1. **Open Studio** with a version that has classes on the canvas.
2. **Open Schema Metrics** and locate **Maintainability index** below dependency graph complexity.
3. **Click the card** and confirm the factor table (documentation, naming, simplicity rows, optional penalties).
4. **Export PDF** from Schema Metrics and confirm summary + “Maintainability index (#613)” section.
5. **Version score compare** (if used): confirm a row **Maintainability index (#613)** with sensible delta tone when scores differ.
6. **AI improvement suggestions** (lightbulb): confirm the digest text includes `Maintainability index (#613)`.

## Risk / notes
- Heuristic weights are fixed constants; tuning may be needed after user feedback.
- Root `yarn build` may still fail locally if `uv` is missing for `objectified-mcp`; **objectified-ui** `yarn build` and `yarn test` were run successfully.

Closes #613

Made with [Cursor](https://cursor.com)