### PR TITLE
Fix #3194 - auth login (PKCE) and auth logout

### DIFF
--- a/docs/PLANNED_ROADMAP_CLI.md
+++ b/docs/PLANNED_ROADMAP_CLI.md
@@ -251,7 +251,6 @@ Part of Epic: CLI Foundation & DevEx (#3174)
 
 | #         | Title                                                  | Description                                                       | Labels                                                  | MVP | Parallel |
 |-----------|--------------------------------------------------------|-------------------------------------------------------------------|---------------------------------------------------------|-----|----------|
-| 2.1 (#3194) | `auth login` (PKCE browser) + `auth logout`         | Loopback PKCE flow, token to keychain                             | `enhancement`, `mvp`, `cli`, `roadmap-cli`, `auth`     | Yes | Yes (with 2.2) |
 | 2.2 (#3195) | API-key auth (`--api-key`, env, file)                | Headless / CI-friendly auth                                       | `enhancement`, `mvp`, `cli`, `roadmap-cli`, `auth`, `api-keys` | Yes | Yes (with 2.1) |
 | 2.3 (#3196) | `auth status` (whoami)                               | Show profile, base-url, tenant, user, expiry, plan                | `enhancement`, `mvp`, `cli`, `roadmap-cli`, `auth`     | Yes | Yes      |
 | 2.4 (#3197) | Secure credential storage (keytar + encrypted fallback) | OS keychain primary, AES-GCM file fallback for headless           | `enhancement`, `mvp`, `cli`, `roadmap-cli`, `auth`, `security` | Yes | No       |
@@ -262,7 +261,7 @@ Part of Epic: CLI Foundation & DevEx (#3174)
 
 ### Detailed Issue Descriptions
 
-#### 2.1 (#3194) — `objectified auth login` (PKCE browser flow) + `auth logout`
+#### 2.1 (#3194) — `objectified auth login` (PKCE browser flow) + `auth logout` — **COMPLETE**
 
 Standard PKCE-on-loopback pattern (same as `gh auth login` and `heroku login`):
 
@@ -773,11 +772,11 @@ The `NPM_REGISTRY` env var lets us point at npmjs.com, GitHub Packages, JFrog Ar
 
 ## MVP Release — Ticket Bundle
 
-The MVP delivers an installable, useful CLI focused on _read_ and _publish_ for a single project's lifecycle. Total: **20 open sub-tickets** across 5 epics (plus completed foundation items such as #3186, #3187, #3188, #3189, #3190, #3191, and #3192).
+The MVP delivers an installable, useful CLI focused on _read_ and _publish_ for a single project's lifecycle. Total: **19 open sub-tickets** across 5 epics (plus completed foundation items such as #3186, #3187, #3188, #3189, #3190, #3191, #3192, #3193, and #3194).
 
 | Epic     | Tickets                                                                                                   | Count |
 |----------|-----------------------------------------------------------------------------------------------------------|-------|
-| 2 (#3175) | #3194, #3195, #3196, #3197, #3198, #3199                                                                  | 6     |
+| 2 (#3175) | #3195, #3196, #3197, #3198, #3199                                                                         | 5     |
 | 3 (#3176) | #3202, #3203, #3204                                                                                        | 3     |
 | 4 (#3177) | #3208, #3209, #3210, #3212                                                                                | 4     |
 | 9 (#3182) | #3244, #3245, #3246, #3247, #3248                                                                          | 5     |
@@ -865,7 +864,7 @@ v2 fills out the writable surface for primitives, properties, classes, paths, da
 The tickets were created in the order below — that is also the recommended **execution** order. Earlier epics provide primitives that later epics rely on.
 
 1. **Epic 1 — Foundation** (#3174: #3186, #3187, #3188, #3189, #3190, #3191, #3192, and #3193 landed). Without the scaffold, no other command can exist.
-2. **Epic 2 — Auth & Tenants** (#3175 then #3194 → #3201). Required for any tenant-scoped command.
+2. **Epic 2 — Auth & Tenants** (#3175; #3194 shipped — continue #3195 → #3201). Required for any tenant-scoped command.
 3. **Epic 3 — Projects** (#3176 then #3202 → #3207). The first useful read/write surface.
 4. **Epic 4 — Versions** (#3177 then #3208 → #3216). The publish flow that makes the CLI valuable in CI.
 5. **Epic 9 — Browse & Schema Export** (#3182 then #3244 → #3252). The most-used consumer surface; lands early because it works without auth.

--- a/objectified-cli/README.md
+++ b/objectified-cli/README.md
@@ -50,7 +50,7 @@ $ npm install -g objectified-cli
 $ objectified COMMAND
 running command...
 $ objectified (--version)
-objectified-cli/0.1.7 <platform> node-v<major.minor.patch>
+objectified-cli/0.1.8 <platform> node-v<major.minor.patch>
 $ objectified --help [COMMAND]
 USAGE
   $ objectified COMMAND
@@ -61,6 +61,8 @@ USAGE
 # Commands
 
 <!-- commands -->
+* [`objectified auth login`](#objectified-auth-login)
+* [`objectified auth logout`](#objectified-auth-logout)
 * [`objectified completion`](#objectified-completion)
 * [`objectified completion install [SHELL]`](#objectified-completion-install-shell)
 * [`objectified completion show [SHELL]`](#objectified-completion-show-shell)
@@ -80,6 +82,96 @@ USAGE
 * [`objectified help [COMMAND]`](#objectified-help-command)
 * [`objectified projects list`](#objectified-projects-list)
 * [`objectified version`](#objectified-version)
+
+## `objectified auth login`
+
+Sign in via PKCE browser flow (stores tokens in the OS keychain).
+
+```
+USAGE
+  $ objectified auth login [--api-key <value>] [--base-url <value>] [--config <value>] [--json] [--color]
+    [--profile <value>] [-q] [--verbose] [--no-browser]
+
+DESCRIPTION
+  Sign in via PKCE browser flow (stores tokens in the OS keychain).
+
+EXAMPLES
+  $ objectified auth login
+
+  $ objectified --profile staging auth login
+
+  $ objectified auth login --no-browser
+
+  $ objectified --json auth login
+
+COMMON
+  --base-url=<value>  Root REST API URL.
+  --config=<value>    Path to config file (default: XDG config dir / Objectified AppData on Windows — see `objectified
+                      config path`).
+  --profile=<value>   Named credentials profile (OBJECTIFIED_PROFILE); falls back to default_profile in config.
+
+OUTPUT
+  --[no-]color  Enable/disable ANSI colors (--no-color sets NO_COLOR; colors are off when stdout is not a TTY).
+      --[no-]json   Emit machine-readable JSON (OBJECTIFIED_JSON=1; auto-enabled when stdout is not a TTY).
+  -q, --quiet       Suppress non-error stdout (spinners, banners, tips).
+      --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
+
+AUTH
+  --api-key=<value>  API key for direct authentication (bypasses login token).
+
+OTHER
+  --no-browser  Do not launch a browser; print the login URL and read the authorization code from stdin.
+
+SEE ALSO
+  objectified auth logout
+
+  objectified docs profiles
+```
+
+## `objectified auth logout`
+
+Revoke CLI refresh token at the API and remove OAuth credentials from the OS keychain.
+
+```
+USAGE
+  $ objectified auth logout [--api-key <value>] [--base-url <value>] [--config <value>] [--json] [--color]
+    [--profile <value>] [-q] [--verbose] [--all-profiles]
+
+DESCRIPTION
+  Revoke CLI refresh token at the API and remove OAuth credentials from the OS keychain.
+
+EXAMPLES
+  $ objectified auth logout
+
+  $ objectified --profile staging auth logout
+
+  $ objectified auth logout --all-profiles
+
+  $ objectified --json auth logout
+
+COMMON
+  --base-url=<value>  Root REST API URL.
+  --config=<value>    Path to config file (default: XDG config dir / Objectified AppData on Windows — see `objectified
+                      config path`).
+  --profile=<value>   Named credentials profile (OBJECTIFIED_PROFILE); falls back to default_profile in config.
+
+OUTPUT
+  --[no-]color  Enable/disable ANSI colors (--no-color sets NO_COLOR; colors are off when stdout is not a TTY).
+      --[no-]json   Emit machine-readable JSON (OBJECTIFIED_JSON=1; auto-enabled when stdout is not a TTY).
+  -q, --quiet       Suppress non-error stdout (spinners, banners, tips).
+      --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
+
+AUTH
+  --api-key=<value>  API key for direct authentication (bypasses login token).
+
+OTHER
+  --all-profiles  Revoke and clear stored OAuth credentials for every profile in config.
+
+SEE ALSO
+  objectified auth login
+
+  objectified docs profiles
+```
 
 ## `objectified completion`
 

--- a/objectified-cli/man/man1/objectified-auth-login.1
+++ b/objectified-cli/man/man1/objectified-auth-login.1
@@ -1,0 +1,50 @@
+.TH OBJECTIFIED\-AUTH\-LOGIN 1 "" "" "User Commands"
+.SH NAME
+objectified auth login \- Sign in via PKCE browser flow (stores tokens in the OS keychain).
+.SH DESCRIPTION
+.nf
+USAGE
+  $ objectified auth login [--api-key <value>] [--base-url <value>]
+    [--config <value>] [--json] [--color] [--profile <value>] [-q] [--verbose]
+    [--no-browser]
+
+DESCRIPTION
+  Sign in via PKCE browser flow (stores tokens in the OS keychain).
+
+EXAMPLES
+  $ objectified auth login
+
+  $ objectified --profile staging auth login
+
+  $ objectified auth login --no-browser
+
+  $ objectified --json auth login
+
+COMMON
+  --base-url=<value>  Root REST API URL.
+  --config=<value>    Path to config file (default: XDG config dir /
+                      Objectified AppData on Windows — see `objectified config
+                      path`).
+  --profile=<value>   Named credentials profile (OBJECTIFIED_PROFILE); falls
+                      back to default_profile in config.
+
+OUTPUT
+  --[no-]color  Enable/disable ANSI colors (--no-color sets NO_COLOR;
+                    colors are off when stdout is not a TTY).
+      --[no-]json   Emit machine-readable JSON (OBJECTIFIED_JSON=1;
+                    auto-enabled when stdout is not a TTY).
+  -q, --quiet       Suppress non-error stdout (spinners, banners, tips).
+      --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
+
+AUTH
+  --api-key=<value>  API key for direct authentication (bypasses login token).
+
+OTHER
+  --no-browser  Do not launch a browser; print the login URL and read the
+                authorization code from stdin.
+
+SEE ALSO
+  objectified auth logout
+
+  objectified docs profiles
+.fi

--- a/objectified-cli/man/man1/objectified-auth-logout.1
+++ b/objectified-cli/man/man1/objectified-auth-logout.1
@@ -1,0 +1,51 @@
+.TH OBJECTIFIED\-AUTH\-LOGOUT 1 "" "" "User Commands"
+.SH NAME
+objectified auth logout \- Revoke CLI refresh token at the API and remove OAuth credentials from the OS keychain.
+.SH DESCRIPTION
+.nf
+USAGE
+  $ objectified auth logout [--api-key <value>] [--base-url <value>]
+    [--config <value>] [--json] [--color] [--profile <value>] [-q] [--verbose]
+    [--all-profiles]
+
+DESCRIPTION
+  Revoke CLI refresh token at the API and remove OAuth credentials from the OS
+  keychain.
+
+EXAMPLES
+  $ objectified auth logout
+
+  $ objectified --profile staging auth logout
+
+  $ objectified auth logout --all-profiles
+
+  $ objectified --json auth logout
+
+COMMON
+  --base-url=<value>  Root REST API URL.
+  --config=<value>    Path to config file (default: XDG config dir /
+                      Objectified AppData on Windows — see `objectified config
+                      path`).
+  --profile=<value>   Named credentials profile (OBJECTIFIED_PROFILE); falls
+                      back to default_profile in config.
+
+OUTPUT
+  --[no-]color  Enable/disable ANSI colors (--no-color sets NO_COLOR;
+                    colors are off when stdout is not a TTY).
+      --[no-]json   Emit machine-readable JSON (OBJECTIFIED_JSON=1;
+                    auto-enabled when stdout is not a TTY).
+  -q, --quiet       Suppress non-error stdout (spinners, banners, tips).
+      --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
+
+AUTH
+  --api-key=<value>  API key for direct authentication (bypasses login token).
+
+OTHER
+  --all-profiles  Revoke and clear stored OAuth credentials for every profile
+                  in config.
+
+SEE ALSO
+  objectified auth login
+
+  objectified docs profiles
+.fi

--- a/objectified-cli/man/man1/objectified.1
+++ b/objectified-cli/man/man1/objectified.1
@@ -6,7 +6,7 @@ objectified \- Objectified command-line interface
 Objectified command-line interface
 
 VERSION
-  objectified-cli/0.1.7 linux-x64 node-v24.14.1
+  objectified-cli/0.1.8 linux-x64 node-v24.14.1
 
 USAGE
   $ objectified [COMMAND]

--- a/objectified-cli/package.json
+++ b/objectified-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-cli",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Objectified command-line interface",
   "author": "Objectified",
   "type": "module",
@@ -49,7 +49,9 @@
     "cli-table3": "^0.6.5",
     "env-paths": "^4.0.0",
     "fs-extra": "^11.3.5",
+    "keytar": "^7.9.0",
     "leven": "^4.0.0",
+    "open": "^11.0.0",
     "ora": "^9.4.0",
     "supports-color": "^10.2.2",
     "yaml": "^2.8.4"
@@ -71,6 +73,8 @@
     "vitest": "^3.2.4"
   },
   "man": [
+    "./man/man1/objectified-auth-login.1",
+    "./man/man1/objectified-auth-logout.1",
     "./man/man1/objectified-completion-install.1",
     "./man/man1/objectified-completion-show.1",
     "./man/man1/objectified-completion-uninstall.1",

--- a/objectified-cli/src/base-command.ts
+++ b/objectified-cli/src/base-command.ts
@@ -6,6 +6,7 @@ import type { CommandError } from "@oclif/core/interfaces";
 import supportsColor from "supports-color";
 
 import { createApiClient, type ApiAuthSnapshot, type ObjectifiedApi } from "./lib/client.js";
+import { loadCliOAuthCredentials } from "./lib/credentials/store.js";
 import {
   buildObjectifiedContext,
   type GlobalCliFlags,
@@ -152,6 +153,17 @@ export abstract class BaseCommand extends Command {
     } as BaseCommand["flags"];
     this.apiAuth.apiKey = this.context.apiKey;
     this.apiAuth.bearer = this.context.accessToken;
+    if (!this.apiAuth.apiKey && !this.apiAuth.bearer) {
+      try {
+        const oauth = await loadCliOAuthCredentials(this.context.profile);
+        if (oauth?.accessToken) this.apiAuth.bearer = oauth.accessToken;
+      } catch (err: unknown) {
+        if (this.verboseEffective) {
+          const msg = err instanceof Error ? err.message : String(err);
+          process.stderr.write(`objectified: could not read CLI credentials: ${msg}\n`);
+        }
+      }
+    }
     this.api = createApiClient({
       baseUrl: this.context.baseUrl,
       auth: this.apiAuth,

--- a/objectified-cli/src/commands/auth/login.ts
+++ b/objectified-cli/src/commands/auth/login.ts
@@ -45,7 +45,10 @@ export default class AuthLogin extends BaseCommand {
       stderrLine: (line) => process.stderr.write(`${line}\n`),
     });
 
-    await saveCliOAuthCredentials(this.context.profile, bundle);
+    await saveCliOAuthCredentials(this.context.profile, {
+      accessToken: bundle.accessToken,
+      refreshToken: bundle.refreshToken,
+    });
     this.apiAuth.bearer = bundle.accessToken;
 
     const tenant = this.context.tenantSlug;

--- a/objectified-cli/src/commands/auth/login.ts
+++ b/objectified-cli/src/commands/auth/login.ts
@@ -1,0 +1,69 @@
+import { Flags } from "@oclif/core";
+
+import { BaseCommand } from "../../base-command.js";
+import { runCliPkceLogin } from "../../lib/auth/cli-login-flow.js";
+import { DEFAULT_CLI_WEB_LOGIN_URL } from "../../lib/constants.js";
+import { saveCliOAuthCredentials } from "../../lib/credentials/store.js";
+
+export default class AuthLogin extends BaseCommand {
+  static description = "Sign in via PKCE browser flow (stores tokens in the OS keychain).";
+
+  static examples = [
+    "<%= config.bin %> <%= command.id %>",
+    "<%= config.bin %> --profile staging <%= command.id %>",
+    "<%= config.bin %> <%= command.id %> --no-browser",
+    "<%= config.bin %> --json <%= command.id %>",
+  ];
+
+  static seeAlso = ["auth logout", "docs profiles"];
+
+  static flags = {
+    ...BaseCommand.baseFlags,
+    "no-browser": Flags.boolean({
+      description:
+        "Do not launch a browser; print the login URL and read the authorization code from stdin.",
+      default: false,
+    }),
+  };
+
+  async run(): Promise<void> {
+    const flags = this.flags as Record<string, unknown>;
+    const noBrowser = Boolean(flags["no-browser"] ?? flags.noBrowser);
+
+    const useStdout = !this.context.json && !this.flags.quiet;
+    const humanOut = (line: string): void => {
+      if (useStdout) this.output.text(line);
+      else process.stderr.write(`${line}\n`);
+    };
+
+    const bundle = await runCliPkceLogin({
+      apiBaseUrl: this.context.baseUrl,
+      webLoginUrl: DEFAULT_CLI_WEB_LOGIN_URL,
+      noBrowserFlag: noBrowser,
+      openBrowser: true,
+      stdoutLine: humanOut,
+      stderrLine: (line) => process.stderr.write(`${line}\n`),
+    });
+
+    await saveCliOAuthCredentials(this.context.profile, bundle);
+    this.apiAuth.bearer = bundle.accessToken;
+
+    const tenant = this.context.tenantSlug;
+    const email = bundle.displayEmail ?? "unknown user";
+
+    if (this.context.json) {
+      this.output.json({
+        ok: true,
+        profile: this.context.profile,
+        email: bundle.displayEmail ?? null,
+        tenant_slug: tenant ?? null,
+      });
+      return;
+    }
+
+    const tenantBit = tenant ? ` (tenant: ${tenant})` : "";
+    this.output.success(`Logged in as ${email}${tenantBit}`);
+    this.output.hint(`Profile: ${this.context.profile}`);
+    this.output.hint("Run `objectified tenants use <slug>` to change the active tenant.");
+  }
+}

--- a/objectified-cli/src/commands/auth/logout.ts
+++ b/objectified-cli/src/commands/auth/logout.ts
@@ -1,0 +1,88 @@
+import { Flags } from "@oclif/core";
+
+import { BaseCommand } from "../../base-command.js";
+import { revokeCliRefreshToken } from "../../lib/auth/cli-oauth.js";
+import {
+  deleteCliOAuthCredentials,
+  loadCliOAuthCredentials,
+} from "../../lib/credentials/store.js";
+import {
+  listAvailableProfileNames,
+  resolveProfileConfigBaseUrl,
+} from "../../lib/cli-context.js";
+
+export default class AuthLogout extends BaseCommand {
+  static description =
+    "Revoke CLI refresh token at the API and remove OAuth credentials from the OS keychain.";
+
+  static examples = [
+    "<%= config.bin %> <%= command.id %>",
+    "<%= config.bin %> --profile staging <%= command.id %>",
+    "<%= config.bin %> <%= command.id %> --all-profiles",
+    "<%= config.bin %> --json <%= command.id %>",
+  ];
+
+  static seeAlso = ["auth login", "docs profiles"];
+
+  static flags = {
+    ...BaseCommand.baseFlags,
+    "all-profiles": Flags.boolean({
+      description: "Revoke and clear stored OAuth credentials for every profile in config.",
+      default: false,
+    }),
+  };
+
+  async run(): Promise<void> {
+    const flags = this.flags as Record<string, unknown>;
+    const allProfiles = Boolean(flags["all-profiles"] ?? flags.allProfiles);
+
+    const targets = allProfiles
+      ? listAvailableProfileNames(this.configDoc)
+      : [this.context.profile];
+
+    const cleared: string[] = [];
+    const revokeFailures: string[] = [];
+
+    for (const profile of targets) {
+      const baseUrl = resolveProfileConfigBaseUrl(this.configDoc, profile);
+      const bundle = await loadCliOAuthCredentials(profile);
+      if (bundle?.refreshToken) {
+        try {
+          await revokeCliRefreshToken({
+            apiBaseUrl: baseUrl,
+            refreshToken: bundle.refreshToken,
+          });
+        } catch {
+          revokeFailures.push(profile);
+        }
+      }
+      await deleteCliOAuthCredentials(profile);
+      cleared.push(profile);
+    }
+
+    if (cleared.includes(this.context.profile)) {
+      this.apiAuth.bearer = undefined;
+    }
+
+    if (this.context.json) {
+      this.output.json({
+        ok: true,
+        cleared_profiles: cleared,
+        revoke_failed_profiles: revokeFailures,
+      });
+      return;
+    }
+
+    if (revokeFailures.length > 0) {
+      this.output.warn(
+        `Server revoke failed for profile(s): ${revokeFailures.join(", ")}; local credentials were still cleared.`,
+      );
+    }
+
+    this.output.success(
+      allProfiles
+        ? `Logged out (${String(cleared.length)} profile(s)).`
+        : `Logged out (profile: ${this.context.profile}).`,
+    );
+  }
+}

--- a/objectified-cli/src/commands/auth/logout.ts
+++ b/objectified-cli/src/commands/auth/logout.ts
@@ -44,7 +44,9 @@ export default class AuthLogout extends BaseCommand {
     const revokeFailures: string[] = [];
 
     for (const profile of targets) {
-      const baseUrl = resolveProfileConfigBaseUrl(this.configDoc, profile);
+      const baseUrl = allProfiles
+        ? resolveProfileConfigBaseUrl(this.configDoc, profile)
+        : this.context.baseUrl;
       const bundle = await loadCliOAuthCredentials(profile);
       if (bundle?.refreshToken) {
         try {

--- a/objectified-cli/src/lib/auth/cli-login-flow.ts
+++ b/objectified-cli/src/lib/auth/cli-login-flow.ts
@@ -76,7 +76,7 @@ export async function runCliPkceLogin(opts: RunCliPkceLoginOpts): Promise<RunCli
     } else {
       const waitForCode = lb?.waitForCode;
       if (!waitForCode) {
-        throw new Error("internal error: loopback server was not started");
+        throw new Error("internal error: browser auth flow expected a loopback server, but none was started");
       }
       opts.stdoutLine(`Opening ${opts.webLoginUrl.replace(/\?.*$/, "")} in your browser…`);
       opts.stderrLine("Waiting for browser… (Ctrl+C to cancel)");

--- a/objectified-cli/src/lib/auth/cli-login-flow.ts
+++ b/objectified-cli/src/lib/auth/cli-login-flow.ts
@@ -1,0 +1,104 @@
+import open from "open";
+
+import type { CliOAuthBundle } from "../credentials/store.js";
+import {
+  buildWebLoginUrl,
+  CLI_LOGIN_BROWSER_TIMEOUT_MS,
+  displayIdentityFromAccessToken,
+  exchangeCliAuthorizationCode,
+  generateCodeVerifier,
+  codeChallengeS256,
+  readAuthorizationCodeFromStdin,
+  shouldOpenBrowser,
+  startLoopbackOAuthServer,
+  withTimeout,
+} from "./cli-oauth.js";
+
+export type RunCliPkceLoginOpts = {
+  apiBaseUrl: string;
+  webLoginUrl: string;
+  noBrowserFlag: boolean;
+  signal?: AbortSignal;
+  fetchImpl?: typeof fetch;
+  /** When false, skip launching the browser (still uses loopback unless manual-code path). */
+  openBrowser: boolean;
+  stdoutLine: (line: string) => void;
+  stderrLine: (line: string) => void;
+  openUrl?: (url: string) => Promise<unknown>;
+  /**
+   * Test-only: skip browser/stdin and use this authorization code (still uses PKCE verifier + redirect_uri).
+   * @internal
+   */
+  testAuthorizationCode?: string;
+};
+
+export type RunCliPkceLoginResult = CliOAuthBundle & {
+  displayEmail?: string;
+};
+
+/**
+ * PKCE login: loopback redirect_uri, optional browser launch, token exchange.
+ * Headless / `--no-browser`: prints URL and reads the authorization code from stdin (loopback closed).
+ */
+export async function runCliPkceLogin(opts: RunCliPkceLoginOpts): Promise<RunCliPkceLoginResult> {
+  const verifier = generateCodeVerifier();
+  if (verifier.length < 43) {
+    throw new Error("internal error: code verifier too short");
+  }
+  const challenge = codeChallengeS256(verifier);
+
+  const lb = await startLoopbackOAuthServer();
+  const redirectUri = lb.redirectUri;
+  const loginUrl = buildWebLoginUrl({
+    webLoginUrl: opts.webLoginUrl,
+    codeChallenge: challenge,
+    redirectUri,
+  });
+
+  let code: string;
+
+  try {
+    const wantOpen = opts.openBrowser && shouldOpenBrowser(opts.noBrowserFlag);
+
+    if (opts.testAuthorizationCode !== undefined) {
+      code = opts.testAuthorizationCode;
+    } else if (!wantOpen) {
+      opts.stdoutLine(`Open this URL in your browser to sign in:\n${loginUrl}`);
+      opts.stderrLine("Waiting for authorization code on stdin… (Ctrl+C to cancel)");
+      code = await readAuthorizationCodeFromStdin();
+    } else {
+      opts.stdoutLine(`Opening ${opts.webLoginUrl.replace(/\?.*$/, "")} in your browser…`);
+      opts.stderrLine("Waiting for browser… (Ctrl+C to cancel)");
+      const opener = opts.openUrl ?? ((url: string) => open(url));
+      await opener(loginUrl);
+      code = await withTimeout(
+        lb.waitForCode,
+        CLI_LOGIN_BROWSER_TIMEOUT_MS,
+        "Waiting for browser login",
+        opts.signal,
+      );
+    }
+  } finally {
+    try {
+      await lb.close();
+    } catch {
+      /* ignore double-close */
+    }
+  }
+
+  const tokens = await exchangeCliAuthorizationCode({
+    apiBaseUrl: opts.apiBaseUrl,
+    code,
+    redirectUri,
+    codeVerifier: verifier,
+    fetchImpl: opts.fetchImpl,
+  });
+
+  const displayEmail = displayIdentityFromAccessToken(tokens.access_token);
+
+  return {
+    accessToken: tokens.access_token,
+    refreshToken: tokens.refresh_token,
+    displayEmail,
+  };
+}

--- a/objectified-cli/src/lib/auth/cli-login-flow.ts
+++ b/objectified-cli/src/lib/auth/cli-login-flow.ts
@@ -37,6 +37,14 @@ export type RunCliPkceLoginResult = CliOAuthBundle & {
   displayEmail?: string;
 };
 
+function shouldUseLoopbackBrowserFlow(opts: RunCliPkceLoginOpts): boolean {
+  return (
+    opts.testAuthorizationCode === undefined &&
+    opts.openBrowser &&
+    (opts.openUrl !== undefined || shouldOpenBrowser(opts.noBrowserFlag))
+  );
+}
+
 /**
  * PKCE login: loopback redirect_uri, optional browser launch, token exchange.
  * Headless / `--no-browser`: prints URL and reads the authorization code from stdin.
@@ -47,10 +55,7 @@ export async function runCliPkceLogin(opts: RunCliPkceLoginOpts): Promise<RunCli
     throw new Error("internal error: code verifier too short");
   }
   const challenge = codeChallengeS256(verifier);
-  const wantOpen =
-    opts.testAuthorizationCode === undefined &&
-    opts.openBrowser &&
-    (opts.openUrl !== undefined || shouldOpenBrowser(opts.noBrowserFlag));
+  const wantOpen = shouldUseLoopbackBrowserFlow(opts);
   const lb = wantOpen ? await startLoopbackOAuthServer() : undefined;
   const redirectUri = lb?.redirectUri ?? (await reserveLoopbackRedirectUri());
   const loginUrl = buildWebLoginUrl({

--- a/objectified-cli/src/lib/auth/cli-login-flow.ts
+++ b/objectified-cli/src/lib/auth/cli-login-flow.ts
@@ -9,6 +9,7 @@ import {
   generateCodeVerifier,
   codeChallengeS256,
   readAuthorizationCodeFromStdin,
+  reserveLoopbackRedirectUri,
   shouldOpenBrowser,
   startLoopbackOAuthServer,
   withTimeout,
@@ -38,7 +39,7 @@ export type RunCliPkceLoginResult = CliOAuthBundle & {
 
 /**
  * PKCE login: loopback redirect_uri, optional browser launch, token exchange.
- * Headless / `--no-browser`: prints URL and reads the authorization code from stdin (loopback closed).
+ * Headless / `--no-browser`: prints URL and reads the authorization code from stdin.
  */
 export async function runCliPkceLogin(opts: RunCliPkceLoginOpts): Promise<RunCliPkceLoginResult> {
   const verifier = generateCodeVerifier();
@@ -46,9 +47,12 @@ export async function runCliPkceLogin(opts: RunCliPkceLoginOpts): Promise<RunCli
     throw new Error("internal error: code verifier too short");
   }
   const challenge = codeChallengeS256(verifier);
-
-  const lb = await startLoopbackOAuthServer();
-  const redirectUri = lb.redirectUri;
+  const wantOpen =
+    opts.testAuthorizationCode === undefined &&
+    opts.openBrowser &&
+    (opts.openUrl !== undefined || shouldOpenBrowser(opts.noBrowserFlag));
+  const lb = wantOpen ? await startLoopbackOAuthServer() : undefined;
+  const redirectUri = lb?.redirectUri ?? (await reserveLoopbackRedirectUri());
   const loginUrl = buildWebLoginUrl({
     webLoginUrl: opts.webLoginUrl,
     codeChallenge: challenge,
@@ -58,8 +62,6 @@ export async function runCliPkceLogin(opts: RunCliPkceLoginOpts): Promise<RunCli
   let code: string;
 
   try {
-    const wantOpen = opts.openBrowser && shouldOpenBrowser(opts.noBrowserFlag);
-
     if (opts.testAuthorizationCode !== undefined) {
       code = opts.testAuthorizationCode;
     } else if (!wantOpen) {
@@ -67,22 +69,28 @@ export async function runCliPkceLogin(opts: RunCliPkceLoginOpts): Promise<RunCli
       opts.stderrLine("Waiting for authorization code on stdin… (Ctrl+C to cancel)");
       code = await readAuthorizationCodeFromStdin();
     } else {
+      const waitForCode = lb?.waitForCode;
+      if (!waitForCode) {
+        throw new Error("internal error: loopback server was not started");
+      }
       opts.stdoutLine(`Opening ${opts.webLoginUrl.replace(/\?.*$/, "")} in your browser…`);
       opts.stderrLine("Waiting for browser… (Ctrl+C to cancel)");
       const opener = opts.openUrl ?? ((url: string) => open(url));
       await opener(loginUrl);
       code = await withTimeout(
-        lb.waitForCode,
+        waitForCode,
         CLI_LOGIN_BROWSER_TIMEOUT_MS,
         "Waiting for browser login",
         opts.signal,
       );
     }
   } finally {
-    try {
-      await lb.close();
-    } catch {
-      /* ignore double-close */
+    if (lb) {
+      try {
+        await lb.close();
+      } catch {
+        /* ignore double-close */
+      }
     }
   }
 

--- a/objectified-cli/src/lib/auth/cli-oauth.ts
+++ b/objectified-cli/src/lib/auth/cli-oauth.ts
@@ -2,6 +2,7 @@ import { createHash, randomBytes } from "node:crypto";
 import { createServer } from "node:http";
 import type { AddressInfo } from "node:net";
 import readline from "node:readline";
+import type { Readable, Writable } from "node:stream";
 import { URL } from "node:url";
 
 import { CliError, ObjectifiedCliError } from "../errors.js";
@@ -51,11 +52,18 @@ export function shouldOpenBrowser(noBrowserFlag: boolean): boolean {
   return true;
 }
 
-export async function readAuthorizationCodeFromStdin(): Promise<string> {
-  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+export async function readAuthorizationCodeFromStdin(opts: {
+  input?: Readable;
+  output?: Writable;
+  prompt?: string;
+} = {}): Promise<string> {
+  const rl = readline.createInterface({
+    input: opts.input ?? process.stdin,
+    output: opts.output ?? process.stderr,
+  });
   try {
     const line: string = await new Promise((resolve, reject) => {
-      rl.question("Paste authorization code: ", (answer) => {
+      rl.question(opts.prompt ?? "Paste authorization code: ", (answer) => {
         resolve(answer);
       });
       rl.on("SIGINT", () => {
@@ -80,6 +88,30 @@ export type LoopbackServer = {
   waitForCode: Promise<string>;
   close: () => Promise<void>;
 };
+
+/** Reserves an ephemeral loopback redirect URI without keeping a listener open. */
+export async function reserveLoopbackRedirectUri(): Promise<string> {
+  const server = createServer();
+  await new Promise<void>((resolveListen, rejectListen) => {
+    server.once("error", rejectListen);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", rejectListen);
+      resolveListen();
+    });
+  });
+
+  try {
+    const addr = server.address() as AddressInfo;
+    return `http://127.0.0.1:${String(addr.port)}/`;
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((e) => {
+        if (e) reject(e);
+        else resolve();
+      });
+    });
+  }
+}
 
 /** Loopback listener on 127.0.0.1 only; OS-assigned port. */
 export async function startLoopbackOAuthServer(): Promise<LoopbackServer> {

--- a/objectified-cli/src/lib/auth/cli-oauth.ts
+++ b/objectified-cli/src/lib/auth/cli-oauth.ts
@@ -1,0 +1,319 @@
+import { createHash, randomBytes } from "node:crypto";
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import readline from "node:readline";
+import { URL } from "node:url";
+
+import { CliError, ObjectifiedCliError } from "../errors.js";
+import { EXIT_CODES } from "../exit-codes.js";
+
+export const CLI_TOKEN_PATH = "/v1/auth/cli/token";
+export const CLI_REVOKE_PATH = "/v1/auth/cli/revoke";
+
+/** Default wait for user to complete browser login (ms). */
+export const CLI_LOGIN_BROWSER_TIMEOUT_MS = 120_000;
+
+function base64UrlEncode(buf: Buffer): string {
+  return buf
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+/** RFC 7636 code verifier (≥ 43 chars); uses 64 random octets → ~86 URL-safe chars. */
+export function generateCodeVerifier(): string {
+  return base64UrlEncode(randomBytes(64));
+}
+
+export function codeChallengeS256(verifier: string): string {
+  const hash = createHash("sha256").update(verifier, "utf8").digest();
+  return base64UrlEncode(hash);
+}
+
+export function buildWebLoginUrl(opts: {
+  webLoginUrl: string;
+  codeChallenge: string;
+  redirectUri: string;
+}): string {
+  const u = new URL(opts.webLoginUrl);
+  u.searchParams.set("code_challenge", opts.codeChallenge);
+  u.searchParams.set("code_challenge_method", "S256");
+  u.searchParams.set("redirect_uri", opts.redirectUri);
+  return u.toString();
+}
+
+export function shouldOpenBrowser(noBrowserFlag: boolean): boolean {
+  if (noBrowserFlag) return false;
+  if (process.platform === "linux" || process.platform === "freebsd") {
+    return Boolean(process.env.DISPLAY?.trim());
+  }
+  return true;
+}
+
+export async function readAuthorizationCodeFromStdin(): Promise<string> {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    const line: string = await new Promise((resolve, reject) => {
+      rl.question("Paste authorization code: ", (answer) => {
+        resolve(answer);
+      });
+      rl.on("SIGINT", () => {
+        reject(new CliError("Cancelled."));
+      });
+    });
+    const code = line.trim();
+    if (!code) throw new CliError("Authorization code is empty.");
+    return code;
+  } finally {
+    rl.close();
+  }
+}
+
+function bodyHtml(message: string): string {
+  const esc = message.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  return `<!doctype html><meta charset="utf-8"><title>Objectified CLI</title><p>${esc}</p>`;
+}
+
+export type LoopbackServer = {
+  redirectUri: string;
+  waitForCode: Promise<string>;
+  close: () => Promise<void>;
+};
+
+/** Loopback listener on 127.0.0.1 only; OS-assigned port. */
+export async function startLoopbackOAuthServer(): Promise<LoopbackServer> {
+  let settled = false;
+  let resolveCode!: (code: string) => void;
+  let rejectWait!: (err: Error) => void;
+  const waitForCode = new Promise<string>((res, rej) => {
+    resolveCode = res;
+    rejectWait = rej;
+  });
+
+  const server = createServer((req, res) => {
+    try {
+      const remote = req.socket.remoteAddress ?? "";
+      const loopback =
+        remote === "127.0.0.1" || remote === "::1" || remote === "::ffff:127.0.0.1";
+      if (!loopback) {
+        res.writeHead(403, { "Content-Type": "text/plain; charset=utf-8" });
+        res.end("Forbidden");
+        return;
+      }
+
+      const url = new URL(req.url ?? "/", "http://127.0.0.1");
+
+      if (url.pathname !== "/" && url.pathname !== "") {
+        res.writeHead(404, { "Content-Type": "text/plain; charset=utf-8" });
+        res.end("Not found");
+        return;
+      }
+
+      const oauthErr = url.searchParams.get("error");
+      const oauthDesc = url.searchParams.get("error_description");
+      const code = url.searchParams.get("code");
+
+      if (oauthErr) {
+        const msg = oauthDesc ?? oauthErr;
+        res.writeHead(400, { "Content-Type": "text/html; charset=utf-8" });
+        res.end(bodyHtml(`Login failed: ${msg}`));
+        if (!settled) {
+          settled = true;
+          rejectWait(
+            new ObjectifiedCliError({
+              message: `OAuth error: ${msg}`,
+              exitCode: EXIT_CODES.NOT_AUTHENTICATED,
+              hint: "Try `objectified auth login` again.",
+            }),
+          );
+        }
+        return;
+      }
+
+      if (!code) {
+        res.writeHead(400, { "Content-Type": "text/html; charset=utf-8" });
+        res.end(bodyHtml("Missing authorization code."));
+        if (!settled) {
+          settled = true;
+          rejectWait(new CliError("Authorization callback missing code parameter."));
+        }
+        return;
+      }
+
+      res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
+      res.end(bodyHtml("You may close this window and return to the CLI."));
+      if (!settled) {
+        settled = true;
+        resolveCode(code);
+      }
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      res.writeHead(500, { "Content-Type": "text/plain; charset=utf-8" });
+      res.end("Internal error");
+      if (!settled) {
+        settled = true;
+        rejectWait(new CliError(msg));
+      }
+    }
+  });
+
+  await new Promise<void>((resolveListen, rejectListen) => {
+    server.once("error", rejectListen);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", rejectListen);
+      resolveListen();
+    });
+  });
+
+  const addr = server.address() as AddressInfo;
+  const port = addr.port;
+  const redirectUri = `http://127.0.0.1:${String(port)}/`;
+
+  const close = (): Promise<void> =>
+    new Promise((resolve, reject) => {
+      server.close((e) => {
+        if (e) reject(e);
+        else resolve();
+      });
+    });
+
+  return { redirectUri, waitForCode, close };
+}
+
+export function withTimeout<T>(
+  promise: Promise<T>,
+  ms: number,
+  label: string,
+  signal?: AbortSignal,
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const to = setTimeout(() => {
+      reject(new CliError(`${label} (timed out after ${String(ms)} ms).`));
+    }, ms);
+
+    const onAbort = (): void => {
+      clearTimeout(to);
+      reject(new CliError("Cancelled."));
+    };
+    signal?.addEventListener("abort", onAbort, { once: true });
+
+    promise.then(
+      (v) => {
+        clearTimeout(to);
+        signal?.removeEventListener("abort", onAbort);
+        resolve(v);
+      },
+      (err: unknown) => {
+        clearTimeout(to);
+        signal?.removeEventListener("abort", onAbort);
+        reject(err instanceof Error ? err : new CliError(String(err)));
+      },
+    );
+  });
+}
+
+export type TokenExchangeResponse = {
+  access_token: string;
+  refresh_token: string;
+  expires_in?: number;
+};
+
+export async function exchangeCliAuthorizationCode(opts: {
+  apiBaseUrl: string;
+  code: string;
+  redirectUri: string;
+  codeVerifier: string;
+  fetchImpl?: typeof fetch;
+}): Promise<TokenExchangeResponse> {
+  const tokenUrl = new URL(CLI_TOKEN_PATH, opts.apiBaseUrl).toString();
+  const fetchFn = opts.fetchImpl ?? globalThis.fetch;
+  const res = await fetchFn(tokenUrl, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+    body: JSON.stringify({
+      grant_type: "authorization_code",
+      code: opts.code,
+      redirect_uri: opts.redirectUri,
+      code_verifier: opts.codeVerifier,
+    }),
+  });
+
+  const rawText = await res.text();
+  if (!res.ok) {
+    throw new ObjectifiedCliError({
+      message: `Token exchange failed (${String(res.status)}): ${rawText.slice(0, 800)}`,
+      exitCode: EXIT_CODES.NOT_AUTHENTICATED,
+      hint: "Verify base URL and try `objectified auth login` again.",
+    });
+  }
+
+  let body: unknown;
+  try {
+    body = JSON.parse(rawText) as unknown;
+  } catch {
+    throw new CliError("Token exchange returned invalid JSON.");
+  }
+
+  if (
+    !body ||
+    typeof body !== "object" ||
+    typeof (body as TokenExchangeResponse).access_token !== "string" ||
+    typeof (body as TokenExchangeResponse).refresh_token !== "string"
+  ) {
+    throw new CliError("Token exchange response missing access_token or refresh_token.");
+  }
+
+  return body as TokenExchangeResponse;
+}
+
+export async function revokeCliRefreshToken(opts: {
+  apiBaseUrl: string;
+  refreshToken: string;
+  fetchImpl?: typeof fetch;
+}): Promise<void> {
+  const revokeUrl = new URL(CLI_REVOKE_PATH, opts.apiBaseUrl).toString();
+  const fetchFn = opts.fetchImpl ?? globalThis.fetch;
+  const res = await fetchFn(revokeUrl, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+    body: JSON.stringify({ refresh_token: opts.refreshToken }),
+  });
+
+  if (!res.ok) {
+    const t = await res.text();
+    throw new ObjectifiedCliError({
+      message: `Token revoke failed (${String(res.status)}): ${t.slice(0, 500)}`,
+      exitCode: EXIT_CODES.NOT_AUTHENTICATED,
+    });
+  }
+}
+
+/** Best-effort JWT payload decode for display (no signature verification). */
+export function displayIdentityFromAccessToken(accessToken: string): string | undefined {
+  const parts = accessToken.split(".");
+  if (parts.length !== 3) return undefined;
+  try {
+    const payload = parts[1];
+    if (payload === undefined) return undefined;
+    const normalized = payload.replace(/-/g, "+").replace(/_/g, "/");
+    const pad = normalized.length % 4 === 0 ? "" : "=".repeat(4 - (normalized.length % 4));
+    const json = Buffer.from(normalized + pad, "base64").toString("utf8");
+    const o = JSON.parse(json) as Record<string, unknown>;
+    const email = o.email;
+    const preferred = o.preferred_username;
+    const sub = o.sub;
+    if (typeof email === "string" && email.includes("@")) return email;
+    if (typeof preferred === "string") return preferred;
+    if (typeof sub === "string") return sub;
+  } catch {
+    /* ignore */
+  }
+  return undefined;
+}

--- a/objectified-cli/src/lib/cli-context.ts
+++ b/objectified-cli/src/lib/cli-context.ts
@@ -84,6 +84,12 @@ export function resolveBaseUrl(
   return firstNonEmpty(flag, env.OBJECTIFIED_BASE_URL, cfg.baseUrl) ?? DEFAULT_BASE_URL;
 }
 
+/** Profile-layer base URL from config only (no env); used for auth revoke across profiles. */
+export function resolveProfileConfigBaseUrl(doc: ParsedTomlConfig, profileName: string): string {
+  const layer = configLayerForProfile(doc, profileName);
+  return layer.baseUrl ?? DEFAULT_BASE_URL;
+}
+
 /** API keys never come from config.toml (#3188); flag and env only until keychain lands. */
 export function resolveApiKey(
   flag: string | undefined,

--- a/objectified-cli/src/lib/constants.ts
+++ b/objectified-cli/src/lib/constants.ts
@@ -1,1 +1,4 @@
 export const DEFAULT_BASE_URL = "https://api.objectified.dev";
+
+/** Web UI entry for CLI OAuth (PKCE); opened by `objectified auth login`. */
+export const DEFAULT_CLI_WEB_LOGIN_URL = "https://app.objectified.dev/cli/login";

--- a/objectified-cli/src/lib/credentials/store.ts
+++ b/objectified-cli/src/lib/credentials/store.ts
@@ -2,6 +2,11 @@ import { ObjectifiedCliError } from "../errors.js";
 import { EXIT_CODES } from "../exit-codes.js";
 
 const SERVICE_NAME = "objectified-cli";
+type KeytarModule = {
+  setPassword: (service: string, account: string, password: string) => Promise<void>;
+  getPassword: (service: string, account: string) => Promise<string | null>;
+  deletePassword: (service: string, account: string) => Promise<boolean>;
+};
 
 export type CliOAuthBundle = {
   accessToken: string;
@@ -9,11 +14,7 @@ export type CliOAuthBundle = {
 };
 
 const memoryBackends = new Map<string, CliOAuthBundle>();
-let keytarPromise: Promise<{
-  setPassword: (service: string, account: string, password: string) => Promise<void>;
-  getPassword: (service: string, account: string) => Promise<string | null>;
-  deletePassword: (service: string, account: string) => Promise<boolean>;
-}> | null = null;
+let keytarPromise: Promise<KeytarModule> | null = null;
 
 function useMemoryBackend(): boolean {
   return process.env.OBJECTIFIED_CLI_CREDENTIAL_BACKEND === "memory";

--- a/objectified-cli/src/lib/credentials/store.ts
+++ b/objectified-cli/src/lib/credentials/store.ts
@@ -1,4 +1,5 @@
-import keytar from "keytar";
+import { ObjectifiedCliError } from "../errors.js";
+import { EXIT_CODES } from "../exit-codes.js";
 
 const SERVICE_NAME = "objectified-cli";
 
@@ -8,9 +9,37 @@ export type CliOAuthBundle = {
 };
 
 const memoryBackends = new Map<string, CliOAuthBundle>();
+let keytarPromise: Promise<{
+  setPassword: (service: string, account: string, password: string) => Promise<void>;
+  getPassword: (service: string, account: string) => Promise<string | null>;
+  deletePassword: (service: string, account: string) => Promise<boolean>;
+}> | null = null;
 
 function useMemoryBackend(): boolean {
   return process.env.OBJECTIFIED_CLI_CREDENTIAL_BACKEND === "memory";
+}
+
+function toStoredBundle(bundle: CliOAuthBundle): CliOAuthBundle {
+  return {
+    accessToken: bundle.accessToken,
+    refreshToken: bundle.refreshToken,
+  };
+}
+
+async function loadKeytar() {
+  keytarPromise ??= import("keytar")
+    .then((mod) => mod.default)
+    .catch((err: unknown) => {
+      keytarPromise = null;
+      const detail = err instanceof Error ? err.message : String(err);
+      throw new ObjectifiedCliError({
+        message: `OS keychain is unavailable for CLI credentials (${detail}).`,
+        exitCode: EXIT_CODES.GENERIC,
+        hint:
+          "Install the required system keychain libraries (for example, libsecret on Linux) or set OBJECTIFIED_CLI_CREDENTIAL_BACKEND=memory for environments without a keychain.",
+      });
+    });
+  return keytarPromise;
 }
 
 /** Test helper: clears the in-memory credential map when backend is `memory`. */
@@ -22,17 +51,20 @@ export async function saveCliOAuthCredentials(
   profile: string,
   bundle: CliOAuthBundle,
 ): Promise<void> {
+  const stored = toStoredBundle(bundle);
   if (useMemoryBackend()) {
-    memoryBackends.set(profile, bundle);
+    memoryBackends.set(profile, stored);
     return;
   }
-  await keytar.setPassword(SERVICE_NAME, profile, JSON.stringify(bundle));
+  const keytar = await loadKeytar();
+  await keytar.setPassword(SERVICE_NAME, profile, JSON.stringify(stored));
 }
 
 export async function loadCliOAuthCredentials(profile: string): Promise<CliOAuthBundle | null> {
   if (useMemoryBackend()) {
     return memoryBackends.get(profile) ?? null;
   }
+  const keytar = await loadKeytar();
   const raw = await keytar.getPassword(SERVICE_NAME, profile);
   if (raw === null) return null;
   try {
@@ -56,5 +88,6 @@ export async function deleteCliOAuthCredentials(profile: string): Promise<void> 
     memoryBackends.delete(profile);
     return;
   }
+  const keytar = await loadKeytar();
   await keytar.deletePassword(SERVICE_NAME, profile);
 }

--- a/objectified-cli/src/lib/credentials/store.ts
+++ b/objectified-cli/src/lib/credentials/store.ts
@@ -1,0 +1,60 @@
+import keytar from "keytar";
+
+const SERVICE_NAME = "objectified-cli";
+
+export type CliOAuthBundle = {
+  accessToken: string;
+  refreshToken: string;
+};
+
+const memoryBackends = new Map<string, CliOAuthBundle>();
+
+function useMemoryBackend(): boolean {
+  return process.env.OBJECTIFIED_CLI_CREDENTIAL_BACKEND === "memory";
+}
+
+/** Test helper: clears the in-memory credential map when backend is `memory`. */
+export function resetMemoryCredentialBackend(): void {
+  memoryBackends.clear();
+}
+
+export async function saveCliOAuthCredentials(
+  profile: string,
+  bundle: CliOAuthBundle,
+): Promise<void> {
+  if (useMemoryBackend()) {
+    memoryBackends.set(profile, bundle);
+    return;
+  }
+  await keytar.setPassword(SERVICE_NAME, profile, JSON.stringify(bundle));
+}
+
+export async function loadCliOAuthCredentials(profile: string): Promise<CliOAuthBundle | null> {
+  if (useMemoryBackend()) {
+    return memoryBackends.get(profile) ?? null;
+  }
+  const raw = await keytar.getPassword(SERVICE_NAME, profile);
+  if (raw === null) return null;
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (
+      !parsed ||
+      typeof parsed !== "object" ||
+      typeof (parsed as CliOAuthBundle).accessToken !== "string" ||
+      typeof (parsed as CliOAuthBundle).refreshToken !== "string"
+    ) {
+      return null;
+    }
+    return parsed as CliOAuthBundle;
+  } catch {
+    return null;
+  }
+}
+
+export async function deleteCliOAuthCredentials(profile: string): Promise<void> {
+  if (useMemoryBackend()) {
+    memoryBackends.delete(profile);
+    return;
+  }
+  await keytar.deletePassword(SERVICE_NAME, profile);
+}

--- a/objectified-cli/test/auth-cli-oauth.test.ts
+++ b/objectified-cli/test/auth-cli-oauth.test.ts
@@ -1,0 +1,188 @@
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import { describe, expect, it } from "vitest";
+
+import {
+  CLI_REVOKE_PATH,
+  CLI_TOKEN_PATH,
+  codeChallengeS256,
+  exchangeCliAuthorizationCode,
+  generateCodeVerifier,
+  revokeCliRefreshToken,
+} from "../src/lib/auth/cli-oauth.js";
+import { runCliPkceLogin } from "../src/lib/auth/cli-login-flow.js";
+import { DEFAULT_CLI_WEB_LOGIN_URL } from "../src/lib/constants.js";
+
+async function mockApiServer(handler: (req: import("node:http").IncomingMessage) => Promise<{
+  status: number;
+  body?: string;
+  contentType?: string;
+}>): Promise<{ baseUrl: string; close: () => Promise<void> }> {
+  const server = createServer((req, res) => {
+    void (async () => {
+      const out = await handler(req);
+      res.writeHead(out.status, {
+        "Content-Type": out.contentType ?? "application/json",
+      });
+      res.end(out.body ?? "");
+    })();
+  });
+  await new Promise<void>((r) => server.listen(0, "127.0.0.1", () => r()));
+  const port = (server.address() as AddressInfo).port;
+  const baseUrl = `http://127.0.0.1:${String(port)}`;
+  const close = (): Promise<void> =>
+    new Promise((resolve, reject) => server.close((e) => (e ? reject(e) : resolve())));
+  return { baseUrl, close };
+}
+
+describe("CLI OAuth / PKCE helpers", () => {
+  it("generates verifier ≥ 43 chars and S256 challenge", () => {
+    const v = generateCodeVerifier();
+    expect(v.length).toBeGreaterThanOrEqual(43);
+    const ch = codeChallengeS256(v);
+    expect(ch.length).toBeGreaterThan(0);
+    expect(ch).not.toContain("+");
+    expect(ch).not.toContain("/");
+    expect(ch).not.toContain("=");
+  });
+
+  it("exchanges authorization code via POST /v1/auth/cli/token (mock server)", async () => {
+    const { baseUrl, close } = await mockApiServer(async (req) => {
+      if (req.url?.startsWith(CLI_TOKEN_PATH) && req.method === "POST") {
+        const chunks: Buffer[] = [];
+        await new Promise<void>((resolve, reject) => {
+          req.on("data", (c: Buffer) => chunks.push(c));
+          req.on("end", () => resolve());
+          req.on("error", reject);
+        });
+        const body = JSON.parse(Buffer.concat(chunks).toString("utf8")) as Record<string, unknown>;
+        expect(body.grant_type).toBe("authorization_code");
+        expect(body.code).toBe("mock-code");
+        expect(typeof body.code_verifier).toBe("string");
+        expect(String(body.code_verifier).length).toBeGreaterThanOrEqual(43);
+        expect(body.redirect_uri).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/$/);
+        return {
+          status: 200,
+          body: JSON.stringify({
+            access_token: "access-mock",
+            refresh_token: "refresh-mock",
+            expires_in: 3600,
+          }),
+        };
+      }
+      return { status: 404, body: "not found", contentType: "text/plain" };
+    });
+
+    try {
+      const tokens = await exchangeCliAuthorizationCode({
+        apiBaseUrl: baseUrl,
+        code: "mock-code",
+        redirectUri: "http://127.0.0.1:54321/",
+        codeVerifier: generateCodeVerifier(),
+      });
+      expect(tokens.access_token).toBe("access-mock");
+      expect(tokens.refresh_token).toBe("refresh-mock");
+    } finally {
+      await close();
+    }
+  });
+
+  it("revokes refresh token via POST /v1/auth/cli/revoke (mock server)", async () => {
+    const { baseUrl, close } = await mockApiServer(async (req) => {
+      if (req.url?.startsWith(CLI_REVOKE_PATH) && req.method === "POST") {
+        const chunks: Buffer[] = [];
+        await new Promise<void>((resolve, reject) => {
+          req.on("data", (c: Buffer) => chunks.push(c));
+          req.on("end", () => resolve());
+          req.on("error", reject);
+        });
+        const body = JSON.parse(Buffer.concat(chunks).toString("utf8")) as Record<string, unknown>;
+        expect(body.refresh_token).toBe("to-revoke");
+        return { status: 204, body: "" };
+      }
+      return { status: 404, body: "not found", contentType: "text/plain" };
+    });
+
+    try {
+      await revokeCliRefreshToken({ apiBaseUrl: baseUrl, refreshToken: "to-revoke" });
+    } finally {
+      await close();
+    }
+  });
+
+  it("runCliPkceLogin completes E2E against mock token URL (no browser)", async () => {
+    const { baseUrl, close } = await mockApiServer(async (req) => {
+      if (req.url?.startsWith(CLI_TOKEN_PATH) && req.method === "POST") {
+        const chunks: Buffer[] = [];
+        await new Promise<void>((resolve, reject) => {
+          req.on("data", (c: Buffer) => chunks.push(c));
+          req.on("end", () => resolve());
+          req.on("error", reject);
+        });
+        const parsed = JSON.parse(Buffer.concat(chunks).toString("utf8")) as {
+          code_verifier: string;
+        };
+        expect(parsed.code_verifier.length).toBeGreaterThanOrEqual(43);
+        return {
+          status: 200,
+          body: JSON.stringify({
+            access_token:
+              "eyJhbGciOiJIUzI1NiJ9.eyJlbWFpbCI6InRlc3RAZXhhbXBsZS5jb20ifQ.signature",
+            refresh_token: "r",
+          }),
+        };
+      }
+      return { status: 404, body: "not found", contentType: "text/plain" };
+    });
+
+    try {
+      const out = await runCliPkceLogin({
+        apiBaseUrl: baseUrl,
+        webLoginUrl: DEFAULT_CLI_WEB_LOGIN_URL,
+        noBrowserFlag: true,
+        openBrowser: true,
+        testAuthorizationCode: "from-mock-browser",
+        stdoutLine: () => {},
+        stderrLine: () => {},
+      });
+      expect(out.accessToken).toContain("eyJ");
+      expect(out.refreshToken).toBe("r");
+      expect(out.displayEmail).toBe("test@example.com");
+    } finally {
+      await close();
+    }
+  });
+
+  it("runCliPkceLogin hits loopback when openUrl triggers redirect (mock browser)", async () => {
+    const { baseUrl, close } = await mockApiServer(async (req) => {
+      if (req.url?.startsWith(CLI_TOKEN_PATH) && req.method === "POST") {
+        return {
+          status: 200,
+          body: JSON.stringify({ access_token: "a", refresh_token: "b" }),
+        };
+      }
+      return { status: 404, body: "not found", contentType: "text/plain" };
+    });
+
+    try {
+      const result = await runCliPkceLogin({
+        apiBaseUrl: baseUrl,
+        webLoginUrl: DEFAULT_CLI_WEB_LOGIN_URL,
+        noBrowserFlag: false,
+        openBrowser: true,
+        stdoutLine: () => {},
+        stderrLine: () => {},
+        openUrl: async (loginUrl) => {
+          const u = new URL(loginUrl);
+          const redirect = u.searchParams.get("redirect_uri");
+          expect(redirect).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/$/);
+          const r = await fetch(`${redirect}?code=loopback-code`);
+          expect(r.ok).toBe(true);
+        },
+      });
+      expect(result.accessToken).toBe("a");
+    } finally {
+      await close();
+    }
+  });
+});

--- a/objectified-cli/test/auth-cli-oauth.test.ts
+++ b/objectified-cli/test/auth-cli-oauth.test.ts
@@ -1,5 +1,6 @@
 import { createServer } from "node:http";
 import type { AddressInfo } from "node:net";
+import { PassThrough } from "node:stream";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -8,6 +9,8 @@ import {
   codeChallengeS256,
   exchangeCliAuthorizationCode,
   generateCodeVerifier,
+  readAuthorizationCodeFromStdin,
+  reserveLoopbackRedirectUri,
   revokeCliRefreshToken,
 } from "../src/lib/auth/cli-oauth.js";
 import { runCliPkceLogin } from "../src/lib/auth/cli-login-flow.js";
@@ -108,6 +111,25 @@ describe("CLI OAuth / PKCE helpers", () => {
     } finally {
       await close();
     }
+  });
+
+  it("reads the authorization code while prompting on stderr", async () => {
+    const input = new PassThrough();
+    const output = new PassThrough();
+    const written: Buffer[] = [];
+    output.on("data", (chunk: Buffer | string) => {
+      written.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    });
+
+    input.end("  from-stdin  \n");
+
+    await expect(readAuthorizationCodeFromStdin({ input, output })).resolves.toBe("from-stdin");
+    expect(Buffer.concat(written).toString("utf8")).toContain("Paste authorization code: ");
+  });
+
+  it("reserves a manual redirect URI without keeping the loopback port open", async () => {
+    const redirectUri = await reserveLoopbackRedirectUri();
+    await expect(fetch(redirectUri)).rejects.toThrow();
   });
 
   it("runCliPkceLogin completes E2E against mock token URL (no browser)", async () => {

--- a/objectified-cli/test/cli.integration.test.ts
+++ b/objectified-cli/test/cli.integration.test.ts
@@ -121,6 +121,12 @@ describe("objectified CLI", () => {
     expect(out).toMatch(/\bAUTH\b/);
   });
 
+  it("auth login help lists PKCE login and --no-browser", () => {
+    const out = run(["auth", "login", "--help"]);
+    expect(out).toMatch(/PKCE/i);
+    expect(out).toMatch(/--no-browser/);
+  });
+
   it("unknown command suggests typo fix when close match", () => {
     const err = runExpectFailure(["helol"]);
     expect(err).toMatch(/Unknown command/);

--- a/objectified-cli/test/credentials-store.test.ts
+++ b/objectified-cli/test/credentials-store.test.ts
@@ -16,13 +16,16 @@ describe("CLI credential store", () => {
     } = await import("../src/lib/credentials/store.js");
 
     resetMemoryCredentialBackend();
+    const bundleWithDisplayEmail: Parameters<typeof saveCliOAuthCredentials>[1] & {
+      displayEmail: string;
+    } = {
+      accessToken: "access",
+      refreshToken: "refresh",
+      displayEmail: "user@example.com",
+    };
     await saveCliOAuthCredentials(
       "default",
-      {
-        accessToken: "access",
-        refreshToken: "refresh",
-        displayEmail: "user@example.com",
-      } as unknown as Parameters<typeof saveCliOAuthCredentials>[1],
+      bundleWithDisplayEmail,
     );
 
     await expect(loadCliOAuthCredentials("default")).resolves.toEqual({

--- a/objectified-cli/test/credentials-store.test.ts
+++ b/objectified-cli/test/credentials-store.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+afterEach(() => {
+  delete process.env.OBJECTIFIED_CLI_CREDENTIAL_BACKEND;
+  vi.resetModules();
+  vi.doUnmock("keytar");
+});
+
+describe("CLI credential store", () => {
+  it("stores only oauth tokens in the memory backend", async () => {
+    process.env.OBJECTIFIED_CLI_CREDENTIAL_BACKEND = "memory";
+    const {
+      loadCliOAuthCredentials,
+      resetMemoryCredentialBackend,
+      saveCliOAuthCredentials,
+    } = await import("../src/lib/credentials/store.js");
+
+    resetMemoryCredentialBackend();
+    await saveCliOAuthCredentials(
+      "default",
+      {
+        accessToken: "access",
+        refreshToken: "refresh",
+        displayEmail: "user@example.com",
+      } as unknown as Parameters<typeof saveCliOAuthCredentials>[1],
+    );
+
+    await expect(loadCliOAuthCredentials("default")).resolves.toEqual({
+      accessToken: "access",
+      refreshToken: "refresh",
+    });
+  });
+
+  it("wraps keytar load failures with an actionable error", async () => {
+    vi.doMock("keytar", () => {
+      throw new Error("libsecret missing");
+    });
+
+    const { saveCliOAuthCredentials } = await import("../src/lib/credentials/store.js");
+
+    await expect(
+      saveCliOAuthCredentials("default", {
+        accessToken: "access",
+        refreshToken: "refresh",
+      }),
+    ).rejects.toMatchObject({
+      name: "ObjectifiedCliError",
+      message: expect.stringContaining("OS keychain is unavailable for CLI credentials"),
+      hint: expect.stringContaining("OBJECTIFIED_CLI_CREDENTIAL_BACKEND=memory"),
+    });
+  });
+});

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.92",
+  "version": "0.11.93",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -8,6 +8,7 @@ We continue to improve the platform based on your feedback with improvements and
 - MCP service is now live
 
 ## CLI
+- **`objectified-cli`**: `objectified auth login` (PKCE loopback + browser or `--no-browser` / headless stdin code) and `objectified auth logout` (`--all-profiles`); tokens stored per profile in the OS keychain via `keytar`, bearer hydration for API calls (#3194).
 - **`objectified-cli`**: `objectified completion install|show|uninstall` for bash, zsh, fish, and PowerShell; manifest-backed static completions plus REST-backed suggestions cached five minutes under `~/.cache/objectified/completion/` (#3193).
 - **`objectified-cli`**: rich `--help` (≥2 examples per command, flag groups **COMMON** / **OUTPUT** / **AUTH**, **SEE ALSO** links), `objectified docs` topic browser + prose topics, troff **man** pages under `man/man1/`, `oclif readme`-synced **README.md**, and CI guard for generated artifacts (#3192).
 - **`objectified-cli`**: shared error layer (`ObjectifiedCliError`, documented exit codes via `objectified docs errors`, stderr template with hints + request-id, `--verbose` / `OBJECTIFIED_DEBUG=1` stacks only), Levenshtein did-you-mean for unknown commands, HTTP status → exit-code mapping, and fetch retries per idempotent vs non-idempotent verbs (#3191).

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
   ],
   "packageManager": "yarn@4.12.0",
   "resolutions": {
+    "semver@npm:6.3.1": "npm:semver@7.7.4",
+    "semver": "^7.6.3",
     "@testing-library/dom/pretty-format": "30.3.0",
     "ansi-regex": "5.0.1",
     "string-width": "4.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7323,6 +7323,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"base64-js@npm:^1.3.1":
+  version: 1.5.1
+  resolution: "base64-js@npm:1.5.1"
+  checksum: 10c0/f23823513b63173a001030fae4f2dabe283b99a9d324ade3ad3d148e218134676f1ee8568c877cd79ec1c53158dcf2d2ba527a97c606618928ba99dd930102bf
+  languageName: node
+  linkType: hard
+
 "baseline-browser-mapping@npm:^2.10.19, baseline-browser-mapping@npm:^2.8.19, baseline-browser-mapping@npm:^2.9.19":
   version: 2.10.20
   resolution: "baseline-browser-mapping@npm:2.10.20"
@@ -7340,6 +7347,17 @@ __metadata:
     node-gyp: "npm:latest"
     node-gyp-build: "npm:^4.8.4"
   checksum: 10c0/006e69d4b3f0f021051fa9d998a768721a51dde28e7848e3e775ab608ba3476b25fa9262a7082ececbb0d493b0b6ca83673a6f3810b114fe90ec1bc6ae4b35b2
+  languageName: node
+  linkType: hard
+
+"bl@npm:^4.0.3":
+  version: 4.1.0
+  resolution: "bl@npm:4.1.0"
+  dependencies:
+    buffer: "npm:^5.5.0"
+    inherits: "npm:^2.0.4"
+    readable-stream: "npm:^3.4.0"
+  checksum: 10c0/02847e1d2cb089c9dc6958add42e3cdeaf07d13f575973963335ac0fdece563a50ac770ac4c8fa06492d2dd276f6cc3b7f08c7cd9c7a7ad0f8d388b2a28def5f
   languageName: node
   linkType: hard
 
@@ -7431,6 +7449,16 @@ __metadata:
   version: 1.1.2
   resolution: "buffer-from@npm:1.1.2"
   checksum: 10c0/124fff9d66d691a86d3b062eff4663fe437a9d9ee4b47b1b9e97f5a5d14f6d5399345db80f796827be7c95e70a8e765dd404b7c3ff3b3324f98e9b0c8826cc34
+  languageName: node
+  linkType: hard
+
+"buffer@npm:^5.5.0":
+  version: 5.7.1
+  resolution: "buffer@npm:5.7.1"
+  dependencies:
+    base64-js: "npm:^1.3.1"
+    ieee754: "npm:^1.1.13"
+  checksum: 10c0/27cac81cff434ed2876058d72e7c4789d11ff1120ef32c9de48f59eab58179b66710c488987d295ae89a228f835fc66d088652dffeb8e3ba8659f80eb091d55e
   languageName: node
   linkType: hard
 
@@ -7738,6 +7766,13 @@ __metadata:
   dependencies:
     readdirp: "npm:^4.0.1"
   checksum: 10c0/a58b9df05bb452f7d105d9e7229ac82fa873741c0c40ddcc7bb82f8a909fbe3f7814c9ebe9bc9a2bef9b737c0ec6e2d699d179048ef06ad3ec46315df0ebe6ad
+  languageName: node
+  linkType: hard
+
+"chownr@npm:^1.1.1":
+  version: 1.1.4
+  resolution: "chownr@npm:1.1.4"
+  checksum: 10c0/ed57952a84cc0c802af900cf7136de643d3aba2eecb59d29344bc2f3f9bf703a301b9d84cdc71f82c3ffc9ccde831b0d92f5b45f91727d6c9da62f23aef9d9db
   languageName: node
   linkType: hard
 
@@ -8646,6 +8681,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"deep-extend@npm:^0.6.0":
+  version: 0.6.0
+  resolution: "deep-extend@npm:0.6.0"
+  checksum: 10c0/1c6b0abcdb901e13a44c7d699116d3d4279fdb261983122a3783e7273844d5f2537dc2e1c454a23fcf645917f93fbf8d07101c1d03c015a87faa662755212566
+  languageName: node
+  linkType: hard
+
 "deep-is@npm:^0.1.3":
   version: 0.1.4
   resolution: "deep-is@npm:0.1.4"
@@ -8667,7 +8709,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"default-browser@npm:^5.2.1":
+"default-browser@npm:^5.2.1, default-browser@npm:^5.4.0":
   version: 5.5.0
   resolution: "default-browser@npm:5.5.0"
   dependencies:
@@ -8750,7 +8792,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"detect-libc@npm:^2.0.3, detect-libc@npm:^2.1.2":
+"detect-libc@npm:^2.0.0, detect-libc@npm:^2.0.3, detect-libc@npm:^2.1.2":
   version: 2.1.2
   resolution: "detect-libc@npm:2.1.2"
   checksum: 10c0/acc675c29a5649fa1fb6e255f993b8ee829e510b6b56b0910666949c80c364738833417d0edb5f90e4e46be17228b0f2b66a010513984e18b15deeeac49369c4
@@ -8924,7 +8966,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"end-of-stream@npm:^1.1.0":
+"end-of-stream@npm:^1.1.0, end-of-stream@npm:^1.4.1":
   version: 1.4.5
   resolution: "end-of-stream@npm:1.4.5"
   dependencies:
@@ -9599,6 +9641,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"expand-template@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "expand-template@npm:2.0.3"
+  checksum: 10c0/1c9e7afe9acadf9d373301d27f6a47b34e89b3391b1ef38b7471d381812537ef2457e620ae7f819d2642ce9c43b189b3583813ec395e2938319abe356a9b2f51
+  languageName: node
+  linkType: hard
+
 "expect-type@npm:^1.2.1":
   version: 1.3.0
   resolution: "expect-type@npm:1.3.0"
@@ -9910,6 +9959,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fs-constants@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "fs-constants@npm:1.0.0"
+  checksum: 10c0/a0cde99085f0872f4d244e83e03a46aa387b74f5a5af750896c6b05e9077fac00e9932fdf5aef84f2f16634cd473c63037d7a512576da7d5c2b9163d1909f3a8
+  languageName: node
+  linkType: hard
+
 "fs-extra@npm:^11.3.5":
   version: 11.3.5
   resolution: "fs-extra@npm:11.3.5"
@@ -10141,6 +10197,13 @@ __metadata:
   version: 3.2.0
   resolution: "git-hooks-list@npm:3.2.0"
   checksum: 10c0/6fdbc727da8e5a6fd9be47b40dd896db3a5c38196a3a52d2f0ed66fe28a6e0df50128b6e674d52b04fa5932a395b693441da9c0cfa7df16f1eff83aee042b127
+  languageName: node
+  linkType: hard
+
+"github-from-package@npm:0.0.0":
+  version: 0.0.0
+  resolution: "github-from-package@npm:0.0.0"
+  checksum: 10c0/737ee3f52d0a27e26332cde85b533c21fcdc0b09fb716c3f8e522cfaa9c600d4a631dec9fcde179ec9d47cca89017b7848ed4d6ae6b6b78f936c06825b1fcc12
   languageName: node
   linkType: hard
 
@@ -10643,6 +10706,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ieee754@npm:^1.1.13":
+  version: 1.2.1
+  resolution: "ieee754@npm:1.2.1"
+  checksum: 10c0/b0782ef5e0935b9f12883a2e2aa37baa75da6e66ce6515c168697b42160807d9330de9a32ec1ed73149aea02e0d822e572bca6f1e22bdcbd2149e13b050b17bb
+  languageName: node
+  linkType: hard
+
 "ignore@npm:^5.2.0":
   version: 5.3.2
   resolution: "ignore@npm:5.3.2"
@@ -10703,14 +10773,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"inherits@npm:2":
+"inherits@npm:2, inherits@npm:^2.0.3, inherits@npm:^2.0.4":
   version: 2.0.4
   resolution: "inherits@npm:2.0.4"
   checksum: 10c0/4e531f648b29039fb7426fb94075e6545faa1eb9fe83c29f0b6d9e7263aceb4289d2d4557db0d428188eeb449cc7c5e77b0a0b2c4e248ff2a65933a0dee49ef2
   languageName: node
   linkType: hard
 
-"ini@npm:^1.3.4":
+"ini@npm:^1.3.4, ini@npm:~1.3.0":
   version: 1.3.8
   resolution: "ini@npm:1.3.8"
   checksum: 10c0/ec93838d2328b619532e4f1ff05df7909760b6f66d9c9e2ded11e5c1897d6f2f9980c54dd638f88654b00919ce31e827040631eab0a3969e4d1abefa0719516a
@@ -10957,6 +11027,13 @@ __metadata:
   version: 2.0.1
   resolution: "is-hexadecimal@npm:2.0.1"
   checksum: 10c0/3eb60fe2f1e2bbc760b927dcad4d51eaa0c60138cf7fc671803f66353ad90c301605b502c7ea4c6bb0548e1c7e79dfd37b73b632652e3b76030bba603a7e9626
+  languageName: node
+  linkType: hard
+
+"is-in-ssh@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "is-in-ssh@npm:1.0.0"
+  checksum: 10c0/fbb4c25d85c543df09997fbe7aeca410ae0c839c5825bba2d4c672df765e9ce0e7558e781b371c0a21d6ef9bbac39b31875617a68eaaea5504438d07db9a2ffa
   languageName: node
   linkType: hard
 
@@ -12056,6 +12133,17 @@ __metadata:
   bin:
     katex: cli.js
   checksum: 10c0/f5f9a8c9f422c8f798081cc3483d44f112d75f65968a643572d9cfa910b9ebcf47f3563111764b91b9298f32776dfc04ebaf950f515ff3f406f058a0b9a33c9a
+  languageName: node
+  linkType: hard
+
+"keytar@npm:^7.9.0":
+  version: 7.9.0
+  resolution: "keytar@npm:7.9.0"
+  dependencies:
+    node-addon-api: "npm:^4.3.0"
+    node-gyp: "npm:latest"
+    prebuild-install: "npm:^7.0.1"
+  checksum: 10c0/a3f987ffc82b8c028c59451f9e50f71620b5455d9d356564d9c825df5bc36c47661caf21df0026795a5fbe0013c18c8e4bedff4da34bb20c9683ef20b685fee3
   languageName: node
   linkType: hard
 
@@ -13201,7 +13289,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimist@npm:^1.2.0, minimist@npm:^1.2.5, minimist@npm:^1.2.6, minimist@npm:^1.2.8":
+"minimist@npm:^1.2.0, minimist@npm:^1.2.3, minimist@npm:^1.2.5, minimist@npm:^1.2.6, minimist@npm:^1.2.8":
   version: 1.2.8
   resolution: "minimist@npm:1.2.8"
   checksum: 10c0/19d3fcdca050087b84c2029841a093691a91259a47def2f18222f41e7645a0b7c44ef4b40e88a1e58a40c84d2ef0ee6047c55594d298146d0eb3f6b737c20ce6
@@ -13247,6 +13335,13 @@ __metadata:
   dependencies:
     minipass: "npm:^7.1.2"
   checksum: 10c0/5aad75ab0090b8266069c9aabe582c021ae53eb33c6c691054a13a45db3b4f91a7fb1bd79151e6b4e9e9a86727b522527c0a06ec7d45206b745d54cd3097bcec
+  languageName: node
+  linkType: hard
+
+"mkdirp-classic@npm:^0.5.2, mkdirp-classic@npm:^0.5.3":
+  version: 0.5.3
+  resolution: "mkdirp-classic@npm:0.5.3"
+  checksum: 10c0/95371d831d196960ddc3833cc6907e6b8f67ac5501a6582f47dfae5eb0f092e9f8ce88e0d83afcae95d6e2b61a01741ba03714eeafb6f7a6e9dcc158ac85b168
   languageName: node
   linkType: hard
 
@@ -13366,6 +13461,13 @@ __metadata:
   bin:
     nanoid: bin/nanoid.cjs
   checksum: 10c0/40e7f70b3d15f725ca072dfc4f74e81fcf1fbb02e491cf58ac0c79093adc9b0a73b152bcde57df4b79cd097e13023d7504acb38404a4da7bc1cd8e887b82fe0b
+  languageName: node
+  linkType: hard
+
+"napi-build-utils@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "napi-build-utils@npm:2.0.0"
+  checksum: 10c0/5833aaeb5cc5c173da47a102efa4680a95842c13e0d9cc70428bd3ee8d96bb2172f8860d2811799b5daa5cbeda779933601492a2028a6a5351c6d0fcf6de83db
   languageName: node
   linkType: hard
 
@@ -13504,6 +13606,24 @@ __metadata:
     lower-case: "npm:^2.0.2"
     tslib: "npm:^2.0.3"
   checksum: 10c0/8ef545f0b3f8677c848f86ecbd42ca0ff3cd9dd71c158527b344c69ba14710d816d8489c746b6ca225e7b615108938a0bda0a54706f8c255933703ac1cf8e703
+  languageName: node
+  linkType: hard
+
+"node-abi@npm:^3.3.0":
+  version: 3.92.0
+  resolution: "node-abi@npm:3.92.0"
+  dependencies:
+    semver: "npm:^7.3.5"
+  checksum: 10c0/d5fe063701542e1beef9017251b64dd648db200ae8d76745ddd07d475504734066ee69966609322ed4842a3b2f20cd3fbb0e1d2e675e3c25ff925d1e20fd06be
+  languageName: node
+  linkType: hard
+
+"node-addon-api@npm:^4.3.0":
+  version: 4.3.0
+  resolution: "node-addon-api@npm:4.3.0"
+  dependencies:
+    node-gyp: "npm:latest"
+  checksum: 10c0/5febe94d58cdef319bc96a357b43d7a13776c93ee3f2edb374000f16454e65cec06035497947d5fdaa50db1cc7ab8e3a30ca8669bb07a1b159f0307dc2c1ccdf
   languageName: node
   linkType: hard
 
@@ -13784,8 +13904,10 @@ __metadata:
     eslint: "npm:^9.39.4"
     eslint-config-prettier: "npm:^10.1.1"
     fs-extra: "npm:^11.3.5"
+    keytar: "npm:^7.9.0"
     leven: "npm:^4.0.0"
     oclif: "npm:^4.23.0"
+    open: "npm:^11.0.0"
     ora: "npm:^9.4.0"
     prettier: "npm:^3.6.2"
     shx: "npm:^0.4.0"
@@ -14039,6 +14161,20 @@ __metadata:
     is-inside-container: "npm:^1.0.0"
     is-wsl: "npm:^3.1.0"
   checksum: 10c0/1bee796f06e549ce764f693272100323fbc04da8fa3c5b0402d6c2d11b3d76fa0aac0be7535e710015ff035326638e3b9a563f3b0e7ac3266473ed5663caae6d
+  languageName: node
+  linkType: hard
+
+"open@npm:^11.0.0":
+  version: 11.0.0
+  resolution: "open@npm:11.0.0"
+  dependencies:
+    default-browser: "npm:^5.4.0"
+    define-lazy-prop: "npm:^3.0.0"
+    is-in-ssh: "npm:^1.0.0"
+    is-inside-container: "npm:^1.0.0"
+    powershell-utils: "npm:^0.1.0"
+    wsl-utils: "npm:^0.3.0"
+  checksum: 10c0/7aeeda4131268ed90f90e7728dda5c46bb0c6205b27a4be3e86ea33593e30dd393423e20e31c00802a8e635ef59becaee33ef9749a8ceb027567cd253e9e7b1e
   languageName: node
   linkType: hard
 
@@ -14588,6 +14724,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"powershell-utils@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "powershell-utils@npm:0.1.0"
+  checksum: 10c0/a64713cf3583259c9ed6be211c06b4b19e8608bcb0f7f6287ffac0a95b8c7582b6b662eea0e201fd659492c8e9f9c5fd0bfc4579645c5add9c1a600075621c95
+  languageName: node
+  linkType: hard
+
 "preact-render-to-string@npm:^5.1.19":
   version: 5.2.6
   resolution: "preact-render-to-string@npm:5.2.6"
@@ -14603,6 +14746,28 @@ __metadata:
   version: 10.27.2
   resolution: "preact@npm:10.27.2"
   checksum: 10c0/951b708f7afa34391e054b0f1026430e8f5f6d5de24020beef70288e17067e473b9ee5503a994e0a80ced014826f56708fea5902f80346432c22dfcf3dff4be7
+  languageName: node
+  linkType: hard
+
+"prebuild-install@npm:^7.0.1":
+  version: 7.1.3
+  resolution: "prebuild-install@npm:7.1.3"
+  dependencies:
+    detect-libc: "npm:^2.0.0"
+    expand-template: "npm:^2.0.3"
+    github-from-package: "npm:0.0.0"
+    minimist: "npm:^1.2.3"
+    mkdirp-classic: "npm:^0.5.3"
+    napi-build-utils: "npm:^2.0.0"
+    node-abi: "npm:^3.3.0"
+    pump: "npm:^3.0.0"
+    rc: "npm:^1.2.7"
+    simple-get: "npm:^4.0.0"
+    tar-fs: "npm:^2.0.0"
+    tunnel-agent: "npm:^0.6.0"
+  bin:
+    prebuild-install: bin.js
+  checksum: 10c0/25919a42b52734606a4036ab492d37cfe8b601273d8dfb1fa3c84e141a0a475e7bad3ab848c741d2f810cef892fcf6059b8c7fe5b29f98d30e0c29ad009bedff
   languageName: node
   linkType: hard
 
@@ -14809,6 +14974,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"rc@npm:^1.2.7":
+  version: 1.2.8
+  resolution: "rc@npm:1.2.8"
+  dependencies:
+    deep-extend: "npm:^0.6.0"
+    ini: "npm:~1.3.0"
+    minimist: "npm:^1.2.0"
+    strip-json-comments: "npm:~2.0.1"
+  bin:
+    rc: ./cli.js
+  checksum: 10c0/24a07653150f0d9ac7168e52943cc3cb4b7a22c0e43c7dff3219977c2fdca5a2760a304a029c20811a0e79d351f57d46c9bde216193a0f73978496afc2b85b15
+  languageName: node
+  linkType: hard
+
 "react-dom@npm:^19.2.5":
   version: 19.2.5
   resolution: "react-dom@npm:19.2.5"
@@ -14920,6 +15099,17 @@ __metadata:
   version: 19.2.5
   resolution: "react@npm:19.2.5"
   checksum: 10c0/4b5f231dbef92886f602533c9ce3bde04d99f0e71dfb5d794c43e02726efaad0421c08688f75fc98a6d6e1dc017372e1af7abbfecdc86a79968f461675931a7a
+  languageName: node
+  linkType: hard
+
+"readable-stream@npm:^3.1.1, readable-stream@npm:^3.4.0":
+  version: 3.6.2
+  resolution: "readable-stream@npm:3.6.2"
+  dependencies:
+    inherits: "npm:^2.0.3"
+    string_decoder: "npm:^1.1.1"
+    util-deprecate: "npm:^1.0.1"
+  checksum: 10c0/e37be5c79c376fdd088a45fa31ea2e423e5d48854be7a22a58869b4e84d25047b193f6acb54f1012331e1bcd667ffb569c01b99d36b0bd59658fb33f513511b7
   languageName: node
   linkType: hard
 
@@ -15379,7 +15569,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"safe-buffer@npm:^5.0.1":
+"safe-buffer@npm:^5.0.1, safe-buffer@npm:~5.2.0":
   version: 5.2.1
   resolution: "safe-buffer@npm:5.2.1"
   checksum: 10c0/6501914237c0a86e9675d4e51d89ca3c21ffd6a31642efeba25ad65720bce6921c9e7e974e5be91a786b25aa058b5303285d3c15dbabf983a919f5f630d349f3
@@ -15430,39 +15620,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^5.5.0":
-  version: 5.7.2
-  resolution: "semver@npm:5.7.2"
-  bin:
-    semver: bin/semver
-  checksum: 10c0/e4cf10f86f168db772ae95d86ba65b3fd6c5967c94d97c708ccb463b778c2ee53b914cd7167620950fc07faf5a564e6efe903836639e512a1aa15fbc9667fa25
-  languageName: node
-  linkType: hard
-
-"semver@npm:^6.3.1":
-  version: 6.3.1
-  resolution: "semver@npm:6.3.1"
-  bin:
-    semver: bin/semver.js
-  checksum: 10c0/e3d79b609071caa78bcb6ce2ad81c7966a46a7431d9d58b8800cfa9cb6a63699b3899a0e4bcce36167a284578212d9ae6942b6929ba4aa5015c079a67751d42d
-  languageName: node
-  linkType: hard
-
-"semver@npm:^7.3.5, semver@npm:^7.5.3, semver@npm:^7.5.4, semver@npm:^7.7.2, semver@npm:^7.7.3, semver@npm:^7.7.4":
+"semver@npm:^7.6.3":
   version: 7.7.4
   resolution: "semver@npm:7.7.4"
   bin:
     semver: bin/semver.js
   checksum: 10c0/5215ad0234e2845d4ea5bb9d836d42b03499546ddafb12075566899fc617f68794bb6f146076b6881d755de17d6c6cc73372555879ec7dce2c2feee947866ad2
-  languageName: node
-  linkType: hard
-
-"semver@npm:^7.6.0, semver@npm:^7.7.1":
-  version: 7.7.3
-  resolution: "semver@npm:7.7.3"
-  bin:
-    semver: bin/semver.js
-  checksum: 10c0/4afe5c986567db82f44c8c6faef8fe9df2a9b1d98098fc1721f57c696c4c21cebd572f297fc21002f81889492345b8470473bc6f4aff5fb032a6ea59ea2bc45e
   languageName: node
   linkType: hard
 
@@ -15722,6 +15885,24 @@ __metadata:
   version: 4.1.0
   resolution: "signal-exit@npm:4.1.0"
   checksum: 10c0/41602dce540e46d599edba9d9860193398d135f7ff72cab629db5171516cfae628d21e7bfccde1bbfdf11c48726bc2a6d1a8fb8701125852fbfda7cf19c6aa83
+  languageName: node
+  linkType: hard
+
+"simple-concat@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "simple-concat@npm:1.0.1"
+  checksum: 10c0/62f7508e674414008910b5397c1811941d457dfa0db4fd5aa7fa0409eb02c3609608dfcd7508cace75b3a0bf67a2a77990711e32cd213d2c76f4fd12ee86d776
+  languageName: node
+  linkType: hard
+
+"simple-get@npm:^4.0.0":
+  version: 4.0.1
+  resolution: "simple-get@npm:4.0.1"
+  dependencies:
+    decompress-response: "npm:^6.0.0"
+    once: "npm:^1.3.1"
+    simple-concat: "npm:^1.0.0"
+  checksum: 10c0/b0649a581dbca741babb960423248899203165769747142033479a7dc5e77d7b0fced0253c731cd57cf21e31e4d77c9157c3069f4448d558ebc96cf9e1eebcf0
   languageName: node
   linkType: hard
 
@@ -16025,6 +16206,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"string_decoder@npm:^1.1.1":
+  version: 1.3.0
+  resolution: "string_decoder@npm:1.3.0"
+  dependencies:
+    safe-buffer: "npm:~5.2.0"
+  checksum: 10c0/810614ddb030e271cd591935dcd5956b2410dd079d64ff92a1844d6b7588bf992b3e1b69b0f4d34a3e06e0bd73046ac646b5264c1987b20d0601f81ef35d731d
+  languageName: node
+  linkType: hard
+
 "stringify-entities@npm:^4.0.0":
   version: 4.0.4
   resolution: "stringify-entities@npm:4.0.4"
@@ -16085,6 +16275,13 @@ __metadata:
   version: 3.1.1
   resolution: "strip-json-comments@npm:3.1.1"
   checksum: 10c0/9681a6257b925a7fa0f285851c0e613cc934a50661fa7bb41ca9cbbff89686bb4a0ee366e6ecedc4daafd01e83eee0720111ab294366fe7c185e935475ebcecd
+  languageName: node
+  linkType: hard
+
+"strip-json-comments@npm:~2.0.1":
+  version: 2.0.1
+  resolution: "strip-json-comments@npm:2.0.1"
+  checksum: 10c0/b509231cbdee45064ff4f9fd73609e2bcc4e84a4d508e9dd0f31f70356473fde18abfb5838c17d56fb236f5a06b102ef115438de0600b749e818a35fbbc48c43
   languageName: node
   linkType: hard
 
@@ -16234,6 +16431,31 @@ __metadata:
   version: 2.3.2
   resolution: "tapable@npm:2.3.2"
   checksum: 10c0/45ec8bd8963907f35bba875f9b3e9a5afa5ba11a9a4e4a2d7b2313d983cb2741386fd7dd3e54b13055b2be942971aac369d197e02263ec9216c59c0a8069ed7f
+  languageName: node
+  linkType: hard
+
+"tar-fs@npm:^2.0.0":
+  version: 2.1.4
+  resolution: "tar-fs@npm:2.1.4"
+  dependencies:
+    chownr: "npm:^1.1.1"
+    mkdirp-classic: "npm:^0.5.2"
+    pump: "npm:^3.0.0"
+    tar-stream: "npm:^2.1.4"
+  checksum: 10c0/decb25acdc6839182c06ec83cba6136205bda1db984e120c8ffd0d80182bc5baa1d916f9b6c5c663ea3f9975b4dd49e3c6bb7b1707cbcdaba4e76042f43ec84c
+  languageName: node
+  linkType: hard
+
+"tar-stream@npm:^2.1.4":
+  version: 2.2.0
+  resolution: "tar-stream@npm:2.2.0"
+  dependencies:
+    bl: "npm:^4.0.3"
+    end-of-stream: "npm:^1.4.1"
+    fs-constants: "npm:^1.0.0"
+    inherits: "npm:^2.0.3"
+    readable-stream: "npm:^3.1.1"
+  checksum: 10c0/2f4c910b3ee7196502e1ff015a7ba321ec6ea837667220d7bcb8d0852d51cb04b87f7ae471008a6fb8f5b1a1b5078f62f3a82d30c706f20ada1238ac797e7692
   languageName: node
   linkType: hard
 
@@ -16969,6 +17191,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"util-deprecate@npm:^1.0.1":
+  version: 1.0.2
+  resolution: "util-deprecate@npm:1.0.2"
+  checksum: 10c0/41a5bdd214df2f6c3ecf8622745e4a366c4adced864bc3c833739791aeeeb1838119af7daed4ba36428114b5c67dcda034a79c882e97e43c03e66a4dd7389942
+  languageName: node
+  linkType: hard
+
 "utrie@npm:^1.0.2":
   version: 1.0.2
   resolution: "utrie@npm:1.0.2"
@@ -17494,6 +17723,16 @@ __metadata:
     utf-8-validate:
       optional: true
   checksum: 10c0/956ac5f11738c914089b65878b9223692ace77337ba55379ae68e1ecbeae9b47a0c6eb9403688f609999a58c80d83d99865fe0029b229d308b08c1ef93d4ea14
+  languageName: node
+  linkType: hard
+
+"wsl-utils@npm:^0.3.0":
+  version: 0.3.1
+  resolution: "wsl-utils@npm:0.3.1"
+  dependencies:
+    is-wsl: "npm:^3.1.0"
+    powershell-utils: "npm:^0.1.0"
+  checksum: 10c0/b3ba99cc6b71f66457eef598d529beeb8cb57a72646877fe25993894b808c60b82f6d47df5463f0b6e54632272f62f5eaea105c12784fd09b06f500f3f53aa2e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
Implements `objectified auth login` (RFC 7636 PKCE on loopback `127.0.0.1`, browser launch via `open`, token exchange at `/v1/auth/cli/token`) and `objectified auth logout` (revoke at `/v1/auth/cli/revoke`, clear keychain). OAuth tokens are stored per profile with `keytar` (`objectified-cli` service name). `BaseCommand` hydrates `Authorization: Bearer` from the keychain when no API key or `OBJECTIFIED_ACCESS_TOKEN` is set.

Headless / CI: `--no-browser` or Linux without `DISPLAY` prints the login URL and reads the authorization code from stdin.

## How to test
- **Build**: `cd objectified-cli && yarn test`
- **Manual login**: run `objectified auth login` with a config profile whose `base_url` matches an API that implements the CLI OAuth endpoints; complete flow in the browser or use `--no-browser` and paste the code.
- **Logout**: `objectified auth logout` or `objectified auth logout --all-profiles`.

## Risks / notes
- REST OpenAPI does not yet define these endpoints; the CLI uses fixed paths `/v1/auth/cli/token` and `/v1/auth/cli/revoke` as specified in the ticket.
- Root `package.json` adds `semver@npm:6.3.1` → `semver@7.7.4` resolution so `oclif readme` resolves `semver/functions/valid` after a clean `yarn install`.
- Vitest uses `testAuthorizationCode` for mock-server E2E; use `OBJECTIFIED_CLI_CREDENTIAL_BACKEND=memory` only if you need in-memory credentials in other tooling.

Closes #3194

Made with [Cursor](https://cursor.com)