### PR TITLE
Fix #622 - AI-generated property documentation examples

### DIFF
--- a/docs/PLANNED_FEATURE_ROADMAP_AI.md
+++ b/docs/PLANNED_FEATURE_ROADMAP_AI.md
@@ -78,12 +78,8 @@ This outlines the planned features for integrating AI capabilities into Objectif
 - ✅ Generate property descriptions from names and types (#619 — Studio **Generate with AI** on property description fields; Ollama `property_description` task)
 - ✅ Generate class descriptions from properties (#620 — Studio **Generate with AI** on class description field; Ollama `class_description` task)
 - ✅ Generate operation summaries from path and method (#621 — Paths operation **Docs** tab **Generate summary & description**; Ollama `operation_description` task)
-- 📋 Generate example values that make sense
+- ✅ Generate example values that make sense (#622 — property **Examples** **Generate example with AI** next to schema-based generate; Ollama `property_example` task)
 - Support multiple languages (i18n)
-
-| Ticket | Feature Description                                        |
-|--------|------------------------------------------------------------|
-| #622   | Generate example values that make sense                    |
 
 ### AI Layout Suggestions
 

--- a/objectified-ui/lib/ai-property-description.ts
+++ b/objectified-ui/lib/ai-property-description.ts
@@ -42,6 +42,29 @@ export function parseGeneratedOperationDocs(raw: string): { summary: string; des
   };
 }
 
+/**
+ * Parses LLM output for a single JSON Schema example value (#622).
+ * Expects a JSON object (optionally inside a markdown fence) with an `example` key holding any JSON-serializable value.
+ * Returns null only when parsing fails; use `.value` which may be null when the model emits `"example": null`.
+ */
+export function parseGeneratedPropertyExample(raw: string): { value: unknown } | null {
+  let t = raw.trim();
+  if (!t) return null;
+  const fenced = extractLastJsonCodeBlock(t);
+  if (fenced) t = fenced;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(t);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+  const o = parsed as Record<string, unknown>;
+  if (!Object.prototype.hasOwnProperty.call(o, 'example')) return null;
+  return { value: o.example };
+}
+
 export function normalizeGeneratedPropertyDescription(raw: string): string {
   let t = raw.trim();
   if (!t) return '';

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.87",
+  "version": "0.11.88",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -30,6 +30,7 @@ We continue to improve the platform based on your feedback with improvements and
 - Projects list includes a **Show deleted** switch; when on, soft-deleted projects appear with a **Deleted** badge and **Restore** or **permanent delete** in the row menu (#2981).
 
 ## Studio
+- Property **Examples** (Advanced Constraints) supports **Generate example with AI** (Ollama): adds a realistic JSON example from the property name, optional description, schema snapshot, and nested member hints on class properties (#622).
 - **Paths** operation **Docs** tab supports **Generate summary & description** (Ollama): drafts OpenAPI **summary** and Markdown **description** from the HTTP method, path template, path parameters, and optional operationId (#621).
 - **Class description** in **Edit class** supports **Generate with AI** (Ollama): drafts short documentation from the class name, linked member properties (names, types, optional member descriptions), and composition (allOf / anyOf / oneOf) (#620).
 - **Property description** fields support **Generate with AI** (Ollama): drafts short documentation from the property name and JSON Schema type — in **Add/Edit Property** (sidebar library) and **Edit class property** on the canvas (#619).

--- a/objectified-ui/src/app/api/ollama/chat/route.ts
+++ b/objectified-ui/src/app/api/ollama/chat/route.ts
@@ -269,6 +269,59 @@ function buildPropertyDescriptionSystem(options: {
   return s;
 }
 
+const PROPERTY_EXAMPLE_SYSTEM = `You produce one realistic JSON example value for a JSON Schema property used in OpenAPI 3.1 documentation.
+
+# Task
+Return **exactly one** markdown fenced JSON block and **nothing outside the fence** (no preamble, no trailing commentary):
+
+\`\`\`json
+{ "example": <any JSON value> }
+\`\`\`
+
+# Rules
+- The value after \`"example"\` must be valid JSON (object, array, string, number, boolean, or null).
+- Ground the value in the **property name**, optional **property documentation description**, optional **nested member** hints, and the **JSON Schema snapshot** from the user message.
+- Respect **enum** (pick one listed value), **string formats** (email, uuid, date-time, uri, etc.), numeric **minimum** / **maximum**, and **pattern** when you can produce a matching string.
+- For **$ref** properties, emit a small plausible stub object using clearly fictional data (for example ids like \`"550e8400-e29b-41d4-a716-446655440000"\`, names like \`"Sample Customer"\`). Do not use real people, organizations, or live URLs implied to be production systems.
+- Avoid realistic secrets: no live API keys, tokens, or passwords — use obvious placeholders only when the field clearly expects a secret.
+- When the schema describes an **array** at the root, \`example\` should be a JSON array (often one representative element).
+- Prefer one concise representative value over large fixtures.
+- Use **Existing classes** / **Existing project properties** only to disambiguate references — do not contradict the supplied schema.`;
+
+function buildPropertyExampleSystem(options: {
+  existingClassNames?: string[];
+  existingProperties?: Array<{ name: string; description?: string | null; data?: Record<string, unknown> }>;
+  targetPropertyName?: string;
+  targetClassName?: string;
+}): string {
+  let s = PROPERTY_EXAMPLE_SYSTEM;
+  const tp = typeof options.targetPropertyName === 'string' ? options.targetPropertyName.trim() : '';
+  if (tp) {
+    s += `\n\n# Target property name\n${tp}\n`;
+  }
+  const tc = typeof options.targetClassName === 'string' ? options.targetClassName.trim() : '';
+  if (tc) {
+    s += `\n\n# Containing class\n${tc}\n`;
+  }
+  if (options.existingClassNames?.length) {
+    s += `\n\n# Existing classes\n${options.existingClassNames.join(', ')}`;
+  }
+  if (options.existingProperties?.length) {
+    s += `\n\n# Existing project properties\n`;
+    options.existingProperties.forEach((p) => {
+      const d = p.data;
+      const typeStr =
+        typeof d?.type === 'string'
+          ? d.type
+          : d && typeof d === 'object' && '$ref' in d && d.$ref
+            ? '$ref'
+            : 'object';
+      s += `- ${p.name}: ${typeStr}${p.description ? ` — ${String(p.description).slice(0, 80)}` : ''}\n`;
+    });
+  }
+  return s;
+}
+
 const CLASS_DESCRIPTION_SYSTEM = `You write concise API documentation for JSON Schema object classes used in OpenAPI 3.1 component schemas.
 
 # Task
@@ -464,6 +517,7 @@ export async function POST(request: NextRequest) {
     const isPropertySuggestions = task === 'property_suggestions';
     const isPropertyTypeSuggestions = task === 'property_type_suggestions';
     const isPropertyDescription = task === 'property_description';
+    const isPropertyExample = task === 'property_example';
     const isClassDescription = task === 'class_description';
     const isOperationDescription = task === 'operation_description';
     const isSchemaImprovementSuggestions = task === 'schema_improvement_suggestions';
@@ -472,6 +526,7 @@ export async function POST(request: NextRequest) {
       isPropertySuggestions ||
       isPropertyTypeSuggestions ||
       isPropertyDescription ||
+      isPropertyExample ||
       isClassDescription;
 
     const digestStr =
@@ -516,6 +571,13 @@ export async function POST(request: NextRequest) {
                   targetPropertyName: typeof targetPropertyName === 'string' ? targetPropertyName : undefined,
                   targetClassName: typeof targetClassName === 'string' ? targetClassName : undefined,
                 })
+              : isPropertyExample
+                ? buildPropertyExampleSystem({
+                    existingClassNames: Array.isArray(existingClassNames) ? existingClassNames : undefined,
+                    existingProperties: Array.isArray(existingProperties) ? existingProperties : undefined,
+                    targetPropertyName: typeof targetPropertyName === 'string' ? targetPropertyName : undefined,
+                    targetClassName: typeof targetClassName === 'string' ? targetClassName : undefined,
+                  })
               : isClassDescription
                 ? buildClassDescriptionSystem({
                     existingClassNames: Array.isArray(existingClassNames) ? existingClassNames : undefined,

--- a/objectified-ui/src/app/components/ade/studio/ClassPropertyEditDialog.tsx
+++ b/objectified-ui/src/app/components/ade/studio/ClassPropertyEditDialog.tsx
@@ -47,6 +47,7 @@ import {
 } from './form';
 import type { PropertyDialogAiContext } from './PropertyDialog';
 import { PropertyDescriptionAiButton } from './PropertyDescriptionAiButton';
+import { PropertyExampleAiButton } from './PropertyExampleAiButton';
 import { summarizeStoredPropertyData } from '@lib/ai-property-description';
 
 interface Props {
@@ -324,6 +325,7 @@ interface ConstraintsSectionProps {
   setFormData: React.Dispatch<React.SetStateAction<PropertyFormData>>;
   nestedProperties?: Array<{ id: string; name: string; data: any; description?: string; parent_id?: string | null }>;
   availableClasses: string[];
+  examplesAiSlot?: React.ReactNode;
   eyebrow?: string;
 }
 
@@ -334,6 +336,7 @@ const ConstraintsSection: React.FC<ConstraintsSectionProps> = ({
   setFormData,
   nestedProperties,
   availableClasses,
+  examplesAiSlot,
   eyebrow = 'Advanced Constraints',
 }) => (
   <FormSection
@@ -360,6 +363,7 @@ const ConstraintsSection: React.FC<ConstraintsSectionProps> = ({
       size="small"
       nestedProperties={nestedProperties}
       availableClasses={availableClasses}
+      examplesAiSlot={examplesAiSlot}
     />
   </FormSection>
 );
@@ -1680,6 +1684,16 @@ export default function ClassPropertyEditDialog({
     }
   }, [editingClassProperty?.data]);
 
+  const nestedMembersForExampleAi = useMemo(() => {
+    if (!editingClassProperty?.id || baseType !== 'object') return undefined;
+    return (allClassProperties || [])
+      .filter((p) => p.parent_id === editingClassProperty.id)
+      .map((p) => ({
+        name: p.name,
+        description: p.description ?? null,
+      }));
+  }, [allClassProperties, editingClassProperty?.id, baseType]);
+
   const classMemberDescriptionAiSlot =
     open && propertyAiContext && editingClassProperty ? (
       <PropertyDescriptionAiButton
@@ -1693,6 +1707,30 @@ export default function ClassPropertyEditDialog({
         existingProperties={propertyAiContext.existingProperties}
         studioContext={propertyAiContext.studioContext}
         onGenerated={(text) => setFormData((prev) => ({ ...prev, description: text }))}
+        disabled={!editPropName.trim()}
+      />
+    ) : null;
+
+  const classMemberExampleAiSlot =
+    open && propertyAiContext && editingClassProperty ? (
+      <PropertyExampleAiButton
+        tenantId={propertyAiContext.tenantId}
+        projectId={propertyAiContext.projectId}
+        versionId={propertyAiContext.versionId}
+        propertyName={editPropName}
+        propertySchema={propertySchemaForAiDescription}
+        propertyDescription={formData.description}
+        nestedMembers={nestedMembersForExampleAi}
+        contextClassName={propertyAiContext.contextClassName}
+        existingClasses={propertyAiContext.existingClasses}
+        existingProperties={propertyAiContext.existingProperties}
+        studioContext={propertyAiContext.studioContext}
+        onGenerated={(jsonLine) =>
+          setFormData((prev) => ({
+            ...prev,
+            examples: [...(prev.examples || []), jsonLine],
+          }))
+        }
         disabled={!editPropName.trim()}
       />
     ) : null;
@@ -1746,6 +1784,7 @@ export default function ClassPropertyEditDialog({
                 : undefined
             }
             availableClasses={existingClassNames}
+            examplesAiSlot={classMemberExampleAiSlot}
             eyebrow="Step 4 · Constraints"
           />
         );
@@ -1790,6 +1829,7 @@ export default function ClassPropertyEditDialog({
             : undefined
         }
         availableClasses={existingClassNames}
+        examplesAiSlot={classMemberExampleAiSlot}
       />
       <DocsSection formData={formData} setFormData={setFormData} changed={changedDocs} />
     </>

--- a/objectified-ui/src/app/components/ade/studio/PropertyDialog.tsx
+++ b/objectified-ui/src/app/components/ade/studio/PropertyDialog.tsx
@@ -35,6 +35,7 @@ import { AiPropertyTypeSuggestionsDialog } from './AiPropertyTypeSuggestionsDial
 import type { AiPropertySuggestion } from '@lib/ai-property-suggestions';
 import { draftPropertySchemaFromDialogForm } from '@lib/ai-property-description';
 import { PropertyDescriptionAiButton } from './PropertyDescriptionAiButton';
+import { PropertyExampleAiButton } from './PropertyExampleAiButton';
 import type { PropertyItem as LibraryPropertyItem } from './StudioSideNav';
 import {
   FormSection,
@@ -492,6 +493,7 @@ interface ConstraintsSectionProps {
   formData: PropertyFormData;
   setFormData: React.Dispatch<React.SetStateAction<PropertyFormData>>;
   availableClasses: string[];
+  examplesAiSlot?: React.ReactNode;
   eyebrow?: string;
 }
 
@@ -501,6 +503,7 @@ const ConstraintsSection: React.FC<ConstraintsSectionProps> = ({
   formData,
   setFormData,
   availableClasses,
+  examplesAiSlot,
   eyebrow = 'Advanced Constraints',
 }) => (
   <FormSection
@@ -526,6 +529,7 @@ const ConstraintsSection: React.FC<ConstraintsSectionProps> = ({
       showHint={false}
       size="small"
       availableClasses={availableClasses}
+      examplesAiSlot={examplesAiSlot}
     />
   </FormSection>
 );
@@ -1698,6 +1702,13 @@ export const PropertyDialog: React.FC<PropertyDialogProps> = ({
     setFormData((prev) => ({ ...prev, description: text }));
   }, []);
 
+  const applyAiExample = useCallback((jsonLine: string) => {
+    setFormData((prev) => ({
+      ...prev,
+      examples: [...(prev.examples || []), jsonLine],
+    }));
+  }, []);
+
   const descriptionAiSlot =
     open && propertyAiContext ? (
       <PropertyDescriptionAiButton
@@ -1711,6 +1722,24 @@ export const PropertyDialog: React.FC<PropertyDialogProps> = ({
         existingProperties={propertyAiContext.existingProperties}
         studioContext={propertyAiContext.studioContext}
         onGenerated={applyAiDescription}
+        disabled={!propertyName.trim()}
+      />
+    ) : null;
+
+  const exampleAiSlot =
+    open && propertyAiContext ? (
+      <PropertyExampleAiButton
+        tenantId={propertyAiContext.tenantId}
+        projectId={propertyAiContext.projectId}
+        versionId={propertyAiContext.versionId}
+        propertyName={propertyName}
+        propertySchema={propertySchemaForAi}
+        propertyDescription={formData.description}
+        contextClassName={propertyAiContext.contextClassName}
+        existingClasses={propertyAiContext.existingClasses}
+        existingProperties={propertyAiContext.existingProperties}
+        studioContext={propertyAiContext.studioContext}
+        onGenerated={applyAiExample}
         disabled={!propertyName.trim()}
       />
     ) : null;
@@ -1824,6 +1853,7 @@ export const PropertyDialog: React.FC<PropertyDialogProps> = ({
                         formData={formData}
                         setFormData={setFormData}
                         availableClasses={availableClasses}
+                        examplesAiSlot={exampleAiSlot}
                         eyebrow="Step 4 of 5"
                       />
                     )}
@@ -1889,6 +1919,7 @@ export const PropertyDialog: React.FC<PropertyDialogProps> = ({
                       formData={formData}
                       setFormData={setFormData}
                       availableClasses={availableClasses}
+                      examplesAiSlot={exampleAiSlot}
                     />
                     <DocsSection formData={formData} setFormData={setFormData} changed={changedDocs} />
                   </div>

--- a/objectified-ui/src/app/components/ade/studio/PropertyExampleAiButton.tsx
+++ b/objectified-ui/src/app/components/ade/studio/PropertyExampleAiButton.tsx
@@ -116,39 +116,39 @@ export function PropertyExampleAiButton({
     setBusy(true);
     setError(null);
 
-    let schemaContextFingerprint: string | undefined;
-    if (studioContext && !isChatStudioContextEmpty(studioContext)) {
-      try {
-        schemaContextFingerprint = await computeStudioSchemaFingerprint(studioContext);
-      } catch {
-        /* optional */
-      }
-    }
-    if (ac.signal.aborted || requestId !== requestIdRef.current) return;
-
-    const existingPropsPayload = existingProperties.map(propertyItemToExistingApiShape);
-
-    const desc = typeof propertyDescription === 'string' ? propertyDescription.trim() : '';
-    const nestedPayload =
-      nestedMembers?.filter((m) => m?.name?.trim()).map((m) => ({
-        name: m.name.trim(),
-        ...(m.description != null && String(m.description).trim()
-          ? { description: String(m.description).trim().slice(0, 500) }
-          : {}),
-      })) ?? [];
-
-    const userLines = [
-      `Generate one realistic example JSON value for this schema property (for OpenAPI / Studio documentation examples).`,
-      `Property name: ${name}`,
-      contextClassName?.trim() ? `Containing class: ${contextClassName.trim()}` : null,
-      desc ? `Property documentation description: ${desc}` : null,
-      nestedPayload.length > 0
-        ? `Nested object members (when shaping objects): ${JSON.stringify(nestedPayload)}`
-        : null,
-      `JSON Schema for the property (library/canvas data): ${JSON.stringify(propertySchema)}`,
-    ].filter(Boolean);
-
     try {
+      let schemaContextFingerprint: string | undefined;
+      if (studioContext && !isChatStudioContextEmpty(studioContext)) {
+        try {
+          schemaContextFingerprint = await computeStudioSchemaFingerprint(studioContext);
+        } catch {
+          /* optional */
+        }
+      }
+      if (ac.signal.aborted || requestId !== requestIdRef.current) return;
+
+      const existingPropsPayload = existingProperties.map(propertyItemToExistingApiShape);
+
+      const desc = typeof propertyDescription === 'string' ? propertyDescription.trim() : '';
+      const nestedPayload =
+        nestedMembers?.filter((m) => m?.name?.trim()).map((m) => ({
+          name: m.name.trim(),
+          ...(m.description != null && String(m.description).trim()
+            ? { description: String(m.description).trim().slice(0, 500) }
+            : {}),
+        })) ?? [];
+
+      const userLines = [
+        `Generate one realistic example JSON value for this schema property (for OpenAPI / Studio documentation examples).`,
+        `Property name: ${name}`,
+        contextClassName?.trim() ? `Containing class: ${contextClassName.trim()}` : null,
+        desc ? `Property documentation description: ${desc}` : null,
+        nestedPayload.length > 0
+          ? `Nested object members (when shaping objects): ${JSON.stringify(nestedPayload)}`
+          : null,
+        `JSON Schema for the property (library/canvas data): ${JSON.stringify(propertySchema)}`,
+      ].filter(Boolean);
+
       const response = await fetch('/api/ollama/chat', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },

--- a/objectified-ui/src/app/components/ade/studio/PropertyExampleAiButton.tsx
+++ b/objectified-ui/src/app/components/ade/studio/PropertyExampleAiButton.tsx
@@ -1,0 +1,275 @@
+'use client';
+
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { Button } from '../../ui/Button';
+import { Loader2, Sparkles, Square } from 'lucide-react';
+import type { PropertyItem } from './StudioSideNav';
+import type { ChatStudioContext } from '@/app/ade/studio/components/chatbot/chat-context';
+import { isChatStudioContextEmpty } from '@/app/ade/studio/components/chatbot/chat-context';
+import {
+  persistOllamaModelChoiceForScope,
+  resolvePreferredOllamaModel,
+} from '@/app/ade/studio/components/chatbot/ollama-model-defaults';
+import { accumulateOllamaSse } from '@lib/ollama-chat-sse';
+import { computeStudioSchemaFingerprint } from '@lib/studio-schema-fingerprint';
+import { propertyItemToExistingApiShape } from '@lib/property-item-utils';
+import { parseGeneratedPropertyExample } from '@lib/ai-property-description';
+
+export interface PropertyExampleAiButtonProps {
+  tenantId: string | null | undefined;
+  projectId: string;
+  versionId: string | null | undefined;
+  propertyName: string;
+  /** Compact JSON Schema snapshot for the property (`data`). */
+  propertySchema: Record<string, unknown>;
+  /** Documentation description field when present — improves example realism (#622). */
+  propertyDescription?: string | null;
+  /** Nested object member names (class canvas editor) for richer object examples. */
+  nestedMembers?: Array<{ name: string; description?: string | null }>;
+  contextClassName?: string | null;
+  existingClasses: string[];
+  existingProperties: PropertyItem[];
+  studioContext: ChatStudioContext;
+  /** Pretty-printed JSON string appended to the property examples list. */
+  onGenerated: (exampleJson: string) => void;
+  disabled?: boolean;
+  className?: string;
+}
+
+export function PropertyExampleAiButton({
+  tenantId,
+  projectId,
+  versionId,
+  propertyName,
+  propertySchema,
+  propertyDescription,
+  nestedMembers,
+  contextClassName,
+  existingClasses,
+  existingProperties,
+  studioContext,
+  onGenerated,
+  disabled,
+  className,
+}: PropertyExampleAiButtonProps) {
+  const [modelNames, setModelNames] = useState<string[]>([]);
+  const [selectedModel, setSelectedModel] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+  const requestIdRef = useRef(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch('/api/ollama/models');
+        const json = (await res.json()) as { success?: boolean; models?: { name?: string }[] };
+        const list = res.ok && json.success && Array.isArray(json.models) ? json.models : undefined;
+        const names = Array.isArray(list)
+          ? list.map((m) => m?.name).filter((n): n is string => typeof n === 'string' && n.trim().length > 0)
+          : [];
+        if (cancelled) return;
+        setModelNames(names);
+        const preferred = resolvePreferredOllamaModel({
+          tenantId,
+          projectId,
+          availableModelNames: names,
+          storage: typeof window !== 'undefined' ? window.localStorage : null,
+        });
+        setSelectedModel(preferred);
+      } catch {
+        if (!cancelled) {
+          setModelNames([]);
+          setSelectedModel('');
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [tenantId, projectId]);
+
+  const stop = useCallback(() => {
+    abortRef.current?.abort();
+    abortRef.current = null;
+  }, []);
+
+  const generate = useCallback(async () => {
+    const name = propertyName.trim();
+    if (!name || !selectedModel.trim()) return;
+
+    persistOllamaModelChoiceForScope({
+      tenantId,
+      projectId,
+      modelName: selectedModel,
+      storage: typeof window !== 'undefined' ? window.localStorage : null,
+    });
+
+    requestIdRef.current += 1;
+    const requestId = requestIdRef.current;
+
+    abortRef.current?.abort();
+    const ac = new AbortController();
+    abortRef.current = ac;
+
+    setBusy(true);
+    setError(null);
+
+    let schemaContextFingerprint: string | undefined;
+    if (studioContext && !isChatStudioContextEmpty(studioContext)) {
+      try {
+        schemaContextFingerprint = await computeStudioSchemaFingerprint(studioContext);
+      } catch {
+        /* optional */
+      }
+    }
+    if (ac.signal.aborted || requestId !== requestIdRef.current) return;
+
+    const existingPropsPayload = existingProperties.map(propertyItemToExistingApiShape);
+
+    const desc = typeof propertyDescription === 'string' ? propertyDescription.trim() : '';
+    const nestedPayload =
+      nestedMembers?.filter((m) => m?.name?.trim()).map((m) => ({
+        name: m.name.trim(),
+        ...(m.description != null && String(m.description).trim()
+          ? { description: String(m.description).trim().slice(0, 500) }
+          : {}),
+      })) ?? [];
+
+    const userLines = [
+      `Generate one realistic example JSON value for this schema property (for OpenAPI / Studio documentation examples).`,
+      `Property name: ${name}`,
+      contextClassName?.trim() ? `Containing class: ${contextClassName.trim()}` : null,
+      desc ? `Property documentation description: ${desc}` : null,
+      nestedPayload.length > 0
+        ? `Nested object members (when shaping objects): ${JSON.stringify(nestedPayload)}`
+        : null,
+      `JSON Schema for the property (library/canvas data): ${JSON.stringify(propertySchema)}`,
+    ].filter(Boolean);
+
+    try {
+      const response = await fetch('/api/ollama/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        signal: ac.signal,
+        body: JSON.stringify({
+          model: selectedModel.trim(),
+          task: 'property_example',
+          messages: [{ role: 'user', content: userLines.join('\n') }],
+          existingClassNames: existingClasses,
+          existingProperties: existingPropsPayload,
+          targetPropertyName: name,
+          targetClassName: typeof contextClassName === 'string' ? contextClassName : undefined,
+          ...(typeof versionId === 'string' && versionId ? { versionId } : {}),
+          ...(schemaContextFingerprint ? { schemaContextFingerprint } : {}),
+        }),
+      });
+
+      if (!response.ok) {
+        const t = await response.text().catch(() => '');
+        throw new Error(t || `Request failed (${response.status})`);
+      }
+
+      const full = await accumulateOllamaSse(response, ac.signal);
+      if (ac.signal.aborted || requestId !== requestIdRef.current) return;
+
+      const parsedExample = parseGeneratedPropertyExample(full);
+      if (!parsedExample) {
+        setError('The model did not return a valid {"example": ...} JSON block. Try again or pick another model.');
+        return;
+      }
+
+      let jsonLine: string;
+      try {
+        jsonLine = JSON.stringify(parsedExample.value, null, 2);
+      } catch {
+        setError('The model returned a value that cannot be serialized as JSON.');
+        return;
+      }
+      if (!jsonLine.trim()) {
+        setError('The model returned an empty example. Try again or pick another model.');
+        return;
+      }
+      onGenerated(jsonLine);
+    } catch (e) {
+      if (ac.signal.aborted || requestId !== requestIdRef.current) return;
+      setError(e instanceof Error ? e.message : 'Something went wrong.');
+    } finally {
+      if (requestId !== requestIdRef.current) return;
+      setBusy(false);
+      if (abortRef.current === ac) abortRef.current = null;
+    }
+  }, [
+    propertyName,
+    selectedModel,
+    tenantId,
+    projectId,
+    versionId,
+    propertySchema,
+    propertyDescription,
+    nestedMembers,
+    contextClassName,
+    existingClasses,
+    existingProperties,
+    studioContext,
+    onGenerated,
+  ]);
+
+  useEffect(
+    () => () => {
+      requestIdRef.current += 1;
+      abortRef.current?.abort();
+      abortRef.current = null;
+    },
+    [],
+  );
+
+  const canRun = Boolean(propertyName.trim() && selectedModel.trim() && !disabled);
+
+  return (
+    <div className={className}>
+      <div className="flex flex-wrap items-center gap-2">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={!canRun || busy || modelNames.length === 0}
+          onClick={() => void generate()}
+          data-testid="property-example-ai-generate"
+          className="shrink-0 border-violet-300 text-violet-800 hover:bg-violet-50 dark:border-violet-700 dark:text-violet-200 dark:hover:bg-violet-950/40"
+        >
+          {busy ? (
+            <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" aria-hidden />
+          ) : (
+            <Sparkles className="mr-1.5 h-3.5 w-3.5" aria-hidden />
+          )}
+          {busy ? 'Generating…' : 'Generate example with AI'}
+        </Button>
+        {busy && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={stop}
+            data-testid="property-example-ai-stop"
+            className="text-slate-600 dark:text-slate-400"
+          >
+            <Square className="mr-1 h-3.5 w-3.5" aria-hidden />
+            Stop
+          </Button>
+        )}
+      </div>
+      {modelNames.length === 0 && !busy && (
+        <p className="mt-1 text-xs text-amber-700 dark:text-amber-300">
+          No Ollama models available. Start Ollama or check OLLAMA_BASE_URL.
+        </p>
+      )}
+      {error && (
+        <p className="mt-1 text-xs text-red-600 dark:text-red-400" role="alert">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/objectified-ui/src/app/components/ade/studio/PropertyFormFields.tsx
+++ b/objectified-ui/src/app/components/ade/studio/PropertyFormFields.tsx
@@ -554,6 +554,9 @@ export interface PropertyFormFieldsProps {
 
   // Available class names for schema references
   availableClasses?: string[];
+
+  /** Ollama-backed example generation (#622); rendered beside schema-based example control. */
+  examplesAiSlot?: React.ReactNode;
 }
 
 // OpenAPI 3.1 format options by type
@@ -604,6 +607,7 @@ export const PropertyFormFields: React.FC<PropertyFormFieldsProps> = ({
                                                                         size = 'medium',
                                                                         nestedProperties,
                                                                         availableClasses = [],
+                                                                        examplesAiSlot,
                                                                       }) => {
   const isDark = useDarkMode();
 
@@ -1000,7 +1004,7 @@ export const PropertyFormFields: React.FC<PropertyFormFieldsProps> = ({
           />
 
           <Box sx={{ gridColumn: showTitle ? 'auto' : '1 / -1' }}>
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap', gap: 1, mb: 1 }}>
               <Typography variant="body2" sx={{ fontWeight: 600, color: isDark ? '#e2e8f0' : '#334155' }}>
                 Examples
               </Typography>
@@ -1020,6 +1024,7 @@ export const PropertyFormFields: React.FC<PropertyFormFieldsProps> = ({
                   <AutoAwesomeIcon fontSize="small" />
                 </IconButton>
               </Tooltip>
+              {examplesAiSlot ? <Box sx={{ flex: '1 1 auto', minWidth: 0 }}>{examplesAiSlot}</Box> : null}
             </Box>
 
             <TextField

--- a/objectified-ui/tests/unit/PropertyExampleAiButton.test.tsx
+++ b/objectified-ui/tests/unit/PropertyExampleAiButton.test.tsx
@@ -1,0 +1,89 @@
+jest.mock('@lib/ollama-chat-sse', () => ({
+  accumulateOllamaSse: jest.fn(),
+}));
+
+jest.mock('../../src/app/components/ui/Button', () => ({
+  Button: ({ disabled, ...props }: JSX.IntrinsicElements['button']) => (
+    <button {...props} data-disabled={String(Boolean(disabled))} />
+  ),
+}));
+
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { PropertyExampleAiButton } from '../../src/app/components/ade/studio/PropertyExampleAiButton';
+import { EMPTY_CHAT_STUDIO_CONTEXT } from '../../src/app/ade/studio/components/chatbot/chat-context';
+
+describe('PropertyExampleAiButton (#622)', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.restoreAllMocks();
+  });
+
+  it('keeps the latest request busy when an earlier generate is aborted', async () => {
+    let chatCallCount = 0;
+    let resolveSecondChat: ((value: Response) => void) | null = null;
+
+    global.fetch = jest.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes('/api/ollama/models')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ success: true, models: [{ name: 'mistral' }] }),
+        } as Response);
+      }
+      if (!url.includes('/api/ollama/chat')) {
+        return Promise.reject(new Error(`unexpected fetch: ${url}`));
+      }
+
+      chatCallCount += 1;
+      if (chatCallCount === 1) {
+        return new Promise<Response>((_resolve, reject) => {
+          const onAbort = () => reject(new DOMException('Aborted', 'AbortError'));
+          if (init?.signal?.aborted) {
+            queueMicrotask(onAbort);
+            return;
+          }
+          init?.signal?.addEventListener('abort', onAbort, { once: true });
+        });
+      }
+
+      return new Promise<Response>((resolve) => {
+        resolveSecondChat = resolve;
+      });
+    }) as typeof fetch;
+
+    render(
+      <PropertyExampleAiButton
+        tenantId="tenant-1"
+        projectId="project-1"
+        versionId={null}
+        propertyName="email"
+        propertySchema={{ type: 'string', format: 'email' }}
+        existingClasses={[]}
+        existingProperties={[]}
+        studioContext={EMPTY_CHAT_STUDIO_CONTEXT}
+        onGenerated={jest.fn()}
+      />,
+    );
+
+    const generateButton = await screen.findByTestId('property-example-ai-generate');
+    await waitFor(() => expect(generateButton).toHaveAttribute('data-disabled', 'false'));
+
+    fireEvent.click(generateButton);
+    fireEvent.click(generateButton);
+
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(3));
+    await waitFor(() => expect(screen.getByTestId('property-example-ai-stop')).toBeInTheDocument());
+    expect(generateButton).toHaveTextContent('Generating…');
+    expect(generateButton).toHaveAttribute('data-disabled', 'true');
+
+    resolveSecondChat?.({
+      ok: false,
+      text: async () => 'stopped for test',
+    } as Response);
+
+    await waitFor(() => expect(screen.queryByTestId('property-example-ai-stop')).not.toBeInTheDocument());
+  });
+});

--- a/objectified-ui/tests/unit/ai-property-description.test.ts
+++ b/objectified-ui/tests/unit/ai-property-description.test.ts
@@ -4,6 +4,7 @@ import {
   draftPropertySchemaFromDialogForm,
   buildClassDescriptionAiPayload,
   parseGeneratedOperationDocs,
+  parseGeneratedPropertyExample,
 } from '../../lib/ai-property-description';
 import type { PropertyFormData } from '../../src/app/components/ade/studio/PropertyFormFields';
 
@@ -134,5 +135,16 @@ describe('ai-property-description (#619)', () => {
         '```JSON\n{"summary":"Update record","description":"Updates the record."}\n```',
       ),
     ).toEqual({ summary: 'Update record', description: 'Updates the record.' });
+  });
+
+  it('parseGeneratedPropertyExample reads fenced JSON (#622)', () => {
+    expect(parseGeneratedPropertyExample('')).toBeNull();
+    expect(
+      parseGeneratedPropertyExample('```json\n{"example":"user@example.com"}\n```'),
+    ).toEqual({ value: 'user@example.com' });
+    expect(parseGeneratedPropertyExample('{"example":42}')).toEqual({ value: 42 });
+    expect(parseGeneratedPropertyExample('{"example":null}')).toEqual({ value: null });
+    expect(parseGeneratedPropertyExample('not json')).toBeNull();
+    expect(parseGeneratedPropertyExample('{"wrong":1}')).toBeNull();
   });
 });


### PR DESCRIPTION
## What changed
- Added Ollama task `property_example` with a fenced JSON response shape `{"example": ...}`.
- New **Generate example with AI** control beside the existing schema-based example generator under property **Examples** (Advanced Constraints) in **Add/Edit Property** and **Edit class property**.
- Class property editor passes nested member names when the property is an object, so the model can shape stubs.

## How to test
1. **Start Ollama** with at least one chat model pulled.
2. Open Studio with AI context, **Add** or **Edit** a reusable property, open **Advanced Constraints**.
3. Under **Examples**, click **Generate example with AI** and confirm a new pretty-printed JSON entry appears in the list.
4. On the canvas, **edit a class property**, open **Advanced Constraints**, repeat for an **object** type with nested members.

## Risk / notes
- Output quality depends on the model; malformed responses surface an inline error (same pattern as other Studio Ollama tasks).

Please request review from **GitHub Copilot** if available.

Closes #622

Made with [Cursor](https://cursor.com)