### PR TITLE
Fix #620 - AI-generated class descriptions

### DIFF
--- a/docs/PLANNED_FEATURE_ROADMAP_AI.md
+++ b/docs/PLANNED_FEATURE_ROADMAP_AI.md
@@ -76,14 +76,13 @@ This outlines the planned features for integrating AI capabilities into Objectif
 
 **Auto-Generate Descriptions** 📋 PLANNED
 - ✅ Generate property descriptions from names and types (#619 — Studio **Generate with AI** on property description fields; Ollama `property_description` task)
-- 📋 Generate class descriptions from properties
+- ✅ Generate class descriptions from properties (#620 — Studio **Generate with AI** on class description field; Ollama `class_description` task)
 - 📋 Generate operation summaries from path and method
 - 📋 Generate example values that make sense
 - Support multiple languages (i18n)
 
 | Ticket | Feature Description                                        |
 |--------|------------------------------------------------------------|
-| #620   | Auto-Generate descriptions for classes                     |
 | #621   | Operations summaries and descriptions from path and method |
 | #622   | Generate example values that make sense                    |
 

--- a/objectified-ui/lib/ai-property-description.ts
+++ b/objectified-ui/lib/ai-property-description.ts
@@ -94,6 +94,53 @@ type SeedPropertyLike = {
 /**
  * Builds a compact JSON Schema snapshot from the property dialog form for AI description (#619).
  */
+/** Canvas / API class member row shape for AI class descriptions (#620). */
+export type ClassMemberLike = {
+  name?: string;
+  description?: string | null;
+  data?: unknown;
+};
+
+/**
+ * Builds a compact JSON payload from class members and composition for `class_description` prompts (#620).
+ */
+export function buildClassDescriptionAiPayload(input: {
+  members: ClassMemberLike[];
+  composition?: { allOf?: string[]; anyOf?: string[]; oneOf?: string[] };
+}): Record<string, unknown> {
+  const properties: Record<string, unknown> = {};
+  for (const m of input.members) {
+    if (!m || typeof m !== 'object') continue;
+    const name = typeof m.name === 'string' ? m.name.trim() : '';
+    if (!name) continue;
+    let data: Record<string, unknown> = {};
+    if (typeof m.data === 'string') {
+      try {
+        data = JSON.parse(m.data) as Record<string, unknown>;
+      } catch {
+        data = {};
+      }
+    } else if (m.data !== null && typeof m.data === 'object' && !Array.isArray(m.data)) {
+      data = { ...(m.data as Record<string, unknown>) };
+    }
+    const schema = summarizeStoredPropertyData(data);
+    const md = m.description;
+    const memberDesc =
+      md != null && String(md).trim() ? String(md).trim().slice(0, 2000) : undefined;
+    properties[name] = memberDesc ? { memberDescription: memberDesc, schema } : { schema };
+  }
+  const out: Record<string, unknown> = { properties };
+  const c = input.composition;
+  if (c) {
+    const comp: Record<string, unknown> = {};
+    if (c.allOf?.length) comp.allOf = c.allOf;
+    if (c.anyOf?.length) comp.anyOf = c.anyOf;
+    if (c.oneOf?.length) comp.oneOf = c.oneOf;
+    if (Object.keys(comp).length > 0) out.composition = comp;
+  }
+  return out;
+}
+
 export function draftPropertySchemaFromDialogForm(input: {
   propertyType: string;
   propertyIsArray: boolean;

--- a/objectified-ui/lib/ai-property-description.ts
+++ b/objectified-ui/lib/ai-property-description.ts
@@ -91,9 +91,6 @@ type SeedPropertyLike = {
   type?: string | string[];
 } | null;
 
-/**
- * Builds a compact JSON Schema snapshot from the property dialog form for AI description (#619).
- */
 /** Canvas / API class member row shape for AI class descriptions (#620). */
 export type ClassMemberLike = {
   name?: string;
@@ -141,6 +138,9 @@ export function buildClassDescriptionAiPayload(input: {
   return out;
 }
 
+/**
+ * Builds a compact JSON Schema snapshot from the property dialog form for AI description (#619).
+ */
 export function draftPropertySchemaFromDialogForm(input: {
   propertyType: string;
   propertyIsArray: boolean;

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.85",
+  "version": "0.11.86",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -30,6 +30,7 @@ We continue to improve the platform based on your feedback with improvements and
 - Projects list includes a **Show deleted** switch; when on, soft-deleted projects appear with a **Deleted** badge and **Restore** or **permanent delete** in the row menu (#2981).
 
 ## Studio
+- **Class description** in **Edit class** supports **Generate with AI** (Ollama): drafts short documentation from the class name, linked member properties (names, types, optional member descriptions), and composition (allOf / anyOf / oneOf) (#620).
 - **Property description** fields support **Generate with AI** (Ollama): drafts short documentation from the property name and JSON Schema type — in **Add/Edit Property** (sidebar library) and **Edit class property** on the canvas (#619).
 - Studio AI **best-practice tips** now include **performance** hints (caching, queues, pagination, search projections, bulk I/O, media payloads, feeds/timelines) when matching names appear on classes or reusable properties (#618).
 - **Studio AI chat** surfaces **domain-aware best-practice tips** from the project’s **domain category** (set on the project in the dashboard) and from **auth / multi-tenant style class names**; tips appear in the chat empty state, the **Sharing context** popover, the prompt preamble sent to the model, and the offline demo’s **Improvement suggestions** (#615).

--- a/objectified-ui/src/app/ade/studio/editor/page.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/page.tsx
@@ -11198,6 +11198,7 @@ const StudioContent = () => {
         versionId={selectedVersionId || ''}
         projectTags={projectTags}
         projectMetadata={(projects.find(p => p.id === selectedProjectId) as any)?.metadata}
+        classDescriptionAiContext={canvasPropertyAiContext}
       />
 
       {/* Tag Manager Dialog */}

--- a/objectified-ui/src/app/ade/studio/layout.tsx
+++ b/objectified-ui/src/app/ade/studio/layout.tsx
@@ -12,7 +12,7 @@ import { GROUP_COLORS } from '@/app/components/ade/studio/GroupNode';
 import { resolveGroupFrameHex } from '@/app/utils/group-frame-colors';
 
 import StudioSideNav, { ClassItem, PropertyItem, StudioSideNavCallbacks } from '@/app/components/ade/studio/StudioSideNav';
-import PropertyDialog from '@/app/components/ade/studio/PropertyDialog';
+import PropertyDialog, { type PropertyDialogAiContext } from '@/app/components/ade/studio/PropertyDialog';
 import ClassEditDialog from '@/app/components/ade/studio/ClassEditDialog';
 import ClassImportDialog from '@/app/components/ade/studio/ClassImportDialog';
 import PropertyTemplateBrowserDialog from '@/app/components/ade/studio/PropertyTemplateBrowserDialog';
@@ -559,6 +559,27 @@ function StudioLayoutContent({ children }: Readonly<{ children: React.ReactNode 
     selectedCanvasNodeIds,
   ]);
 
+  const layoutClassDescriptionAiContext = React.useMemo((): PropertyDialogAiContext | undefined => {
+    if (!currentTenantId || !selectedProjectId) return undefined;
+    return {
+      tenantId: currentTenantId,
+      projectId: selectedProjectId,
+      versionId: selectedVersionId || undefined,
+      existingClasses: classes.map((c) => c.name).filter(Boolean),
+      existingProperties: properties,
+      studioContext: chatbotStudioContext,
+      contextClassName: selectedClassNameForPropertyAi,
+    };
+  }, [
+    currentTenantId,
+    selectedProjectId,
+    selectedVersionId,
+    classes,
+    properties,
+    chatbotStudioContext,
+    selectedClassNameForPropertyAi,
+  ]);
+
   // Convert classes to nodes format expected by ClassEditDialog
   const classNodes = React.useMemo(() => {
     return classes.map(cls => ({
@@ -644,6 +665,7 @@ function StudioLayoutContent({ children }: Readonly<{ children: React.ReactNode 
         projectId={selectedProjectId || ''}
         versionId={selectedVersionId || ''}
         projectTags={projectTags}
+        classDescriptionAiContext={layoutClassDescriptionAiContext}
       />
 
       {/* Class Import Dialog */}

--- a/objectified-ui/src/app/api/ollama/chat/route.ts
+++ b/objectified-ui/src/app/api/ollama/chat/route.ts
@@ -269,6 +269,48 @@ function buildPropertyDescriptionSystem(options: {
   return s;
 }
 
+const CLASS_DESCRIPTION_SYSTEM = `You write concise API documentation for JSON Schema object classes used in OpenAPI 3.1 component schemas.
+
+# Task
+Return **plain prose only**: one to three sentences describing what the class represents as a whole for API consumers.
+
+# Rules
+- No markdown, no bullet lists, no JSON, no code fences — output readable sentences only.
+- Ground the summary in the provided **Summarized class shape**: member property names, optional member descriptions, summarized per-property schemas, and optional composition (allOf / anyOf / oneOf class names).
+- Synthesize the entity the class models; do not paste a bullet list of fields.
+- Avoid redundant openers like "This class is" unless it reads most natural that way.
+- Prefer staying under 600 characters; use more only when composition or many references need explicit explanation.
+- Use **Existing classes** / **Existing project properties** only to disambiguate references — do not invent domain facts unsupported by the supplied shape.`;
+
+function buildClassDescriptionSystem(options: {
+  existingClassNames?: string[];
+  existingProperties?: Array<{ name: string; description?: string | null; data?: Record<string, unknown> }>;
+  targetClassName?: string;
+}): string {
+  let s = CLASS_DESCRIPTION_SYSTEM;
+  const tc = typeof options.targetClassName === 'string' ? options.targetClassName.trim() : '';
+  if (tc) {
+    s += `\n\n# Target class name\n${tc}\n`;
+  }
+  if (options.existingClassNames?.length) {
+    s += `\n\n# Existing classes\n${options.existingClassNames.join(', ')}`;
+  }
+  if (options.existingProperties?.length) {
+    s += `\n\n# Existing project properties\n`;
+    options.existingProperties.forEach((p) => {
+      const d = p.data;
+      const typeStr =
+        typeof d?.type === 'string'
+          ? d.type
+          : d && typeof d === 'object' && '$ref' in d && d.$ref
+            ? '$ref'
+            : 'object';
+      s += `- ${p.name}: ${typeStr}${p.description ? ` — ${String(p.description).slice(0, 80)}` : ''}\n`;
+    });
+  }
+  return s;
+}
+
 function buildPropertyTypeSuggestionsSystem(options: {
   existingClassNames?: string[];
   existingProperties?: Array<{ name: string; description?: string | null; data?: Record<string, unknown> }>;
@@ -403,9 +445,14 @@ export async function POST(request: NextRequest) {
     const isPropertySuggestions = task === 'property_suggestions';
     const isPropertyTypeSuggestions = task === 'property_type_suggestions';
     const isPropertyDescription = task === 'property_description';
+    const isClassDescription = task === 'class_description';
     const isSchemaImprovementSuggestions = task === 'schema_improvement_suggestions';
     const usesPropertyLibraryContext =
-      isClassSkeleton || isPropertySuggestions || isPropertyTypeSuggestions || isPropertyDescription;
+      isClassSkeleton ||
+      isPropertySuggestions ||
+      isPropertyTypeSuggestions ||
+      isPropertyDescription ||
+      isClassDescription;
 
     const digestStr =
       typeof studioMetricsDigest === 'string' && studioMetricsDigest.trim().length > 0
@@ -449,6 +496,12 @@ export async function POST(request: NextRequest) {
                   targetPropertyName: typeof targetPropertyName === 'string' ? targetPropertyName : undefined,
                   targetClassName: typeof targetClassName === 'string' ? targetClassName : undefined,
                 })
+              : isClassDescription
+                ? buildClassDescriptionSystem({
+                    existingClassNames: Array.isArray(existingClassNames) ? existingClassNames : undefined,
+                    existingProperties: Array.isArray(existingProperties) ? existingProperties : undefined,
+                    targetClassName: typeof targetClassName === 'string' ? targetClassName : undefined,
+                  })
             : isSchemaImprovementSuggestions
               ? buildSchemaImprovementSuggestionsSystem({
                   studioMetricsDigest: digestStr,

--- a/objectified-ui/src/app/components/ade/studio/ClassDescriptionAiButton.tsx
+++ b/objectified-ui/src/app/components/ade/studio/ClassDescriptionAiButton.tsx
@@ -1,0 +1,238 @@
+'use client';
+
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { Button } from '../../ui/Button';
+import { Loader2, Sparkles, Square } from 'lucide-react';
+import type { PropertyItem } from './StudioSideNav';
+import type { ChatStudioContext } from '@/app/ade/studio/components/chatbot/chat-context';
+import { isChatStudioContextEmpty } from '@/app/ade/studio/components/chatbot/chat-context';
+import {
+  persistOllamaModelChoiceForScope,
+  resolvePreferredOllamaModel,
+} from '@/app/ade/studio/components/chatbot/ollama-model-defaults';
+import { accumulateOllamaSse } from '@lib/ollama-chat-sse';
+import { computeStudioSchemaFingerprint } from '@lib/studio-schema-fingerprint';
+import { propertyItemToExistingApiShape } from '@lib/property-item-utils';
+import { normalizeGeneratedPropertyDescription } from '@lib/ai-property-description';
+
+export interface ClassDescriptionAiButtonProps {
+  tenantId: string | null | undefined;
+  projectId: string;
+  versionId: string | null | undefined;
+  /** PascalCase class being edited in Studio. */
+  studioClassName: string;
+  /** Summarized members + composition from `buildClassDescriptionAiPayload`. */
+  classShape: Record<string, unknown>;
+  existingClasses: string[];
+  existingProperties: PropertyItem[];
+  studioContext: ChatStudioContext;
+  onGenerated: (description: string) => void;
+  disabled?: boolean;
+  /** Optional layout class for the wrapper */
+  wrapperClassName?: string;
+}
+
+export function ClassDescriptionAiButton({
+  tenantId,
+  projectId,
+  versionId,
+  studioClassName,
+  classShape,
+  existingClasses,
+  existingProperties,
+  studioContext,
+  onGenerated,
+  disabled,
+  wrapperClassName,
+}: ClassDescriptionAiButtonProps) {
+  const [modelNames, setModelNames] = useState<string[]>([]);
+  const [selectedModel, setSelectedModel] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+  const requestIdRef = useRef(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch('/api/ollama/models');
+        const json = (await res.json()) as { success?: boolean; models?: { name?: string }[] };
+        const list = res.ok && json.success && Array.isArray(json.models) ? json.models : undefined;
+        const names = Array.isArray(list)
+          ? list.map((m) => m?.name).filter((n): n is string => typeof n === 'string' && n.trim().length > 0)
+          : [];
+        if (cancelled) return;
+        setModelNames(names);
+        const preferred = resolvePreferredOllamaModel({
+          tenantId,
+          projectId,
+          availableModelNames: names,
+          storage: typeof window !== 'undefined' ? window.localStorage : null,
+        });
+        setSelectedModel(preferred);
+      } catch {
+        if (!cancelled) {
+          setModelNames([]);
+          setSelectedModel('');
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [tenantId, projectId]);
+
+  const stop = useCallback(() => {
+    abortRef.current?.abort();
+    abortRef.current = null;
+  }, []);
+
+  const generate = useCallback(async () => {
+    const cn = studioClassName.trim();
+    if (!cn || !selectedModel.trim()) return;
+
+    persistOllamaModelChoiceForScope({
+      tenantId,
+      projectId,
+      modelName: selectedModel,
+      storage: typeof window !== 'undefined' ? window.localStorage : null,
+    });
+
+    requestIdRef.current += 1;
+    const requestId = requestIdRef.current;
+
+    abortRef.current?.abort();
+    const ac = new AbortController();
+    abortRef.current = ac;
+
+    setBusy(true);
+    setError(null);
+
+    let schemaContextFingerprint: string | undefined;
+    if (studioContext && !isChatStudioContextEmpty(studioContext)) {
+      try {
+        schemaContextFingerprint = await computeStudioSchemaFingerprint(studioContext);
+      } catch {
+        /* optional */
+      }
+    }
+    if (ac.signal.aborted || requestId !== requestIdRef.current) return;
+
+    const existingPropsPayload = existingProperties.map(propertyItemToExistingApiShape);
+
+    const userLines = [
+      `Write a documentation description for this JSON Schema class (OpenAPI components/schemas style).`,
+      `Class name: ${cn}`,
+      `Summarized class shape (members, optional composition): ${JSON.stringify(classShape)}`,
+    ];
+
+    try {
+      const response = await fetch('/api/ollama/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        signal: ac.signal,
+        body: JSON.stringify({
+          model: selectedModel.trim(),
+          task: 'class_description',
+          messages: [{ role: 'user', content: userLines.join('\n') }],
+          existingClassNames: existingClasses,
+          existingProperties: existingPropsPayload,
+          targetClassName: cn,
+          ...(typeof versionId === 'string' && versionId ? { versionId } : {}),
+          ...(schemaContextFingerprint ? { schemaContextFingerprint } : {}),
+        }),
+      });
+
+      if (!response.ok) {
+        const t = await response.text().catch(() => '');
+        throw new Error(t || `Request failed (${response.status})`);
+      }
+
+      const full = await accumulateOllamaSse(response, ac.signal);
+      if (ac.signal.aborted || requestId !== requestIdRef.current) return;
+
+      const normalized = normalizeGeneratedPropertyDescription(full);
+      if (!normalized) {
+        setError('The model returned an empty description. Try again or pick another model.');
+        return;
+      }
+      onGenerated(normalized);
+    } catch (e) {
+      if (ac.signal.aborted || requestId !== requestIdRef.current) return;
+      setError(e instanceof Error ? e.message : 'Something went wrong.');
+    } finally {
+      if (requestId !== requestIdRef.current) return;
+      setBusy(false);
+      if (abortRef.current === ac) abortRef.current = null;
+    }
+  }, [
+    studioClassName,
+    selectedModel,
+    tenantId,
+    projectId,
+    versionId,
+    classShape,
+    existingClasses,
+    existingProperties,
+    studioContext,
+    onGenerated,
+  ]);
+
+  useEffect(
+    () => () => {
+      requestIdRef.current += 1;
+      abortRef.current?.abort();
+      abortRef.current = null;
+    },
+    [],
+  );
+
+  const canRun = Boolean(studioClassName.trim() && selectedModel.trim() && !disabled);
+
+  return (
+    <div className={wrapperClassName}>
+      <div className="flex flex-wrap items-center gap-2">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={!canRun || busy || modelNames.length === 0}
+          onClick={() => void generate()}
+          data-testid="class-description-ai-generate"
+          className="shrink-0 border-violet-300 text-violet-800 hover:bg-violet-50 dark:border-violet-700 dark:text-violet-200 dark:hover:bg-violet-950/40"
+        >
+          {busy ? (
+            <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" aria-hidden />
+          ) : (
+            <Sparkles className="mr-1.5 h-3.5 w-3.5" aria-hidden />
+          )}
+          {busy ? 'Generating…' : 'Generate with AI'}
+        </Button>
+        {busy && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={stop}
+            data-testid="class-description-ai-stop"
+            className="text-slate-600 dark:text-slate-400"
+          >
+            <Square className="mr-1 h-3.5 w-3.5" aria-hidden />
+            Stop
+          </Button>
+        )}
+      </div>
+      {modelNames.length === 0 && !busy && (
+        <p className="mt-1 text-xs text-amber-700 dark:text-amber-300">
+          No Ollama models available. Start Ollama or check OLLAMA_BASE_URL.
+        </p>
+      )}
+      {error && (
+        <p className="mt-1 text-xs text-red-600 dark:text-red-400" role="alert">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/objectified-ui/src/app/components/ade/studio/ClassEditDialog.tsx
+++ b/objectified-ui/src/app/components/ade/studio/ClassEditDialog.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useRef, useMemo } from 'react';
+import { useState, useEffect, useRef, useMemo, useCallback } from 'react';
 import dynamic from 'next/dynamic';
 import {
   Dialog,
@@ -49,6 +49,9 @@ import {
 } from './form';
 import { AiClassCreatePreviewDialog } from '@/app/ade/studio/components/chatbot/AiClassCreatePreviewDialog';
 import { parseClassDefinitionFromAssistantMarkdown } from '@/app/ade/studio/components/chatbot/assistant-action-detection';
+import type { PropertyDialogAiContext } from './PropertyDialog';
+import { ClassDescriptionAiButton } from './ClassDescriptionAiButton';
+import { buildClassDescriptionAiPayload } from '@lib/ai-property-description';
 
 // Custom hook for dark mode detection - prioritizes localStorage, then system preference
 const useDarkMode = () => {
@@ -240,6 +243,8 @@ interface ClassEditDialogProps {
   onAiAssistantSeedConsumed?: () => void;
   /** Fires once per Add Class session when the class name reaches 2+ characters (#275). */
   onClassNameEnteredForPropertySuggestions?: () => void;
+  /** When set, class **Description** supports **Generate with AI** (#620). */
+  classDescriptionAiContext?: PropertyDialogAiContext;
 }
 
 const ClassEditDialog = ({
@@ -256,6 +261,7 @@ const ClassEditDialog = ({
   aiAssistantSeedMarkdown = null,
   onAiAssistantSeedConsumed,
   onClassNameEnteredForPropertySuggestions,
+  classDescriptionAiContext,
 }: ClassEditDialogProps) => {
   const isDark = useDarkMode();
 
@@ -386,6 +392,38 @@ const ClassEditDialog = ({
       extensions: Object.keys(d.extensions).length > 0,
     };
   }, [formData]);
+
+  const classDescriptionAiPayload = useMemo(() => {
+    const members = Array.isArray(editingClassData?.properties) ? editingClassData.properties : [];
+    return buildClassDescriptionAiPayload({
+      members,
+      composition: {
+        allOf: formData.allOf,
+        anyOf: formData.anyOf,
+        oneOf: formData.oneOf,
+      },
+    });
+  }, [editingClassData?.properties, formData.allOf, formData.anyOf, formData.oneOf]);
+
+  const handleClassDescriptionAiGenerated = useCallback((text: string) => {
+    setFormData((prev) => ({ ...prev, description: text }));
+  }, []);
+
+  const classDescriptionAiSlot =
+    open && classDescriptionAiContext && projectId.trim() ? (
+      <ClassDescriptionAiButton
+        tenantId={classDescriptionAiContext.tenantId}
+        projectId={classDescriptionAiContext.projectId}
+        versionId={classDescriptionAiContext.versionId}
+        studioClassName={formData.name}
+        classShape={classDescriptionAiPayload}
+        existingClasses={classDescriptionAiContext.existingClasses}
+        existingProperties={classDescriptionAiContext.existingProperties}
+        studioContext={classDescriptionAiContext.studioContext}
+        onGenerated={handleClassDescriptionAiGenerated}
+        disabled={isReadOnly || !formData.name.trim()}
+      />
+    ) : null;
 
   // Reset view and form when dialog opens
   useEffect(() => {
@@ -1897,6 +1935,7 @@ const ClassEditDialog = ({
                       disabled={isReadOnly}
                       rows={2}
                     />
+                    {classDescriptionAiSlot ? <div className="mt-2">{classDescriptionAiSlot}</div> : null}
                   </FormFieldGroup>
                 </FormGrid>
 

--- a/objectified-ui/src/app/components/ade/studio/ClassEditDialog.tsx
+++ b/objectified-ui/src/app/components/ade/studio/ClassEditDialog.tsx
@@ -410,7 +410,7 @@ const ClassEditDialog = ({
   }, []);
 
   const classDescriptionAiSlot =
-    open && classDescriptionAiContext && projectId.trim() ? (
+    open && classDescriptionAiContext && classDescriptionAiContext.projectId.trim() ? (
       <ClassDescriptionAiButton
         tenantId={classDescriptionAiContext.tenantId}
         projectId={classDescriptionAiContext.projectId}

--- a/objectified-ui/tests/unit/ai-property-description.test.ts
+++ b/objectified-ui/tests/unit/ai-property-description.test.ts
@@ -2,6 +2,7 @@ import {
   normalizeGeneratedPropertyDescription,
   summarizeStoredPropertyData,
   draftPropertySchemaFromDialogForm,
+  buildClassDescriptionAiPayload,
 } from '../../lib/ai-property-description';
 import type { PropertyFormData } from '../../src/app/components/ade/studio/PropertyFormFields';
 
@@ -65,5 +66,22 @@ describe('ai-property-description (#619)', () => {
     });
     expect(arr.type).toBe('array');
     expect((arr.items as { $ref?: string }).$ref).toBe('#/components/schemas/LineItem');
+  });
+
+  it('buildClassDescriptionAiPayload summarizes members and composition (#620)', () => {
+    const payload = buildClassDescriptionAiPayload({
+      members: [
+        {
+          name: 'email',
+          description: 'Primary contact',
+          data: JSON.stringify({ type: 'string', format: 'email' }),
+        },
+      ],
+      composition: { allOf: ['Auditable'] },
+    });
+    expect(payload.composition).toEqual({ allOf: ['Auditable'] });
+    const email = payload.properties as Record<string, { memberDescription?: string; schema: Record<string, unknown> }>;
+    expect(email.email.memberDescription).toBe('Primary contact');
+    expect(email.email.schema.format).toBe('email');
   });
 });


### PR DESCRIPTION
## Summary
Adds **Generate with AI** on the class **Description** field in **Edit class**, using a new Ollama task `class_description`. The prompt includes the class name, summarized linked member properties (names, optional member descriptions, compact JSON Schema snippets via existing `summarizeStoredPropertyData`), and composition (allOf / anyOf / oneOf). Mirrors the property-description flow (model picker, SSE, stop, cache keys via existing property-library context).

## How to test
1. **Start Ollama** with at least one model pulled.
2. **Open Studio** → canvas → **double-click a class** (or open **Edit class** from the sidebar).
3. In **Basic Information**, enter or confirm the **Class name**.
4. Under **Description**, click **Generate with AI**, pick a model if needed, wait for text.
5. Confirm **Stop** cancels; save the class if desired.

## Risks / notes
- Sidebar-opened class rows may not include **properties** on `editingClassData` until loaded elsewhere; AI still uses **composition** from the form and **existing project properties** context from the canvas/layout.
- Root `yarn lint` reports many pre-existing issues; **Next.js build** (`yarn workspace objectified-ui build`) and **root `yarn test`** were run successfully.

Closes #620

Made with [Cursor](https://cursor.com)