### PR TITLE
Fix #3189 - CLI output renderers (table/JSON/YAML, TTY, NO_COLOR)

### DIFF
--- a/docs/PLANNED_ROADMAP_CLI.md
+++ b/docs/PLANNED_ROADMAP_CLI.md
@@ -106,7 +106,6 @@ Total: **12 epics**, **88 sub-tickets** (open roadmap items; completed work is d
 
 | #         | Title                                                              | Description                                                                  | Labels                                          | MVP | Parallel |
 |-----------|--------------------------------------------------------------------|------------------------------------------------------------------------------|-------------------------------------------------|-----|----------|
-| 1.4 (#3189) | Output renderers (text/table/JSON/YAML)                          | `output.table/json/yaml/spinner`, NO_COLOR + TTY aware                       | `enhancement`, `mvp`, `cli`, `roadmap-cli`     | Yes | Yes      |
 | 1.5 (#3190) | Generated REST client from `openapi.yaml`                        | Codegen step, typed SDK, retry/refresh wrapper, single import path           | `enhancement`, `mvp`, `cli`, `roadmap-cli`, `typescript`, `openapi` | Yes | Yes      |
 | 1.6 (#3191) | Error handling, exit codes, retries, hints                       | `ObjectifiedCliError` hierarchy, sysexits-style exit codes, did-you-mean     | `enhancement`, `mvp`, `cli`, `roadmap-cli`     | Yes | Yes      |
 | 1.7 (#3192) | Help system, examples, man pages, `objectified docs`             | Rich help, ≥2 examples per command, generated man pages, `docs <topic>`     | `enhancement`, `mvp`, `cli`, `roadmap-cli`, `documentation` | Yes | Yes      |
@@ -164,9 +163,9 @@ Part of Epic: CLI Foundation & DevEx (#3174)
 
 ---
 
-#### 1.4 (#3189) — Output renderers
+#### 1.4 (#3189) — Output renderers (**done**)
 
-Single `lib/output.ts` module shared by every command:
+Landed: `src/lib/output.ts` exposes `createCliOutput()` with `table` (TTY → styled table / pipe → TSV / `--json` → stable sorted JSON array), `json` (pretty on TTY, compact when piped or `--quiet`), `yaml`, `text`, `kv`, `spinner` (ora on stderr; silent when non-TTY, `--json`, or `--quiet`), `success`, `warn`, `error` (stderr), plus `banner` / `hint`. `BaseCommand` exposes `this.output` wired to globals (`supports-color`, `LANG`/`LC_ALL` for ASCII borders when `LANG=C` or `--no-color`). Snapshot tests cover TTY vs pipe vs `--json`. Legacy helpers `logInfo` / `writeJsonLine` remain for narrow call sites.
 
 ```
             stdout TTY    stdout pipe   --json    --quiet
@@ -177,11 +176,7 @@ banner      shown         hidden       hidden    hidden
 errors      stderr+color  stderr       stderr    stderr (kept)
 ```
 
-`--json` overrides any default. JSON output is **stable** (sorted keys), errors always on stderr.
-
-**Acceptance Criteria:** snapshot tests cover TTY + non-TTY; `--json` valid for `jq`; tables ASCII-safe under `LANG=C`.
-
-**Parallelism / Dependencies:** Depends on 1.1, 1.2. Parallel with 1.3, 1.5, 1.6, 1.7.
+**Parallelism / Dependencies:** Depended on 1.1, 1.2. Parallel with 1.3, 1.5, 1.6, 1.7.
 
 Part of Epic: CLI Foundation & DevEx (#3174)
 
@@ -810,11 +805,11 @@ The `NPM_REGISTRY` env var lets us point at npmjs.com, GitHub Packages, JFrog Ar
 
 ## MVP Release — Ticket Bundle
 
-The MVP delivers an installable, useful CLI focused on _read_ and _publish_ for a single project's lifecycle. Total: **24 open sub-tickets** across 6 epics (plus completed foundation items such as #3186, #3187, and #3188).
+The MVP delivers an installable, useful CLI focused on _read_ and _publish_ for a single project's lifecycle. Total: **23 open sub-tickets** across 6 epics (plus completed foundation items such as #3186, #3187, #3188, and #3189).
 
 | Epic     | Tickets                                                                                                   | Count |
 |----------|-----------------------------------------------------------------------------------------------------------|-------|
-| 1 (#3174) | #3189, #3190, #3191, #3192                                                                                 | 4     |
+| 1 (#3174) | #3190, #3191, #3192                                                                                        | 3     |
 | 2 (#3175) | #3194, #3195, #3196, #3197, #3198, #3199                                                                  | 6     |
 | 3 (#3176) | #3202, #3203, #3204                                                                                        | 3     |
 | 4 (#3177) | #3208, #3209, #3210, #3212                                                                                | 4     |
@@ -902,7 +897,7 @@ v2 fills out the writable surface for primitives, properties, classes, paths, da
 
 The tickets were created in the order below — that is also the recommended **execution** order. Earlier epics provide primitives that later epics rely on.
 
-1. **Epic 1 — Foundation** (#3174: #3186, #3187, and #3188 landed; then #3189 → #3193). Without the scaffold, no other command can exist.
+1. **Epic 1 — Foundation** (#3174: #3186, #3187, #3188, and #3189 landed; then #3190 → #3193). Without the scaffold, no other command can exist.
 2. **Epic 2 — Auth & Tenants** (#3175 then #3194 → #3201). Required for any tenant-scoped command.
 3. **Epic 3 — Projects** (#3176 then #3202 → #3207). The first useful read/write surface.
 4. **Epic 4 — Versions** (#3177 then #3208 → #3216). The publish flow that makes the CLI valuable in CI.

--- a/objectified-cli/package.json
+++ b/objectified-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-cli",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Objectified command-line interface",
   "author": "Objectified",
   "type": "module",
@@ -43,9 +43,12 @@
     "@oclif/plugin-help": "^6.2.46",
     "@oclif/plugin-version": "^2.2.43",
     "chalk": "^5.6.2",
+    "cli-table3": "^0.6.5",
     "env-paths": "^4.0.0",
     "fs-extra": "^11.3.5",
-    "supports-color": "^10.2.2"
+    "ora": "^9.4.0",
+    "supports-color": "^10.2.2",
+    "yaml": "^2.8.4"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",

--- a/objectified-cli/src/base-command.ts
+++ b/objectified-cli/src/base-command.ts
@@ -17,6 +17,7 @@ import {
   type ParsedTomlConfig,
 } from "./lib/config.js";
 import { CliError } from "./lib/errors.js";
+import { createCliOutput, localePrefersAsciiTable, type CliOutput } from "./lib/output.js";
 
 export abstract class BaseCommand extends Command {
   static baseFlags = {
@@ -65,6 +66,23 @@ export abstract class BaseCommand extends Command {
 
   /** Parsed flags including globals and command-specific options. */
   declare flags: GlobalCliFlags & Record<string, unknown>;
+
+  private cliOutput?: CliOutput;
+
+  /** Shared renderers: tables, JSON/YAML, spinners, stderr warnings (TTY / --json / --quiet aware). */
+  protected get output(): CliOutput {
+    this.cliOutput ??= createCliOutput({
+      json: this.context.json,
+      color: this.context.color,
+      quiet: Boolean(this.flags.quiet),
+      stdoutIsTTY: process.stdout.isTTY,
+      stderrIsTTY: process.stderr.isTTY,
+      langAscii: localePrefersAsciiTable(process.env),
+      stdoutWrite: (chunk) => process.stdout.write(chunk),
+      stderrWrite: (chunk) => process.stderr.write(chunk),
+    });
+    return this.cliOutput;
+  }
 
   /** Resolved API/client context (flag > env > profile config > [default] > built-ins). */
   context!: ObjectifiedContext;

--- a/objectified-cli/src/commands/config/list.ts
+++ b/objectified-cli/src/commands/config/list.ts
@@ -3,18 +3,6 @@ import TOML from "@iarna/toml";
 import { BaseCommand } from "../../base-command.js";
 import { loadRawTomlDocument } from "../../lib/config.js";
 
-function sortKeysDeep(value: unknown): unknown {
-  if (Array.isArray(value)) return value.map(sortKeysDeep);
-  if (value && typeof value === "object") {
-    const o = value as Record<string, unknown>;
-    const sortedKeys = Object.keys(o).sort();
-    const out: Record<string, unknown> = {};
-    for (const k of sortedKeys) out[k] = sortKeysDeep(o[k]);
-    return out;
-  }
-  return value;
-}
-
 export default class ConfigList extends BaseCommand {
   static description = "Print the entire config file (stable JSON with --json, otherwise TOML)";
 
@@ -23,7 +11,7 @@ export default class ConfigList extends BaseCommand {
   run(): Promise<void> {
     const raw = loadRawTomlDocument(this.resolvedConfigPath);
     if (this.context.json) {
-      process.stdout.write(JSON.stringify(sortKeysDeep(raw), null, 2) + "\n");
+      this.output.json(raw);
       return Promise.resolve();
     }
     process.stdout.write(TOML.stringify(raw) + "\n");

--- a/objectified-cli/src/commands/hello.ts
+++ b/objectified-cli/src/commands/hello.ts
@@ -1,7 +1,7 @@
 import { Args } from "@oclif/core";
 
 import { BaseCommand } from "../base-command.js";
-import { logInfo, writeJsonLine } from "../lib/output.js";
+import { chalkForContext } from "../lib/output.js";
 
 export default class Hello extends BaseCommand {
   static description = "Smoke-test greeting for the Objectified CLI";
@@ -22,8 +22,11 @@ export default class Hello extends BaseCommand {
     const rawName = this.commandArgs.name;
     const who = typeof rawName === "string" ? rawName : "world";
     const message = `Hello ${who} from Objectified CLI`;
-    writeJsonLine(this, { message });
-    logInfo(this, message);
+    if (this.context.json) {
+      this.output.json({ message });
+    } else {
+      this.output.text(chalkForContext(this.context.color).bold(message));
+    }
     return Promise.resolve();
   }
 }

--- a/objectified-cli/src/commands/projects/list.ts
+++ b/objectified-cli/src/commands/projects/list.ts
@@ -1,5 +1,5 @@
 import { BaseCommand } from "../../base-command.js";
-import { logInfo, writeJsonLine } from "../../lib/output.js";
+import { chalkForContext } from "../../lib/output.js";
 
 export default class ProjectsList extends BaseCommand {
   static description = "List Objectified projects";
@@ -8,8 +8,11 @@ export default class ProjectsList extends BaseCommand {
 
   run(): Promise<void> {
     const payload = { projects: [] as unknown[] };
-    writeJsonLine(this, payload);
-    logInfo(this, "No projects yet.");
+    if (this.context.json) {
+      this.output.json(payload);
+    } else {
+      this.output.text(chalkForContext(this.context.color).bold("No projects yet."));
+    }
     return Promise.resolve();
   }
 }

--- a/objectified-cli/src/lib/output.ts
+++ b/objectified-cli/src/lib/output.ts
@@ -11,11 +11,17 @@ export function localePrefersAsciiTable(env: NodeJS.ProcessEnv): boolean {
 }
 
 /** Recursively sort object keys for stable JSON/YAML output. */
+function compareCodepoint(a: string, b: string): number {
+  if (a < b) return -1;
+  if (a > b) return 1;
+  return 0;
+}
+
 export function stableDeepSort(value: unknown): unknown {
   if (Array.isArray(value)) return value.map(stableDeepSort);
   if (value && typeof value === "object") {
     const o = value as Record<string, unknown>;
-    const sortedKeys = Object.keys(o).sort((a, b) => a.localeCompare(b));
+    const sortedKeys = Object.keys(o).sort(compareCodepoint);
     const out: Record<string, unknown> = {};
     for (const k of sortedKeys) out[k] = stableDeepSort(o[k]);
     return out;
@@ -52,11 +58,11 @@ export type CliOutput = {
 
 const ASCII_TABLE_CHARS = {
   top: "-",
-  "top-mid": "-",
+  "top-mid": "+",
   "top-left": "+",
   "top-right": "+",
   bottom: "-",
-  "bottom-mid": "-",
+  "bottom-mid": "+",
   "bottom-left": "+",
   "bottom-right": "+",
   left: "|",
@@ -163,7 +169,7 @@ export function createCliOutput(opts: CliOutputOptions): CliOutput {
       if (suppressHumanStdout(opts)) return;
       const sorted = stableDeepSort(value);
       const doc = stringifyYaml(sorted, {
-        sortMapEntries: (a, b) => String(a.key).localeCompare(String(b.key)),
+        sortMapEntries: (a, b) => compareCodepoint(String(a.key), String(b.key)),
         lineWidth: 0,
       });
       writeStdout(doc.endsWith("\n") ? doc : `${doc}\n`);
@@ -176,7 +182,7 @@ export function createCliOutput(opts: CliOutputOptions): CliOutput {
 
     kv(entries: Record<string, unknown>): void {
       if (suppressHumanStdout(opts)) return;
-      const keys = Object.keys(entries).sort((a, b) => a.localeCompare(b));
+      const keys = Object.keys(entries).sort(compareCodepoint);
       const labelWidth = keys.reduce((m, k) => Math.max(m, k.length), 0);
       for (const key of keys) {
         const pad = " ".repeat(Math.max(1, labelWidth - key.length + 1));
@@ -185,7 +191,7 @@ export function createCliOutput(opts: CliOutputOptions): CliOutput {
     },
 
     spinner(text: string): Ora {
-      const allow = opts.stdoutIsTTY && !opts.json && !opts.quiet;
+      const allow = opts.stdoutIsTTY && opts.stderrIsTTY && !opts.json && !opts.quiet;
       return ora({
         text,
         color: opts.color ? "cyan" : undefined,

--- a/objectified-cli/src/lib/output.ts
+++ b/objectified-cli/src/lib/output.ts
@@ -1,4 +1,226 @@
 import chalk, { Chalk, type ChalkInstance } from "chalk";
+import Table from "cli-table3";
+import ora, { type Ora } from "ora";
+import { stringify as stringifyYaml } from "yaml";
+
+/** True when LC_ALL/LANG indicate C/POSIX-style locale (ASCII table borders). */
+export function localePrefersAsciiTable(env: NodeJS.ProcessEnv): boolean {
+  const loc = (env.LC_ALL ?? env.LANG ?? "").trim();
+  if (!loc) return false;
+  return loc === "C" || loc === "POSIX" || loc.startsWith("C.");
+}
+
+/** Recursively sort object keys for stable JSON/YAML output. */
+export function stableDeepSort(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(stableDeepSort);
+  if (value && typeof value === "object") {
+    const o = value as Record<string, unknown>;
+    const sortedKeys = Object.keys(o).sort((a, b) => a.localeCompare(b));
+    const out: Record<string, unknown> = {};
+    for (const k of sortedKeys) out[k] = stableDeepSort(o[k]);
+    return out;
+  }
+  return value;
+}
+
+export type OutputColumn = { key: string; label?: string };
+
+export type CliOutputOptions = {
+  json: boolean;
+  color: boolean;
+  quiet: boolean;
+  stdoutIsTTY: boolean;
+  stderrIsTTY: boolean;
+  langAscii: boolean;
+  stdoutWrite: (chunk: string) => void;
+  stderrWrite: (chunk: string) => void;
+};
+
+export type CliOutput = {
+  table(rows: Record<string, unknown>[], columns: OutputColumn[]): void;
+  json(value: unknown): void;
+  yaml(value: unknown): void;
+  text(line: string): void;
+  kv(entries: Record<string, unknown>): void;
+  spinner(text: string): Ora;
+  success(message: string): void;
+  warn(message: string): void;
+  error(message: string): void;
+  banner(message: string): void;
+  hint(message: string): void;
+};
+
+const ASCII_TABLE_CHARS = {
+  top: "-",
+  "top-mid": "-",
+  "top-left": "+",
+  "top-right": "+",
+  bottom: "-",
+  "bottom-mid": "-",
+  "bottom-left": "+",
+  "bottom-right": "+",
+  left: "|",
+  "left-mid": "+",
+  mid: "-",
+  "mid-mid": "+",
+  right: "|",
+  "right-mid": "+",
+  middle: "|",
+} as const;
+
+/** Chalk instance that respects resolved CLI color (NO_COLOR / non-TTY → no ANSI). */
+export function chalkForContext(color: boolean): ChalkInstance {
+  return color ? chalk : new Chalk({ level: 0 });
+}
+
+function suppressHumanStdout(opts: CliOutputOptions): boolean {
+  return opts.quiet || opts.json;
+}
+
+function suppressAuxHumanStdout(opts: CliOutputOptions): boolean {
+  return opts.quiet || opts.json || !opts.stdoutIsTTY;
+}
+
+function jsonPretty(opts: CliOutputOptions): boolean {
+  return opts.stdoutIsTTY && !opts.quiet;
+}
+
+function stableJsonString(opts: CliOutputOptions, value: unknown): string {
+  const sorted = stableDeepSort(value);
+  const body = jsonPretty(opts)
+    ? `${JSON.stringify(sorted, null, 2)}\n`
+    : `${JSON.stringify(sorted)}\n`;
+  return body;
+}
+
+function formatUnknownCell(v: unknown): string {
+  if (v === null || v === undefined) return "";
+  if (typeof v === "object") return JSON.stringify(v);
+  if (
+    typeof v === "string" ||
+    typeof v === "number" ||
+    typeof v === "boolean" ||
+    typeof v === "bigint" ||
+    typeof v === "symbol"
+  ) {
+    return String(v);
+  }
+  if (typeof v === "function") return `[function ${v.name || "anonymous"}]`;
+  return "";
+}
+
+function tsvCell(v: unknown): string {
+  return formatUnknownCell(v).replace(/\r?\n/g, " ").replace(/\t/g, " ");
+}
+
+export function createCliOutput(opts: CliOutputOptions): CliOutput {
+  const c = chalkForContext(opts.color);
+  const useAsciiBorders = !opts.color || opts.langAscii;
+
+  const writeStdout = (chunk: string): void => {
+    opts.stdoutWrite(chunk);
+  };
+
+  const writeStderr = (chunk: string): void => {
+    opts.stderrWrite(chunk);
+  };
+
+  return {
+    table(rows: Record<string, unknown>[], columns: OutputColumn[]): void {
+      if (suppressHumanStdout(opts)) {
+        if (opts.json) writeStdout(stableJsonString(opts, rows));
+        return;
+      }
+
+      if (opts.stdoutIsTTY) {
+        const head = columns.map((col) => col.label ?? col.key);
+        const table = new Table({
+          head,
+          chars: useAsciiBorders ? { ...ASCII_TABLE_CHARS } : undefined,
+          style: {
+            head: opts.color ? ["cyan"] : [],
+            border: opts.color ? ["gray"] : [],
+          },
+          wordWrap: true,
+        });
+        for (const row of rows) {
+          table.push(columns.map((col) => formatUnknownCell(row[col.key])));
+        }
+        writeStdout(`${table.toString()}\n`);
+        return;
+      }
+
+      const header = columns.map((col) => tsvCell(col.label ?? col.key)).join("\t");
+      const lines = [header, ...rows.map((row) => columns.map((col) => tsvCell(row[col.key])).join("\t"))];
+      writeStdout(`${lines.join("\n")}\n`);
+    },
+
+    json(value: unknown): void {
+      writeStdout(stableJsonString(opts, value));
+    },
+
+    yaml(value: unknown): void {
+      if (suppressHumanStdout(opts)) return;
+      const sorted = stableDeepSort(value);
+      const doc = stringifyYaml(sorted, {
+        sortMapEntries: (a, b) => String(a.key).localeCompare(String(b.key)),
+        lineWidth: 0,
+      });
+      writeStdout(doc.endsWith("\n") ? doc : `${doc}\n`);
+    },
+
+    text(line: string): void {
+      if (suppressHumanStdout(opts)) return;
+      writeStdout(`${line}\n`);
+    },
+
+    kv(entries: Record<string, unknown>): void {
+      if (suppressHumanStdout(opts)) return;
+      const keys = Object.keys(entries).sort((a, b) => a.localeCompare(b));
+      const labelWidth = keys.reduce((m, k) => Math.max(m, k.length), 0);
+      for (const key of keys) {
+        const pad = " ".repeat(Math.max(1, labelWidth - key.length + 1));
+        writeStdout(`${c.bold(key)}:${pad}${formatUnknownCell(entries[key])}\n`);
+      }
+    },
+
+    spinner(text: string): Ora {
+      const allow = opts.stdoutIsTTY && !opts.json && !opts.quiet;
+      return ora({
+        text,
+        color: opts.color ? "cyan" : undefined,
+        isSilent: !allow,
+        stream: process.stderr,
+      });
+    },
+
+    success(message: string): void {
+      if (suppressHumanStdout(opts)) return;
+      const mark = opts.color ? c.green("✔") : "OK";
+      writeStdout(`${mark} ${message}\n`);
+    },
+
+    warn(message: string): void {
+      const prefix = opts.color ? c.yellow("Warning:") : "Warning:";
+      writeStderr(`${prefix} ${message}\n`);
+    },
+
+    error(message: string): void {
+      const prefix = opts.color ? c.red("Error:") : "Error:";
+      writeStderr(`${prefix} ${message}\n`);
+    },
+
+    banner(message: string): void {
+      if (suppressAuxHumanStdout(opts)) return;
+      writeStdout(`${c.bold(message)}\n`);
+    },
+
+    hint(message: string): void {
+      if (suppressAuxHumanStdout(opts)) return;
+      writeStdout(`${c.dim(message)}\n`);
+    },
+  };
+}
 
 export type OutputCapableCommand = {
   flags: { quiet?: boolean };
@@ -6,19 +228,31 @@ export type OutputCapableCommand = {
   log: (msg?: string, ...args: unknown[]) => void;
 };
 
-function chalkIf(color: boolean): ChalkInstance {
-  return color ? chalk : new Chalk({ level: 0 });
+function commandToOpts(cmd: Pick<OutputCapableCommand, "context" | "flags">): CliOutputOptions {
+  return {
+    json: cmd.context.json,
+    color: cmd.context.color,
+    quiet: Boolean(cmd.flags.quiet),
+    stdoutIsTTY: process.stdout.isTTY,
+    stderrIsTTY: process.stderr.isTTY,
+    langAscii: localePrefersAsciiTable(process.env),
+    stdoutWrite: (chunk) => process.stdout.write(chunk),
+    stderrWrite: (chunk) => process.stderr.write(chunk),
+  };
 }
 
 /** Normal informational line (respects --quiet and JSON mode). */
 export function logInfo(cmd: OutputCapableCommand, message: string): void {
-  if (cmd.flags.quiet) return;
-  if (cmd.context.json) return;
-  cmd.log(chalkIf(cmd.context.color).bold(message));
+  createCliOutput(commandToOpts(cmd)).text(chalkForContext(cmd.context.color).bold(message));
 }
 
-/** Structured stdout for JSON mode (single JSON object per invocation). */
-export function writeJsonLine(cmd: Pick<OutputCapableCommand, "context">, payload: unknown): void {
+/** Structured stdout for JSON mode (single JSON document per invocation). */
+export function writeJsonLine(
+  cmd: Pick<OutputCapableCommand, "context"> & { flags?: { quiet?: boolean } },
+  payload: unknown,
+): void {
   if (!cmd.context.json) return;
-  process.stdout.write(`${JSON.stringify(payload)}\n`);
+  createCliOutput(
+    commandToOpts({ context: cmd.context, flags: cmd.flags ?? {} } as OutputCapableCommand),
+  ).json(payload);
 }

--- a/objectified-cli/test/__snapshots__/output-renderers.test.ts.snap
+++ b/objectified-cli/test/__snapshots__/output-renderers.test.ts.snap
@@ -66,13 +66,13 @@ exports[`createCliOutput snapshots > table emits stable JSON when json mode 1`] 
 exports[`createCliOutput snapshots > table uses ASCII borders when langAscii 1`] = `
 {
   "stderr": "",
-  "stdout": "+------------+
+  "stdout": "+-------+----+
 | Name  | ID |
 +-------+----+
 | beta  | 2  |
 +-------+----+
 | alpha | 1  |
-+------------+
++-------+----+
 ",
 }
 `;

--- a/objectified-cli/test/__snapshots__/output-renderers.test.ts.snap
+++ b/objectified-cli/test/__snapshots__/output-renderers.test.ts.snap
@@ -1,0 +1,95 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`createCliOutput snapshots > banner and hint show when TTY and human mode 1`] = `
+"Title
+Tip
+"
+`;
+
+exports[`createCliOutput snapshots > json is compact when piped or quiet 1`] = `
+{
+  "piped": "{"a":{"nested":true},"z":1}
+",
+  "quiet": "{"a":{"nested":true},"z":1}
+",
+}
+`;
+
+exports[`createCliOutput snapshots > json is pretty with 2-space indent when TTY and not quiet 1`] = `
+"{
+  "a": {
+    "nested": true
+  },
+  "z": 1
+}
+"
+`;
+
+exports[`createCliOutput snapshots > kv writes aligned keys when human 1`] = `
+"muchLongerKey: y
+short:         x
+"
+`;
+
+exports[`createCliOutput snapshots > table as ANSI table when TTY + color + non-ASCII locale border allowed 1`] = `
+{
+  "stderr": "",
+  "stdout": "┌───────┬────┐
+│ Name  │ ID │
+├───────┼────┤
+│ beta  │ 2  │
+├───────┼────┤
+│ alpha │ 1  │
+└───────┴────┘
+",
+}
+`;
+
+exports[`createCliOutput snapshots > table as TSV when stdout is not a TTY 1`] = `
+{
+  "stderr": "",
+  "stdout": "Name	ID
+beta	2
+alpha	1
+",
+}
+`;
+
+exports[`createCliOutput snapshots > table emits stable JSON when json mode 1`] = `
+{
+  "stderr": "",
+  "stdout": "[{"id":2,"name":"beta"},{"id":1,"name":"alpha"}]
+",
+}
+`;
+
+exports[`createCliOutput snapshots > table uses ASCII borders when langAscii 1`] = `
+{
+  "stderr": "",
+  "stdout": "+------------+
+| Name  | ID |
++-------+----+
+| beta  | 2  |
++-------+----+
+| alpha | 1  |
++------------+
+",
+}
+`;
+
+exports[`createCliOutput snapshots > warn and error go to stderr 1`] = `
+{
+  "stderr": "Warning: one
+Error: two
+",
+  "stdout": "",
+}
+`;
+
+exports[`createCliOutput snapshots > yaml writes sorted stable YAML when human stdout 1`] = `
+"b:
+  - a: 1
+    q: 2
+z: 1
+"
+`;

--- a/objectified-cli/test/output-renderers.test.ts
+++ b/objectified-cli/test/output-renderers.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createCliOutput,
+  localePrefersAsciiTable,
+  stableDeepSort,
+  type CliOutputOptions,
+} from "../src/lib/output.js";
+
+function capture(
+  overrides: Partial<CliOutputOptions>,
+): { out: ReturnType<typeof createCliOutput>; stdout: () => string; stderr: () => string } {
+  let stdoutBuf = "";
+  let stderrBuf = "";
+  const opts: CliOutputOptions = {
+    json: false,
+    color: false,
+    quiet: false,
+    stdoutIsTTY: false,
+    stderrIsTTY: false,
+    langAscii: false,
+    stdoutWrite: (c) => {
+      stdoutBuf += c;
+    },
+    stderrWrite: (c) => {
+      stderrBuf += c;
+    },
+    ...overrides,
+  };
+  return {
+    out: createCliOutput(opts),
+    stdout: () => stdoutBuf,
+    stderr: () => stderrBuf,
+  };
+}
+
+const sampleColumns = [
+  { key: "name", label: "Name" },
+  { key: "id", label: "ID" },
+];
+
+const sampleRows = [
+  { id: 2, name: "beta" },
+  { id: 1, name: "alpha" },
+];
+
+describe("localePrefersAsciiTable", () => {
+  it("detects C/POSIX locales", () => {
+    expect(localePrefersAsciiTable({ LANG: "C" })).toBe(true);
+    expect(localePrefersAsciiTable({ LANG: "POSIX" })).toBe(true);
+    expect(localePrefersAsciiTable({ LANG: "C.UTF-8" })).toBe(true);
+    expect(localePrefersAsciiTable({ LC_ALL: "C", LANG: "en_US.UTF-8" })).toBe(true);
+  });
+
+  it("returns false for typical UTF-8 locales", () => {
+    expect(localePrefersAsciiTable({ LANG: "en_US.UTF-8" })).toBe(false);
+    expect(localePrefersAsciiTable({})).toBe(false);
+  });
+});
+
+describe("stableDeepSort", () => {
+  it("sorts nested keys", () => {
+    expect(stableDeepSort({ z: 1, a: { m: 2, b: 3 } })).toEqual({
+      a: { b: 3, m: 2 },
+      z: 1,
+    });
+  });
+});
+
+describe("createCliOutput snapshots", () => {
+  it("table as TSV when stdout is not a TTY", () => {
+    const { out, stdout, stderr } = capture({});
+    out.table(sampleRows, sampleColumns);
+    expect({ stdout: stdout(), stderr: stderr() }).toMatchSnapshot();
+  });
+
+  it("table as ANSI table when TTY + color + non-ASCII locale border allowed", () => {
+    const { out, stdout, stderr } = capture({
+      stdoutIsTTY: true,
+      color: true,
+      langAscii: false,
+    });
+    out.table(sampleRows, sampleColumns);
+    expect({ stdout: stdout(), stderr: stderr() }).toMatchSnapshot();
+  });
+
+  it("table uses ASCII borders when langAscii", () => {
+    const { out, stdout, stderr } = capture({
+      stdoutIsTTY: true,
+      color: true,
+      langAscii: true,
+    });
+    out.table(sampleRows, sampleColumns);
+    expect({ stdout: stdout(), stderr: stderr() }).toMatchSnapshot();
+  });
+
+  it("table emits stable JSON when json mode", () => {
+    const { out, stdout, stderr } = capture({ json: true });
+    out.table(sampleRows, sampleColumns);
+    expect({ stdout: stdout(), stderr: stderr() }).toMatchSnapshot();
+  });
+
+  it("json is compact when piped or quiet", () => {
+    const piped = capture({ json: true, stdoutIsTTY: false });
+    piped.out.json({ z: 1, a: { nested: true } });
+    const quiet = capture({ json: true, stdoutIsTTY: true, quiet: true });
+    quiet.out.json({ z: 1, a: { nested: true } });
+    expect({ piped: piped.stdout(), quiet: quiet.stdout() }).toMatchSnapshot();
+  });
+
+  it("json is pretty with 2-space indent when TTY and not quiet", () => {
+    const { out, stdout } = capture({ json: true, stdoutIsTTY: true, quiet: false });
+    out.json({ z: 1, a: { nested: true } });
+    expect(stdout()).toMatchSnapshot();
+  });
+
+  it("yaml writes sorted stable YAML when human stdout", () => {
+    const { out, stdout } = capture({ stdoutIsTTY: true });
+    out.yaml({ z: 1, b: [{ q: 2, a: 1 }] });
+    expect(stdout()).toMatchSnapshot();
+  });
+
+  it("suppresses yaml under json or quiet", () => {
+    const jsonMode = capture({ json: true, stdoutIsTTY: true });
+    jsonMode.out.yaml({ a: 1 });
+    const quietMode = capture({ quiet: true, stdoutIsTTY: true });
+    quietMode.out.yaml({ a: 1 });
+    expect({ jsonMode: jsonMode.stdout(), quietMode: quietMode.stdout() }).toEqual({
+      jsonMode: "",
+      quietMode: "",
+    });
+  });
+
+  it("text and kv respect quiet and json", () => {
+    const quiet = capture({ quiet: true, stdoutIsTTY: true });
+    quiet.out.text("nope");
+    quiet.out.kv({ a: 1 });
+    const jsonMode = capture({ json: true, stdoutIsTTY: true });
+    jsonMode.out.text("nope");
+    jsonMode.out.kv({ a: 1 });
+    expect({ quiet: quiet.stdout(), jsonMode: jsonMode.stdout() }).toEqual({
+      quiet: "",
+      jsonMode: "",
+    });
+  });
+
+  it("kv writes aligned keys when human", () => {
+    const { out, stdout } = capture({ stdoutIsTTY: true });
+    out.kv({ short: "x", muchLongerKey: "y" });
+    expect(stdout()).toMatchSnapshot();
+  });
+
+  it("warn and error go to stderr", () => {
+    const { out, stdout, stderr } = capture({ color: false });
+    out.warn("one");
+    out.error("two");
+    expect({ stdout: stdout(), stderr: stderr() }).toMatchSnapshot();
+  });
+
+  it("banner and hint hide when not TTY", () => {
+    const { out, stdout } = capture({ stdoutIsTTY: false });
+    out.banner("Title");
+    out.hint("Tip");
+    expect(stdout()).toBe("");
+  });
+
+  it("banner and hint show when TTY and human mode", () => {
+    const { out, stdout } = capture({ stdoutIsTTY: true });
+    out.banner("Title");
+    out.hint("Tip");
+    expect(stdout()).toMatchSnapshot();
+  });
+
+  it("spinner is silent when json, quiet, or non-TTY", () => {
+    for (const overrides of [
+      { json: true, stdoutIsTTY: true, stderrIsTTY: true },
+      { quiet: true, stdoutIsTTY: true, stderrIsTTY: true },
+      { stdoutIsTTY: false, stderrIsTTY: true },
+    ] as const) {
+      const { out } = capture({ stderrIsTTY: true, ...overrides });
+      const spin = out.spinner("Working…");
+      spin.start();
+      spin.stop();
+      expect(spin.isSilent).toBe(true);
+    }
+  });
+
+  it("success line suppressed when quiet", () => {
+    const { out, stdout } = capture({ quiet: true, stdoutIsTTY: true });
+    out.success("Done.");
+    expect(stdout()).toBe("");
+  });
+});

--- a/objectified-cli/test/output-renderers.test.ts
+++ b/objectified-cli/test/output-renderers.test.ts
@@ -176,6 +176,7 @@ describe("createCliOutput snapshots", () => {
       { json: true, stdoutIsTTY: true, stderrIsTTY: true },
       { quiet: true, stdoutIsTTY: true, stderrIsTTY: true },
       { stdoutIsTTY: false, stderrIsTTY: true },
+      { stdoutIsTTY: true, stderrIsTTY: false },
     ] as const) {
       const { out } = capture({ stderrIsTTY: true, ...overrides });
       const spin = out.spinner("Working…");

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -11,6 +11,7 @@ We continue to improve the platform based on your feedback with improvements and
 - New **`objectified-cli`** package (oclif v4) adds the `objectified` binary scaffold with `hello`, `--version`, and `--help` (#3186).
 - **`objectified-cli`**: shared global flags on `BaseCommand` (`--base-url`, `--profile`, `--api-key`, `--config`, `--json`, `--no-color`, `--quiet`, `--verbose`), TOML profile resolution, root help text for precedence rules, argv normalization for globals-before-subcommand, and stub `projects list` (#3187).
 - **`objectified-cli`**: TOML config with XDG / Windows paths, `default_profile`, `objectified config path|get|set|list`, auto-created `config.toml` (`0600` on Unix), strict profile validation, env-based API keys only, and tenant slug from config/env (#3188).
+- **`objectified-cli`**: shared output layer (`lib/output.ts`) with `this.output` on `BaseCommand` — tables (`cli-table3`), stable sorted JSON/YAML, ora spinners, stderr warnings/errors, and TTY / `--json` / `--quiet` / `--no-color` / `LANG=C` behavior; Vitest snapshots cover render modes (#3189).
 
 ## Import
 - Race condition fixed in 3.0.1 specification imports

--- a/yarn.lock
+++ b/yarn.lock
@@ -1159,6 +1159,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@colors/colors@npm:1.5.0":
+  version: 1.5.0
+  resolution: "@colors/colors@npm:1.5.0"
+  checksum: 10c0/eb42729851adca56d19a08e48d5a1e95efd2a32c55ae0323de8119052be0510d4b7a1611f2abcbf28c044a6c11e6b7d38f99fccdad7429300c37a8ea5fb95b44
+  languageName: node
+  linkType: hard
+
 "@cspotcode/source-map-support@npm:^0.8.0":
   version: 0.8.1
   resolution: "@cspotcode/source-map-support@npm:0.8.1"
@@ -7690,10 +7697,39 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cli-cursor@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "cli-cursor@npm:5.0.0"
+  dependencies:
+    restore-cursor: "npm:^5.0.0"
+  checksum: 10c0/7ec62f69b79f6734ab209a3e4dbdc8af7422d44d360a7cb1efa8a0887bbe466a6e625650c466fe4359aee44dbe2dc0b6994b583d40a05d0808a5cb193641d220
+  languageName: node
+  linkType: hard
+
 "cli-spinners@npm:^2.9.2":
   version: 2.9.2
   resolution: "cli-spinners@npm:2.9.2"
   checksum: 10c0/907a1c227ddf0d7a101e7ab8b300affc742ead4b4ebe920a5bf1bc6d45dce2958fcd195eb28fa25275062fe6fa9b109b93b63bc8033396ed3bcb50297008b3a3
+  languageName: node
+  linkType: hard
+
+"cli-spinners@npm:^3.2.0":
+  version: 3.4.0
+  resolution: "cli-spinners@npm:3.4.0"
+  checksum: 10c0/91296c32e147d5b973c9d439d1512306499215437b92f0c0d8be44ec850b555acb8795c19c606b2f6747f31d50c4e41fdde7dcef653f18f0ae7cdd58e99a4764
+  languageName: node
+  linkType: hard
+
+"cli-table3@npm:^0.6.5":
+  version: 0.6.5
+  resolution: "cli-table3@npm:0.6.5"
+  dependencies:
+    "@colors/colors": "npm:1.5.0"
+    string-width: "npm:^4.2.0"
+  dependenciesMeta:
+    "@colors/colors":
+      optional: true
+  checksum: 10c0/d7cc9ed12212ae68241cc7a3133c52b844113b17856e11f4f81308acc3febcea7cc9fd298e70933e294dd642866b29fd5d113c2c098948701d0c35f09455de78
   languageName: node
   linkType: hard
 
@@ -10690,6 +10726,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-interactive@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "is-interactive@npm:2.0.0"
+  checksum: 10c0/801c8f6064f85199dc6bf99b5dd98db3282e930c3bc197b32f2c5b89313bb578a07d1b8a01365c4348c2927229234f3681eb861b9c2c92bee72ff397390fa600
+  languageName: node
+  linkType: hard
+
 "is-map@npm:^2.0.3":
   version: 2.0.3
   resolution: "is-map@npm:2.0.3"
@@ -10818,6 +10861,13 @@ __metadata:
   dependencies:
     which-typed-array: "npm:^1.1.16"
   checksum: 10c0/415511da3669e36e002820584e264997ffe277ff136643a3126cc949197e6ca3334d0f12d084e83b1994af2e9c8141275c741cf2b7da5a2ff62dd0cac26f76c4
+  languageName: node
+  linkType: hard
+
+"is-unicode-supported@npm:^2.0.0, is-unicode-supported@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "is-unicode-supported@npm:2.1.0"
+  checksum: 10c0/a0f53e9a7c1fdbcf2d2ef6e40d4736fdffff1c9f8944c75e15425118ff3610172c87bf7bc6c34d3903b04be59790bb2212ddbe21ee65b5a97030fc50370545a5
   languageName: node
   linkType: hard
 
@@ -12058,6 +12108,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"log-symbols@npm:^7.0.1":
+  version: 7.0.1
+  resolution: "log-symbols@npm:7.0.1"
+  dependencies:
+    is-unicode-supported: "npm:^2.0.0"
+    yoctocolors: "npm:^2.1.1"
+  checksum: 10c0/71d30f9a44b8604b14df5e7c9b579d739997253db7385339d493ece41ee2cc74c1f96c5b4c0b2c1e0829b05348d4f287e68faab495b7a094a80f51351c816075
+  languageName: node
+  linkType: hard
+
 "longest-streak@npm:^3.0.0":
   version: 3.1.0
   resolution: "longest-streak@npm:3.1.0"
@@ -12807,6 +12867,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mimic-function@npm:^5.0.0":
+  version: 5.0.1
+  resolution: "mimic-function@npm:5.0.1"
+  checksum: 10c0/f3d9464dd1816ecf6bdf2aec6ba32c0728022039d992f178237d8e289b48764fee4131319e72eedd4f7f094e22ded0af836c3187a7edc4595d28dd74368fd81d
+  languageName: node
+  linkType: hard
+
 "mimic-response@npm:^3.1.0":
   version: 3.1.0
   resolution: "mimic-response@npm:3.1.0"
@@ -13371,11 +13438,13 @@ __metadata:
     "@types/node": "npm:^22.10.0"
     "@types/supports-color": "npm:^10.0.0"
     chalk: "npm:^5.6.2"
+    cli-table3: "npm:^0.6.5"
     env-paths: "npm:^4.0.0"
     eslint: "npm:^9.39.4"
     eslint-config-prettier: "npm:^10.1.1"
     fs-extra: "npm:^11.3.5"
     oclif: "npm:^4.23.0"
+    ora: "npm:^9.4.0"
     prettier: "npm:^3.6.2"
     shx: "npm:^0.4.0"
     supports-color: "npm:^10.2.2"
@@ -13383,6 +13452,7 @@ __metadata:
     typescript: "npm:^5.9.3"
     typescript-eslint: "npm:^8.46.0"
     vitest: "npm:^3.2.4"
+    yaml: "npm:^2.8.4"
   bin:
     objectified: ./bin/run.js
   languageName: unknown
@@ -13593,6 +13663,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"onetime@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "onetime@npm:7.0.0"
+  dependencies:
+    mimic-function: "npm:^5.0.0"
+  checksum: 10c0/5cb9179d74b63f52a196a2e7037ba2b9a893245a5532d3f44360012005c9cadb60851d56716ebff18a6f47129dab7168022445df47c2aff3b276d92585ed1221
+  languageName: node
+  linkType: hard
+
 "ono@npm:^4.0.11":
   version: 4.0.11
   resolution: "ono@npm:4.0.11"
@@ -13625,6 +13704,22 @@ __metadata:
     type-check: "npm:^0.4.0"
     word-wrap: "npm:^1.2.5"
   checksum: 10c0/4afb687a059ee65b61df74dfe87d8d6815cd6883cb8b3d5883a910df72d0f5d029821f37025e4bccf4048873dbdb09acc6d303d27b8f76b1a80dd5a7d5334675
+  languageName: node
+  linkType: hard
+
+"ora@npm:^9.4.0":
+  version: 9.4.0
+  resolution: "ora@npm:9.4.0"
+  dependencies:
+    chalk: "npm:^5.6.2"
+    cli-cursor: "npm:^5.0.0"
+    cli-spinners: "npm:^3.2.0"
+    is-interactive: "npm:^2.0.0"
+    is-unicode-supported: "npm:^2.1.0"
+    log-symbols: "npm:^7.0.1"
+    stdin-discarder: "npm:^0.3.2"
+    string-width: "npm:^8.1.0"
+  checksum: 10c0/8f2d7a8869cd68607797ac0ffe9f5cdceeb6009437672510d9920aea794cdd055164e3fe804248624c4940a71b22f94f1ffd94ce8fecf0746baef97a5c121a91
   languageName: node
   linkType: hard
 
@@ -14709,6 +14804,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"restore-cursor@npm:^5.0.0":
+  version: 5.1.0
+  resolution: "restore-cursor@npm:5.1.0"
+  dependencies:
+    onetime: "npm:^7.0.0"
+    signal-exit: "npm:^4.1.0"
+  checksum: 10c0/c2ba89131eea791d1b25205bdfdc86699767e2b88dee2a590b1a6caa51737deac8bad0260a5ded2f7c074b7db2f3a626bcf1fcf3cdf35974cbeea5e2e6764f60
+  languageName: node
+  linkType: hard
+
 "retry@npm:0.13.1":
   version: 0.13.1
   resolution: "retry@npm:0.13.1"
@@ -15400,6 +15505,13 @@ __metadata:
   version: 3.10.0
   resolution: "std-env@npm:3.10.0"
   checksum: 10c0/1814927a45004d36dde6707eaf17552a546769bc79a6421be2c16ce77d238158dfe5de30910b78ec30d95135cc1c59ea73ee22d2ca170f8b9753f84da34c427f
+  languageName: node
+  linkType: hard
+
+"stdin-discarder@npm:^0.3.2":
+  version: 0.3.2
+  resolution: "stdin-discarder@npm:0.3.2"
+  checksum: 10c0/5dbaba9efbcb447a4450d5ae19794641ea9166abe96dc4b5547a109db1bb6e8bdb17bbe1029e02ca8d9d8ee996b7c7cbcce12b12c18c121871cd4f574292381a
   languageName: node
   linkType: hard
 
@@ -17030,6 +17142,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"yaml@npm:^2.8.4":
+  version: 2.8.4
+  resolution: "yaml@npm:2.8.4"
+  bin:
+    yaml: bin.mjs
+  checksum: 10c0/0a33a1fa28d4bc79f61a12ec7ef7a2bce0ce5f8e80c6eaecfb4a0c88c08767dd1ede372b6a3bcd70891213b8c9f3169b355c97e77026d3b3459e10d2cccaef1e
+  languageName: node
+  linkType: hard
+
 "yargs-parser@npm:^21.1.1":
   version: 21.1.1
   resolution: "yargs-parser@npm:21.1.1"
@@ -17070,6 +17191,13 @@ __metadata:
   version: 2.1.3
   resolution: "yoctocolors-cjs@npm:2.1.3"
   checksum: 10c0/584168ef98eb5d913473a4858dce128803c4a6cd87c0f09e954fa01126a59a33ab9e513b633ad9ab953786ed16efdd8c8700097a51635aafaeed3fef7712fa79
+  languageName: node
+  linkType: hard
+
+"yoctocolors@npm:^2.1.1":
+  version: 2.1.2
+  resolution: "yoctocolors@npm:2.1.2"
+  checksum: 10c0/b220f30f53ebc2167330c3adc86a3c7f158bcba0236f6c67e25644c3188e2571a6014ffc1321943bb619460259d3d27eb4c9cc58c2d884c1b195805883ec7066
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What / why
Implements `lib/output.ts` as the single stdout/stderr rendering surface for `objectified-cli`: `table` (TTY table vs pipe TSV vs `--json` stable array), `json` / `yaml`, `text`, `kv`, `spinner` (ora on stderr), `success`, `warn`, `error`, plus `banner` / `hint`. `BaseCommand` exposes `this.output` wired from global flags and environment (`supports-color`, `LANG`/`LC_ALL`). Commands `hello`, `projects list`, and `config list` use the new API where appropriate.

## How to test
- **Build CLI**: `yarn workspace objectified-cli build`
- **Unit + integration tests**: `yarn workspace objectified-cli test`
- **Manual**: run **`node objectified-cli/bin/run.js hello`** and **`node objectified-cli/bin/run.js --json hello | jq`**; confirm stderr stays empty on success.
- **Snapshots**: Vitest snapshots under `objectified-cli/test/__snapshots__/output-renderers.test.ts.snap` cover TTY vs pipe vs `--json`.

## Risk / notes
- Root `yarn build` may fail locally if `uv` is missing for `objectified-mcp`; CLI package build/test were run successfully.
- `objectified docs output` prose is ticket **#3192** (not in this PR).

Closes #3189

Made with [Cursor](https://cursor.com)