### PR TITLE
Fix #3188 - CLI configuration system (TOML, profiles, config commands)

### DIFF
--- a/docs/PLANNED_ROADMAP_CLI.md
+++ b/docs/PLANNED_ROADMAP_CLI.md
@@ -106,7 +106,6 @@ Total: **12 epics**, **88 sub-tickets** (open roadmap items; completed work is d
 
 | #         | Title                                                              | Description                                                                  | Labels                                          | MVP | Parallel |
 |-----------|--------------------------------------------------------------------|------------------------------------------------------------------------------|-------------------------------------------------|-----|----------|
-| 1.3 (#3188) | Configuration system (TOML + env + profiles)                     | `~/.config/objectified/config.toml`, `config get/set/list/path`, profiles    | `enhancement`, `mvp`, `cli`, `roadmap-cli`     | Yes | Yes      |
 | 1.4 (#3189) | Output renderers (text/table/JSON/YAML)                          | `output.table/json/yaml/spinner`, NO_COLOR + TTY aware                       | `enhancement`, `mvp`, `cli`, `roadmap-cli`     | Yes | Yes      |
 | 1.5 (#3190) | Generated REST client from `openapi.yaml`                        | Codegen step, typed SDK, retry/refresh wrapper, single import path           | `enhancement`, `mvp`, `cli`, `roadmap-cli`, `typescript`, `openapi` | Yes | Yes      |
 | 1.6 (#3191) | Error handling, exit codes, retries, hints                       | `ObjectifiedCliError` hierarchy, sysexits-style exit codes, did-you-mean     | `enhancement`, `mvp`, `cli`, `roadmap-cli`     | Yes | Yes      |
@@ -155,27 +154,11 @@ Part of Epic: CLI Foundation & DevEx (#3174)
 
 ---
 
-#### 1.3 (#3188) — Configuration system
+#### 1.3 (#3188) — Configuration system (**done**)
 
-TOML-backed config with named profiles and XDG-spec paths. No secrets stored here — those go in the OS keychain (2.4).
+Landed: XDG-style config dir on Linux/macOS (`env-paths` on Linux; `~/.config/objectified` when `XDG_CONFIG_HOME` unset on macOS), `%APPDATA%\\Objectified\\config.toml` on Windows; `default_profile` + `[profile.*]` / `[default]` parsing; auto-created `config.toml` at `0600` on Unix; `objectified config path|get|set|list`; profile validation with friendly errors; API keys never read from file (flag/env only); `OBJECTIFIED_TENANT` + `tenant_slug` in context; Vitest coverage for resolution order and paths.
 
-```toml
-default_profile = "prod"
-
-[profile.prod]
-base_url    = "https://api.objectified.dev"
-tenant_slug = "acme-corp"
-
-[profile.staging]
-base_url    = "https://api.staging.objectified.dev"
-tenant_slug = "acme-staging"
-```
-
-Commands: `config get/set/list/path`. File auto-created on first run; permissions `0600` on Unix.
-
-**Acceptance Criteria:** `--profile staging` reads `[profile.staging]`; missing profile prints helpful error with available list; resolution-order tests pass.
-
-**Parallelism / Dependencies:** Depends on 1.1, 1.2. Blocks Epic 2.
+**Parallelism / Dependencies:** Depended on 1.1, 1.2. Blocks Epic 2.
 
 Part of Epic: CLI Foundation & DevEx (#3174)
 
@@ -827,11 +810,11 @@ The `NPM_REGISTRY` env var lets us point at npmjs.com, GitHub Packages, JFrog Ar
 
 ## MVP Release — Ticket Bundle
 
-The MVP delivers an installable, useful CLI focused on _read_ and _publish_ for a single project's lifecycle. Total: **25 open sub-tickets** across 6 epics (plus completed foundation items such as #3186 and #3187).
+The MVP delivers an installable, useful CLI focused on _read_ and _publish_ for a single project's lifecycle. Total: **24 open sub-tickets** across 6 epics (plus completed foundation items such as #3186, #3187, and #3188).
 
 | Epic     | Tickets                                                                                                   | Count |
 |----------|-----------------------------------------------------------------------------------------------------------|-------|
-| 1 (#3174) | #3188, #3189, #3190, #3191, #3192                                                                          | 5     |
+| 1 (#3174) | #3189, #3190, #3191, #3192                                                                                 | 4     |
 | 2 (#3175) | #3194, #3195, #3196, #3197, #3198, #3199                                                                  | 6     |
 | 3 (#3176) | #3202, #3203, #3204                                                                                        | 3     |
 | 4 (#3177) | #3208, #3209, #3210, #3212                                                                                | 4     |
@@ -919,7 +902,7 @@ v2 fills out the writable surface for primitives, properties, classes, paths, da
 
 The tickets were created in the order below — that is also the recommended **execution** order. Earlier epics provide primitives that later epics rely on.
 
-1. **Epic 1 — Foundation** (#3174: #3186 and #3187 landed; then #3188 → #3193). Without the scaffold, no other command can exist.
+1. **Epic 1 — Foundation** (#3174: #3186, #3187, and #3188 landed; then #3189 → #3193). Without the scaffold, no other command can exist.
 2. **Epic 2 — Auth & Tenants** (#3175 then #3194 → #3201). Required for any tenant-scoped command.
 3. **Epic 3 — Projects** (#3176 then #3202 → #3207). The first useful read/write surface.
 4. **Epic 4 — Versions** (#3177 then #3208 → #3216). The publish flow that makes the CLI valuable in CI.

--- a/objectified-cli/package.json
+++ b/objectified-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-cli",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Objectified command-line interface",
   "author": "Objectified",
   "type": "module",
@@ -43,10 +43,13 @@
     "@oclif/plugin-help": "^6.2.46",
     "@oclif/plugin-version": "^2.2.43",
     "chalk": "^5.6.2",
+    "env-paths": "^4.0.0",
+    "fs-extra": "^11.3.5",
     "supports-color": "^10.2.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
+    "@types/fs-extra": "^11.0.4",
     "@types/node": "^22.10.0",
     "@types/supports-color": "^10.0.0",
     "eslint": "^9.39.4",

--- a/objectified-cli/src/base-command.ts
+++ b/objectified-cli/src/base-command.ts
@@ -1,16 +1,22 @@
 import os from "node:os";
 
 import { Command, Flags } from "@oclif/core";
+import type { CommandError } from "@oclif/core/interfaces";
 import supportsColor from "supports-color";
 
 import { createApiClient } from "./lib/client.js";
 import {
   buildObjectifiedContext,
-  resolveConfigPath,
   type GlobalCliFlags,
   type ObjectifiedContext,
 } from "./lib/cli-context.js";
-import { loadTomlConfigFile } from "./lib/config.js";
+import {
+  ensureDefaultConfigFile,
+  loadTomlConfigFile,
+  resolveConfigFilePath,
+  type ParsedTomlConfig,
+} from "./lib/config.js";
+import { CliError } from "./lib/errors.js";
 
 export abstract class BaseCommand extends Command {
   static baseFlags = {
@@ -25,7 +31,8 @@ export abstract class BaseCommand extends Command {
       helpGroup: "GLOBAL",
     }),
     config: Flags.string({
-      description: `Path to config file (default: ~/.config/objectified/config.toml).`,
+      description:
+        "Path to config file (default: XDG config dir / Objectified AppData on Windows — see `objectified config path`).",
       helpGroup: "GLOBAL",
     }),
     json: Flags.boolean({
@@ -41,7 +48,8 @@ export abstract class BaseCommand extends Command {
       helpGroup: "GLOBAL",
     }),
     profile: Flags.string({
-      description: "Named credentials profile (OBJECTIFIED_PROFILE).",
+      description:
+        "Named credentials profile (OBJECTIFIED_PROFILE); falls back to default_profile in config.",
       helpGroup: "GLOBAL",
     }),
     quiet: Flags.boolean({
@@ -58,8 +66,11 @@ export abstract class BaseCommand extends Command {
   /** Parsed flags including globals and command-specific options. */
   declare flags: GlobalCliFlags & Record<string, unknown>;
 
-  /** Resolved API/client context (flag > env > config profile > [default] > built-ins). */
+  /** Resolved API/client context (flag > env > profile config > [default] > built-ins). */
   context!: ObjectifiedContext;
+
+  /** Parsed config document after loading `config.toml`. */
+  protected configDoc!: ParsedTomlConfig;
 
   /** True when --verbose or OBJECTIFIED_VERBOSE=1. */
   protected verboseEffective!: boolean;
@@ -79,15 +90,16 @@ export abstract class BaseCommand extends Command {
     const globalPart = parsed.flags as GlobalCliFlags;
     this.commandArgs = parsed.args as Record<string, unknown>;
 
-    this.resolvedConfigPath = resolveConfigPath(globalPart.config, process.env, os.homedir);
-    const configDoc = loadTomlConfigFile(this.resolvedConfigPath);
+    this.resolvedConfigPath = resolveConfigFilePath(globalPart.config, process.env, os.homedir);
+    await ensureDefaultConfigFile(this.resolvedConfigPath);
+    this.configDoc = loadTomlConfigFile(this.resolvedConfigPath);
 
     const built = buildObjectifiedContext({
       flags: globalPart,
       env: process.env,
       stdoutIsTTY: process.stdout.isTTY,
       supportsColorStdout: typeof supportsColor.stdout === "object",
-      configDoc,
+      configDoc: this.configDoc,
       configPath: this.resolvedConfigPath,
     });
 
@@ -98,5 +110,13 @@ export abstract class BaseCommand extends Command {
       verboseEffective: built.verboseEffective,
     } as BaseCommand["flags"];
     this.api = createApiClient(this.context.baseUrl);
+  }
+
+  protected override async catch(err: CommandError): Promise<void> {
+    if (err instanceof CliError) {
+      this.error(err.message, { exit: err.exitCode });
+      return;
+    }
+    await super.catch(err);
   }
 }

--- a/objectified-cli/src/commands/config/get.ts
+++ b/objectified-cli/src/commands/config/get.ts
@@ -1,0 +1,43 @@
+import { Args } from "@oclif/core";
+
+import { BaseCommand } from "../../base-command.js";
+import {
+  formatConfigScalar,
+  getNestedValue,
+  loadRawTomlDocument,
+  splitDottedKey,
+} from "../../lib/config.js";
+import { CliError } from "../../lib/errors.js";
+
+export default class ConfigGet extends BaseCommand {
+  static description = "Print a single config value by dotted key";
+
+  static examples = ["<%= config.bin %> <%= command.id %> profile.prod.base_url"];
+
+  static args = {
+    key: Args.string({
+      description: "Dotted path (e.g. default_profile, profile.prod.base_url)",
+      required: true,
+    }),
+  };
+
+  run(): Promise<void> {
+    const key = this.commandArgs.key;
+    if (typeof key !== "string") throw new CliError("Missing config key.", 11);
+
+    const raw = loadRawTomlDocument(this.resolvedConfigPath);
+    const parts = splitDottedKey(key);
+    const value = getNestedValue(raw, parts);
+    if (value === undefined) {
+      throw new CliError(`No value for "${key}".`, 11);
+    }
+
+    const printed = formatConfigScalar(value);
+    if (this.context.json) {
+      process.stdout.write(JSON.stringify({ key, value: printed }) + "\n");
+      return Promise.resolve();
+    }
+    process.stdout.write(printed + "\n");
+    return Promise.resolve();
+  }
+}

--- a/objectified-cli/src/commands/config/list.ts
+++ b/objectified-cli/src/commands/config/list.ts
@@ -1,0 +1,32 @@
+import TOML from "@iarna/toml";
+
+import { BaseCommand } from "../../base-command.js";
+import { loadRawTomlDocument } from "../../lib/config.js";
+
+function sortKeysDeep(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortKeysDeep);
+  if (value && typeof value === "object") {
+    const o = value as Record<string, unknown>;
+    const sortedKeys = Object.keys(o).sort();
+    const out: Record<string, unknown> = {};
+    for (const k of sortedKeys) out[k] = sortKeysDeep(o[k]);
+    return out;
+  }
+  return value;
+}
+
+export default class ConfigList extends BaseCommand {
+  static description = "Print the entire config file (stable JSON with --json, otherwise TOML)";
+
+  static examples = ["<%= config.bin %> <%= command.id %>"];
+
+  run(): Promise<void> {
+    const raw = loadRawTomlDocument(this.resolvedConfigPath);
+    if (this.context.json) {
+      process.stdout.write(JSON.stringify(sortKeysDeep(raw), null, 2) + "\n");
+      return Promise.resolve();
+    }
+    process.stdout.write(TOML.stringify(raw) + "\n");
+    return Promise.resolve();
+  }
+}

--- a/objectified-cli/src/commands/config/path.ts
+++ b/objectified-cli/src/commands/config/path.ts
@@ -1,0 +1,16 @@
+import { BaseCommand } from "../../base-command.js";
+
+export default class ConfigPath extends BaseCommand {
+  static description = "Print the resolved config.toml path";
+
+  static examples = ["<%= config.bin %> <%= command.id %>"];
+
+  run(): Promise<void> {
+    if (this.context.json) {
+      process.stdout.write(JSON.stringify({ path: this.resolvedConfigPath }) + "\n");
+      return Promise.resolve();
+    }
+    process.stdout.write(this.resolvedConfigPath + "\n");
+    return Promise.resolve();
+  }
+}

--- a/objectified-cli/src/commands/config/set.ts
+++ b/objectified-cli/src/commands/config/set.ts
@@ -1,0 +1,67 @@
+import fs from "node:fs";
+
+import TOML from "@iarna/toml";
+import { Args } from "@oclif/core";
+
+import { BaseCommand } from "../../base-command.js";
+import {
+  assertWritableConfigKey,
+  defaultConfigToml,
+  loadRawTomlDocument,
+  parseTomlConfig,
+  saveRawTomlDocument,
+  setNestedValue,
+  splitDottedKey,
+} from "../../lib/config.js";
+import { CliError } from "../../lib/errors.js";
+
+export default class ConfigSet extends BaseCommand {
+  static description = "Set a config value by dotted key and persist config.toml";
+
+  static examples = [
+    "<%= config.bin %> <%= command.id %> profile.staging.base_url https://api.staging.example",
+  ];
+
+  static args = {
+    key: Args.string({
+      description: "Dotted path (e.g. default_profile, profile.prod.tenant_slug)",
+      required: true,
+    }),
+    value: Args.string({
+      description: "New value (stored as a TOML string)",
+      required: true,
+    }),
+  };
+
+  run(): Promise<void> {
+    const key = this.commandArgs.key;
+    const value = this.commandArgs.value;
+    if (typeof key !== "string" || typeof value !== "string") {
+      throw new CliError("Usage: objectified config set <key> <value>", 11);
+    }
+
+    assertWritableConfigKey(key);
+
+    let raw = loadRawTomlDocument(this.resolvedConfigPath);
+    if (Object.keys(raw).length === 0) {
+      raw = TOML.parse(defaultConfigToml());
+    }
+
+    setNestedValue(raw, splitDottedKey(key), value);
+    saveRawTomlDocument(this.resolvedConfigPath, raw);
+
+    try {
+      parseTomlConfig(fs.readFileSync(this.resolvedConfigPath, "utf8"));
+    } catch (e) {
+      throw new CliError(
+        `Updated config failed validation: ${e instanceof Error ? e.message : String(e)}`,
+        11,
+      );
+    }
+
+    if (this.context.json) {
+      process.stdout.write(JSON.stringify({ key, value }) + "\n");
+    }
+    return Promise.resolve();
+  }
+}

--- a/objectified-cli/src/help.ts
+++ b/objectified-cli/src/help.ts
@@ -1,26 +1,29 @@
 import { Help } from "@oclif/core";
 
-/** Duplicated from cli-context DEFAULT_BASE_URL so this module stays standalone for oclif help loading. */
+/** Same value as `src/lib/constants.ts` — inlined so oclif’s dynamic help import does not pull extra modules. */
 const DEFAULT_BASE_URL = "https://api.objectified.dev";
 
 const GLOBAL_FLAGS_BODY = [
   "Global flags apply to every command:",
   "",
-  `  --api-key       OBJECTIFIED_API_KEY       Direct API-key auth`,
+  `  --api-key       OBJECTIFIED_API_KEY       Direct API-key auth (not read from config.toml)`,
   `  --base-url      OBJECTIFIED_BASE_URL      Root REST endpoint (built-in default: ${DEFAULT_BASE_URL})`,
-  `  --config        OBJECTIFIED_CONFIG        Config file (~/.config/objectified/config.toml)`,
+  `  --config        OBJECTIFIED_CONFIG        config.toml (default: XDG config dir, or %APPDATA%\\Objectified on Windows)`,
   `  --json          OBJECTIFIED_JSON=1        Machine-readable JSON (auto when stdout is not a TTY)`,
   `  --no-color      NO_COLOR=1                Disable ANSI color (auto when stdout is not a TTY)`,
-  `  --profile       OBJECTIFIED_PROFILE       Named profile (default: default)`,
+  `  --profile       OBJECTIFIED_PROFILE       Profile name; falls back to default_profile in config, else "default"`,
   `  --quiet, -q                               Suppress non-error stdout`,
   `  --verbose       OBJECTIFIED_VERBOSE=1     Verbose stderr logging`,
   "",
-  "Resolution order for URL and API key (highest precedence wins):",
-  "  1. Command-line flag",
-  "  2. Environment variable",
-  "  3. Config [profile.NAME] section",
-  "  4. Config [default] section",
-  `  5. Built-in default (base URL only: ${DEFAULT_BASE_URL})`,
+  "Resolution order for base URL (highest precedence wins):",
+  "  1. Command-line flag            (--base-url=…)",
+  "  2. Environment variable         (OBJECTIFIED_BASE_URL=…)",
+  "  3. Config [profile.NAME]        (base_url=…)",
+  "  4. Config [default]              (base_url=…)",
+  `  5. Built-in default              (${DEFAULT_BASE_URL})`,
+  "",
+  "Resolution order for API key: --api-key, then OBJECTIFIED_API_KEY (never from config file; see #3188).",
+  "Resolution order for tenant slug: OBJECTIFIED_TENANT, then config profile / [default] (tenant_slug).",
 ].join("\n");
 
 export default class ObjectifiedHelp extends Help {

--- a/objectified-cli/src/lib/cli-context.ts
+++ b/objectified-cli/src/lib/cli-context.ts
@@ -1,8 +1,6 @@
-import path from "node:path";
-
+import { CliError } from "./errors.js";
 import type { ParsedTomlConfig } from "./config.js";
-
-export const DEFAULT_BASE_URL = "https://api.objectified.dev";
+import { DEFAULT_BASE_URL } from "./constants.js";
 
 /** Parsed global flags (oclif uses camelCase keys). */
 export type GlobalCliFlags = {
@@ -22,6 +20,7 @@ export type ObjectifiedContext = {
   baseUrl: string;
   profile: string;
   apiKey: string | undefined;
+  tenantSlug: string | undefined;
   json: boolean;
   color: boolean;
 };
@@ -38,33 +37,41 @@ function envTruthy(env: NodeJS.ProcessEnv, key: string): boolean {
   return v === "1" || v === "true" || v === "yes";
 }
 
-/** Profile-specific values overlay [default] (issue #3187 resolution order for config). */
+export function listAvailableProfileNames(doc: ParsedTomlConfig): string[] {
+  const names = new Set<string>(["default"]);
+  for (const k of Object.keys(doc.profiles)) names.add(k);
+  return [...names].sort((a, b) => a.localeCompare(b));
+}
+
+export function assertProfileExists(doc: ParsedTomlConfig, profileName: string): void {
+  if (profileName === "default") return;
+  if (doc.profiles[profileName] !== undefined) return;
+  const available = listAvailableProfileNames(doc);
+  throw new CliError(
+    `Profile '${profileName}' not found. Available: ${available.join(", ")}. Run \`objectified config set …\` to add one.`,
+    11,
+  );
+}
+
+/** Flag → env → `default_profile` in file → literal `"default"`. */
+export function resolveEffectiveProfile(
+  flag: string | undefined,
+  env: NodeJS.ProcessEnv,
+  doc: ParsedTomlConfig,
+): string {
+  return firstNonEmpty(flag, env.OBJECTIFIED_PROFILE, doc.defaultProfile) ?? "default";
+}
+
+/** Profile-specific values overlay `[default]` (issue #3187 / #3188). */
 export function configLayerForProfile(
   doc: ParsedTomlConfig,
   profileName: string,
-): { baseUrl?: string; apiKey?: string } {
+): { baseUrl?: string; tenantSlug?: string } {
   const prof = doc.profiles[profileName];
   return {
     baseUrl: firstNonEmpty(prof?.baseUrl, doc.default.baseUrl),
-    apiKey: firstNonEmpty(prof?.apiKey, doc.default.apiKey),
+    tenantSlug: firstNonEmpty(prof?.tenantSlug, doc.default.tenantSlug),
   };
-}
-
-export function resolveConfigPath(
-  flagConfig: string | undefined,
-  env: NodeJS.ProcessEnv,
-  homedir: () => string,
-): string {
-  const fromFlag = flagConfig;
-  const fromEnv = env.OBJECTIFIED_CONFIG;
-  const raw = firstNonEmpty(fromFlag, fromEnv);
-  if (raw === undefined) return path.join(homedir(), ".config/objectified/config.toml");
-  if (raw.startsWith("~/")) return path.join(homedir(), raw.slice(2));
-  return raw;
-}
-
-export function resolveProfile(flag: string | undefined, env: NodeJS.ProcessEnv): string {
-  return firstNonEmpty(flag, env.OBJECTIFIED_PROFILE) ?? "default";
 }
 
 export function resolveBaseUrl(
@@ -75,12 +82,20 @@ export function resolveBaseUrl(
   return firstNonEmpty(flag, env.OBJECTIFIED_BASE_URL, cfg.baseUrl) ?? DEFAULT_BASE_URL;
 }
 
+/** API keys never come from config.toml (#3188); flag and env only until keychain lands. */
 export function resolveApiKey(
   flag: string | undefined,
   env: NodeJS.ProcessEnv,
-  cfg: { apiKey?: string },
 ): string | undefined {
-  return firstNonEmpty(flag, env.OBJECTIFIED_API_KEY, cfg.apiKey);
+  return firstNonEmpty(flag, env.OBJECTIFIED_API_KEY);
+}
+
+export function resolveTenantSlug(
+  flag: string | undefined,
+  env: NodeJS.ProcessEnv,
+  cfg: { tenantSlug?: string },
+): string | undefined {
+  return firstNonEmpty(flag, env.OBJECTIFIED_TENANT, cfg.tenantSlug);
 }
 
 export function resolveJson(
@@ -120,11 +135,14 @@ export function buildObjectifiedContext(opts: {
   configDoc: ParsedTomlConfig;
   configPath: string;
 }): { context: ObjectifiedContext; verboseEffective: boolean; configPath: string } {
-  const profile = resolveProfile(opts.flags.profile, opts.env);
+  const profile = resolveEffectiveProfile(opts.flags.profile, opts.env, opts.configDoc);
+  assertProfileExists(opts.configDoc, profile);
+
   const cfgLayer = configLayerForProfile(opts.configDoc, profile);
 
   const baseUrl = resolveBaseUrl(opts.flags.baseUrl, opts.env, cfgLayer);
-  const apiKey = resolveApiKey(opts.flags.apiKey, opts.env, cfgLayer);
+  const apiKey = resolveApiKey(opts.flags.apiKey, opts.env);
+  const tenantSlug = resolveTenantSlug(undefined, opts.env, cfgLayer);
 
   const json = resolveJson(opts.flags.json, opts.env, opts.stdoutIsTTY);
   const color = resolveAllowColor(
@@ -141,6 +159,7 @@ export function buildObjectifiedContext(opts: {
       baseUrl,
       profile,
       apiKey,
+      tenantSlug,
       json,
       color,
     },

--- a/objectified-cli/src/lib/config.ts
+++ b/objectified-cli/src/lib/config.ts
@@ -70,8 +70,9 @@ export function loadTomlConfigFile(configFilePath: string): ParsedTomlConfig {
     return parseTomlConfig(content);
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err);
-    throw new Error(
+    throw new CliError(
       `Failed to parse config file "${configFilePath}": ${msg}\nHint: Use --config or OBJECTIFIED_CONFIG to point to a valid TOML file.`,
+      11,
     );
   }
 }
@@ -127,8 +128,16 @@ function chmodConfigFile(configPath: string): void {
 
 /** Creates parent dirs and a default `config.toml` when missing (permissions `0600` on Unix). */
 export async function ensureDefaultConfigFile(configPath: string): Promise<void> {
-  const exists = await fse.pathExists(configPath);
-  if (exists) return;
+  if (await fse.pathExists(configPath)) {
+    const stat = await fse.stat(configPath);
+    if (!stat.isFile()) {
+      throw new CliError(
+        `Config path "${configPath}" exists but is not a regular file; remove it or set a different path via --config or OBJECTIFIED_CONFIG.`,
+        11,
+      );
+    }
+    return;
+  }
   await fse.ensureDir(path.dirname(configPath));
   await fse.writeFile(configPath, defaultConfigToml(), { encoding: "utf8", mode: 0o600 });
   chmodConfigFile(configPath);
@@ -170,15 +179,37 @@ export function saveRawTomlDocument(configPath: string, doc: RawTomlDoc): void {
 export function splitDottedKey(key: string): string[] {
   const trimmed = key.trim();
   if (trimmed === "") throw new CliError("Config key must not be empty.", 11);
-  return trimmed
-    .split(".")
-    .map((p) => p.trim())
-    .filter(Boolean);
+  const parts = trimmed.split(".").map((p) => p.trim());
+  if (parts.some((p) => p === "")) {
+    throw new CliError(
+      `Config key "${key}" contains an empty segment; use dotted.key notation with no consecutive or trailing dots.`,
+      11,
+    );
+  }
+  return parts;
 }
 
 export function assertWritableConfigKey(dottedKey: string): void {
-  const lower = dottedKey.toLowerCase();
-  if (lower.includes("api_key") || lower.includes("refresh_token")) {
+  // Normalize each segment: lowercase + strip underscores/hyphens to catch
+  // camelCase and snake_case variants (e.g. apiKey, api-key, api_key → apikey).
+  const normalizedSegments = dottedKey
+    .toLowerCase()
+    .split(".")
+    .map((s) => s.replace(/[-_]/g, ""));
+  const secretKeywords = [
+    "apikey",
+    "accesstoken",
+    "refreshtoken",
+    "token",
+    "secret",
+    "password",
+    "credential",
+    "privatekey",
+  ];
+  const isSecret = normalizedSegments.some((seg) =>
+    secretKeywords.some((kw) => seg.includes(kw)),
+  );
+  if (isSecret) {
     throw new CliError(
       "Secrets are not stored in config.toml; use the OS keychain when implemented (see roadmap).",
       11,

--- a/objectified-cli/src/lib/config.ts
+++ b/objectified-cli/src/lib/config.ts
@@ -199,7 +199,8 @@ export function assertWritableConfigKey(dottedKey: string): void {
   // Compound keywords are specific enough to use as substrings safely.
   const substringKeywords = ["apikey", "accesstoken", "refreshtoken", "privatekey"];
   // Short/generic keywords use exact segment matching to avoid false positives
-  // (e.g. "notification" should not be blocked even though "notif-i-c-a-t-i-o-n" ≠ "token").
+  // (e.g. "reset_token_count" → "resettokencount" should not be blocked since
+  // the normalized segment does not exactly equal "token").
   const exactKeywords = new Set(["token", "secret", "password", "credential"]);
   const isSecret = normalizedSegments.some(
     (seg) => exactKeywords.has(seg) || substringKeywords.some((kw) => seg.includes(kw)),

--- a/objectified-cli/src/lib/config.ts
+++ b/objectified-cli/src/lib/config.ts
@@ -1,13 +1,29 @@
 import fs from "node:fs";
+import path from "node:path";
 
 import TOML from "@iarna/toml";
+import envPaths from "env-paths";
+import fse from "fs-extra";
+
+import { DEFAULT_BASE_URL } from "./constants.js";
+import { CliError } from "./errors.js";
+
+function firstNonEmpty(...vals: (string | undefined)[]): string | undefined {
+  for (const v of vals) {
+    if (v !== undefined && v !== "") return v;
+  }
+  return undefined;
+}
 
 export type ProfileValues = {
   baseUrl?: string;
-  apiKey?: string;
+  tenantSlug?: string;
 };
 
 export type ParsedTomlConfig = {
+  /** From `default_profile` when unset, commands use profile name `"default"`. */
+  defaultProfile?: string;
+  /** Values from `[default]` merged under every named profile. */
   default: ProfileValues;
   profiles: Record<string, ProfileValues>;
 };
@@ -16,13 +32,17 @@ function readProfileTable(raw: unknown): ProfileValues {
   if (!raw || typeof raw !== "object" || Array.isArray(raw)) return {};
   const o = raw as Record<string, unknown>;
   const baseUrl = typeof o.base_url === "string" ? o.base_url : undefined;
-  const apiKey = typeof o.api_key === "string" ? o.api_key : undefined;
-  return { baseUrl, apiKey };
+  const tenantSlug = typeof o.tenant_slug === "string" ? o.tenant_slug : undefined;
+  return { baseUrl, tenantSlug };
 }
 
-/** Normalize TOML root: `[default]` and `[profile.NAME]` sections per roadmap #3187. */
+/** Normalize TOML: `default_profile`, `[default]`, and `[profile.NAME]` (#3188). */
 export function parseTomlConfig(content: string): ParsedTomlConfig {
   const doc = TOML.parse(content) as Record<string, unknown>;
+  const defaultProfile =
+    typeof doc.default_profile === "string" && doc.default_profile !== ""
+      ? doc.default_profile
+      : undefined;
   const def = readProfileTable(doc.default);
   const profiles: Record<string, ProfileValues> = {};
   const profileRoot = doc.profile;
@@ -31,7 +51,7 @@ export function parseTomlConfig(content: string): ParsedTomlConfig {
       profiles[name] = readProfileTable(section);
     }
   }
-  return { default: def, profiles };
+  return { defaultProfile, default: def, profiles };
 }
 
 export function loadTomlConfigFile(configFilePath: string): ParsedTomlConfig {
@@ -54,4 +74,146 @@ export function loadTomlConfigFile(configFilePath: string): ParsedTomlConfig {
       `Failed to parse config file "${configFilePath}": ${msg}\nHint: Use --config or OBJECTIFIED_CONFIG to point to a valid TOML file.`,
     );
   }
+}
+
+/** Linux: `env-paths` (XDG). macOS / other Unix: `$XDG_CONFIG_HOME/objectified` per #3188. Windows: `%APPDATA%\\Objectified`. */
+export function defaultConfigDirectory(env: NodeJS.ProcessEnv, homedir: () => string): string {
+  if (process.platform === "win32") {
+    const appData = env.APPDATA || path.win32.join(homedir(), "AppData", "Roaming");
+    return path.win32.join(appData, "Objectified");
+  }
+  if (process.platform === "linux") {
+    return envPaths("objectified", { suffix: "" }).config;
+  }
+  return path.join(env.XDG_CONFIG_HOME || path.join(homedir(), ".config"), "objectified");
+}
+
+export function defaultConfigFilePath(env: NodeJS.ProcessEnv, homedir: () => string): string {
+  const dir = defaultConfigDirectory(env, homedir);
+  return process.platform === "win32"
+    ? path.win32.join(dir, "config.toml")
+    : path.join(dir, "config.toml");
+}
+
+export function resolveConfigFilePath(
+  flagConfig: string | undefined,
+  env: NodeJS.ProcessEnv,
+  homedir: () => string,
+): string {
+  const raw = firstNonEmpty(flagConfig, env.OBJECTIFIED_CONFIG);
+  if (raw === undefined) return defaultConfigFilePath(env, homedir);
+  if (raw.startsWith("~/")) return path.join(homedir(), raw.slice(2));
+  return raw;
+}
+
+export function defaultConfigToml(): string {
+  return [
+    `default_profile = "default"`,
+    "",
+    "[profile.default]",
+    `base_url = "${DEFAULT_BASE_URL}"`,
+    "",
+  ].join("\n");
+}
+
+function chmodConfigFile(configPath: string): void {
+  if (process.platform === "win32") return;
+  try {
+    fs.chmodSync(configPath, 0o600);
+  } catch {
+    /* ignore chmod failures on exotic filesystems */
+  }
+}
+
+/** Creates parent dirs and a default `config.toml` when missing (permissions `0600` on Unix). */
+export async function ensureDefaultConfigFile(configPath: string): Promise<void> {
+  const exists = await fse.pathExists(configPath);
+  if (exists) return;
+  await fse.ensureDir(path.dirname(configPath));
+  await fse.writeFile(configPath, defaultConfigToml(), { encoding: "utf8", mode: 0o600 });
+  chmodConfigFile(configPath);
+}
+
+/** Parsed TOML root document (`@iarna/toml` shape). */
+export type RawTomlDoc = ReturnType<typeof TOML.parse>;
+
+export function loadRawTomlDocument(configPath: string): RawTomlDoc {
+  let content: string;
+  try {
+    content = fs.readFileSync(configPath, "utf8");
+  } catch (err: unknown) {
+    const code =
+      typeof err === "object" && err && "code" in err
+        ? (err as NodeJS.ErrnoException).code
+        : undefined;
+    if (code === "ENOENT") {
+      const empty: RawTomlDoc = {};
+      return empty;
+    }
+    throw err;
+  }
+  try {
+    return TOML.parse(content);
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new CliError(`Invalid TOML in "${configPath}": ${msg}`, 11);
+  }
+}
+
+export function saveRawTomlDocument(configPath: string, doc: RawTomlDoc): void {
+  fse.ensureDirSync(path.dirname(configPath));
+  const body = TOML.stringify(doc);
+  fs.writeFileSync(configPath, body, { encoding: "utf8", mode: 0o600 });
+  chmodConfigFile(configPath);
+}
+
+export function splitDottedKey(key: string): string[] {
+  const trimmed = key.trim();
+  if (trimmed === "") throw new CliError("Config key must not be empty.", 11);
+  return trimmed
+    .split(".")
+    .map((p) => p.trim())
+    .filter(Boolean);
+}
+
+export function assertWritableConfigKey(dottedKey: string): void {
+  const lower = dottedKey.toLowerCase();
+  if (lower.includes("api_key") || lower.includes("refresh_token")) {
+    throw new CliError(
+      "Secrets are not stored in config.toml; use the OS keychain when implemented (see roadmap).",
+      11,
+    );
+  }
+}
+
+export function getNestedValue(doc: RawTomlDoc, parts: string[]): unknown {
+  let cur: unknown = doc;
+  for (const p of parts) {
+    if (!cur || typeof cur !== "object" || Array.isArray(cur)) return undefined;
+    cur = (cur as RawTomlDoc)[p];
+  }
+  return cur;
+}
+
+export function setNestedValue(doc: RawTomlDoc, parts: string[], value: string): void {
+  if (parts.length === 0) throw new CliError("Config key must include at least one segment.", 11);
+  const leaf = parts[parts.length - 1];
+  if (leaf === undefined) throw new CliError("Config key must include at least one segment.", 11);
+
+  let cur: RawTomlDoc = doc;
+  for (const segment of parts.slice(0, -1)) {
+    const next = cur[segment];
+    if (next === undefined || typeof next !== "object" || Array.isArray(next)) {
+      cur[segment] = {};
+    }
+    cur = cur[segment] as RawTomlDoc;
+  }
+  cur[leaf] = value;
+}
+
+export function formatConfigScalar(value: unknown): string {
+  if (value === undefined || value === null) return "";
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  throw new CliError("Value is not a scalar; use `objectified config list`.", 11);
 }

--- a/objectified-cli/src/lib/config.ts
+++ b/objectified-cli/src/lib/config.ts
@@ -196,18 +196,13 @@ export function assertWritableConfigKey(dottedKey: string): void {
     .toLowerCase()
     .split(".")
     .map((s) => s.replace(/[-_]/g, ""));
-  const secretKeywords = [
-    "apikey",
-    "accesstoken",
-    "refreshtoken",
-    "token",
-    "secret",
-    "password",
-    "credential",
-    "privatekey",
-  ];
-  const isSecret = normalizedSegments.some((seg) =>
-    secretKeywords.some((kw) => seg.includes(kw)),
+  // Compound keywords are specific enough to use as substrings safely.
+  const substringKeywords = ["apikey", "accesstoken", "refreshtoken", "privatekey"];
+  // Short/generic keywords use exact segment matching to avoid false positives
+  // (e.g. "notification" should not be blocked even though "notif-i-c-a-t-i-o-n" ≠ "token").
+  const exactKeywords = new Set(["token", "secret", "password", "credential"]);
+  const isSecret = normalizedSegments.some(
+    (seg) => exactKeywords.has(seg) || substringKeywords.some((kw) => seg.includes(kw)),
   );
   if (isSecret) {
     throw new CliError(

--- a/objectified-cli/src/lib/constants.ts
+++ b/objectified-cli/src/lib/constants.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_BASE_URL = "https://api.objectified.dev";

--- a/objectified-cli/test/cli-context.test.ts
+++ b/objectified-cli/test/cli-context.test.ts
@@ -1,14 +1,20 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  assertProfileExists,
   buildObjectifiedContext,
-  DEFAULT_BASE_URL,
+  configLayerForProfile,
+  listAvailableProfileNames,
   resolveAllowColor,
   resolveApiKey,
+  resolveEffectiveProfile,
   resolveJson,
+  resolveTenantSlug,
   resolveVerbose,
 } from "../src/lib/cli-context.js";
 import { parseTomlConfig } from "../src/lib/config.js";
+import { DEFAULT_BASE_URL } from "../src/lib/constants.js";
+import { CliError } from "../src/lib/errors.js";
 
 function docFromToml(): ReturnType<typeof parseTomlConfig> {
   return parseTomlConfig(`
@@ -17,7 +23,6 @@ base_url = "https://cfg-default.example"
 
 [profile.prod]
 base_url = "https://cfg-prod.example"
-api_key = "cfg-prod-key"
 
 [profile.staging]
 base_url = "https://cfg-staging.example"
@@ -64,7 +69,7 @@ describe("cli-context resolution", () => {
 
     expect(
       buildObjectifiedContext({
-        flags: { profile: "unknown" },
+        flags: {},
         env: {},
         stdoutIsTTY: tty,
         supportsColorStdout: true,
@@ -72,6 +77,17 @@ describe("cli-context resolution", () => {
         configPath: "/tmp/fake/objectified/config.toml",
       }).context.baseUrl,
     ).toBe("https://cfg-default.example");
+
+    expect(() =>
+      buildObjectifiedContext({
+        flags: { profile: "unknown" },
+        env: {},
+        stdoutIsTTY: tty,
+        supportsColorStdout: true,
+        configDoc: doc,
+        configPath: "/tmp/fake/objectified/config.toml",
+      }),
+    ).toThrow(CliError);
 
     expect(
       buildObjectifiedContext({
@@ -85,22 +101,88 @@ describe("cli-context resolution", () => {
     ).toBe(DEFAULT_BASE_URL);
   });
 
-  it("resolves API key: flag > env > profile config > default config", () => {
+  it("resolves effective profile: flag > OBJECTIFIED_PROFILE > default_profile > default", () => {
     const doc = parseTomlConfig(`
-[default]
-api_key = "cfg-default-key"
+default_profile = "staging"
 
 [profile.prod]
-api_key = "cfg-prod-key"
+base_url = "https://prod.example"
+
+[profile.staging]
+base_url = "https://staging.example"
 `);
 
+    expect(resolveEffectiveProfile(undefined, {}, doc)).toBe("staging");
+
+    expect(resolveEffectiveProfile("prod", {}, doc)).toBe("prod");
+
+    expect(resolveEffectiveProfile(undefined, { OBJECTIFIED_PROFILE: "prod" }, doc)).toBe("prod");
+
     expect(
-      resolveApiKey("flag-key", { OBJECTIFIED_API_KEY: "env-key" }, { apiKey: "cfg-key" }),
-    ).toBe("flag-key");
-    expect(
-      resolveApiKey(undefined, { OBJECTIFIED_API_KEY: "env-key" }, { apiKey: "cfg-key" }),
-    ).toBe("env-key");
-    expect(resolveApiKey(undefined, {}, { apiKey: "cfg-key" })).toBe("cfg-key");
+      resolveEffectiveProfile(undefined, {}, parseTomlConfig(`[profile.x]\nbase_url="y"`)),
+    ).toBe("default");
+  });
+
+  it("rejects a missing named profile with a friendly message", () => {
+    const doc = parseTomlConfig(`
+[profile.prod]
+base_url = "https://prod.example"
+`);
+    expect(() =>
+      buildObjectifiedContext({
+        flags: { profile: "staging" },
+        env: {},
+        stdoutIsTTY: true,
+        supportsColorStdout: true,
+        configDoc: doc,
+        configPath: "/tmp/cfg.toml",
+      }),
+    ).toThrow(CliError);
+
+    try {
+      buildObjectifiedContext({
+        flags: { profile: "staging" },
+        env: {},
+        stdoutIsTTY: true,
+        supportsColorStdout: true,
+        configDoc: doc,
+        configPath: "/tmp/cfg.toml",
+      });
+    } catch (e) {
+      expect(e).toBeInstanceOf(CliError);
+      expect((e as CliError).message).toMatch(/Profile 'staging' not found/);
+      expect((e as CliError).message).toMatch(/Available:/);
+      expect((e as CliError).exitCode).toBe(11);
+    }
+  });
+
+  it("lists available profile names including implicit default", () => {
+    const doc = parseTomlConfig(`
+[profile.prod]
+base_url = "https://x"
+`);
+    expect(listAvailableProfileNames(doc)).toEqual(["default", "prod"]);
+  });
+
+  it("assertProfileExists allows default without profile.default table", () => {
+    const doc = parseTomlConfig(`[profile.prod]\nbase_url="https://x"`);
+    expect(() => assertProfileExists(doc, "default")).not.toThrow();
+    expect(() => assertProfileExists(doc, "prod")).not.toThrow();
+    expect(() => assertProfileExists(doc, "nope")).toThrow(CliError);
+  });
+
+  it("resolves API key from flag and env only (never from config file)", () => {
+    expect(resolveApiKey("flag-key", { OBJECTIFIED_API_KEY: "env-key" })).toBe("flag-key");
+    expect(resolveApiKey(undefined, { OBJECTIFIED_API_KEY: "env-key" })).toBe("env-key");
+    expect(resolveApiKey(undefined, {})).toBe(undefined);
+
+    const doc = parseTomlConfig(`
+[default]
+api_key = "ignored"
+
+[profile.prod]
+api_key = "ignored"
+`);
     expect(
       buildObjectifiedContext({
         flags: { profile: "prod" },
@@ -110,18 +192,49 @@ api_key = "cfg-prod-key"
         configDoc: doc,
         configPath: "/tmp/fake/objectified/config.toml",
       }).context.apiKey,
-    ).toBe("cfg-prod-key");
+    ).toBe(undefined);
 
     expect(
       buildObjectifiedContext({
-        flags: { profile: "staging" },
+        flags: { profile: "prod", apiKey: "flag" },
         env: {},
         stdoutIsTTY: true,
         supportsColorStdout: true,
         configDoc: doc,
         configPath: "/tmp/fake/objectified/config.toml",
       }).context.apiKey,
-    ).toBe("cfg-default-key");
+    ).toBe("flag");
+
+    expect(
+      buildObjectifiedContext({
+        flags: { profile: "prod" },
+        env: { OBJECTIFIED_API_KEY: "envk" },
+        stdoutIsTTY: true,
+        supportsColorStdout: true,
+        configDoc: doc,
+        configPath: "/tmp/fake/objectified/config.toml",
+      }).context.apiKey,
+    ).toBe("envk");
+  });
+
+  it("resolves tenant slug: env > profile overlay > default section", () => {
+    const doc = parseTomlConfig(`
+[default]
+tenant_slug = "tenant-default"
+
+[profile.prod]
+tenant_slug = "tenant-prod"
+`);
+    expect(resolveTenantSlug(undefined, {}, configLayerForProfile(doc, "prod"))).toBe(
+      "tenant-prod",
+    );
+    expect(
+      resolveTenantSlug(
+        undefined,
+        { OBJECTIFIED_TENANT: "env-tenant" },
+        configLayerForProfile(doc, "prod"),
+      ),
+    ).toBe("env-tenant");
   });
 
   it("resolves JSON: flag > OBJECTIFIED_JSON > auto when stdout is not a TTY", () => {
@@ -140,17 +253,11 @@ api_key = "cfg-prod-key"
   });
 
   it("disables color for --no-color, NO_COLOR, or non-TTY; enables with --color", () => {
-    // --no-color explicitly disables (color flag = false)
     expect(resolveAllowColor(false, {}, true, true)).toBe(false);
-    // --color explicitly enables even without TTY
     expect(resolveAllowColor(true, {}, false, false)).toBe(true);
-    // NO_COLOR env var disables
     expect(resolveAllowColor(undefined, { NO_COLOR: "1" }, true, true)).toBe(false);
-    // non-TTY disables when not explicitly set
     expect(resolveAllowColor(undefined, {}, false, true)).toBe(false);
-    // no color support disables
     expect(resolveAllowColor(undefined, {}, true, false)).toBe(false);
-    // TTY + color support with no flag → enabled
     expect(resolveAllowColor(undefined, {}, true, true)).toBe(true);
   });
 

--- a/objectified-cli/test/cli.integration.test.ts
+++ b/objectified-cli/test/cli.integration.test.ts
@@ -1,4 +1,6 @@
 import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
 import { performance } from "node:perf_hooks";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -8,11 +10,26 @@ import { describe, expect, it } from "vitest";
 const pkgRoot = path.join(path.dirname(fileURLToPath(import.meta.url)), "..");
 
 function run(args: string[], extraEnv: Record<string, string> = {}): string {
+  const env = { ...process.env, FORCE_COLOR: "0", ...extraEnv };
+  delete env.NODE_OPTIONS;
   return execFileSync("node", [path.join(pkgRoot, "bin/run.js"), ...args], {
     cwd: pkgRoot,
     encoding: "utf8",
-    env: { ...process.env, FORCE_COLOR: "0", ...extraEnv },
+    env,
   });
+}
+
+function runExpectFailure(args: string[], extraEnv: Record<string, string> = {}): string {
+  try {
+    run(args, extraEnv);
+    throw new Error(`Expected command to fail: ${args.join(" ")}`);
+  } catch (err: unknown) {
+    if (err && typeof err === "object" && "stderr" in err) {
+      const se = (err as { stderr: Buffer | string }).stderr;
+      return typeof se === "string" ? se : se.toString("utf8");
+    }
+    throw err;
+  }
 }
 
 describe("objectified CLI", () => {
@@ -26,7 +43,7 @@ describe("objectified CLI", () => {
     expect(out).toContain("VERSION");
     expect(out).toContain("COMMANDS");
     expect(out).toContain("GLOBAL FLAGS");
-    expect(out).toContain("Resolution order");
+    expect(out).toContain("Resolution order for base URL");
     expect(out).toContain("--base-url");
   });
 
@@ -51,6 +68,59 @@ describe("objectified CLI", () => {
   it("outputs JSON for projects list with global flags before subcommand", () => {
     const out = run(["--json", "projects", "list"]);
     expect(JSON.parse(out.trim())).toEqual({ projects: [] });
+  });
+
+  it("config path respects OBJECTIFIED_CONFIG", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "obj-cli-int-"));
+    const cfg = path.join(dir, "objectified.toml");
+    const out = run(["--no-json", "config", "path"], { OBJECTIFIED_CONFIG: cfg }).trim();
+    expect(out).toBe(cfg);
+    expect(fs.existsSync(cfg)).toBe(true);
+  });
+
+  it("config get reads default_profile after auto-create", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "obj-cli-int-"));
+    const cfg = path.join(dir, "c.toml");
+    const out = run(["--no-json", "config", "get", "default_profile"], {
+      OBJECTIFIED_CONFIG: cfg,
+    }).trim();
+    expect(out).toBe("default");
+  });
+
+  it("--profile staging uses [profile.staging] when present", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "obj-cli-prof-"));
+    const cfg = path.join(dir, "config.toml");
+    fs.writeFileSync(
+      cfg,
+      `
+default_profile = "prod"
+
+[profile.prod]
+base_url = "https://api.prod.example"
+
+[profile.staging]
+base_url = "https://api.staging.example"
+`,
+      "utf8",
+    );
+    const out = run(["--json", "--profile", "staging", "--config", cfg, "projects", "list"]).trim();
+    expect(JSON.parse(out)).toEqual({ projects: [] });
+  });
+
+  it("missing profile prints a friendly error", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "obj-cli-miss-"));
+    const cfg = path.join(dir, "config.toml");
+    fs.writeFileSync(
+      cfg,
+      `
+[profile.prod]
+base_url = "https://api.prod.example"
+`,
+      "utf8",
+    );
+    const err = runExpectFailure(["--profile", "staging", "--config", cfg, "projects", "list"]);
+    expect(err).toMatch(/Profile 'staging' not found/);
+    expect(err).toMatch(/Available:/);
   });
 
   it("suppresses hello stdout with --quiet", () => {

--- a/objectified-cli/test/config-path.test.ts
+++ b/objectified-cli/test/config-path.test.ts
@@ -5,11 +5,15 @@ import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
+  assertWritableConfigKey,
   defaultConfigDirectory,
   defaultConfigFilePath,
   ensureDefaultConfigFile,
+  loadTomlConfigFile,
   resolveConfigFilePath,
+  splitDottedKey,
 } from "../src/lib/config.js";
+import { CliError } from "../src/lib/errors.js";
 
 describe("config path resolution (#3188)", () => {
   const homedir = () => "/home/testuser";
@@ -76,5 +80,96 @@ describe("config path resolution (#3188)", () => {
     if (process.platform !== "win32") {
       expect((stat.mode & 0o777).toString(8)).toBe("600");
     }
+  });
+
+  it("ensureDefaultConfigFile: skips creation when file already exists", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "obj-cli-exists-"));
+    const cfg = path.join(dir, "config.toml");
+    fs.writeFileSync(cfg, "default_profile = \"default\"\n");
+    await ensureDefaultConfigFile(cfg); // should not throw
+    expect(fs.readFileSync(cfg, "utf8")).toBe("default_profile = \"default\"\n");
+  });
+
+  it("ensureDefaultConfigFile: throws CliError when path is a directory", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "obj-cli-dir-"));
+    const asDir = path.join(dir, "config.toml");
+    fs.mkdirSync(asDir);
+    await expect(ensureDefaultConfigFile(asDir)).rejects.toThrow(CliError);
+  });
+});
+
+describe("loadTomlConfigFile (#3188)", () => {
+  it("throws CliError on invalid TOML", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "obj-cli-parse-"));
+    const cfg = path.join(dir, "bad.toml");
+    fs.writeFileSync(cfg, "this is not valid toml = = =\n");
+    expect(() => loadTomlConfigFile(cfg)).toThrow(CliError);
+  });
+
+  it("CliError on parse failure has exit code 11", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "obj-cli-parse-"));
+    const cfg = path.join(dir, "bad.toml");
+    fs.writeFileSync(cfg, "[[broken\n");
+    let err: unknown;
+    try {
+      loadTomlConfigFile(cfg);
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(CliError);
+    expect((err as CliError).exitCode).toBe(11);
+  });
+});
+
+describe("splitDottedKey (#3188)", () => {
+  it("rejects keys with consecutive dots", () => {
+    expect(() => splitDottedKey("profile..prod")).toThrow(CliError);
+  });
+
+  it("rejects keys with a trailing dot", () => {
+    expect(() => splitDottedKey("profile.")).toThrow(CliError);
+  });
+
+  it("rejects keys with a leading dot", () => {
+    expect(() => splitDottedKey(".profile.prod")).toThrow(CliError);
+  });
+
+  it("accepts a valid dotted key", () => {
+    expect(splitDottedKey("profile.staging.base_url")).toEqual(["profile", "staging", "base_url"]);
+  });
+
+  it("rejects an empty key", () => {
+    expect(() => splitDottedKey("")).toThrow(CliError);
+  });
+});
+
+describe("assertWritableConfigKey (#3188)", () => {
+  const shouldBlock = [
+    "api_key",
+    "apiKey",
+    "apikey",
+    "profile.staging.api_key",
+    "access_token",
+    "accessToken",
+    "refresh_token",
+    "refreshToken",
+    "profile.prod.token",
+    "password",
+    "secret",
+    "credential",
+    "private_key",
+    "privateKey",
+  ];
+
+  for (const key of shouldBlock) {
+    it(`blocks secret key: ${key}`, () => {
+      expect(() => assertWritableConfigKey(key)).toThrow(CliError);
+    });
+  }
+
+  it("allows legitimate config keys", () => {
+    expect(() => assertWritableConfigKey("profile.staging.base_url")).not.toThrow();
+    expect(() => assertWritableConfigKey("profile.staging.tenant_slug")).not.toThrow();
+    expect(() => assertWritableConfigKey("default_profile")).not.toThrow();
   });
 });

--- a/objectified-cli/test/config-path.test.ts
+++ b/objectified-cli/test/config-path.test.ts
@@ -146,6 +146,7 @@ describe("splitDottedKey (#3188)", () => {
 describe("assertWritableConfigKey (#3188)", () => {
   const shouldBlock = [
     "api_key",
+    "api-key",
     "apiKey",
     "apikey",
     "profile.staging.api_key",

--- a/objectified-cli/test/config-path.test.ts
+++ b/objectified-cli/test/config-path.test.ts
@@ -1,0 +1,80 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  defaultConfigDirectory,
+  defaultConfigFilePath,
+  ensureDefaultConfigFile,
+  resolveConfigFilePath,
+} from "../src/lib/config.js";
+
+describe("config path resolution (#3188)", () => {
+  const homedir = () => "/home/testuser";
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it("uses OBJECTIFIED_CONFIG when set", () => {
+    vi.stubEnv("OBJECTIFIED_CONFIG", "/custom/objectified.toml");
+    expect(resolveConfigFilePath(undefined, process.env, homedir)).toBe("/custom/objectified.toml");
+  });
+
+  it("expands ~/ in OBJECTIFIED_CONFIG", () => {
+    vi.stubEnv("OBJECTIFIED_CONFIG", "~/foo/config.toml");
+    expect(resolveConfigFilePath(undefined, process.env, homedir)).toBe(
+      "/home/testuser/foo/config.toml",
+    );
+  });
+
+  it("prefers --config flag over OBJECTIFIED_CONFIG", () => {
+    vi.stubEnv("OBJECTIFIED_CONFIG", "/env.toml");
+    expect(resolveConfigFilePath("/flag.toml", process.env, homedir)).toBe("/flag.toml");
+  });
+
+  it("on Linux uses XDG_CONFIG_HOME/objectified (env-paths)", () => {
+    vi.stubEnv("XDG_CONFIG_HOME", "/xdg-config");
+    const spy = vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+    expect(defaultConfigDirectory(process.env, homedir)).toBe("/xdg-config/objectified");
+    expect(defaultConfigFilePath(process.env, homedir)).toBe("/xdg-config/objectified/config.toml");
+    spy.mockRestore();
+  });
+
+  it("on macOS uses ~/.config/objectified when XDG_CONFIG_HOME is unset", () => {
+    const spy = vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
+    expect(defaultConfigDirectory({}, homedir)).toBe("/home/testuser/.config/objectified");
+    spy.mockRestore();
+  });
+
+  it("on macOS respects XDG_CONFIG_HOME", () => {
+    const spy = vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
+    expect(defaultConfigDirectory({ XDG_CONFIG_HOME: "/xdg" }, homedir)).toBe("/xdg/objectified");
+    spy.mockRestore();
+  });
+
+  it("on Windows uses APPDATA\\\\Objectified\\\\config.toml", () => {
+    const spy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    vi.stubEnv("APPDATA", "C:\\Users\\Me\\AppData\\Roaming");
+    expect(defaultConfigDirectory(process.env, () => "C:\\Users\\Me")).toBe(
+      "C:\\Users\\Me\\AppData\\Roaming\\Objectified",
+    );
+    expect(resolveConfigFilePath(undefined, process.env, () => "C:\\Users\\Me")).toBe(
+      "C:\\Users\\Me\\AppData\\Roaming\\Objectified\\config.toml",
+    );
+    spy.mockRestore();
+  });
+
+  it("creates default config with mode 0600 on Unix", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "obj-cli-mode-"));
+    const cfg = path.join(dir, "config.toml");
+    await ensureDefaultConfigFile(cfg);
+    const stat = fs.statSync(cfg);
+    if (process.platform !== "win32") {
+      expect((stat.mode & 0o777).toString(8)).toBe("600");
+    }
+  });
+});

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -10,6 +10,7 @@ We continue to improve the platform based on your feedback with improvements and
 ## CLI
 - New **`objectified-cli`** package (oclif v4) adds the `objectified` binary scaffold with `hello`, `--version`, and `--help` (#3186).
 - **`objectified-cli`**: shared global flags on `BaseCommand` (`--base-url`, `--profile`, `--api-key`, `--config`, `--json`, `--no-color`, `--quiet`, `--verbose`), TOML profile resolution, root help text for precedence rules, argv normalization for globals-before-subcommand, and stub `projects list` (#3187).
+- **`objectified-cli`**: TOML config with XDG / Windows paths, `default_profile`, `objectified config path|get|set|list`, auto-created `config.toml` (`0600` on Unix), strict profile validation, env-based API keys only, and tenant slug from config/env (#3188).
 
 ## Import
 - Race condition fixed in 3.0.1 specification imports

--- a/yarn.lock
+++ b/yarn.lock
@@ -6071,6 +6071,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/fs-extra@npm:^11.0.4":
+  version: 11.0.4
+  resolution: "@types/fs-extra@npm:11.0.4"
+  dependencies:
+    "@types/jsonfile": "npm:*"
+    "@types/node": "npm:*"
+  checksum: 10c0/9e34f9b24ea464f3c0b18c3f8a82aefc36dc524cc720fc2b886e5465abc66486ff4e439ea3fb2c0acebf91f6d3f74e514f9983b1f02d4243706bdbb7511796ad
+  languageName: node
+  linkType: hard
+
 "@types/geojson@npm:*":
   version: 7946.0.16
   resolution: "@types/geojson@npm:7946.0.16"
@@ -6160,6 +6170,15 @@ __metadata:
   version: 0.0.29
   resolution: "@types/json5@npm:0.0.29"
   checksum: 10c0/6bf5337bc447b706bb5b4431d37686aa2ea6d07cfd6f79cc31de80170d6ff9b1c7384a9c0ccbc45b3f512bae9e9f75c2e12109806a15331dc94e8a8db6dbb4ac
+  languageName: node
+  linkType: hard
+
+"@types/jsonfile@npm:*":
+  version: 6.1.4
+  resolution: "@types/jsonfile@npm:6.1.4"
+  dependencies:
+    "@types/node": "npm:*"
+  checksum: 10c0/b12d068b021e4078f6ac4441353965769be87acf15326173e2aea9f3bf8ead41bd0ad29421df5bbeb0123ec3fc02eb0a734481d52903704a1454a1845896b9eb
   languageName: node
   linkType: hard
 
@@ -8721,6 +8740,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"env-paths@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "env-paths@npm:4.0.0"
+  dependencies:
+    is-safe-filename: "npm:^0.1.0"
+  checksum: 10c0/13ee7fa4047786ca28f1fbf2239606f8a53304bdf71bfc426e95f806e429060181205316f2c45b4ac560e81c854ded5a45fd9dc3105414c01d504b3469a1294b
+  languageName: node
+  linkType: hard
+
 "error-ex@npm:^1.3.1":
   version: 1.3.4
   resolution: "error-ex@npm:1.3.4"
@@ -9662,6 +9690,17 @@ __metadata:
     react-dom:
       optional: true
   checksum: 10c0/bca830d85606ba49e84a1b12fb2b5353622a992809a4ae302084f06fd142e21d790f07ca3678c27e4fb75a8b8e687f42f2ae0cbb13345f2e5730a3fa2c4a5ecf
+  languageName: node
+  linkType: hard
+
+"fs-extra@npm:^11.3.5":
+  version: 11.3.5
+  resolution: "fs-extra@npm:11.3.5"
+  dependencies:
+    graceful-fs: "npm:^4.2.0"
+    jsonfile: "npm:^6.0.1"
+    universalify: "npm:^2.0.0"
+  checksum: 10c0/33e80bad6b5d17308faa197e5ede99ecba4b6f6cb4aa4645d52745476c75afc57665bdf39ec75b2ebb38b97b7110f634a8dcc0a546e248eb4de059275cf5ac90
   languageName: node
   linkType: hard
 
@@ -10715,6 +10754,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-safe-filename@npm:^0.1.0":
+  version: 0.1.1
+  resolution: "is-safe-filename@npm:0.1.1"
+  checksum: 10c0/45c35d2253b96348e2c26590e14feed51d1e6b72aaa567930ccb34e68c0eef00ebcf3b7e01b46bf45e578a27355cd8f5bc12f7d6d79a34d33dc93d4560c0f6b6
+  languageName: node
+  linkType: hard
+
 "is-set@npm:^2.0.3":
   version: 2.0.3
   resolution: "is-set@npm:2.0.3"
@@ -11584,6 +11630,19 @@ __metadata:
     graceful-fs:
       optional: true
   checksum: 10c0/7dc94b628d57a66b71fb1b79510d460d662eb975b5f876d723f81549c2e9cd316d58a2ddf742b2b93a4fa6b17b2accaf1a738a0e2ea114bdfb13a32e5377e480
+  languageName: node
+  linkType: hard
+
+"jsonfile@npm:^6.0.1":
+  version: 6.2.1
+  resolution: "jsonfile@npm:6.2.1"
+  dependencies:
+    graceful-fs: "npm:^4.1.6"
+    universalify: "npm:^2.0.0"
+  dependenciesMeta:
+    graceful-fs:
+      optional: true
+  checksum: 10c0/e1abf000ecee9942d4d028a8e02dc752617face227d72afd1cfb2187e2433079e625bf82b807a313689db71b6472c6b2b389a2340d2798737b1199a39631c28a
   languageName: node
   linkType: hard
 
@@ -13308,11 +13367,14 @@ __metadata:
     "@oclif/core": "npm:^4.11.0"
     "@oclif/plugin-help": "npm:^6.2.46"
     "@oclif/plugin-version": "npm:^2.2.43"
+    "@types/fs-extra": "npm:^11.0.4"
     "@types/node": "npm:^22.10.0"
     "@types/supports-color": "npm:^10.0.0"
     chalk: "npm:^5.6.2"
+    env-paths: "npm:^4.0.0"
     eslint: "npm:^9.39.4"
     eslint-config-prettier: "npm:^10.1.1"
+    fs-extra: "npm:^11.3.5"
     oclif: "npm:^4.23.0"
     prettier: "npm:^3.6.2"
     shx: "npm:^0.4.0"
@@ -16217,6 +16279,13 @@ __metadata:
   version: 0.1.2
   resolution: "universalify@npm:0.1.2"
   checksum: 10c0/e70e0339f6b36f34c9816f6bf9662372bd241714dc77508d231d08386d94f2c4aa1ba1318614f92015f40d45aae1b9075cd30bd490efbe39387b60a76ca3f045
+  languageName: node
+  linkType: hard
+
+"universalify@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "universalify@npm:2.0.1"
+  checksum: 10c0/73e8ee3809041ca8b818efb141801a1004e3fc0002727f1531f4de613ea281b494a40909596dae4a042a4fb6cd385af5d4db2e137b1362e0e91384b828effd3a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What changed
- Added file-backed TOML configuration with `default_profile`, `[profile.*]`, and `[default]` merging; resolved paths use **XDG** (`env-paths` on Linux, `$XDG_CONFIG_HOME/objectified` on macOS) and **%APPDATA%\\Objectified** on Windows.
- New commands: `objectified config path`, `config get`, `config set`, `config list`; default `config.toml` is created on first command run with mode **0600** on Unix.
- **API keys** are no longer read from config (flag/env only per issue); **tenant slug** is read from profile/`[default]` plus `OBJECTIFIED_TENANT`.
- Missing profile names produce exit code **11** with the requested hint text.
- Dependencies: `env-paths`, `fs-extra`; tests cover resolution order and path matrix.

## How to test
1. **Build CLI**: `cd objectified-cli && yarn build`.
2. **Temp config**: `export OBJECTIFIED_CONFIG=$(mktemp)` then run `node bin/run.js --no-json config path` and confirm the path prints and file is created.
3. **Profiles**: write a TOML with `[profile.staging]` and run `objectified --profile staging projects list`; use a bad profile and confirm the friendly error on stderr.
4. **Unit tests**: `yarn workspace objectified-cli test`.

## Risks / notes
- Full monorepo `yarn build` was not completed here because `objectified-mcp` requires `uv` (missing in this environment); **objectified-cli** builds and tests cleanly via Turbo filter and local `yarn test`.
- Root help duplicates `DEFAULT_BASE_URL` string (see comment in `help.ts`) so Vitest subprocesses do not resolve source-mapped TS through an extra import graph.

Closes #3188

Made with [Cursor](https://cursor.com)