### PR TITLE
Fix #621 - AI operation summary and description from path and method

### DIFF
--- a/docs/PLANNED_FEATURE_ROADMAP_AI.md
+++ b/docs/PLANNED_FEATURE_ROADMAP_AI.md
@@ -77,13 +77,12 @@ This outlines the planned features for integrating AI capabilities into Objectif
 **Auto-Generate Descriptions** 📋 PLANNED
 - ✅ Generate property descriptions from names and types (#619 — Studio **Generate with AI** on property description fields; Ollama `property_description` task)
 - ✅ Generate class descriptions from properties (#620 — Studio **Generate with AI** on class description field; Ollama `class_description` task)
-- 📋 Generate operation summaries from path and method
+- ✅ Generate operation summaries from path and method (#621 — Paths operation **Docs** tab **Generate summary & description**; Ollama `operation_description` task)
 - 📋 Generate example values that make sense
 - Support multiple languages (i18n)
 
 | Ticket | Feature Description                                        |
 |--------|------------------------------------------------------------|
-| #621   | Operations summaries and descriptions from path and method |
 | #622   | Generate example values that make sense                    |
 
 ### AI Layout Suggestions

--- a/objectified-ui/lib/ai-property-description.ts
+++ b/objectified-ui/lib/ai-property-description.ts
@@ -3,6 +3,35 @@ import type { PropertyFormData } from '@/app/components/ade/studio/PropertyFormF
 /**
  * Normalizes LLM output into a single plain-text property description (#619).
  */
+const OPERATION_DOCS_JSON_FENCE = /^```(?:json)?\s*\n?([\s\S]*?)\n?```$/;
+
+/**
+ * Parses LLM output for OpenAPI operation summary + description (#621).
+ * Expects a single JSON object (optionally inside a markdown fence) with string fields `summary` and `description`.
+ */
+export function parseGeneratedOperationDocs(raw: string): { summary: string; description: string } | null {
+  let t = raw.trim();
+  if (!t) return null;
+  const fenced = t.match(OPERATION_DOCS_JSON_FENCE);
+  if (fenced) t = fenced[1].trim();
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(t);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+  const o = parsed as Record<string, unknown>;
+  const summaryRaw = typeof o.summary === 'string' ? o.summary.trim().replace(/\s+/g, ' ') : '';
+  const descriptionRaw = typeof o.description === 'string' ? o.description.trim() : '';
+  if (!summaryRaw && !descriptionRaw) return null;
+  return {
+    summary: summaryRaw.slice(0, 400),
+    description: descriptionRaw.slice(0, 16_000),
+  };
+}
+
 export function normalizeGeneratedPropertyDescription(raw: string): string {
   let t = raw.trim();
   if (!t) return '';

--- a/objectified-ui/lib/ai-property-description.ts
+++ b/objectified-ui/lib/ai-property-description.ts
@@ -1,19 +1,29 @@
 import type { PropertyFormData } from '@/app/components/ade/studio/PropertyFormFields';
 
 /**
- * Normalizes LLM output into a single plain-text property description (#619).
+ * Extracts the last ```json ... ``` (or ``` ... ```) code block from LLM output (#621).
+ * Case-insensitive and tolerates preamble/trailing text, matching the pattern used in other AI parsers.
  */
-const OPERATION_DOCS_JSON_FENCE = /^```(?:json)?\s*\n?([\s\S]*?)\n?```$/;
+function extractLastJsonCodeBlock(text: string): string | null {
+  const re = /```(?:json)?\s*([\s\S]*?)```/gi;
+  let last: string | null = null;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(text)) !== null) {
+    last = m[1].trim();
+  }
+  return last;
+}
 
 /**
  * Parses LLM output for OpenAPI operation summary + description (#621).
- * Expects a single JSON object (optionally inside a markdown fence) with string fields `summary` and `description`.
+ * Expects a JSON object (optionally inside a markdown fence) with non-empty string fields
+ * `summary` and `description`. Returns null unless both fields are present and non-empty.
  */
 export function parseGeneratedOperationDocs(raw: string): { summary: string; description: string } | null {
   let t = raw.trim();
   if (!t) return null;
-  const fenced = t.match(OPERATION_DOCS_JSON_FENCE);
-  if (fenced) t = fenced[1].trim();
+  const fenced = extractLastJsonCodeBlock(t);
+  if (fenced) t = fenced;
 
   let parsed: unknown;
   try {
@@ -25,7 +35,7 @@ export function parseGeneratedOperationDocs(raw: string): { summary: string; des
   const o = parsed as Record<string, unknown>;
   const summaryRaw = typeof o.summary === 'string' ? o.summary.trim().replace(/\s+/g, ' ') : '';
   const descriptionRaw = typeof o.description === 'string' ? o.description.trim() : '';
-  if (!summaryRaw && !descriptionRaw) return null;
+  if (!summaryRaw || !descriptionRaw) return null;
   return {
     summary: summaryRaw.slice(0, 400),
     description: descriptionRaw.slice(0, 16_000),

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.86",
+  "version": "0.11.87",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -30,6 +30,7 @@ We continue to improve the platform based on your feedback with improvements and
 - Projects list includes a **Show deleted** switch; when on, soft-deleted projects appear with a **Deleted** badge and **Restore** or **permanent delete** in the row menu (#2981).
 
 ## Studio
+- **Paths** operation **Docs** tab supports **Generate summary & description** (Ollama): drafts OpenAPI **summary** and Markdown **description** from the HTTP method, path template, path parameters, and optional operationId (#621).
 - **Class description** in **Edit class** supports **Generate with AI** (Ollama): drafts short documentation from the class name, linked member properties (names, types, optional member descriptions), and composition (allOf / anyOf / oneOf) (#620).
 - **Property description** fields support **Generate with AI** (Ollama): drafts short documentation from the property name and JSON Schema type — in **Add/Edit Property** (sidebar library) and **Edit class property** on the canvas (#619).
 - Studio AI **best-practice tips** now include **performance** hints (caching, queues, pagination, search projections, bulk I/O, media payloads, feeds/timelines) when matching names appear on classes or reusable properties (#618).

--- a/objectified-ui/src/app/ade/studio/paths/components/OperationDocsAiButton.tsx
+++ b/objectified-ui/src/app/ade/studio/paths/components/OperationDocsAiButton.tsx
@@ -1,0 +1,228 @@
+'use client';
+
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { Button } from '../../../../components/ui/Button';
+import { Loader2, Sparkles, Square } from 'lucide-react';
+import {
+  persistOllamaModelChoiceForScope,
+  resolvePreferredOllamaModel,
+} from '@/app/ade/studio/components/chatbot/ollama-model-defaults';
+import { accumulateOllamaSse } from '@lib/ollama-chat-sse';
+import { parseGeneratedOperationDocs } from '@lib/ai-property-description';
+
+export interface OperationDocsAiButtonProps {
+  tenantId: string | null | undefined;
+  projectId: string | null | undefined;
+  versionId: string | null | undefined;
+  pathname: string;
+  httpMethod: string;
+  /** Optional operationId already chosen — helps the model stay aligned with codegen names. */
+  operationIdHint?: string;
+  /** Path template parameters extracted from the path (e.g. userId). */
+  pathParameterNames?: string[];
+  onGenerated: (docs: { summary: string; description: string }) => void;
+  disabled?: boolean;
+  wrapperClassName?: string;
+}
+
+export function OperationDocsAiButton({
+  tenantId,
+  projectId,
+  versionId,
+  pathname,
+  httpMethod,
+  operationIdHint,
+  pathParameterNames,
+  onGenerated,
+  disabled,
+  wrapperClassName,
+}: OperationDocsAiButtonProps) {
+  const [modelNames, setModelNames] = useState<string[]>([]);
+  const [selectedModel, setSelectedModel] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+  const requestIdRef = useRef(0);
+
+  const pid = typeof projectId === 'string' ? projectId.trim() : '';
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch('/api/ollama/models');
+        const json = (await res.json()) as { success?: boolean; models?: { name?: string }[] };
+        const list = res.ok && json.success && Array.isArray(json.models) ? json.models : undefined;
+        const names = Array.isArray(list)
+          ? list.map((m) => m?.name).filter((n): n is string => typeof n === 'string' && n.trim().length > 0)
+          : [];
+        if (cancelled) return;
+        setModelNames(names);
+        const preferred = resolvePreferredOllamaModel({
+          tenantId,
+          projectId: pid || undefined,
+          availableModelNames: names,
+          storage: typeof window !== 'undefined' ? window.localStorage : null,
+        });
+        setSelectedModel(preferred);
+      } catch {
+        if (!cancelled) {
+          setModelNames([]);
+          setSelectedModel('');
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [tenantId, pid]);
+
+  const stop = useCallback(() => {
+    abortRef.current?.abort();
+    abortRef.current = null;
+  }, []);
+
+  const generate = useCallback(async () => {
+    const path = pathname.trim();
+    const method = httpMethod.trim().toUpperCase();
+    if (!path || !method || !selectedModel.trim() || !pid) return;
+
+    persistOllamaModelChoiceForScope({
+      tenantId,
+      projectId: pid,
+      modelName: selectedModel,
+      storage: typeof window !== 'undefined' ? window.localStorage : null,
+    });
+
+    requestIdRef.current += 1;
+    const requestId = requestIdRef.current;
+
+    abortRef.current?.abort();
+    const ac = new AbortController();
+    abortRef.current = ac;
+
+    setBusy(true);
+    setError(null);
+
+    const paramLine =
+      pathParameterNames && pathParameterNames.length > 0
+        ? `Path parameters: ${pathParameterNames.join(', ')}`
+        : '';
+    const opIdLine =
+      typeof operationIdHint === 'string' && operationIdHint.trim()
+        ? `operationId (hint): ${operationIdHint.trim()}`
+        : '';
+
+    const userLines = [
+      `Draft OpenAPI summary and description for this operation.`,
+      `HTTP method: ${method}`,
+      `Path template: ${path}`,
+      paramLine,
+      opIdLine,
+    ].filter((line) => line.length > 0);
+
+    try {
+      const response = await fetch('/api/ollama/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        signal: ac.signal,
+        body: JSON.stringify({
+          model: selectedModel.trim(),
+          task: 'operation_description',
+          messages: [{ role: 'user', content: userLines.join('\n') }],
+          ...(typeof versionId === 'string' && versionId ? { versionId } : {}),
+        }),
+      });
+
+      if (!response.ok) {
+        const t = await response.text().catch(() => '');
+        throw new Error(t || `Request failed (${response.status})`);
+      }
+
+      const full = await accumulateOllamaSse(response, ac.signal);
+      if (ac.signal.aborted || requestId !== requestIdRef.current) return;
+
+      const parsed = parseGeneratedOperationDocs(full);
+      if (!parsed) {
+        setError('Could not parse the model response. Try again or pick another model.');
+        return;
+      }
+      onGenerated(parsed);
+    } catch (e) {
+      if (ac.signal.aborted || requestId !== requestIdRef.current) return;
+      setError(e instanceof Error ? e.message : 'Something went wrong.');
+    } finally {
+      if (requestId !== requestIdRef.current) return;
+      setBusy(false);
+      if (abortRef.current === ac) abortRef.current = null;
+    }
+  }, [
+    pathname,
+    httpMethod,
+    operationIdHint,
+    pathParameterNames,
+    selectedModel,
+    tenantId,
+    pid,
+    versionId,
+    onGenerated,
+  ]);
+
+  useEffect(
+    () => () => {
+      requestIdRef.current += 1;
+      abortRef.current?.abort();
+      abortRef.current = null;
+    },
+    [],
+  );
+
+  const pathOk = Boolean(pathname.trim() && httpMethod.trim());
+  const canRun = Boolean(pathOk && pid && selectedModel.trim() && !disabled);
+
+  return (
+    <div className={wrapperClassName}>
+      <div className="flex flex-wrap items-center gap-2">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={!canRun || busy || modelNames.length === 0}
+          onClick={() => void generate()}
+          data-testid="operation-docs-ai-generate"
+          className="shrink-0 border-violet-300 text-violet-800 hover:bg-violet-50 dark:border-violet-700 dark:text-violet-200 dark:hover:bg-violet-950/40"
+        >
+          {busy ? (
+            <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" aria-hidden />
+          ) : (
+            <Sparkles className="mr-1.5 h-3.5 w-3.5" aria-hidden />
+          )}
+          {busy ? 'Generating…' : 'Generate summary & description'}
+        </Button>
+        {busy && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={stop}
+            data-testid="operation-docs-ai-stop"
+            className="text-slate-600 dark:text-slate-400"
+          >
+            <Square className="mr-1 h-3.5 w-3.5" aria-hidden />
+            Stop
+          </Button>
+        )}
+      </div>
+      {modelNames.length === 0 && !busy && (
+        <p className="mt-1 text-xs text-amber-700 dark:text-amber-300">
+          No Ollama models available. Start Ollama or check OLLAMA_BASE_URL.
+        </p>
+      )}
+      {error && (
+        <p className="mt-1 text-xs text-red-600 dark:text-red-400" role="alert">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/objectified-ui/src/app/ade/studio/paths/components/OperationPropertiesPanel.tsx
+++ b/objectified-ui/src/app/ade/studio/paths/components/OperationPropertiesPanel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useState, useEffect, useMemo, useCallback } from 'react';
 import { Save, Plus, Trash2, ArrowLeft, Lock, Unlock, ExternalLink, ListChecks, Zap, X } from 'lucide-react';
 import { Button } from '../../../../components/ui/Button';
 import PropertiesPanelShell from './PropertiesPanelShell';
@@ -43,6 +43,7 @@ import { extractPathParameters } from '../../../../../../lib/utils/path-params';
 import { validateOpenApiParameterName } from '../../../../../../lib/utils/openapi-parameter-name';
 import ResponseSection from './ResponseSection';
 import RequestBodySection from './RequestBodySection';
+import { OperationDocsAiButton } from './OperationDocsAiButton';
 import ReuseSearchCombobox from './ReuseSearchCombobox';
 import { getHttpStatusDescription } from '../../../../../../lib/utils/http-status-codes';
 import type { SecurityRequirement } from '../../../../../../lib/utils/openapi-paths-generator';
@@ -79,7 +80,7 @@ export default function OperationPropertiesPanel({
   onRefresh,
   refreshKey,
 }: OperationPropertiesPanelProps) {
-  const { selectedVersionId } = useStudio();
+  const { selectedVersionId, selectedProjectId } = useStudio();
   const isDark = useDarkMode();
   const { alert: alertDialog, confirm: confirmDialog } = useDialog();
 
@@ -148,6 +149,11 @@ export default function OperationPropertiesPanel({
 
   // Custom x-* extensions (OpenAPI extension properties)
   const [extensions, setExtensions] = useState<Record<string, unknown>>({});
+
+  const handleOperationDocsAiGenerated = useCallback((docs: { summary: string; description: string }) => {
+    setSummary(docs.summary);
+    setDescription(docs.description);
+  }, []);
 
   /** Reuse library (#2652): attach existing shared parameter / response */
   const [paramAttachMode, setParamAttachMode] = useState<'create' | 'reuse'>('create');
@@ -1530,6 +1536,17 @@ export default function OperationPropertiesPanel({
               </TabsContent>
 
               <TabsContent value="docs" className="mt-0 flex flex-col gap-4 outline-none">
+                <OperationDocsAiButton
+                  tenantId={null}
+                  projectId={selectedProjectId}
+                  versionId={selectedVersionId}
+                  pathname={pathname}
+                  httpMethod={operation}
+                  operationIdHint={operationIdName}
+                  pathParameterNames={availablePathParams}
+                  onGenerated={handleOperationDocsAiGenerated}
+                  disabled={!operationId}
+                />
                 <div>
                   <Label className="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">
                     summary

--- a/objectified-ui/src/app/api/ollama/chat/route.ts
+++ b/objectified-ui/src/app/api/ollama/chat/route.ts
@@ -311,6 +311,25 @@ function buildClassDescriptionSystem(options: {
   return s;
 }
 
+const OPERATION_DESCRIPTION_SYSTEM = `You draft OpenAPI-style documentation for a single HTTP operation in an API spec.
+
+# Task
+Return **exactly one** markdown fenced JSON block and **nothing outside the fence** (no preamble, no trailing commentary):
+
+\`\`\`json
+{
+  "summary": "Short phrase for the operation summary field.",
+  "description": "Markdown-friendly explanation for API consumers."
+}
+\`\`\`
+
+# Rules
+- Infer typical REST semantics from the **HTTP method** (GET fetch/list, POST create, PUT replace, PATCH partial update, DELETE remove, HEAD/OPTIONS as appropriate) and from the **path template** (collection vs single resource, nested resources, \`{parameter}\` placeholders).
+- **summary**: single line, plain text (no Markdown), imperative or concise noun phrase; prefer staying under 120 characters and omit a trailing period unless it aids clarity.
+- **description**: one to three short paragraphs and/or a small Markdown bullet list; explain what the operation does, how path parameters map to the resource, and mention idempotency or side effects only when strongly implied by the method and path. Stay factual—do not invent domain-specific business rules not suggested by the path.
+- When the path lists template parameters, name them generically (e.g. "resource identifier") unless the segment name clearly implies a role (e.g. \`userId\`).
+- Both **summary** and **description** must be non-empty strings.`;
+
 function buildPropertyTypeSuggestionsSystem(options: {
   existingClassNames?: string[];
   existingProperties?: Array<{ name: string; description?: string | null; data?: Record<string, unknown> }>;
@@ -446,6 +465,7 @@ export async function POST(request: NextRequest) {
     const isPropertyTypeSuggestions = task === 'property_type_suggestions';
     const isPropertyDescription = task === 'property_description';
     const isClassDescription = task === 'class_description';
+    const isOperationDescription = task === 'operation_description';
     const isSchemaImprovementSuggestions = task === 'schema_improvement_suggestions';
     const usesPropertyLibraryContext =
       isClassSkeleton ||
@@ -502,6 +522,8 @@ export async function POST(request: NextRequest) {
                     existingProperties: Array.isArray(existingProperties) ? existingProperties : undefined,
                     targetClassName: typeof targetClassName === 'string' ? targetClassName : undefined,
                   })
+                : isOperationDescription
+                  ? OPERATION_DESCRIPTION_SYSTEM
             : isSchemaImprovementSuggestions
               ? buildSchemaImprovementSuggestionsSystem({
                   studioMetricsDigest: digestStr,

--- a/objectified-ui/tests/unit/ai-property-description.test.ts
+++ b/objectified-ui/tests/unit/ai-property-description.test.ts
@@ -3,6 +3,7 @@ import {
   summarizeStoredPropertyData,
   draftPropertySchemaFromDialogForm,
   buildClassDescriptionAiPayload,
+  parseGeneratedOperationDocs,
 } from '../../lib/ai-property-description';
 import type { PropertyFormData } from '../../src/app/components/ade/studio/PropertyFormFields';
 
@@ -83,5 +84,19 @@ describe('ai-property-description (#619)', () => {
     const email = payload.properties as Record<string, { memberDescription?: string; schema: Record<string, unknown> }>;
     expect(email.email.memberDescription).toBe('Primary contact');
     expect(email.email.schema.format).toBe('email');
+  });
+
+  it('parseGeneratedOperationDocs reads fenced JSON (#621)', () => {
+    expect(parseGeneratedOperationDocs('')).toBeNull();
+    expect(
+      parseGeneratedOperationDocs(
+        '```json\n{"summary":"List users","description":"Returns **users**."}\n```',
+      ),
+    ).toEqual({ summary: 'List users', description: 'Returns **users**.' });
+    expect(parseGeneratedOperationDocs('{"summary":"x","description":"y"}')).toEqual({
+      summary: 'x',
+      description: 'y',
+    });
+    expect(parseGeneratedOperationDocs('not json')).toBeNull();
   });
 });

--- a/objectified-ui/tests/unit/ai-property-description.test.ts
+++ b/objectified-ui/tests/unit/ai-property-description.test.ts
@@ -99,4 +99,40 @@ describe('ai-property-description (#619)', () => {
     });
     expect(parseGeneratedOperationDocs('not json')).toBeNull();
   });
+
+  it('parseGeneratedOperationDocs requires both summary and description to be non-empty (#621)', () => {
+    // missing summary key
+    expect(parseGeneratedOperationDocs('{"description":"Some description."}')).toBeNull();
+    // missing description key
+    expect(parseGeneratedOperationDocs('{"summary":"Some summary."}')).toBeNull();
+    // empty summary string
+    expect(parseGeneratedOperationDocs('{"summary":"","description":"Some description."}')).toBeNull();
+    // empty description string (whitespace only)
+    expect(parseGeneratedOperationDocs('{"summary":"Some summary.","description":"   "}')).toBeNull();
+    // both non-empty — must succeed
+    expect(
+      parseGeneratedOperationDocs('{"summary":"Get user","description":"Returns a user by ID."}'),
+    ).toEqual({ summary: 'Get user', description: 'Returns a user by ID.' });
+  });
+
+  it('parseGeneratedOperationDocs tolerates preamble/trailing text and uppercase JSON fence tag (#621)', () => {
+    // preamble before the fence
+    expect(
+      parseGeneratedOperationDocs(
+        'Here is the result:\n```json\n{"summary":"Create order","description":"Creates a new order."}\n```',
+      ),
+    ).toEqual({ summary: 'Create order', description: 'Creates a new order.' });
+    // trailing text after the fence
+    expect(
+      parseGeneratedOperationDocs(
+        '```json\n{"summary":"Delete item","description":"Removes the item."}\n```\nLet me know if you need changes.',
+      ),
+    ).toEqual({ summary: 'Delete item', description: 'Removes the item.' });
+    // uppercase JSON fence tag
+    expect(
+      parseGeneratedOperationDocs(
+        '```JSON\n{"summary":"Update record","description":"Updates the record."}\n```',
+      ),
+    ).toEqual({ summary: 'Update record', description: 'Updates the record.' });
+  });
 });


### PR DESCRIPTION
## What was done and why
Adds Ollama-backed generation of OpenAPI **summary** and Markdown **description** for path operations from the HTTP method, path template, path parameter names, and optional operationId. Implements GitHub #621.

## How to test
1. **Open Studio** → **Paths**, select project/version.
2. **Select a path operation** and open the properties panel → **Docs** tab.
3. Ensure **Ollama** is running with at least one model.
4. Click **Generate summary & description** and confirm **summary** and **description** fields fill; edit if needed and **Save**.

## Risk / notes
- Depends on model following JSON output instructions; parse failures show an inline error.
- Generated text should be reviewed before publishing.

**Reviewer:** Please request a review from **GitHub Copilot** in the PR UI if available (CLI `--reviewer copilot` is not supported for this bot).

Closes #621

Made with [Cursor](https://cursor.com)