### PR TITLE
Fix #618 - Add performance optimization tips

### DIFF
--- a/docs/PLANNED_FEATURE_ROADMAP_AI.md
+++ b/docs/PLANNED_FEATURE_ROADMAP_AI.md
@@ -81,11 +81,7 @@ This outlines the planned features for integrating AI capabilities into Objectif
     - Several modeling-pattern bullets per registered **project domain** category (catalog in Studio; **#616** expanded from one short line per domain)
 - ✅ Industry-specific patterns (#616): multiple actionable patterns per domain (e.g. inventory/idempotency for e-commerce, ledger/idempotency for finance, FHIR-friendly identifiers for healthcare).
 - ✅ Security hardening suggestions (#617): domain-based payment/PHI guidance, auth rate-limit hints, vault/logging guidance for secret-like properties, password-hash modeling, and webhook signature verification for webhook-style class names.
-- Performance optimization tips
-
-| Ticket | Feature Description            |
-|--------|--------------------------------|
-| #618   | Performance Optimization Tips  |
+- ✅ Performance optimization suggestions (#618): cache namespacing/TTL, background job idempotency and retries, cursor/keyset pagination, search projections vs canonical entities, chunked bulk I/O, separating heavy binary metadata, and fan-out/timeline modeling when cache, queue, paging, search, export, media, or feed-style names appear on classes or reusable properties.
 
 ### AI Documentation Generation
 

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.83",
+  "version": "0.11.84",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -30,6 +30,7 @@ We continue to improve the platform based on your feedback with improvements and
 - Projects list includes a **Show deleted** switch; when on, soft-deleted projects appear with a **Deleted** badge and **Restore** or **permanent delete** in the row menu (#2981).
 
 ## Studio
+- Studio AI **best-practice tips** now include **performance** hints (caching, queues, pagination, search projections, bulk I/O, media payloads, feeds/timelines) when matching names appear on classes or reusable properties (#618).
 - **Studio AI chat** surfaces **domain-aware best-practice tips** from the project’s **domain category** (set on the project in the dashboard) and from **auth / multi-tenant style class names**; tips appear in the chat empty state, the **Sharing context** popover, the prompt preamble sent to the model, and the offline demo’s **Improvement suggestions** (#615).
 - Each **domain category** now contributes **several industry-specific modeling patterns** (not a single generic line), for example inventory and checkout idempotency for e-commerce and ledger-style money movement for finance (#616).
 - Studio AI **best-practice tips** now include **security-hardening** hints from domain (payment card handling, PHI encryption), auth-related class names, secret- or password-like property names, and webhook-oriented classes (#617).

--- a/objectified-ui/src/app/utils/studio-ai-best-practice-tips.ts
+++ b/objectified-ui/src/app/utils/studio-ai-best-practice-tips.ts
@@ -1,11 +1,12 @@
 /**
- * Context-aware Studio AI best-practice tips (#615, #616, #617).
+ * Context-aware Studio AI best-practice tips (#615, #616, #617, #618).
  *
  * Combines the project metadata `domainCategory` (see project-domain-categories)
  * with light heuristics on class and property names so e-commerce, multi-tenant,
- * auth-heavy, and secret-bearing workspaces get targeted guidance without calling
- * a model. Each known domain emits several industry-specific modeling patterns
- * (not a single generic hint), plus security-hardening hints when signals match.
+ * auth-heavy, secret-bearing, and performance-sensitive workspaces get targeted
+ * guidance without calling a model. Each known domain emits several
+ * industry-specific modeling patterns (not a single generic hint), plus
+ * security-hardening and performance hints when signals match.
  */
 
 import {
@@ -17,7 +18,7 @@ import {
 export type StudioAiTipSignalContext = {
   domainCategory?: string | null;
   classNames: readonly string[];
-  /** Reusable property definition names — used for secret / credential heuristics (#617). */
+  /** Reusable property definition names — secret / credential (#617) and performance (#618) heuristics. */
   propertyNames?: readonly string[];
 };
 
@@ -131,6 +132,34 @@ const SENSITIVE_CLASS_NAME_SIGNAL =
 /** Compound names like `StripeWebhookEndpoint` must match without assuming token boundaries. */
 const WEBHOOK_CLASS_SIGNAL = /Webhook/i;
 
+/** Response caches, edge caches, and explicit revalidation hooks. */
+const CACHE_LAYER_SIGNAL =
+  /\b(Cache|Caching|Cached|Redis|Etag|Memcached|CDN)\b/i;
+
+/** Background workers, queues, and outbox-style durability. */
+const QUEUE_WORKER_SIGNAL =
+  /\b(Queue|Job|Worker|BackgroundTask|AsyncJob|Outbox|DeadLetter)\b/i;
+
+/** List endpoints and stable paging primitives (includes tokenized `page_token` → "page token"). */
+const PAGINATION_SIGNAL =
+  /\b(Pagination|PageToken|CursorToken|Keyset|InfiniteScroll|OffsetPage)\b|\bpage\s+token\b|\bcursor\s+token\b/i;
+
+/** Search indexes and autocomplete projections (`SearchIndex` often appears inside CamelCase names). */
+const SEARCH_INDEX_SIGNAL =
+  /SearchIndex|Elasticsearch|OpenSearch|FullText|AutocompleteIndex|\bsearch\s+index\b/i;
+
+/** Large imports, exports, or migrations (`CsvExport` often appears inside CamelCase names). */
+const BULK_IO_SIGNAL =
+  /BulkImport|BulkExport|CsvExport|ExportJob|ImportBatch|DataMigration|\bcsv\s+export\b|\bexport\s+job\b/i;
+
+/** Large binary or media payloads. */
+const MEDIA_PAYLOAD_SIGNAL =
+  /\b(Attachment|Blob|MediaAsset|VideoAsset|ImageUpload|FileUpload|BinaryPayload)\b/i;
+
+/** Hot read paths such as feeds and timelines (`Timeline` often appears inside CamelCase names). */
+const FEED_TIMELINE_SIGNAL =
+  /Timeline|ActivityStream|NotificationFeed|Fanout|\bfeed\b/i;
+
 function asBullet(line: string): string {
   const t = line.trim();
   if (t.startsWith('-')) return t;
@@ -229,6 +258,75 @@ function collectSecurityHardeningTipLines(signals: StudioAiTipSignalContext): st
   return lines;
 }
 
+function collectPerformanceOptimizationTipLines(signals: StudioAiTipSignalContext): string[] {
+  const classNames = signals.classNames.filter(Boolean);
+  const propertyNames = signals.propertyNames?.filter(Boolean) ?? [];
+
+  const classHaystack = classNames.map((c) => `${c} ${tokenizeClassName(c)}`).join(' ');
+  const propHaystack = propertyNames.map((p) => `${p} ${tokenizeClassName(p)}`).join(' ');
+  const combinedHaystack = `${classHaystack} ${propHaystack}`.trim();
+
+  const lines: string[] = [];
+
+  if (CACHE_LAYER_SIGNAL.test(combinedHaystack)) {
+    lines.push(
+      asBullet(
+        'Namespace cache entries per tenant or bounded context; record TTL or stale-after semantics so callers know when refreshed reads are required.',
+      ),
+    );
+  }
+
+  if (QUEUE_WORKER_SIGNAL.test(combinedHaystack)) {
+    lines.push(
+      asBullet(
+        'Make background jobs idempotent with dedupe keys where retries are possible; model retry counts and terminal failure states for safe backoff under load.',
+      ),
+    );
+  }
+
+  if (PAGINATION_SIGNAL.test(combinedHaystack)) {
+    lines.push(
+      asBullet(
+        'Prefer opaque cursors or keyset pagination fields on large lists over unbounded offset scans as data grows.',
+      ),
+    );
+  }
+
+  if (SEARCH_INDEX_SIGNAL.test(combinedHaystack)) {
+    lines.push(
+      asBullet(
+        'Treat search documents as projections of canonical entities; model index lag or sequence tokens when read-after-write consistency matters.',
+      ),
+    );
+  }
+
+  if (BULK_IO_SIGNAL.test(combinedHaystack)) {
+    lines.push(
+      asBullet(
+        'Stream or chunk large imports and exports; avoid schemas that require loading unbounded collections into one aggregate.',
+      ),
+    );
+  }
+
+  if (MEDIA_PAYLOAD_SIGNAL.test(combinedHaystack)) {
+    lines.push(
+      asBullet(
+        'Keep heavy binary metadata separate from core transactional rows; reference storage keys, checksums, and content types instead of inlining large payloads.',
+      ),
+    );
+  }
+
+  if (FEED_TIMELINE_SIGNAL.test(combinedHaystack)) {
+    lines.push(
+      asBullet(
+        'Model fan-out or materialized timelines explicitly; denormalize read models when hot paths must stay predictable at scale.',
+      ),
+    );
+  }
+
+  return lines;
+}
+
 export function collectStudioAiBestPracticeTipLines(signals: StudioAiTipSignalContext): string[] {
   const rawDomain = signals.domainCategory?.trim() || '';
   const domainId = rawDomain === PROJECT_DOMAIN_CATEGORY_NONE ? '' : rawDomain;
@@ -254,6 +352,10 @@ export function collectStudioAiBestPracticeTipLines(signals: StudioAiTipSignalCo
   }
 
   for (const line of collectSecurityHardeningTipLines(signals)) {
+    lines.push(line);
+  }
+
+  for (const line of collectPerformanceOptimizationTipLines(signals)) {
     lines.push(line);
   }
 

--- a/objectified-ui/src/app/utils/studio-ai-best-practice-tips.ts
+++ b/objectified-ui/src/app/utils/studio-ai-best-practice-tips.ts
@@ -134,11 +134,11 @@ const WEBHOOK_CLASS_SIGNAL = /Webhook/i;
 
 /** Response caches, edge caches, and explicit revalidation hooks. */
 const CACHE_LAYER_SIGNAL =
-  /\b(Cache|Caching|Cached|Redis|Etag|Memcached|CDN)\b/i;
+  /\b(Cache|Caching|Cached|Redis|Memcached|CDN)\b|ETag|\bE\s+Tag\b/i;
 
 /** Background workers, queues, and outbox-style durability. */
 const QUEUE_WORKER_SIGNAL =
-  /\b(Queue|Job|Worker|BackgroundTask|AsyncJob|Outbox|DeadLetter)\b/i;
+  /\b(Queue|Job|Worker|Outbox)\b|BackgroundTask|AsyncJob|DeadLetter|\bBackground\s+Task\b|\bAsync\s+Job\b|\bDead\s+Letter\b/i;
 
 /** List endpoints and stable paging primitives (includes tokenized `page_token` → "page token"). */
 const PAGINATION_SIGNAL =
@@ -154,7 +154,7 @@ const BULK_IO_SIGNAL =
 
 /** Large binary or media payloads. */
 const MEDIA_PAYLOAD_SIGNAL =
-  /\b(Attachment|Blob|MediaAsset|VideoAsset|ImageUpload|FileUpload|BinaryPayload)\b/i;
+  /\b(Attachment|Blob)\b|MediaAsset|VideoAsset|ImageUpload|FileUpload|BinaryPayload|\bMedia\s+Asset\b|\bVideo\s+Asset\b|\bImage\s+Upload\b|\bFile\s+Upload\b|\bBinary\s+Payload\b/i;
 
 /** Hot read paths such as feeds and timelines (`Timeline` often appears inside CamelCase names). */
 const FEED_TIMELINE_SIGNAL =

--- a/objectified-ui/tests/unit/studio-ai-best-practice-tips.test.ts
+++ b/objectified-ui/tests/unit/studio-ai-best-practice-tips.test.ts
@@ -155,6 +155,76 @@ describe('collectStudioAiBestPracticeTipLines (#615, #616)', () => {
   });
 });
 
+describe('collectStudioAiBestPracticeTipLines performance hints (#618)', () => {
+  it('adds cache guidance when cache- or Redis-like names appear', () => {
+    const lines = collectStudioAiBestPracticeTipLines({
+      domainCategory: '',
+      classNames: ['ProductCatalogCache'],
+    });
+    expect(lines.some((l) => l.toLowerCase().includes('namespace cache'))).toBe(true);
+    expect(lines.some((l) => l.toLowerCase().includes('ttl'))).toBe(true);
+  });
+
+  it('adds queue and job guidance when worker-style names appear', () => {
+    const lines = collectStudioAiBestPracticeTipLines({
+      domainCategory: '',
+      classNames: ['EmailOutbox'],
+    });
+    expect(lines.some((l) => l.toLowerCase().includes('idempotent'))).toBe(true);
+    expect(lines.some((l) => l.toLowerCase().includes('retry'))).toBe(true);
+  });
+
+  it('adds pagination guidance when paging primitives appear', () => {
+    const lines = collectStudioAiBestPracticeTipLines({
+      domainCategory: '',
+      classNames: ['CursorToken'],
+    });
+    expect(lines.some((l) => l.toLowerCase().includes('cursor'))).toBe(true);
+    expect(lines.some((l) => l.toLowerCase().includes('offset'))).toBe(true);
+  });
+
+  it('adds search-index guidance when search projection names appear', () => {
+    const lines = collectStudioAiBestPracticeTipLines({
+      domainCategory: '',
+      classNames: ['ListingSearchIndex'],
+    });
+    expect(lines.some((l) => l.toLowerCase().includes('search documents'))).toBe(true);
+  });
+
+  it('adds bulk I/O guidance when export or migration names appear', () => {
+    const lines = collectStudioAiBestPracticeTipLines({
+      domainCategory: '',
+      classNames: ['CsvExportJob'],
+    });
+    expect(lines.some((l) => l.toLowerCase().includes('chunk'))).toBe(true);
+  });
+
+  it('adds media payload guidance when blob or attachment names appear', () => {
+    const lines = collectStudioAiBestPracticeTipLines({
+      domainCategory: '',
+      classNames: ['InvoicePdfAttachment'],
+    });
+    expect(lines.some((l) => l.toLowerCase().includes('binary'))).toBe(true);
+  });
+
+  it('adds feed and timeline guidance when hot-read path names appear', () => {
+    const lines = collectStudioAiBestPracticeTipLines({
+      domainCategory: '',
+      classNames: ['HomeTimeline'],
+    });
+    expect(lines.some((l) => l.toLowerCase().includes('fan-out'))).toBe(true);
+  });
+
+  it('detects performance signals on reusable property names (#618)', () => {
+    const lines = collectStudioAiBestPracticeTipLines({
+      domainCategory: '',
+      classNames: [],
+      propertyNames: ['redis_cache_key'],
+    });
+    expect(lines.some((l) => l.toLowerCase().includes('namespace cache'))).toBe(true);
+  });
+});
+
 describe('collectStudioAiBestPracticeLinesFromStudio (#615)', () => {
   it('reads domain from project metadata shape', () => {
     const lines = collectStudioAiBestPracticeLinesFromStudio({
@@ -171,5 +241,14 @@ describe('collectStudioAiBestPracticeLinesFromStudio (#615)', () => {
       properties: [{ name: 'client_secret' }],
     });
     expect(lines.some((l) => l.toLowerCase().includes('vault'))).toBe(true);
+  });
+
+  it('passes property names for performance heuristics (#618)', () => {
+    const lines = collectStudioAiBestPracticeLinesFromStudio({
+      project: null,
+      classes: [{ name: 'ReportRow' }],
+      properties: [{ name: 'next_page_token' }],
+    });
+    expect(lines.some((l) => l.toLowerCase().includes('cursor'))).toBe(true);
   });
 });

--- a/objectified-ui/tests/unit/studio-ai-best-practice-tips.test.ts
+++ b/objectified-ui/tests/unit/studio-ai-best-practice-tips.test.ts
@@ -173,6 +173,15 @@ describe('collectStudioAiBestPracticeTipLines performance hints (#618)', () => {
     expect(lines.some((l) => l.toLowerCase().includes('namespace cache'))).toBe(true);
   });
 
+  it('adds cache guidance for tokenized snake_case ETag properties', () => {
+    const lines = collectStudioAiBestPracticeTipLines({
+      domainCategory: '',
+      classNames: [],
+      propertyNames: ['etag', 'e_tag'],
+    });
+    expect(lines.some((l) => l.toLowerCase().includes('namespace cache'))).toBe(true);
+  });
+
   it('adds queue and job guidance when worker-style names appear', () => {
     const lines = collectStudioAiBestPracticeTipLines({
       domainCategory: '',
@@ -186,6 +195,15 @@ describe('collectStudioAiBestPracticeTipLines performance hints (#618)', () => {
     const lines = collectStudioAiBestPracticeTipLines({
       domainCategory: '',
       classNames: ['UserBackgroundTask'],
+    });
+    expect(lines.some((l) => l.toLowerCase().includes('idempotent'))).toBe(true);
+  });
+
+  it('adds queue guidance for tokenized snake_case worker properties', () => {
+    const lines = collectStudioAiBestPracticeTipLines({
+      domainCategory: '',
+      classNames: [],
+      propertyNames: ['background_task'],
     });
     expect(lines.some((l) => l.toLowerCase().includes('idempotent'))).toBe(true);
   });
@@ -227,6 +245,15 @@ describe('collectStudioAiBestPracticeTipLines performance hints (#618)', () => {
     const lines = collectStudioAiBestPracticeTipLines({
       domainCategory: '',
       classNames: ['OrderBinaryPayload'],
+    });
+    expect(lines.some((l) => l.toLowerCase().includes('binary'))).toBe(true);
+  });
+
+  it('adds media guidance for tokenized snake_case payload properties', () => {
+    const lines = collectStudioAiBestPracticeTipLines({
+      domainCategory: '',
+      classNames: [],
+      propertyNames: ['binary_payload'],
     });
     expect(lines.some((l) => l.toLowerCase().includes('binary'))).toBe(true);
   });

--- a/objectified-ui/tests/unit/studio-ai-best-practice-tips.test.ts
+++ b/objectified-ui/tests/unit/studio-ai-best-practice-tips.test.ts
@@ -165,6 +165,14 @@ describe('collectStudioAiBestPracticeTipLines performance hints (#618)', () => {
     expect(lines.some((l) => l.toLowerCase().includes('ttl'))).toBe(true);
   });
 
+  it('adds cache guidance for tokenized ETag CamelCase compounds', () => {
+    const lines = collectStudioAiBestPracticeTipLines({
+      domainCategory: '',
+      classNames: ['OrderETag'],
+    });
+    expect(lines.some((l) => l.toLowerCase().includes('namespace cache'))).toBe(true);
+  });
+
   it('adds queue and job guidance when worker-style names appear', () => {
     const lines = collectStudioAiBestPracticeTipLines({
       domainCategory: '',
@@ -172,6 +180,14 @@ describe('collectStudioAiBestPracticeTipLines performance hints (#618)', () => {
     });
     expect(lines.some((l) => l.toLowerCase().includes('idempotent'))).toBe(true);
     expect(lines.some((l) => l.toLowerCase().includes('retry'))).toBe(true);
+  });
+
+  it('adds queue guidance for tokenized CamelCase worker compounds', () => {
+    const lines = collectStudioAiBestPracticeTipLines({
+      domainCategory: '',
+      classNames: ['UserBackgroundTask'],
+    });
+    expect(lines.some((l) => l.toLowerCase().includes('idempotent'))).toBe(true);
   });
 
   it('adds pagination guidance when paging primitives appear', () => {
@@ -203,6 +219,14 @@ describe('collectStudioAiBestPracticeTipLines performance hints (#618)', () => {
     const lines = collectStudioAiBestPracticeTipLines({
       domainCategory: '',
       classNames: ['InvoicePdfAttachment'],
+    });
+    expect(lines.some((l) => l.toLowerCase().includes('binary'))).toBe(true);
+  });
+
+  it('adds media guidance for tokenized CamelCase payload compounds', () => {
+    const lines = collectStudioAiBestPracticeTipLines({
+      domainCategory: '',
+      classNames: ['OrderBinaryPayload'],
     });
     expect(lines.some((l) => l.toLowerCase().includes('binary'))).toBe(true);
   });


### PR DESCRIPTION
## Summary
Adds signal-based **performance** bullets to `collectStudioAiBestPracticeTipLines`, matching the existing domain + security pattern: cache/Redis, queues/outbox, pagination (`page_token`, cursors), search indexes, bulk export/import, media attachments, and timeline/feed naming on classes or reusable properties.

## How to test
- **Run unit tests**: `cd objectified-ui && yarn test tests/unit/studio-ai-best-practice-tips.test.ts`
- **Manual**: Open Studio AI chat or sharing-context UI with classes/properties whose names include signals above (e.g. `ProductCatalogCache`, `CsvExportJob`) and confirm performance bullets appear alongside domain/security tips.

## Risk / notes
- Tips only appear when heuristics match; no change when schema names are neutral.
- Regex tuned for CamelCase compounds (e.g. `ListingSearchIndex`) and tokenized snake_case properties.

Closes #618

Made with [Cursor](https://cursor.com)