### PR TITLE
Fix #3191 - CLI error handling, exit codes, retries, hints

### DIFF
--- a/docs/PLANNED_ROADMAP_CLI.md
+++ b/docs/PLANNED_ROADMAP_CLI.md
@@ -106,7 +106,6 @@ Total: **12 epics**, **88 sub-tickets** (open roadmap items; completed work is d
 
 | #         | Title                                                              | Description                                                                  | Labels                                          | MVP | Parallel |
 |-----------|--------------------------------------------------------------------|------------------------------------------------------------------------------|-------------------------------------------------|-----|----------|
-| 1.6 (#3191) | Error handling, exit codes, retries, hints                       | `ObjectifiedCliError` hierarchy, sysexits-style exit codes, did-you-mean     | `enhancement`, `mvp`, `cli`, `roadmap-cli`     | Yes | Yes      |
 | 1.7 (#3192) | Help system, examples, man pages, `objectified docs`             | Rich help, ≥2 examples per command, generated man pages, `docs <topic>`     | `enhancement`, `mvp`, `cli`, `roadmap-cli`, `documentation` | Yes | Yes      |
 | 1.8 (#3193) | Shell completions (bash/zsh/fish/PowerShell)                     | Static completions + dynamic (tenant/project/version slugs)                  | `enhancement`, `cli`, `roadmap-cli`            | No  | Yes      |
 
@@ -191,7 +190,9 @@ Part of Epic: CLI Foundation & DevEx (#3174)
 
 ---
 
-#### 1.6 (#3191) — Error handling, exit codes, retries
+#### 1.6 (#3191) — Error handling, exit codes, retries (**done**)
+
+Landed: `ObjectifiedCliError` + `httpStatusToCliError` (all 4xx/5xx), `formatAndReportCliFailure` / `handleError` template (Reason, Hint, Request-Id, Exit code), top-level `run`+`handle` replacement in `bin/run.js` / `dev.js` (stacks only with `--verbose` or `OBJECTIFIED_DEBUG=1`), `leven` did-you-mean for unknown commands, network errno hints, client retries (idempotent: 429+5xx with 250/500/1s/2s, max 4 attempts; `POST`/`PATCH`: 429 only), `objectified docs errors`, Vitest HTTP mapping + `handleError` snapshots, integration coverage.
 
 Documented BSD/sysexits-inspired exit codes:
 
@@ -779,11 +780,11 @@ The `NPM_REGISTRY` env var lets us point at npmjs.com, GitHub Packages, JFrog Ar
 
 ## MVP Release — Ticket Bundle
 
-The MVP delivers an installable, useful CLI focused on _read_ and _publish_ for a single project's lifecycle. Total: **22 open sub-tickets** across 6 epics (plus completed foundation items such as #3186, #3187, #3188, #3189, and #3190).
+The MVP delivers an installable, useful CLI focused on _read_ and _publish_ for a single project's lifecycle. Total: **21 open sub-tickets** across 6 epics (plus completed foundation items such as #3186, #3187, #3188, #3189, #3190, and #3191).
 
 | Epic     | Tickets                                                                                                   | Count |
 |----------|-----------------------------------------------------------------------------------------------------------|-------|
-| 1 (#3174) | #3191, #3192                                                                                               | 2     |
+| 1 (#3174) | #3192                                                                                                      | 1     |
 | 2 (#3175) | #3194, #3195, #3196, #3197, #3198, #3199                                                                  | 6     |
 | 3 (#3176) | #3202, #3203, #3204                                                                                        | 3     |
 | 4 (#3177) | #3208, #3209, #3210, #3212                                                                                | 4     |
@@ -871,7 +872,7 @@ v2 fills out the writable surface for primitives, properties, classes, paths, da
 
 The tickets were created in the order below — that is also the recommended **execution** order. Earlier epics provide primitives that later epics rely on.
 
-1. **Epic 1 — Foundation** (#3174: #3186, #3187, #3188, #3189, and #3190 landed; then #3191 → #3193). Without the scaffold, no other command can exist.
+1. **Epic 1 — Foundation** (#3174: #3186, #3187, #3188, #3189, #3190, and #3191 landed; then #3192 → #3193). Without the scaffold, no other command can exist.
 2. **Epic 2 — Auth & Tenants** (#3175 then #3194 → #3201). Required for any tenant-scoped command.
 3. **Epic 3 — Projects** (#3176 then #3202 → #3207). The first useful read/write surface.
 4. **Epic 4 — Versions** (#3177 then #3208 → #3216). The publish flow that makes the CLI valuable in CI.

--- a/objectified-cli/bin/dev.js
+++ b/objectified-cli/bin/dev.js
@@ -1,11 +1,34 @@
 #!/usr/bin/env -S node --loader ts-node/esm --disable-warning=ExperimentalWarning
 
-import { execute } from "@oclif/core";
+import { flush } from "@oclif/core/flush";
+import { ExitError } from "@oclif/core/errors";
+import { run } from "@oclif/core/run";
+import { settings } from "@oclif/core/settings";
 
 import { promoteLeadingGlobalFlags } from "../src/lib/normalize-argv.js";
+import {
+  formatAndReportCliFailure,
+  resolveDebugStacks,
+} from "../src/lib/handle-error.js";
 
-await execute({
-  development: true,
-  dir: import.meta.url,
-  args: promoteLeadingGlobalFlags(process.argv.slice(2)),
-});
+process.env.NODE_ENV = "development";
+settings.debug = true;
+
+const argv = promoteLeadingGlobalFlags(process.argv.slice(2));
+
+try {
+  await run(argv, import.meta.url);
+  flush();
+} catch (error) {
+  flush();
+  if (error instanceof ExitError) {
+    process.exit(error.oclif?.exit ?? 1);
+  }
+  const debugStacks = resolveDebugStacks(argv, process.env);
+  const color =
+    process.env.NO_COLOR === undefined || process.env.NO_COLOR === ""
+      ? Boolean(process.stderr.isTTY)
+      : false;
+  const code = formatAndReportCliFailure(error, { debugStacks, color });
+  process.exit(code);
+}

--- a/objectified-cli/bin/run.js
+++ b/objectified-cli/bin/run.js
@@ -1,10 +1,30 @@
 #!/usr/bin/env node
 
-import { execute } from "@oclif/core";
+import { flush } from "@oclif/core/flush";
+import { ExitError } from "@oclif/core/errors";
+import { run } from "@oclif/core/run";
 
 import { promoteLeadingGlobalFlags } from "../dist/lib/normalize-argv.js";
+import {
+  formatAndReportCliFailure,
+  resolveDebugStacks,
+} from "../dist/lib/handle-error.js";
 
-await execute({
-  dir: import.meta.url,
-  args: promoteLeadingGlobalFlags(process.argv.slice(2)),
-});
+const argv = promoteLeadingGlobalFlags(process.argv.slice(2));
+
+try {
+  await run(argv, import.meta.url);
+  flush();
+} catch (error) {
+  flush();
+  if (error instanceof ExitError) {
+    process.exit(error.oclif?.exit ?? 1);
+  }
+  const debugStacks = resolveDebugStacks(argv, process.env);
+  const color =
+    process.env.NO_COLOR === undefined || process.env.NO_COLOR === ""
+      ? Boolean(process.stderr.isTTY)
+      : false;
+  const code = formatAndReportCliFailure(error, { debugStacks, color });
+  process.exit(code);
+}

--- a/objectified-cli/package.json
+++ b/objectified-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-cli",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Objectified command-line interface",
   "author": "Objectified",
   "type": "module",
@@ -48,6 +48,7 @@
     "cli-table3": "^0.6.5",
     "env-paths": "^4.0.0",
     "fs-extra": "^11.3.5",
+    "leven": "^4.0.0",
     "ora": "^9.4.0",
     "supports-color": "^10.2.2",
     "yaml": "^2.8.4"

--- a/objectified-cli/src/base-command.ts
+++ b/objectified-cli/src/base-command.ts
@@ -165,8 +165,8 @@ export abstract class BaseCommand extends Command {
       resolveAllowColor(
         this.parsedGlobalFlags?.color,
         process.env,
-        process.stdout.isTTY,
-        typeof supportsColor.stdout === "object",
+        process.stderr.isTTY,
+        typeof supportsColor.stderr === "object",
       );
     const code = formatAndReportCliFailure(err, { debugStacks, color });
     return Promise.reject(new ExitError(code));

--- a/objectified-cli/src/base-command.ts
+++ b/objectified-cli/src/base-command.ts
@@ -10,6 +10,7 @@ import {
   buildObjectifiedContext,
   type GlobalCliFlags,
   type ObjectifiedContext,
+  resolveAllowColor,
 } from "./lib/cli-context.js";
 import {
   ensureDefaultConfigFile,
@@ -105,6 +106,8 @@ export abstract class BaseCommand extends Command {
   /** Command arguments after parse (subcommands read typed fields from here). */
   protected commandArgs!: Record<string, unknown>;
 
+  protected parsedGlobalFlags?: GlobalCliFlags;
+
   /** Mutable snapshot passed to the REST wrapper (401 hook may refresh credentials). */
   protected readonly apiAuth: ApiAuthSnapshot = {};
 
@@ -115,6 +118,7 @@ export abstract class BaseCommand extends Command {
     const Cmd = this.constructor as typeof Command;
     const parsed = await this.parse(Cmd);
     const globalPart = parsed.flags as GlobalCliFlags;
+    this.parsedGlobalFlags = globalPart;
     this.commandArgs = parsed.args as Record<string, unknown>;
 
     this.resolvedConfigPath = resolveConfigFilePath(globalPart.config, process.env, os.homedir);
@@ -155,10 +159,15 @@ export abstract class BaseCommand extends Command {
     }
 
     const debugStacks = resolveDebugStacks(process.argv, process.env);
+    const colorFromContext = (this as { context?: ObjectifiedContext }).context?.color;
     const color =
-      process.env.NO_COLOR === undefined || process.env.NO_COLOR === ""
-        ? typeof supportsColor.stderr === "object"
-        : false;
+      colorFromContext ??
+      resolveAllowColor(
+        this.parsedGlobalFlags?.color,
+        process.env,
+        process.stdout.isTTY,
+        typeof supportsColor.stdout === "object",
+      );
     const code = formatAndReportCliFailure(err, { debugStacks, color });
     return Promise.reject(new ExitError(code));
   }

--- a/objectified-cli/src/base-command.ts
+++ b/objectified-cli/src/base-command.ts
@@ -1,6 +1,7 @@
 import os from "node:os";
 
 import { Command, Flags } from "@oclif/core";
+import { ExitError } from "@oclif/core/errors";
 import type { CommandError } from "@oclif/core/interfaces";
 import supportsColor from "supports-color";
 
@@ -16,7 +17,12 @@ import {
   resolveConfigFilePath,
   type ParsedTomlConfig,
 } from "./lib/config.js";
-import { CliError } from "./lib/errors.js";
+import {
+  cliFailureJsonEnvelope,
+  formatAndReportCliFailure,
+  resolveDebugStacks,
+  resolveEffectiveExitCode,
+} from "./lib/handle-error.js";
 import { createCliOutput, localePrefersAsciiTable, type CliOutput } from "./lib/output.js";
 
 export abstract class BaseCommand extends Command {
@@ -140,11 +146,20 @@ export abstract class BaseCommand extends Command {
     });
   }
 
-  protected override async catch(err: CommandError): Promise<void> {
-    if (err instanceof CliError) {
-      this.error(err.message, { exit: err.exitCode });
-      return;
+  protected override catch(err: CommandError): Promise<void> {
+    if (this.jsonEnabled()) {
+      // `api` is assigned late in `init()`; failures before `createApiClient` must not crash JSON rendering.
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- optional when init aborted early
+      this.logJson(cliFailureJsonEnvelope(err, this.api?.lastRequestId));
+      return Promise.reject(new ExitError(resolveEffectiveExitCode(err)));
     }
-    await super.catch(err);
+
+    const debugStacks = resolveDebugStacks(process.argv, process.env);
+    const color =
+      process.env.NO_COLOR === undefined || process.env.NO_COLOR === ""
+        ? typeof supportsColor.stderr === "object"
+        : false;
+    const code = formatAndReportCliFailure(err, { debugStacks, color });
+    return Promise.reject(new ExitError(code));
   }
 }

--- a/objectified-cli/src/commands/docs/errors.ts
+++ b/objectified-cli/src/commands/docs/errors.ts
@@ -1,0 +1,17 @@
+import { BaseCommand } from "../../base-command.js";
+import { exitCodeReferenceJson, formatExitCodeDocs } from "../../lib/exit-codes.js";
+
+export default class DocsErrors extends BaseCommand {
+  static description = "Exit codes, hints, and error-handling reference";
+
+  static examples = ["<%= config.bin %> <%= command.id %>"];
+
+  run(): Promise<void> {
+    if (this.context.json) {
+      this.output.json(exitCodeReferenceJson());
+      return Promise.resolve();
+    }
+    this.output.text(formatExitCodeDocs());
+    return Promise.resolve();
+  }
+}

--- a/objectified-cli/src/commands/projects/list.ts
+++ b/objectified-cli/src/commands/projects/list.ts
@@ -1,5 +1,6 @@
 import { BaseCommand } from "../../base-command.js";
-import { CliError } from "../../lib/errors.js";
+import { EXIT_CODES } from "../../lib/exit-codes.js";
+import { ObjectifiedCliError } from "../../lib/errors.js";
 import { chalkForContext } from "../../lib/output.js";
 
 export default class ProjectsList extends BaseCommand {
@@ -10,10 +11,13 @@ export default class ProjectsList extends BaseCommand {
   async run(): Promise<void> {
     const tenant = this.context.tenantSlug;
     if (tenant === undefined || tenant === "") {
-      throw new CliError(
-        "Tenant slug is required for this command. Set OBJECTIFIED_TENANT or `tenant_slug` in your profile (config.toml).",
-        11,
-      );
+      throw new ObjectifiedCliError({
+        message:
+          "Tenant slug is required for this command. Set OBJECTIFIED_TENANT or `tenant_slug` in your profile (config.toml).",
+        exitCode: EXIT_CODES.CONFIG,
+        title: "Configuration error",
+        hint: "Run `objectified config path` to locate config.toml, then set tenant_slug for your profile.",
+      });
     }
 
     const projects = await this.api.listProjects(tenant);

--- a/objectified-cli/src/index.ts
+++ b/objectified-cli/src/index.ts
@@ -1,2 +1,16 @@
 export { BaseCommand } from "./base-command.js";
-export { CliError } from "./lib/errors.js";
+export { EXIT_CODES, exitCodeReferenceJson, formatExitCodeDocs } from "./lib/exit-codes.js";
+export {
+  CliError,
+  httpStatusToCliError,
+  networkErrnoToCliError,
+  ObjectifiedCliError,
+} from "./lib/errors.js";
+export {
+  cliFailureJsonEnvelope,
+  formatAndReportCliFailure,
+  handleError,
+  resolveDebugStacks,
+  resolveEffectiveExitCode,
+  truncateRequestId,
+} from "./lib/handle-error.js";

--- a/objectified-cli/src/lib/client.ts
+++ b/objectified-cli/src/lib/client.ts
@@ -2,7 +2,12 @@ import { createClient, type Client } from "../generated/client.js";
 import type { ProjectSchema } from "../generated/models.js";
 import { listProjectsV1ProjectsTenantSlugGet } from "../generated/operations.js";
 
-import { CliError } from "./errors.js";
+import { EXIT_CODES } from "./exit-codes.js";
+import {
+  httpStatusToCliError,
+  networkErrnoToCliError,
+  ObjectifiedCliError,
+} from "./errors.js";
 
 /** Mutable auth fields read on every request (supports 401 refresh hook). */
 export type ApiAuthSnapshot = {
@@ -22,11 +27,16 @@ export type CreateApiClientOptions = {
 
 export type ObjectifiedApi = {
   readonly lastRequestId: string | undefined;
+  /** Transient HTTP retries consumed on the last instrumented request (429 / 5xx policy). */
+  readonly lastRetriesAttempted: number;
   listProjects(tenantSlug: string): Promise<ProjectSchema[]>;
 };
 
 const MAX_RETRY_AFTER_MS = 120_000;
-const MAX_TRANSIENT_ATTEMPTS = 4;
+export const MAX_TRANSIENT_ATTEMPTS = 4;
+
+const IDEMPOTENT_METHODS = new Set(["GET", "HEAD", "PUT", "DELETE"]);
+const BACKOFF_MS = [250, 500, 1000, 2000];
 
 function trimTrailingSlash(url: string): string {
   return url.replace(/\/+$/, "");
@@ -58,12 +68,10 @@ export function parseRetryAfterMs(headerValue: string | null): number | undefine
   return undefined;
 }
 
+/** Delay before retry `attemptIndex` (0-based), capped at 2s (#3191). */
 export function exponentialBackoffMs(attemptIndex: number): number {
-  const base = 250;
-  const cap = 8000;
-  const raw = Math.min(base * 2 ** attemptIndex, cap);
-  const jitter = Math.floor(Math.random() * 120);
-  return raw + jitter;
+  const idx = Math.min(Math.max(attemptIndex, 0), BACKOFF_MS.length - 1);
+  return BACKOFF_MS[idx] ?? 2000;
 }
 
 function sleep(ms: number): Promise<void> {
@@ -91,19 +99,35 @@ function formatApiError(error: unknown): string {
   }
 }
 
-function isTransientHttpStatus(status: number): boolean {
-  return status === 502 || status === 503 || status === 504;
+function methodIsIdempotent(method: string): boolean {
+  return IDEMPOTENT_METHODS.has(method.toUpperCase());
+}
+
+function shouldRetryStatus(status: number, idempotent: boolean): boolean {
+  if (status === 429) return true;
+  if (idempotent && status >= 500 && status <= 599) return true;
+  return false;
 }
 
 /** Validates the list endpoint payload enough for CLI rendering (required OpenAPI fields). */
 function parseProjectsPayload(data: unknown): ProjectSchema[] {
   if (!Array.isArray(data)) {
-    throw new CliError("API error: unexpected response shape for projects list.", 1);
+    throw new ObjectifiedCliError({
+      message: "Unexpected response shape for projects list.",
+      exitCode: EXIT_CODES.VALIDATION,
+      title: "Validation failed",
+      hint: "The API returned an unexpected JSON shape; try again or upgrade the CLI.",
+    });
   }
   const projects: ProjectSchema[] = [];
   for (const raw of data) {
     if (!raw || typeof raw !== "object") {
-      throw new CliError("API error: invalid project entry in response.", 1);
+      throw new ObjectifiedCliError({
+        message: "Invalid project entry in response.",
+        exitCode: EXIT_CODES.VALIDATION,
+        title: "Validation failed",
+        hint: "The API returned invalid project rows; include request-id when reporting.",
+      });
     }
     const p = raw as Record<string, unknown>;
     if (
@@ -112,14 +136,24 @@ function parseProjectsPayload(data: unknown): ProjectSchema[] {
       typeof p.name !== "string" ||
       typeof p.slug !== "string"
     ) {
-      throw new CliError("API error: invalid project fields in response.", 1);
+      throw new ObjectifiedCliError({
+        message: "Invalid project fields in response.",
+        exitCode: EXIT_CODES.VALIDATION,
+        title: "Validation failed",
+        hint: "Required project fields were missing or mistyped.",
+      });
     }
     if (
       p.enabled !== undefined &&
       p.enabled !== null &&
       typeof p.enabled !== "boolean"
     ) {
-      throw new CliError("API error: invalid project fields in response.", 1);
+      throw new ObjectifiedCliError({
+        message: "Invalid project fields in response.",
+        exitCode: EXIT_CODES.VALIDATION,
+        title: "Validation failed",
+        hint: "`enabled` must be boolean when present.",
+      });
     }
     projects.push({
       ...(raw as ProjectSchema),
@@ -135,14 +169,22 @@ function createInstrumentedFetch(opts: {
   verbose?: boolean;
   stderrWrite?: (line: string) => void;
   onUnauthorized?: () => Promise<void>;
+  onRetryStats?: (count: number) => void;
 }): typeof fetch {
   const log = opts.stderrWrite ?? ((line: string) => process.stderr.write(`${line}\n`));
 
   return async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
     const baseReq = input instanceof Request ? input : new Request(input, init);
     let req = mergeAuthHeaders(baseReq, opts.auth);
-    let transientAttempt = 0;
+    let transientRetries = 0;
     let didReauth = false;
+
+    opts.onRetryStats?.(0);
+
+    const bumpRetry = (): void => {
+      transientRetries++;
+      opts.onRetryStats?.(transientRetries);
+    };
 
     for (;;) {
       const response = await opts.inner(req);
@@ -156,19 +198,27 @@ function createInstrumentedFetch(opts: {
         continue;
       }
 
-      if (response.status === 429 && transientAttempt < MAX_TRANSIENT_ATTEMPTS - 1) {
-        const wait = parseRetryAfterMs(response.headers.get("retry-after"));
-        if (wait !== undefined) {
-          transientAttempt++;
-          await sleep(wait);
-          req = mergeAuthHeaders(baseReq, opts.auth);
-          continue;
-        }
-      }
+      const idem = methodIsIdempotent(req.method);
+      const attemptNumber = transientRetries + 1;
 
-      if (isTransientHttpStatus(response.status) && transientAttempt < MAX_TRANSIENT_ATTEMPTS - 1) {
-        transientAttempt++;
-        await sleep(exponentialBackoffMs(transientAttempt - 1));
+      if (
+        attemptNumber < MAX_TRANSIENT_ATTEMPTS &&
+        shouldRetryStatus(response.status, idem)
+      ) {
+        if (!idem && response.status !== 429) {
+          return response;
+        }
+
+        let waitMs: number;
+        if (response.status === 429) {
+          const ra = parseRetryAfterMs(response.headers.get("retry-after"));
+          waitMs = ra ?? exponentialBackoffMs(transientRetries);
+        } else {
+          waitMs = exponentialBackoffMs(transientRetries);
+        }
+
+        bumpRetry();
+        await sleep(waitMs);
         req = mergeAuthHeaders(baseReq, opts.auth);
         continue;
       }
@@ -181,18 +231,29 @@ function createInstrumentedFetch(opts: {
 export function createApiClient(options: CreateApiClientOptions): ObjectifiedApi {
   const innerFetch = globalThis.fetch.bind(globalThis);
   let lastRequestId: string | undefined;
+  let lastRetriesAttempted = 0;
 
   const instrumented = createInstrumentedFetch({
     inner: async (input, init) => {
-      const res = await innerFetch(input, init);
-      const rid = res.headers.get("x-request-id") ?? res.headers.get("X-Request-Id") ?? undefined;
-      if (rid !== undefined) lastRequestId = rid;
-      return res;
+      try {
+        const res = await innerFetch(input, init);
+        const rid = res.headers.get("x-request-id") ?? res.headers.get("X-Request-Id") ?? undefined;
+        if (rid !== undefined) lastRequestId = rid;
+        return res;
+      } catch (e) {
+        if (e !== null && typeof e === "object" && "code" in e) {
+          throw networkErrnoToCliError(e as NodeJS.ErrnoException);
+        }
+        throw e;
+      }
     },
     auth: options.auth,
     verbose: options.verbose,
     stderrWrite: options.stderrWrite,
     onUnauthorized: options.onUnauthorized,
+    onRetryStats: (n) => {
+      lastRetriesAttempted = n;
+    },
   });
 
   const hey: Client = createClient({
@@ -204,13 +265,25 @@ export function createApiClient(options: CreateApiClientOptions): ObjectifiedApi
     get lastRequestId() {
       return lastRequestId;
     },
+    get lastRetriesAttempted() {
+      return lastRetriesAttempted;
+    },
 
     async listProjects(tenantSlug: string): Promise<ProjectSchema[]> {
-      const rawUnknown: unknown = await listProjectsV1ProjectsTenantSlugGet({
-        client: hey,
-        path: { tenant_slug: tenantSlug },
-        throwOnError: false,
-      });
+      let rawUnknown: unknown;
+      try {
+        rawUnknown = await listProjectsV1ProjectsTenantSlugGet({
+          client: hey,
+          path: { tenant_slug: tenantSlug },
+          throwOnError: false,
+        });
+      } catch (e) {
+        if (e instanceof ObjectifiedCliError) throw e;
+        if (e !== null && typeof e === "object" && "code" in e) {
+          throw networkErrnoToCliError(e as NodeJS.ErrnoException);
+        }
+        throw e;
+      }
 
       const rawBundle =
         rawUnknown && typeof rawUnknown === "object"
@@ -222,12 +295,24 @@ export function createApiClient(options: CreateApiClientOptions): ObjectifiedApi
           : undefined;
 
       if (rawBundle === undefined) {
-        throw new CliError("API error: empty SDK response.", 1);
+        throw new ObjectifiedCliError({
+          message: "Empty SDK response from the API client.",
+          exitCode: EXIT_CODES.GENERIC,
+          title: "API error",
+          hint: "Retry the command; set OBJECTIFIED_DEBUG=1 if you need a stack trace.",
+        });
       }
 
       if (rawBundle.error !== undefined && rawBundle.error !== null && rawBundle.error !== "") {
-        const status = rawBundle.response?.status ?? "?";
-        throw new CliError(`API error (${String(status)}): ${formatApiError(rawBundle.error)}`, 1);
+        const status = rawBundle.response?.status ?? 0;
+        const hdrId =
+          rawBundle.response?.headers.get("x-request-id") ??
+          rawBundle.response?.headers.get("X-Request-Id") ??
+          undefined;
+        throw httpStatusToCliError(status, formatApiError(rawBundle.error), {
+          requestId: hdrId ?? lastRequestId,
+          retriesAttempted: lastRetriesAttempted,
+        });
       }
 
       return parseProjectsPayload(rawBundle.data);

--- a/objectified-cli/src/lib/errors.ts
+++ b/objectified-cli/src/lib/errors.ts
@@ -1,10 +1,230 @@
-/** Root error type for CLI failures (richer hierarchy in #3191). */
-export class CliError extends Error {
-  readonly exitCode: number;
+import { EXIT_CODES } from "./exit-codes.js";
 
-  constructor(message: string, exitCode = 1) {
-    super(message);
-    this.name = "CliError";
-    this.exitCode = exitCode;
+export type ObjectifiedCliErrorOptions = {
+  message: string;
+  exitCode: number;
+  hint?: string;
+  requestId?: string;
+  title?: string;
+  retriesAttempted?: number;
+};
+
+/** Root CLI failure type; richer subclasses align with documented exit codes (#3191). */
+export class ObjectifiedCliError extends Error {
+  readonly exitCode: number;
+  readonly hint?: string;
+  readonly requestId?: string;
+  readonly title?: string;
+  readonly retriesAttempted?: number;
+
+  constructor(opts: ObjectifiedCliErrorOptions) {
+    super(opts.message);
+    this.name = "ObjectifiedCliError";
+    this.exitCode = opts.exitCode;
+    this.hint = opts.hint;
+    this.requestId = opts.requestId;
+    this.title = opts.title;
+    this.retriesAttempted = opts.retriesAttempted;
   }
+}
+
+/** Prefer {@link ObjectifiedCliError} for new code; kept for existing call sites/tests. */
+export class CliError extends ObjectifiedCliError {
+  constructor(message: string, exitCode?: number) {
+    super({ message, exitCode: exitCode ?? EXIT_CODES.GENERIC });
+    this.name = "CliError";
+  }
+}
+
+export type HttpErrorContext = {
+  requestId?: string;
+  retriesAttempted?: number;
+};
+
+function retryHint(ctx: HttpErrorContext): string | undefined {
+  if (ctx.retriesAttempted === undefined || ctx.retriesAttempted <= 0) return undefined;
+  return `Retried ${String(ctx.retriesAttempted)} time(s); include request-id in support tickets when available.`;
+}
+
+function mergeHints(...parts: Array<string | undefined>): string | undefined {
+  const xs = parts.filter((p): p is string => p !== undefined && p !== "");
+  if (xs.length === 0) return undefined;
+  return xs.join(" ");
+}
+
+/** Maps HTTP status to a CLI error with hints; covers all 4xx/5xx (#3191). */
+export function httpStatusToCliError(
+  status: number,
+  apiMessage: string,
+  ctx: HttpErrorContext = {},
+): ObjectifiedCliError {
+  const base = apiMessage.trim() || `HTTP ${String(status)}`;
+  const rHint = retryHint(ctx);
+
+  if (status === 401) {
+    return new ObjectifiedCliError({
+      message: base,
+      exitCode: EXIT_CODES.NOT_AUTHENTICATED,
+      title: "Not authenticated",
+      hint: mergeHints("Run `objectified auth login` or set OBJECTIFIED_API_KEY.", rHint),
+      requestId: ctx.requestId,
+      retriesAttempted: ctx.retriesAttempted,
+    });
+  }
+  if (status === 403 || status === 402 || status === 451) {
+    return new ObjectifiedCliError({
+      message: base,
+      exitCode: EXIT_CODES.FORBIDDEN,
+      title: "Forbidden",
+      hint: mergeHints("Switch tenant or API key; verify you have access to this resource.", rHint),
+      requestId: ctx.requestId,
+      retriesAttempted: ctx.retriesAttempted,
+    });
+  }
+  if (status === 404 || status === 410) {
+    return new ObjectifiedCliError({
+      message: base,
+      exitCode: EXIT_CODES.NOT_FOUND,
+      title: "Not found",
+      hint: mergeHints("Check slugs, IDs, and tenant scope.", rHint),
+      requestId: ctx.requestId,
+      retriesAttempted: ctx.retriesAttempted,
+    });
+  }
+  if (status === 409 || status === 423) {
+    return new ObjectifiedCliError({
+      message: base,
+      exitCode: EXIT_CODES.CONFLICT,
+      title: "Conflict",
+      hint: mergeHints("Pull remote changes or fork before retrying.", rHint),
+      requestId: ctx.requestId,
+      retriesAttempted: ctx.retriesAttempted,
+    });
+  }
+  if (status === 408) {
+    return new ObjectifiedCliError({
+      message: base,
+      exitCode: EXIT_CODES.NETWORK,
+      title: "Request timeout",
+      hint: mergeHints(
+        "The server closed an idle request; check `--base-url` or OBJECTIFIED_BASE_URL.",
+        rHint,
+      ),
+      requestId: ctx.requestId,
+      retriesAttempted: ctx.retriesAttempted,
+    });
+  }
+  if (status === 429) {
+    return new ObjectifiedCliError({
+      message: base,
+      exitCode: EXIT_CODES.RATE_LIMITED,
+      title: "Rate limited",
+      hint: mergeHints("Wait for Retry-After (shown in verbose logs), then retry.", rHint),
+      requestId: ctx.requestId,
+      retriesAttempted: ctx.retriesAttempted,
+    });
+  }
+  if (status === 405 || status === 431) {
+    return new ObjectifiedCliError({
+      message: base,
+      exitCode: EXIT_CODES.MISUSE,
+      title: "Misuse",
+      hint: mergeHints("Wrong HTTP method or oversized headers for this client build."),
+      requestId: ctx.requestId,
+      retriesAttempted: ctx.retriesAttempted,
+    });
+  }
+  if (status === 426) {
+    return new ObjectifiedCliError({
+      message: base,
+      exitCode: EXIT_CODES.NETWORK,
+      title: "Upgrade required",
+      hint: mergeHints("TLS / protocol upgrade required; check `--base-url`."),
+      requestId: ctx.requestId,
+      retriesAttempted: ctx.retriesAttempted,
+    });
+  }
+  if (status === 407) {
+    return new ObjectifiedCliError({
+      message: base,
+      exitCode: EXIT_CODES.NOT_AUTHENTICATED,
+      title: "Proxy authentication required",
+      hint: mergeHints("Configure proxy credentials for your environment."),
+      requestId: ctx.requestId,
+      retriesAttempted: ctx.retriesAttempted,
+    });
+  }
+
+  if (status >= 500 && status <= 599) {
+    const exit =
+      status === 504 ? EXIT_CODES.NETWORK : EXIT_CODES.SERVER_ERROR;
+    const title = status === 504 ? "Gateway timeout" : "Server error";
+    return new ObjectifiedCliError({
+      message: base,
+      exitCode: exit,
+      title,
+      hint: mergeHints(
+        exit === EXIT_CODES.NETWORK
+          ? "Upstream timed out; check network path and `--base-url`."
+          : "API returned an error; retry later.",
+        rHint,
+      ),
+      requestId: ctx.requestId,
+      retriesAttempted: ctx.retriesAttempted,
+    });
+  }
+
+  if (status === 418) {
+    return new ObjectifiedCliError({
+      message: base,
+      exitCode: EXIT_CODES.GENERIC,
+      title: "Unsupported response",
+      hint: mergeHints("This HTTP status is unexpected from the Objectified API."),
+      requestId: ctx.requestId,
+      retriesAttempted: ctx.retriesAttempted,
+    });
+  }
+
+  if (status >= 400 && status <= 499) {
+    return new ObjectifiedCliError({
+      message: base,
+      exitCode: EXIT_CODES.VALIDATION,
+      title: "Validation error",
+      hint: mergeHints("Fix the request; use --dry-run where supported."),
+      requestId: ctx.requestId,
+      retriesAttempted: ctx.retriesAttempted,
+    });
+  }
+
+  return new ObjectifiedCliError({
+    message: base,
+    exitCode: EXIT_CODES.GENERIC,
+    title: "API error",
+    hint: undefined,
+    requestId: ctx.requestId,
+    retriesAttempted: ctx.retriesAttempted,
+  });
+}
+
+export function networkErrnoToCliError(err: NodeJS.ErrnoException): ObjectifiedCliError {
+  const code = err.code ?? "";
+  const msg = err.message || code || "Network error";
+  const baseHint =
+    "Check VPN / firewall / DNS; verify `--base-url` or OBJECTIFIED_BASE_URL reaches the API.";
+  const specifics: Record<string, string> = {
+    ECONNREFUSED: "Connection refused — nothing is listening at this host/port or a firewall blocked it.",
+    ENOTFOUND: "DNS lookup failed — check the hostname in `--base-url`.",
+    EAI_AGAIN: "Temporary DNS failure — retry or check resolver / VPN.",
+    ETIMEDOUT: "Connection timed out — host may be down or blocked.",
+    EPIPE: "Connection closed unexpectedly — retry or verify `--base-url`.",
+    CERT_HAS_EXPIRED: "TLS certificate expired — update server or trust store.",
+    UNABLE_TO_VERIFY_LEAF_SIGNATURE: "TLS verification failed — check corporate proxy or `--base-url`.",
+  };
+  const detail = specifics[code];
+  return new ObjectifiedCliError({
+    message: detail ?? msg,
+    exitCode: EXIT_CODES.NETWORK,
+    title: "Network error",
+    hint: mergeHints(baseHint, code ? `(errno ${code})` : undefined),
+  });
 }

--- a/objectified-cli/src/lib/exit-codes.ts
+++ b/objectified-cli/src/lib/exit-codes.ts
@@ -1,0 +1,84 @@
+/** BSD/sysexits-inspired CLI exit codes (#3191). */
+export const EXIT_CODES = {
+  SUCCESS: 0,
+  GENERIC: 1,
+  MISUSE: 2,
+  NOT_AUTHENTICATED: 3,
+  FORBIDDEN: 4,
+  NOT_FOUND: 5,
+  CONFLICT: 6,
+  VALIDATION: 7,
+  SERVER_ERROR: 8,
+  NETWORK: 9,
+  RATE_LIMITED: 10,
+  CONFIG: 11,
+} as const;
+
+export type ExitCode = (typeof EXIT_CODES)[keyof typeof EXIT_CODES];
+
+export type ExitCodeRow = {
+  code: ExitCode;
+  label: string;
+  hint: string;
+};
+
+export const EXIT_CODE_TABLE: ExitCodeRow[] = [
+  { code: 0, label: "success", hint: "Command completed normally." },
+  { code: 1, label: "generic failure", hint: "Unexpected error; see message and retry with OBJECTIFIED_DEBUG=1." },
+  { code: 2, label: "misuse", hint: "Fix flags or arguments; try --help on the command." },
+  {
+    code: 3,
+    label: "not authenticated",
+    hint: "Run `objectified auth login` or set OBJECTIFIED_API_KEY / bearer token.",
+  },
+  { code: 4, label: "forbidden", hint: "Switch tenant or API key; check permissions for this resource." },
+  { code: 5, label: "not found", hint: "Check spelling of slugs and IDs; see suggestions when available." },
+  { code: 6, label: "conflict", hint: "Pull remote changes or fork before retrying." },
+  { code: 7, label: "validation", hint: "Fix request payload; use --dry-run where supported to preview changes." },
+  {
+    code: 8,
+    label: "server error",
+    hint: "API returned 5xx; retry later. Request-id is printed when the server sends one.",
+  },
+  {
+    code: 9,
+    label: "network / timeout",
+    hint: "Check VPN / firewall / DNS; verify `--base-url` or OBJECTIFIED_BASE_URL.",
+  },
+  {
+    code: 10,
+    label: "rate limited",
+    hint: "Wait for Retry-After (shown when present), then retry with backoff.",
+  },
+  { code: 11, label: "config error", hint: "Run `objectified config path` and fix config.toml / profile entries." },
+];
+
+export function formatExitCodeDocs(): string {
+  const lines = [
+    "Exit codes (BSD/sysexits-inspired):",
+    "",
+    ...EXIT_CODE_TABLE.filter((r) => r.code !== 0).map(
+      (r) => `  ${String(r.code).padEnd(3)}  ${r.label.padEnd(22)} ${r.hint}`,
+    ),
+    "",
+    "Stacks and SDK traces print only with `--verbose` or OBJECTIFIED_DEBUG=1.",
+    "",
+    "Related:",
+    "  • Global flags: objectified --help",
+    "  • Config file path: objectified config path",
+  ];
+  return lines.join("\n");
+}
+
+export function exitCodeReferenceJson(): {
+  exitCodes: Array<{ code: number; label: string; hint: string }>;
+  notes: string[];
+} {
+  return {
+    exitCodes: EXIT_CODE_TABLE.map(({ code, label, hint }) => ({ code, label, hint })),
+    notes: [
+      "Stacks and SDK traces print only with --verbose or OBJECTIFIED_DEBUG=1.",
+      "See objectified --help for global flags.",
+    ],
+  };
+}

--- a/objectified-cli/src/lib/handle-error.ts
+++ b/objectified-cli/src/lib/handle-error.ts
@@ -280,15 +280,5 @@ export function formatAndReportCliFailure(err: unknown, opts: HandleCliErrorOpti
     console.error(text);
   }
 
-  if (opts.debugStacks && err instanceof Error && !(err instanceof ObjectifiedCliError)) {
-    const skip =
-      err instanceof CLIError ||
-      err.constructor.name === "CLIParseError" ||
-      /^command .+ not found$/i.test(err.message.trim());
-    if (!skip && err.stack !== undefined && err.stack.trim() !== "") {
-      console.error(`\n${err.stack}`);
-    }
-  }
-
   return effectiveExit;
 }

--- a/objectified-cli/src/lib/handle-error.ts
+++ b/objectified-cli/src/lib/handle-error.ts
@@ -1,0 +1,294 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { CLIError, ExitError } from "@oclif/core/errors";
+import { Chalk } from "chalk";
+import leven from "leven";
+
+import { EXIT_CODES } from "./exit-codes.js";
+import { ObjectifiedCliError } from "./errors.js";
+
+const MANIFEST_REL = "../../oclif.manifest.json";
+
+export type HandleCliErrorOptions = {
+  /** When true, include JS stack traces after the formatted message. */
+  debugStacks: boolean;
+  /** When false, disable ANSI emphasis. */
+  color: boolean;
+};
+
+let cachedCommandIds: string[] | undefined;
+
+function loadRegisteredCommandIds(): string[] {
+  if (cachedCommandIds !== undefined) return cachedCommandIds;
+  try {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const raw = readFileSync(join(here, MANIFEST_REL), "utf8");
+    const manifest = JSON.parse(raw) as { commands?: Record<string, unknown> };
+    cachedCommandIds = Object.keys(manifest.commands ?? {}).sort();
+    return cachedCommandIds;
+  } catch {
+    cachedCommandIds = [];
+    return cachedCommandIds;
+  }
+}
+
+export function resolveDebugStacks(argv: string[], env: NodeJS.ProcessEnv): boolean {
+  if (env.OBJECTIFIED_DEBUG === "1" || env.OBJECTIFIED_DEBUG === "true") return true;
+  return argv.some((a) => a === "--verbose" || a.startsWith("--verbose="));
+}
+
+export function truncateRequestId(id: string): string {
+  const t = id.trim();
+  if (t.length <= 12) return t;
+  return `${t.slice(0, 4)}…${t.slice(-4)}`;
+}
+
+function suggestDidYouMean(rawId: string): string | undefined {
+  const q = rawId.trim();
+  if (q === "") return undefined;
+  const ids = loadRegisteredCommandIds();
+  const scored = ids
+    .map((id) => ({ id, d: leven(q, id) }))
+    .filter((x) => x.d > 0 && x.d < 3)
+    .sort((a, b) => a.d - b.d || a.id.localeCompare(b.id));
+  if (scored.length === 0) return undefined;
+  const best = scored[0];
+  if (best === undefined) return undefined;
+  const bin = "objectified";
+  const pretty = best.id.replace(/:/g, " ");
+  return `Did you mean \`${bin} ${pretty}\`?`;
+}
+
+function formatCommandNotFoundMessage(message: string): { headline: string; hint?: string } {
+  const m = /^command (.+) not found$/i.exec(message.trim());
+  if (!m || m[1] === undefined) return { headline: message };
+  const typed = m[1];
+  const hint = suggestDidYouMean(typed);
+  return {
+    headline: `Unknown command "${typed}".`,
+    hint,
+  };
+}
+
+function defaultHeadlineForExit(code: number): string {
+  switch (code) {
+    case EXIT_CODES.MISUSE:
+      return "Invalid usage";
+    case EXIT_CODES.NOT_AUTHENTICATED:
+      return "Not authenticated";
+    case EXIT_CODES.FORBIDDEN:
+      return "Forbidden";
+    case EXIT_CODES.NOT_FOUND:
+      return "Not found";
+    case EXIT_CODES.CONFLICT:
+      return "Conflict";
+    case EXIT_CODES.VALIDATION:
+      return "Validation failed";
+    case EXIT_CODES.SERVER_ERROR:
+      return "Server error";
+    case EXIT_CODES.NETWORK:
+      return "Network error";
+    case EXIT_CODES.RATE_LIMITED:
+      return "Rate limited";
+    case EXIT_CODES.CONFIG:
+      return "Configuration error";
+    default:
+      return "Command failed";
+  }
+}
+
+/** Canonical string formatter for CLI failures (#3191). */
+export function handleError(err: unknown, opts: HandleCliErrorOptions): string {
+  return formatHandleableError(err, opts);
+}
+
+/** Shared formatter for stderr (also used from snapshot tests). */
+export function formatHandleableError(err: unknown, opts: HandleCliErrorOptions): string {
+  const c = new Chalk({ level: opts.color && process.stderr.isTTY ? 3 : 0 });
+
+  const lines: string[] = [];
+
+  const pushHint = (h?: string) => {
+    if (h !== undefined && h !== "") lines.push(`${c.dim("Hint:")}   ${h}`);
+  };
+
+  if (err instanceof ExitError) {
+    return "";
+  }
+
+  if (err instanceof ObjectifiedCliError) {
+    const headline = err.title ?? defaultHeadlineForExit(err.exitCode);
+    lines.push(`${c.red("✖")} ${c.bold(headline)}`);
+    lines.push(`${c.dim("Reason:")} ${err.message}`);
+    pushHint(err.hint);
+    if (err.requestId !== undefined && err.requestId !== "") {
+      lines.push(`${c.dim("Request-Id:")} ${truncateRequestId(err.requestId)}`);
+    }
+    lines.push(`${c.dim("Exit code:")}  ${String(err.exitCode)}`);
+    return lines.join("\n");
+  }
+
+  if (err instanceof CLIError) {
+    const exit =
+      typeof err.oclif.exit === "number" && Number.isFinite(err.oclif.exit)
+        ? err.oclif.exit
+        : EXIT_CODES.GENERIC;
+    const raw = err.message;
+    const isCmdMissing = /^command .+ not found$/i.test(raw.trim());
+    const misuse =
+      exit === EXIT_CODES.MISUSE ||
+      err.constructor.name === "CLIParseError" ||
+      raw.includes("See more help with --help") ||
+      raw.includes("Unexpected flag") ||
+      raw.includes("Nonexistent flag") ||
+      raw.includes("Unexpected argument");
+
+    if (isCmdMissing) {
+      const { headline, hint } = formatCommandNotFoundMessage(raw);
+      lines.push(`${c.red("✖")} ${c.bold(headline)}`);
+      lines.push(`${c.dim("Reason:")} ${raw}`);
+      pushHint(hint);
+      lines.push(`${c.dim("Exit code:")}  ${String(EXIT_CODES.MISUSE)}`);
+      return lines.join("\n");
+    }
+
+    if (misuse) {
+      lines.push(`${c.red("✖")} ${c.bold("Invalid usage")}`);
+      lines.push(`${c.dim("Reason:")} ${raw}`);
+      pushHint("Run the command with `--help`, or fix flags and arguments.");
+      lines.push(`${c.dim("Exit code:")}  ${String(EXIT_CODES.MISUSE)}`);
+      return lines.join("\n");
+    }
+
+    lines.push(`${c.red("✖")} ${c.bold(defaultHeadlineForExit(exit))}`);
+    lines.push(`${c.dim("Reason:")} ${raw}`);
+    lines.push(`${c.dim("Exit code:")}  ${String(exit)}`);
+    return lines.join("\n");
+  }
+
+  if (err instanceof Error) {
+    lines.push(`${c.red("✖")} ${c.bold("Command failed")}`);
+    lines.push(`${c.dim("Reason:")} ${err.message || err.name}`);
+    lines.push(`${c.dim("Exit code:")}  ${String(EXIT_CODES.GENERIC)}`);
+    const body = lines.join("\n");
+    if (!opts.debugStacks) return body;
+    if (err.stack !== undefined && err.stack.trim() !== "") {
+      return `${body}\n\n${err.stack}`;
+    }
+    return body;
+  }
+
+  lines.push(`${c.red("✖")} ${c.bold("Command failed")}`);
+  lines.push(`${c.dim("Reason:")} ${String(err)}`);
+  lines.push(`${c.dim("Exit code:")}  ${String(EXIT_CODES.GENERIC)}`);
+  return lines.join("\n");
+}
+
+export function resolveEffectiveExitCode(err: unknown): number {
+  if (err instanceof ExitError) {
+    const code = Number.parseInt(String(err.oclif.exit ?? 1), 10);
+    return Number.isFinite(code) ? code : 1;
+  }
+
+  let exitCode: number = EXIT_CODES.GENERIC;
+  if (err instanceof ObjectifiedCliError) exitCode = err.exitCode;
+  else if (err instanceof CLIError) {
+    const code = err.oclif.exit;
+    exitCode = typeof code === "number" && Number.isFinite(code) ? code : EXIT_CODES.GENERIC;
+  }
+
+  const misuseFromUnknownCommand =
+    err instanceof CLIError && /^command .+ not found$/i.test(err.message.trim());
+  return misuseFromUnknownCommand && exitCode !== EXIT_CODES.MISUSE ? EXIT_CODES.MISUSE : exitCode;
+}
+
+export function cliFailureJsonEnvelope(
+  err: unknown,
+  requestIdFallback?: string,
+): {
+  error: {
+    title?: string;
+    message: string;
+    exitCode: number;
+    hint?: string;
+    requestId?: string;
+    retriesAttempted?: number;
+  };
+} {
+  if (err instanceof ObjectifiedCliError) {
+    return {
+      error: {
+        title: err.title,
+        message: err.message,
+        exitCode: err.exitCode,
+        hint: err.hint,
+        requestId: err.requestId ?? requestIdFallback,
+        retriesAttempted: err.retriesAttempted,
+      },
+    };
+  }
+
+  if (err instanceof CLIError) {
+    const raw = err.message;
+    const hint = /^command .+ not found$/i.test(raw.trim())
+      ? formatCommandNotFoundMessage(raw).hint
+      : undefined;
+    return {
+      error: {
+        message: raw,
+        exitCode: resolveEffectiveExitCode(err),
+        hint,
+        requestId: requestIdFallback,
+      },
+    };
+  }
+
+  if (err instanceof Error) {
+    return {
+      error: {
+        message: err.message || err.name,
+        exitCode: EXIT_CODES.GENERIC,
+        requestId: requestIdFallback,
+      },
+    };
+  }
+
+  return {
+    error: {
+      message: String(err),
+      exitCode: EXIT_CODES.GENERIC,
+      requestId: requestIdFallback,
+    },
+  };
+}
+
+/**
+ * Prints the canonical multi-line error template and returns a process exit code.
+ * ExitError is passed through without printing.
+ */
+export function formatAndReportCliFailure(err: unknown, opts: HandleCliErrorOptions): number {
+  if (err instanceof ExitError) {
+    return resolveEffectiveExitCode(err);
+  }
+
+  const effectiveExit = resolveEffectiveExitCode(err);
+
+  const text = formatHandleableError(err, opts);
+  if (text !== "") {
+    console.error(text);
+  }
+
+  if (opts.debugStacks && err instanceof Error && !(err instanceof ObjectifiedCliError)) {
+    const skip =
+      err instanceof CLIError ||
+      err.constructor.name === "CLIParseError" ||
+      /^command .+ not found$/i.test(err.message.trim());
+    if (!skip && err.stack !== undefined && err.stack.trim() !== "") {
+      console.error(`\n${err.stack}`);
+    }
+  }
+
+  return effectiveExit;
+}

--- a/objectified-cli/test/__snapshots__/handle-error.snap.test.ts.snap
+++ b/objectified-cli/test/__snapshots__/handle-error.snap.test.ts.snap
@@ -1,0 +1,94 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`handleError snapshots by category > config error 1`] = `
+"✖ Configuration error
+Reason: Invalid TOML in config.
+Hint:   Run \`objectified config path\` and repair the file.
+Exit code:  11"
+`;
+
+exports[`handleError snapshots by category > conflict 1`] = `
+"✖ Conflict
+Reason: Version already exists
+Hint:   Pull remote changes or fork before retrying.
+Request-Id: rid-409
+Exit code:  6"
+`;
+
+exports[`handleError snapshots by category > forbidden 1`] = `
+"✖ Forbidden
+Reason: Tenant mismatch
+Hint:   Switch tenant or API key; verify you have access to this resource.
+Request-Id: rid-403
+Exit code:  4"
+`;
+
+exports[`handleError snapshots by category > generic ObjectifiedCliError 1`] = `
+"✖ Unexpected failure
+Reason: Something unexpected happened.
+Hint:   Retry later or contact support with the request-id.
+Request-Id: 7f2c…cafe
+Exit code:  1"
+`;
+
+exports[`handleError snapshots by category > misuse (oclif unknown flag) 1`] = `
+"✖ Invalid usage
+Reason: Unexpected flag --frobnitz
+See more help with --help
+Hint:   Run the command with \`--help\`, or fix flags and arguments.
+Exit code:  2"
+`;
+
+exports[`handleError snapshots by category > network / errno 1`] = `
+"✖ Network error
+Reason: Connection refused — nothing is listening at this host/port or a firewall blocked it.
+Hint:   Check VPN / firewall / DNS; verify \`--base-url\` or OBJECTIFIED_BASE_URL reaches the API. (errno ECONNREFUSED)
+Exit code:  9"
+`;
+
+exports[`handleError snapshots by category > not authenticated 1`] = `
+"✖ Not authenticated
+Reason: Missing bearer token
+Hint:   Run \`objectified auth login\` or set OBJECTIFIED_API_KEY.
+Request-Id: rid-401
+Exit code:  3"
+`;
+
+exports[`handleError snapshots by category > not found 1`] = `
+"✖ Not found
+Reason: Project unknown
+Hint:   Check slugs, IDs, and tenant scope.
+Request-Id: rid-404
+Exit code:  5"
+`;
+
+exports[`handleError snapshots by category > rate limited 1`] = `
+"✖ Rate limited
+Reason: Slow down
+Hint:   Wait for Retry-After (shown in verbose logs), then retry.
+Request-Id: rid-429
+Exit code:  10"
+`;
+
+exports[`handleError snapshots by category > server error 1`] = `
+"✖ Server error
+Reason: Upstream unavailable
+Hint:   API returned an error; retry later. Retried 3 time(s); include request-id in support tickets when available.
+Request-Id: rid-503
+Exit code:  8"
+`;
+
+exports[`handleError snapshots by category > unknown command with did-you-mean 1`] = `
+"✖ Unknown command "helol".
+Reason: command helol not found
+Hint:   Did you mean \`objectified hello\`?
+Exit code:  2"
+`;
+
+exports[`handleError snapshots by category > validation 1`] = `
+"✖ Validation error
+Reason: Invalid payload
+Hint:   Fix the request; use --dry-run where supported.
+Request-Id: rid-422
+Exit code:  7"
+`;

--- a/objectified-cli/test/api-client.test.ts
+++ b/objectified-cli/test/api-client.test.ts
@@ -131,7 +131,6 @@ describe("createApiClient + generated SDK", () => {
 
   it("retries transient 5xx with exponential backoff", async () => {
     vi.useFakeTimers();
-    vi.spyOn(Math, "random").mockReturnValue(0);
 
     let calls = 0;
     const mockFetch = vi.fn(async () => {

--- a/objectified-cli/test/cli.integration.test.ts
+++ b/objectified-cli/test/cli.integration.test.ts
@@ -158,6 +158,11 @@ base_url = "https://api.prod.example"
     expect(out.includes("\u001B[")).toBe(false);
   });
 
+  it("does not emit ANSI escapes for errors when --no-color is set", () => {
+    const err = runExpectFailure(["--no-color", "helol"]);
+    expect(err.includes("\u001B[")).toBe(false);
+  });
+
   it("cold-starts --version within 200 ms on developer machines", () => {
     const iterations = process.env.CI ? 2 : 5;
     let fastest = Number.POSITIVE_INFINITY;

--- a/objectified-cli/test/cli.integration.test.ts
+++ b/objectified-cli/test/cli.integration.test.ts
@@ -70,6 +70,20 @@ describe("objectified CLI", () => {
     expect(err).toMatch(/Tenant slug is required/i);
   });
 
+  it("docs errors prints exit code reference", () => {
+    const out = run(["docs", "errors", "--no-json"]);
+    expect(out).toMatch(/Exit codes/);
+    expect(out).toMatch(/not authenticated/);
+    expect(out).toMatch(/OBJECTIFIED_DEBUG/);
+  });
+
+  it("unknown command suggests typo fix when close match", () => {
+    const err = runExpectFailure(["helol"]);
+    expect(err).toMatch(/Unknown command/);
+    expect(err).toMatch(/Did you mean/);
+    expect(err).toMatch(/hello/);
+  });
+
   it("config path respects OBJECTIFIED_CONFIG", () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "obj-cli-int-"));
     const cfg = path.join(dir, "objectified.toml");

--- a/objectified-cli/test/handle-error.snap.test.ts
+++ b/objectified-cli/test/handle-error.snap.test.ts
@@ -1,11 +1,15 @@
 import { CLIError } from "@oclif/core/errors";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { EXIT_CODES } from "../src/lib/exit-codes.js";
 import { httpStatusToCliError, networkErrnoToCliError, ObjectifiedCliError } from "../src/lib/errors.js";
-import { handleError } from "../src/lib/handle-error.js";
+import { formatAndReportCliFailure, handleError } from "../src/lib/handle-error.js";
 
 const noColor = { debugStacks: false, color: false };
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe("handleError snapshots by category", () => {
   it("generic ObjectifiedCliError", () => {
@@ -100,5 +104,18 @@ describe("handleError snapshots by category", () => {
 
   it("unknown command with did-you-mean", () => {
     expect(handleError(new CLIError("command helol not found"), noColor)).toMatchSnapshot();
+  });
+
+  it("prints generic error stack once when debug stacks are enabled", () => {
+    const err = new Error("boom");
+    err.stack = "Error: boom\n  at test";
+    const stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const exit = formatAndReportCliFailure(err, { debugStacks: true, color: false });
+
+    expect(exit).toBe(EXIT_CODES.GENERIC);
+    expect(stderrSpy).toHaveBeenCalledTimes(1);
+    const rendered = String(stderrSpy.mock.calls[0]?.[0] ?? "");
+    expect(rendered.match(/Error: boom/g)?.length ?? 0).toBe(1);
   });
 });

--- a/objectified-cli/test/handle-error.snap.test.ts
+++ b/objectified-cli/test/handle-error.snap.test.ts
@@ -1,0 +1,104 @@
+import { CLIError } from "@oclif/core/errors";
+import { describe, expect, it } from "vitest";
+
+import { EXIT_CODES } from "../src/lib/exit-codes.js";
+import { httpStatusToCliError, networkErrnoToCliError, ObjectifiedCliError } from "../src/lib/errors.js";
+import { handleError } from "../src/lib/handle-error.js";
+
+const noColor = { debugStacks: false, color: false };
+
+describe("handleError snapshots by category", () => {
+  it("generic ObjectifiedCliError", () => {
+    expect(
+      handleError(
+        new ObjectifiedCliError({
+          message: "Something unexpected happened.",
+          exitCode: EXIT_CODES.GENERIC,
+          title: "Unexpected failure",
+          hint: "Retry later or contact support with the request-id.",
+          requestId: "7f2c9d01a041cafe",
+        }),
+        noColor,
+      ),
+    ).toMatchSnapshot();
+  });
+
+  it("misuse (oclif unknown flag)", () => {
+    expect(
+      handleError(new CLIError("Unexpected flag --frobnitz\nSee more help with --help"), noColor),
+    ).toMatchSnapshot();
+  });
+
+  it("not authenticated", () => {
+    expect(
+      handleError(httpStatusToCliError(401, "Missing bearer token", { requestId: "rid-401" }), noColor),
+    ).toMatchSnapshot();
+  });
+
+  it("forbidden", () => {
+    expect(
+      handleError(httpStatusToCliError(403, "Tenant mismatch", { requestId: "rid-403" }), noColor),
+    ).toMatchSnapshot();
+  });
+
+  it("not found", () => {
+    expect(
+      handleError(httpStatusToCliError(404, "Project unknown", { requestId: "rid-404" }), noColor),
+    ).toMatchSnapshot();
+  });
+
+  it("conflict", () => {
+    expect(
+      handleError(httpStatusToCliError(409, "Version already exists", { requestId: "rid-409" }), noColor),
+    ).toMatchSnapshot();
+  });
+
+  it("validation", () => {
+    expect(
+      handleError(httpStatusToCliError(422, "Invalid payload", { requestId: "rid-422" }), noColor),
+    ).toMatchSnapshot();
+  });
+
+  it("server error", () => {
+    expect(
+      handleError(
+        httpStatusToCliError(503, "Upstream unavailable", {
+          requestId: "rid-503",
+          retriesAttempted: 3,
+        }),
+        noColor,
+      ),
+    ).toMatchSnapshot();
+  });
+
+  it("network / errno", () => {
+    const err = networkErrnoToCliError(
+      Object.assign(new Error("connect ECONNREFUSED 127.0.0.1:9"), { code: "ECONNREFUSED" }),
+    );
+    expect(handleError(err, noColor)).toMatchSnapshot();
+  });
+
+  it("rate limited", () => {
+    expect(
+      handleError(httpStatusToCliError(429, "Slow down", { requestId: "rid-429" }), noColor),
+    ).toMatchSnapshot();
+  });
+
+  it("config error", () => {
+    expect(
+      handleError(
+        new ObjectifiedCliError({
+          message: "Invalid TOML in config.",
+          exitCode: EXIT_CODES.CONFIG,
+          title: "Configuration error",
+          hint: "Run `objectified config path` and repair the file.",
+        }),
+        noColor,
+      ),
+    ).toMatchSnapshot();
+  });
+
+  it("unknown command with did-you-mean", () => {
+    expect(handleError(new CLIError("command helol not found"), noColor)).toMatchSnapshot();
+  });
+});

--- a/objectified-cli/test/http-status-mapping.test.ts
+++ b/objectified-cli/test/http-status-mapping.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import { EXIT_CODES } from "../src/lib/exit-codes.js";
+import { httpStatusToCliError } from "../src/lib/errors.js";
+
+const handled4xx = new Set([
+  401, 402, 403, 404, 405, 407, 408, 409, 410, 418, 423, 426, 429, 431, 451,
+]);
+
+describe("httpStatusToCliError", () => {
+  const ctx = { requestId: "7f2c9d01-a041", retriesAttempted: 3 };
+
+  it("maps representative statuses", () => {
+    expect(httpStatusToCliError(401, "nope", ctx).exitCode).toBe(EXIT_CODES.NOT_AUTHENTICATED);
+    expect(httpStatusToCliError(403, "nope", ctx).exitCode).toBe(EXIT_CODES.FORBIDDEN);
+    expect(httpStatusToCliError(404, "nope", ctx).exitCode).toBe(EXIT_CODES.NOT_FOUND);
+    expect(httpStatusToCliError(409, "nope", ctx).exitCode).toBe(EXIT_CODES.CONFLICT);
+    expect(httpStatusToCliError(408, "nope", ctx).exitCode).toBe(EXIT_CODES.NETWORK);
+    expect(httpStatusToCliError(429, "nope", ctx).exitCode).toBe(EXIT_CODES.RATE_LIMITED);
+    expect(httpStatusToCliError(405, "nope", ctx).exitCode).toBe(EXIT_CODES.MISUSE);
+    expect(httpStatusToCliError(500, "nope", ctx).exitCode).toBe(EXIT_CODES.SERVER_ERROR);
+    expect(httpStatusToCliError(504, "nope", ctx).exitCode).toBe(EXIT_CODES.NETWORK);
+    expect(httpStatusToCliError(418, "teapot", ctx).exitCode).toBe(EXIT_CODES.GENERIC);
+  });
+
+  it("maps every unhandled 4xx to validation", () => {
+    for (let s = 400; s <= 499; s++) {
+      if (handled4xx.has(s)) continue;
+      expect(httpStatusToCliError(s, "", {}).exitCode).toBe(EXIT_CODES.VALIDATION);
+    }
+  });
+
+  it("maps every 5xx", () => {
+    for (let s = 500; s <= 599; s++) {
+      const want = s === 504 ? EXIT_CODES.NETWORK : EXIT_CODES.SERVER_ERROR;
+      expect(httpStatusToCliError(s, "", {}).exitCode).toBe(want);
+    }
+  });
+});

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -8,6 +8,7 @@ We continue to improve the platform based on your feedback with improvements and
 - MCP service is now live
 
 ## CLI
+- **`objectified-cli`**: shared error layer (`ObjectifiedCliError`, documented exit codes via `objectified docs errors`, stderr template with hints + request-id, `--verbose` / `OBJECTIFIED_DEBUG=1` stacks only), Levenshtein did-you-mean for unknown commands, HTTP status → exit-code mapping, and fetch retries per idempotent vs non-idempotent verbs (#3191).
 - **`objectified-cli`**: OpenAPI codegen (`yarn codegen` → `src/generated/`), typed `@hey-api/client-fetch` SDK, `lib/client.ts` wrapper (retries, `Retry-After`, 401 hook, request IDs), ESLint single-import guard, `codegen:check` in tests, and `projects list` backed by the generated client (#3190).
 - New **`objectified-cli`** package (oclif v4) adds the `objectified` binary scaffold with `hello`, `--version`, and `--help` (#3186).
 - **`objectified-cli`**: shared global flags on `BaseCommand` (`--base-url`, `--profile`, `--api-key`, `--config`, `--json`, `--no-color`, `--quiet`, `--verbose`), TOML profile resolution, root help text for precedence rules, argv normalization for globals-before-subcommand, and stub `projects list` (#3187).

--- a/yarn.lock
+++ b/yarn.lock
@@ -12125,6 +12125,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"leven@npm:^4.0.0":
+  version: 4.1.0
+  resolution: "leven@npm:4.1.0"
+  checksum: 10c0/de45316555624d7616c562055ce4773ad44dff7486a1696be300b040eb85472a429c2f18fd0f6352101b1fb01b336405b893f048d88d30f6fb7f8a2a2999a0c0
+  languageName: node
+  linkType: hard
+
 "levn@npm:^0.4.1":
   version: 0.4.1
   resolution: "levn@npm:0.4.1"
@@ -13777,6 +13784,7 @@ __metadata:
     eslint: "npm:^9.39.4"
     eslint-config-prettier: "npm:^10.1.1"
     fs-extra: "npm:^11.3.5"
+    leven: "npm:^4.0.0"
     oclif: "npm:^4.23.0"
     ora: "npm:^9.4.0"
     prettier: "npm:^3.6.2"


### PR DESCRIPTION
## Summary
Implements the shared CLI error layer from #3191: structured `ObjectifiedCliError`, documented BSD-style exit codes, centralized stderr formatting (`handleError` / `formatAndReportCliFailure`), did-you-mean for unknown commands (`leven`), HTTP status→exit-code mapping with hints and request-id lines, fetch retry policy (idempotent vs POST/PATCH), `objectified docs errors`, and Vitest coverage (snapshots + mapping loops).

## How to test
- **Build**: `yarn workspace objectified-cli build`
- **Unit/integration**: `yarn workspace objectified-cli test`
- **Manual**: Run `objectified docs errors` and confirm the exit-code table prints.
- **Manual**: Run `objectified helol` (typo) and confirm **Did you mean** suggests `hello`.
- **Manual**: Run `objectified projects list` without tenant env/profile and confirm formatted **Configuration error** with exit **11**.
- **Stacks**: Confirm a thrown generic error does **not** print a JS stack unless **`--verbose`** or **`OBJECTIFIED_DEBUG=1`**.

## Risks / notes
- Top-level entry replaces `@oclif/core` `execute().catch(handle)` with `run` + `flush` + `formatAndReportCliFailure` + `process.exit` so stderr formatting stays consistent.
- Root `yarn build` may still fail where `uv` is missing for `objectified-mcp`; CLI package builds and tests clean locally.

Closes #3191

Made with [Cursor](https://cursor.com)