### PR TITLE
Fix #3193 - Shell completions for bash, zsh, fish, and PowerShell

### DIFF
--- a/docs/PLANNED_ROADMAP_CLI.md
+++ b/docs/PLANNED_ROADMAP_CLI.md
@@ -96,7 +96,7 @@ Every command lives in one of three connection modes:
 | 11  | [Migration Plans & Version Tags (CLI)](https://github.com/KenSuenobu/objectified-commercial/issues/3184)   | #3184   | 7           | 0 (v2)       |
 | 12  | [Distribution, Release & Self-Update](https://github.com/KenSuenobu/objectified-commercial/issues/3185)    | #3185   | 8           | 2 of 8       |
 
-Total: **12 epics**, **88 sub-tickets** (open roadmap items; completed work is dropped from the Epic 1 summary table below).
+Total: **12 epics**, **87 sub-tickets** (open roadmap items; completed work is dropped from the Epic 1 summary table below).
 
 ---
 
@@ -104,9 +104,7 @@ Total: **12 epics**, **88 sub-tickets** (open roadmap items; completed work is d
 
 ### Summary Table
 
-| #         | Title                                                              | Description                                                                  | Labels                                          | MVP | Parallel |
-|-----------|--------------------------------------------------------------------|------------------------------------------------------------------------------|-------------------------------------------------|-----|----------|
-| 1.8 (#3193) | Shell completions (bash/zsh/fish/PowerShell)                     | Static completions + dynamic (tenant/project/version slugs)                  | `enhancement`, `cli`, `roadmap-cli`            | No  | Yes      |
+No open tickets in this epic’s summary pack (foundation items #3186–#3193 are complete).
 
 ### Detailed Issue Descriptions
 
@@ -232,18 +230,16 @@ Part of Epic: CLI Foundation & DevEx (#3174)
 
 ---
 
-#### 1.8 (#3193) — Shell completions for bash, zsh, fish, PowerShell
+#### 1.8 (#3193) — Shell completions for bash, zsh, fish, PowerShell (**done**)
 
-Static completions for topics + flags; dynamic completions hit cached REST data for tenant/project/version/class/primitive names.
+Landed: `objectified completion install|show|uninstall`, hidden `completion candidates` driver, bash/zsh/fish/PowerShell wrappers that complete manifest-backed commands/flags offline and merge REST-backed suggestions (projects, versions, classes, primitives; tenant slugs from config for `tenants use`) with a five-minute cache under `~/.cache/objectified/completion/`, degrading to no dynamic hits when offline; managed `# >>> objectified completion >>>` blocks for uninstall; `objectified docs completions` + README coverage.
 
 ```
 $ objectified projects show pay<TAB>
 payments-api      payouts-api      payroll-api
 ```
 
-**Acceptance Criteria:** `completion install` writes to the right rc file; bash/zsh/fish/PowerShell all pass linters; dynamic completion gracefully degrades when offline.
-
-**Parallelism / Dependencies:** Depends on 1.1, 1.2. Best landed after MVP.
+**Parallelism / Dependencies:** Depended on 1.1, 1.2.
 
 Part of Epic: CLI Foundation & DevEx (#3174)
 
@@ -807,7 +803,7 @@ v2 fills out the writable surface for primitives, properties, classes, paths, da
 
 | Epic     | v2 Tickets                                                                                                                     | Count |
 |----------|--------------------------------------------------------------------------------------------------------------------------------|-------|
-| 1 (#3174) | #3193                                                                                                                          | 1     |
+| 1 (#3174) | *(complete in this pack)*                                                                                                       | 0     |
 | 2 (#3175) | #3200, #3201                                                                                                                   | 2     |
 | 3 (#3176) | #3205, #3206, #3207                                                                                                            | 3     |
 | 4 (#3177) | #3211, #3213, #3214, #3215, #3216                                                                                              | 5     |
@@ -868,7 +864,7 @@ v2 fills out the writable surface for primitives, properties, classes, paths, da
 
 The tickets were created in the order below — that is also the recommended **execution** order. Earlier epics provide primitives that later epics rely on.
 
-1. **Epic 1 — Foundation** (#3174: #3186, #3187, #3188, #3189, #3190, #3191, and #3192 landed; next #3193). Without the scaffold, no other command can exist.
+1. **Epic 1 — Foundation** (#3174: #3186, #3187, #3188, #3189, #3190, #3191, #3192, and #3193 landed). Without the scaffold, no other command can exist.
 2. **Epic 2 — Auth & Tenants** (#3175 then #3194 → #3201). Required for any tenant-scoped command.
 3. **Epic 3 — Projects** (#3176 then #3202 → #3207). The first useful read/write surface.
 4. **Epic 4 — Versions** (#3177 then #3208 → #3216). The publish flow that makes the CLI valuable in CI.

--- a/objectified-cli/README.md
+++ b/objectified-cli/README.md
@@ -495,7 +495,7 @@ AUTH
   --api-key=<value>  API key for direct authentication (bypasses login token).
 
 SEE ALSO
-  objectified docs
+  objectified completion install
 
   objectified docs output
 ```

--- a/objectified-cli/README.md
+++ b/objectified-cli/README.md
@@ -50,7 +50,7 @@ $ npm install -g objectified-cli
 $ objectified COMMAND
 running command...
 $ objectified (--version)
-objectified-cli/0.1.6 <platform> node-v<major.minor.patch>
+objectified-cli/0.1.7 <platform> node-v<major.minor.patch>
 $ objectified --help [COMMAND]
 USAGE
   $ objectified COMMAND
@@ -61,6 +61,10 @@ USAGE
 # Commands
 
 <!-- commands -->
+* [`objectified completion`](#objectified-completion)
+* [`objectified completion install [SHELL]`](#objectified-completion-install-shell)
+* [`objectified completion show [SHELL]`](#objectified-completion-show-shell)
+* [`objectified completion uninstall`](#objectified-completion-uninstall)
 * [`objectified config get KEY`](#objectified-config-get-key)
 * [`objectified config list`](#objectified-config-list)
 * [`objectified config path`](#objectified-config-path)
@@ -76,6 +80,176 @@ USAGE
 * [`objectified help [COMMAND]`](#objectified-help-command)
 * [`objectified projects list`](#objectified-projects-list)
 * [`objectified version`](#objectified-version)
+
+## `objectified completion`
+
+Install or print shell completion scripts for bash, zsh, fish, or PowerShell.
+
+```
+USAGE
+  $ objectified completion [--api-key <value>] [--base-url <value>] [--config <value>] [--json] [--color]
+    [--profile <value>] [-q] [--verbose]
+
+DESCRIPTION
+  Install or print shell completion scripts for bash, zsh, fish, or PowerShell.
+
+EXAMPLES
+  $ objectified completion install
+
+  $ objectified completion install zsh
+
+  $ objectified completion show bash
+
+  $ objectified completion uninstall
+
+COMMON
+  --base-url=<value>  Root REST API URL.
+  --config=<value>    Path to config file (default: XDG config dir / Objectified AppData on Windows — see `objectified
+                      config path`).
+  --profile=<value>   Named credentials profile (OBJECTIFIED_PROFILE); falls back to default_profile in config.
+
+OUTPUT
+  --[no-]color  Enable/disable ANSI colors (--no-color sets NO_COLOR; colors are off when stdout is not a TTY).
+      --[no-]json   Emit machine-readable JSON (OBJECTIFIED_JSON=1; auto-enabled when stdout is not a TTY).
+  -q, --quiet       Suppress non-error stdout (spinners, banners, tips).
+      --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
+
+AUTH
+  --api-key=<value>  API key for direct authentication (bypasses login token).
+
+SEE ALSO
+  objectified docs completions
+
+  objectified hello
+
+  objectified config path
+```
+
+## `objectified completion install [SHELL]`
+
+Append shell completion glue to the right startup file for your shell.
+
+```
+USAGE
+  $ objectified completion install [SHELL] [--api-key <value>] [--base-url <value>] [--config <value>] [--json]
+    [--color] [--profile <value>] [-q] [--verbose]
+
+ARGUMENTS
+  [SHELL]  (bash|zsh|fish|powershell) Shell to install for (default: inferred from $SHELL / OS)
+
+DESCRIPTION
+  Append shell completion glue to the right startup file for your shell.
+
+EXAMPLES
+  $ objectified completion install
+
+  $ objectified completion install fish
+
+  $ objectified --profile staging completion install zsh
+
+COMMON
+  --base-url=<value>  Root REST API URL.
+  --config=<value>    Path to config file (default: XDG config dir / Objectified AppData on Windows — see `objectified
+                      config path`).
+  --profile=<value>   Named credentials profile (OBJECTIFIED_PROFILE); falls back to default_profile in config.
+
+OUTPUT
+  --[no-]color  Enable/disable ANSI colors (--no-color sets NO_COLOR; colors are off when stdout is not a TTY).
+      --[no-]json   Emit machine-readable JSON (OBJECTIFIED_JSON=1; auto-enabled when stdout is not a TTY).
+  -q, --quiet       Suppress non-error stdout (spinners, banners, tips).
+      --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
+
+AUTH
+  --api-key=<value>  API key for direct authentication (bypasses login token).
+
+SEE ALSO
+  objectified completion show
+
+  objectified docs completions
+
+  objectified config path
+```
+
+## `objectified completion show [SHELL]`
+
+Print shell completion glue (with marker comments) to stdout.
+
+```
+USAGE
+  $ objectified completion show [SHELL] [--api-key <value>] [--base-url <value>] [--config <value>] [--json]
+    [--color] [--profile <value>] [-q] [--verbose]
+
+ARGUMENTS
+  [SHELL]  (bash|zsh|fish|powershell) Shell to generate
+
+DESCRIPTION
+  Print shell completion glue (with marker comments) to stdout.
+
+EXAMPLES
+  $ objectified completion show
+
+  $ objectified completion show bash
+
+  $ objectified completion show fish >> ~/.config/fish/completions/objectified.fish
+
+COMMON
+  --base-url=<value>  Root REST API URL.
+  --config=<value>    Path to config file (default: XDG config dir / Objectified AppData on Windows — see `objectified
+                      config path`).
+  --profile=<value>   Named credentials profile (OBJECTIFIED_PROFILE); falls back to default_profile in config.
+
+OUTPUT
+  --[no-]color  Enable/disable ANSI colors (--no-color sets NO_COLOR; colors are off when stdout is not a TTY).
+      --[no-]json   Emit machine-readable JSON (OBJECTIFIED_JSON=1; auto-enabled when stdout is not a TTY).
+  -q, --quiet       Suppress non-error stdout (spinners, banners, tips).
+      --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
+
+AUTH
+  --api-key=<value>  API key for direct authentication (bypasses login token).
+
+SEE ALSO
+  objectified completion install
+
+  objectified docs completions
+```
+
+## `objectified completion uninstall`
+
+Remove Objectified completion blocks added by `completion install`.
+
+```
+USAGE
+  $ objectified completion uninstall [--api-key <value>] [--base-url <value>] [--config <value>] [--json] [--color]
+    [--profile <value>] [-q] [--verbose]
+
+DESCRIPTION
+  Remove Objectified completion blocks added by `completion install`.
+
+EXAMPLES
+  $ objectified completion uninstall
+
+  $ objectified --json completion uninstall
+
+COMMON
+  --base-url=<value>  Root REST API URL.
+  --config=<value>    Path to config file (default: XDG config dir / Objectified AppData on Windows — see `objectified
+                      config path`).
+  --profile=<value>   Named credentials profile (OBJECTIFIED_PROFILE); falls back to default_profile in config.
+
+OUTPUT
+  --[no-]color  Enable/disable ANSI colors (--no-color sets NO_COLOR; colors are off when stdout is not a TTY).
+      --[no-]json   Emit machine-readable JSON (OBJECTIFIED_JSON=1; auto-enabled when stdout is not a TTY).
+  -q, --quiet       Suppress non-error stdout (spinners, banners, tips).
+      --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
+
+AUTH
+  --api-key=<value>  API key for direct authentication (bypasses login token).
+
+SEE ALSO
+  objectified completion install
+
+  objectified docs completions
+```
 
 ## `objectified config get KEY`
 
@@ -288,7 +462,7 @@ SEE ALSO
 
 ## `objectified docs completions`
 
-Shell completions roadmap and interim guidance
+Shell completions (install/show/uninstall, static manifest + cached REST suggestions)
 
 ```
 USAGE
@@ -296,7 +470,7 @@ USAGE
     [--profile <value>] [-q] [--verbose]
 
 DESCRIPTION
-  Shell completions roadmap and interim guidance
+  Shell completions (install/show/uninstall, static manifest + cached REST suggestions)
 
 EXAMPLES
   $ objectified docs completions

--- a/objectified-cli/man/man1/objectified-completion-install.1
+++ b/objectified-cli/man/man1/objectified-completion-install.1
@@ -1,22 +1,26 @@
-.TH OBJECTIFIED\-DOCS\-COMPLETIONS 1 "" "" "User Commands"
+.TH OBJECTIFIED\-COMPLETION\-INSTALL 1 "" "" "User Commands"
 .SH NAME
-objectified docs completions \- Shell completions (install/show/uninstall, static manifest + cached REST suggestions)
+objectified completion install \- Append shell completion glue to the right startup file for your shell.
 .SH DESCRIPTION
 .nf
 USAGE
-  $ objectified docs completions [--api-key <value>] [--base-url <value>]
-    [--config <value>] [--json] [--color] [--profile <value>] [-q] [--verbose]
+  $ objectified completion install [SHELL] [--api-key <value>] [--base-url
+    <value>] [--config <value>] [--json] [--color] [--profile <value>] [-q]
+    [--verbose]
+
+ARGUMENTS
+  [SHELL]  (bash|zsh|fish|powershell) Shell to install for (default: inferred
+           from $SHELL / OS)
 
 DESCRIPTION
-  Shell completions (install/show/uninstall, static manifest + cached REST
-  suggestions)
+  Append shell completion glue to the right startup file for your shell.
 
 EXAMPLES
-  $ objectified docs completions
+  $ objectified completion install
 
-  $ objectified --help
+  $ objectified completion install fish
 
-  $ objectified docs completions --json
+  $ objectified --profile staging completion install zsh
 
 COMMON
   --base-url=<value>  Root REST API URL.
@@ -38,7 +42,9 @@ AUTH
   --api-key=<value>  API key for direct authentication (bypasses login token).
 
 SEE ALSO
-  objectified docs
+  objectified completion show
 
-  objectified docs output
+  objectified docs completions
+
+  objectified config path
 .fi

--- a/objectified-cli/man/man1/objectified-completion-show.1
+++ b/objectified-cli/man/man1/objectified-completion-show.1
@@ -1,22 +1,25 @@
-.TH OBJECTIFIED\-DOCS\-COMPLETIONS 1 "" "" "User Commands"
+.TH OBJECTIFIED\-COMPLETION\-SHOW 1 "" "" "User Commands"
 .SH NAME
-objectified docs completions \- Shell completions (install/show/uninstall, static manifest + cached REST suggestions)
+objectified completion show \- Print shell completion glue (with marker comments) to stdout.
 .SH DESCRIPTION
 .nf
 USAGE
-  $ objectified docs completions [--api-key <value>] [--base-url <value>]
-    [--config <value>] [--json] [--color] [--profile <value>] [-q] [--verbose]
+  $ objectified completion show [SHELL] [--api-key <value>] [--base-url
+    <value>] [--config <value>] [--json] [--color] [--profile <value>] [-q]
+    [--verbose]
+
+ARGUMENTS
+  [SHELL]  (bash|zsh|fish|powershell) Shell to generate
 
 DESCRIPTION
-  Shell completions (install/show/uninstall, static manifest + cached REST
-  suggestions)
+  Print shell completion glue (with marker comments) to stdout.
 
 EXAMPLES
-  $ objectified docs completions
+  $ objectified completion show
 
-  $ objectified --help
+  $ objectified completion show bash
 
-  $ objectified docs completions --json
+  $ objectified completion show fish >> ~/.config/fish/completions/objectified.fish
 
 COMMON
   --base-url=<value>  Root REST API URL.
@@ -38,7 +41,7 @@ AUTH
   --api-key=<value>  API key for direct authentication (bypasses login token).
 
 SEE ALSO
-  objectified docs
+  objectified completion install
 
-  objectified docs output
+  objectified docs completions
 .fi

--- a/objectified-cli/man/man1/objectified-completion-uninstall.1
+++ b/objectified-cli/man/man1/objectified-completion-uninstall.1
@@ -1,22 +1,19 @@
-.TH OBJECTIFIED\-DOCS\-COMPLETIONS 1 "" "" "User Commands"
+.TH OBJECTIFIED\-COMPLETION\-UNINSTALL 1 "" "" "User Commands"
 .SH NAME
-objectified docs completions \- Shell completions (install/show/uninstall, static manifest + cached REST suggestions)
+objectified completion uninstall \- Remove Objectified completion blocks added by `completion install`.
 .SH DESCRIPTION
 .nf
 USAGE
-  $ objectified docs completions [--api-key <value>] [--base-url <value>]
+  $ objectified completion uninstall [--api-key <value>] [--base-url <value>]
     [--config <value>] [--json] [--color] [--profile <value>] [-q] [--verbose]
 
 DESCRIPTION
-  Shell completions (install/show/uninstall, static manifest + cached REST
-  suggestions)
+  Remove Objectified completion blocks added by `completion install`.
 
 EXAMPLES
-  $ objectified docs completions
+  $ objectified completion uninstall
 
-  $ objectified --help
-
-  $ objectified docs completions --json
+  $ objectified --json completion uninstall
 
 COMMON
   --base-url=<value>  Root REST API URL.
@@ -38,7 +35,7 @@ AUTH
   --api-key=<value>  API key for direct authentication (bypasses login token).
 
 SEE ALSO
-  objectified docs
+  objectified completion install
 
-  objectified docs output
+  objectified docs completions
 .fi

--- a/objectified-cli/man/man1/objectified-completion.1
+++ b/objectified-cli/man/man1/objectified-completion.1
@@ -1,22 +1,24 @@
-.TH OBJECTIFIED\-DOCS\-COMPLETIONS 1 "" "" "User Commands"
+.TH OBJECTIFIED\-COMPLETION 1 "" "" "User Commands"
 .SH NAME
-objectified docs completions \- Shell completions (install/show/uninstall, static manifest + cached REST suggestions)
+objectified completion \- Install or print shell completion scripts for bash, zsh, fish, or PowerShell.
 .SH DESCRIPTION
 .nf
 USAGE
-  $ objectified docs completions [--api-key <value>] [--base-url <value>]
+  $ objectified completion [--api-key <value>] [--base-url <value>]
     [--config <value>] [--json] [--color] [--profile <value>] [-q] [--verbose]
 
 DESCRIPTION
-  Shell completions (install/show/uninstall, static manifest + cached REST
-  suggestions)
+  Install or print shell completion scripts for bash, zsh, fish, or
+  PowerShell.
 
 EXAMPLES
-  $ objectified docs completions
+  $ objectified completion install
 
-  $ objectified --help
+  $ objectified completion install zsh
 
-  $ objectified docs completions --json
+  $ objectified completion show bash
+
+  $ objectified completion uninstall
 
 COMMON
   --base-url=<value>  Root REST API URL.
@@ -38,7 +40,9 @@ AUTH
   --api-key=<value>  API key for direct authentication (bypasses login token).
 
 SEE ALSO
-  objectified docs
+  objectified docs completions
 
-  objectified docs output
+  objectified hello
+
+  objectified config path
 .fi

--- a/objectified-cli/man/man1/objectified-docs-completions.1
+++ b/objectified-cli/man/man1/objectified-docs-completions.1
@@ -38,7 +38,7 @@ AUTH
   --api-key=<value>  API key for direct authentication (bypasses login token).
 
 SEE ALSO
-  objectified docs
+  objectified completion install
 
   objectified docs output
 .fi

--- a/objectified-cli/man/man1/objectified.1
+++ b/objectified-cli/man/man1/objectified.1
@@ -6,7 +6,7 @@ objectified \- Objectified command-line interface
 Objectified command-line interface
 
 VERSION
-  objectified-cli/0.1.6 linux-x64 node-v24.14.1
+  objectified-cli/0.1.7 linux-x64 node-v24.14.1
 
 USAGE
   $ objectified [COMMAND]

--- a/objectified-cli/package.json
+++ b/objectified-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-cli",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Objectified command-line interface",
   "author": "Objectified",
   "type": "module",
@@ -71,6 +71,10 @@
     "vitest": "^3.2.4"
   },
   "man": [
+    "./man/man1/objectified-completion-install.1",
+    "./man/man1/objectified-completion-show.1",
+    "./man/man1/objectified-completion-uninstall.1",
+    "./man/man1/objectified-completion.1",
     "./man/man1/objectified-config-get.1",
     "./man/man1/objectified-config-list.1",
     "./man/man1/objectified-config-path.1",

--- a/objectified-cli/src/commands/completion/candidates.ts
+++ b/objectified-cli/src/commands/completion/candidates.ts
@@ -1,0 +1,66 @@
+import { Flags } from "@oclif/core";
+
+import { BaseCommand } from "../../base-command.js";
+import { computeCompletionCandidates } from "../../lib/completion/candidates-logic.js";
+
+function readStdinUtf8(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    process.stdin.on("data", (d: string | Buffer) => {
+      chunks.push(typeof d === "string" ? Buffer.from(d) : d);
+    });
+    process.stdin.on("end", () => {
+      resolve(Buffer.concat(chunks).toString("utf8"));
+    });
+    process.stdin.on("error", reject);
+  });
+}
+
+export default class CompletionCandidates extends BaseCommand {
+  static hidden = true;
+
+  static description = "Emit newline-separated completion candidates (stdin: one CLI token per line).";
+
+  static examples = [
+    "printf '%s\\n' objectified projects | <%= config.bin %> --no-json <%= command.id %> --shell bash --cword 1",
+    "printf '%s\\n' objectified projects list | <%= config.bin %> --no-json <%= command.id %> --shell bash --cword 2",
+  ];
+
+  static flags = {
+    shell: Flags.string({
+      description: "Shell driver",
+      options: ["bash", "zsh", "fish", "powershell"],
+      required: true,
+    }),
+    cword: Flags.integer({
+      description: "Index into token list for the word being completed",
+      required: true,
+    }),
+  };
+
+  async run(): Promise<void> {
+    const { flags } = await this.parse(CompletionCandidates);
+    const cword = flags.cword;
+
+    const raw = await readStdinUtf8();
+    const words = raw.split("\n").filter((line) => line !== "");
+
+    if (words.length === 0 || cword < 0) {
+      return;
+    }
+
+    const candidates = await computeCompletionCandidates({
+      config: this.config,
+      api: this.api,
+      baseUrl: this.context.baseUrl,
+      configDoc: this.configDoc,
+      env: process.env,
+      words,
+      cword,
+    });
+
+    for (const line of candidates) {
+      process.stdout.write(`${line}\n`);
+    }
+  }
+}

--- a/objectified-cli/src/commands/completion/index.ts
+++ b/objectified-cli/src/commands/completion/index.ts
@@ -1,0 +1,38 @@
+import { BaseCommand } from "../../base-command.js";
+
+export default class CompletionIndex extends BaseCommand {
+  static description =
+    "Install or print shell completion scripts for bash, zsh, fish, or PowerShell.";
+
+  static examples = [
+    "<%= config.bin %> <%= command.id %> install",
+    "<%= config.bin %> <%= command.id %> install zsh",
+    "<%= config.bin %> <%= command.id %> show bash",
+    "<%= config.bin %> <%= command.id %> uninstall",
+  ];
+
+  static seeAlso = ["docs completions", "hello", "config path"];
+
+  run(): Promise<void> {
+    const topics = [
+      { command: "completion install [bash|zsh|fish|powershell]", summary: "Append completion glue to your shell rc file" },
+      { command: "completion show [bash|zsh|fish|powershell]", summary: "Print completion glue to stdout" },
+      { command: "completion uninstall", summary: "Remove Objectified completion blocks we added" },
+    ];
+
+    if (this.context.json) {
+      this.output.json({ topic: "completion", commands: topics });
+      return Promise.resolve();
+    }
+
+    this.output.table(
+      topics.map((t) => ({ command: t.command, summary: t.summary })),
+      [
+        { key: "command", label: "Command" },
+        { key: "summary", label: "Summary" },
+      ],
+    );
+    this.output.text(`\nTry ${this.config.bin} docs completions for behavior and caching notes.`);
+    return Promise.resolve();
+  }
+}

--- a/objectified-cli/src/commands/completion/install.ts
+++ b/objectified-cli/src/commands/completion/install.ts
@@ -1,0 +1,134 @@
+import { Args } from "@oclif/core";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { BaseCommand } from "../../base-command.js";
+import { chalkForContext } from "../../lib/output.js";
+import {
+  bashCompletionBody,
+  fishCompletionBody,
+  powershellCompletionBody,
+  zshCompletionBody,
+} from "../../lib/completion/shell-snippets.js";
+import { readRcSafe, upsertMarkedCompletionBlock } from "../../lib/completion/rc-file.js";
+
+type CompletionShell = "bash" | "zsh" | "fish" | "powershell";
+
+function inferShell(): CompletionShell {
+  if (process.platform === "win32") return "powershell";
+  const sh = process.env.SHELL ?? "";
+  if (sh.includes("zsh")) return "zsh";
+  if (sh.includes("fish")) return "fish";
+  return "bash";
+}
+
+function powershellProfilePath(): string {
+  const home = os.homedir();
+  if (process.platform === "win32") {
+    return path.join(home, "Documents", "PowerShell", "Microsoft.PowerShell_profile.ps1");
+  }
+  return path.join(home, ".config", "powershell", "Microsoft.PowerShell_profile.ps1");
+}
+
+function completionInner(shell: CompletionShell, bin: string): string {
+  switch (shell) {
+    case "bash":
+      return bashCompletionBody(bin);
+    case "zsh":
+      return zshCompletionBody(bin);
+    case "fish":
+      return fishCompletionBody(bin);
+    case "powershell":
+      return powershellCompletionBody(bin);
+    default:
+      throw new Error(`unsupported shell: ${String(shell)}`);
+  }
+}
+
+export default class CompletionInstall extends BaseCommand {
+  static description = "Append shell completion glue to the right startup file for your shell.";
+
+  static args = {
+    shell: Args.string({
+      description: "Shell to install for (default: inferred from $SHELL / OS)",
+      options: ["bash", "zsh", "fish", "powershell"],
+      required: false,
+    }),
+  };
+
+  static examples = [
+    "<%= config.bin %> <%= command.id %>",
+    "<%= config.bin %> <%= command.id %> fish",
+    "<%= config.bin %> --profile staging <%= command.id %> zsh",
+  ];
+
+  static seeAlso = ["completion show", "docs completions", "config path"];
+
+  async run(): Promise<void> {
+    const { args } = await this.parse(CompletionInstall);
+    const shell = (args.shell ?? inferShell()) as CompletionShell;
+    const bin = this.config.bin;
+    const inner = completionInner(shell, bin);
+
+    if (shell === "bash") {
+      const rc = path.join(os.homedir(), ".bashrc");
+      const next = upsertMarkedCompletionBlock(readRcSafe(rc), inner);
+      fs.writeFileSync(rc, next.endsWith("\n") ? next : next + "\n", "utf8");
+      if (this.context.json) {
+        this.output.json({ shell, rcFile: rc, action: "installed" });
+        return;
+      }
+      this.output.text(
+        `${chalkForContext(this.context.color).bold("Installed")} bash completion into ${rc}`,
+      );
+      this.output.text(`Run ${chalkForContext(this.context.color).cyan(`source ${rc}`)} to load it in this session.`);
+      return;
+    }
+
+    if (shell === "zsh") {
+      const rc = path.join(os.homedir(), ".zshrc");
+      const next = upsertMarkedCompletionBlock(readRcSafe(rc), inner);
+      fs.writeFileSync(rc, next.endsWith("\n") ? next : next + "\n", "utf8");
+      if (this.context.json) {
+        this.output.json({ shell, rcFile: rc, action: "installed" });
+        return;
+      }
+      this.output.text(
+        `${chalkForContext(this.context.color).bold("Installed")} zsh completion into ${rc}`,
+      );
+      this.output.text(`Run ${chalkForContext(this.context.color).cyan(`source ${rc}`)} to load it in this session.`);
+      return;
+    }
+
+    if (shell === "fish") {
+      const dir = path.join(os.homedir(), ".config", "fish", "completions");
+      fs.mkdirSync(dir, { recursive: true });
+      const rc = path.join(dir, `${bin}.fish`);
+      const next = upsertMarkedCompletionBlock(readRcSafe(rc), inner);
+      fs.writeFileSync(rc, next.endsWith("\n") ? next : next + "\n", "utf8");
+      if (this.context.json) {
+        this.output.json({ shell, rcFile: rc, action: "installed" });
+        return;
+      }
+      this.output.text(
+        `${chalkForContext(this.context.color).bold("Installed")} fish completion into ${rc}`,
+      );
+      this.output.text(`Open a new fish session or run ${chalkForContext(this.context.color).cyan("exec fish")}.`);
+      return;
+    }
+
+    const rc = powershellProfilePath();
+    fs.mkdirSync(path.dirname(rc), { recursive: true });
+    const next = upsertMarkedCompletionBlock(readRcSafe(rc), inner);
+    fs.writeFileSync(rc, next.endsWith("\n") ? next : next + "\n", "utf8");
+    if (this.context.json) {
+      this.output.json({ shell, rcFile: rc, action: "installed" });
+      return;
+    }
+    this.output.text(
+      `${chalkForContext(this.context.color).bold("Installed")} PowerShell completion into ${rc}`,
+    );
+    this.output.text(`Run ${chalkForContext(this.context.color).cyan(`. "${rc}"`)} to load it in this session.`);
+  }
+}

--- a/objectified-cli/src/commands/completion/show.ts
+++ b/objectified-cli/src/commands/completion/show.ts
@@ -1,0 +1,80 @@
+import { Args } from "@oclif/core";
+
+import { BaseCommand } from "../../base-command.js";
+import {
+  bashCompletionBody,
+  fishCompletionBody,
+  powershellCompletionBody,
+  zshCompletionBody,
+} from "../../lib/completion/shell-snippets.js";
+import { upsertMarkedCompletionBlock } from "../../lib/completion/rc-file.js";
+
+type CompletionShell = "bash" | "zsh" | "fish" | "powershell";
+
+function inferShell(): CompletionShell {
+  if (process.platform === "win32") return "powershell";
+  const sh = process.env.SHELL ?? "";
+  if (sh.includes("zsh")) return "zsh";
+  if (sh.includes("fish")) return "fish";
+  return "bash";
+}
+
+function completionInner(shell: CompletionShell, bin: string): string {
+  switch (shell) {
+    case "bash":
+      return bashCompletionBody(bin);
+    case "zsh":
+      return zshCompletionBody(bin);
+    case "fish":
+      return fishCompletionBody(bin);
+    case "powershell":
+      return powershellCompletionBody(bin);
+    default:
+      throw new Error(`unsupported shell: ${String(shell)}`);
+  }
+}
+
+export default class CompletionShow extends BaseCommand {
+  static description = "Print shell completion glue (with marker comments) to stdout.";
+
+  static args = {
+    shell: Args.string({
+      description: "Shell to generate",
+      options: ["bash", "zsh", "fish", "powershell"],
+      required: false,
+    }),
+  };
+
+  static examples = [
+    "<%= config.bin %> <%= command.id %>",
+    "<%= config.bin %> <%= command.id %> bash",
+    "<%= config.bin %> <%= command.id %> fish >> ~/.config/fish/completions/objectified.fish",
+  ];
+
+  static seeAlso = ["completion install", "docs completions"];
+
+  async run(): Promise<void> {
+    const { args } = await this.parse(CompletionShow);
+    const shell = (args.shell ?? inferShell()) as CompletionShell;
+    const inner = completionInner(shell, this.config.bin);
+    const marked = upsertMarkedCompletionBlock("", inner);
+
+    if (this.context.json) {
+      this.output.json({
+        shell,
+        script: marked.trimEnd(),
+        hint:
+          shell === "fish"
+            ? `Default install path: ~/.config/fish/completions/${this.config.bin}.fish`
+            : shell === "powershell"
+              ? "Append to $PROFILE on Windows or ~/.config/powershell/Microsoft.PowerShell_profile.ps1"
+              : shell === "zsh"
+                ? "~/.zshrc"
+                : "~/.bashrc",
+      });
+      return;
+    }
+
+    process.stdout.write(marked.endsWith("\n") ? marked : `${marked}\n`);
+  }
+}

--- a/objectified-cli/src/commands/completion/uninstall.ts
+++ b/objectified-cli/src/commands/completion/uninstall.ts
@@ -1,0 +1,72 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { BaseCommand } from "../../base-command.js";
+import { chalkForContext } from "../../lib/output.js";
+import { readRcSafe, stripMarkedCompletionBlock } from "../../lib/completion/rc-file.js";
+
+function powershellProfilePath(): string {
+  const home = os.homedir();
+  if (process.platform === "win32") {
+    return path.join(home, "Documents", "PowerShell", "Microsoft.PowerShell_profile.ps1");
+  }
+  return path.join(home, ".config", "powershell", "Microsoft.PowerShell_profile.ps1");
+}
+
+export default class CompletionUninstall extends BaseCommand {
+  static description = "Remove Objectified completion blocks added by `completion install`.";
+
+  static examples = [
+    "<%= config.bin %> <%= command.id %>",
+    "<%= config.bin %> --json <%= command.id %>",
+  ];
+
+  static seeAlso = ["completion install", "docs completions"];
+
+  run(): Promise<void> {
+    const bin = this.config.bin;
+    const home = os.homedir();
+    const targets = [
+      path.join(home, ".bashrc"),
+      path.join(home, ".zshrc"),
+      powershellProfilePath(),
+      path.join(home, ".config", "fish", "completions", `${bin}.fish`),
+    ];
+
+    const touched: string[] = [];
+
+    for (const file of targets) {
+      const before = readRcSafe(file);
+      if (before === "") continue;
+      const after = stripMarkedCompletionBlock(before);
+      if (after === before) continue;
+
+      if (after.trim() === "" && file.endsWith(".fish")) {
+        fs.unlinkSync(file);
+        touched.push(file);
+        continue;
+      }
+
+      fs.writeFileSync(file, after.endsWith("\n") ? after : after + "\n", "utf8");
+      touched.push(file);
+    }
+
+    if (this.context.json) {
+      this.output.json({ removedFrom: touched });
+      return Promise.resolve();
+    }
+
+    if (touched.length === 0) {
+      this.output.text(
+        chalkForContext(this.context.color).bold("No Objectified completion markers found."),
+      );
+      return Promise.resolve();
+    }
+
+    this.output.text(
+      `${chalkForContext(this.context.color).bold("Removed")} completion blocks from:\n${touched.map((t) => `  - ${t}`).join("\n")}`,
+    );
+    return Promise.resolve();
+  }
+}

--- a/objectified-cli/src/commands/docs/completions.ts
+++ b/objectified-cli/src/commands/docs/completions.ts
@@ -2,7 +2,8 @@ import { BaseCommand } from "../../base-command.js";
 import { docsTopicCompletions } from "../../lib/docs-content.js";
 
 export default class DocsCompletions extends BaseCommand {
-  static description = "Shell completions roadmap and interim guidance";
+  static description =
+    "Shell completions (install/show/uninstall, static manifest + cached REST suggestions)";
 
   static examples = [
     "<%= config.bin %> <%= command.id %>",
@@ -10,7 +11,7 @@ export default class DocsCompletions extends BaseCommand {
     "<%= config.bin %> <%= command.id %> --json",
   ];
 
-  static seeAlso = ["docs", "docs output"];
+  static seeAlso = ["completion install", "docs output"];
 
   run(): Promise<void> {
     if (this.context.json) {

--- a/objectified-cli/src/lib/client.ts
+++ b/objectified-cli/src/lib/client.ts
@@ -1,6 +1,16 @@
 import { createClient, type Client } from "../generated/client.js";
-import type { ProjectSchema } from "../generated/models.js";
-import { listProjectsV1ProjectsTenantSlugGet } from "../generated/operations.js";
+import type {
+  ClassSchema,
+  PrimitiveSchema,
+  ProjectSchema,
+  VersionSchema,
+} from "../generated/models.js";
+import {
+  listClassesV1ClassesTenantSlugGet,
+  listPrimitivesV1PrimitivesTenantSlugGet,
+  listProjectsV1ProjectsTenantSlugGet,
+  listVersionsV1VersionsTenantSlugProjectIdGet,
+} from "../generated/operations.js";
 
 import { EXIT_CODES } from "./exit-codes.js";
 import {
@@ -30,6 +40,9 @@ export type ObjectifiedApi = {
   /** Transient HTTP retries consumed on the last instrumented request (429 / 5xx policy). */
   readonly lastRetriesAttempted: number;
   listProjects(tenantSlug: string): Promise<ProjectSchema[]>;
+  listVersions(tenantSlug: string, projectId: string): Promise<VersionSchema[]>;
+  listClasses(tenantSlug: string, versionId?: string): Promise<ClassSchema[]>;
+  listPrimitives(tenantSlug: string): Promise<PrimitiveSchema[]>;
 };
 
 const MAX_RETRY_AFTER_MS = 120_000;
@@ -163,6 +176,143 @@ function parseProjectsPayload(data: unknown): ProjectSchema[] {
   return projects;
 }
 
+function unwrapSdkGet(
+  rawUnknown: unknown,
+  lastRequestId: string | undefined,
+  lastRetriesAttempted: number,
+): unknown {
+  const rawBundle =
+    rawUnknown && typeof rawUnknown === "object"
+      ? (rawUnknown as {
+          data?: unknown;
+          error?: unknown;
+          response?: Response;
+        })
+      : undefined;
+
+  if (rawBundle === undefined) {
+    throw new ObjectifiedCliError({
+      message: "Empty SDK response from the API client.",
+      exitCode: EXIT_CODES.GENERIC,
+      title: "API error",
+      hint: "Retry the command; set OBJECTIFIED_DEBUG=1 if you need a stack trace.",
+    });
+  }
+
+  if (rawBundle.error !== undefined && rawBundle.error !== null && rawBundle.error !== "") {
+    const status = rawBundle.response?.status ?? 0;
+    const hdrId =
+      rawBundle.response?.headers.get("x-request-id") ??
+      rawBundle.response?.headers.get("X-Request-Id") ??
+      undefined;
+    throw httpStatusToCliError(status, formatApiError(rawBundle.error), {
+      requestId: hdrId ?? lastRequestId,
+      retriesAttempted: lastRetriesAttempted,
+    });
+  }
+
+  return rawBundle.data;
+}
+
+function parseVersionsPayload(data: unknown): VersionSchema[] {
+  if (!Array.isArray(data)) {
+    throw new ObjectifiedCliError({
+      message: "Unexpected response shape for versions list.",
+      exitCode: EXIT_CODES.VALIDATION,
+      title: "Validation failed",
+      hint: "The API returned an unexpected JSON shape; try again or upgrade the CLI.",
+    });
+  }
+  const versions: VersionSchema[] = [];
+  for (const raw of data) {
+    if (!raw || typeof raw !== "object") {
+      throw new ObjectifiedCliError({
+        message: "Invalid version entry in response.",
+        exitCode: EXIT_CODES.VALIDATION,
+        title: "Validation failed",
+        hint: "The API returned invalid version rows.",
+      });
+    }
+    const v = raw as Record<string, unknown>;
+    if (typeof v.version_id !== "string" || typeof v.id !== "string") {
+      throw new ObjectifiedCliError({
+        message: "Invalid version fields in response.",
+        exitCode: EXIT_CODES.VALIDATION,
+        title: "Validation failed",
+        hint: "Required version fields were missing or mistyped.",
+      });
+    }
+    versions.push(raw as VersionSchema);
+  }
+  return versions;
+}
+
+function parseClassesPayload(data: unknown): ClassSchema[] {
+  if (!Array.isArray(data)) {
+    throw new ObjectifiedCliError({
+      message: "Unexpected response shape for classes list.",
+      exitCode: EXIT_CODES.VALIDATION,
+      title: "Validation failed",
+      hint: "The API returned an unexpected JSON shape; try again or upgrade the CLI.",
+    });
+  }
+  const classes: ClassSchema[] = [];
+  for (const raw of data) {
+    if (!raw || typeof raw !== "object") {
+      throw new ObjectifiedCliError({
+        message: "Invalid class entry in response.",
+        exitCode: EXIT_CODES.VALIDATION,
+        title: "Validation failed",
+        hint: "The API returned invalid class rows.",
+      });
+    }
+    const c = raw as Record<string, unknown>;
+    if (typeof c.name !== "string") {
+      throw new ObjectifiedCliError({
+        message: "Invalid class fields in response.",
+        exitCode: EXIT_CODES.VALIDATION,
+        title: "Validation failed",
+        hint: "Required class fields were missing or mistyped.",
+      });
+    }
+    classes.push(raw as ClassSchema);
+  }
+  return classes;
+}
+
+function parsePrimitivesPayload(data: unknown): PrimitiveSchema[] {
+  if (!Array.isArray(data)) {
+    throw new ObjectifiedCliError({
+      message: "Unexpected response shape for primitives list.",
+      exitCode: EXIT_CODES.VALIDATION,
+      title: "Validation failed",
+      hint: "The API returned an unexpected JSON shape; try again or upgrade the CLI.",
+    });
+  }
+  const primitives: PrimitiveSchema[] = [];
+  for (const raw of data) {
+    if (!raw || typeof raw !== "object") {
+      throw new ObjectifiedCliError({
+        message: "Invalid primitive entry in response.",
+        exitCode: EXIT_CODES.VALIDATION,
+        title: "Validation failed",
+        hint: "The API returned invalid primitive rows.",
+      });
+    }
+    const p = raw as Record<string, unknown>;
+    if (typeof p.name !== "string") {
+      throw new ObjectifiedCliError({
+        message: "Invalid primitive fields in response.",
+        exitCode: EXIT_CODES.VALIDATION,
+        title: "Validation failed",
+        hint: "Required primitive fields were missing or mistyped.",
+      });
+    }
+    primitives.push(raw as PrimitiveSchema);
+  }
+  return primitives;
+}
+
 function createInstrumentedFetch(opts: {
   inner: typeof fetch;
   auth: ApiAuthSnapshot;
@@ -285,37 +435,62 @@ export function createApiClient(options: CreateApiClientOptions): ObjectifiedApi
         throw e;
       }
 
-      const rawBundle =
-        rawUnknown && typeof rawUnknown === "object"
-          ? (rawUnknown as {
-              data?: unknown;
-              error?: unknown;
-              response?: Response;
-            })
-          : undefined;
+      return parseProjectsPayload(unwrapSdkGet(rawUnknown, lastRequestId, lastRetriesAttempted));
+    },
 
-      if (rawBundle === undefined) {
-        throw new ObjectifiedCliError({
-          message: "Empty SDK response from the API client.",
-          exitCode: EXIT_CODES.GENERIC,
-          title: "API error",
-          hint: "Retry the command; set OBJECTIFIED_DEBUG=1 if you need a stack trace.",
+    async listVersions(tenantSlug: string, projectId: string): Promise<VersionSchema[]> {
+      let rawUnknown: unknown;
+      try {
+        rawUnknown = await listVersionsV1VersionsTenantSlugProjectIdGet({
+          client: hey,
+          path: { tenant_slug: tenantSlug, project_id: projectId },
+          throwOnError: false,
         });
+      } catch (e) {
+        if (e instanceof ObjectifiedCliError) throw e;
+        if (e !== null && typeof e === "object" && "code" in e) {
+          throw networkErrnoToCliError(e as NodeJS.ErrnoException);
+        }
+        throw e;
       }
+      return parseVersionsPayload(unwrapSdkGet(rawUnknown, lastRequestId, lastRetriesAttempted));
+    },
 
-      if (rawBundle.error !== undefined && rawBundle.error !== null && rawBundle.error !== "") {
-        const status = rawBundle.response?.status ?? 0;
-        const hdrId =
-          rawBundle.response?.headers.get("x-request-id") ??
-          rawBundle.response?.headers.get("X-Request-Id") ??
-          undefined;
-        throw httpStatusToCliError(status, formatApiError(rawBundle.error), {
-          requestId: hdrId ?? lastRequestId,
-          retriesAttempted: lastRetriesAttempted,
+    async listClasses(tenantSlug: string, versionId?: string): Promise<ClassSchema[]> {
+      let rawUnknown: unknown;
+      try {
+        rawUnknown = await listClassesV1ClassesTenantSlugGet({
+          client: hey,
+          path: { tenant_slug: tenantSlug },
+          query: versionId !== undefined ? { version_id: versionId } : {},
+          throwOnError: false,
         });
+      } catch (e) {
+        if (e instanceof ObjectifiedCliError) throw e;
+        if (e !== null && typeof e === "object" && "code" in e) {
+          throw networkErrnoToCliError(e as NodeJS.ErrnoException);
+        }
+        throw e;
       }
+      return parseClassesPayload(unwrapSdkGet(rawUnknown, lastRequestId, lastRetriesAttempted));
+    },
 
-      return parseProjectsPayload(rawBundle.data);
+    async listPrimitives(tenantSlug: string): Promise<PrimitiveSchema[]> {
+      let rawUnknown: unknown;
+      try {
+        rawUnknown = await listPrimitivesV1PrimitivesTenantSlugGet({
+          client: hey,
+          path: { tenant_slug: tenantSlug },
+          throwOnError: false,
+        });
+      } catch (e) {
+        if (e instanceof ObjectifiedCliError) throw e;
+        if (e !== null && typeof e === "object" && "code" in e) {
+          throw networkErrnoToCliError(e as NodeJS.ErrnoException);
+        }
+        throw e;
+      }
+      return parsePrimitivesPayload(unwrapSdkGet(rawUnknown, lastRequestId, lastRetriesAttempted));
     },
   };
 }

--- a/objectified-cli/src/lib/completion/cache.ts
+++ b/objectified-cli/src/lib/completion/cache.ts
@@ -1,0 +1,60 @@
+import { createHash } from "node:crypto";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import { COMPLETION_CACHE_SEGMENT, COMPLETION_CACHE_TTL_MS } from "./constants.js";
+
+export function completionCacheDir(): string {
+  return join(homedir(), ".cache", "objectified", COMPLETION_CACHE_SEGMENT);
+}
+
+function cacheFile(profileKey: string, parts: string[]): string {
+  const id = createHash("sha256").update(`${profileKey}\0${parts.join("\0")}`).digest("hex").slice(0, 40);
+  return join(completionCacheDir(), `${id}.json`);
+}
+
+type CacheRow = { expiresAt: number; values: string[] };
+
+export async function readCompletionCache(
+  profileKey: string,
+  parts: string[],
+): Promise<string[] | undefined> {
+  try {
+    const raw = await readFile(cacheFile(profileKey, parts), "utf8");
+    const row = JSON.parse(raw) as CacheRow;
+    if (!Array.isArray(row.values) || typeof row.expiresAt !== "number") return undefined;
+    if (Date.now() > row.expiresAt) return undefined;
+    return row.values;
+  } catch {
+    return undefined;
+  }
+}
+
+export async function writeCompletionCache(
+  profileKey: string,
+  parts: string[],
+  values: string[],
+): Promise<void> {
+  const dir = completionCacheDir();
+  await mkdir(dir, { recursive: true });
+  const row: CacheRow = { expiresAt: Date.now() + COMPLETION_CACHE_TTL_MS, values };
+  await writeFile(cacheFile(profileKey, parts), `${JSON.stringify(row)}\n`, "utf8");
+}
+
+/** Returns cached values, or runs fetcher (network). On failure returns []. */
+export async function withCompletionCache(
+  profileKey: string,
+  parts: string[],
+  fetcher: () => Promise<string[]>,
+): Promise<string[]> {
+  const hit = await readCompletionCache(profileKey, parts);
+  if (hit !== undefined) return hit;
+  try {
+    const values = await fetcher();
+    await writeCompletionCache(profileKey, parts, values);
+    return values;
+  } catch {
+    return [];
+  }
+}

--- a/objectified-cli/src/lib/completion/candidates-logic.ts
+++ b/objectified-cli/src/lib/completion/candidates-logic.ts
@@ -1,0 +1,285 @@
+import type { Config } from "@oclif/core";
+
+import {
+  configLayerForProfile,
+  listAvailableProfileNames,
+  resolveEffectiveProfile,
+} from "../cli-context.js";
+import type { ObjectifiedApi } from "../client.js";
+import type { ParsedTomlConfig } from "../config.js";
+import { withCompletionCache } from "./cache.js";
+import { extractProfileFromWords, matchesPrefix, splitCommandTokens } from "./parse-line.js";
+
+const GLOBAL_FLAG_TOKENS = [
+  "--api-key",
+  "--base-url",
+  "--config",
+  "--json",
+  "--no-json",
+  "--color",
+  "--no-color",
+  "--profile",
+  "--quiet",
+  "--no-quiet",
+  "-q",
+  "--verbose",
+  "--no-verbose",
+  "--help",
+  "-h",
+];
+
+/** Roadmap commands not yet registered — still complete for power users (#3193). */
+const EXTRA_SUBCOMMANDS: Record<string, string[]> = {
+  projects: ["show"],
+  versions: ["list", "show"],
+  classes: ["show"],
+  primitives: ["show"],
+  tenants: ["use"],
+};
+
+function uniqSorted(values: string[]): string[] {
+  return [...new Set(values)].sort((a, b) => a.localeCompare(b));
+}
+
+function tenantSlugsFromConfig(doc: ParsedTomlConfig): string[] {
+  const s = new Set<string>();
+  if (doc.default.tenantSlug) s.add(doc.default.tenantSlug);
+  for (const p of Object.values(doc.profiles)) {
+    const slug = p.tenantSlug;
+    if (slug) s.add(slug);
+  }
+  return uniqSorted([...s]);
+}
+
+function resolveCommandId(config: Config, cmdParts: string[]): string | undefined {
+  for (let len = cmdParts.length; len >= 1; len--) {
+    const id = cmdParts.slice(0, len).join(":");
+    if (config.commands.some((c) => c.id === id)) return id;
+  }
+  return undefined;
+}
+
+function flagsForResolvedCommand(config: Config, cmdId: string | undefined): string[] {
+  const out = new Set<string>(GLOBAL_FLAG_TOKENS);
+  if (cmdId === undefined) return uniqSorted([...out]);
+  const cmd = config.commands.find((c) => c.id === cmdId);
+  if (!cmd) return uniqSorted([...out]);
+  for (const name of Object.keys(cmd.flags)) {
+    const f = cmd.flags[name];
+    if (!f || f.hidden) continue;
+    if ("char" in f && typeof f.char === "string") out.add(`-${f.char}`);
+    out.add(`--${name}`);
+  }
+  return uniqSorted([...out]);
+}
+
+function nextStaticSegments(config: Config, cmdParts: string[]): string[] {
+  const seen = new Set<string>();
+  const prefix = cmdParts.length === 0 ? "" : `${cmdParts.join(":")}:`;
+
+  if (cmdParts.length === 0) {
+    for (const c of config.commands) {
+      if (c.hidden) continue;
+      const head = c.id.split(":")[0];
+      if (head) seen.add(head);
+    }
+  } else {
+    for (const c of config.commands) {
+      if (c.hidden) continue;
+      const id = c.id;
+      if (!id.startsWith(prefix)) continue;
+      const rest = id.slice(prefix.length);
+      const seg = rest.split(":")[0];
+      if (seg !== undefined && seg !== "") seen.add(seg);
+    }
+  }
+
+  const topicHead = cmdParts[0];
+  if (topicHead !== undefined && cmdParts.length === 1 && EXTRA_SUBCOMMANDS[topicHead]) {
+    for (const x of EXTRA_SUBCOMMANDS[topicHead]) seen.add(x);
+  }
+
+  return uniqSorted([...seen]);
+}
+
+function filterByPrefix(values: string[], partial: string): string[] {
+  return values.filter((v) => matchesPrefix(v, partial));
+}
+
+async function loadProjectSlugIdRows(
+  api: ObjectifiedApi,
+  profileCacheKey: string,
+  tenantSlug: string,
+): Promise<Array<{ slug: string; id: string }>> {
+  const rows = await withCompletionCache(profileCacheKey, ["projects-map", tenantSlug], async () => {
+    const list = await api.listProjects(tenantSlug);
+    return list.map((p) => `${p.slug}\t${p.id}`);
+  });
+  const out: Array<{ slug: string; id: string }> = [];
+  for (const row of rows) {
+    const tab = row.indexOf("\t");
+    if (tab <= 0) continue;
+    const slug = row.slice(0, tab);
+    const id = row.slice(tab + 1);
+    if (slug !== "" && id !== "") out.push({ slug, id });
+  }
+  return out;
+}
+
+async function resolveProjectIdBySlug(
+  api: ObjectifiedApi,
+  profileCacheKey: string,
+  tenantSlug: string,
+  projectSlug: string,
+): Promise<string | undefined> {
+  const rows = await loadProjectSlugIdRows(api, profileCacheKey, tenantSlug);
+  return rows.find((r) => r.slug === projectSlug)?.id;
+}
+
+async function tryDynamicCandidates(opts: {
+  api: ObjectifiedApi;
+  tenantSlug: string | undefined;
+  profileCacheKey: string;
+  configDoc: ParsedTomlConfig;
+  cmdParts: string[];
+  current: string;
+}): Promise<string[] | undefined> {
+  const { api, tenantSlug, profileCacheKey, configDoc, cmdParts, current } = opts;
+
+  if (cmdParts[0] === "tenants" && cmdParts[1] === "use" && cmdParts.length === 2) {
+    return filterByPrefix(tenantSlugsFromConfig(configDoc), current);
+  }
+
+  if (!tenantSlug || tenantSlug === "") return undefined;
+
+  if (cmdParts[0] === "projects" && cmdParts[1] === "show" && cmdParts.length === 2) {
+    const rows = await loadProjectSlugIdRows(api, profileCacheKey, tenantSlug);
+    return filterByPrefix(
+      uniqSorted(rows.map((r) => r.slug)),
+      current,
+    );
+  }
+
+  if (cmdParts[0] === "versions" && cmdParts[1] === "list" && cmdParts.length === 2) {
+    const rows = await loadProjectSlugIdRows(api, profileCacheKey, tenantSlug);
+    return filterByPrefix(
+      uniqSorted(rows.map((r) => r.slug)),
+      current,
+    );
+  }
+
+  if (cmdParts[0] === "versions" && cmdParts[1] === "list" && cmdParts.length === 3) {
+    const projectSlug = cmdParts[2];
+    if (projectSlug === undefined || projectSlug === "") return [];
+    const projectId = await resolveProjectIdBySlug(api, profileCacheKey, tenantSlug, projectSlug);
+    if (projectId === undefined) return [];
+    const values = await withCompletionCache(
+      profileCacheKey,
+      ["versions", tenantSlug, projectId],
+      async () => {
+        const rows = await api.listVersions(tenantSlug, projectId);
+        const ids = rows.flatMap((v) => [v.version_id, v.id]);
+        return uniqSorted(ids);
+      },
+    );
+    return filterByPrefix(values, current);
+  }
+
+  if (cmdParts[0] === "versions" && cmdParts[1] === "show" && cmdParts.length === 2) {
+    const rows = await loadProjectSlugIdRows(api, profileCacheKey, tenantSlug);
+    return filterByPrefix(
+      uniqSorted(rows.map((r) => r.slug)),
+      current,
+    );
+  }
+
+  if (cmdParts[0] === "versions" && cmdParts[1] === "show" && cmdParts.length === 3) {
+    const projectSlug = cmdParts[2];
+    if (projectSlug === undefined || projectSlug === "") return [];
+    const projectId = await resolveProjectIdBySlug(api, profileCacheKey, tenantSlug, projectSlug);
+    if (projectId === undefined) return [];
+    const values = await withCompletionCache(
+      profileCacheKey,
+      ["versions", tenantSlug, projectId],
+      async () => {
+        const rows = await api.listVersions(tenantSlug, projectId);
+        const ids = rows.flatMap((v) => [v.version_id, v.id]);
+        return uniqSorted(ids);
+      },
+    );
+    return filterByPrefix(values, current);
+  }
+
+  if (cmdParts[0] === "classes" && cmdParts[1] === "show" && cmdParts.length === 2) {
+    const values = await withCompletionCache(profileCacheKey, ["classes", tenantSlug], async () => {
+      const rows = await api.listClasses(tenantSlug);
+      return uniqSorted(rows.map((c) => c.name));
+    });
+    return filterByPrefix(values, current);
+  }
+
+  if (cmdParts[0] === "primitives" && cmdParts[1] === "show" && cmdParts.length === 2) {
+    const values = await withCompletionCache(profileCacheKey, ["primitives", tenantSlug], async () => {
+      const rows = await api.listPrimitives(tenantSlug);
+      return uniqSorted(rows.map((p) => p.name));
+    });
+    return filterByPrefix(values, current);
+  }
+
+  return undefined;
+}
+
+export async function computeCompletionCandidates(opts: {
+  config: Config;
+  api: ObjectifiedApi;
+  baseUrl: string;
+  configDoc: ParsedTomlConfig;
+  env: NodeJS.ProcessEnv;
+  words: string[];
+  cword: number;
+}): Promise<string[]> {
+  const { config, api, baseUrl, configDoc, env, words, cword } = opts;
+  const stdinProfile = extractProfileFromWords(words, cword);
+  const effectiveProfile = resolveEffectiveProfile(stdinProfile, env, configDoc);
+  const layer = configLayerForProfile(configDoc, effectiveProfile);
+  const tenantSlug =
+    typeof env.OBJECTIFIED_TENANT === "string" && env.OBJECTIFIED_TENANT !== ""
+      ? env.OBJECTIFIED_TENANT
+      : layer.tenantSlug;
+
+  const profileCacheKey = `${baseUrl}|${effectiveProfile}|${tenantSlug ?? ""}`;
+
+  const prev = cword > 0 ? words[cword - 1] : undefined;
+  const { cmdParts, current } = splitCommandTokens(words, cword);
+
+  if (prev === "--profile") {
+    return filterByPrefix(listAvailableProfileNames(configDoc), current);
+  }
+
+  if (current.startsWith("--profile=")) {
+    const rest = current.slice("--profile=".length);
+    return filterByPrefix(listAvailableProfileNames(configDoc), rest).map((p) => `--profile=${p}`);
+  }
+
+  if (current.startsWith("-")) {
+    const cmdId = resolveCommandId(config, cmdParts);
+    return filterByPrefix(flagsForResolvedCommand(config, cmdId), current);
+  }
+
+  try {
+    const dyn = await tryDynamicCandidates({
+      api,
+      tenantSlug,
+      profileCacheKey,
+      configDoc,
+      cmdParts,
+      current,
+    });
+    if (dyn !== undefined) return dyn;
+  } catch {
+    /* offline / auth — fall through */
+  }
+
+  const next = nextStaticSegments(config, cmdParts);
+  return filterByPrefix(next, current);
+}

--- a/objectified-cli/src/lib/completion/constants.ts
+++ b/objectified-cli/src/lib/completion/constants.ts
@@ -1,0 +1,7 @@
+export const COMPLETION_BEGIN = "# >>> objectified completion >>>";
+export const COMPLETION_END = "# <<< objectified completion <<<";
+
+/** Dynamic REST-backed completion entries (#3193). */
+export const COMPLETION_CACHE_TTL_MS = 5 * 60 * 1000;
+
+export const COMPLETION_CACHE_SEGMENT = "completion";

--- a/objectified-cli/src/lib/completion/parse-line.ts
+++ b/objectified-cli/src/lib/completion/parse-line.ts
@@ -1,0 +1,72 @@
+/** Split CLI words (from the shell driver) into profile override and command tokens. */
+
+export function extractProfileFromWords(words: string[], uptoInclusive: number): string | undefined {
+  const hi = Math.min(uptoInclusive, words.length - 1);
+  for (let i = 1; i <= hi; i++) {
+    const w = words[i];
+    if (w === undefined) continue;
+    if (w === "--profile") {
+      const next = words[i + 1];
+      if (next !== undefined && i + 1 <= hi) return next;
+      continue;
+    }
+    if (w.startsWith("--profile=")) {
+      const v = w.slice("--profile=".length);
+      if (v !== "") return v;
+    }
+  }
+  return undefined;
+}
+
+export type SplitWordsResult = {
+  /** Non-flag command tokens before the cursor word (subcommands only). */
+  cmdParts: string[];
+  /** Word being completed (`COMP_WORDS[cword]`). */
+  current: string;
+};
+
+/**
+ * Parse completion words: `words[0]` is the CLI binary, `cword` indexes the active token.
+ * Returns command tokens (no globals) strictly before `cword`, and the current token.
+ */
+export function splitCommandTokens(words: string[], cword: number): SplitWordsResult {
+  const current = words[cword] ?? "";
+  const cmdParts: string[] = [];
+  let i = 1;
+  while (i < cword && i < words.length) {
+    const w = words[i];
+    if (w === undefined) break;
+    if (w === "--") break;
+    if (w.startsWith("-")) {
+      if (w === "--profile" || w.startsWith("--profile=")) {
+        if (w === "--profile") i += 2;
+        else i += 1;
+        continue;
+      }
+      if (w === "--api-key" || w.startsWith("--api-key=")) {
+        if (w === "--api-key") i += 2;
+        else i += 1;
+        continue;
+      }
+      if (w === "--base-url" || w.startsWith("--base-url=")) {
+        if (w === "--base-url") i += 2;
+        else i += 1;
+        continue;
+      }
+      if (w === "--config" || w.startsWith("--config=")) {
+        if (w === "--config") i += 2;
+        else i += 1;
+        continue;
+      }
+      i += 1;
+      continue;
+    }
+    cmdParts.push(w);
+    i += 1;
+  }
+  return { cmdParts, current };
+}
+
+export function matchesPrefix(candidate: string, partial: string): boolean {
+  return partial === "" || candidate.startsWith(partial);
+}

--- a/objectified-cli/src/lib/completion/rc-file.ts
+++ b/objectified-cli/src/lib/completion/rc-file.ts
@@ -8,7 +8,7 @@ function escapeRegExp(s: string): string {
 
 const BLOCK_RE = new RegExp(
   `${escapeRegExp(COMPLETION_BEGIN)}\\s*\\n([\\s\\S]*?)\\n${escapeRegExp(COMPLETION_END)}\\s*\\n?`,
-  "m",
+  "gm",
 );
 
 export function upsertMarkedCompletionBlock(existing: string, innerBody: string): string {
@@ -17,7 +17,8 @@ export function upsertMarkedCompletionBlock(existing: string, innerBody: string)
   if (!trimmed.includes(COMPLETION_BEGIN)) {
     return trimmed === "" ? wrapped : `${trimmed}\n\n${wrapped}`;
   }
-  return trimmed.replace(BLOCK_RE, wrapped);
+  const withoutBlocks = trimmed.replace(BLOCK_RE, "").replace(/\n{3,}/g, "\n\n").trimEnd();
+  return withoutBlocks === "" ? wrapped : `${withoutBlocks}\n\n${wrapped}`;
 }
 
 export function stripMarkedCompletionBlock(existing: string): string {

--- a/objectified-cli/src/lib/completion/rc-file.ts
+++ b/objectified-cli/src/lib/completion/rc-file.ts
@@ -1,0 +1,36 @@
+import fs from "node:fs";
+
+import { COMPLETION_BEGIN, COMPLETION_END } from "./constants.js";
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+const BLOCK_RE = new RegExp(
+  `${escapeRegExp(COMPLETION_BEGIN)}\\s*\\n([\\s\\S]*?)\\n${escapeRegExp(COMPLETION_END)}\\s*\\n?`,
+  "m",
+);
+
+export function upsertMarkedCompletionBlock(existing: string, innerBody: string): string {
+  const wrapped = `${COMPLETION_BEGIN}\n${innerBody.trimEnd()}\n${COMPLETION_END}\n`;
+  const trimmed = existing.replace(/\s+$/, "");
+  if (!trimmed.includes(COMPLETION_BEGIN)) {
+    return trimmed === "" ? wrapped : `${trimmed}\n\n${wrapped}`;
+  }
+  return trimmed.replace(BLOCK_RE, wrapped);
+}
+
+export function stripMarkedCompletionBlock(existing: string): string {
+  const stripped = existing.replace(BLOCK_RE, "");
+  return stripped.replace(/\n{3,}/g, "\n\n").trimEnd();
+}
+
+export function readRcSafe(path: string): string {
+  try {
+    return fs.readFileSync(path, "utf8");
+  } catch (e: unknown) {
+    const code = typeof e === "object" && e && "code" in e ? (e as NodeJS.ErrnoException).code : undefined;
+    if (code === "ENOENT") return "";
+    throw e;
+  }
+}

--- a/objectified-cli/src/lib/completion/shell-snippets.ts
+++ b/objectified-cli/src/lib/completion/shell-snippets.ts
@@ -1,0 +1,57 @@
+/** Shell glue that shells out to `objectified completion candidates` (newline-separated words on stdin). */
+
+export function bashCompletionBody(bin: string): string {
+  return `_${bin}_completion() {
+  local cur=\${COMP_WORDS[COMP_CWORD]}
+  COMPREPLY=()
+  local line
+  while IFS= read -r line; do
+    [[ -z "$line" ]] && continue
+    if [[ -z "$cur" || "$line" == "$cur"* ]]; then
+      COMPREPLY+=("$line")
+    fi
+  done < <(printf '%s\\n' "\${COMP_WORDS[@]}" | command ${bin} --no-json completion candidates --shell bash --cword "$COMP_CWORD" 2>/dev/null)
+}
+complete -F _${bin}_completion -o default ${bin}
+`;
+}
+
+export function zshCompletionBody(bin: string): string {
+  return `_${bin}() {
+  local -a lines
+  lines=()
+  local line
+  while IFS= read -r line; do
+    [[ -z "$line" ]] && continue
+    lines+=("$line")
+  done < <(printf '%s\\n' "\${words[@]}" | command ${bin} --no-json completion candidates --shell zsh --cword "$CURRENT" 2>/dev/null)
+  compadd -a lines
+}
+compdef _${bin} ${bin}
+`;
+}
+
+export function fishCompletionBody(bin: string): string {
+  return `function __fish_${bin}_completion_words
+  set -l tok (commandline -opc)
+  printf '%s\\n' $tok | command ${bin} --no-json completion candidates --shell fish --cword (math (count $tok) - 1) 2>/dev/null
+end
+complete -c ${bin} -f -a '(__fish_${bin}_completion_words)'
+`;
+}
+
+export function powershellCompletionBody(bin: string): string {
+  return `Register-ArgumentCompleter -Native -CommandName ${bin} -ScriptBlock {
+  param($wordToComplete, $commandAst, $cursorPosition)
+  $before = $commandAst.ToString().Substring(0, $cursorPosition)
+  $parts = @($before -split '\\s+' | Where-Object { $_ -ne '' })
+  $cword = [Math]::Max(0, $parts.Count - 1)
+  $words = ($parts | ForEach-Object { $_ }) -join [Environment]::NewLine
+  $out = $words | & ${bin} --no-json completion candidates --shell powershell --cword $cword 2>$null
+  if (-not $out) { return }
+  $out -split '\\r?\\n' | Where-Object { $_ -and ($_ -like ($wordToComplete + '*')) } | ForEach-Object {
+    [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)
+  }
+}
+`;
+}

--- a/objectified-cli/src/lib/completion/shell-snippets.ts
+++ b/objectified-cli/src/lib/completion/shell-snippets.ts
@@ -24,7 +24,7 @@ export function zshCompletionBody(bin: string): string {
   while IFS= read -r line; do
     [[ -z "$line" ]] && continue
     lines+=("$line")
-  done < <(printf '%s\\n' "\${words[@]}" | command ${bin} --no-json completion candidates --shell zsh --cword "$CURRENT" 2>/dev/null)
+  done < <(printf '%s\\n' "\${words[@]}" | command ${bin} --no-json completion candidates --shell zsh --cword "$((CURRENT-1))" 2>/dev/null)
   compadd -a lines
 }
 compdef _${bin} ${bin}

--- a/objectified-cli/src/lib/docs-content.ts
+++ b/objectified-cli/src/lib/docs-content.ts
@@ -38,11 +38,21 @@ Switching profiles
 export const docsTopicCompletions = `
 SHELL COMPLETIONS
 
-Status
-  Interactive completion installers are tracked in roadmap ticket #3193 (bash, zsh, fish, PowerShell). This topic reserves the docs slot until that work lands.
+Commands
+  objectified completion install [bash|zsh|fish|powershell] — append a small wrapper to your shell startup file (bash ~/.bashrc, zsh ~/.zshrc, fish ~/.config/fish/completions/<bin>.fish, PowerShell profile). It prints a one-liner to source or dot the file in the current session.
+  objectified completion show [shell] — print the same managed block to stdout (for packaging or manual install).
+  objectified completion uninstall — remove only the marked block we added.
 
-Today
-  Use objectified --help and objectified docs <topic> for discoverability, or generate completion scripts from oclif once the completion command ships.
+Static vs dynamic
+  Topics, subcommands, and flags are completed offline from the CLI manifest.
+  Tenant slugs from config profiles, project slugs, version identifiers, class names, and primitive names are loaded from the REST API when online, cached for five minutes per profile under ~/.cache/objectified/completion/, and omitted when the API is unreachable.
+
+Examples
+  objectified projects show pay<TAB> completes project slugs for the active tenant profile.
+  objectified versions list my-api v<TAB> completes version_id / revision ids after the project slug.
+
+Linting
+  Generated bash/zsh/fish snippets are written for portability; run shellcheck or fish --no-execute in CI when available.
 `.trim();
 
 export const docsTopicPlugins = `

--- a/objectified-cli/src/lib/docs-index.ts
+++ b/objectified-cli/src/lib/docs-index.ts
@@ -6,7 +6,7 @@ export const DOCS_TOPIC_INDEX: DocsTopicMeta[] = [
   { topic: "errors", summary: "Exit codes, stderr shape, and debugging hints" },
   { topic: "output", summary: "TTY vs JSON, quiet, verbose, and color rules" },
   { topic: "profiles", summary: "config.toml profiles, defaults, and resolution order" },
-  { topic: "completions", summary: "Shell completions roadmap (#3193)" },
+  { topic: "completions", summary: "Shell completions (install/show/uninstall, cached dynamic lists)" },
   { topic: "plugins", summary: "Plugin roadmap for third-party commands" },
   { topic: "telemetry", summary: "Telemetry posture and verbose diagnostics" },
 ];

--- a/objectified-cli/test/cli.integration.test.ts
+++ b/objectified-cli/test/cli.integration.test.ts
@@ -214,6 +214,11 @@ base_url = "https://api.prod.example"
     expect(out).toContain("completion candidates");
   });
 
+  it("completion show zsh passes zero-based cword", () => {
+    const out = run(["completion", "show", "zsh", "--no-json"]);
+    expect(out).toContain('--cword "$((CURRENT-1))"');
+  });
+
   it("completion candidates lists next static segment offline", () => {
     const stdin = ["objectified", "projects", ""].join("\n");
     const out = runStdin(

--- a/objectified-cli/test/cli.integration.test.ts
+++ b/objectified-cli/test/cli.integration.test.ts
@@ -32,6 +32,17 @@ function runExpectFailure(args: string[], extraEnv: Record<string, string> = {})
   }
 }
 
+function runStdin(args: string[], stdin: string, extraEnv: Record<string, string> = {}): string {
+  const env = { ...process.env, FORCE_COLOR: "0", ...extraEnv };
+  delete env.NODE_OPTIONS;
+  return execFileSync("node", [path.join(pkgRoot, "bin/run.js"), ...args], {
+    cwd: pkgRoot,
+    encoding: "utf8",
+    input: stdin,
+    env,
+  });
+}
+
 describe("objectified CLI", () => {
   it("prints version", () => {
     const out = run(["--version"]);
@@ -86,6 +97,13 @@ describe("objectified CLI", () => {
     expect(out).toMatch(/\bcompletions\b/);
     expect(out).toMatch(/\bplugins\b/);
     expect(out).toMatch(/\btelemetry\b/);
+  });
+
+  it("docs completions describes completion install/show/uninstall", () => {
+    const out = run(["docs", "completions", "--no-json"]);
+    expect(out).toMatch(/completion install/);
+    expect(out).toMatch(/completion show/);
+    expect(out).toMatch(/completion uninstall/);
   });
 
   it("docs output prints long-form prose", () => {
@@ -187,6 +205,28 @@ base_url = "https://api.prod.example"
   it("does not emit ANSI escapes for errors when --no-color is set", () => {
     const err = runExpectFailure(["--no-color", "helol"]);
     expect(err.includes("\u001B[")).toBe(false);
+  });
+
+  it("completion show bash prints bash complete function", () => {
+    const out = run(["completion", "show", "bash", "--no-json"]);
+    expect(out).toContain(">>> objectified completion >>>");
+    expect(out).toMatch(/complete\s+-F/);
+    expect(out).toContain("completion candidates");
+  });
+
+  it("completion candidates lists next static segment offline", () => {
+    const stdin = ["objectified", "projects", ""].join("\n");
+    const out = runStdin(
+      ["--no-json", "completion", "candidates", "--shell", "bash", "--cword", "2"],
+      `${stdin}\n`,
+    );
+    const lines = out
+      .trim()
+      .split("\n")
+      .map((l) => l.trim())
+      .filter(Boolean);
+    expect(lines).toContain("list");
+    expect(lines).toContain("show");
   });
 
   it("cold-starts --version within 200 ms on developer machines", () => {

--- a/objectified-cli/test/rc-completion.test.ts
+++ b/objectified-cli/test/rc-completion.test.ts
@@ -30,4 +30,45 @@ describe("completion rc markers", () => {
     expect(stripped).not.toContain(COMPLETION_BEGIN);
     expect(stripped).not.toContain("mid");
   });
+
+  it("stripMarkedCompletionBlock removes all marked regions", () => {
+    const withBlocks = [
+      "before",
+      COMPLETION_BEGIN,
+      "one",
+      COMPLETION_END,
+      "between",
+      COMPLETION_BEGIN,
+      "two",
+      COMPLETION_END,
+      "after",
+      "",
+    ].join("\n");
+    const stripped = stripMarkedCompletionBlock(withBlocks);
+    expect(stripped).toBe("before\nbetween\nafter");
+    expect(stripped).not.toContain(COMPLETION_BEGIN);
+    expect(stripped).not.toContain("one");
+    expect(stripped).not.toContain("two");
+  });
+
+  it("upsertMarkedCompletionBlock replaces all marked regions with a single block", () => {
+    const withBlocks = [
+      "before",
+      COMPLETION_BEGIN,
+      "one",
+      COMPLETION_END,
+      "between",
+      COMPLETION_BEGIN,
+      "two",
+      COMPLETION_END,
+      "",
+    ].join("\n");
+    const next = upsertMarkedCompletionBlock(withBlocks, "new");
+    expect(next.match(new RegExp(COMPLETION_BEGIN, "g"))?.length).toBe(1);
+    expect(next).toContain("before");
+    expect(next).toContain("between");
+    expect(next).toContain("new");
+    expect(next).not.toContain("one");
+    expect(next).not.toContain("two");
+  });
 });

--- a/objectified-cli/test/rc-completion.test.ts
+++ b/objectified-cli/test/rc-completion.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import { COMPLETION_BEGIN, COMPLETION_END } from "../src/lib/completion/constants.js";
+import {
+  stripMarkedCompletionBlock,
+  upsertMarkedCompletionBlock,
+} from "../src/lib/completion/rc-file.js";
+
+describe("completion rc markers", () => {
+  it("upserts a new marked block", () => {
+    const next = upsertMarkedCompletionBlock("echo hello\n", "body line");
+    expect(next).toContain(COMPLETION_BEGIN);
+    expect(next).toContain(COMPLETION_END);
+    expect(next).toContain("body line");
+    expect(next).toContain("echo hello");
+  });
+
+  it("replaces an existing marked block", () => {
+    const first = upsertMarkedCompletionBlock("", "v1");
+    const second = upsertMarkedCompletionBlock(first, "v2");
+    expect(second.match(new RegExp(COMPLETION_BEGIN, "g"))?.length).toBe(1);
+    expect(second).toContain("v2");
+    expect(second).not.toContain("v1");
+  });
+
+  it("stripMarkedCompletionBlock removes only the marked region", () => {
+    const wrapped = upsertMarkedCompletionBlock("before\n", "mid");
+    const stripped = stripMarkedCompletionBlock(wrapped);
+    expect(stripped).toContain("before");
+    expect(stripped).not.toContain(COMPLETION_BEGIN);
+    expect(stripped).not.toContain("mid");
+  });
+});

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -8,6 +8,7 @@ We continue to improve the platform based on your feedback with improvements and
 - MCP service is now live
 
 ## CLI
+- **`objectified-cli`**: `objectified completion install|show|uninstall` for bash, zsh, fish, and PowerShell; manifest-backed static completions plus REST-backed suggestions cached five minutes under `~/.cache/objectified/completion/` (#3193).
 - **`objectified-cli`**: rich `--help` (≥2 examples per command, flag groups **COMMON** / **OUTPUT** / **AUTH**, **SEE ALSO** links), `objectified docs` topic browser + prose topics, troff **man** pages under `man/man1/`, `oclif readme`-synced **README.md**, and CI guard for generated artifacts (#3192).
 - **`objectified-cli`**: shared error layer (`ObjectifiedCliError`, documented exit codes via `objectified docs errors`, stderr template with hints + request-id, `--verbose` / `OBJECTIFIED_DEBUG=1` stacks only), Levenshtein did-you-mean for unknown commands, HTTP status → exit-code mapping, and fetch retries per idempotent vs non-idempotent verbs (#3191).
 - **`objectified-cli`**: OpenAPI codegen (`yarn codegen` → `src/generated/`), typed `@hey-api/client-fetch` SDK, `lib/client.ts` wrapper (retries, `Retry-After`, 401 hook, request IDs), ESLint single-import guard, `codegen:check` in tests, and `projects list` backed by the generated client (#3190).


### PR DESCRIPTION
## What changed
- Added `objectified completion` topic: **install**, **show**, **uninstall**, plus hidden **candidates** used by shell wrappers.
- Bash/zsh/fish/PowerShell snippets call `objectified --no-json completion candidates` with newline-separated tokens on stdin so non-TTY runs stay plain-text.
- Static suggestions come from the oclif command tree (topics/subcommands/flags). Dynamic suggestions call `listProjects` / `listVersions` / `listClasses` / `listPrimitives` with a **5-minute** JSON cache under `~/.cache/objectified/completion/`, keyed by profile context; failures return no dynamic hits.
- **Install** writes managed blocks between `# >>> objectified completion >>>` markers; **uninstall** removes only those blocks (fish completion file removed when empty).
- Extended `lib/client.ts` with list helpers for versions/classes/primitives; updated `objectified docs completions`, README/man pages, roadmap (#3193 marked done), and WHATS_NEW.

## How to test
- **Build/test CLI**: from repo root, `yarn workspace objectified-cli test` (runs codegen check, build, Vitest).
- **Smoke**: `objectified completion show bash | head` then **install** to a throwaway rc file path via **show** output + manual append, or run **completion install bash** in a temp HOME.
- **Static**: `printf '%s\\n' objectified projects \"\" | objectified --no-json completion candidates --shell bash --cword 2` → expect `list` and `show`.
- **Dynamic** (needs auth + tenant): complete after `projects show`, `versions list <slug>`, etc.; go offline and confirm Tab yields no API-backed spam on stderr.

## Risks / notes
- PowerShell completion script is best-effort and was not executed on a Windows shell in this environment.
- Full root `yarn test` may require tools such as `uv` for other workspaces; CLI workspace tests passed.

Closes #3193

Made with [Cursor](https://cursor.com)