### PR TITLE
Fix #3192 — CLI help, docs topics, man pages, readme sync

### DIFF
--- a/.github/workflows/objectified-cli.yml
+++ b/.github/workflows/objectified-cli.yml
@@ -1,0 +1,31 @@
+name: objectified-cli
+
+on:
+  push:
+    paths:
+      - "objectified-cli/**"
+      - ".github/workflows/objectified-cli.yml"
+      - "yarn.lock"
+      - "package.json"
+  pull_request:
+    paths:
+      - "objectified-cli/**"
+      - ".github/workflows/objectified-cli.yml"
+      - "yarn.lock"
+      - "package.json"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: yarn
+          cache-dependency-path: yarn.lock
+      - run: corepack enable
+      - run: yarn install --immutable
+      - run: yarn workspace objectified-cli test
+      - name: Generated README, manifest, man pages must match git
+        run: git diff --exit-code

--- a/docs/PLANNED_ROADMAP_CLI.md
+++ b/docs/PLANNED_ROADMAP_CLI.md
@@ -106,7 +106,6 @@ Total: **12 epics**, **88 sub-tickets** (open roadmap items; completed work is d
 
 | #         | Title                                                              | Description                                                                  | Labels                                          | MVP | Parallel |
 |-----------|--------------------------------------------------------------------|------------------------------------------------------------------------------|-------------------------------------------------|-----|----------|
-| 1.7 (#3192) | Help system, examples, man pages, `objectified docs`             | Rich help, ≥2 examples per command, generated man pages, `docs <topic>`     | `enhancement`, `mvp`, `cli`, `roadmap-cli`, `documentation` | Yes | Yes      |
 | 1.8 (#3193) | Shell completions (bash/zsh/fish/PowerShell)                     | Static completions + dynamic (tenant/project/version slugs)                  | `enhancement`, `cli`, `roadmap-cli`            | No  | Yes      |
 
 ### Detailed Issue Descriptions
@@ -223,13 +222,11 @@ Part of Epic: CLI Foundation & DevEx (#3174)
 
 ---
 
-#### 1.7 (#3192) — Help system, examples, man pages, `objectified docs`
+#### 1.7 (#3192) — Help system, examples, man pages, `objectified docs` (**done**)
 
-Custom oclif help renderer with ≥2 examples per command, grouped flag sections (`Required`/`Common`/`Output`/`Auth`), `See also`, and a topic-level `objectified docs <topic>` browser. Man pages generated at build time, shipped under `man/man1/`.
+Landed: custom `CommandHelp` (grouped **COMMON** / **OUTPUT** / **AUTH** / **OTHER**, **EXAMPLES** before flag groups, **SEE ALSO** from `static seeAlso`), ≥2 `examples` per command enforced in tests, `objectified docs` topic index plus prose topics (`errors`, `output`, `profiles`, `completions`, `plugins`, `telemetry`), `oclif readme` + `scripts/generate-man.mjs` writing `man/man1/*.1` and `package.json` `man`, CI workflow guards `git diff` after `yarn workspace objectified-cli test`, help honors **NO_COLOR**, non-TTY stdout, and `--no-color` via `stripAnsi`.
 
-**Acceptance Criteria:** every command has ≥2 examples; `man objectified` works after global install; README auto-generated and CI-guarded.
-
-**Parallelism / Dependencies:** Depends on 1.1, 1.2.
+**Parallelism / Dependencies:** Depended on 1.1, 1.2.
 
 Part of Epic: CLI Foundation & DevEx (#3174)
 
@@ -780,11 +777,10 @@ The `NPM_REGISTRY` env var lets us point at npmjs.com, GitHub Packages, JFrog Ar
 
 ## MVP Release — Ticket Bundle
 
-The MVP delivers an installable, useful CLI focused on _read_ and _publish_ for a single project's lifecycle. Total: **21 open sub-tickets** across 6 epics (plus completed foundation items such as #3186, #3187, #3188, #3189, #3190, and #3191).
+The MVP delivers an installable, useful CLI focused on _read_ and _publish_ for a single project's lifecycle. Total: **20 open sub-tickets** across 5 epics (plus completed foundation items such as #3186, #3187, #3188, #3189, #3190, #3191, and #3192).
 
 | Epic     | Tickets                                                                                                   | Count |
 |----------|-----------------------------------------------------------------------------------------------------------|-------|
-| 1 (#3174) | #3192                                                                                                      | 1     |
 | 2 (#3175) | #3194, #3195, #3196, #3197, #3198, #3199                                                                  | 6     |
 | 3 (#3176) | #3202, #3203, #3204                                                                                        | 3     |
 | 4 (#3177) | #3208, #3209, #3210, #3212                                                                                | 4     |
@@ -872,7 +868,7 @@ v2 fills out the writable surface for primitives, properties, classes, paths, da
 
 The tickets were created in the order below — that is also the recommended **execution** order. Earlier epics provide primitives that later epics rely on.
 
-1. **Epic 1 — Foundation** (#3174: #3186, #3187, #3188, #3189, #3190, and #3191 landed; then #3192 → #3193). Without the scaffold, no other command can exist.
+1. **Epic 1 — Foundation** (#3174: #3186, #3187, #3188, #3189, #3190, #3191, and #3192 landed; next #3193). Without the scaffold, no other command can exist.
 2. **Epic 2 — Auth & Tenants** (#3175 then #3194 → #3201). Required for any tenant-scoped command.
 3. **Epic 3 — Projects** (#3176 then #3202 → #3207). The first useful read/write surface.
 4. **Epic 4 — Versions** (#3177 then #3208 → #3216). The publish flow that makes the CLI valuable in CI.

--- a/objectified-cli/README.md
+++ b/objectified-cli/README.md
@@ -83,7 +83,7 @@ Print a single config value by dotted key
 
 ```
 USAGE
-  $ objectified config get KEY [--apiKey <value>] [--baseUrl <value>] [--config <value>] [--json] [--color]
+  $ objectified config get KEY [--api-key <value>] [--base-url <value>] [--config <value>] [--json] [--color]
     [--profile <value>] [-q] [--verbose]
 
 ARGUMENTS
@@ -100,10 +100,10 @@ EXAMPLES
   $ objectified --json config get profile.staging.tenant_slug
 
 COMMON
-  --baseUrl=<value>  Root REST API URL.
-  --config=<value>   Path to config file (default: XDG config dir / Objectified AppData on Windows — see `objectified
-                     config path`).
-  --profile=<value>  Named credentials profile (OBJECTIFIED_PROFILE); falls back to default_profile in config.
+  --base-url=<value>  Root REST API URL.
+  --config=<value>    Path to config file (default: XDG config dir / Objectified AppData on Windows — see `objectified
+                      config path`).
+  --profile=<value>   Named credentials profile (OBJECTIFIED_PROFILE); falls back to default_profile in config.
 
 OUTPUT
   --[no-]color  Enable/disable ANSI colors (--no-color sets NO_COLOR; colors are off when stdout is not a TTY).
@@ -112,7 +112,7 @@ OUTPUT
       --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
 
 AUTH
-  --apiKey=<value>  API key for direct authentication (bypasses login token).
+  --api-key=<value>  API key for direct authentication (bypasses login token).
 
 SEE ALSO
   objectified config set
@@ -126,7 +126,7 @@ Print the entire config file (stable JSON with --json, otherwise TOML)
 
 ```
 USAGE
-  $ objectified config list [--apiKey <value>] [--baseUrl <value>] [--config <value>] [--json] [--color]
+  $ objectified config list [--api-key <value>] [--base-url <value>] [--config <value>] [--json] [--color]
     [--profile <value>] [-q] [--verbose]
 
 DESCRIPTION
@@ -140,10 +140,10 @@ EXAMPLES
   $ objectified config list > backup.toml
 
 COMMON
-  --baseUrl=<value>  Root REST API URL.
-  --config=<value>   Path to config file (default: XDG config dir / Objectified AppData on Windows — see `objectified
-                     config path`).
-  --profile=<value>  Named credentials profile (OBJECTIFIED_PROFILE); falls back to default_profile in config.
+  --base-url=<value>  Root REST API URL.
+  --config=<value>    Path to config file (default: XDG config dir / Objectified AppData on Windows — see `objectified
+                      config path`).
+  --profile=<value>   Named credentials profile (OBJECTIFIED_PROFILE); falls back to default_profile in config.
 
 OUTPUT
   --[no-]color  Enable/disable ANSI colors (--no-color sets NO_COLOR; colors are off when stdout is not a TTY).
@@ -152,7 +152,7 @@ OUTPUT
       --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
 
 AUTH
-  --apiKey=<value>  API key for direct authentication (bypasses login token).
+  --api-key=<value>  API key for direct authentication (bypasses login token).
 
 SEE ALSO
   objectified config path
@@ -166,7 +166,7 @@ Print the resolved config.toml path
 
 ```
 USAGE
-  $ objectified config path [--apiKey <value>] [--baseUrl <value>] [--config <value>] [--json] [--color]
+  $ objectified config path [--api-key <value>] [--base-url <value>] [--config <value>] [--json] [--color]
     [--profile <value>] [-q] [--verbose]
 
 DESCRIPTION
@@ -180,10 +180,10 @@ EXAMPLES
   $ objectified config path | pbcopy
 
 COMMON
-  --baseUrl=<value>  Root REST API URL.
-  --config=<value>   Path to config file (default: XDG config dir / Objectified AppData on Windows — see `objectified
-                     config path`).
-  --profile=<value>  Named credentials profile (OBJECTIFIED_PROFILE); falls back to default_profile in config.
+  --base-url=<value>  Root REST API URL.
+  --config=<value>    Path to config file (default: XDG config dir / Objectified AppData on Windows — see `objectified
+                      config path`).
+  --profile=<value>   Named credentials profile (OBJECTIFIED_PROFILE); falls back to default_profile in config.
 
 OUTPUT
   --[no-]color  Enable/disable ANSI colors (--no-color sets NO_COLOR; colors are off when stdout is not a TTY).
@@ -192,7 +192,7 @@ OUTPUT
       --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
 
 AUTH
-  --apiKey=<value>  API key for direct authentication (bypasses login token).
+  --api-key=<value>  API key for direct authentication (bypasses login token).
 
 SEE ALSO
   objectified config get
@@ -206,7 +206,7 @@ Set a config value by dotted key and persist config.toml
 
 ```
 USAGE
-  $ objectified config set KEY VALUE [--apiKey <value>] [--baseUrl <value>] [--config <value>] [--json]
+  $ objectified config set KEY VALUE [--api-key <value>] [--base-url <value>] [--config <value>] [--json]
     [--color] [--profile <value>] [-q] [--verbose]
 
 ARGUMENTS
@@ -224,10 +224,10 @@ EXAMPLES
   $ objectified --json config set profile.prod.tenant_slug acme-corp
 
 COMMON
-  --baseUrl=<value>  Root REST API URL.
-  --config=<value>   Path to config file (default: XDG config dir / Objectified AppData on Windows — see `objectified
-                     config path`).
-  --profile=<value>  Named credentials profile (OBJECTIFIED_PROFILE); falls back to default_profile in config.
+  --base-url=<value>  Root REST API URL.
+  --config=<value>    Path to config file (default: XDG config dir / Objectified AppData on Windows — see `objectified
+                      config path`).
+  --profile=<value>   Named credentials profile (OBJECTIFIED_PROFILE); falls back to default_profile in config.
 
 OUTPUT
   --[no-]color  Enable/disable ANSI colors (--no-color sets NO_COLOR; colors are off when stdout is not a TTY).
@@ -236,7 +236,7 @@ OUTPUT
       --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
 
 AUTH
-  --apiKey=<value>  API key for direct authentication (bypasses login token).
+  --api-key=<value>  API key for direct authentication (bypasses login token).
 
 SEE ALSO
   objectified config get
@@ -250,7 +250,7 @@ List documentation topics (`objectified docs`) or open one with `objectified doc
 
 ```
 USAGE
-  $ objectified docs [--apiKey <value>] [--baseUrl <value>] [--config <value>] [--json] [--color]
+  $ objectified docs [--api-key <value>] [--base-url <value>] [--config <value>] [--json] [--color]
     [--profile <value>] [-q] [--verbose]
 
 DESCRIPTION
@@ -264,10 +264,10 @@ EXAMPLES
   $ objectified --json docs
 
 COMMON
-  --baseUrl=<value>  Root REST API URL.
-  --config=<value>   Path to config file (default: XDG config dir / Objectified AppData on Windows — see `objectified
-                     config path`).
-  --profile=<value>  Named credentials profile (OBJECTIFIED_PROFILE); falls back to default_profile in config.
+  --base-url=<value>  Root REST API URL.
+  --config=<value>    Path to config file (default: XDG config dir / Objectified AppData on Windows — see `objectified
+                      config path`).
+  --profile=<value>   Named credentials profile (OBJECTIFIED_PROFILE); falls back to default_profile in config.
 
 OUTPUT
   --[no-]color  Enable/disable ANSI colors (--no-color sets NO_COLOR; colors are off when stdout is not a TTY).
@@ -276,7 +276,7 @@ OUTPUT
       --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
 
 AUTH
-  --apiKey=<value>  API key for direct authentication (bypasses login token).
+  --api-key=<value>  API key for direct authentication (bypasses login token).
 
 SEE ALSO
   objectified docs errors
@@ -292,7 +292,7 @@ Shell completions roadmap and interim guidance
 
 ```
 USAGE
-  $ objectified docs completions [--apiKey <value>] [--baseUrl <value>] [--config <value>] [--json] [--color]
+  $ objectified docs completions [--api-key <value>] [--base-url <value>] [--config <value>] [--json] [--color]
     [--profile <value>] [-q] [--verbose]
 
 DESCRIPTION
@@ -306,10 +306,10 @@ EXAMPLES
   $ objectified docs completions --json
 
 COMMON
-  --baseUrl=<value>  Root REST API URL.
-  --config=<value>   Path to config file (default: XDG config dir / Objectified AppData on Windows — see `objectified
-                     config path`).
-  --profile=<value>  Named credentials profile (OBJECTIFIED_PROFILE); falls back to default_profile in config.
+  --base-url=<value>  Root REST API URL.
+  --config=<value>    Path to config file (default: XDG config dir / Objectified AppData on Windows — see `objectified
+                      config path`).
+  --profile=<value>   Named credentials profile (OBJECTIFIED_PROFILE); falls back to default_profile in config.
 
 OUTPUT
   --[no-]color  Enable/disable ANSI colors (--no-color sets NO_COLOR; colors are off when stdout is not a TTY).
@@ -318,7 +318,7 @@ OUTPUT
       --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
 
 AUTH
-  --apiKey=<value>  API key for direct authentication (bypasses login token).
+  --api-key=<value>  API key for direct authentication (bypasses login token).
 
 SEE ALSO
   objectified docs
@@ -332,7 +332,7 @@ Exit codes, hints, and error-handling reference
 
 ```
 USAGE
-  $ objectified docs errors [--apiKey <value>] [--baseUrl <value>] [--config <value>] [--json] [--color]
+  $ objectified docs errors [--api-key <value>] [--base-url <value>] [--config <value>] [--json] [--color]
     [--profile <value>] [-q] [--verbose]
 
 DESCRIPTION
@@ -346,10 +346,10 @@ EXAMPLES
   $ objectified projects list --json
 
 COMMON
-  --baseUrl=<value>  Root REST API URL.
-  --config=<value>   Path to config file (default: XDG config dir / Objectified AppData on Windows — see `objectified
-                     config path`).
-  --profile=<value>  Named credentials profile (OBJECTIFIED_PROFILE); falls back to default_profile in config.
+  --base-url=<value>  Root REST API URL.
+  --config=<value>    Path to config file (default: XDG config dir / Objectified AppData on Windows — see `objectified
+                      config path`).
+  --profile=<value>   Named credentials profile (OBJECTIFIED_PROFILE); falls back to default_profile in config.
 
 OUTPUT
   --[no-]color  Enable/disable ANSI colors (--no-color sets NO_COLOR; colors are off when stdout is not a TTY).
@@ -358,7 +358,7 @@ OUTPUT
       --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
 
 AUTH
-  --apiKey=<value>  API key for direct authentication (bypasses login token).
+  --api-key=<value>  API key for direct authentication (bypasses login token).
 
 SEE ALSO
   objectified docs
@@ -374,7 +374,7 @@ TTY vs JSON output, quiet mode, verbose logs, and color
 
 ```
 USAGE
-  $ objectified docs output [--apiKey <value>] [--baseUrl <value>] [--config <value>] [--json] [--color]
+  $ objectified docs output [--api-key <value>] [--base-url <value>] [--config <value>] [--json] [--color]
     [--profile <value>] [-q] [--verbose]
 
 DESCRIPTION
@@ -388,10 +388,10 @@ EXAMPLES
   $ objectified docs output > ./output-notes.txt
 
 COMMON
-  --baseUrl=<value>  Root REST API URL.
-  --config=<value>   Path to config file (default: XDG config dir / Objectified AppData on Windows — see `objectified
-                     config path`).
-  --profile=<value>  Named credentials profile (OBJECTIFIED_PROFILE); falls back to default_profile in config.
+  --base-url=<value>  Root REST API URL.
+  --config=<value>    Path to config file (default: XDG config dir / Objectified AppData on Windows — see `objectified
+                      config path`).
+  --profile=<value>   Named credentials profile (OBJECTIFIED_PROFILE); falls back to default_profile in config.
 
 OUTPUT
   --[no-]color  Enable/disable ANSI colors (--no-color sets NO_COLOR; colors are off when stdout is not a TTY).
@@ -400,7 +400,7 @@ OUTPUT
       --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
 
 AUTH
-  --apiKey=<value>  API key for direct authentication (bypasses login token).
+  --api-key=<value>  API key for direct authentication (bypasses login token).
 
 SEE ALSO
   objectified docs
@@ -416,7 +416,7 @@ Future oclif plugin extensibility for Objectified
 
 ```
 USAGE
-  $ objectified docs plugins [--apiKey <value>] [--baseUrl <value>] [--config <value>] [--json] [--color]
+  $ objectified docs plugins [--api-key <value>] [--base-url <value>] [--config <value>] [--json] [--color]
     [--profile <value>] [-q] [--verbose]
 
 DESCRIPTION
@@ -430,10 +430,10 @@ EXAMPLES
   $ objectified docs telemetry
 
 COMMON
-  --baseUrl=<value>  Root REST API URL.
-  --config=<value>   Path to config file (default: XDG config dir / Objectified AppData on Windows — see `objectified
-                     config path`).
-  --profile=<value>  Named credentials profile (OBJECTIFIED_PROFILE); falls back to default_profile in config.
+  --base-url=<value>  Root REST API URL.
+  --config=<value>    Path to config file (default: XDG config dir / Objectified AppData on Windows — see `objectified
+                      config path`).
+  --profile=<value>   Named credentials profile (OBJECTIFIED_PROFILE); falls back to default_profile in config.
 
 OUTPUT
   --[no-]color  Enable/disable ANSI colors (--no-color sets NO_COLOR; colors are off when stdout is not a TTY).
@@ -442,7 +442,7 @@ OUTPUT
       --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
 
 AUTH
-  --apiKey=<value>  API key for direct authentication (bypasses login token).
+  --api-key=<value>  API key for direct authentication (bypasses login token).
 
 SEE ALSO
   objectified docs
@@ -456,7 +456,7 @@ config.toml profiles, defaults, and precedence rules
 
 ```
 USAGE
-  $ objectified docs profiles [--apiKey <value>] [--baseUrl <value>] [--config <value>] [--json] [--color]
+  $ objectified docs profiles [--api-key <value>] [--base-url <value>] [--config <value>] [--json] [--color]
     [--profile <value>] [-q] [--verbose]
 
 DESCRIPTION
@@ -470,10 +470,10 @@ EXAMPLES
   $ objectified docs profiles | sed -n '1,12p'
 
 COMMON
-  --baseUrl=<value>  Root REST API URL.
-  --config=<value>   Path to config file (default: XDG config dir / Objectified AppData on Windows — see `objectified
-                     config path`).
-  --profile=<value>  Named credentials profile (OBJECTIFIED_PROFILE); falls back to default_profile in config.
+  --base-url=<value>  Root REST API URL.
+  --config=<value>    Path to config file (default: XDG config dir / Objectified AppData on Windows — see `objectified
+                      config path`).
+  --profile=<value>   Named credentials profile (OBJECTIFIED_PROFILE); falls back to default_profile in config.
 
 OUTPUT
   --[no-]color  Enable/disable ANSI colors (--no-color sets NO_COLOR; colors are off when stdout is not a TTY).
@@ -482,7 +482,7 @@ OUTPUT
       --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
 
 AUTH
-  --apiKey=<value>  API key for direct authentication (bypasses login token).
+  --api-key=<value>  API key for direct authentication (bypasses login token).
 
 SEE ALSO
   objectified docs
@@ -498,7 +498,7 @@ Telemetry posture and safe verbose debugging
 
 ```
 USAGE
-  $ objectified docs telemetry [--apiKey <value>] [--baseUrl <value>] [--config <value>] [--json] [--color]
+  $ objectified docs telemetry [--api-key <value>] [--base-url <value>] [--config <value>] [--json] [--color]
     [--profile <value>] [-q] [--verbose]
 
 DESCRIPTION
@@ -513,10 +513,10 @@ EXAMPLES
   $ objectified docs telemetry > notes.txt
 
 COMMON
-  --baseUrl=<value>  Root REST API URL.
-  --config=<value>   Path to config file (default: XDG config dir / Objectified AppData on Windows — see `objectified
-                     config path`).
-  --profile=<value>  Named credentials profile (OBJECTIFIED_PROFILE); falls back to default_profile in config.
+  --base-url=<value>  Root REST API URL.
+  --config=<value>    Path to config file (default: XDG config dir / Objectified AppData on Windows — see `objectified
+                      config path`).
+  --profile=<value>   Named credentials profile (OBJECTIFIED_PROFILE); falls back to default_profile in config.
 
 OUTPUT
   --[no-]color  Enable/disable ANSI colors (--no-color sets NO_COLOR; colors are off when stdout is not a TTY).
@@ -525,7 +525,7 @@ OUTPUT
       --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
 
 AUTH
-  --apiKey=<value>  API key for direct authentication (bypasses login token).
+  --api-key=<value>  API key for direct authentication (bypasses login token).
 
 SEE ALSO
   objectified docs errors
@@ -539,7 +539,7 @@ Smoke-test greeting for the Objectified CLI
 
 ```
 USAGE
-  $ objectified hello [NAME] [--apiKey <value>] [--baseUrl <value>] [--config <value>] [--json] [--color]
+  $ objectified hello [NAME] [--api-key <value>] [--base-url <value>] [--config <value>] [--json] [--color]
     [--profile <value>] [-q] [--verbose]
 
 ARGUMENTS
@@ -556,10 +556,10 @@ EXAMPLES
   $ objectified --json hello
 
 COMMON
-  --baseUrl=<value>  Root REST API URL.
-  --config=<value>   Path to config file (default: XDG config dir / Objectified AppData on Windows — see `objectified
-                     config path`).
-  --profile=<value>  Named credentials profile (OBJECTIFIED_PROFILE); falls back to default_profile in config.
+  --base-url=<value>  Root REST API URL.
+  --config=<value>    Path to config file (default: XDG config dir / Objectified AppData on Windows — see `objectified
+                      config path`).
+  --profile=<value>   Named credentials profile (OBJECTIFIED_PROFILE); falls back to default_profile in config.
 
 OUTPUT
   --[no-]color  Enable/disable ANSI colors (--no-color sets NO_COLOR; colors are off when stdout is not a TTY).
@@ -568,7 +568,7 @@ OUTPUT
       --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
 
 AUTH
-  --apiKey=<value>  API key for direct authentication (bypasses login token).
+  --api-key=<value>  API key for direct authentication (bypasses login token).
 
 SEE ALSO
   objectified docs output
@@ -602,7 +602,7 @@ List Objectified projects
 
 ```
 USAGE
-  $ objectified projects list [--apiKey <value>] [--baseUrl <value>] [--config <value>] [--json] [--color]
+  $ objectified projects list [--api-key <value>] [--base-url <value>] [--config <value>] [--json] [--color]
     [--profile <value>] [-q] [--verbose]
 
 DESCRIPTION
@@ -616,10 +616,10 @@ EXAMPLES
   $ objectified --profile staging projects list
 
 COMMON
-  --baseUrl=<value>  Root REST API URL.
-  --config=<value>   Path to config file (default: XDG config dir / Objectified AppData on Windows — see `objectified
-                     config path`).
-  --profile=<value>  Named credentials profile (OBJECTIFIED_PROFILE); falls back to default_profile in config.
+  --base-url=<value>  Root REST API URL.
+  --config=<value>    Path to config file (default: XDG config dir / Objectified AppData on Windows — see `objectified
+                      config path`).
+  --profile=<value>   Named credentials profile (OBJECTIFIED_PROFILE); falls back to default_profile in config.
 
 OUTPUT
   --[no-]color  Enable/disable ANSI colors (--no-color sets NO_COLOR; colors are off when stdout is not a TTY).
@@ -628,7 +628,7 @@ OUTPUT
       --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
 
 AUTH
-  --apiKey=<value>  API key for direct authentication (bypasses login token).
+  --api-key=<value>  API key for direct authentication (bypasses login token).
 
 SEE ALSO
   objectified config path

--- a/objectified-cli/README.md
+++ b/objectified-cli/README.md
@@ -2,11 +2,22 @@
 
 TypeScript CLI for [Objectified](https://objectified.dev), built with [oclif](https://oclif.io/) v4.
 
-## Requirements
+<!-- toc -->
+* [objectified-cli](#objectified-cli)
+* [Requirements](#requirements)
+* [Install (monorepo / local)](#install-monorepo--local)
+* [or](#or)
+* [Development](#development)
+* [Usage](#usage)
+* [Commands](#commands)
+* [Performance](#performance)
+<!-- tocstop -->
+
+# Requirements
 
 - Node.js 20+
 
-## Install (monorepo / local)
+# Install (monorepo / local)
 
 From this directory:
 
@@ -16,9 +27,9 @@ npm install -g .
 npm link
 ```
 
-The `objectified` binary should be on your `PATH`.
+The `objectified` binary should be on your `PATH`. Man pages ship under `man/man1/` (`man objectified`, `man objectified-config-get`, …) when installed from npm.
 
-## Development
+# Development
 
 ```bash
 yarn install   # from repo root
@@ -29,20 +40,631 @@ yarn workspace objectified-cli test
 
 The workspace root pins `ansi-regex`, `string-width`, and `strip-ansi` so oclif’s help layout (`widest-line` / `wrap-ansi`) always resolves CommonJS-compatible builds under Yarn’s hoisting.
 
-## Commands
+`yarn build` runs `oclif manifest`, `oclif readme` (this file), and `scripts/generate-man.mjs`. **Commit** updated `README.md`, `package.json` (`man` array), `man/man1/*.1`, and `oclif.manifest.json` when commands change—`yarn test` fails if they drift from `HEAD`.
 
-| Command                     | Description                              |
-| --------------------------- | ---------------------------------------- |
-| `objectified hello`         | Smoke-test greeting                      |
-| `objectified projects list` | List projects (stub; JSON with `--json`) |
-| `objectified --help`        | Built-in help + global flag docs         |
+# Usage
+
+<!-- usage -->
+```sh-session
+$ npm install -g objectified-cli
+$ objectified COMMAND
+running command...
+$ objectified (--version)
+objectified-cli/0.1.6 linux-x64 node-v24.14.1
+$ objectified --help [COMMAND]
+USAGE
+  $ objectified COMMAND
+...
+```
+<!-- usagestop -->
+
+# Commands
+
+<!-- commands -->
+* [`objectified config get KEY`](#objectified-config-get-key)
+* [`objectified config list`](#objectified-config-list)
+* [`objectified config path`](#objectified-config-path)
+* [`objectified config set KEY VALUE`](#objectified-config-set-key-value)
+* [`objectified docs`](#objectified-docs)
+* [`objectified docs completions`](#objectified-docs-completions)
+* [`objectified docs errors`](#objectified-docs-errors)
+* [`objectified docs output`](#objectified-docs-output)
+* [`objectified docs plugins`](#objectified-docs-plugins)
+* [`objectified docs profiles`](#objectified-docs-profiles)
+* [`objectified docs telemetry`](#objectified-docs-telemetry)
+* [`objectified hello [NAME]`](#objectified-hello-name)
+* [`objectified help [COMMAND]`](#objectified-help-command)
+* [`objectified projects list`](#objectified-projects-list)
+* [`objectified version`](#objectified-version)
+
+## `objectified config get KEY`
+
+Print a single config value by dotted key
+
+```
+USAGE
+  $ objectified config get KEY [--apiKey <value>] [--baseUrl <value>] [--config <value>] [--json] [--color]
+    [--profile <value>] [-q] [--verbose]
+
+ARGUMENTS
+  KEY  Dotted path (e.g. default_profile, profile.prod.base_url)
+
+DESCRIPTION
+  Print a single config value by dotted key
+
+EXAMPLES
+  $ objectified config get default_profile
+
+  $ objectified config get profile.prod.base_url
+
+  $ objectified --json config get profile.staging.tenant_slug
+
+COMMON
+  --baseUrl=<value>  Root REST API URL.
+  --config=<value>   Path to config file (default: XDG config dir / Objectified AppData on Windows — see `objectified
+                     config path`).
+  --profile=<value>  Named credentials profile (OBJECTIFIED_PROFILE); falls back to default_profile in config.
+
+OUTPUT
+  --[no-]color  Enable/disable ANSI colors (--no-color sets NO_COLOR; colors are off when stdout is not a TTY).
+      --[no-]json   Emit machine-readable JSON (OBJECTIFIED_JSON=1; auto-enabled when stdout is not a TTY).
+  -q, --quiet       Suppress non-error stdout (spinners, banners, tips).
+      --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
+
+AUTH
+  --apiKey=<value>  API key for direct authentication (bypasses login token).
+
+SEE ALSO
+  objectified config set
+
+  objectified config path
+```
+
+## `objectified config list`
+
+Print the entire config file (stable JSON with --json, otherwise TOML)
+
+```
+USAGE
+  $ objectified config list [--apiKey <value>] [--baseUrl <value>] [--config <value>] [--json] [--color]
+    [--profile <value>] [-q] [--verbose]
+
+DESCRIPTION
+  Print the entire config file (stable JSON with --json, otherwise TOML)
+
+EXAMPLES
+  $ objectified config list
+
+  $ objectified --json config list
+
+  $ objectified config list > backup.toml
+
+COMMON
+  --baseUrl=<value>  Root REST API URL.
+  --config=<value>   Path to config file (default: XDG config dir / Objectified AppData on Windows — see `objectified
+                     config path`).
+  --profile=<value>  Named credentials profile (OBJECTIFIED_PROFILE); falls back to default_profile in config.
+
+OUTPUT
+  --[no-]color  Enable/disable ANSI colors (--no-color sets NO_COLOR; colors are off when stdout is not a TTY).
+      --[no-]json   Emit machine-readable JSON (OBJECTIFIED_JSON=1; auto-enabled when stdout is not a TTY).
+  -q, --quiet       Suppress non-error stdout (spinners, banners, tips).
+      --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
+
+AUTH
+  --apiKey=<value>  API key for direct authentication (bypasses login token).
+
+SEE ALSO
+  objectified config path
+
+  objectified config get
+```
+
+## `objectified config path`
+
+Print the resolved config.toml path
+
+```
+USAGE
+  $ objectified config path [--apiKey <value>] [--baseUrl <value>] [--config <value>] [--json] [--color]
+    [--profile <value>] [-q] [--verbose]
+
+DESCRIPTION
+  Print the resolved config.toml path
+
+EXAMPLES
+  $ objectified config path
+
+  $ objectified --json config path
+
+  $ objectified config path | pbcopy
+
+COMMON
+  --baseUrl=<value>  Root REST API URL.
+  --config=<value>   Path to config file (default: XDG config dir / Objectified AppData on Windows — see `objectified
+                     config path`).
+  --profile=<value>  Named credentials profile (OBJECTIFIED_PROFILE); falls back to default_profile in config.
+
+OUTPUT
+  --[no-]color  Enable/disable ANSI colors (--no-color sets NO_COLOR; colors are off when stdout is not a TTY).
+      --[no-]json   Emit machine-readable JSON (OBJECTIFIED_JSON=1; auto-enabled when stdout is not a TTY).
+  -q, --quiet       Suppress non-error stdout (spinners, banners, tips).
+      --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
+
+AUTH
+  --apiKey=<value>  API key for direct authentication (bypasses login token).
+
+SEE ALSO
+  objectified config get
+
+  objectified config list
+```
+
+## `objectified config set KEY VALUE`
+
+Set a config value by dotted key and persist config.toml
+
+```
+USAGE
+  $ objectified config set KEY VALUE [--apiKey <value>] [--baseUrl <value>] [--config <value>] [--json]
+    [--color] [--profile <value>] [-q] [--verbose]
+
+ARGUMENTS
+  KEY    Dotted path (e.g. default_profile, profile.prod.tenant_slug)
+  VALUE  New value (stored as a TOML string)
+
+DESCRIPTION
+  Set a config value by dotted key and persist config.toml
+
+EXAMPLES
+  $ objectified config set profile.staging.base_url https://api.staging.example
+
+  $ objectified config set default_profile staging
+
+  $ objectified --json config set profile.prod.tenant_slug acme-corp
+
+COMMON
+  --baseUrl=<value>  Root REST API URL.
+  --config=<value>   Path to config file (default: XDG config dir / Objectified AppData on Windows — see `objectified
+                     config path`).
+  --profile=<value>  Named credentials profile (OBJECTIFIED_PROFILE); falls back to default_profile in config.
+
+OUTPUT
+  --[no-]color  Enable/disable ANSI colors (--no-color sets NO_COLOR; colors are off when stdout is not a TTY).
+      --[no-]json   Emit machine-readable JSON (OBJECTIFIED_JSON=1; auto-enabled when stdout is not a TTY).
+  -q, --quiet       Suppress non-error stdout (spinners, banners, tips).
+      --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
+
+AUTH
+  --apiKey=<value>  API key for direct authentication (bypasses login token).
+
+SEE ALSO
+  objectified config get
+
+  objectified docs profiles
+```
+
+## `objectified docs`
+
+List documentation topics (`objectified docs`) or open one with `objectified docs <topic>`.
+
+```
+USAGE
+  $ objectified docs [--apiKey <value>] [--baseUrl <value>] [--config <value>] [--json] [--color]
+    [--profile <value>] [-q] [--verbose]
+
+DESCRIPTION
+  List documentation topics (`objectified docs`) or open one with `objectified docs <topic>`.
+
+EXAMPLES
+  $ objectified docs
+
+  $ objectified docs output
+
+  $ objectified --json docs
+
+COMMON
+  --baseUrl=<value>  Root REST API URL.
+  --config=<value>   Path to config file (default: XDG config dir / Objectified AppData on Windows — see `objectified
+                     config path`).
+  --profile=<value>  Named credentials profile (OBJECTIFIED_PROFILE); falls back to default_profile in config.
+
+OUTPUT
+  --[no-]color  Enable/disable ANSI colors (--no-color sets NO_COLOR; colors are off when stdout is not a TTY).
+      --[no-]json   Emit machine-readable JSON (OBJECTIFIED_JSON=1; auto-enabled when stdout is not a TTY).
+  -q, --quiet       Suppress non-error stdout (spinners, banners, tips).
+      --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
+
+AUTH
+  --apiKey=<value>  API key for direct authentication (bypasses login token).
+
+SEE ALSO
+  objectified docs errors
+
+  objectified hello
+
+  objectified config path
+```
+
+## `objectified docs completions`
+
+Shell completions roadmap and interim guidance
+
+```
+USAGE
+  $ objectified docs completions [--apiKey <value>] [--baseUrl <value>] [--config <value>] [--json] [--color]
+    [--profile <value>] [-q] [--verbose]
+
+DESCRIPTION
+  Shell completions roadmap and interim guidance
+
+EXAMPLES
+  $ objectified docs completions
+
+  $ objectified --help
+
+  $ objectified docs completions --json
+
+COMMON
+  --baseUrl=<value>  Root REST API URL.
+  --config=<value>   Path to config file (default: XDG config dir / Objectified AppData on Windows — see `objectified
+                     config path`).
+  --profile=<value>  Named credentials profile (OBJECTIFIED_PROFILE); falls back to default_profile in config.
+
+OUTPUT
+  --[no-]color  Enable/disable ANSI colors (--no-color sets NO_COLOR; colors are off when stdout is not a TTY).
+      --[no-]json   Emit machine-readable JSON (OBJECTIFIED_JSON=1; auto-enabled when stdout is not a TTY).
+  -q, --quiet       Suppress non-error stdout (spinners, banners, tips).
+      --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
+
+AUTH
+  --apiKey=<value>  API key for direct authentication (bypasses login token).
+
+SEE ALSO
+  objectified docs
+
+  objectified docs output
+```
+
+## `objectified docs errors`
+
+Exit codes, hints, and error-handling reference
+
+```
+USAGE
+  $ objectified docs errors [--apiKey <value>] [--baseUrl <value>] [--config <value>] [--json] [--color]
+    [--profile <value>] [-q] [--verbose]
+
+DESCRIPTION
+  Exit codes, hints, and error-handling reference
+
+EXAMPLES
+  $ objectified docs errors
+
+  $ objectified docs errors --json
+
+  $ objectified projects list --json
+
+COMMON
+  --baseUrl=<value>  Root REST API URL.
+  --config=<value>   Path to config file (default: XDG config dir / Objectified AppData on Windows — see `objectified
+                     config path`).
+  --profile=<value>  Named credentials profile (OBJECTIFIED_PROFILE); falls back to default_profile in config.
+
+OUTPUT
+  --[no-]color  Enable/disable ANSI colors (--no-color sets NO_COLOR; colors are off when stdout is not a TTY).
+      --[no-]json   Emit machine-readable JSON (OBJECTIFIED_JSON=1; auto-enabled when stdout is not a TTY).
+  -q, --quiet       Suppress non-error stdout (spinners, banners, tips).
+      --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
+
+AUTH
+  --apiKey=<value>  API key for direct authentication (bypasses login token).
+
+SEE ALSO
+  objectified docs
+
+  objectified docs output
+
+  objectified hello
+```
+
+## `objectified docs output`
+
+TTY vs JSON output, quiet mode, verbose logs, and color
+
+```
+USAGE
+  $ objectified docs output [--apiKey <value>] [--baseUrl <value>] [--config <value>] [--json] [--color]
+    [--profile <value>] [-q] [--verbose]
+
+DESCRIPTION
+  TTY vs JSON output, quiet mode, verbose logs, and color
+
+EXAMPLES
+  $ objectified docs output
+
+  $ objectified --json hello
+
+  $ objectified docs output > ./output-notes.txt
+
+COMMON
+  --baseUrl=<value>  Root REST API URL.
+  --config=<value>   Path to config file (default: XDG config dir / Objectified AppData on Windows — see `objectified
+                     config path`).
+  --profile=<value>  Named credentials profile (OBJECTIFIED_PROFILE); falls back to default_profile in config.
+
+OUTPUT
+  --[no-]color  Enable/disable ANSI colors (--no-color sets NO_COLOR; colors are off when stdout is not a TTY).
+      --[no-]json   Emit machine-readable JSON (OBJECTIFIED_JSON=1; auto-enabled when stdout is not a TTY).
+  -q, --quiet       Suppress non-error stdout (spinners, banners, tips).
+      --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
+
+AUTH
+  --apiKey=<value>  API key for direct authentication (bypasses login token).
+
+SEE ALSO
+  objectified docs
+
+  objectified docs errors
+
+  objectified hello
+```
+
+## `objectified docs plugins`
+
+Future oclif plugin extensibility for Objectified
+
+```
+USAGE
+  $ objectified docs plugins [--apiKey <value>] [--baseUrl <value>] [--config <value>] [--json] [--color]
+    [--profile <value>] [-q] [--verbose]
+
+DESCRIPTION
+  Future oclif plugin extensibility for Objectified
+
+EXAMPLES
+  $ objectified docs plugins
+
+  $ objectified docs plugins --json
+
+  $ objectified docs telemetry
+
+COMMON
+  --baseUrl=<value>  Root REST API URL.
+  --config=<value>   Path to config file (default: XDG config dir / Objectified AppData on Windows — see `objectified
+                     config path`).
+  --profile=<value>  Named credentials profile (OBJECTIFIED_PROFILE); falls back to default_profile in config.
+
+OUTPUT
+  --[no-]color  Enable/disable ANSI colors (--no-color sets NO_COLOR; colors are off when stdout is not a TTY).
+      --[no-]json   Emit machine-readable JSON (OBJECTIFIED_JSON=1; auto-enabled when stdout is not a TTY).
+  -q, --quiet       Suppress non-error stdout (spinners, banners, tips).
+      --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
+
+AUTH
+  --apiKey=<value>  API key for direct authentication (bypasses login token).
+
+SEE ALSO
+  objectified docs
+
+  objectified docs telemetry
+```
+
+## `objectified docs profiles`
+
+config.toml profiles, defaults, and precedence rules
+
+```
+USAGE
+  $ objectified docs profiles [--apiKey <value>] [--baseUrl <value>] [--config <value>] [--json] [--color]
+    [--profile <value>] [-q] [--verbose]
+
+DESCRIPTION
+  config.toml profiles, defaults, and precedence rules
+
+EXAMPLES
+  $ objectified docs profiles
+
+  $ objectified --profile staging config path
+
+  $ objectified docs profiles | sed -n '1,12p'
+
+COMMON
+  --baseUrl=<value>  Root REST API URL.
+  --config=<value>   Path to config file (default: XDG config dir / Objectified AppData on Windows — see `objectified
+                     config path`).
+  --profile=<value>  Named credentials profile (OBJECTIFIED_PROFILE); falls back to default_profile in config.
+
+OUTPUT
+  --[no-]color  Enable/disable ANSI colors (--no-color sets NO_COLOR; colors are off when stdout is not a TTY).
+      --[no-]json   Emit machine-readable JSON (OBJECTIFIED_JSON=1; auto-enabled when stdout is not a TTY).
+  -q, --quiet       Suppress non-error stdout (spinners, banners, tips).
+      --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
+
+AUTH
+  --apiKey=<value>  API key for direct authentication (bypasses login token).
+
+SEE ALSO
+  objectified docs
+
+  objectified config path
+
+  objectified config get
+```
+
+## `objectified docs telemetry`
+
+Telemetry posture and safe verbose debugging
+
+```
+USAGE
+  $ objectified docs telemetry [--apiKey <value>] [--baseUrl <value>] [--config <value>] [--json] [--color]
+    [--profile <value>] [-q] [--verbose]
+
+DESCRIPTION
+  Telemetry posture and safe verbose debugging
+
+EXAMPLES
+  $ objectified docs telemetry
+
+  $ objectified --verbose hello
+  $ objectified docs telemetry
+
+  $ objectified docs telemetry > notes.txt
+
+COMMON
+  --baseUrl=<value>  Root REST API URL.
+  --config=<value>   Path to config file (default: XDG config dir / Objectified AppData on Windows — see `objectified
+                     config path`).
+  --profile=<value>  Named credentials profile (OBJECTIFIED_PROFILE); falls back to default_profile in config.
+
+OUTPUT
+  --[no-]color  Enable/disable ANSI colors (--no-color sets NO_COLOR; colors are off when stdout is not a TTY).
+      --[no-]json   Emit machine-readable JSON (OBJECTIFIED_JSON=1; auto-enabled when stdout is not a TTY).
+  -q, --quiet       Suppress non-error stdout (spinners, banners, tips).
+      --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
+
+AUTH
+  --apiKey=<value>  API key for direct authentication (bypasses login token).
+
+SEE ALSO
+  objectified docs errors
+
+  objectified docs output
+```
+
+## `objectified hello [NAME]`
+
+Smoke-test greeting for the Objectified CLI
+
+```
+USAGE
+  $ objectified hello [NAME] [--apiKey <value>] [--baseUrl <value>] [--config <value>] [--json] [--color]
+    [--profile <value>] [-q] [--verbose]
+
+ARGUMENTS
+  [NAME]  Who to greet
+
+DESCRIPTION
+  Smoke-test greeting for the Objectified CLI
+
+EXAMPLES
+  $ objectified hello
+
+  $ objectified hello Ada
+
+  $ objectified --json hello
+
+COMMON
+  --baseUrl=<value>  Root REST API URL.
+  --config=<value>   Path to config file (default: XDG config dir / Objectified AppData on Windows — see `objectified
+                     config path`).
+  --profile=<value>  Named credentials profile (OBJECTIFIED_PROFILE); falls back to default_profile in config.
+
+OUTPUT
+  --[no-]color  Enable/disable ANSI colors (--no-color sets NO_COLOR; colors are off when stdout is not a TTY).
+      --[no-]json   Emit machine-readable JSON (OBJECTIFIED_JSON=1; auto-enabled when stdout is not a TTY).
+  -q, --quiet       Suppress non-error stdout (spinners, banners, tips).
+      --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
+
+AUTH
+  --apiKey=<value>  API key for direct authentication (bypasses login token).
+
+SEE ALSO
+  objectified docs output
+
+  objectified config path
+```
+
+## `objectified help [COMMAND]`
+
+Display help for objectified.
+
+```
+USAGE
+  $ objectified help [COMMAND...] [-n]
+
+ARGUMENTS
+  [COMMAND...]  Command to show help for.
+
+DESCRIPTION
+  Display help for objectified.
+
+OTHER
+  -n, --nested-commands  Include all nested commands in the output.
+```
+
+_See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/6.2.46/src/commands/help.ts)_
+
+## `objectified projects list`
+
+List Objectified projects
+
+```
+USAGE
+  $ objectified projects list [--apiKey <value>] [--baseUrl <value>] [--config <value>] [--json] [--color]
+    [--profile <value>] [-q] [--verbose]
+
+DESCRIPTION
+  List Objectified projects
+
+EXAMPLES
+  $ objectified projects list
+
+  $ objectified --json projects list
+
+  $ objectified --profile staging projects list
+
+COMMON
+  --baseUrl=<value>  Root REST API URL.
+  --config=<value>   Path to config file (default: XDG config dir / Objectified AppData on Windows — see `objectified
+                     config path`).
+  --profile=<value>  Named credentials profile (OBJECTIFIED_PROFILE); falls back to default_profile in config.
+
+OUTPUT
+  --[no-]color  Enable/disable ANSI colors (--no-color sets NO_COLOR; colors are off when stdout is not a TTY).
+      --[no-]json   Emit machine-readable JSON (OBJECTIFIED_JSON=1; auto-enabled when stdout is not a TTY).
+  -q, --quiet       Suppress non-error stdout (spinners, banners, tips).
+      --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
+
+AUTH
+  --apiKey=<value>  API key for direct authentication (bypasses login token).
+
+SEE ALSO
+  objectified config path
+
+  objectified docs errors
+
+  objectified hello
+```
+
+## `objectified version`
+
+```
+USAGE
+  $ objectified version [--json] [--verbose]
+
+OTHER
+  --verbose  Show additional information about the CLI.
+
+GLOBAL
+  --json  Format output as json.
+
+FLAG DESCRIPTIONS
+  --verbose  Show additional information about the CLI.
+
+    Additionally shows the architecture, node version, operating system, and versions of plugins that the CLI is using.
+```
+
+_See code: [@oclif/plugin-version](https://github.com/oclif/plugin-version/blob/2.2.43/src/commands/version.ts)_
+<!-- commandsstop -->
 
 Global flags apply to every command (see **`objectified --help`**): `--api-key`, `--base-url`, `--config`, `--json`, `--no-color`, `--profile`, `--quiet`/`-q`, `--verbose`, plus env vars `OBJECTIFIED_*` and `NO_COLOR`. Effective API URL and optional API key resolve in order: **CLI flag → environment → `[profile.NAME]` in config → `[default]` in config → built-in default** (`https://api.objectified.dev` for the URL). Config file default path: `~/.config/objectified/config.toml`.
 
 You may place global flags before the subcommand (for example `objectified --json projects list`); the runtime reorders them for oclif.
 
-Ticket **#3188** adds interactive `config` management commands on top of this file format.
+Longer prose lives under **`objectified docs <topic>`** (`output`, `errors`, `profiles`, `completions`, `plugins`, `telemetry`).
 
-## Performance
+# Performance
 
 `objectified --version` and `objectified --help` are sized for sub‑200 ms cold start on typical developer hardware (see integration test budgets).

--- a/objectified-cli/man/man1/objectified-config-get.1
+++ b/objectified-cli/man/man1/objectified-config-get.1
@@ -4,8 +4,9 @@ objectified config get \- Print a single config value by dotted key
 .SH DESCRIPTION
 .nf
 USAGE
-  $ objectified config get KEY [--apiKey <value>] [--baseUrl <value>]
-    [--config <value>] [--json] [--color] [--profile <value>] [-q] [--verbose]
+  $ objectified config get KEY [--api-key <value>] [--base-url
+    <value>] [--config <value>] [--json] [--color] [--profile <value>] [-q]
+    [--verbose]
 
 ARGUMENTS
   KEY  Dotted path (e.g. default_profile, profile.prod.base_url)
@@ -21,12 +22,12 @@ EXAMPLES
   $ objectified --json config get profile.staging.tenant_slug
 
 COMMON
-  --baseUrl=<value>  Root REST API URL.
-  --config=<value>   Path to config file (default: XDG config dir /
-                     Objectified AppData on Windows — see `objectified config
-                     path`).
-  --profile=<value>  Named credentials profile (OBJECTIFIED_PROFILE); falls
-                     back to default_profile in config.
+  --base-url=<value>  Root REST API URL.
+  --config=<value>    Path to config file (default: XDG config dir /
+                      Objectified AppData on Windows — see `objectified config
+                      path`).
+  --profile=<value>   Named credentials profile (OBJECTIFIED_PROFILE); falls
+                      back to default_profile in config.
 
 OUTPUT
   --[no-]color  Enable/disable ANSI colors (--no-color sets NO_COLOR;
@@ -37,7 +38,7 @@ OUTPUT
       --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
 
 AUTH
-  --apiKey=<value>  API key for direct authentication (bypasses login token).
+  --api-key=<value>  API key for direct authentication (bypasses login token).
 
 SEE ALSO
   objectified config set

--- a/objectified-cli/man/man1/objectified-config-get.1
+++ b/objectified-cli/man/man1/objectified-config-get.1
@@ -1,0 +1,46 @@
+.TH OBJECTIFIED\-CONFIG\-GET 1 "" "" "User Commands"
+.SH NAME
+objectified config get \- Print a single config value by dotted key
+.SH DESCRIPTION
+.nf
+USAGE
+  $ objectified config get KEY [--apiKey <value>] [--baseUrl <value>]
+    [--config <value>] [--json] [--color] [--profile <value>] [-q] [--verbose]
+
+ARGUMENTS
+  KEY  Dotted path (e.g. default_profile, profile.prod.base_url)
+
+DESCRIPTION
+  Print a single config value by dotted key
+
+EXAMPLES
+  $ objectified config get default_profile
+
+  $ objectified config get profile.prod.base_url
+
+  $ objectified --json config get profile.staging.tenant_slug
+
+COMMON
+  --baseUrl=<value>  Root REST API URL.
+  --config=<value>   Path to config file (default: XDG config dir /
+                     Objectified AppData on Windows — see `objectified config
+                     path`).
+  --profile=<value>  Named credentials profile (OBJECTIFIED_PROFILE); falls
+                     back to default_profile in config.
+
+OUTPUT
+  --[no-]color  Enable/disable ANSI colors (--no-color sets NO_COLOR;
+                    colors are off when stdout is not a TTY).
+      --[no-]json   Emit machine-readable JSON (OBJECTIFIED_JSON=1;
+                    auto-enabled when stdout is not a TTY).
+  -q, --quiet       Suppress non-error stdout (spinners, banners, tips).
+      --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
+
+AUTH
+  --apiKey=<value>  API key for direct authentication (bypasses login token).
+
+SEE ALSO
+  objectified config set
+
+  objectified config path
+.fi

--- a/objectified-cli/man/man1/objectified-config-list.1
+++ b/objectified-cli/man/man1/objectified-config-list.1
@@ -4,7 +4,7 @@ objectified config list \- Print the entire config file (stable JSON with --json
 .SH DESCRIPTION
 .nf
 USAGE
-  $ objectified config list [--apiKey <value>] [--baseUrl <value>]
+  $ objectified config list [--api-key <value>] [--base-url <value>]
     [--config <value>] [--json] [--color] [--profile <value>] [-q] [--verbose]
 
 DESCRIPTION
@@ -18,12 +18,12 @@ EXAMPLES
   $ objectified config list > backup.toml
 
 COMMON
-  --baseUrl=<value>  Root REST API URL.
-  --config=<value>   Path to config file (default: XDG config dir /
-                     Objectified AppData on Windows — see `objectified config
-                     path`).
-  --profile=<value>  Named credentials profile (OBJECTIFIED_PROFILE); falls
-                     back to default_profile in config.
+  --base-url=<value>  Root REST API URL.
+  --config=<value>    Path to config file (default: XDG config dir /
+                      Objectified AppData on Windows — see `objectified config
+                      path`).
+  --profile=<value>   Named credentials profile (OBJECTIFIED_PROFILE); falls
+                      back to default_profile in config.
 
 OUTPUT
   --[no-]color  Enable/disable ANSI colors (--no-color sets NO_COLOR;
@@ -34,7 +34,7 @@ OUTPUT
       --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
 
 AUTH
-  --apiKey=<value>  API key for direct authentication (bypasses login token).
+  --api-key=<value>  API key for direct authentication (bypasses login token).
 
 SEE ALSO
   objectified config path

--- a/objectified-cli/man/man1/objectified-config-list.1
+++ b/objectified-cli/man/man1/objectified-config-list.1
@@ -1,0 +1,43 @@
+.TH OBJECTIFIED\-CONFIG\-LIST 1 "" "" "User Commands"
+.SH NAME
+objectified config list \- Print the entire config file (stable JSON with --json, otherwise TOML)
+.SH DESCRIPTION
+.nf
+USAGE
+  $ objectified config list [--apiKey <value>] [--baseUrl <value>]
+    [--config <value>] [--json] [--color] [--profile <value>] [-q] [--verbose]
+
+DESCRIPTION
+  Print the entire config file (stable JSON with --json, otherwise TOML)
+
+EXAMPLES
+  $ objectified config list
+
+  $ objectified --json config list
+
+  $ objectified config list > backup.toml
+
+COMMON
+  --baseUrl=<value>  Root REST API URL.
+  --config=<value>   Path to config file (default: XDG config dir /
+                     Objectified AppData on Windows — see `objectified config
+                     path`).
+  --profile=<value>  Named credentials profile (OBJECTIFIED_PROFILE); falls
+                     back to default_profile in config.
+
+OUTPUT
+  --[no-]color  Enable/disable ANSI colors (--no-color sets NO_COLOR;
+                    colors are off when stdout is not a TTY).
+      --[no-]json   Emit machine-readable JSON (OBJECTIFIED_JSON=1;
+                    auto-enabled when stdout is not a TTY).
+  -q, --quiet       Suppress non-error stdout (spinners, banners, tips).
+      --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
+
+AUTH
+  --apiKey=<value>  API key for direct authentication (bypasses login token).
+
+SEE ALSO
+  objectified config path
+
+  objectified config get
+.fi

--- a/objectified-cli/man/man1/objectified-config-path.1
+++ b/objectified-cli/man/man1/objectified-config-path.1
@@ -4,7 +4,7 @@ objectified config path \- Print the resolved config.toml path
 .SH DESCRIPTION
 .nf
 USAGE
-  $ objectified config path [--apiKey <value>] [--baseUrl <value>]
+  $ objectified config path [--api-key <value>] [--base-url <value>]
     [--config <value>] [--json] [--color] [--profile <value>] [-q] [--verbose]
 
 DESCRIPTION
@@ -18,12 +18,12 @@ EXAMPLES
   $ objectified config path | pbcopy
 
 COMMON
-  --baseUrl=<value>  Root REST API URL.
-  --config=<value>   Path to config file (default: XDG config dir /
-                     Objectified AppData on Windows — see `objectified config
-                     path`).
-  --profile=<value>  Named credentials profile (OBJECTIFIED_PROFILE); falls
-                     back to default_profile in config.
+  --base-url=<value>  Root REST API URL.
+  --config=<value>    Path to config file (default: XDG config dir /
+                      Objectified AppData on Windows — see `objectified config
+                      path`).
+  --profile=<value>   Named credentials profile (OBJECTIFIED_PROFILE); falls
+                      back to default_profile in config.
 
 OUTPUT
   --[no-]color  Enable/disable ANSI colors (--no-color sets NO_COLOR;
@@ -34,7 +34,7 @@ OUTPUT
       --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
 
 AUTH
-  --apiKey=<value>  API key for direct authentication (bypasses login token).
+  --api-key=<value>  API key for direct authentication (bypasses login token).
 
 SEE ALSO
   objectified config get

--- a/objectified-cli/man/man1/objectified-config-path.1
+++ b/objectified-cli/man/man1/objectified-config-path.1
@@ -1,0 +1,43 @@
+.TH OBJECTIFIED\-CONFIG\-PATH 1 "" "" "User Commands"
+.SH NAME
+objectified config path \- Print the resolved config.toml path
+.SH DESCRIPTION
+.nf
+USAGE
+  $ objectified config path [--apiKey <value>] [--baseUrl <value>]
+    [--config <value>] [--json] [--color] [--profile <value>] [-q] [--verbose]
+
+DESCRIPTION
+  Print the resolved config.toml path
+
+EXAMPLES
+  $ objectified config path
+
+  $ objectified --json config path
+
+  $ objectified config path | pbcopy
+
+COMMON
+  --baseUrl=<value>  Root REST API URL.
+  --config=<value>   Path to config file (default: XDG config dir /
+                     Objectified AppData on Windows — see `objectified config
+                     path`).
+  --profile=<value>  Named credentials profile (OBJECTIFIED_PROFILE); falls
+                     back to default_profile in config.
+
+OUTPUT
+  --[no-]color  Enable/disable ANSI colors (--no-color sets NO_COLOR;
+                    colors are off when stdout is not a TTY).
+      --[no-]json   Emit machine-readable JSON (OBJECTIFIED_JSON=1;
+                    auto-enabled when stdout is not a TTY).
+  -q, --quiet       Suppress non-error stdout (spinners, banners, tips).
+      --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
+
+AUTH
+  --apiKey=<value>  API key for direct authentication (bypasses login token).
+
+SEE ALSO
+  objectified config get
+
+  objectified config list
+.fi

--- a/objectified-cli/man/man1/objectified-config-set.1
+++ b/objectified-cli/man/man1/objectified-config-set.1
@@ -4,7 +4,7 @@ objectified config set \- Set a config value by dotted key and persist config.to
 .SH DESCRIPTION
 .nf
 USAGE
-  $ objectified config set KEY VALUE [--apiKey <value>] [--baseUrl
+  $ objectified config set KEY VALUE [--api-key <value>] [--base-url
     <value>] [--config <value>] [--json] [--color] [--profile <value>] [-q]
     [--verbose]
 
@@ -23,12 +23,12 @@ EXAMPLES
   $ objectified --json config set profile.prod.tenant_slug acme-corp
 
 COMMON
-  --baseUrl=<value>  Root REST API URL.
-  --config=<value>   Path to config file (default: XDG config dir /
-                     Objectified AppData on Windows — see `objectified config
-                     path`).
-  --profile=<value>  Named credentials profile (OBJECTIFIED_PROFILE); falls
-                     back to default_profile in config.
+  --base-url=<value>  Root REST API URL.
+  --config=<value>    Path to config file (default: XDG config dir /
+                      Objectified AppData on Windows — see `objectified config
+                      path`).
+  --profile=<value>   Named credentials profile (OBJECTIFIED_PROFILE); falls
+                      back to default_profile in config.
 
 OUTPUT
   --[no-]color  Enable/disable ANSI colors (--no-color sets NO_COLOR;
@@ -39,7 +39,7 @@ OUTPUT
       --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
 
 AUTH
-  --apiKey=<value>  API key for direct authentication (bypasses login token).
+  --api-key=<value>  API key for direct authentication (bypasses login token).
 
 SEE ALSO
   objectified config get

--- a/objectified-cli/man/man1/objectified-config-set.1
+++ b/objectified-cli/man/man1/objectified-config-set.1
@@ -1,0 +1,48 @@
+.TH OBJECTIFIED\-CONFIG\-SET 1 "" "" "User Commands"
+.SH NAME
+objectified config set \- Set a config value by dotted key and persist config.toml
+.SH DESCRIPTION
+.nf
+USAGE
+  $ objectified config set KEY VALUE [--apiKey <value>] [--baseUrl
+    <value>] [--config <value>] [--json] [--color] [--profile <value>] [-q]
+    [--verbose]
+
+ARGUMENTS
+  KEY    Dotted path (e.g. default_profile, profile.prod.tenant_slug)
+  VALUE  New value (stored as a TOML string)
+
+DESCRIPTION
+  Set a config value by dotted key and persist config.toml
+
+EXAMPLES
+  $ objectified config set profile.staging.base_url https://api.staging.example
+
+  $ objectified config set default_profile staging
+
+  $ objectified --json config set profile.prod.tenant_slug acme-corp
+
+COMMON
+  --baseUrl=<value>  Root REST API URL.
+  --config=<value>   Path to config file (default: XDG config dir /
+                     Objectified AppData on Windows — see `objectified config
+                     path`).
+  --profile=<value>  Named credentials profile (OBJECTIFIED_PROFILE); falls
+                     back to default_profile in config.
+
+OUTPUT
+  --[no-]color  Enable/disable ANSI colors (--no-color sets NO_COLOR;
+                    colors are off when stdout is not a TTY).
+      --[no-]json   Emit machine-readable JSON (OBJECTIFIED_JSON=1;
+                    auto-enabled when stdout is not a TTY).
+  -q, --quiet       Suppress non-error stdout (spinners, banners, tips).
+      --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
+
+AUTH
+  --apiKey=<value>  API key for direct authentication (bypasses login token).
+
+SEE ALSO
+  objectified config get
+
+  objectified docs profiles
+.fi

--- a/objectified-cli/man/man1/objectified-docs-completions.1
+++ b/objectified-cli/man/man1/objectified-docs-completions.1
@@ -1,0 +1,43 @@
+.TH OBJECTIFIED\-DOCS\-COMPLETIONS 1 "" "" "User Commands"
+.SH NAME
+objectified docs completions \- Shell completions roadmap and interim guidance
+.SH DESCRIPTION
+.nf
+USAGE
+  $ objectified docs completions [--apiKey <value>] [--baseUrl <value>]
+    [--config <value>] [--json] [--color] [--profile <value>] [-q] [--verbose]
+
+DESCRIPTION
+  Shell completions roadmap and interim guidance
+
+EXAMPLES
+  $ objectified docs completions
+
+  $ objectified --help
+
+  $ objectified docs completions --json
+
+COMMON
+  --baseUrl=<value>  Root REST API URL.
+  --config=<value>   Path to config file (default: XDG config dir /
+                     Objectified AppData on Windows — see `objectified config
+                     path`).
+  --profile=<value>  Named credentials profile (OBJECTIFIED_PROFILE); falls
+                     back to default_profile in config.
+
+OUTPUT
+  --[no-]color  Enable/disable ANSI colors (--no-color sets NO_COLOR;
+                    colors are off when stdout is not a TTY).
+      --[no-]json   Emit machine-readable JSON (OBJECTIFIED_JSON=1;
+                    auto-enabled when stdout is not a TTY).
+  -q, --quiet       Suppress non-error stdout (spinners, banners, tips).
+      --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
+
+AUTH
+  --apiKey=<value>  API key for direct authentication (bypasses login token).
+
+SEE ALSO
+  objectified docs
+
+  objectified docs output
+.fi

--- a/objectified-cli/man/man1/objectified-docs-completions.1
+++ b/objectified-cli/man/man1/objectified-docs-completions.1
@@ -4,7 +4,7 @@ objectified docs completions \- Shell completions roadmap and interim guidance
 .SH DESCRIPTION
 .nf
 USAGE
-  $ objectified docs completions [--apiKey <value>] [--baseUrl <value>]
+  $ objectified docs completions [--api-key <value>] [--base-url <value>]
     [--config <value>] [--json] [--color] [--profile <value>] [-q] [--verbose]
 
 DESCRIPTION
@@ -18,12 +18,12 @@ EXAMPLES
   $ objectified docs completions --json
 
 COMMON
-  --baseUrl=<value>  Root REST API URL.
-  --config=<value>   Path to config file (default: XDG config dir /
-                     Objectified AppData on Windows — see `objectified config
-                     path`).
-  --profile=<value>  Named credentials profile (OBJECTIFIED_PROFILE); falls
-                     back to default_profile in config.
+  --base-url=<value>  Root REST API URL.
+  --config=<value>    Path to config file (default: XDG config dir /
+                      Objectified AppData on Windows — see `objectified config
+                      path`).
+  --profile=<value>   Named credentials profile (OBJECTIFIED_PROFILE); falls
+                      back to default_profile in config.
 
 OUTPUT
   --[no-]color  Enable/disable ANSI colors (--no-color sets NO_COLOR;
@@ -34,7 +34,7 @@ OUTPUT
       --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
 
 AUTH
-  --apiKey=<value>  API key for direct authentication (bypasses login token).
+  --api-key=<value>  API key for direct authentication (bypasses login token).
 
 SEE ALSO
   objectified docs

--- a/objectified-cli/man/man1/objectified-docs-errors.1
+++ b/objectified-cli/man/man1/objectified-docs-errors.1
@@ -1,0 +1,45 @@
+.TH OBJECTIFIED\-DOCS\-ERRORS 1 "" "" "User Commands"
+.SH NAME
+objectified docs errors \- Exit codes, hints, and error-handling reference
+.SH DESCRIPTION
+.nf
+USAGE
+  $ objectified docs errors [--apiKey <value>] [--baseUrl <value>]
+    [--config <value>] [--json] [--color] [--profile <value>] [-q] [--verbose]
+
+DESCRIPTION
+  Exit codes, hints, and error-handling reference
+
+EXAMPLES
+  $ objectified docs errors
+
+  $ objectified docs errors --json
+
+  $ objectified projects list --json
+
+COMMON
+  --baseUrl=<value>  Root REST API URL.
+  --config=<value>   Path to config file (default: XDG config dir /
+                     Objectified AppData on Windows — see `objectified config
+                     path`).
+  --profile=<value>  Named credentials profile (OBJECTIFIED_PROFILE); falls
+                     back to default_profile in config.
+
+OUTPUT
+  --[no-]color  Enable/disable ANSI colors (--no-color sets NO_COLOR;
+                    colors are off when stdout is not a TTY).
+      --[no-]json   Emit machine-readable JSON (OBJECTIFIED_JSON=1;
+                    auto-enabled when stdout is not a TTY).
+  -q, --quiet       Suppress non-error stdout (spinners, banners, tips).
+      --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
+
+AUTH
+  --apiKey=<value>  API key for direct authentication (bypasses login token).
+
+SEE ALSO
+  objectified docs
+
+  objectified docs output
+
+  objectified hello
+.fi

--- a/objectified-cli/man/man1/objectified-docs-errors.1
+++ b/objectified-cli/man/man1/objectified-docs-errors.1
@@ -4,7 +4,7 @@ objectified docs errors \- Exit codes, hints, and error-handling reference
 .SH DESCRIPTION
 .nf
 USAGE
-  $ objectified docs errors [--apiKey <value>] [--baseUrl <value>]
+  $ objectified docs errors [--api-key <value>] [--base-url <value>]
     [--config <value>] [--json] [--color] [--profile <value>] [-q] [--verbose]
 
 DESCRIPTION
@@ -18,12 +18,12 @@ EXAMPLES
   $ objectified projects list --json
 
 COMMON
-  --baseUrl=<value>  Root REST API URL.
-  --config=<value>   Path to config file (default: XDG config dir /
-                     Objectified AppData on Windows — see `objectified config
-                     path`).
-  --profile=<value>  Named credentials profile (OBJECTIFIED_PROFILE); falls
-                     back to default_profile in config.
+  --base-url=<value>  Root REST API URL.
+  --config=<value>    Path to config file (default: XDG config dir /
+                      Objectified AppData on Windows — see `objectified config
+                      path`).
+  --profile=<value>   Named credentials profile (OBJECTIFIED_PROFILE); falls
+                      back to default_profile in config.
 
 OUTPUT
   --[no-]color  Enable/disable ANSI colors (--no-color sets NO_COLOR;
@@ -34,7 +34,7 @@ OUTPUT
       --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
 
 AUTH
-  --apiKey=<value>  API key for direct authentication (bypasses login token).
+  --api-key=<value>  API key for direct authentication (bypasses login token).
 
 SEE ALSO
   objectified docs

--- a/objectified-cli/man/man1/objectified-docs-output.1
+++ b/objectified-cli/man/man1/objectified-docs-output.1
@@ -1,0 +1,45 @@
+.TH OBJECTIFIED\-DOCS\-OUTPUT 1 "" "" "User Commands"
+.SH NAME
+objectified docs output \- TTY vs JSON output, quiet mode, verbose logs, and color
+.SH DESCRIPTION
+.nf
+USAGE
+  $ objectified docs output [--apiKey <value>] [--baseUrl <value>]
+    [--config <value>] [--json] [--color] [--profile <value>] [-q] [--verbose]
+
+DESCRIPTION
+  TTY vs JSON output, quiet mode, verbose logs, and color
+
+EXAMPLES
+  $ objectified docs output
+
+  $ objectified --json hello
+
+  $ objectified docs output > ./output-notes.txt
+
+COMMON
+  --baseUrl=<value>  Root REST API URL.
+  --config=<value>   Path to config file (default: XDG config dir /
+                     Objectified AppData on Windows — see `objectified config
+                     path`).
+  --profile=<value>  Named credentials profile (OBJECTIFIED_PROFILE); falls
+                     back to default_profile in config.
+
+OUTPUT
+  --[no-]color  Enable/disable ANSI colors (--no-color sets NO_COLOR;
+                    colors are off when stdout is not a TTY).
+      --[no-]json   Emit machine-readable JSON (OBJECTIFIED_JSON=1;
+                    auto-enabled when stdout is not a TTY).
+  -q, --quiet       Suppress non-error stdout (spinners, banners, tips).
+      --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
+
+AUTH
+  --apiKey=<value>  API key for direct authentication (bypasses login token).
+
+SEE ALSO
+  objectified docs
+
+  objectified docs errors
+
+  objectified hello
+.fi

--- a/objectified-cli/man/man1/objectified-docs-output.1
+++ b/objectified-cli/man/man1/objectified-docs-output.1
@@ -4,7 +4,7 @@ objectified docs output \- TTY vs JSON output, quiet mode, verbose logs, and col
 .SH DESCRIPTION
 .nf
 USAGE
-  $ objectified docs output [--apiKey <value>] [--baseUrl <value>]
+  $ objectified docs output [--api-key <value>] [--base-url <value>]
     [--config <value>] [--json] [--color] [--profile <value>] [-q] [--verbose]
 
 DESCRIPTION
@@ -18,12 +18,12 @@ EXAMPLES
   $ objectified docs output > ./output-notes.txt
 
 COMMON
-  --baseUrl=<value>  Root REST API URL.
-  --config=<value>   Path to config file (default: XDG config dir /
-                     Objectified AppData on Windows — see `objectified config
-                     path`).
-  --profile=<value>  Named credentials profile (OBJECTIFIED_PROFILE); falls
-                     back to default_profile in config.
+  --base-url=<value>  Root REST API URL.
+  --config=<value>    Path to config file (default: XDG config dir /
+                      Objectified AppData on Windows — see `objectified config
+                      path`).
+  --profile=<value>   Named credentials profile (OBJECTIFIED_PROFILE); falls
+                      back to default_profile in config.
 
 OUTPUT
   --[no-]color  Enable/disable ANSI colors (--no-color sets NO_COLOR;
@@ -34,7 +34,7 @@ OUTPUT
       --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
 
 AUTH
-  --apiKey=<value>  API key for direct authentication (bypasses login token).
+  --api-key=<value>  API key for direct authentication (bypasses login token).
 
 SEE ALSO
   objectified docs

--- a/objectified-cli/man/man1/objectified-docs-plugins.1
+++ b/objectified-cli/man/man1/objectified-docs-plugins.1
@@ -4,7 +4,7 @@ objectified docs plugins \- Future oclif plugin extensibility for Objectified
 .SH DESCRIPTION
 .nf
 USAGE
-  $ objectified docs plugins [--apiKey <value>] [--baseUrl <value>]
+  $ objectified docs plugins [--api-key <value>] [--base-url <value>]
     [--config <value>] [--json] [--color] [--profile <value>] [-q] [--verbose]
 
 DESCRIPTION
@@ -18,12 +18,12 @@ EXAMPLES
   $ objectified docs telemetry
 
 COMMON
-  --baseUrl=<value>  Root REST API URL.
-  --config=<value>   Path to config file (default: XDG config dir /
-                     Objectified AppData on Windows — see `objectified config
-                     path`).
-  --profile=<value>  Named credentials profile (OBJECTIFIED_PROFILE); falls
-                     back to default_profile in config.
+  --base-url=<value>  Root REST API URL.
+  --config=<value>    Path to config file (default: XDG config dir /
+                      Objectified AppData on Windows — see `objectified config
+                      path`).
+  --profile=<value>   Named credentials profile (OBJECTIFIED_PROFILE); falls
+                      back to default_profile in config.
 
 OUTPUT
   --[no-]color  Enable/disable ANSI colors (--no-color sets NO_COLOR;
@@ -34,7 +34,7 @@ OUTPUT
       --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
 
 AUTH
-  --apiKey=<value>  API key for direct authentication (bypasses login token).
+  --api-key=<value>  API key for direct authentication (bypasses login token).
 
 SEE ALSO
   objectified docs

--- a/objectified-cli/man/man1/objectified-docs-plugins.1
+++ b/objectified-cli/man/man1/objectified-docs-plugins.1
@@ -1,0 +1,43 @@
+.TH OBJECTIFIED\-DOCS\-PLUGINS 1 "" "" "User Commands"
+.SH NAME
+objectified docs plugins \- Future oclif plugin extensibility for Objectified
+.SH DESCRIPTION
+.nf
+USAGE
+  $ objectified docs plugins [--apiKey <value>] [--baseUrl <value>]
+    [--config <value>] [--json] [--color] [--profile <value>] [-q] [--verbose]
+
+DESCRIPTION
+  Future oclif plugin extensibility for Objectified
+
+EXAMPLES
+  $ objectified docs plugins
+
+  $ objectified docs plugins --json
+
+  $ objectified docs telemetry
+
+COMMON
+  --baseUrl=<value>  Root REST API URL.
+  --config=<value>   Path to config file (default: XDG config dir /
+                     Objectified AppData on Windows — see `objectified config
+                     path`).
+  --profile=<value>  Named credentials profile (OBJECTIFIED_PROFILE); falls
+                     back to default_profile in config.
+
+OUTPUT
+  --[no-]color  Enable/disable ANSI colors (--no-color sets NO_COLOR;
+                    colors are off when stdout is not a TTY).
+      --[no-]json   Emit machine-readable JSON (OBJECTIFIED_JSON=1;
+                    auto-enabled when stdout is not a TTY).
+  -q, --quiet       Suppress non-error stdout (spinners, banners, tips).
+      --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
+
+AUTH
+  --apiKey=<value>  API key for direct authentication (bypasses login token).
+
+SEE ALSO
+  objectified docs
+
+  objectified docs telemetry
+.fi

--- a/objectified-cli/man/man1/objectified-docs-profiles.1
+++ b/objectified-cli/man/man1/objectified-docs-profiles.1
@@ -4,7 +4,7 @@ objectified docs profiles \- config.toml profiles, defaults, and precedence rule
 .SH DESCRIPTION
 .nf
 USAGE
-  $ objectified docs profiles [--apiKey <value>] [--baseUrl <value>]
+  $ objectified docs profiles [--api-key <value>] [--base-url <value>]
     [--config <value>] [--json] [--color] [--profile <value>] [-q] [--verbose]
 
 DESCRIPTION
@@ -18,12 +18,12 @@ EXAMPLES
   $ objectified docs profiles | sed -n '1,12p'
 
 COMMON
-  --baseUrl=<value>  Root REST API URL.
-  --config=<value>   Path to config file (default: XDG config dir /
-                     Objectified AppData on Windows — see `objectified config
-                     path`).
-  --profile=<value>  Named credentials profile (OBJECTIFIED_PROFILE); falls
-                     back to default_profile in config.
+  --base-url=<value>  Root REST API URL.
+  --config=<value>    Path to config file (default: XDG config dir /
+                      Objectified AppData on Windows — see `objectified config
+                      path`).
+  --profile=<value>   Named credentials profile (OBJECTIFIED_PROFILE); falls
+                      back to default_profile in config.
 
 OUTPUT
   --[no-]color  Enable/disable ANSI colors (--no-color sets NO_COLOR;
@@ -34,7 +34,7 @@ OUTPUT
       --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
 
 AUTH
-  --apiKey=<value>  API key for direct authentication (bypasses login token).
+  --api-key=<value>  API key for direct authentication (bypasses login token).
 
 SEE ALSO
   objectified docs

--- a/objectified-cli/man/man1/objectified-docs-profiles.1
+++ b/objectified-cli/man/man1/objectified-docs-profiles.1
@@ -1,0 +1,45 @@
+.TH OBJECTIFIED\-DOCS\-PROFILES 1 "" "" "User Commands"
+.SH NAME
+objectified docs profiles \- config.toml profiles, defaults, and precedence rules
+.SH DESCRIPTION
+.nf
+USAGE
+  $ objectified docs profiles [--apiKey <value>] [--baseUrl <value>]
+    [--config <value>] [--json] [--color] [--profile <value>] [-q] [--verbose]
+
+DESCRIPTION
+  config.toml profiles, defaults, and precedence rules
+
+EXAMPLES
+  $ objectified docs profiles
+
+  $ objectified --profile staging config path
+
+  $ objectified docs profiles | sed -n '1,12p'
+
+COMMON
+  --baseUrl=<value>  Root REST API URL.
+  --config=<value>   Path to config file (default: XDG config dir /
+                     Objectified AppData on Windows — see `objectified config
+                     path`).
+  --profile=<value>  Named credentials profile (OBJECTIFIED_PROFILE); falls
+                     back to default_profile in config.
+
+OUTPUT
+  --[no-]color  Enable/disable ANSI colors (--no-color sets NO_COLOR;
+                    colors are off when stdout is not a TTY).
+      --[no-]json   Emit machine-readable JSON (OBJECTIFIED_JSON=1;
+                    auto-enabled when stdout is not a TTY).
+  -q, --quiet       Suppress non-error stdout (spinners, banners, tips).
+      --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
+
+AUTH
+  --apiKey=<value>  API key for direct authentication (bypasses login token).
+
+SEE ALSO
+  objectified docs
+
+  objectified config path
+
+  objectified config get
+.fi

--- a/objectified-cli/man/man1/objectified-docs-telemetry.1
+++ b/objectified-cli/man/man1/objectified-docs-telemetry.1
@@ -1,0 +1,44 @@
+.TH OBJECTIFIED\-DOCS\-TELEMETRY 1 "" "" "User Commands"
+.SH NAME
+objectified docs telemetry \- Telemetry posture and safe verbose debugging
+.SH DESCRIPTION
+.nf
+USAGE
+  $ objectified docs telemetry [--apiKey <value>] [--baseUrl <value>]
+    [--config <value>] [--json] [--color] [--profile <value>] [-q] [--verbose]
+
+DESCRIPTION
+  Telemetry posture and safe verbose debugging
+
+EXAMPLES
+  $ objectified docs telemetry
+
+  $ objectified --verbose hello
+  $ objectified docs telemetry
+
+  $ objectified docs telemetry > notes.txt
+
+COMMON
+  --baseUrl=<value>  Root REST API URL.
+  --config=<value>   Path to config file (default: XDG config dir /
+                     Objectified AppData on Windows — see `objectified config
+                     path`).
+  --profile=<value>  Named credentials profile (OBJECTIFIED_PROFILE); falls
+                     back to default_profile in config.
+
+OUTPUT
+  --[no-]color  Enable/disable ANSI colors (--no-color sets NO_COLOR;
+                    colors are off when stdout is not a TTY).
+      --[no-]json   Emit machine-readable JSON (OBJECTIFIED_JSON=1;
+                    auto-enabled when stdout is not a TTY).
+  -q, --quiet       Suppress non-error stdout (spinners, banners, tips).
+      --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
+
+AUTH
+  --apiKey=<value>  API key for direct authentication (bypasses login token).
+
+SEE ALSO
+  objectified docs errors
+
+  objectified docs output
+.fi

--- a/objectified-cli/man/man1/objectified-docs-telemetry.1
+++ b/objectified-cli/man/man1/objectified-docs-telemetry.1
@@ -4,7 +4,7 @@ objectified docs telemetry \- Telemetry posture and safe verbose debugging
 .SH DESCRIPTION
 .nf
 USAGE
-  $ objectified docs telemetry [--apiKey <value>] [--baseUrl <value>]
+  $ objectified docs telemetry [--api-key <value>] [--base-url <value>]
     [--config <value>] [--json] [--color] [--profile <value>] [-q] [--verbose]
 
 DESCRIPTION
@@ -19,12 +19,12 @@ EXAMPLES
   $ objectified docs telemetry > notes.txt
 
 COMMON
-  --baseUrl=<value>  Root REST API URL.
-  --config=<value>   Path to config file (default: XDG config dir /
-                     Objectified AppData on Windows — see `objectified config
-                     path`).
-  --profile=<value>  Named credentials profile (OBJECTIFIED_PROFILE); falls
-                     back to default_profile in config.
+  --base-url=<value>  Root REST API URL.
+  --config=<value>    Path to config file (default: XDG config dir /
+                      Objectified AppData on Windows — see `objectified config
+                      path`).
+  --profile=<value>   Named credentials profile (OBJECTIFIED_PROFILE); falls
+                      back to default_profile in config.
 
 OUTPUT
   --[no-]color  Enable/disable ANSI colors (--no-color sets NO_COLOR;
@@ -35,7 +35,7 @@ OUTPUT
       --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
 
 AUTH
-  --apiKey=<value>  API key for direct authentication (bypasses login token).
+  --api-key=<value>  API key for direct authentication (bypasses login token).
 
 SEE ALSO
   objectified docs errors

--- a/objectified-cli/man/man1/objectified-docs.1
+++ b/objectified-cli/man/man1/objectified-docs.1
@@ -4,7 +4,7 @@ objectified docs \- List documentation topics (`objectified docs`) or open one w
 .SH DESCRIPTION
 .nf
 USAGE
-  $ objectified docs [--apiKey <value>] [--baseUrl <value>]
+  $ objectified docs [--api-key <value>] [--base-url <value>]
     [--config <value>] [--json] [--color] [--profile <value>] [-q] [--verbose]
 
 DESCRIPTION
@@ -19,12 +19,12 @@ EXAMPLES
   $ objectified --json docs
 
 COMMON
-  --baseUrl=<value>  Root REST API URL.
-  --config=<value>   Path to config file (default: XDG config dir /
-                     Objectified AppData on Windows — see `objectified config
-                     path`).
-  --profile=<value>  Named credentials profile (OBJECTIFIED_PROFILE); falls
-                     back to default_profile in config.
+  --base-url=<value>  Root REST API URL.
+  --config=<value>    Path to config file (default: XDG config dir /
+                      Objectified AppData on Windows — see `objectified config
+                      path`).
+  --profile=<value>   Named credentials profile (OBJECTIFIED_PROFILE); falls
+                      back to default_profile in config.
 
 OUTPUT
   --[no-]color  Enable/disable ANSI colors (--no-color sets NO_COLOR;
@@ -35,7 +35,7 @@ OUTPUT
       --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
 
 AUTH
-  --apiKey=<value>  API key for direct authentication (bypasses login token).
+  --api-key=<value>  API key for direct authentication (bypasses login token).
 
 SEE ALSO
   objectified docs errors

--- a/objectified-cli/man/man1/objectified-docs.1
+++ b/objectified-cli/man/man1/objectified-docs.1
@@ -1,0 +1,46 @@
+.TH OBJECTIFIED\-DOCS 1 "" "" "User Commands"
+.SH NAME
+objectified docs \- List documentation topics (`objectified docs`) or open one with `objectified docs <topic>`.
+.SH DESCRIPTION
+.nf
+USAGE
+  $ objectified docs [--apiKey <value>] [--baseUrl <value>]
+    [--config <value>] [--json] [--color] [--profile <value>] [-q] [--verbose]
+
+DESCRIPTION
+  List documentation topics (`objectified docs`) or open one with `objectified
+  docs <topic>`.
+
+EXAMPLES
+  $ objectified docs
+
+  $ objectified docs output
+
+  $ objectified --json docs
+
+COMMON
+  --baseUrl=<value>  Root REST API URL.
+  --config=<value>   Path to config file (default: XDG config dir /
+                     Objectified AppData on Windows — see `objectified config
+                     path`).
+  --profile=<value>  Named credentials profile (OBJECTIFIED_PROFILE); falls
+                     back to default_profile in config.
+
+OUTPUT
+  --[no-]color  Enable/disable ANSI colors (--no-color sets NO_COLOR;
+                    colors are off when stdout is not a TTY).
+      --[no-]json   Emit machine-readable JSON (OBJECTIFIED_JSON=1;
+                    auto-enabled when stdout is not a TTY).
+  -q, --quiet       Suppress non-error stdout (spinners, banners, tips).
+      --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
+
+AUTH
+  --apiKey=<value>  API key for direct authentication (bypasses login token).
+
+SEE ALSO
+  objectified docs errors
+
+  objectified hello
+
+  objectified config path
+.fi

--- a/objectified-cli/man/man1/objectified-hello.1
+++ b/objectified-cli/man/man1/objectified-hello.1
@@ -4,7 +4,7 @@ objectified hello \- Smoke-test greeting for the Objectified CLI
 .SH DESCRIPTION
 .nf
 USAGE
-  $ objectified hello [NAME] [--apiKey <value>] [--baseUrl
+  $ objectified hello [NAME] [--api-key <value>] [--base-url
     <value>] [--config <value>] [--json] [--color] [--profile <value>] [-q]
     [--verbose]
 
@@ -22,12 +22,12 @@ EXAMPLES
   $ objectified --json hello
 
 COMMON
-  --baseUrl=<value>  Root REST API URL.
-  --config=<value>   Path to config file (default: XDG config dir /
-                     Objectified AppData on Windows — see `objectified config
-                     path`).
-  --profile=<value>  Named credentials profile (OBJECTIFIED_PROFILE); falls
-                     back to default_profile in config.
+  --base-url=<value>  Root REST API URL.
+  --config=<value>    Path to config file (default: XDG config dir /
+                      Objectified AppData on Windows — see `objectified config
+                      path`).
+  --profile=<value>   Named credentials profile (OBJECTIFIED_PROFILE); falls
+                      back to default_profile in config.
 
 OUTPUT
   --[no-]color  Enable/disable ANSI colors (--no-color sets NO_COLOR;
@@ -38,7 +38,7 @@ OUTPUT
       --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
 
 AUTH
-  --apiKey=<value>  API key for direct authentication (bypasses login token).
+  --api-key=<value>  API key for direct authentication (bypasses login token).
 
 SEE ALSO
   objectified docs output

--- a/objectified-cli/man/man1/objectified-hello.1
+++ b/objectified-cli/man/man1/objectified-hello.1
@@ -1,0 +1,47 @@
+.TH OBJECTIFIED\-HELLO 1 "" "" "User Commands"
+.SH NAME
+objectified hello \- Smoke-test greeting for the Objectified CLI
+.SH DESCRIPTION
+.nf
+USAGE
+  $ objectified hello [NAME] [--apiKey <value>] [--baseUrl
+    <value>] [--config <value>] [--json] [--color] [--profile <value>] [-q]
+    [--verbose]
+
+ARGUMENTS
+  [NAME]  Who to greet
+
+DESCRIPTION
+  Smoke-test greeting for the Objectified CLI
+
+EXAMPLES
+  $ objectified hello
+
+  $ objectified hello Ada
+
+  $ objectified --json hello
+
+COMMON
+  --baseUrl=<value>  Root REST API URL.
+  --config=<value>   Path to config file (default: XDG config dir /
+                     Objectified AppData on Windows — see `objectified config
+                     path`).
+  --profile=<value>  Named credentials profile (OBJECTIFIED_PROFILE); falls
+                     back to default_profile in config.
+
+OUTPUT
+  --[no-]color  Enable/disable ANSI colors (--no-color sets NO_COLOR;
+                    colors are off when stdout is not a TTY).
+      --[no-]json   Emit machine-readable JSON (OBJECTIFIED_JSON=1;
+                    auto-enabled when stdout is not a TTY).
+  -q, --quiet       Suppress non-error stdout (spinners, banners, tips).
+      --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
+
+AUTH
+  --apiKey=<value>  API key for direct authentication (bypasses login token).
+
+SEE ALSO
+  objectified docs output
+
+  objectified config path
+.fi

--- a/objectified-cli/man/man1/objectified-help.1
+++ b/objectified-cli/man/man1/objectified-help.1
@@ -1,0 +1,17 @@
+.TH OBJECTIFIED\-HELP 1 "" "" "User Commands"
+.SH NAME
+objectified help \- Display help for <%= config.bin %>.
+.SH DESCRIPTION
+.nf
+USAGE
+  $ objectified help [COMMAND...] [-n]
+
+ARGUMENTS
+  [COMMAND...]  Command to show help for.
+
+DESCRIPTION
+  Display help for objectified.
+
+OTHER
+  -n, --nested-commands  Include all nested commands in the output.
+.fi

--- a/objectified-cli/man/man1/objectified-help.1
+++ b/objectified-cli/man/man1/objectified-help.1
@@ -1,6 +1,6 @@
 .TH OBJECTIFIED\-HELP 1 "" "" "User Commands"
 .SH NAME
-objectified help \- Display help for <%= config.bin %>.
+objectified help \- Display help for objectified.
 .SH DESCRIPTION
 .nf
 USAGE

--- a/objectified-cli/man/man1/objectified-projects-list.1
+++ b/objectified-cli/man/man1/objectified-projects-list.1
@@ -1,0 +1,45 @@
+.TH OBJECTIFIED\-PROJECTS\-LIST 1 "" "" "User Commands"
+.SH NAME
+objectified projects list \- List Objectified projects
+.SH DESCRIPTION
+.nf
+USAGE
+  $ objectified projects list [--apiKey <value>] [--baseUrl <value>]
+    [--config <value>] [--json] [--color] [--profile <value>] [-q] [--verbose]
+
+DESCRIPTION
+  List Objectified projects
+
+EXAMPLES
+  $ objectified projects list
+
+  $ objectified --json projects list
+
+  $ objectified --profile staging projects list
+
+COMMON
+  --baseUrl=<value>  Root REST API URL.
+  --config=<value>   Path to config file (default: XDG config dir /
+                     Objectified AppData on Windows — see `objectified config
+                     path`).
+  --profile=<value>  Named credentials profile (OBJECTIFIED_PROFILE); falls
+                     back to default_profile in config.
+
+OUTPUT
+  --[no-]color  Enable/disable ANSI colors (--no-color sets NO_COLOR;
+                    colors are off when stdout is not a TTY).
+      --[no-]json   Emit machine-readable JSON (OBJECTIFIED_JSON=1;
+                    auto-enabled when stdout is not a TTY).
+  -q, --quiet       Suppress non-error stdout (spinners, banners, tips).
+      --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
+
+AUTH
+  --apiKey=<value>  API key for direct authentication (bypasses login token).
+
+SEE ALSO
+  objectified config path
+
+  objectified docs errors
+
+  objectified hello
+.fi

--- a/objectified-cli/man/man1/objectified-projects-list.1
+++ b/objectified-cli/man/man1/objectified-projects-list.1
@@ -4,7 +4,7 @@ objectified projects list \- List Objectified projects
 .SH DESCRIPTION
 .nf
 USAGE
-  $ objectified projects list [--apiKey <value>] [--baseUrl <value>]
+  $ objectified projects list [--api-key <value>] [--base-url <value>]
     [--config <value>] [--json] [--color] [--profile <value>] [-q] [--verbose]
 
 DESCRIPTION
@@ -18,12 +18,12 @@ EXAMPLES
   $ objectified --profile staging projects list
 
 COMMON
-  --baseUrl=<value>  Root REST API URL.
-  --config=<value>   Path to config file (default: XDG config dir /
-                     Objectified AppData on Windows — see `objectified config
-                     path`).
-  --profile=<value>  Named credentials profile (OBJECTIFIED_PROFILE); falls
-                     back to default_profile in config.
+  --base-url=<value>  Root REST API URL.
+  --config=<value>    Path to config file (default: XDG config dir /
+                      Objectified AppData on Windows — see `objectified config
+                      path`).
+  --profile=<value>   Named credentials profile (OBJECTIFIED_PROFILE); falls
+                      back to default_profile in config.
 
 OUTPUT
   --[no-]color  Enable/disable ANSI colors (--no-color sets NO_COLOR;
@@ -34,7 +34,7 @@ OUTPUT
       --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
 
 AUTH
-  --apiKey=<value>  API key for direct authentication (bypasses login token).
+  --api-key=<value>  API key for direct authentication (bypasses login token).
 
 SEE ALSO
   objectified config path

--- a/objectified-cli/man/man1/objectified-version.1
+++ b/objectified-cli/man/man1/objectified-version.1
@@ -1,0 +1,20 @@
+.TH OBJECTIFIED\-VERSION 1 "" "" "User Commands"
+.SH NAME
+objectified version \- version
+.SH DESCRIPTION
+.nf
+USAGE
+  $ objectified version [--json] [--verbose]
+
+OTHER
+  --verbose  Show additional information about the CLI.
+
+GLOBAL
+  --json  Format output as json.
+
+FLAG DESCRIPTIONS
+  --verbose  Show additional information about the CLI.
+
+    Additionally shows the architecture, node version, operating system, and
+    versions of plugins that the CLI is using.
+.fi

--- a/objectified-cli/man/man1/objectified.1
+++ b/objectified-cli/man/man1/objectified.1
@@ -19,7 +19,7 @@ GLOBAL FLAGS
   --base-url      OBJECTIFIED_BASE_URL      Root REST endpoint (built-in
   default: https://api.objectified.dev)
   --config        OBJECTIFIED_CONFIG        config.toml (default: XDG config
-  dir, or %APPDATA%\Objectified on Windows)
+  dir, or %APPDATA%\\Objectified on Windows)
   --json          OBJECTIFIED_JSON=1        Machine-readable JSON (auto when
   stdout is not a TTY)
   --no-color      NO_COLOR=1                Disable ANSI color (auto when

--- a/objectified-cli/man/man1/objectified.1
+++ b/objectified-cli/man/man1/objectified.1
@@ -1,0 +1,43 @@
+.TH OBJECTIFIED 1 "" "" "User Commands"
+.SH NAME
+objectified \- Objectified command-line interface
+.SH DESCRIPTION
+.nf
+Objectified command-line interface
+
+VERSION
+  objectified-cli/0.1.6 linux-x64 node-v24.14.1
+
+USAGE
+  $ objectified [COMMAND]
+
+GLOBAL FLAGS
+  Global flags apply to every command:
+
+  --api-key       OBJECTIFIED_API_KEY       Direct API-key auth (not read from
+  config.toml)
+  --base-url      OBJECTIFIED_BASE_URL      Root REST endpoint (built-in
+  default: https://api.objectified.dev)
+  --config        OBJECTIFIED_CONFIG        config.toml (default: XDG config
+  dir, or %APPDATA%\Objectified on Windows)
+  --json          OBJECTIFIED_JSON=1        Machine-readable JSON (auto when
+  stdout is not a TTY)
+  --no-color      NO_COLOR=1                Disable ANSI color (auto when
+  stdout is not a TTY)
+  --profile       OBJECTIFIED_PROFILE       Profile name; falls back to
+  default_profile in config, else "default"
+  --quiet, -q                               Suppress non-error stdout
+  --verbose       OBJECTIFIED_VERBOSE=1     Verbose stderr logging
+
+  Resolution order for base URL (highest precedence wins):
+  1. Command-line flag            (--base-url=…)
+  2. Environment variable         (OBJECTIFIED_BASE_URL=…)
+  3. Config [profile.NAME]        (base_url=…)
+  4. Config [default]              (base_url=…)
+  5. Built-in default              (https://api.objectified.dev)
+
+  Resolution order for API key: --api-key, then OBJECTIFIED_API_KEY (never
+  from config file; see #3188).
+  Resolution order for tenant slug: OBJECTIFIED_TENANT, then config profile /
+  [default] (tenant_slug).
+.fi

--- a/objectified-cli/package.json
+++ b/objectified-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-cli",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Objectified command-line interface",
   "author": "Objectified",
   "type": "module",
@@ -22,12 +22,13 @@
   "files": [
     "/bin",
     "/dist",
+    "/man",
     "/oclif.manifest.json"
   ],
   "scripts": {
     "codegen": "openapi-ts -i ../objectified-rest/openapi.yaml -o src/generated -c @hey-api/client-fetch && node ./scripts/fix-generated-imports.mjs && node ./scripts/finish-codegen.mjs",
     "codegen:check": "yarn codegen && git diff --quiet HEAD -- src/generated || (echo '' >&2 && echo 'OpenAPI-generated client is out of date. From objectified-cli/, run: yarn codegen' >&2 && echo '' >&2 && exit 1)",
-    "build": "shx rm -rf dist && tsc && oclif manifest",
+    "build": "shx rm -rf dist && tsc && oclif manifest && oclif readme && node ./scripts/generate-man.mjs",
     "dev": "node bin/dev.js",
     "lint": "eslint .",
     "format": "prettier --write .",
@@ -68,5 +69,23 @@
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.46.0",
     "vitest": "^3.2.4"
-  }
+  },
+  "man": [
+    "./man/man1/objectified-config-get.1",
+    "./man/man1/objectified-config-list.1",
+    "./man/man1/objectified-config-path.1",
+    "./man/man1/objectified-config-set.1",
+    "./man/man1/objectified-docs-completions.1",
+    "./man/man1/objectified-docs-errors.1",
+    "./man/man1/objectified-docs-output.1",
+    "./man/man1/objectified-docs-plugins.1",
+    "./man/man1/objectified-docs-profiles.1",
+    "./man/man1/objectified-docs-telemetry.1",
+    "./man/man1/objectified-docs.1",
+    "./man/man1/objectified-hello.1",
+    "./man/man1/objectified-help.1",
+    "./man/man1/objectified-projects-list.1",
+    "./man/man1/objectified-version.1",
+    "./man/man1/objectified.1"
+  ]
 }

--- a/objectified-cli/scripts/generate-man.mjs
+++ b/objectified-cli/scripts/generate-man.mjs
@@ -16,8 +16,9 @@ function escapeMan(text) {
   return text
     .split("\n")
     .map((line) => {
-      if (line.startsWith(".") || line.startsWith("'")) return `\\&${line}`;
-      return line;
+      const escaped = line.replace(/\\/g, "\\\\");
+      if (escaped.startsWith(".") || escaped.startsWith("'")) return `\\&${escaped}`;
+      return escaped;
     })
     .join("\n");
 }
@@ -54,6 +55,11 @@ async function main() {
 
   const HelpClass = await loadHelpClass(config);
   const help = new HelpClass(config, { stripAnsi: true, maxWidth: 78 });
+  const renderTemplate = (value) => {
+    if (!value) return undefined;
+    const rendered = help.render(value);
+    return rendered.replace(/<%[\s\S]*?%>/g, "").trim();
+  };
 
   const topicSep = config.topicSeparator ?? " ";
 
@@ -70,8 +76,8 @@ async function main() {
     const cmd = { ...c, aliases: c.aliases ? [...c.aliases] : c.aliases };
     const displayId = cmd.id.replace(/:/g, topicSep);
     const summaryLine =
-      (cmd.summary && cmd.summary.split("\n")[0]) ||
-      (cmd.description && cmd.description.split("\n")[0]) ||
+      (renderTemplate(cmd.summary)?.split("\n")[0]) ||
+      (renderTemplate(cmd.description)?.split("\n")[0]) ||
       displayId;
     const body = help.formatCommand(cmd);
     const base = manFileBase(cmd.id, topicSep);

--- a/objectified-cli/scripts/generate-man.mjs
+++ b/objectified-cli/scripts/generate-man.mjs
@@ -58,7 +58,7 @@ async function main() {
   const renderTemplate = (value) => {
     if (!value) return undefined;
     const rendered = help.render(value);
-    return rendered.replace(/<%[\s\S]*?%>/g, "").trim();
+    return rendered.replace(/<%[^%]*%>/g, "").trim();
   };
 
   const topicSep = config.topicSeparator ?? " ";

--- a/objectified-cli/scripts/generate-man.mjs
+++ b/objectified-cli/scripts/generate-man.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+/**
+ * Writes troff man pages under man/man1 from oclif Help output (stripAnsi).
+ * Updates package.json "man" array to match generated files.
+ */
+
+import { Config, loadHelpClass } from "@oclif/core";
+import { mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const manDir = join(root, "man", "man1");
+
+function escapeMan(text) {
+  return text
+    .split("\n")
+    .map((line) => {
+      if (line.startsWith(".") || line.startsWith("'")) return `\\&${line}`;
+      return line;
+    })
+    .join("\n");
+}
+
+function manFileBase(commandId, topicSeparator) {
+  if (!commandId) return "objectified";
+  const spaced = commandId.replace(/:/g, topicSeparator);
+  return `objectified-${spaced.replace(/\s+/g, "-")}`;
+}
+
+function manTitle(baseName) {
+  return baseName.replace(/-/g, "\\-").toUpperCase();
+}
+
+function writeManPage({ base, title, nameLine, body }) {
+  const escaped = escapeMan(body.trimEnd());
+  const page = `.TH ${title} 1 "" "" "User Commands"
+.SH NAME
+${nameLine}
+.SH DESCRIPTION
+.nf
+${escaped}
+.fi
+`;
+  writeFileSync(join(manDir, `${base}.1`), page, "utf8");
+}
+
+async function main() {
+  rmSync(manDir, { recursive: true, force: true });
+  mkdirSync(manDir, { recursive: true });
+
+  const config = await Config.load(root);
+  await config.load();
+
+  const HelpClass = await loadHelpClass(config);
+  const help = new HelpClass(config, { stripAnsi: true, maxWidth: 78 });
+
+  const topicSep = config.topicSeparator ?? " ";
+
+  const rootBody = help.formatRoot();
+  writeManPage({
+    base: "objectified",
+    title: "OBJECTIFIED",
+    nameLine: `${config.bin} \\- ${config.pjson.description ?? "Objectified CLI"}`,
+    body: rootBody,
+  });
+
+  const commands = config.commands.filter((c) => !c.hidden && c.pluginType === "core");
+  for (const c of commands) {
+    const cmd = { ...c, aliases: c.aliases ? [...c.aliases] : c.aliases };
+    const displayId = cmd.id.replace(/:/g, topicSep);
+    const summaryLine =
+      (cmd.summary && cmd.summary.split("\n")[0]) ||
+      (cmd.description && cmd.description.split("\n")[0]) ||
+      displayId;
+    const body = help.formatCommand(cmd);
+    const base = manFileBase(cmd.id, topicSep);
+    writeManPage({
+      base,
+      title: manTitle(base),
+      nameLine: `${config.bin} ${displayId} \\- ${summaryLine}`,
+      body,
+    });
+  }
+
+  const generated = readdirSync(manDir)
+    .filter((f) => f.endsWith(".1"))
+    .sort()
+    .map((f) => `./man/man1/${f}`);
+
+  const pkgPath = join(root, "package.json");
+  const pkg = JSON.parse(readFileSync(pkgPath, "utf8"));
+  pkg.man = generated;
+  writeFileSync(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`, "utf8");
+}
+
+await main();

--- a/objectified-cli/src/base-command.ts
+++ b/objectified-cli/src/base-command.ts
@@ -116,7 +116,7 @@ export abstract class BaseCommand extends Command {
     const Cmd = this.constructor as typeof Command;
     const parsed = await this.parse(Cmd);
     const parsedFlags = parsed.flags as Record<string, unknown>;
-    // Keep camelCase fallback for compatibility with argv normalization/tests that still accept legacy forms.
+    // Keep camelCase fallback for compatibility while normalize-argv continues accepting legacy aliases.
     const globalPart: GlobalCliFlags = {
       apiKey: (parsedFlags["api-key"] as string | undefined) ?? (parsedFlags.apiKey as string | undefined),
       baseUrl:

--- a/objectified-cli/src/base-command.ts
+++ b/objectified-cli/src/base-command.ts
@@ -28,13 +28,11 @@ import { createCliOutput, localePrefersAsciiTable, type CliOutput } from "./lib/
 
 export abstract class BaseCommand extends Command {
   static baseFlags = {
-    apiKey: Flags.string({
-      name: "api-key",
+    "api-key": Flags.string({
       description: "API key for direct authentication (bypasses login token).",
       helpGroup: "Auth",
     }),
-    baseUrl: Flags.string({
-      name: "base-url",
+    "base-url": Flags.string({
       description: "Root REST API URL.",
       helpGroup: "Common",
     }),
@@ -117,7 +115,18 @@ export abstract class BaseCommand extends Command {
     await super.init();
     const Cmd = this.constructor as typeof Command;
     const parsed = await this.parse(Cmd);
-    const globalPart = parsed.flags as GlobalCliFlags;
+    const parsedFlags = parsed.flags as Record<string, unknown>;
+    const globalPart: GlobalCliFlags = {
+      apiKey: (parsedFlags["api-key"] as string | undefined) ?? (parsedFlags.apiKey as string | undefined),
+      baseUrl:
+        (parsedFlags["base-url"] as string | undefined) ?? (parsedFlags.baseUrl as string | undefined),
+      config: parsedFlags.config as string | undefined,
+      json: parsedFlags.json as boolean | undefined,
+      color: parsedFlags.color as boolean | undefined,
+      profile: parsedFlags.profile as string | undefined,
+      quiet: parsedFlags.quiet as boolean | undefined,
+      verbose: parsedFlags.verbose as boolean | undefined,
+    };
     this.parsedGlobalFlags = globalPart;
     this.commandArgs = parsed.args as Record<string, unknown>;
 

--- a/objectified-cli/src/base-command.ts
+++ b/objectified-cli/src/base-command.ts
@@ -116,6 +116,7 @@ export abstract class BaseCommand extends Command {
     const Cmd = this.constructor as typeof Command;
     const parsed = await this.parse(Cmd);
     const parsedFlags = parsed.flags as Record<string, unknown>;
+    // Keep camelCase fallback for compatibility with argv normalization/tests that still accept legacy forms.
     const globalPart: GlobalCliFlags = {
       apiKey: (parsedFlags["api-key"] as string | undefined) ?? (parsedFlags.apiKey as string | undefined),
       baseUrl:

--- a/objectified-cli/src/base-command.ts
+++ b/objectified-cli/src/base-command.ts
@@ -31,43 +31,43 @@ export abstract class BaseCommand extends Command {
     apiKey: Flags.string({
       name: "api-key",
       description: "API key for direct authentication (bypasses login token).",
-      helpGroup: "GLOBAL",
+      helpGroup: "Auth",
     }),
     baseUrl: Flags.string({
       name: "base-url",
       description: "Root REST API URL.",
-      helpGroup: "GLOBAL",
+      helpGroup: "Common",
     }),
     config: Flags.string({
       description:
         "Path to config file (default: XDG config dir / Objectified AppData on Windows — see `objectified config path`).",
-      helpGroup: "GLOBAL",
+      helpGroup: "Common",
     }),
     json: Flags.boolean({
       description:
         "Emit machine-readable JSON (OBJECTIFIED_JSON=1; auto-enabled when stdout is not a TTY).",
       allowNo: true,
-      helpGroup: "GLOBAL",
+      helpGroup: "Output",
     }),
     color: Flags.boolean({
       description:
         "Enable/disable ANSI colors (--no-color sets NO_COLOR; colors are off when stdout is not a TTY).",
       allowNo: true,
-      helpGroup: "GLOBAL",
+      helpGroup: "Output",
     }),
     profile: Flags.string({
       description:
         "Named credentials profile (OBJECTIFIED_PROFILE); falls back to default_profile in config.",
-      helpGroup: "GLOBAL",
+      helpGroup: "Common",
     }),
     quiet: Flags.boolean({
       char: "q",
       description: "Suppress non-error stdout (spinners, banners, tips).",
-      helpGroup: "GLOBAL",
+      helpGroup: "Output",
     }),
     verbose: Flags.boolean({
       description: "Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).",
-      helpGroup: "GLOBAL",
+      helpGroup: "Output",
     }),
   };
 

--- a/objectified-cli/src/commands/config/get.ts
+++ b/objectified-cli/src/commands/config/get.ts
@@ -12,7 +12,13 @@ import { CliError } from "../../lib/errors.js";
 export default class ConfigGet extends BaseCommand {
   static description = "Print a single config value by dotted key";
 
-  static examples = ["<%= config.bin %> <%= command.id %> profile.prod.base_url"];
+  static examples = [
+    "<%= config.bin %> <%= command.id %> default_profile",
+    "<%= config.bin %> <%= command.id %> profile.prod.base_url",
+    "<%= config.bin %> --json <%= command.id %> profile.staging.tenant_slug",
+  ];
+
+  static seeAlso = ["config set", "config path"];
 
   static args = {
     key: Args.string({

--- a/objectified-cli/src/commands/config/list.ts
+++ b/objectified-cli/src/commands/config/list.ts
@@ -6,7 +6,13 @@ import { loadRawTomlDocument } from "../../lib/config.js";
 export default class ConfigList extends BaseCommand {
   static description = "Print the entire config file (stable JSON with --json, otherwise TOML)";
 
-  static examples = ["<%= config.bin %> <%= command.id %>"];
+  static examples = [
+    "<%= config.bin %> <%= command.id %>",
+    "<%= config.bin %> --json <%= command.id %>",
+    "<%= config.bin %> <%= command.id %> > backup.toml",
+  ];
+
+  static seeAlso = ["config path", "config get"];
 
   run(): Promise<void> {
     const raw = loadRawTomlDocument(this.resolvedConfigPath);

--- a/objectified-cli/src/commands/config/path.ts
+++ b/objectified-cli/src/commands/config/path.ts
@@ -3,7 +3,13 @@ import { BaseCommand } from "../../base-command.js";
 export default class ConfigPath extends BaseCommand {
   static description = "Print the resolved config.toml path";
 
-  static examples = ["<%= config.bin %> <%= command.id %>"];
+  static examples = [
+    "<%= config.bin %> <%= command.id %>",
+    "<%= config.bin %> --json <%= command.id %>",
+    "<%= config.bin %> <%= command.id %> | pbcopy",
+  ];
+
+  static seeAlso = ["config get", "config list"];
 
   run(): Promise<void> {
     if (this.context.json) {

--- a/objectified-cli/src/commands/config/set.ts
+++ b/objectified-cli/src/commands/config/set.ts
@@ -20,7 +20,11 @@ export default class ConfigSet extends BaseCommand {
 
   static examples = [
     "<%= config.bin %> <%= command.id %> profile.staging.base_url https://api.staging.example",
+    "<%= config.bin %> <%= command.id %> default_profile staging",
+    "<%= config.bin %> --json <%= command.id %> profile.prod.tenant_slug acme-corp",
   ];
+
+  static seeAlso = ["config get", "docs profiles"];
 
   static args = {
     key: Args.string({

--- a/objectified-cli/src/commands/docs.ts
+++ b/objectified-cli/src/commands/docs.ts
@@ -1,0 +1,37 @@
+import { BaseCommand } from "../base-command.js";
+import { DOCS_TOPIC_INDEX } from "../lib/docs-index.js";
+
+export default class Docs extends BaseCommand {
+  static description =
+    "List documentation topics (`objectified docs`) or open one with `objectified docs <topic>`.";
+
+  static examples = [
+    "<%= config.bin %> <%= command.id %>",
+    "<%= config.bin %> <%= command.id %> output",
+    "<%= config.bin %> --json <%= command.id %>",
+  ];
+
+  static seeAlso = ["docs errors", "hello", "config path"];
+
+  run(): Promise<void> {
+    if (this.context.json) {
+      this.output.json({ topics: DOCS_TOPIC_INDEX });
+      return Promise.resolve();
+    }
+
+    this.output.table(
+      DOCS_TOPIC_INDEX.map((t) => ({
+        topic: t.topic,
+        summary: t.summary,
+      })),
+      [
+        { key: "topic", label: "Topic" },
+        { key: "summary", label: "Summary" },
+      ],
+    );
+    this.output.text(
+      `\nRun ${this.config.bin} docs <topic> for full prose (try ${this.config.bin} docs output).`,
+    );
+    return Promise.resolve();
+  }
+}

--- a/objectified-cli/src/commands/docs/completions.ts
+++ b/objectified-cli/src/commands/docs/completions.ts
@@ -1,0 +1,23 @@
+import { BaseCommand } from "../../base-command.js";
+import { docsTopicCompletions } from "../../lib/docs-content.js";
+
+export default class DocsCompletions extends BaseCommand {
+  static description = "Shell completions roadmap and interim guidance";
+
+  static examples = [
+    "<%= config.bin %> <%= command.id %>",
+    "<%= config.bin %> --help",
+    "<%= config.bin %> <%= command.id %> --json",
+  ];
+
+  static seeAlso = ["docs", "docs output"];
+
+  run(): Promise<void> {
+    if (this.context.json) {
+      this.output.json({ topic: "completions", body: docsTopicCompletions });
+      return Promise.resolve();
+    }
+    this.output.text(docsTopicCompletions);
+    return Promise.resolve();
+  }
+}

--- a/objectified-cli/src/commands/docs/errors.ts
+++ b/objectified-cli/src/commands/docs/errors.ts
@@ -4,7 +4,13 @@ import { exitCodeReferenceJson, formatExitCodeDocs } from "../../lib/exit-codes.
 export default class DocsErrors extends BaseCommand {
   static description = "Exit codes, hints, and error-handling reference";
 
-  static examples = ["<%= config.bin %> <%= command.id %>"];
+  static examples = [
+    "<%= config.bin %> <%= command.id %>",
+    "<%= config.bin %> <%= command.id %> --json",
+    "<%= config.bin %> projects list --json",
+  ];
+
+  static seeAlso = ["docs", "docs output", "hello"];
 
   run(): Promise<void> {
     if (this.context.json) {

--- a/objectified-cli/src/commands/docs/output.ts
+++ b/objectified-cli/src/commands/docs/output.ts
@@ -1,0 +1,23 @@
+import { BaseCommand } from "../../base-command.js";
+import { docsTopicOutput } from "../../lib/docs-content.js";
+
+export default class DocsOutput extends BaseCommand {
+  static description = "TTY vs JSON output, quiet mode, verbose logs, and color";
+
+  static examples = [
+    "<%= config.bin %> <%= command.id %>",
+    "<%= config.bin %> --json hello",
+    "<%= config.bin %> <%= command.id %> > ./output-notes.txt",
+  ];
+
+  static seeAlso = ["docs", "docs errors", "hello"];
+
+  run(): Promise<void> {
+    if (this.context.json) {
+      this.output.json({ topic: "output", body: docsTopicOutput });
+      return Promise.resolve();
+    }
+    this.output.text(docsTopicOutput);
+    return Promise.resolve();
+  }
+}

--- a/objectified-cli/src/commands/docs/plugins.ts
+++ b/objectified-cli/src/commands/docs/plugins.ts
@@ -1,0 +1,23 @@
+import { BaseCommand } from "../../base-command.js";
+import { docsTopicPlugins } from "../../lib/docs-content.js";
+
+export default class DocsPlugins extends BaseCommand {
+  static description = "Future oclif plugin extensibility for Objectified";
+
+  static examples = [
+    "<%= config.bin %> <%= command.id %>",
+    "<%= config.bin %> <%= command.id %> --json",
+    "<%= config.bin %> docs telemetry",
+  ];
+
+  static seeAlso = ["docs", "docs telemetry"];
+
+  run(): Promise<void> {
+    if (this.context.json) {
+      this.output.json({ topic: "plugins", body: docsTopicPlugins });
+      return Promise.resolve();
+    }
+    this.output.text(docsTopicPlugins);
+    return Promise.resolve();
+  }
+}

--- a/objectified-cli/src/commands/docs/profiles.ts
+++ b/objectified-cli/src/commands/docs/profiles.ts
@@ -1,0 +1,23 @@
+import { BaseCommand } from "../../base-command.js";
+import { docsTopicProfiles } from "../../lib/docs-content.js";
+
+export default class DocsProfiles extends BaseCommand {
+  static description = "config.toml profiles, defaults, and precedence rules";
+
+  static examples = [
+    "<%= config.bin %> <%= command.id %>",
+    "<%= config.bin %> --profile staging config path",
+    "<%= config.bin %> <%= command.id %> | sed -n '1,12p'",
+  ];
+
+  static seeAlso = ["docs", "config path", "config get"];
+
+  run(): Promise<void> {
+    if (this.context.json) {
+      this.output.json({ topic: "profiles", body: docsTopicProfiles });
+      return Promise.resolve();
+    }
+    this.output.text(docsTopicProfiles);
+    return Promise.resolve();
+  }
+}

--- a/objectified-cli/src/commands/docs/telemetry.ts
+++ b/objectified-cli/src/commands/docs/telemetry.ts
@@ -1,0 +1,23 @@
+import { BaseCommand } from "../../base-command.js";
+import { docsTopicTelemetry } from "../../lib/docs-content.js";
+
+export default class DocsTelemetry extends BaseCommand {
+  static description = "Telemetry posture and safe verbose debugging";
+
+  static examples = [
+    "<%= config.bin %> <%= command.id %>",
+    "<%= config.bin %> --verbose hello\n<%= config.bin %> <%= command.id %>",
+    "<%= config.bin %> <%= command.id %> > notes.txt",
+  ];
+
+  static seeAlso = ["docs errors", "docs output"];
+
+  run(): Promise<void> {
+    if (this.context.json) {
+      this.output.json({ topic: "telemetry", body: docsTopicTelemetry });
+      return Promise.resolve();
+    }
+    this.output.text(docsTopicTelemetry);
+    return Promise.resolve();
+  }
+}

--- a/objectified-cli/src/commands/hello.ts
+++ b/objectified-cli/src/commands/hello.ts
@@ -9,7 +9,10 @@ export default class Hello extends BaseCommand {
   static examples = [
     "<%= config.bin %> <%= command.id %>",
     "<%= config.bin %> <%= command.id %> Ada",
+    "<%= config.bin %> --json <%= command.id %>",
   ];
+
+  static seeAlso = ["docs output", "config path"];
 
   static args = {
     name: Args.string({

--- a/objectified-cli/src/commands/projects/list.ts
+++ b/objectified-cli/src/commands/projects/list.ts
@@ -6,7 +6,13 @@ import { chalkForContext } from "../../lib/output.js";
 export default class ProjectsList extends BaseCommand {
   static description = "List Objectified projects";
 
-  static examples = ["<%= config.bin %> <%= command.id %>"];
+  static examples = [
+    "<%= config.bin %> <%= command.id %>",
+    "<%= config.bin %> --json <%= command.id %>",
+    "<%= config.bin %> --profile staging <%= command.id %>",
+  ];
+
+  static seeAlso = ["config path", "docs errors", "hello"];
 
   async run(): Promise<void> {
     const tenant = this.context.tenantSlug;

--- a/objectified-cli/src/help.ts
+++ b/objectified-cli/src/help.ts
@@ -75,7 +75,7 @@ function helpShouldStripAnsi(optsStrip: boolean | undefined, argv: string[]): bo
   if (colorFlag === false) return true;
   if (colorFlag === true) return false;
   if (process.env.NO_COLOR !== undefined && process.env.NO_COLOR !== "") return true;
-  return !(typeof supportsColor.stdout === "object" && process.stdout.isTTY);
+  return typeof supportsColor.stdout !== "object" || !process.stdout.isTTY;
 }
 
 type CommandWithSeeAlso = Command.Loadable & { seeAlso?: string[] };

--- a/objectified-cli/src/help.ts
+++ b/objectified-cli/src/help.ts
@@ -62,7 +62,6 @@ function argvColorFlag(argv: string[]): boolean | undefined {
     if (arg.startsWith("--no-color=")) {
       const parsed = parseBooleanArg(arg.slice("--no-color=".length));
       if (parsed !== undefined) out = !parsed;
-      else out = false;
     }
   }
   return out;

--- a/objectified-cli/src/help.ts
+++ b/objectified-cli/src/help.ts
@@ -1,4 +1,5 @@
 import { Command, CommandHelp, Help, type HelpSectionRenderer } from "@oclif/core";
+import supportsColor from "supports-color";
 
 type HelpGenCtx = Parameters<HelpSectionRenderer>[0];
 type HelpGenHeader = Parameters<HelpSectionRenderer>[1];
@@ -35,17 +36,46 @@ function compactSections<T>(xs: (T | undefined)[]): T[] {
   return xs.filter((x): x is T => Boolean(x));
 }
 
-function argvRequestsNoColor(argv: string[]): boolean {
-  return argv.some((a) => a === "--no-color" || a.startsWith("--no-color="));
+function parseBooleanArg(value: string): boolean | undefined {
+  const normalized = value.trim().toLowerCase();
+  if (normalized === "1" || normalized === "true" || normalized === "yes") return true;
+  if (normalized === "0" || normalized === "false" || normalized === "no") return false;
+  return undefined;
+}
+
+function argvColorFlag(argv: string[]): boolean | undefined {
+  let out: boolean | undefined;
+  for (const arg of argv) {
+    if (arg === "--color") {
+      out = true;
+      continue;
+    }
+    if (arg.startsWith("--color=")) {
+      const parsed = parseBooleanArg(arg.slice("--color=".length));
+      if (parsed !== undefined) out = parsed;
+      continue;
+    }
+    if (arg === "--no-color") {
+      out = false;
+      continue;
+    }
+    if (arg.startsWith("--no-color=")) {
+      const parsed = parseBooleanArg(arg.slice("--no-color=".length));
+      if (parsed !== undefined) out = !parsed;
+      else out = false;
+    }
+  }
+  return out;
 }
 
 function helpShouldStripAnsi(optsStrip: boolean | undefined, argv: string[]): boolean {
   if (optsStrip === true) return true;
   if (optsStrip === false) return false;
-  if (!process.stdout.isTTY) return true;
+  const colorFlag = argvColorFlag(argv);
+  if (colorFlag === false) return true;
+  if (colorFlag === true) return false;
   if (process.env.NO_COLOR !== undefined && process.env.NO_COLOR !== "") return true;
-  if (argvRequestsNoColor(argv)) return true;
-  return false;
+  return !(typeof supportsColor.stdout === "object" && process.stdout.isTTY);
 }
 
 type CommandWithSeeAlso = Command.Loadable & { seeAlso?: string[] };

--- a/objectified-cli/src/help.ts
+++ b/objectified-cli/src/help.ts
@@ -1,4 +1,7 @@
-import { Help } from "@oclif/core";
+import { Command, CommandHelp, Help, type HelpSectionRenderer } from "@oclif/core";
+
+type HelpGenCtx = Parameters<HelpSectionRenderer>[0];
+type HelpGenHeader = Parameters<HelpSectionRenderer>[1];
 
 /** Same value as `src/lib/constants.ts` — inlined so oclif’s dynamic help import does not pull extra modules. */
 const DEFAULT_BASE_URL = "https://api.objectified.dev";
@@ -26,8 +29,158 @@ const GLOBAL_FLAGS_BODY = [
   "Resolution order for tenant slug: OBJECTIFIED_TENANT, then config profile / [default] (tenant_slug).",
 ].join("\n");
 
+const FLAG_GROUP_ORDER = ["Required", "Common", "Output", "Auth", "Other"] as const;
+
+function compactSections<T>(xs: (T | undefined)[]): T[] {
+  return xs.filter((x): x is T => Boolean(x));
+}
+
+function argvRequestsNoColor(argv: string[]): boolean {
+  return argv.some((a) => a === "--no-color" || a.startsWith("--no-color="));
+}
+
+function helpShouldStripAnsi(optsStrip: boolean | undefined, argv: string[]): boolean {
+  if (optsStrip === true) return true;
+  if (optsStrip === false) return false;
+  if (!process.stdout.isTTY) return true;
+  if (process.env.NO_COLOR !== undefined && process.env.NO_COLOR !== "") return true;
+  if (argvRequestsNoColor(argv)) return true;
+  return false;
+}
+
+type CommandWithSeeAlso = Command.Loadable & { seeAlso?: string[] };
+
+class ObjectifiedCommandHelp extends CommandHelp {
+  private flagHelpSections(
+    flags: Command.Flag.Any[],
+  ): { header: string; body: [string, string | undefined][] }[] {
+    const buckets = new Map<string, Command.Flag.Any[]>();
+
+    for (const flag of flags) {
+      const raw = flag.helpGroup?.trim();
+      const bucket = raw && raw.length > 0 ? raw : "Other";
+      const arr = buckets.get(bucket);
+      if (arr) arr.push(flag);
+      else buckets.set(bucket, [flag]);
+    }
+
+    const sortFlags = (fs: Command.Flag.Any[]) =>
+      [...fs].sort((a, b) => {
+        return a.name.localeCompare(b.name);
+      });
+
+    const out: { header: string; body: [string, string | undefined][] }[] = [];
+
+    for (const name of FLAG_GROUP_ORDER) {
+      const fs = buckets.get(name);
+      if (!fs?.length) continue;
+      const body = this.flags(sortFlags(fs));
+      if (body) out.push({ header: name.toUpperCase(), body });
+      buckets.delete(name);
+    }
+
+    const remaining = [...buckets.keys()].sort((a, b) => a.localeCompare(b));
+    for (const name of remaining) {
+      const fs = buckets.get(name);
+      if (!fs?.length) continue;
+      const body = this.flags(sortFlags(fs));
+      if (body) out.push({ header: name.toUpperCase(), body });
+    }
+
+    return out;
+  }
+
+  private seeAlsoBody(cmd: Command.Loadable): string | undefined {
+    const ids = (cmd as CommandWithSeeAlso).seeAlso;
+    if (!ids?.length) return undefined;
+    const lines = ids.map(
+      (id: string) => `${this.config.bin} ${id.replace(/:/g, this.config.topicSeparator)}`,
+    );
+    return this.wrap(lines.join("\n\n"));
+  }
+
+  public override sections() {
+    const usageHeader = this.opts.usageHeader || "USAGE";
+    const sections = [
+      {
+        generate: (_ctx: HelpGenCtx, header: HelpGenHeader) => {
+          void _ctx;
+          void header;
+          return this.usage();
+        },
+        header: usageHeader,
+      },
+      {
+        generate: ({ args }: HelpGenCtx, header: HelpGenHeader) => [
+          { body: this.args(args), header },
+        ],
+        header: "ARGUMENTS",
+      },
+      {
+        generate: (_ctx: HelpGenCtx, header: HelpGenHeader) => {
+          void _ctx;
+          void header;
+          return this.description();
+        },
+        header: "DESCRIPTION",
+      },
+      {
+        generate: ({ cmd }: HelpGenCtx, header: HelpGenHeader) => {
+          void header;
+          return this.examples(cmd.examples as Command.Example[] | string | undefined);
+        },
+        header: "EXAMPLES",
+      },
+      {
+        generate: ({ flags }: HelpGenCtx, header: HelpGenHeader) => {
+          void header;
+          return compactSections(
+            this.flagHelpSections(flags).map((s) => ({ body: s.body, header: s.header })),
+          );
+        },
+        header: "FLAGS",
+      },
+      {
+        generate: ({ cmd }: HelpGenCtx, header: HelpGenHeader) => {
+          void header;
+          return this.seeAlsoBody(cmd);
+        },
+        header: "SEE ALSO",
+      },
+      {
+        generate: ({ cmd }: HelpGenCtx, header: HelpGenHeader) => {
+          void header;
+          return this.aliases(cmd.aliases);
+        },
+        header: "ALIASES",
+      },
+      {
+        generate: ({ flags }: HelpGenCtx, header: HelpGenHeader) => {
+          void header;
+          return this.flagsDescriptions(flags);
+        },
+        header: "FLAG DESCRIPTIONS",
+      },
+    ];
+
+    const allowed = this.opts.sections?.map((s) => s.toLowerCase());
+    return sections.filter(({ header }) => !allowed || allowed.includes(header.toLowerCase()));
+  }
+}
+
 export default class ObjectifiedHelp extends Help {
-  formatRoot(): string {
+  public CommandHelpClass = ObjectifiedCommandHelp;
+
+  public constructor(
+    config: ConstructorParameters<typeof Help>[0],
+    opts: ConstructorParameters<typeof Help>[1] = {},
+  ) {
+    const argv = process.argv.slice(2);
+    const stripAnsi = helpShouldStripAnsi(opts.stripAnsi, argv);
+    super(config, { ...opts, stripAnsi });
+  }
+
+  public formatRoot(): string {
     return `${super.formatRoot()}\n\n${this.section("GLOBAL FLAGS", this.wrap(GLOBAL_FLAGS_BODY))}`;
   }
 }

--- a/objectified-cli/src/lib/docs-content.ts
+++ b/objectified-cli/src/lib/docs-content.ts
@@ -4,7 +4,7 @@ export const docsTopicOutput = `
 OUTPUT FORMATTING
 
 Human vs machine
-  When stdout is a terminal, commands print tables, hints, and optional color (unless NO_COLOR or --no-color applies). When stdout is not a TTY, JSON mode is chosen automatically unless you pass --json=false.
+  When stdout is a terminal, commands print tables, hints, and optional color (unless NO_COLOR or --no-color applies). When stdout is not a TTY, JSON mode is chosen automatically unless you pass --no-json.
 
 Stable JSON
   With --json (or non-TTY stdout), emitted JSON is sorted by key where applicable and avoids decorative fields. Pipe output to jq or similar tools.

--- a/objectified-cli/src/lib/docs-content.ts
+++ b/objectified-cli/src/lib/docs-content.ts
@@ -1,0 +1,66 @@
+/** Long-form prose for `objectified docs <topic>` (single source with command classes). */
+
+export const docsTopicOutput = `
+OUTPUT FORMATTING
+
+Human vs machine
+  When stdout is a terminal, commands print tables, hints, and optional color (unless NO_COLOR or --no-color applies). When stdout is not a TTY, JSON mode is chosen automatically unless you pass --json=false.
+
+Stable JSON
+  With --json (or non-TTY stdout), emitted JSON is sorted by key where applicable and avoids decorative fields. Pipe output to jq or similar tools.
+
+Quiet and verbose
+  --quiet (-q) hides non-error stdout such as banners and spinners while keeping errors on stderr. --verbose adds diagnostic detail on stderr without changing stdout payloads.
+
+Color
+  Color follows --color / --no-color, NO_COLOR, TTY detection, and terminal capability. Help output uses the same rules.
+
+YAML and tables
+  Some commands may offer YAML for debugging; tables use cli-table3 with ASCII-friendly borders when LANG suggests C/POSIX locales.
+`.trim();
+
+export const docsTopicProfiles = `
+CONFIG PROFILES
+
+config.toml
+  The CLI reads ~/.config/objectified/config.toml by default (or OBJECTIFIED_CONFIG / --config). Profiles live under [profile.NAME] with defaults under [default].
+
+default_profile
+  default_profile selects which profile is active when --profile is omitted. Use objectified config get default_profile or objectified config set default_profile staging.
+
+Resolution order
+  Base URL and tenant slug resolve per profile: explicit flags and env vars override profile values, which override [default]. API keys are never read from the file (#3188); use --api-key or OBJECTIFIED_API_KEY.
+
+Switching profiles
+  Pass --profile <name> for a single invocation or change default_profile for every command.
+`.trim();
+
+export const docsTopicCompletions = `
+SHELL COMPLETIONS
+
+Status
+  Interactive completion installers are tracked in roadmap ticket #3193 (bash, zsh, fish, PowerShell). This topic reserves the docs slot until that work lands.
+
+Today
+  Use objectified --help and objectified docs <topic> for discoverability, or generate completion scripts from oclif once the completion command ships.
+`.trim();
+
+export const docsTopicPlugins = `
+PLUGINS
+
+Status
+  An oclif plugin ecosystem for Objectified is planned for post-MVP releases. This CLI currently ships core commands only.
+
+Extensibility
+  Future builds may expose objectified plugins:* commands for third-party commands alongside versioned API compatibility guarantees.
+`.trim();
+
+export const docsTopicTelemetry = `
+TELEMETRY
+
+Default posture
+  The open-source CLI does not phone home by default. Any future telemetry would be opt-in, documented per release, and scoped to aggregate usage without secrets.
+
+Verbose diagnostics
+  Use --verbose or OBJECTIFIED_VERBOSE=1 for stderr diagnostics. OBJECTIFIED_DEBUG=1 may include stack traces for unexpected failures—avoid enabling in CI logs that are world-readable.
+`.trim();

--- a/objectified-cli/src/lib/docs-index.ts
+++ b/objectified-cli/src/lib/docs-index.ts
@@ -1,0 +1,12 @@
+/** Topics served under \`objectified docs <topic>\` (parent command lists this table). */
+
+export type DocsTopicMeta = { topic: string; summary: string };
+
+export const DOCS_TOPIC_INDEX: DocsTopicMeta[] = [
+  { topic: "errors", summary: "Exit codes, stderr shape, and debugging hints" },
+  { topic: "output", summary: "TTY vs JSON, quiet, verbose, and color rules" },
+  { topic: "profiles", summary: "config.toml profiles, defaults, and resolution order" },
+  { topic: "completions", summary: "Shell completions roadmap (#3193)" },
+  { topic: "plugins", summary: "Plugin roadmap for third-party commands" },
+  { topic: "telemetry", summary: "Telemetry posture and verbose diagnostics" },
+];

--- a/objectified-cli/test/cli.integration.test.ts
+++ b/objectified-cli/test/cli.integration.test.ts
@@ -77,6 +77,32 @@ describe("objectified CLI", () => {
     expect(out).toMatch(/OBJECTIFIED_DEBUG/);
   });
 
+  it("docs lists available topics", () => {
+    const out = run(["docs", "--no-json"]);
+    expect(out).toMatch(/Topic/);
+    expect(out).toMatch(/\berrors\b/);
+    expect(out).toMatch(/\boutput\b/);
+    expect(out).toMatch(/\bprofiles\b/);
+    expect(out).toMatch(/\bcompletions\b/);
+    expect(out).toMatch(/\bplugins\b/);
+    expect(out).toMatch(/\btelemetry\b/);
+  });
+
+  it("docs output prints long-form prose", () => {
+    const out = run(["docs", "output", "--no-json"]);
+    expect(out).toMatch(/OUTPUT FORMATTING/);
+    expect(out).toMatch(/Stable JSON/);
+  });
+
+  it("command help includes EXAMPLES and SEE ALSO", () => {
+    const out = run(["hello", "--help"]);
+    expect(out).toMatch(/^EXAMPLES/m);
+    expect(out).toMatch(/^SEE ALSO/m);
+    expect(out).toMatch(/\bCOMMON\b/);
+    expect(out).toMatch(/\bOUTPUT\b/);
+    expect(out).toMatch(/\bAUTH\b/);
+  });
+
   it("unknown command suggests typo fix when close match", () => {
     const err = runExpectFailure(["helol"]);
     expect(err).toMatch(/Unknown command/);

--- a/objectified-cli/test/help-manifest.test.ts
+++ b/objectified-cli/test/help-manifest.test.ts
@@ -41,6 +41,12 @@ describe("CLI manifest help metadata", () => {
     expect(pkg.man?.includes("./man/man1/objectified-help.1")).toBe(true);
     expect(pkg.man?.includes("./man/man1/objectified-version.1")).toBe(true);
 
+    const rootManBody = readFileSync(path.join(pkgRoot, "man", "man1", "objectified.1"), "utf8");
+    expect(rootManBody).toContain("%APPDATA%\\\\Objectified");
+
+    const helpManBody = readFileSync(path.join(pkgRoot, "man", "man1", "objectified-help.1"), "utf8");
+    expect(helpManBody).not.toContain("<%= ");
+
     for (const id of coreIds) {
       const slug = `objectified-${id.replace(/:/g, "-")}.1`;
       expect(pkg.man?.includes(`./man/man1/${slug}`), `missing man entry for ${id}`).toBe(true);

--- a/objectified-cli/test/help-manifest.test.ts
+++ b/objectified-cli/test/help-manifest.test.ts
@@ -1,0 +1,54 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const pkgRoot = path.join(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+type ManifestCommand = {
+  examples?: unknown;
+};
+
+describe("CLI manifest help metadata", () => {
+  it("lists at least two examples for every command", () => {
+    const raw = readFileSync(path.join(pkgRoot, "oclif.manifest.json"), "utf8");
+    const manifest = JSON.parse(raw) as { commands: Record<string, ManifestCommand> };
+    const ids = Object.keys(manifest.commands).sort();
+    expect(ids.length).toBeGreaterThan(0);
+    for (const id of ids) {
+      const ex = manifest.commands[id]?.examples;
+      expect(Array.isArray(ex), `${id} missing examples[]`).toBe(true);
+      expect((ex as unknown[]).length, `${id} must have ≥2 examples`).toBeGreaterThanOrEqual(2);
+    }
+  });
+
+  it("ships a root man page and one page per core command id", () => {
+    const raw = readFileSync(path.join(pkgRoot, "oclif.manifest.json"), "utf8");
+    const manifest = JSON.parse(raw) as {
+      commands: Record<string, { hidden?: boolean; pluginType?: string }>;
+    };
+    const pkg = JSON.parse(readFileSync(path.join(pkgRoot, "package.json"), "utf8")) as {
+      man?: string[];
+    };
+
+    const coreIds = Object.entries(manifest.commands)
+      .filter(([, c]) => !c.hidden && c.pluginType === "core")
+      .map(([id]) => id)
+      .sort();
+
+    expect(pkg.man?.includes("./man/man1/objectified.1")).toBe(true);
+    expect(pkg.man?.includes("./man/man1/objectified-help.1")).toBe(true);
+    expect(pkg.man?.includes("./man/man1/objectified-version.1")).toBe(true);
+
+    for (const id of coreIds) {
+      const slug = `objectified-${id.replace(/:/g, "-")}.1`;
+      expect(pkg.man?.includes(`./man/man1/${slug}`), `missing man entry for ${id}`).toBe(true);
+      const manPath = path.join(pkgRoot, "man", "man1", slug);
+      const body = readFileSync(manPath, "utf8");
+      expect(body.startsWith(".TH ")).toBe(true);
+      expect(body).toContain(".SH NAME");
+      expect(body).toContain(".SH DESCRIPTION");
+    }
+  });
+});

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -8,6 +8,7 @@ We continue to improve the platform based on your feedback with improvements and
 - MCP service is now live
 
 ## CLI
+- **`objectified-cli`**: rich `--help` (≥2 examples per command, flag groups **COMMON** / **OUTPUT** / **AUTH**, **SEE ALSO** links), `objectified docs` topic browser + prose topics, troff **man** pages under `man/man1/`, `oclif readme`-synced **README.md**, and CI guard for generated artifacts (#3192).
 - **`objectified-cli`**: shared error layer (`ObjectifiedCliError`, documented exit codes via `objectified docs errors`, stderr template with hints + request-id, `--verbose` / `OBJECTIFIED_DEBUG=1` stacks only), Levenshtein did-you-mean for unknown commands, HTTP status → exit-code mapping, and fetch retries per idempotent vs non-idempotent verbs (#3191).
 - **`objectified-cli`**: OpenAPI codegen (`yarn codegen` → `src/generated/`), typed `@hey-api/client-fetch` SDK, `lib/client.ts` wrapper (retries, `Retry-After`, 401 hook, request IDs), ESLint single-import guard, `codegen:check` in tests, and `projects list` backed by the generated client (#3190).
 - New **`objectified-cli`** package (oclif v4) adds the `objectified` binary scaffold with `hello`, `--version`, and `--help` (#3186).


### PR DESCRIPTION
## Summary
Implements **#3192**: richer oclif help (examples, grouped flags, SEE ALSO), `objectified docs` topic browser + prose topics, build-time man pages under `man/man1/`, `oclif readme` integration, tests, and CI guard.

## What changed
- **Help**: `ObjectifiedCommandHelp` extends oclif `CommandHelp` — section order USAGE → ARGUMENTS → DESCRIPTION → EXAMPLES → **COMMON** / **OUTPUT** / **AUTH** / **OTHER** → SEE ALSO → … ; global flags regrouped on `BaseCommand`; `static seeAlso` on commands.
- **Docs**: `objectified docs` lists topics; `docs output|profiles|completions|plugins|telemetry` plus existing `docs errors`; content in `src/lib/docs-content.ts`.
- **Man**: `scripts/generate-man.mjs` + `package.json` `man` array; npm tarball ships `man/man1/*.1`.
- **README**: oclif `<!-- usage -->` / `<!-- commands -->` / `<!-- toc -->` tags; `yarn build` runs `oclif readme`.
- **CI**: `.github/workflows/objectified-cli.yml` runs workspace tests then `git diff --exit-code` so generated artifacts stay committed.

## How to test
1. **Build**: `yarn workspace objectified-cli build`
2. **Help**: **run** `node objectified-cli/bin/run.js hello --help` — expect **EXAMPLES** (≥2), **SEE ALSO**, and **COMMON**/**OUTPUT**/**AUTH** sections.
3. **Docs**: **run** `objectified docs` then `objectified docs output`.
4. **Man**: **set** `MANPATH=$PWD/objectified-cli/man` and **run** `man -P cat objectified` (or inspect `man/man1/objectified.1`).
5. **Tests**: `yarn workspace objectified-cli test`

## Risks / notes
- Root `yarn build` (turbo) may still require unrelated tooling (e.g. `uv` for MCP); CLI verified via `yarn workspace objectified-cli test`.
- `oclif.manifest.json` remains gitignored locally; CI generates it during build.

Please request **Copilot** review from the PR reviewers UI if desired (`gh pr create --reviewer copilot` is not supported on this org).

Closes #3192

Made with [Cursor](https://cursor.com)