### PR TITLE
Fix #619 - Autogenerate property descriptions from names and types

### DIFF
--- a/docs/PLANNED_FEATURE_ROADMAP_AI.md
+++ b/docs/PLANNED_FEATURE_ROADMAP_AI.md
@@ -75,7 +75,7 @@ This outlines the planned features for integrating AI capabilities into Objectif
 ### AI Documentation Generation
 
 **Auto-Generate Descriptions** 📋 PLANNED
-- 📋 Generate property descriptions from names and types
+- ✅ Generate property descriptions from names and types (#619 — Studio **Generate with AI** on property description fields; Ollama `property_description` task)
 - 📋 Generate class descriptions from properties
 - 📋 Generate operation summaries from path and method
 - 📋 Generate example values that make sense
@@ -83,7 +83,6 @@ This outlines the planned features for integrating AI capabilities into Objectif
 
 | Ticket | Feature Description                                        |
 |--------|------------------------------------------------------------|
-| #619   | Auto-Generate Descriptions                                 |
 | #620   | Auto-Generate descriptions for classes                     |
 | #621   | Operations summaries and descriptions from path and method |
 | #622   | Generate example values that make sense                    |

--- a/objectified-ui/lib/ai-property-description.ts
+++ b/objectified-ui/lib/ai-property-description.ts
@@ -1,0 +1,180 @@
+import type { PropertyFormData } from '@/app/components/ade/studio/PropertyFormFields';
+
+/**
+ * Normalizes LLM output into a single plain-text property description (#619).
+ */
+export function normalizeGeneratedPropertyDescription(raw: string): string {
+  let t = raw.trim();
+  if (!t) return '';
+  const fenceWrapped = /^```[a-zA-Z]*\n?([\s\S]*?)\n?```$/;
+  const m = t.match(fenceWrapped);
+  if (m) t = m[1].trim();
+  t = t.replace(/^#{1,6}\s+/gm, '').replace(/\*\*([^*]+)\*\*/g, '$1');
+  const firstBlock = t.split(/\n\n+/)[0] ?? t;
+  return firstBlock.replace(/\s+/g, ' ').trim().slice(0, 4000);
+}
+
+const DESCRIPTION_SCHEMA_KEYS = [
+  'type',
+  'format',
+  'pattern',
+  '$ref',
+  'items',
+  'enum',
+  'const',
+  'additionalProperties',
+  'properties',
+  'required',
+  'oneOf',
+  'anyOf',
+  'allOf',
+  'prefixItems',
+  'tupleMode',
+  'minLength',
+  'maxLength',
+  'minimum',
+  'maximum',
+  'exclusiveMinimum',
+  'exclusiveMaximum',
+  'minItems',
+  'maxItems',
+  'uniqueItems',
+  'nullable',
+  'description',
+  'title',
+  'deprecated',
+  'readOnly',
+  'writeOnly',
+] as const;
+
+function truncateDeep(value: unknown, depth: number): unknown {
+  if (depth <= 0) return '[…]';
+  if (value === null || value === undefined) return value;
+  if (typeof value !== 'object') return value;
+  if (Array.isArray(value)) {
+    const cap = 12;
+    const slice = value.slice(0, cap).map((x) => truncateDeep(x, depth - 1));
+    return value.length > cap ? [...slice, `… +${value.length - cap} more`] : slice;
+  }
+  const o = value as Record<string, unknown>;
+  const out: Record<string, unknown> = {};
+  for (const k of Object.keys(o)) {
+    out[k] = truncateDeep(o[k], depth - 1);
+  }
+  return out;
+}
+
+/**
+ * Reduces persisted property `data` JSON for prompt size while keeping type semantics.
+ */
+export function summarizeStoredPropertyData(data: unknown): Record<string, unknown> {
+  if (!data || typeof data !== 'object' || Array.isArray(data)) return {};
+  const src = data as Record<string, unknown>;
+  const out: Record<string, unknown> = {};
+  for (const k of DESCRIPTION_SCHEMA_KEYS) {
+    if (!(k in src)) continue;
+    out[k] = truncateDeep(src[k], 3);
+  }
+  if (Object.keys(out).length > 0) return out;
+  return truncateDeep(src, 2) as Record<string, unknown>;
+}
+
+type SeedPropertyLike = {
+  $ref?: string;
+  items?: { $ref?: string; type?: string };
+  type?: string | string[];
+} | null;
+
+/**
+ * Builds a compact JSON Schema snapshot from the property dialog form for AI description (#619).
+ */
+export function draftPropertySchemaFromDialogForm(input: {
+  propertyType: string;
+  propertyIsArray: boolean;
+  formData: PropertyFormData;
+  seedProperty: SeedPropertyLike;
+}): Record<string, unknown> {
+  const { propertyType, propertyIsArray, formData, seedProperty } = input;
+
+  const valueHints = (): Record<string, unknown> => {
+    const o: Record<string, unknown> = {};
+    if (formData.format?.trim()) o.format = formData.format.trim();
+    if (formData.pattern?.trim()) o.pattern = formData.pattern.trim();
+    if (formData.enum && formData.enum.length > 0) o.enum = formData.enum.slice(0, 24);
+    if (formData.minLength?.trim()) {
+      const n = Number.parseInt(formData.minLength, 10);
+      if (!Number.isNaN(n)) o.minLength = n;
+    }
+    if (formData.maxLength?.trim()) {
+      const n = Number.parseInt(formData.maxLength, 10);
+      if (!Number.isNaN(n)) o.maxLength = n;
+    }
+    if (formData.minimum?.trim()) {
+      const n = Number.parseFloat(formData.minimum);
+      if (!Number.isNaN(n)) {
+        if (formData.minimumType === 'exclusive') o.exclusiveMinimum = n;
+        else o.minimum = n;
+      }
+    }
+    if (formData.maximum?.trim()) {
+      const n = Number.parseFloat(formData.maximum);
+      if (!Number.isNaN(n)) {
+        if (formData.maximumType === 'exclusive') o.exclusiveMaximum = n;
+        else o.maximum = n;
+      }
+    }
+    return o;
+  };
+
+  const arrayHints = (): Record<string, unknown> => {
+    const o: Record<string, unknown> = {};
+    if (formData.minItems?.trim()) {
+      const n = Number.parseInt(formData.minItems, 10);
+      if (!Number.isNaN(n)) o.minItems = n;
+    }
+    if (formData.maxItems?.trim()) {
+      const n = Number.parseInt(formData.maxItems, 10);
+      if (!Number.isNaN(n)) o.maxItems = n;
+    }
+    if (formData.uniqueItems) o.uniqueItems = true;
+    if (formData.tupleMode && formData.prefixItems?.length) {
+      o.prefixItems = truncateDeep(formData.prefixItems, 3);
+      o.tupleMode = true;
+    }
+    return o;
+  };
+
+  if (propertyType === '$ref') {
+    const ref =
+      (seedProperty && typeof seedProperty.$ref === 'string' && seedProperty.$ref) ||
+      (seedProperty?.items && typeof seedProperty.items.$ref === 'string' && seedProperty.items.$ref) ||
+      '';
+    if (propertyIsArray) {
+      return {
+        type: 'array',
+        items: ref ? { $ref: ref, ...valueHints() } : { type: 'object', ...valueHints() },
+        ...arrayHints(),
+      };
+    }
+    return ref ? { $ref: ref, ...valueHints() } : { type: 'object', ...valueHints() };
+  }
+
+  const nullable = Boolean(formData.nullable);
+  const itemType = propertyType || 'string';
+
+  const elementSchema = (): Record<string, unknown> => {
+    const base = valueHints();
+    if (nullable) return { type: [itemType, 'null'], ...base };
+    return { type: itemType, ...base };
+  };
+
+  if (propertyIsArray) {
+    return {
+      type: 'array',
+      items: elementSchema(),
+      ...arrayHints(),
+    };
+  }
+
+  return elementSchema();
+}

--- a/objectified-ui/lib/ai-property-description.ts
+++ b/objectified-ui/lib/ai-property-description.ts
@@ -50,6 +50,10 @@ const DESCRIPTION_SCHEMA_KEYS = [
 function truncateDeep(value: unknown, depth: number): unknown {
   if (depth <= 0) return '[…]';
   if (value === null || value === undefined) return value;
+  if (typeof value === 'string') {
+    const cap = 320;
+    return value.length > cap ? `${value.slice(0, cap - 1)}…` : value;
+  }
   if (typeof value !== 'object') return value;
   if (Array.isArray(value)) {
     const cap = 12;
@@ -95,6 +99,8 @@ export function draftPropertySchemaFromDialogForm(input: {
   seedProperty: SeedPropertyLike;
 }): Record<string, unknown> {
   const { propertyType, propertyIsArray, formData, seedProperty } = input;
+  const nullable = Boolean(formData.nullable);
+  const arrayType: string | string[] = nullable ? ['array', 'null'] : 'array';
 
   const valueHints = (): Record<string, unknown> => {
     const o: Record<string, unknown> = {};
@@ -151,7 +157,7 @@ export function draftPropertySchemaFromDialogForm(input: {
       '';
     if (propertyIsArray) {
       return {
-        type: 'array',
+        type: arrayType,
         items: ref ? { $ref: ref, ...valueHints() } : { type: 'object', ...valueHints() },
         ...arrayHints(),
       };
@@ -159,22 +165,21 @@ export function draftPropertySchemaFromDialogForm(input: {
     return ref ? { $ref: ref, ...valueHints() } : { type: 'object', ...valueHints() };
   }
 
-  const nullable = Boolean(formData.nullable);
   const itemType = propertyType || 'string';
 
-  const elementSchema = (): Record<string, unknown> => {
+  const elementSchema = (includeNullable: boolean): Record<string, unknown> => {
     const base = valueHints();
-    if (nullable) return { type: [itemType, 'null'], ...base };
+    if (includeNullable) return { type: [itemType, 'null'], ...base };
     return { type: itemType, ...base };
   };
 
   if (propertyIsArray) {
     return {
-      type: 'array',
-      items: elementSchema(),
+      type: arrayType,
+      items: elementSchema(false),
       ...arrayHints(),
     };
   }
 
-  return elementSchema();
+  return elementSchema(nullable);
 }

--- a/objectified-ui/lib/ai-property-description.ts
+++ b/objectified-ui/lib/ai-property-description.ts
@@ -52,7 +52,9 @@ function truncateDeep(value: unknown, depth: number): unknown {
   if (value === null || value === undefined) return value;
   if (typeof value === 'string') {
     const cap = 320;
-    return value.length > cap ? `${value.slice(0, cap - 1)}…` : value;
+    const ellipsis = '…';
+    const contentCap = cap - ellipsis.length;
+    return value.length > cap ? `${value.slice(0, contentCap)}${ellipsis}` : value;
   }
   if (typeof value !== 'object') return value;
   if (Array.isArray(value)) {

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.84",
+  "version": "0.11.85",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -30,6 +30,7 @@ We continue to improve the platform based on your feedback with improvements and
 - Projects list includes a **Show deleted** switch; when on, soft-deleted projects appear with a **Deleted** badge and **Restore** or **permanent delete** in the row menu (#2981).
 
 ## Studio
+- **Property description** fields support **Generate with AI** (Ollama): drafts short documentation from the property name and JSON Schema type — in **Add/Edit Property** (sidebar library) and **Edit class property** on the canvas (#619).
 - Studio AI **best-practice tips** now include **performance** hints (caching, queues, pagination, search projections, bulk I/O, media payloads, feeds/timelines) when matching names appear on classes or reusable properties (#618).
 - **Studio AI chat** surfaces **domain-aware best-practice tips** from the project’s **domain category** (set on the project in the dashboard) and from **auth / multi-tenant style class names**; tips appear in the chat empty state, the **Sharing context** popover, the prompt preamble sent to the model, and the offline demo’s **Improvement suggestions** (#615).
 - Each **domain category** now contributes **several industry-specific modeling patterns** (not a single generic line), for example inventory and checkout idempotency for e-commerce and ledger-style money movement for finance (#616).

--- a/objectified-ui/src/app/ade/studio/editor/page.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/page.tsx
@@ -247,6 +247,9 @@ import { Switch } from '@/app/components/ui/Switch';
 // Import extracted components
 import { useExportFunctions } from './components';
 import type { Project, Version, ViewMode } from './components/types';
+import type { PropertyDialogAiContext } from '@/app/components/ade/studio/PropertyDialog';
+import type { PropertyItem } from '@/app/components/ade/studio/StudioSideNav';
+import type { ChatStudioContext } from '@/app/ade/studio/components/chatbot/chat-context';
 
 // Dynamically import Monaco Editor with SSR disabled
 const PRESENTATION_SAVE_DEBOUNCE_MS = 500;
@@ -677,6 +680,83 @@ const StudioContent = () => {
   const [classEditDialogOpen, setClassEditDialogOpen] = useState(false);
   const [editingClassData, setEditingClassData] = useState<any>(null);
   // Note: dialog-specific form state moved to ClassPropertyEditDialog component
+
+  const canvasPropertyAiContext = useMemo((): PropertyDialogAiContext | undefined => {
+    if (!currentTenantId || !selectedProjectId) return undefined;
+
+    const readNodeData = (raw: unknown) =>
+      raw !== null && typeof raw === 'object'
+        ? (raw as { name?: string; description?: unknown; properties?: unknown })
+        : undefined;
+
+    const existingClasses = nodes
+      .map((n) => String(readNodeData(n.data)?.name ?? '').trim())
+      .filter(Boolean);
+    const byName = new Map<string, PropertyItem>();
+    for (const n of nodes) {
+      const rawProps = readNodeData(n.data)?.properties;
+      const props = Array.isArray(rawProps) ? rawProps : [];
+      for (const entry of props) {
+        if (!entry || typeof entry !== 'object') continue;
+        const p = entry as {
+          id?: string;
+          property_id?: string;
+          name?: string;
+          description?: string | null;
+          data?: unknown;
+        };
+        if (!p.name || byName.has(String(p.name))) continue;
+        const dataObj =
+          typeof p.data === 'string'
+            ? (() => {
+                try {
+                  return JSON.parse(p.data) as Record<string, unknown>;
+                } catch {
+                  return {};
+                }
+              })()
+            : p.data !== null && typeof p.data === 'object'
+              ? { ...(p.data as Record<string, unknown>) }
+              : {};
+        const item = {
+          ...dataObj,
+          id: String(p.id ?? p.property_id ?? p.name),
+          name: String(p.name),
+        } as PropertyItem;
+        if (p.description != null) item.description = p.description;
+        byName.set(String(p.name), item);
+      }
+    }
+    const selectedProject = projects.find((pr) => String(pr.id) === String(selectedProjectId));
+    const selectedVersion = versions.find((v) => String(v.id) === String(selectedVersionId));
+    const studioContext: ChatStudioContext = {
+      project: selectedProjectId ? { id: selectedProjectId, name: selectedProject?.name ?? null } : null,
+      version: selectedVersionId ? { id: selectedVersionId, label: selectedVersion?.version_id ?? null } : null,
+      classes: nodes.map((n) => {
+        const d = readNodeData(n.data);
+        const desc = d?.description;
+        return {
+          id: n.id,
+          name: String(d?.name ?? ''),
+          description: typeof desc === 'string' || desc === null ? desc : null,
+        };
+      }),
+      properties: [],
+      selectedClassIds: [],
+    };
+    const editingClassName = editingClassId
+      ? String(readNodeData(nodes.find((node) => node.id === editingClassId)?.data)?.name ?? '').trim()
+      : '';
+    return {
+      tenantId: currentTenantId,
+      projectId: selectedProjectId,
+      versionId: selectedVersionId || undefined,
+      existingClasses,
+      existingProperties: [...byName.values()],
+      studioContext,
+      contextClassName: editingClassName || null,
+    };
+  }, [currentTenantId, selectedProjectId, selectedVersionId, nodes, projects, versions, editingClassId]);
 
   // Reference dialog state
   const [referenceDialogOpen, setReferenceDialogOpen] = useState(false);
@@ -11085,6 +11165,7 @@ const StudioContent = () => {
           id: n.id,
           name: (n.data as any).name
         })).filter(c => c.name)}
+        propertyAiContext={canvasPropertyAiContext}
       />
 
       {/* Reference Dialog */}

--- a/objectified-ui/src/app/api/ollama/chat/route.ts
+++ b/objectified-ui/src/app/api/ollama/chat/route.ts
@@ -222,6 +222,53 @@ function buildPropertySuggestionsSystem(options: {
   return PROPERTY_SUGGESTIONS_SYSTEM + extra;
 }
 
+const PROPERTY_DESCRIPTION_SYSTEM = `You write concise API documentation for JSON Schema properties used in OpenAPI 3.1.
+
+# Task
+Return **plain prose only**: one or two sentences describing what the property holds or represents for API consumers.
+
+# Rules
+- No markdown, no bullet lists, no JSON, no code fences — output readable sentences only.
+- Infer intent from the property name (typically camelCase), the schema type/format/constraints, and optional class context.
+- Avoid redundant openers like "This property is" unless it reads most natural that way.
+- Prefer staying under 400 characters; use more only when enums, formats, or references need explicit explanation.
+- When the schema uses a component reference (\`$ref\`), say briefly that the field relates to or embeds that referenced model.
+- Use **Existing classes** / **Existing project properties** only to disambiguate names — do not invent domain facts unsupported by the schema.`;
+
+function buildPropertyDescriptionSystem(options: {
+  existingClassNames?: string[];
+  existingProperties?: Array<{ name: string; description?: string | null; data?: Record<string, unknown> }>;
+  targetPropertyName?: string;
+  targetClassName?: string;
+}): string {
+  let s = PROPERTY_DESCRIPTION_SYSTEM;
+  const tp = typeof options.targetPropertyName === 'string' ? options.targetPropertyName.trim() : '';
+  if (tp) {
+    s += `\n\n# Target property name\n${tp}\n`;
+  }
+  const tc = typeof options.targetClassName === 'string' ? options.targetClassName.trim() : '';
+  if (tc) {
+    s += `\n\n# Containing class\n${tc}\n`;
+  }
+  if (options.existingClassNames?.length) {
+    s += `\n\n# Existing classes\n${options.existingClassNames.join(', ')}`;
+  }
+  if (options.existingProperties?.length) {
+    s += `\n\n# Existing project properties\n`;
+    options.existingProperties.forEach((p) => {
+      const d = p.data;
+      const typeStr =
+        typeof d?.type === 'string'
+          ? d.type
+          : d && typeof d === 'object' && '$ref' in d && d.$ref
+            ? '$ref'
+            : 'object';
+      s += `- ${p.name}: ${typeStr}${p.description ? ` — ${String(p.description).slice(0, 80)}` : ''}\n`;
+    });
+  }
+  return s;
+}
+
 function buildPropertyTypeSuggestionsSystem(options: {
   existingClassNames?: string[];
   existingProperties?: Array<{ name: string; description?: string | null; data?: Record<string, unknown> }>;
@@ -355,8 +402,10 @@ export async function POST(request: NextRequest) {
     const isDataQuery = task === 'data_query';
     const isPropertySuggestions = task === 'property_suggestions';
     const isPropertyTypeSuggestions = task === 'property_type_suggestions';
+    const isPropertyDescription = task === 'property_description';
     const isSchemaImprovementSuggestions = task === 'schema_improvement_suggestions';
-    const usesPropertyLibraryContext = isClassSkeleton || isPropertySuggestions || isPropertyTypeSuggestions;
+    const usesPropertyLibraryContext =
+      isClassSkeleton || isPropertySuggestions || isPropertyTypeSuggestions || isPropertyDescription;
 
     const digestStr =
       typeof studioMetricsDigest === 'string' && studioMetricsDigest.trim().length > 0
@@ -393,6 +442,13 @@ export async function POST(request: NextRequest) {
                 targetPropertyName: typeof targetPropertyName === 'string' ? targetPropertyName : undefined,
                 targetClassName: typeof targetClassName === 'string' ? targetClassName : undefined,
               })
+            : isPropertyDescription
+              ? buildPropertyDescriptionSystem({
+                  existingClassNames: Array.isArray(existingClassNames) ? existingClassNames : undefined,
+                  existingProperties: Array.isArray(existingProperties) ? existingProperties : undefined,
+                  targetPropertyName: typeof targetPropertyName === 'string' ? targetPropertyName : undefined,
+                  targetClassName: typeof targetClassName === 'string' ? targetClassName : undefined,
+                })
             : isSchemaImprovementSuggestions
               ? buildSchemaImprovementSuggestionsSystem({
                   studioMetricsDigest: digestStr,

--- a/objectified-ui/src/app/components/ade/studio/ClassPropertyEditDialog.tsx
+++ b/objectified-ui/src/app/components/ade/studio/ClassPropertyEditDialog.tsx
@@ -45,6 +45,9 @@ import {
   type FormSectionNavItem,
   type FormWizardStep,
 } from './form';
+import type { PropertyDialogAiContext } from './PropertyDialog';
+import { PropertyDescriptionAiButton } from './PropertyDescriptionAiButton';
+import { summarizeStoredPropertyData } from '@lib/ai-property-description';
 
 interface Props {
   open: boolean;
@@ -65,6 +68,8 @@ interface Props {
   existingClassNames?: string[];
   // Available classes for reference selection (id, name pairs)
   availableClasses?: Array<{ id: string; name: string }>;
+  /** Ollama-backed description generation (#619); same shape as Property dialog AI context. */
+  propertyAiContext?: PropertyDialogAiContext;
 }
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -82,6 +87,7 @@ interface BasicsSectionProps {
   hasRef: boolean;
   propertyType: string;
   primitiveAvailable: boolean;
+  descriptionAiSlot?: React.ReactNode;
   changed?: boolean;
   eyebrow?: string;
 }
@@ -95,6 +101,7 @@ const BasicsSection: React.FC<BasicsSectionProps> = ({
   hasRef,
   propertyType,
   primitiveAvailable,
+  descriptionAiSlot,
   changed,
   eyebrow = 'Basics',
 }) => (
@@ -148,6 +155,7 @@ const BasicsSection: React.FC<BasicsSectionProps> = ({
         placeholder="Brief description of this property"
         rows={3}
       />
+      {descriptionAiSlot ? <div className="mt-2">{descriptionAiSlot}</div> : null}
     </FormFieldGroup>
 
     {primitiveAvailable && (
@@ -655,7 +663,16 @@ const ReferenceSection: React.FC<ReferenceSectionProps> = ({
   );
 };
 
-export default function ClassPropertyEditDialog({ open, onClose, editingClassProperty, onSaved, allClassProperties, existingClassNames = [], availableClasses = [] }: Props) {
+export default function ClassPropertyEditDialog({
+  open,
+  onClose,
+  editingClassProperty,
+  onSaved,
+  allClassProperties,
+  existingClassNames = [],
+  availableClasses = [],
+  propertyAiContext,
+}: Props) {
   const [editPropName, setEditPropName] = useState('');
   const [editPropertyError, setEditPropertyError] = useState('');
   const [extractDialogOpen, setExtractDialogOpen] = useState(false);
@@ -1650,6 +1667,36 @@ export default function ClassPropertyEditDialog({ open, onClose, editingClassPro
     setCurrentStepIndex((i) => Math.max(i - 1, 0));
   };
 
+  const propertySchemaForAiDescription = useMemo(() => {
+    if (!editingClassProperty?.data) return {};
+    try {
+      const raw =
+        typeof editingClassProperty.data === 'string'
+          ? JSON.parse(editingClassProperty.data)
+          : editingClassProperty.data;
+      return summarizeStoredPropertyData(raw);
+    } catch {
+      return {};
+    }
+  }, [editingClassProperty?.data]);
+
+  const classMemberDescriptionAiSlot =
+    open && propertyAiContext && editingClassProperty ? (
+      <PropertyDescriptionAiButton
+        tenantId={propertyAiContext.tenantId}
+        projectId={propertyAiContext.projectId}
+        versionId={propertyAiContext.versionId}
+        propertyName={editPropName}
+        propertySchema={propertySchemaForAiDescription}
+        contextClassName={propertyAiContext.contextClassName}
+        existingClasses={propertyAiContext.existingClasses}
+        existingProperties={propertyAiContext.existingProperties}
+        studioContext={propertyAiContext.studioContext}
+        onGenerated={(text) => setFormData((prev) => ({ ...prev, description: text }))}
+        disabled={!editPropName.trim()}
+      />
+    ) : null;
+
   const guidedSection = (id: string) => {
     switch (id) {
       case 'basics':
@@ -1663,6 +1710,7 @@ export default function ClassPropertyEditDialog({ open, onClose, editingClassPro
             hasRef={!!typeInfo.hasRef}
             propertyType={baseType}
             primitiveAvailable={primitiveAvailable}
+            descriptionAiSlot={classMemberDescriptionAiSlot}
             changed={changedBasics}
             eyebrow="Step 1 · Basics"
           />
@@ -1726,6 +1774,7 @@ export default function ClassPropertyEditDialog({ open, onClose, editingClassPro
         hasRef={!!typeInfo.hasRef}
         propertyType={baseType}
         primitiveAvailable={primitiveAvailable}
+        descriptionAiSlot={classMemberDescriptionAiSlot}
         changed={changedBasics}
       />
       <FlagsSection formData={formData} setFormData={setFormData} changed={changedFlags} />

--- a/objectified-ui/src/app/components/ade/studio/PropertyDescriptionAiButton.tsx
+++ b/objectified-ui/src/app/components/ade/studio/PropertyDescriptionAiButton.tsx
@@ -1,0 +1,230 @@
+'use client';
+
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { Button } from '../../ui/Button';
+import { Loader2, Sparkles, Square } from 'lucide-react';
+import type { PropertyItem } from './StudioSideNav';
+import type { ChatStudioContext } from '@/app/ade/studio/components/chatbot/chat-context';
+import { isChatStudioContextEmpty } from '@/app/ade/studio/components/chatbot/chat-context';
+import {
+  persistOllamaModelChoiceForScope,
+  resolvePreferredOllamaModel,
+} from '@/app/ade/studio/components/chatbot/ollama-model-defaults';
+import { accumulateOllamaSse } from '@lib/ollama-chat-sse';
+import { computeStudioSchemaFingerprint } from '@lib/studio-schema-fingerprint';
+import { propertyItemToExistingApiShape } from '@lib/property-item-utils';
+import { normalizeGeneratedPropertyDescription } from '@lib/ai-property-description';
+
+export interface PropertyDescriptionAiButtonProps {
+  tenantId: string | null | undefined;
+  projectId: string;
+  versionId: string | null | undefined;
+  propertyName: string;
+  /** Compact JSON Schema snapshot for the property (`data`). */
+  propertySchema: Record<string, unknown>;
+  contextClassName?: string | null;
+  existingClasses: string[];
+  existingProperties: PropertyItem[];
+  studioContext: ChatStudioContext;
+  onGenerated: (description: string) => void;
+  disabled?: boolean;
+  /** Optional label for tests / layout */
+  className?: string;
+}
+
+export function PropertyDescriptionAiButton({
+  tenantId,
+  projectId,
+  versionId,
+  propertyName,
+  propertySchema,
+  contextClassName,
+  existingClasses,
+  existingProperties,
+  studioContext,
+  onGenerated,
+  disabled,
+  className,
+}: PropertyDescriptionAiButtonProps) {
+  const [modelNames, setModelNames] = useState<string[]>([]);
+  const [selectedModel, setSelectedModel] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch('/api/ollama/models');
+        const json = (await res.json()) as { success?: boolean; models?: { name?: string }[] };
+        const list = res.ok && json.success && Array.isArray(json.models) ? json.models : undefined;
+        const names = Array.isArray(list)
+          ? list.map((m) => m?.name).filter((n): n is string => typeof n === 'string' && n.trim().length > 0)
+          : [];
+        if (cancelled) return;
+        setModelNames(names);
+        const preferred = resolvePreferredOllamaModel({
+          tenantId,
+          projectId,
+          availableModelNames: names,
+          storage: typeof window !== 'undefined' ? window.localStorage : null,
+        });
+        setSelectedModel(preferred);
+      } catch {
+        if (!cancelled) {
+          setModelNames([]);
+          setSelectedModel('');
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [tenantId, projectId]);
+
+  const stop = useCallback(() => {
+    abortRef.current?.abort();
+    abortRef.current = null;
+  }, []);
+
+  const generate = useCallback(async () => {
+    const name = propertyName.trim();
+    if (!name || !selectedModel.trim()) return;
+
+    persistOllamaModelChoiceForScope({
+      tenantId,
+      projectId,
+      modelName: selectedModel,
+      storage: typeof window !== 'undefined' ? window.localStorage : null,
+    });
+
+    stop();
+    const ac = new AbortController();
+    abortRef.current = ac;
+
+    setBusy(true);
+    setError(null);
+
+    let schemaContextFingerprint: string | undefined;
+    if (studioContext && !isChatStudioContextEmpty(studioContext)) {
+      try {
+        schemaContextFingerprint = await computeStudioSchemaFingerprint(studioContext);
+      } catch {
+        /* optional */
+      }
+    }
+
+    const existingPropsPayload = existingProperties.map(propertyItemToExistingApiShape);
+
+    const userLines = [
+      `Write a documentation description for this schema property.`,
+      `Property name: ${name}`,
+      contextClassName?.trim() ? `Containing class: ${contextClassName.trim()}` : null,
+      `JSON Schema for the property (library/canvas data): ${JSON.stringify(propertySchema)}`,
+    ].filter(Boolean);
+
+    try {
+      const response = await fetch('/api/ollama/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        signal: ac.signal,
+        body: JSON.stringify({
+          model: selectedModel.trim(),
+          task: 'property_description',
+          messages: [{ role: 'user', content: userLines.join('\n') }],
+          existingClassNames: existingClasses,
+          existingProperties: existingPropsPayload,
+          targetPropertyName: name,
+          targetClassName: typeof contextClassName === 'string' ? contextClassName : undefined,
+          ...(typeof versionId === 'string' && versionId ? { versionId } : {}),
+          ...(schemaContextFingerprint ? { schemaContextFingerprint } : {}),
+        }),
+      });
+
+      if (!response.ok) {
+        const t = await response.text().catch(() => '');
+        throw new Error(t || `Request failed (${response.status})`);
+      }
+
+      const full = await accumulateOllamaSse(response, ac.signal);
+      if (ac.signal.aborted) return;
+
+      const normalized = normalizeGeneratedPropertyDescription(full);
+      if (!normalized) {
+        setError('The model returned an empty description. Try again or pick another model.');
+        return;
+      }
+      onGenerated(normalized);
+    } catch (e) {
+      if (ac.signal.aborted) return;
+      setError(e instanceof Error ? e.message : 'Something went wrong.');
+    } finally {
+      setBusy(false);
+      if (abortRef.current === ac) abortRef.current = null;
+    }
+  }, [
+    propertyName,
+    selectedModel,
+    tenantId,
+    projectId,
+    versionId,
+    propertySchema,
+    contextClassName,
+    existingClasses,
+    existingProperties,
+    studioContext,
+    onGenerated,
+    stop,
+  ]);
+
+  useEffect(() => () => stop(), [stop]);
+
+  const canRun = Boolean(propertyName.trim() && selectedModel.trim() && !disabled);
+
+  return (
+    <div className={className}>
+      <div className="flex flex-wrap items-center gap-2">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={!canRun || busy || modelNames.length === 0}
+          onClick={() => void generate()}
+          data-testid="property-description-ai-generate"
+          className="shrink-0 border-violet-300 text-violet-800 hover:bg-violet-50 dark:border-violet-700 dark:text-violet-200 dark:hover:bg-violet-950/40"
+        >
+          {busy ? (
+            <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" aria-hidden />
+          ) : (
+            <Sparkles className="mr-1.5 h-3.5 w-3.5" aria-hidden />
+          )}
+          {busy ? 'Generating…' : 'Generate with AI'}
+        </Button>
+        {busy && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={stop}
+            data-testid="property-description-ai-stop"
+            className="text-slate-600 dark:text-slate-400"
+          >
+            <Square className="mr-1 h-3.5 w-3.5" aria-hidden />
+            Stop
+          </Button>
+        )}
+      </div>
+      {modelNames.length === 0 && !busy && (
+        <p className="mt-1 text-xs text-amber-700 dark:text-amber-300">
+          No Ollama models available. Start Ollama or check OLLAMA_BASE_URL.
+        </p>
+      )}
+      {error && (
+        <p className="mt-1 text-xs text-red-600 dark:text-red-400" role="alert">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/objectified-ui/src/app/components/ade/studio/PropertyDescriptionAiButton.tsx
+++ b/objectified-ui/src/app/components/ade/studio/PropertyDescriptionAiButton.tsx
@@ -51,6 +51,7 @@ export function PropertyDescriptionAiButton({
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const abortRef = useRef<AbortController | null>(null);
+  const requestIdRef = useRef(0);
 
   useEffect(() => {
     let cancelled = false;
@@ -84,8 +85,10 @@ export function PropertyDescriptionAiButton({
   }, [tenantId, projectId]);
 
   const stop = useCallback(() => {
+    requestIdRef.current += 1;
     abortRef.current?.abort();
     abortRef.current = null;
+    setBusy(false);
   }, []);
 
   const generate = useCallback(async () => {
@@ -99,7 +102,10 @@ export function PropertyDescriptionAiButton({
       storage: typeof window !== 'undefined' ? window.localStorage : null,
     });
 
-    stop();
+    requestIdRef.current += 1;
+    const requestId = requestIdRef.current;
+
+    abortRef.current?.abort();
     const ac = new AbortController();
     abortRef.current = ac;
 
@@ -114,6 +120,7 @@ export function PropertyDescriptionAiButton({
         /* optional */
       }
     }
+    if (ac.signal.aborted || requestId !== requestIdRef.current) return;
 
     const existingPropsPayload = existingProperties.map(propertyItemToExistingApiShape);
 
@@ -148,18 +155,20 @@ export function PropertyDescriptionAiButton({
       }
 
       const full = await accumulateOllamaSse(response, ac.signal);
-      if (ac.signal.aborted) return;
+      if (ac.signal.aborted || requestId !== requestIdRef.current) return;
 
       const normalized = normalizeGeneratedPropertyDescription(full);
       if (!normalized) {
+        if (requestId !== requestIdRef.current) return;
         setError('The model returned an empty description. Try again or pick another model.');
         return;
       }
       onGenerated(normalized);
     } catch (e) {
-      if (ac.signal.aborted) return;
+      if (ac.signal.aborted || requestId !== requestIdRef.current) return;
       setError(e instanceof Error ? e.message : 'Something went wrong.');
     } finally {
+      if (requestId !== requestIdRef.current) return;
       setBusy(false);
       if (abortRef.current === ac) abortRef.current = null;
     }
@@ -175,10 +184,16 @@ export function PropertyDescriptionAiButton({
     existingProperties,
     studioContext,
     onGenerated,
-    stop,
   ]);
 
-  useEffect(() => () => stop(), [stop]);
+  useEffect(
+    () => () => {
+      requestIdRef.current += 1;
+      abortRef.current?.abort();
+      abortRef.current = null;
+    },
+    [],
+  );
 
   const canRun = Boolean(propertyName.trim() && selectedModel.trim() && !disabled);
 

--- a/objectified-ui/src/app/components/ade/studio/PropertyDescriptionAiButton.tsx
+++ b/objectified-ui/src/app/components/ade/studio/PropertyDescriptionAiButton.tsx
@@ -85,10 +85,8 @@ export function PropertyDescriptionAiButton({
   }, [tenantId, projectId]);
 
   const stop = useCallback(() => {
-    requestIdRef.current += 1;
     abortRef.current?.abort();
     abortRef.current = null;
-    setBusy(false);
   }, []);
 
   const generate = useCallback(async () => {
@@ -159,7 +157,6 @@ export function PropertyDescriptionAiButton({
 
       const normalized = normalizeGeneratedPropertyDescription(full);
       if (!normalized) {
-        if (requestId !== requestIdRef.current) return;
         setError('The model returned an empty description. Try again or pick another model.');
         return;
       }

--- a/objectified-ui/src/app/components/ade/studio/PropertyDialog.tsx
+++ b/objectified-ui/src/app/components/ade/studio/PropertyDialog.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useEffect, useMemo, useRef } from 'react';
+import React, { useState, useEffect, useMemo, useRef, useCallback } from 'react';
 import dynamic from 'next/dynamic';
 import {
   Dialog,
@@ -33,6 +33,8 @@ import {
 import type { ChatStudioContext } from '@/app/ade/studio/components/chatbot/chat-context';
 import { AiPropertyTypeSuggestionsDialog } from './AiPropertyTypeSuggestionsDialog';
 import type { AiPropertySuggestion } from '@lib/ai-property-suggestions';
+import { draftPropertySchemaFromDialogForm } from '@lib/ai-property-description';
+import { PropertyDescriptionAiButton } from './PropertyDescriptionAiButton';
 import type { PropertyItem as LibraryPropertyItem } from './StudioSideNav';
 import {
   FormSection,
@@ -154,6 +156,7 @@ interface BasicsSectionProps {
   setPrimitiveDialogOpen: (next: boolean) => void;
   addModeAiTypeSuggest?: { onOpen: () => void } | null;
   onOpenAiPropertySuggestions?: () => void;
+  descriptionAiSlot?: React.ReactNode;
   changed?: boolean;
   eyebrow?: string;
 }
@@ -172,6 +175,7 @@ const BasicsSection: React.FC<BasicsSectionProps> = ({
   setPrimitiveDialogOpen,
   addModeAiTypeSuggest,
   onOpenAiPropertySuggestions,
+  descriptionAiSlot,
   changed,
   eyebrow = 'Basics',
 }) => (
@@ -311,6 +315,7 @@ const BasicsSection: React.FC<BasicsSectionProps> = ({
         placeholder="Brief description of this property"
         rows={3}
       />
+      {descriptionAiSlot ? <div className="mt-2">{descriptionAiSlot}</div> : null}
     </FormFieldGroup>
 
     {primitiveAvailable && (
@@ -1678,6 +1683,38 @@ export const PropertyDialog: React.FC<PropertyDialogProps> = ({
       ? { onOpen: () => setAiTypeSuggestOpen(true) }
       : null;
 
+  const propertySchemaForAi = useMemo(
+    () =>
+      draftPropertySchemaFromDialogForm({
+        propertyType,
+        propertyIsArray,
+        formData,
+        seedProperty: property,
+      }),
+    [propertyType, propertyIsArray, formData, property],
+  );
+
+  const applyAiDescription = useCallback((text: string) => {
+    setFormData((prev) => ({ ...prev, description: text }));
+  }, []);
+
+  const descriptionAiSlot =
+    open && propertyAiContext ? (
+      <PropertyDescriptionAiButton
+        tenantId={propertyAiContext.tenantId}
+        projectId={propertyAiContext.projectId}
+        versionId={propertyAiContext.versionId}
+        propertyName={propertyName}
+        propertySchema={propertySchemaForAi}
+        contextClassName={propertyAiContext.contextClassName}
+        existingClasses={propertyAiContext.existingClasses}
+        existingProperties={propertyAiContext.existingProperties}
+        studioContext={propertyAiContext.studioContext}
+        onGenerated={applyAiDescription}
+        disabled={!propertyName.trim()}
+      />
+    ) : null;
+
   const handleApplyAiTypeSuggestion = (s: AiPropertySuggestion) => {
     if (!onApplyAiTypeSchema) return;
     onApplyAiTypeSchema({
@@ -1759,6 +1796,7 @@ export const PropertyDialog: React.FC<PropertyDialogProps> = ({
                         setPrimitiveDialogOpen={setPrimitiveDialogOpen}
                         addModeAiTypeSuggest={addModeAiTypeSuggest}
                         onOpenAiPropertySuggestions={onOpenAiPropertySuggestions}
+                        descriptionAiSlot={descriptionAiSlot}
                         changed={changedBasics}
                         eyebrow="Step 1 of 5"
                       />
@@ -1840,6 +1878,7 @@ export const PropertyDialog: React.FC<PropertyDialogProps> = ({
                       setPrimitiveDialogOpen={setPrimitiveDialogOpen}
                       addModeAiTypeSuggest={addModeAiTypeSuggest}
                       onOpenAiPropertySuggestions={onOpenAiPropertySuggestions}
+                      descriptionAiSlot={descriptionAiSlot}
                       changed={changedBasics}
                     />
                     <FlagsSection formData={formData} setFormData={setFormData} changed={changedFlags} />

--- a/objectified-ui/tests/unit/PropertyDescriptionAiButton.test.tsx
+++ b/objectified-ui/tests/unit/PropertyDescriptionAiButton.test.tsx
@@ -1,0 +1,89 @@
+jest.mock('@lib/ollama-chat-sse', () => ({
+  accumulateOllamaSse: jest.fn(),
+}));
+
+jest.mock('../../src/app/components/ui/Button', () => ({
+  Button: ({ disabled, ...props }: JSX.IntrinsicElements['button']) => (
+    <button {...props} data-disabled={String(Boolean(disabled))} />
+  ),
+}));
+
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { PropertyDescriptionAiButton } from '../../src/app/components/ade/studio/PropertyDescriptionAiButton';
+import { EMPTY_CHAT_STUDIO_CONTEXT } from '../../src/app/ade/studio/components/chatbot/chat-context';
+
+describe('PropertyDescriptionAiButton', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.restoreAllMocks();
+  });
+
+  it('keeps the latest request busy when an earlier generate is aborted', async () => {
+    let chatCallCount = 0;
+    let resolveSecondChat: ((value: Response) => void) | null = null;
+
+    global.fetch = jest.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes('/api/ollama/models')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ success: true, models: [{ name: 'mistral' }] }),
+        } as Response);
+      }
+      if (!url.includes('/api/ollama/chat')) {
+        return Promise.reject(new Error(`unexpected fetch: ${url}`));
+      }
+
+      chatCallCount += 1;
+      if (chatCallCount === 1) {
+        return new Promise<Response>((_resolve, reject) => {
+          const onAbort = () => reject(new DOMException('Aborted', 'AbortError'));
+          if (init?.signal?.aborted) {
+            queueMicrotask(onAbort);
+            return;
+          }
+          init?.signal?.addEventListener('abort', onAbort, { once: true });
+        });
+      }
+
+      return new Promise<Response>((resolve) => {
+        resolveSecondChat = resolve;
+      });
+    }) as typeof fetch;
+
+    render(
+      <PropertyDescriptionAiButton
+        tenantId="tenant-1"
+        projectId="project-1"
+        versionId={null}
+        propertyName="email"
+        propertySchema={{ type: 'string', format: 'email' }}
+        existingClasses={[]}
+        existingProperties={[]}
+        studioContext={EMPTY_CHAT_STUDIO_CONTEXT}
+        onGenerated={jest.fn()}
+      />,
+    );
+
+    const generateButton = await screen.findByTestId('property-description-ai-generate');
+    await waitFor(() => expect(generateButton).toHaveAttribute('data-disabled', 'false'));
+
+    fireEvent.click(generateButton);
+    fireEvent.click(generateButton);
+
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(3));
+    await waitFor(() => expect(screen.getByTestId('property-description-ai-stop')).toBeInTheDocument());
+    expect(generateButton).toHaveTextContent('Generating…');
+    expect(generateButton).toHaveAttribute('data-disabled', 'true');
+
+    resolveSecondChat?.({
+      ok: false,
+      text: async () => 'stopped for test',
+    } as Response);
+
+    await waitFor(() => expect(screen.queryByTestId('property-description-ai-stop')).not.toBeInTheDocument());
+  });
+});

--- a/objectified-ui/tests/unit/ai-property-description.test.ts
+++ b/objectified-ui/tests/unit/ai-property-description.test.ts
@@ -25,7 +25,7 @@ describe('ai-property-description (#619)', () => {
     });
     expect(s.type).toBe('string');
     expect(s.format).toBe('email');
-    expect(s.description).toBeDefined();
+    expect(s.description).toHaveLength(320);
   });
 
   it('draftPropertySchemaFromDialogForm reflects array and nullable', () => {
@@ -41,8 +41,8 @@ describe('ai-property-description (#619)', () => {
       formData,
       seedProperty: null,
     });
-    expect(doc.type).toBe('array');
-    expect(doc.items).toEqual({ type: ['string', 'null'], format: 'uuid' });
+    expect(doc.type).toEqual(['array', 'null']);
+    expect(doc.items).toEqual({ type: 'string', format: 'uuid' });
     expect(doc.minItems).toBe(1);
     expect(doc.maxItems).toBe(10);
   });

--- a/objectified-ui/tests/unit/ai-property-description.test.ts
+++ b/objectified-ui/tests/unit/ai-property-description.test.ts
@@ -1,0 +1,69 @@
+import {
+  normalizeGeneratedPropertyDescription,
+  summarizeStoredPropertyData,
+  draftPropertySchemaFromDialogForm,
+} from '../../lib/ai-property-description';
+import type { PropertyFormData } from '../../src/app/components/ade/studio/PropertyFormFields';
+
+describe('ai-property-description (#619)', () => {
+  it('normalizeGeneratedPropertyDescription strips fences and markdown noise', () => {
+    expect(normalizeGeneratedPropertyDescription('')).toBe('');
+    expect(normalizeGeneratedPropertyDescription('  hello world  ')).toBe('hello world');
+    expect(
+      normalizeGeneratedPropertyDescription('```\nThe customer email.\n```'),
+    ).toBe('The customer email.');
+    expect(normalizeGeneratedPropertyDescription('First para.\n\nSecond ignored.')).toBe('First para.');
+  });
+
+  it('summarizeStoredPropertyData keeps schema semantics', () => {
+    expect(summarizeStoredPropertyData(null)).toEqual({});
+    const s = summarizeStoredPropertyData({
+      type: 'string',
+      format: 'email',
+      description: 'x'.repeat(5000),
+      extra: { nested: true },
+    });
+    expect(s.type).toBe('string');
+    expect(s.format).toBe('email');
+    expect(s.description).toBeDefined();
+  });
+
+  it('draftPropertySchemaFromDialogForm reflects array and nullable', () => {
+    const formData: PropertyFormData = {
+      nullable: true,
+      format: 'uuid',
+      minItems: '1',
+      maxItems: '10',
+    };
+    const doc = draftPropertySchemaFromDialogForm({
+      propertyType: 'string',
+      propertyIsArray: true,
+      formData,
+      seedProperty: null,
+    });
+    expect(doc.type).toBe('array');
+    expect(doc.items).toEqual({ type: ['string', 'null'], format: 'uuid' });
+    expect(doc.minItems).toBe(1);
+    expect(doc.maxItems).toBe(10);
+  });
+
+  it('draftPropertySchemaFromDialogForm handles $ref', () => {
+    const formData: PropertyFormData = {};
+    expect(
+      draftPropertySchemaFromDialogForm({
+        propertyType: '$ref',
+        propertyIsArray: false,
+        formData,
+        seedProperty: { $ref: '#/components/schemas/Order' },
+      }).$ref,
+    ).toBe('#/components/schemas/Order');
+    const arr = draftPropertySchemaFromDialogForm({
+      propertyType: '$ref',
+      propertyIsArray: true,
+      formData,
+      seedProperty: { items: { $ref: '#/components/schemas/LineItem' } },
+    });
+    expect(arr.type).toBe('array');
+    expect((arr.items as { $ref?: string }).$ref).toBe('#/components/schemas/LineItem');
+  });
+});


### PR DESCRIPTION
## Summary
Adds Ollama-backed **Generate with AI** next to property description fields: the model receives the property name, a compact JSON Schema snapshot (types, formats, refs, array hints), optional containing class name, and the same class/property library context used by other Studio AI tasks (`task: property_description` on `/api/ollama/chat`).

## UI
- **Add/Edit Property** (sidebar library) when AI context is available
- **Edit class property** on the canvas (studio editor builds canvas-scoped context from nodes)

## How to test
1. **Run Ollama** with at least one chat model installed; ensure `OLLAMA_BASE_URL` points at it from the Next server.
2. **Open Studio** → **property library** → **Add Property** (or edit an existing property).
3. Enter a **property name** and choose a **type** (and optional format/constraints).
4. Under **Description**, click **Generate with AI** and confirm prose fills the textarea; edit if needed and **Save**.
5. On the **canvas**, **edit a class member property**, repeat **Generate with AI** — the containing class name should appear in context.

## Risks / notes
- Requires Ollama (same as other Studio AI features). Empty or malformed model output shows an inline error.
- Generated text is normalized (strips code fences / extra paragraphs); users should review before publishing.

Please request review from **GitHub Copilot** if available in this repo.

Closes #619

Made with [Cursor](https://cursor.com)