### PR TITLE
Fix #623 - AI-powered ReactFlow canvas layout intelligence

### DIFF
--- a/docs/PLANNED_FEATURE_ROADMAP_AI.md
+++ b/docs/PLANNED_FEATURE_ROADMAP_AI.md
@@ -72,28 +72,16 @@ This outlines the planned features for integrating AI capabilities into Objectif
 |--------|-----------------------------------------------------|
 | #527   | Implementation of Guardrails for prompts/responses  |
 
-### AI Documentation Generation
-
-**Auto-Generate Descriptions** 📋 PLANNED
-- ✅ Generate property descriptions from names and types (#619 — Studio **Generate with AI** on property description fields; Ollama `property_description` task)
-- ✅ Generate class descriptions from properties (#620 — Studio **Generate with AI** on class description field; Ollama `class_description` task)
-- ✅ Generate operation summaries from path and method (#621 — Paths operation **Docs** tab **Generate summary & description**; Ollama `operation_description` task)
-- ✅ Generate example values that make sense (#622 — property **Examples** **Generate example with AI** next to schema-based generate; Ollama `property_example` task)
-- Support multiple languages (i18n)
-
 ### AI Layout Suggestions
 
-**Intelligent Layout Suggestions** 📋 PLANNED
-- AI-powered layout recommendations:
-    - 📋 Analyze schema structure and suggest best layout type
-    - 📋 Detect strongly connected components
-    - 📋 Suggest groupings based on relationships
-    - 📋 Identify central/hub classes
-    - 📋 Recommend hierarchy roots
-
-| Ticket | Feature Description            |
-|--------|--------------------------------|
-| #623   | Intelligent Layout Suggestions |
+**Intelligent Layout Suggestions** ✅ (#623)
+- ✅ AI-powered layout recommendations:
+    - ✅ Analyze schema structure and suggest best layout type (TB vs LR heuristic + schema depth)
+    - ✅ Detect strongly connected components on the canvas graph
+    - ✅ Suggest groupings based on relationships (weak components, SCC cycles — surfaced in metrics + suggestions)
+    - ✅ Identify central/hub classes (degree on collapsed layout graph)
+    - ✅ Recommend hierarchy roots (no incoming directed edges)
+    - ✅ Optional Ollama narrative (`task: canvas_layout_recommendations`)
 
 ---
 
@@ -255,3 +243,12 @@ This outlines the planned features for integrating AI capabilities into Objectif
 - ✅ Industry-specific patterns (#616): multiple actionable patterns per domain (e.g. inventory/idempotency for e-commerce, ledger/idempotency for finance, FHIR-friendly identifiers for healthcare).
 - ✅ Security hardening suggestions (#617): domain-based payment/PHI guidance, auth rate-limit hints, vault/logging guidance for secret-like properties, password-hash modeling, and webhook signature verification for webhook-style class names.
 - ✅ Performance optimization suggestions (#618): cache namespacing/TTL, background job idempotency and retries, cursor/keyset pagination, search projections vs canonical entities, chunked bulk I/O, separating heavy binary metadata, and fan-out/timeline modeling when cache, queue, paging, search, export, media, or feed-style names appear on classes or reusable properties.
+
+### AI Documentation Generation
+
+**Auto-Generate Descriptions** 📋 PLANNED
+- ✅ Generate property descriptions from names and types (#619 — Studio **Generate with AI** on property description fields; Ollama `property_description` task)
+- ✅ Generate class descriptions from properties (#620 — Studio **Generate with AI** on class description field; Ollama `class_description` task)
+- ✅ Generate operation summaries from path and method (#621 — Paths operation **Docs** tab **Generate summary & description**; Ollama `operation_description` task)
+- ✅ Generate example values that make sense (#622 — property **Examples** **Generate example with AI** next to schema-based generate; Ollama `property_example` task)
+- Support multiple languages (i18n)

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.88",
+  "version": "0.11.89",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -30,6 +30,7 @@ We continue to improve the platform based on your feedback with improvements and
 - Projects list includes a **Show deleted** switch; when on, soft-deleted projects appear with a **Deleted** badge and **Restore** or **permanent delete** in the row menu (#2981).
 
 ## Studio
+- **Schema Metrics** includes **Canvas layout intelligence**: analyzes the live ReactFlow graph (strongly connected components, hubs, hierarchy roots, weakly connected islands), recommends **Top→Bottom** vs **Left→Right** auto-layout, adds matching **Suggestions**, and optional **AI narrative** via Ollama (`canvas_layout_recommendations`) (#623).
 - Property **Examples** (Advanced Constraints) supports **Generate example with AI** (Ollama): adds a realistic JSON example from the property name, optional description, schema snapshot, and nested member hints on class properties (#622).
 - **Paths** operation **Docs** tab supports **Generate summary & description** (Ollama): drafts OpenAPI **summary** and Markdown **description** from the HTTP method, path template, path parameters, and optional operationId (#621).
 - **Class description** in **Edit class** supports **Generate with AI** (Ollama): drafts short documentation from the class name, linked member properties (names, types, optional member descriptions), and composition (allOf / anyOf / oneOf) (#620).

--- a/objectified-ui/src/app/ade/studio/components/CanvasLayoutIntelligenceSection.tsx
+++ b/objectified-ui/src/app/ade/studio/components/CanvasLayoutIntelligenceSection.tsx
@@ -1,0 +1,263 @@
+'use client';
+
+import * as React from 'react';
+import ReactMarkdown from 'react-markdown';
+import { Sparkles, Square, LayoutGrid } from 'lucide-react';
+import {
+  persistOllamaModelChoiceForScope,
+  resolvePreferredOllamaModel,
+} from '@/app/ade/studio/components/chatbot/ollama-model-defaults';
+import { accumulateOllamaSse } from '@lib/ollama-chat-sse';
+import {
+  canvasLayoutAnalysisDigest,
+  type CanvasLayoutGraphAnalysis,
+} from '@/app/utils/canvas-layout-graph-analysis';
+import { cn } from '../../../../../lib/utils';
+
+export interface CanvasLayoutIntelligenceSectionProps {
+  analysis: CanvasLayoutGraphAnalysis;
+  tenantId: string | null | undefined;
+  projectId: string | null | undefined;
+  versionId: string | null | undefined;
+  onPreviewLayoutDirection: (direction: 'TB' | 'LR') => void;
+}
+
+export function CanvasLayoutIntelligenceSection({
+  analysis,
+  tenantId,
+  projectId,
+  versionId,
+  onPreviewLayoutDirection,
+}: CanvasLayoutIntelligenceSectionProps) {
+  const pid = typeof projectId === 'string' ? projectId.trim() : '';
+  const [modelNames, setModelNames] = React.useState<string[]>([]);
+  const [selectedModel, setSelectedModel] = React.useState('');
+  const [busy, setBusy] = React.useState(false);
+  const [aiText, setAiText] = React.useState('');
+  const [error, setError] = React.useState<string | null>(null);
+  const abortRef = React.useRef<AbortController | null>(null);
+
+  React.useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch('/api/ollama/models');
+        const json = (await res.json()) as { success?: boolean; models?: { name?: string }[] };
+        const list = res.ok && json.success && Array.isArray(json.models) ? json.models : undefined;
+        const names = Array.isArray(list)
+          ? list.map((m) => m?.name).filter((n): n is string => typeof n === 'string' && n.trim().length > 0)
+          : [];
+        if (cancelled) return;
+        setModelNames(names);
+        const preferred = resolvePreferredOllamaModel({
+          tenantId,
+          projectId: pid || undefined,
+          availableModelNames: names,
+          storage: typeof window !== 'undefined' ? window.localStorage : null,
+        });
+        setSelectedModel(preferred);
+      } catch {
+        if (!cancelled) {
+          setModelNames([]);
+          setSelectedModel('');
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [tenantId, pid]);
+
+  const stop = React.useCallback(() => {
+    abortRef.current?.abort();
+    abortRef.current = null;
+    setBusy(false);
+  }, []);
+
+  const runAi = React.useCallback(async () => {
+    if (!selectedModel.trim() || !pid) {
+      setError('Pick a project and Ollama model first.');
+      return;
+    }
+    const digest = canvasLayoutAnalysisDigest(analysis);
+    if (!digest.trim()) {
+      setError('Layout analysis is empty.');
+      return;
+    }
+
+    persistOllamaModelChoiceForScope({
+      tenantId,
+      projectId: pid,
+      modelName: selectedModel,
+      storage: typeof window !== 'undefined' ? window.localStorage : null,
+    });
+
+    abortRef.current?.abort();
+    const ac = new AbortController();
+    abortRef.current = ac;
+
+    setBusy(true);
+    setError(null);
+    setAiText('');
+
+    try {
+      const response = await fetch('/api/ollama/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        signal: ac.signal,
+        body: JSON.stringify({
+          model: selectedModel.trim(),
+          task: 'canvas_layout_recommendations',
+          canvasLayoutDigest: digest,
+          messages: [
+            {
+              role: 'user',
+              content:
+                'Summarize the canvas layout analysis JSON from your system context and give concrete ReactFlow arrangement advice.',
+            },
+          ],
+          ...(typeof versionId === 'string' && versionId ? { versionId } : {}),
+        }),
+      });
+
+      if (!response.ok) {
+        const t = await response.text().catch(() => '');
+        throw new Error(t || `Request failed (${response.status})`);
+      }
+
+      const full = await accumulateOllamaSse(response, ac.signal, (acc) => setAiText(acc));
+      if (!ac.signal.aborted) setAiText(full);
+    } catch (e) {
+      if (!ac.signal.aborted) {
+        setError(e instanceof Error ? e.message : 'AI request failed.');
+      }
+    } finally {
+      if (!ac.signal.aborted) setBusy(false);
+      abortRef.current = null;
+    }
+  }, [analysis, pid, selectedModel, tenantId, versionId]);
+
+  const dirLabel = analysis.recommendedDirection === 'TB' ? 'Top → Bottom' : 'Left → Right';
+  const topScc = analysis.stronglyConnectedComponents.find((s) => s.memberIds.length > 1);
+  const hubPreview = analysis.hubClasses.slice(0, 3).map((h) => h.name);
+
+  return (
+    <div className="pt-2 border-t border-gray-200 dark:border-gray-700 space-y-2">
+      <div className="flex items-center gap-1.5 text-[10px] text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+        <LayoutGrid className="w-3 h-3" aria-hidden />
+        Canvas layout intelligence (#623)
+      </div>
+
+      <div className="rounded-lg border border-indigo-200/80 dark:border-indigo-800/60 bg-indigo-50/50 dark:bg-indigo-950/20 px-2.5 py-2 space-y-1.5">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="text-xs font-semibold text-indigo-900 dark:text-indigo-200">Suggested direction</span>
+          <span className="text-xs font-bold tabular-nums text-indigo-800 dark:text-indigo-100">{dirLabel}</span>
+          <button
+            type="button"
+            onClick={() => onPreviewLayoutDirection(analysis.recommendedDirection)}
+            className="ml-auto text-[11px] font-medium text-indigo-700 dark:text-indigo-300 hover:underline flex items-center gap-1"
+          >
+            <LayoutGrid className="w-3.5 h-3.5" aria-hidden />
+            Preview auto-layout
+          </button>
+        </div>
+        <p className="text-[11px] text-indigo-900/85 dark:text-indigo-200/85 leading-snug">{analysis.recommendationReason}</p>
+        <dl className="grid grid-cols-2 gap-x-2 gap-y-1 text-[10px] text-indigo-800/90 dark:text-indigo-200/80">
+          <div>
+            <dt className="text-gray-500 dark:text-gray-400">Vertices (layout graph)</dt>
+            <dd className="font-medium tabular-nums">{analysis.vertexCount}</dd>
+          </div>
+          <div>
+            <dt className="text-gray-500 dark:text-gray-400">Directed cycles (SCCs)</dt>
+            <dd className="font-medium tabular-nums">{analysis.nonTrivialSccCount}</dd>
+          </div>
+          <div>
+            <dt className="text-gray-500 dark:text-gray-400">Weak components</dt>
+            <dd className="font-medium tabular-nums">{analysis.weaklyConnectedComponentCount}</dd>
+          </div>
+          <div>
+            <dt className="text-gray-500 dark:text-gray-400">Pseudo depth × width</dt>
+            <dd className="font-medium tabular-nums">
+              {analysis.pseudoLayerDepth} × {analysis.pseudoLayerMaxWidth}
+            </dd>
+          </div>
+        </dl>
+        {topScc && (
+          <p className="text-[10px] text-indigo-800/80 dark:text-indigo-300/80 leading-snug">
+            <span className="font-medium">Largest cycle:</span> {topScc.memberNames.slice(0, 8).join(', ')}
+            {topScc.memberNames.length > 8 ? '…' : ''}
+          </p>
+        )}
+        {hubPreview.length > 0 && (
+          <p className="text-[10px] text-indigo-800/80 dark:text-indigo-300/80 leading-snug">
+            <span className="font-medium">Hubs:</span> {hubPreview.join(', ')}
+            {analysis.hubClasses.length > 3 ? '…' : ''}
+          </p>
+        )}
+        {analysis.hierarchyRoots.length > 0 && (
+          <p className="text-[10px] text-indigo-800/80 dark:text-indigo-300/80 leading-snug">
+            <span className="font-medium">Roots:</span>{' '}
+            {analysis.hierarchyRoots
+              .slice(0, 6)
+              .map((r) => r.name)
+              .join(', ')}
+            {analysis.hierarchyRoots.length > 6 ? '…' : ''}
+          </p>
+        )}
+      </div>
+
+      <div className="space-y-1.5">
+        <div className="flex flex-wrap items-center gap-2">
+          <select
+            value={selectedModel}
+            onChange={(e) => setSelectedModel(e.target.value)}
+            disabled={busy || modelNames.length === 0}
+            className="flex-1 min-w-0 text-[11px] rounded-md border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-900 px-2 py-1 text-gray-800 dark:text-gray-200"
+            aria-label="Ollama model for layout advice"
+          >
+            {modelNames.length === 0 ? (
+              <option value="">No models — start Ollama</option>
+            ) : (
+              modelNames.map((m) => (
+                <option key={m} value={m}>
+                  {m}
+                </option>
+              ))
+            )}
+          </select>
+          {busy ? (
+            <button
+              type="button"
+              onClick={stop}
+              className="inline-flex items-center gap-1 rounded-md border border-gray-300 dark:border-gray-600 px-2 py-1 text-[11px] font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-800"
+            >
+              <Square className="w-3 h-3" aria-hidden />
+              Stop
+            </button>
+          ) : (
+            <button
+              type="button"
+              onClick={() => void runAi()}
+              disabled={!selectedModel.trim() || !pid}
+              className={cn(
+                'inline-flex items-center gap-1 rounded-md px-2 py-1 text-[11px] font-medium',
+                selectedModel.trim() && pid
+                  ? 'bg-amber-600 text-white hover:bg-amber-700 dark:bg-amber-700 dark:hover:bg-amber-600'
+                  : 'bg-gray-200 text-gray-500 cursor-not-allowed dark:bg-gray-700 dark:text-gray-400',
+              )}
+            >
+              <Sparkles className="w-3 h-3" aria-hidden />
+              AI narrative
+            </button>
+          )}
+        </div>
+        {error && <p className="text-[11px] text-rose-600 dark:text-rose-400">{error}</p>}
+        {aiText.trim().length > 0 && (
+          <div className="max-h-40 overflow-y-auto rounded-md border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-900/80 px-2 py-1.5 text-[11px] prose prose-sm dark:prose-invert max-w-none">
+            <ReactMarkdown>{aiText}</ReactMarkdown>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/objectified-ui/src/app/ade/studio/components/CanvasLayoutIntelligenceSection.tsx
+++ b/objectified-ui/src/app/ade/studio/components/CanvasLayoutIntelligenceSection.tsx
@@ -140,8 +140,7 @@ export function CanvasLayoutIntelligenceSection({
       if (ac.signal.aborted || requestId !== requestIdRef.current) return;
       setError(e instanceof Error ? e.message : 'AI request failed.');
     } finally {
-      if (requestId !== requestIdRef.current) return;
-      if (!ac.signal.aborted) setBusy(false);
+      if (requestId === requestIdRef.current && !ac.signal.aborted) setBusy(false);
       if (abortRef.current === ac) abortRef.current = null;
     }
   }, [analysis, pid, selectedModel, tenantId, versionId]);

--- a/objectified-ui/src/app/ade/studio/components/CanvasLayoutIntelligenceSection.tsx
+++ b/objectified-ui/src/app/ade/studio/components/CanvasLayoutIntelligenceSection.tsx
@@ -36,6 +36,7 @@ export function CanvasLayoutIntelligenceSection({
   const [aiText, setAiText] = React.useState('');
   const [error, setError] = React.useState<string | null>(null);
   const abortRef = React.useRef<AbortController | null>(null);
+  const requestIdRef = React.useRef(0);
 
   React.useEffect(() => {
     let cancelled = false;
@@ -69,6 +70,7 @@ export function CanvasLayoutIntelligenceSection({
   }, [tenantId, pid]);
 
   const stop = React.useCallback(() => {
+    requestIdRef.current += 1;
     abortRef.current?.abort();
     abortRef.current = null;
     setBusy(false);
@@ -91,6 +93,9 @@ export function CanvasLayoutIntelligenceSection({
       modelName: selectedModel,
       storage: typeof window !== 'undefined' ? window.localStorage : null,
     });
+
+    requestIdRef.current += 1;
+    const requestId = requestIdRef.current;
 
     abortRef.current?.abort();
     const ac = new AbortController();
@@ -125,17 +130,30 @@ export function CanvasLayoutIntelligenceSection({
         throw new Error(t || `Request failed (${response.status})`);
       }
 
-      const full = await accumulateOllamaSse(response, ac.signal, (acc) => setAiText(acc));
-      if (!ac.signal.aborted) setAiText(full);
+      const full = await accumulateOllamaSse(response, ac.signal, (acc) => {
+        if (ac.signal.aborted || requestId !== requestIdRef.current) return;
+        setAiText(acc);
+      });
+      if (ac.signal.aborted || requestId !== requestIdRef.current) return;
+      setAiText(full);
     } catch (e) {
-      if (!ac.signal.aborted) {
-        setError(e instanceof Error ? e.message : 'AI request failed.');
-      }
+      if (ac.signal.aborted || requestId !== requestIdRef.current) return;
+      setError(e instanceof Error ? e.message : 'AI request failed.');
     } finally {
+      if (requestId !== requestIdRef.current) return;
       if (!ac.signal.aborted) setBusy(false);
-      abortRef.current = null;
+      if (abortRef.current === ac) abortRef.current = null;
     }
   }, [analysis, pid, selectedModel, tenantId, versionId]);
+
+  React.useEffect(
+    () => () => {
+      requestIdRef.current += 1;
+      abortRef.current?.abort();
+      abortRef.current = null;
+    },
+    [],
+  );
 
   const dirLabel = analysis.recommendedDirection === 'TB' ? 'Top → Bottom' : 'Left → Right';
   const topScc = analysis.stronglyConnectedComponents.find((s) => s.memberIds.length > 1);

--- a/objectified-ui/src/app/ade/studio/components/SchemaMetricsPanel.tsx
+++ b/objectified-ui/src/app/ade/studio/components/SchemaMetricsPanel.tsx
@@ -8,7 +8,9 @@ import { cn } from '../../../../../lib/utils';
 import type { LayoutQualityResult } from '@/app/utils/layout-quality';
 import type { SchemaMetricsResult } from '@/app/utils/schema-metrics';
 import type { CanvasSuggestion } from '@/app/utils/canvas-suggestions';
+import type { CanvasLayoutGraphAnalysis } from '@/app/utils/canvas-layout-graph-analysis';
 import { downloadSchemaScoreReportPdf } from '@/app/utils/export-schema-score-report-pdf';
+import { CanvasLayoutIntelligenceSection } from './CanvasLayoutIntelligenceSection';
 import { getNumericScoreTier, NUMERIC_SCORE_TIER_LEGEND } from '@/app/utils/numeric-score-tier';
 import { OVERALL_SCHEMA_QUALITY_WEIGHTS, type OverallSchemaQualityDetail } from '@/app/utils/overall-schema-quality';
 
@@ -19,6 +21,12 @@ interface SchemaMetricsPanelProps {
   overallSchemaQualityDetail?: OverallSchemaQualityDetail | null;
   /** Canvas improvement suggestions (#474) */
   suggestions?: CanvasSuggestion[];
+  /** Deterministic ReactFlow layout analysis (#623) */
+  canvasLayoutAnalysis?: CanvasLayoutGraphAnalysis | null;
+  tenantId?: string | null;
+  projectId?: string | null;
+  versionId?: string | null;
+  onPreviewLayoutDirection?: (direction: 'TB' | 'LR') => void;
   /** Shown on exported PDF cover (#252) */
   projectName?: string;
   versionLabel?: string;
@@ -36,6 +44,11 @@ export default function SchemaMetricsPanel({
   layoutQuality,
   overallSchemaQualityDetail = null,
   suggestions = [],
+  canvasLayoutAnalysis = null,
+  tenantId,
+  projectId,
+  versionId,
+  onPreviewLayoutDirection,
   projectName,
   versionLabel,
   onSuggestionAction,
@@ -1091,6 +1104,16 @@ export default function SchemaMetricsPanel({
                 </div>
               </div>
             </>
+          )}
+
+          {canvasLayoutAnalysis && canvasLayoutAnalysis.classCount >= 2 && onPreviewLayoutDirection && (
+            <CanvasLayoutIntelligenceSection
+              analysis={canvasLayoutAnalysis}
+              tenantId={tenantId}
+              projectId={projectId}
+              versionId={versionId}
+              onPreviewLayoutDirection={onPreviewLayoutDirection}
+            />
           )}
 
           {/* Suggestions (#474) */}

--- a/objectified-ui/src/app/ade/studio/editor/page.tsx
+++ b/objectified-ui/src/app/ade/studio/editor/page.tsx
@@ -165,6 +165,7 @@ import { mapProjectTagToGroupOption, normalizeStoredGroupTags } from '@/app/util
 import { computeTagGroupPlan } from '@/app/utils/group-classes-by-tag-name';
 import { applyEdgeStyling } from '@/app/utils/edge-styling';
 import { computeCanvasSuggestions } from '@/app/utils/canvas-suggestions';
+import { analyzeCanvasLayoutGraph } from '@/app/utils/canvas-layout-graph-analysis';
 import { getVisibleNodeIdsForIsolateSelection } from '@/app/utils/canvas-node-visibility';
 import {
   hasActiveCanvasVisibilityRestrictions,
@@ -1141,6 +1142,14 @@ const StudioContent = () => {
       groupMemberIds,
     });
   }, [nodes, edges, schemaMetrics, layoutQuality, groupMemberIds]);
+
+  const canvasLayoutAnalysis = useMemo(
+    () =>
+      analyzeCanvasLayoutGraph(nodes, edges, {
+        deepestDependencyChainLength: schemaMetrics?.deepestChainLength ?? null,
+      }),
+    [nodes, edges, schemaMetrics?.deepestChainLength],
+  );
 
   // #559: Sync per-node relationship count from edges into class node data (for badges)
   useEffect(() => {
@@ -10740,6 +10749,11 @@ const StudioContent = () => {
                   layoutQuality={layoutQuality}
                   overallSchemaQualityDetail={overallSchemaQualityDetail}
                   suggestions={canvasSuggestions}
+                  canvasLayoutAnalysis={canvasLayoutAnalysis}
+                  tenantId={currentTenantId}
+                  projectId={selectedProjectId}
+                  versionId={selectedVersionId}
+                  onPreviewLayoutDirection={handlePreviewLayout}
                   projectName={selectedProject?.name}
                   versionLabel={selectedVersion?.version_id}
                   onSuggestionAction={handleSuggestionAction}

--- a/objectified-ui/src/app/api/ollama/chat/query-cache.ts
+++ b/objectified-ui/src/app/api/ollama/chat/query-cache.ts
@@ -66,6 +66,8 @@ export type OllamaChatCacheKeyInput = {
   schemaContextFingerprint?: unknown;
   /** Studio metrics digest for schema_improvement_suggestions (#253). */
   studioMetricsDigest?: unknown;
+  /** Serialized canvas layout analysis for canvas_layout_recommendations (#623). */
+  canvasLayoutDigest?: unknown;
   messages: unknown;
 };
 
@@ -82,6 +84,10 @@ export function ollamaChatSemanticContextKey(input: Omit<OllamaChatCacheKeyInput
     typeof input.studioMetricsDigest === 'string' && input.studioMetricsDigest.trim()
       ? input.studioMetricsDigest.trim().slice(0, 64_000)
       : null;
+  const layoutDigest =
+    typeof input.canvasLayoutDigest === 'string' && input.canvasLayoutDigest.trim()
+      ? input.canvasLayoutDigest.trim().slice(0, 64_000)
+      : null;
   const payload = stableStringify({
     model: input.model.trim(),
     task: input.task ?? null,
@@ -92,6 +98,7 @@ export function ollamaChatSemanticContextKey(input: Omit<OllamaChatCacheKeyInput
     versionId: input.versionId ?? null,
     schemaContextFingerprint: fp,
     studioMetricsDigest: digest,
+    canvasLayoutDigest: layoutDigest,
   });
   return createHash('sha256').update(payload, 'utf8').digest('hex');
 }
@@ -123,6 +130,10 @@ export function ollamaChatCacheKey(input: OllamaChatCacheKeyInput): string {
     typeof input.studioMetricsDigest === 'string' && input.studioMetricsDigest.trim()
       ? input.studioMetricsDigest.trim().slice(0, 64_000)
       : null;
+  const layoutDigest =
+    typeof input.canvasLayoutDigest === 'string' && input.canvasLayoutDigest.trim()
+      ? input.canvasLayoutDigest.trim().slice(0, 64_000)
+      : null;
   const payload = stableStringify({
     model: input.model.trim(),
     task: input.task ?? null,
@@ -133,6 +144,7 @@ export function ollamaChatCacheKey(input: OllamaChatCacheKeyInput): string {
     versionId: input.versionId ?? null,
     schemaContextFingerprint: fp,
     studioMetricsDigest: digest,
+    canvasLayoutDigest: layoutDigest,
     messages: input.messages,
   });
   return createHash('sha256').update(payload, 'utf8').digest('hex');

--- a/objectified-ui/src/app/api/ollama/chat/route.ts
+++ b/objectified-ui/src/app/api/ollama/chat/route.ts
@@ -488,6 +488,29 @@ function buildSchemaImprovementSuggestionsSystem(options: {
   return s;
 }
 
+const CANVAS_LAYOUT_RECOMMENDATIONS_SYSTEM = `You help Objectified Studio users arrange **ReactFlow** class diagrams.
+
+The **Canvas layout analysis** JSON below was computed deterministically from the live canvas (classes, optional groups, and edges). It includes:
+- recommendedDirection ("TB" or "LR") with rationale text
+- stronglyConnectedComponents (directed cycles / tight clusters on the layout graph)
+- hubClasses (high total degree after collapsing grouped classes into group nodes)
+- hierarchyRoots (vertices with no incoming directed edges)
+- weaklyConnectedComponentCount (relationship islands using undirected edges)
+
+Respond in **markdown** with:
+1. One short paragraph that agrees with or gently refines the TB vs LR recommendation for this graph.
+2. A bullet list of 3–6 concrete steps for arranging or grouping nodes on the canvas (anchors, cycles, hubs, disconnected islands).
+3. One sentence naming the main pitfall to avoid.
+
+Rules:
+- Reference only class or group labels that appear in the JSON.
+- Stay under 350 words.
+- Do not output JSON or fenced code blocks.`;
+
+function buildCanvasLayoutRecommendationsSystem(layoutDigest: string): string {
+  return `${CANVAS_LAYOUT_RECOMMENDATIONS_SYSTEM}\n\n# Canvas layout analysis JSON\n\n${layoutDigest}`;
+}
+
 export async function POST(request: NextRequest) {
   try {
     const {
@@ -501,6 +524,7 @@ export async function POST(request: NextRequest) {
       versionId,
       schemaContextFingerprint,
       studioMetricsDigest,
+      canvasLayoutDigest,
       targetPropertyName,
       targetClassName,
     } = await request.json();
@@ -521,6 +545,7 @@ export async function POST(request: NextRequest) {
     const isClassDescription = task === 'class_description';
     const isOperationDescription = task === 'operation_description';
     const isSchemaImprovementSuggestions = task === 'schema_improvement_suggestions';
+    const isCanvasLayoutRecommendations = task === 'canvas_layout_recommendations';
     const usesPropertyLibraryContext =
       isClassSkeleton ||
       isPropertySuggestions ||
@@ -534,9 +559,21 @@ export async function POST(request: NextRequest) {
         ? studioMetricsDigest.trim().slice(0, 64_000)
         : '';
 
+    const canvasLayoutDigestStr =
+      typeof canvasLayoutDigest === 'string' && canvasLayoutDigest.trim().length > 0
+        ? canvasLayoutDigest.trim().slice(0, 64_000)
+        : '';
+
     if (isSchemaImprovementSuggestions && !digestStr) {
       return new Response(
         JSON.stringify({ error: 'Invalid request: studioMetricsDigest is required for schema_improvement_suggestions' }),
+        { status: 400, headers: { 'Content-Type': 'application/json' } },
+      );
+    }
+
+    if (isCanvasLayoutRecommendations && !canvasLayoutDigestStr) {
+      return new Response(
+        JSON.stringify({ error: 'Invalid request: canvasLayoutDigest is required for canvas_layout_recommendations' }),
         { status: 400, headers: { 'Content-Type': 'application/json' } },
       );
     }
@@ -593,6 +630,8 @@ export async function POST(request: NextRequest) {
                     ? existingClassNames.filter((n: unknown): n is string => typeof n === 'string' && n.trim().length > 0)
                     : undefined,
                 })
+              : isCanvasLayoutRecommendations
+                ? buildCanvasLayoutRecommendationsSystem(canvasLayoutDigestStr)
             : `You are an expert API designer and OpenAPI specification generator. Your task is to help users create OpenAPI 3.1.0 specifications based on their natural language descriptions.
 
 # Rules
@@ -672,6 +711,7 @@ Do not repeat the full JSON spec outside the code block. Do not add other sectio
       versionId: typeof versionId === 'string' ? versionId : undefined,
       schemaContextFingerprint,
       studioMetricsDigest: isSchemaImprovementSuggestions ? digestStr : undefined,
+      canvasLayoutDigest: isCanvasLayoutRecommendations ? canvasLayoutDigestStr : undefined,
       messages,
     });
 
@@ -685,6 +725,7 @@ Do not repeat the full JSON spec outside the code block. Do not add other sectio
       versionId: typeof versionId === 'string' ? versionId : undefined,
       schemaContextFingerprint,
       studioMetricsDigest: isSchemaImprovementSuggestions ? digestStr : undefined,
+      canvasLayoutDigest: isCanvasLayoutRecommendations ? canvasLayoutDigestStr : undefined,
     });
 
     const cached = getCachedOllamaChatResponse(cacheKey);

--- a/objectified-ui/src/app/utils/canvas-layout-graph-analysis.ts
+++ b/objectified-ui/src/app/utils/canvas-layout-graph-analysis.ts
@@ -40,13 +40,25 @@ export interface CanvasLayoutGraphAnalysis {
   pseudoLayerMaxWidth: number;
 }
 
-function getVertexLabel(nodes: Node[], id: string): string {
-  const n = nodes.find((x) => x.id === id);
-  if (!n) return id;
-  const d = n.data as { name?: string; label?: string } | undefined;
-  const label = typeof d?.label === 'string' ? d.label.trim() : '';
-  const name = typeof d?.name === 'string' ? d.name.trim() : '';
-  return name || label || id;
+function compareLabels(a: string, b: string): number {
+  if (a < b) return -1;
+  if (a > b) return 1;
+  return 0;
+}
+
+function buildVertexLabelMap(nodes: Node[]): Map<string, string> {
+  const labels = new Map<string, string>();
+  for (const n of nodes) {
+    const d = n.data as { name?: string; label?: string } | undefined;
+    const label = typeof d?.label === 'string' ? d.label.trim() : '';
+    const name = typeof d?.name === 'string' ? d.name.trim() : '';
+    labels.set(n.id, name || label || n.id);
+  }
+  return labels;
+}
+
+function getVertexLabel(vertexLabels: Map<string, string>, id: string): string {
+  return vertexLabels.get(id) ?? id;
 }
 
 function buildAdjacencyMaps(edges: Array<{ source: string; target: string }>): {
@@ -72,7 +84,7 @@ function assignPseudoLayers(
   adj: { outgoing: Map<string, string[]>; incoming: Map<string, string[]> }
 ): Map<string, number> {
   const layers = new Map<string, number>();
-  const visited = new Set<string>();
+  const maxLayer = Math.max(0, vertexIds.length - 1);
 
   const rootNodes = vertexIds.filter((id) => (adj.incoming.get(id) ?? []).length === 0);
 
@@ -91,18 +103,18 @@ function assignPseudoLayers(
   }
 
   const queue: { id: string; layer: number }[] = seeds.map((id) => ({ id, layer: 0 }));
+  let queueIndex = 0;
 
-  while (queue.length > 0) {
-    const { id, layer } = queue.shift()!;
-    if (visited.has(id)) {
-      const existing = layers.get(id) ?? 0;
-      if (layer > existing) layers.set(id, layer);
-      continue;
-    }
-    visited.add(id);
-    layers.set(id, layer);
+  while (queueIndex < queue.length) {
+    const { id, layer } = queue[queueIndex++];
+    const boundedLayer = Math.min(layer, maxLayer);
+    const existing = layers.get(id);
+    if (existing !== undefined && boundedLayer <= existing) continue;
+    layers.set(id, boundedLayer);
+
+    const nextLayer = Math.min(boundedLayer + 1, maxLayer);
     for (const targetId of adj.outgoing.get(id) ?? []) {
-      queue.push({ id: targetId, layer: layer + 1 });
+      queue.push({ id: targetId, layer: nextLayer });
     }
   }
 
@@ -253,6 +265,7 @@ export function analyzeCanvasLayoutGraph(
 
   const { vertexIds, directedEdges } = remapStudioCanvasLayoutVertices(nodes, edges);
   if (vertexIds.length === 0) return null;
+  const vertexLabels = buildVertexLabelMap(nodes);
 
   const adjacency = buildAdjacencyMaps(directedEdges);
   const adjacencyMap = new Map<string, string[]>();
@@ -273,25 +286,25 @@ export function analyzeCanvasLayoutGraph(
       const out = outDeg.get(id) ?? 0;
       return {
         id,
-        name: getVertexLabel(nodes, id),
+        name: getVertexLabel(vertexLabels, id),
         inDegree: inc,
         outDegree: out,
         totalDegree: inc + out,
       };
     })
-    .sort((a, b) => b.totalDegree - a.totalDegree || a.name.localeCompare(b.name))
+    .sort((a, b) => b.totalDegree - a.totalDegree || compareLabels(a.name, b.name))
     .slice(0, 12);
 
   const roots: CanvasLayoutRootEntry[] = vertexIds
     .filter((id) => (inDeg.get(id) ?? 0) === 0)
-    .map((id) => ({ id, name: getVertexLabel(nodes, id) }))
-    .sort((a, b) => a.name.localeCompare(b.name));
+    .map((id) => ({ id, name: getVertexLabel(vertexLabels, id) }))
+    .sort((a, b) => compareLabels(a.name, b.name));
 
   const rawSccs = tarjanStronglyConnectedComponents(vertexIds, adjacencyMap);
   const sccEntries: CanvasLayoutSccEntry[] = rawSccs
     .map((memberIds) => ({
       memberIds: [...memberIds].sort(),
-      memberNames: [...memberIds].map((id) => getVertexLabel(nodes, id)).sort(),
+      memberNames: [...memberIds].map((id) => getVertexLabel(vertexLabels, id)).sort(compareLabels),
     }))
     .sort((a, b) => b.memberIds.length - a.memberIds.length);
 

--- a/objectified-ui/src/app/utils/canvas-layout-graph-analysis.ts
+++ b/objectified-ui/src/app/utils/canvas-layout-graph-analysis.ts
@@ -1,0 +1,349 @@
+/**
+ * Canvas / ReactFlow layout graph analysis (#623).
+ * Directed strongly connected components, hierarchy roots, hubs, and layout direction hints.
+ */
+
+import type { Edge, Node } from '@xyflow/react';
+import { stableStringify } from '@lib/stable-json';
+
+export interface CanvasLayoutHubEntry {
+  id: string;
+  name: string;
+  inDegree: number;
+  outDegree: number;
+  totalDegree: number;
+}
+
+export interface CanvasLayoutSccEntry {
+  memberIds: string[];
+  memberNames: string[];
+}
+
+export interface CanvasLayoutRootEntry {
+  id: string;
+  name: string;
+}
+
+export interface CanvasLayoutGraphAnalysis {
+  classCount: number;
+  edgeCount: number;
+  /** Vertices after collapsing grouped classes into group nodes (matches auto-layout graph). */
+  vertexCount: number;
+  recommendedDirection: 'TB' | 'LR';
+  recommendationReason: string;
+  stronglyConnectedComponents: CanvasLayoutSccEntry[];
+  nonTrivialSccCount: number;
+  hubClasses: CanvasLayoutHubEntry[];
+  hierarchyRoots: CanvasLayoutRootEntry[];
+  weaklyConnectedComponentCount: number;
+  pseudoLayerDepth: number;
+  pseudoLayerMaxWidth: number;
+}
+
+function getVertexLabel(nodes: Node[], id: string): string {
+  const n = nodes.find((x) => x.id === id);
+  if (!n) return id;
+  const d = n.data as { name?: string; label?: string } | undefined;
+  const label = typeof d?.label === 'string' ? d.label.trim() : '';
+  const name = typeof d?.name === 'string' ? d.name.trim() : '';
+  return name || label || id;
+}
+
+function buildAdjacencyMaps(edges: Array<{ source: string; target: string }>): {
+  outgoing: Map<string, string[]>;
+  incoming: Map<string, string[]>;
+} {
+  const outgoing = new Map<string, string[]>();
+  const incoming = new Map<string, string[]>();
+  for (const e of edges) {
+    const os = outgoing.get(e.source) ?? [];
+    os.push(e.target);
+    outgoing.set(e.source, os);
+    const ins = incoming.get(e.target) ?? [];
+    ins.push(e.source);
+    incoming.set(e.target, ins);
+  }
+  return { outgoing, incoming };
+}
+
+/** Same layering idea as canvas-auto-layout: roots at 0, longest path layering. */
+function assignPseudoLayers(
+  vertexIds: string[],
+  adj: { outgoing: Map<string, string[]>; incoming: Map<string, string[]> }
+): Map<string, number> {
+  const layers = new Map<string, number>();
+  const visited = new Set<string>();
+
+  const rootNodes = vertexIds.filter((id) => (adj.incoming.get(id) ?? []).length === 0);
+
+  let seeds = rootNodes;
+  if (seeds.length === 0 && vertexIds.length > 0) {
+    let minIncoming = Infinity;
+    let minNode = vertexIds[0];
+    for (const id of vertexIds) {
+      const inc = (adj.incoming.get(id) ?? []).length;
+      if (inc < minIncoming) {
+        minIncoming = inc;
+        minNode = id;
+      }
+    }
+    seeds = [minNode];
+  }
+
+  const queue: { id: string; layer: number }[] = seeds.map((id) => ({ id, layer: 0 }));
+
+  while (queue.length > 0) {
+    const { id, layer } = queue.shift()!;
+    if (visited.has(id)) {
+      const existing = layers.get(id) ?? 0;
+      if (layer > existing) layers.set(id, layer);
+      continue;
+    }
+    visited.add(id);
+    layers.set(id, layer);
+    for (const targetId of adj.outgoing.get(id) ?? []) {
+      queue.push({ id: targetId, layer: layer + 1 });
+    }
+  }
+
+  for (const id of vertexIds) {
+    if (!layers.has(id)) layers.set(id, 0);
+  }
+
+  return layers;
+}
+
+function layerDepthAndMaxWidth(layerAssignments: Map<string, number>): { depth: number; maxWidth: number } {
+  const byLayer = new Map<number, number>();
+  layerAssignments.forEach((layer) => {
+    byLayer.set(layer, (byLayer.get(layer) ?? 0) + 1);
+  });
+  const depth =
+    byLayer.size === 0 ? 0 : Math.max(...Array.from(byLayer.keys())) - Math.min(...Array.from(byLayer.keys())) + 1;
+  const maxWidth = byLayer.size === 0 ? 0 : Math.max(...Array.from(byLayer.values()));
+  return { depth, maxWidth };
+}
+
+/** Tarjan SCC — returns components in reverse finishing order (each SCC contiguous). */
+function tarjanStronglyConnectedComponents(
+  vertexIds: string[],
+  adj: Map<string, string[]>
+): string[][] {
+  const ids = [...vertexIds];
+  let index = 0;
+  const stack: string[] = [];
+  const onStack = new Set<string>();
+  const indices = new Map<string, number>();
+  const lowlink = new Map<string, number>();
+  const sccs: string[][] = [];
+
+  function strongConnect(v: string): void {
+    indices.set(v, index);
+    lowlink.set(v, index);
+    index += 1;
+    stack.push(v);
+    onStack.add(v);
+
+    for (const w of adj.get(v) ?? []) {
+      if (!indices.has(w)) {
+        strongConnect(w);
+        lowlink.set(v, Math.min(lowlink.get(v)!, lowlink.get(w)!));
+      } else if (onStack.has(w)) {
+        lowlink.set(v, Math.min(lowlink.get(v)!, indices.get(w)!));
+      }
+    }
+
+    if (lowlink.get(v) === indices.get(v)) {
+      const comp: string[] = [];
+      while (stack.length > 0) {
+        const w = stack.pop()!;
+        onStack.delete(w);
+        comp.push(w);
+        if (w === v) break;
+      }
+      sccs.push(comp);
+    }
+  }
+
+  for (const v of ids) {
+    if (!indices.has(v)) strongConnect(v);
+  }
+
+  return sccs;
+}
+
+function countWeaklyConnectedComponents(vertexIds: string[], edges: Array<{ source: string; target: string }>): number {
+  const adj = new Map<string, Set<string>>();
+  for (const id of vertexIds) adj.set(id, new Set());
+  for (const e of edges) {
+    adj.get(e.source)?.add(e.target);
+    adj.get(e.target)?.add(e.source);
+  }
+  const visited = new Set<string>();
+  let count = 0;
+  for (const id of vertexIds) {
+    if (visited.has(id)) continue;
+    count++;
+    const stack = [id];
+    visited.add(id);
+    while (stack.length) {
+      const v = stack.pop()!;
+      for (const n of adj.get(v) ?? []) {
+        if (!visited.has(n)) {
+          visited.add(n);
+          stack.push(n);
+        }
+      }
+    }
+  }
+  return count;
+}
+
+export function remapStudioCanvasLayoutVertices(
+  nodes: Node[],
+  edges: Edge[]
+): {
+  vertexIds: string[];
+  directedEdges: Array<{ source: string; target: string }>;
+} {
+  const groupNodes = nodes.filter((n) => n.type === 'groupNode');
+  const classNodes = nodes.filter((n) => n.type !== 'groupNode');
+  const nodeToGroup = new Map<string, string>();
+  for (const g of groupNodes) {
+    const memberIds = (g.data as { nodeIds?: string[] })?.nodeIds ?? [];
+    for (const id of memberIds) nodeToGroup.set(id, g.id);
+  }
+
+  const vertexSet = new Set<string>();
+  for (const n of classNodes) {
+    if (nodeToGroup.has(n.id)) continue;
+    vertexSet.add(n.id);
+  }
+  for (const g of groupNodes) vertexSet.add(g.id);
+
+  const remapEndpoint = (id: string): string | null => {
+    if (vertexSet.has(id)) return id;
+    const g = nodeToGroup.get(id);
+    return g && vertexSet.has(g) ? g : null;
+  };
+
+  const seen = new Set<string>();
+  const directedEdges: Array<{ source: string; target: string }> = [];
+
+  for (const e of edges) {
+    const s = remapEndpoint(e.source);
+    const t = remapEndpoint(e.target);
+    if (!s || !t || s === t) continue;
+    const key = `${s}\0${t}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    directedEdges.push({ source: s, target: t });
+  }
+
+  return { vertexIds: [...vertexSet], directedEdges };
+}
+
+export function analyzeCanvasLayoutGraph(
+  nodes: Node[],
+  edges: Edge[],
+  options?: { deepestDependencyChainLength?: number | null }
+): CanvasLayoutGraphAnalysis | null {
+  const classNodes = nodes.filter((n) => n.type !== 'groupNode');
+  if (classNodes.length === 0) return null;
+
+  const { vertexIds, directedEdges } = remapStudioCanvasLayoutVertices(nodes, edges);
+  if (vertexIds.length === 0) return null;
+
+  const adjacency = buildAdjacencyMaps(directedEdges);
+  const adjacencyMap = new Map<string, string[]>();
+  for (const id of vertexIds) {
+    adjacencyMap.set(id, adjacency.outgoing.get(id) ?? []);
+  }
+
+  const inDeg = new Map<string, number>();
+  const outDeg = new Map<string, number>();
+  for (const id of vertexIds) {
+    inDeg.set(id, (adjacency.incoming.get(id) ?? []).length);
+    outDeg.set(id, (adjacency.outgoing.get(id) ?? []).length);
+  }
+
+  const hubs: CanvasLayoutHubEntry[] = vertexIds
+    .map((id) => {
+      const inc = inDeg.get(id) ?? 0;
+      const out = outDeg.get(id) ?? 0;
+      return {
+        id,
+        name: getVertexLabel(nodes, id),
+        inDegree: inc,
+        outDegree: out,
+        totalDegree: inc + out,
+      };
+    })
+    .sort((a, b) => b.totalDegree - a.totalDegree || a.name.localeCompare(b.name))
+    .slice(0, 12);
+
+  const roots: CanvasLayoutRootEntry[] = vertexIds
+    .filter((id) => (inDeg.get(id) ?? 0) === 0)
+    .map((id) => ({ id, name: getVertexLabel(nodes, id) }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  const rawSccs = tarjanStronglyConnectedComponents(vertexIds, adjacencyMap);
+  const sccEntries: CanvasLayoutSccEntry[] = rawSccs
+    .map((memberIds) => ({
+      memberIds: [...memberIds].sort(),
+      memberNames: [...memberIds].map((id) => getVertexLabel(nodes, id)).sort(),
+    }))
+    .sort((a, b) => b.memberIds.length - a.memberIds.length);
+
+  const nonTrivialSccCount = sccEntries.filter((s) => s.memberIds.length > 1).length;
+
+  const layerAssignments = assignPseudoLayers(vertexIds, adjacency);
+  const { depth: pseudoLayerDepth, maxWidth: pseudoLayerMaxWidth } = layerDepthAndMaxWidth(layerAssignments);
+
+  const schemaDepth = options?.deepestDependencyChainLength;
+  const hasSchemaDepth = typeof schemaDepth === 'number' && schemaDepth > 0;
+
+  let recommendedDirection: 'TB' | 'LR' = 'TB';
+  let recommendationReason =
+    'Top-to-bottom fits typical dependency flow and matches the default hierarchical auto-layout.';
+
+  if (directedEdges.length === 0) {
+    recommendationReason = 'No canvas edges — either stack (TB) or arrange in a row (LR); TB is the default.';
+  } else if (nonTrivialSccCount > 0) {
+    recommendedDirection = 'LR';
+    recommendationReason =
+      'Directed cycles detected (strongly connected components). A left-to-right flow often separates cyclic clusters more readably than a strict vertical stack.';
+  } else if (hasSchemaDepth && schemaDepth >= 5 && pseudoLayerMaxWidth <= pseudoLayerDepth + 2) {
+    recommendedDirection = 'TB';
+    recommendationReason = `Long dependency chains (${schemaDepth} steps in the schema graph) favor top-to-bottom layering.`;
+  } else if (pseudoLayerMaxWidth > pseudoLayerDepth + 1 && pseudoLayerMaxWidth >= 4) {
+    recommendedDirection = 'LR';
+    recommendationReason =
+      'Wide layers (many siblings at once) often read better left-to-right so parallel branches do not crowd vertically.';
+  } else if (pseudoLayerDepth > pseudoLayerMaxWidth + 1 && pseudoLayerDepth >= 4) {
+    recommendedDirection = 'TB';
+    recommendationReason = 'Deep layering from canvas edges suggests top-to-bottom hierarchical layout.';
+  }
+
+  const weaklyConnectedComponentCount = countWeaklyConnectedComponents(vertexIds, directedEdges);
+
+  return {
+    classCount: classNodes.length,
+    edgeCount: edges.length,
+    vertexCount: vertexIds.length,
+    recommendedDirection,
+    recommendationReason,
+    stronglyConnectedComponents: sccEntries,
+    nonTrivialSccCount,
+    hubClasses: hubs,
+    hierarchyRoots: roots,
+    weaklyConnectedComponentCount,
+    pseudoLayerDepth,
+    pseudoLayerMaxWidth,
+  };
+}
+
+/** Stable digest for Ollama cache keys and request bodies. */
+export function canvasLayoutAnalysisDigest(analysis: CanvasLayoutGraphAnalysis): string {
+  return stableStringify(analysis);
+}

--- a/objectified-ui/src/app/utils/canvas-layout-graph-analysis.ts
+++ b/objectified-ui/src/app/utils/canvas-layout-graph-analysis.ts
@@ -84,7 +84,8 @@ function assignPseudoLayers(
   adj: { outgoing: Map<string, string[]>; incoming: Map<string, string[]> }
 ): Map<string, number> {
   const layers = new Map<string, number>();
-  const maxLayer = Math.max(0, vertexIds.length - 1);
+  const unreachable = Number.NEGATIVE_INFINITY;
+  for (const id of vertexIds) layers.set(id, unreachable);
 
   const rootNodes = vertexIds.filter((id) => (adj.incoming.get(id) ?? []).length === 0);
 
@@ -102,24 +103,28 @@ function assignPseudoLayers(
     seeds = [minNode];
   }
 
-  const queue: { id: string; layer: number }[] = seeds.map((id) => ({ id, layer: 0 }));
-  let queueIndex = 0;
+  for (const id of seeds) layers.set(id, 0);
 
-  while (queueIndex < queue.length) {
-    const { id, layer } = queue[queueIndex++];
-    const boundedLayer = Math.min(layer, maxLayer);
-    const existing = layers.get(id);
-    if (existing !== undefined && boundedLayer <= existing) continue;
-    layers.set(id, boundedLayer);
-
-    const nextLayer = Math.min(boundedLayer + 1, maxLayer);
-    for (const targetId of adj.outgoing.get(id) ?? []) {
-      queue.push({ id: targetId, layer: nextLayer });
+  // Iterative longest-path relaxation from chosen seeds.
+  for (let i = 0; i < vertexIds.length - 1; i += 1) {
+    let changed = false;
+    for (const sourceId of vertexIds) {
+      const sourceLayer = layers.get(sourceId) ?? unreachable;
+      if (!Number.isFinite(sourceLayer)) continue;
+      const nextLayer = sourceLayer + 1;
+      for (const targetId of adj.outgoing.get(sourceId) ?? []) {
+        const targetLayer = layers.get(targetId) ?? unreachable;
+        if (nextLayer > targetLayer) {
+          layers.set(targetId, nextLayer);
+          changed = true;
+        }
+      }
     }
+    if (!changed) break;
   }
 
   for (const id of vertexIds) {
-    if (!layers.has(id)) layers.set(id, 0);
+    if (!Number.isFinite(layers.get(id) ?? unreachable)) layers.set(id, 0);
   }
 
   return layers;

--- a/objectified-ui/src/app/utils/canvas-suggestions.ts
+++ b/objectified-ui/src/app/utils/canvas-suggestions.ts
@@ -6,8 +6,14 @@
 import type { Node, Edge } from '@xyflow/react';
 import type { LayoutQualityResult } from '@/app/utils/layout-quality';
 import type { SchemaMetricsResult } from '@/app/utils/schema-metrics';
+import { analyzeCanvasLayoutGraph } from '@/app/utils/canvas-layout-graph-analysis';
 
 export type CanvasSuggestionKind =
+  | 'recommended_layout_direction'
+  | 'strongly_connected_canvas'
+  | 'canvas_hub_layout'
+  | 'hierarchy_roots_layout'
+  | 'weakly_disconnected_canvas'
   | 'reduce_edge_crossings'
   | 'group_related'
   | 'isolated_class'
@@ -128,15 +134,95 @@ export function computeCanvasSuggestions(input: ComputeSuggestionsInput): Canvas
   const adj = buildUndirectedAdjacency(edges);
   const components = getConnectedComponents(nodeIds, adj);
 
+  const layoutAnalysis = analyzeCanvasLayoutGraph(nodes, edges, {
+    deepestDependencyChainLength: metrics?.deepestChainLength ?? null,
+  });
+
+  if (layoutAnalysis && layoutAnalysis.classCount >= 2) {
+    const dir = layoutAnalysis.recommendedDirection;
+    const dirLabel = dir === 'TB' ? 'Top → Bottom' : 'Left → Right';
+    suggestions.push({
+      id: 'suggest-layout-direction-analysis',
+      kind: 'recommended_layout_direction',
+      title: `Recommended auto-layout: ${dirLabel}`,
+      description: layoutAnalysis.recommendationReason,
+      detail: `Pseudo depth ${layoutAnalysis.pseudoLayerDepth}, max width ${layoutAnalysis.pseudoLayerMaxWidth}${
+        layoutAnalysis.nonTrivialSccCount ? ` · ${layoutAnalysis.nonTrivialSccCount} cyclic SCC(s)` : ''
+      }`,
+      action: { type: 'apply_hierarchical_layout', direction: dir },
+    });
+
+    const cyclicComponents = layoutAnalysis.stronglyConnectedComponents.filter((s) => s.memberIds.length > 1);
+    for (let i = 0; i < Math.min(3, cyclicComponents.length); i++) {
+      const scc = cyclicComponents[i];
+      const preview = scc.memberNames.slice(0, 6).join(', ');
+      const extra = scc.memberNames.length > 6 ? ` +${scc.memberNames.length - 6} more` : '';
+      suggestions.push({
+        id: `suggest-scc-${scc.memberIds.slice().sort().join('-').slice(0, 48)}`,
+        kind: 'strongly_connected_canvas',
+        title: `Directed cycle cluster (${scc.memberIds.length} classes)`,
+        description:
+          'These classes reach each other along directed canvas edges — a tightly coupled subgraph. Consider grouping them or emphasizing them near the layout anchor.',
+        detail: `${preview}${extra}`,
+      });
+    }
+
+    const topHub = layoutAnalysis.hubClasses[0];
+    if (topHub && topHub.totalDegree >= 4 && layoutAnalysis.vertexCount >= 3) {
+      const others = layoutAnalysis.hubClasses
+        .slice(1, 4)
+        .map((h) => h.name)
+        .filter(Boolean);
+      suggestions.push({
+        id: `suggest-canvas-hub-${topHub.id}`,
+        kind: 'canvas_hub_layout',
+        title: `${topHub.name} is a canvas hub`,
+        description:
+          'High in + out degree on the canvas graph — place it centrally or use it as a backbone when you run auto-layout.',
+        detail: others.length ? `Also busy: ${others.join(', ')}` : `${topHub.inDegree} in · ${topHub.outDegree} out`,
+      });
+    }
+
+    if (layoutAnalysis.hierarchyRoots.length > 0 && edges.length > 0) {
+      const roots = layoutAnalysis.hierarchyRoots;
+      const names = roots.slice(0, 10).map((r) => r.name);
+      suggestions.push({
+        id: 'suggest-hierarchy-roots',
+        kind: 'hierarchy_roots_layout',
+        title:
+          roots.length === 1
+            ? `${roots[0].name} is a hierarchy root`
+            : `${roots.length} hierarchy roots on the canvas`,
+        description:
+          'No incoming canvas edges — good anchors at the top (TB) or left (LR) when running hierarchical layout.',
+        detail: names.join(', ') + (roots.length > 10 ? ` +${roots.length - 10} more` : ''),
+        action: { type: 'apply_hierarchical_layout', direction: layoutAnalysis.recommendedDirection },
+      });
+    }
+
+    if (layoutAnalysis.weaklyConnectedComponentCount > 1 && edges.length > 0) {
+      suggestions.push({
+        id: 'suggest-weak-components',
+        kind: 'weakly_disconnected_canvas',
+        title: `${layoutAnalysis.weaklyConnectedComponentCount} disconnected subgraphs`,
+        description:
+          'Relationship islands detected — arrange clusters separately or run auto-layout per island for clearer structure.',
+        detail: 'Uses undirected canvas edges between classes/groups.',
+        action: { type: 'apply_hierarchical_layout', direction: layoutAnalysis.recommendedDirection },
+      });
+    }
+  }
+
   // 1. Reduce edge crossings by switching layout
   if (layoutQuality && layoutQuality.edgeCrossingCount >= EDGE_CROSSING_THRESHOLD) {
+    const crossingDir = layoutAnalysis?.recommendedDirection ?? 'TB';
     suggestions.push({
       id: 'suggest-reduce-edge-crossings',
       kind: 'reduce_edge_crossings',
       title: 'Reduce edge crossings',
       description: 'Try a different layout direction (e.g. Top↔Bottom or Left↔Right) or use Auto-organize to improve readability.',
       detail: `${layoutQuality.edgeCrossingCount} crossing${layoutQuality.edgeCrossingCount !== 1 ? 's' : ''} detected.`,
-      action: { type: 'apply_hierarchical_layout', direction: 'TB' },
+      action: { type: 'apply_hierarchical_layout', direction: crossingDir },
     });
   }
 

--- a/objectified-ui/tests/unit/canvas-layout-graph-analysis.test.ts
+++ b/objectified-ui/tests/unit/canvas-layout-graph-analysis.test.ts
@@ -1,0 +1,103 @@
+import type { Edge, Node } from '@xyflow/react';
+import {
+  analyzeCanvasLayoutGraph,
+  canvasLayoutAnalysisDigest,
+  remapStudioCanvasLayoutVertices,
+} from '@/app/utils/canvas-layout-graph-analysis';
+
+function classNode(id: string, name: string): Node {
+  return {
+    id,
+    type: 'classNode',
+    position: { x: 0, y: 0 },
+    data: { name },
+  };
+}
+
+describe('remapStudioCanvasLayoutVertices', () => {
+  it('maps grouped class endpoints to the group node', () => {
+    const nodes: Node[] = [
+      classNode('a', 'A'),
+      classNode('b', 'B'),
+      {
+        id: 'g1',
+        type: 'groupNode',
+        position: { x: 0, y: 0 },
+        data: { nodeIds: ['b'], label: 'G1' },
+      },
+    ];
+    const edges: Edge[] = [{ id: 'e1', source: 'a', target: 'b' }];
+    const { vertexIds, directedEdges } = remapStudioCanvasLayoutVertices(nodes, edges);
+    expect(vertexIds.sort()).toEqual(['a', 'g1']);
+    expect(directedEdges).toEqual([{ source: 'a', target: 'g1' }]);
+  });
+
+  it('dedupes parallel edges after remap', () => {
+    const nodes: Node[] = [classNode('a', 'A'), classNode('b', 'B')];
+    const edges: Edge[] = [
+      { id: 'e1', source: 'a', target: 'b' },
+      { id: 'e2', source: 'a', target: 'b' },
+    ];
+    const { directedEdges } = remapStudioCanvasLayoutVertices(nodes, edges);
+    expect(directedEdges).toEqual([{ source: 'a', target: 'b' }]);
+  });
+});
+
+describe('analyzeCanvasLayoutGraph', () => {
+  it('returns null when there are no class nodes', () => {
+    const nodes: Node[] = [
+      { id: 'g', type: 'groupNode', position: { x: 0, y: 0 }, data: { nodeIds: [] } },
+    ];
+    expect(analyzeCanvasLayoutGraph(nodes, [])).toBeNull();
+  });
+
+  it('detects a 2-node directed cycle as one SCC', () => {
+    const nodes = [classNode('a', 'A'), classNode('b', 'B')];
+    const edges: Edge[] = [
+      { id: 'e1', source: 'a', target: 'b' },
+      { id: 'e2', source: 'b', target: 'a' },
+    ];
+    const a = analyzeCanvasLayoutGraph(nodes, edges);
+    expect(a).not.toBeNull();
+    expect(a!.nonTrivialSccCount).toBe(1);
+    expect(a!.stronglyConnectedComponents[0].memberIds.sort()).toEqual(['a', 'b']);
+    expect(a!.recommendedDirection).toBe('LR');
+    expect(a!.hierarchyRoots).toHaveLength(0);
+  });
+
+  it('finds a single hierarchy root in a DAG chain', () => {
+    const nodes = [classNode('a', 'A'), classNode('b', 'B'), classNode('c', 'C')];
+    const edges: Edge[] = [
+      { id: 'e1', source: 'a', target: 'b' },
+      { id: 'e2', source: 'b', target: 'c' },
+    ];
+    const a = analyzeCanvasLayoutGraph(nodes, edges, { deepestDependencyChainLength: 3 });
+    expect(a!.hierarchyRoots.map((r) => r.id)).toEqual(['a']);
+    expect(a!.nonTrivialSccCount).toBe(0);
+    expect(a!.recommendedDirection).toBe('TB');
+  });
+
+  it('ranks hubs by total degree', () => {
+    const nodes = [
+      classNode('hub', 'Hub'),
+      classNode('x', 'X'),
+      classNode('y', 'Y'),
+      classNode('z', 'Z'),
+    ];
+    const edges: Edge[] = [
+      { id: 'e1', source: 'x', target: 'hub' },
+      { id: 'e2', source: 'y', target: 'hub' },
+      { id: 'e3', source: 'hub', target: 'z' },
+    ];
+    const a = analyzeCanvasLayoutGraph(nodes, edges);
+    expect(a!.hubClasses[0].id).toBe('hub');
+    expect(a!.hubClasses[0].totalDegree).toBe(3);
+  });
+
+  it('canvasLayoutAnalysisDigest is stable', () => {
+    const nodes = [classNode('a', 'A')];
+    const a1 = analyzeCanvasLayoutGraph(nodes, [])!;
+    const a2 = analyzeCanvasLayoutGraph(nodes, [])!;
+    expect(canvasLayoutAnalysisDigest(a1)).toBe(canvasLayoutAnalysisDigest(a2));
+  });
+});

--- a/objectified-ui/tests/unit/canvas-layout-graph-analysis.test.ts
+++ b/objectified-ui/tests/unit/canvas-layout-graph-analysis.test.ts
@@ -77,6 +77,29 @@ describe('analyzeCanvasLayoutGraph', () => {
     expect(a!.recommendedDirection).toBe('TB');
   });
 
+  it('propagates deeper revisits through descendants for pseudo layering', () => {
+    const nodes = [
+      classNode('a', 'A'),
+      classNode('b', 'B'),
+      classNode('c', 'C'),
+      classNode('d', 'D'),
+      classNode('e', 'E'),
+      classNode('f', 'F'),
+    ];
+    const edges: Edge[] = [
+      { id: 'e1', source: 'a', target: 'b' },
+      { id: 'e2', source: 'a', target: 'c' },
+      { id: 'e3', source: 'b', target: 'd' },
+      { id: 'e4', source: 'c', target: 'e' },
+      { id: 'e5', source: 'e', target: 'd' },
+      { id: 'e6', source: 'd', target: 'f' },
+    ];
+    const a = analyzeCanvasLayoutGraph(nodes, edges);
+    expect(a).not.toBeNull();
+    expect(a!.pseudoLayerDepth).toBe(5);
+    expect(a!.pseudoLayerMaxWidth).toBe(2);
+  });
+
   it('ranks hubs by total degree', () => {
     const nodes = [
       classNode('hub', 'Hub'),


### PR DESCRIPTION
## Summary
- Deterministic canvas graph analysis (groups collapsed consistently with auto-layout): strongly connected components (Tarjan), hierarchy roots, hub classes by degree, weakly connected island count, pseudo layer depth/width, and a TB vs LR heuristic (schema deepest dependency chain when available).
- **Schema Metrics** panel: **Canvas layout intelligence** section with **Preview auto-layout** and optional **AI narrative** via Ollama (`task: canvas_layout_recommendations`, `canvasLayoutDigest`) including cache-key support.
- **Suggestions** list gains layout-focused items; reduce-edge-crossings uses the same recommended direction.

## How to test
1. **Open Studio** with a version that has **two or more classes** on the canvas (add edges for richer metrics).
2. **Open Schema Metrics**.
3. Verify **Canvas layout intelligence** shows recommended direction, SCC/hub/root/disconnected summaries when applicable.
4. **Preview auto-layout** applies hierarchical preview in the suggested direction.
5. With Ollama available, select a model and run **AI narrative**; markdown should stream.

## Risks / notes
- Direction recommendation is a fast heuristic, not full graph layout optimization.
- Graph collapsing follows grouped-class remap aligned with `applyAutoLayout`.

Closes #623

Made with [Cursor](https://cursor.com)