### PR TITLE
Fix #3195 - API-key auth (CLI flags, env, file, auth status)

### DIFF
--- a/docs/PLANNED_ROADMAP_CLI.md
+++ b/docs/PLANNED_ROADMAP_CLI.md
@@ -251,7 +251,6 @@ Part of Epic: CLI Foundation & DevEx (#3174)
 
 | #         | Title                                                  | Description                                                       | Labels                                                  | MVP | Parallel |
 |-----------|--------------------------------------------------------|-------------------------------------------------------------------|---------------------------------------------------------|-----|----------|
-| 2.2 (#3195) | API-key auth (`--api-key`, env, file)                | Headless / CI-friendly auth                                       | `enhancement`, `mvp`, `cli`, `roadmap-cli`, `auth`, `api-keys` | Yes | Yes (with 2.1) |
 | 2.3 (#3196) | `auth status` (whoami)                               | Show profile, base-url, tenant, user, expiry, plan                | `enhancement`, `mvp`, `cli`, `roadmap-cli`, `auth`     | Yes | Yes      |
 | 2.4 (#3197) | Secure credential storage (keytar + encrypted fallback) | OS keychain primary, AES-GCM file fallback for headless           | `enhancement`, `mvp`, `cli`, `roadmap-cli`, `auth`, `security` | Yes | No       |
 | 2.5 (#3198) | `tenants list` / `tenants info`                      | Enumerate user's tenants and inspect one                          | `enhancement`, `mvp`, `cli`, `roadmap-cli`, `tenancy`  | Yes | Yes      |
@@ -285,9 +284,9 @@ Part of Epic: Authentication & Tenant Context (#3175)
 
 ---
 
-#### 2.2 (#3195) — API-key auth
+#### 2.2 (#3195) — API-key auth — **COMPLETE**
 
-Three input methods: `--api-key <key>`, `OBJECTIFIED_API_KEY` env, `--api-key-file <path>`. Optional `auth login --api-key` persists into keychain. API key wins over OAuth token when both present (matches AWS / GitHub CLI).
+Landed: global `--api-key` / `OBJECTIFIED_API_KEY` (oclif `env`) / `--api-key-file`; API key wins over bearer when both are available; `objectified auth login --api-key` stores keys in the OS keychain per profile (memory backend in tests); `objectified auth status` reports credential kind; verbose logs redact keys as `sk_***`; HTTP 401 after sending credentials maps to exit **4**, missing credentials to exit **3**; integration tests exercise `X-API-Key` against a loopback stub.
 
 **Acceptance Criteria:** key never echoed in logs (redacted as `sk_***`); never persisted unless explicit `auth login --api-key`; `auth status` indicates auth type.
 
@@ -772,11 +771,11 @@ The `NPM_REGISTRY` env var lets us point at npmjs.com, GitHub Packages, JFrog Ar
 
 ## MVP Release — Ticket Bundle
 
-The MVP delivers an installable, useful CLI focused on _read_ and _publish_ for a single project's lifecycle. Total: **19 open sub-tickets** across 5 epics (plus completed foundation items such as #3186, #3187, #3188, #3189, #3190, #3191, #3192, #3193, and #3194).
+The MVP delivers an installable, useful CLI focused on _read_ and _publish_ for a single project's lifecycle. Total: **18 open sub-tickets** across 5 epics (plus completed foundation items such as #3186, #3187, #3188, #3189, #3190, #3191, #3192, #3193, #3194, and #3195).
 
 | Epic     | Tickets                                                                                                   | Count |
 |----------|-----------------------------------------------------------------------------------------------------------|-------|
-| 2 (#3175) | #3195, #3196, #3197, #3198, #3199                                                                         | 5     |
+| 2 (#3175) | #3196, #3197, #3198, #3199                                                                                | 4     |
 | 3 (#3176) | #3202, #3203, #3204                                                                                        | 3     |
 | 4 (#3177) | #3208, #3209, #3210, #3212                                                                                | 4     |
 | 9 (#3182) | #3244, #3245, #3246, #3247, #3248                                                                          | 5     |
@@ -864,7 +863,7 @@ v2 fills out the writable surface for primitives, properties, classes, paths, da
 The tickets were created in the order below — that is also the recommended **execution** order. Earlier epics provide primitives that later epics rely on.
 
 1. **Epic 1 — Foundation** (#3174: #3186, #3187, #3188, #3189, #3190, #3191, #3192, and #3193 landed). Without the scaffold, no other command can exist.
-2. **Epic 2 — Auth & Tenants** (#3175; #3194 shipped — continue #3195 → #3201). Required for any tenant-scoped command.
+2. **Epic 2 — Auth & Tenants** (#3175; #3194 and #3195 shipped — continue #3196 → #3201). Required for any tenant-scoped command.
 3. **Epic 3 — Projects** (#3176 then #3202 → #3207). The first useful read/write surface.
 4. **Epic 4 — Versions** (#3177 then #3208 → #3216). The publish flow that makes the CLI valuable in CI.
 5. **Epic 9 — Browse & Schema Export** (#3182 then #3244 → #3252). The most-used consumer surface; lands early because it works without auth.

--- a/objectified-cli/README.md
+++ b/objectified-cli/README.md
@@ -50,7 +50,7 @@ $ npm install -g objectified-cli
 $ objectified COMMAND
 running command...
 $ objectified (--version)
-objectified-cli/0.1.8 <platform> node-v<major.minor.patch>
+objectified-cli/0.1.9 <platform> node-v<major.minor.patch>
 $ objectified --help [COMMAND]
 USAGE
   $ objectified COMMAND
@@ -63,6 +63,7 @@ USAGE
 <!-- commands -->
 * [`objectified auth login`](#objectified-auth-login)
 * [`objectified auth logout`](#objectified-auth-logout)
+* [`objectified auth status`](#objectified-auth-status)
 * [`objectified completion`](#objectified-completion)
 * [`objectified completion install [SHELL]`](#objectified-completion-install-shell)
 * [`objectified completion show [SHELL]`](#objectified-completion-show-shell)
@@ -85,15 +86,15 @@ USAGE
 
 ## `objectified auth login`
 
-Sign in via PKCE browser flow (stores tokens in the OS keychain).
+Sign in via PKCE browser flow or store an API key in the OS keychain (`--api-key`).
 
 ```
 USAGE
-  $ objectified auth login [--api-key <value>] [--base-url <value>] [--config <value>] [--json] [--color]
-    [--profile <value>] [-q] [--verbose] [--no-browser]
+  $ objectified auth login [--api-key <value>] [--api-key-file <value>] [--base-url <value>] [--config <value>]
+    [--json] [--color] [--profile <value>] [-q] [--verbose] [--no-browser]
 
 DESCRIPTION
-  Sign in via PKCE browser flow (stores tokens in the OS keychain).
+  Sign in via PKCE browser flow or store an API key in the OS keychain (`--api-key`).
 
 EXAMPLES
   $ objectified auth login
@@ -101,6 +102,10 @@ EXAMPLES
   $ objectified --profile staging auth login
 
   $ objectified auth login --no-browser
+
+  $ objectified auth login --api-key
+
+  $ objectified auth login --api-key sk_live_…
 
   $ objectified --json auth login
 
@@ -117,7 +122,9 @@ OUTPUT
       --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
 
 AUTH
-  --api-key=<value>  API key for direct authentication (bypasses login token).
+  --api-key=<value>       [env: OBJECTIFIED_API_KEY] API key for direct authentication (OBJECTIFIED_API_KEY). Not
+                          persisted unless you run `auth login --api-key`.
+  --api-key-file=<value>  Read API key from a file (single line; avoids shell history).
 
 OTHER
   --no-browser  Do not launch a browser; print the login URL and read the authorization code from stdin.
@@ -125,20 +132,22 @@ OTHER
 SEE ALSO
   objectified auth logout
 
+  objectified auth status
+
   objectified docs profiles
 ```
 
 ## `objectified auth logout`
 
-Revoke CLI refresh token at the API and remove OAuth credentials from the OS keychain.
+Revoke CLI refresh token at the API (OAuth profiles) and remove stored credentials from the OS keychain.
 
 ```
 USAGE
-  $ objectified auth logout [--api-key <value>] [--base-url <value>] [--config <value>] [--json] [--color]
-    [--profile <value>] [-q] [--verbose] [--all-profiles]
+  $ objectified auth logout [--api-key <value>] [--api-key-file <value>] [--base-url <value>] [--config <value>]
+    [--json] [--color] [--profile <value>] [-q] [--verbose] [--all-profiles]
 
 DESCRIPTION
-  Revoke CLI refresh token at the API and remove OAuth credentials from the OS keychain.
+  Revoke CLI refresh token at the API (OAuth profiles) and remove stored credentials from the OS keychain.
 
 EXAMPLES
   $ objectified auth logout
@@ -162,13 +171,61 @@ OUTPUT
       --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
 
 AUTH
-  --api-key=<value>  API key for direct authentication (bypasses login token).
+  --api-key=<value>       [env: OBJECTIFIED_API_KEY] API key for direct authentication (OBJECTIFIED_API_KEY). Not
+                          persisted unless you run `auth login --api-key`.
+  --api-key-file=<value>  Read API key from a file (single line; avoids shell history).
 
 OTHER
   --all-profiles  Revoke and clear stored OAuth credentials for every profile in config.
 
 SEE ALSO
   objectified auth login
+
+  objectified auth status
+
+  objectified docs profiles
+```
+
+## `objectified auth status`
+
+Show the active profile, base URL, and whether you are using an API key or OAuth token.
+
+```
+USAGE
+  $ objectified auth status [--api-key <value>] [--api-key-file <value>] [--base-url <value>] [--config <value>]
+    [--json] [--color] [--profile <value>] [-q] [--verbose]
+
+DESCRIPTION
+  Show the active profile, base URL, and whether you are using an API key or OAuth token.
+
+EXAMPLES
+  $ objectified auth status
+
+  $ objectified --profile staging auth status
+
+  $ objectified --json auth status
+
+COMMON
+  --base-url=<value>  Root REST API URL.
+  --config=<value>    Path to config file (default: XDG config dir / Objectified AppData on Windows — see `objectified
+                      config path`).
+  --profile=<value>   Named credentials profile (OBJECTIFIED_PROFILE); falls back to default_profile in config.
+
+OUTPUT
+  --[no-]color  Enable/disable ANSI colors (--no-color sets NO_COLOR; colors are off when stdout is not a TTY).
+      --[no-]json   Emit machine-readable JSON (OBJECTIFIED_JSON=1; auto-enabled when stdout is not a TTY).
+  -q, --quiet       Suppress non-error stdout (spinners, banners, tips).
+      --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
+
+AUTH
+  --api-key=<value>       [env: OBJECTIFIED_API_KEY] API key for direct authentication (OBJECTIFIED_API_KEY). Not
+                          persisted unless you run `auth login --api-key`.
+  --api-key-file=<value>  Read API key from a file (single line; avoids shell history).
+
+SEE ALSO
+  objectified auth login
+
+  objectified auth logout
 
   objectified docs profiles
 ```
@@ -179,8 +236,8 @@ Install or print shell completion scripts for bash, zsh, fish, or PowerShell.
 
 ```
 USAGE
-  $ objectified completion [--api-key <value>] [--base-url <value>] [--config <value>] [--json] [--color]
-    [--profile <value>] [-q] [--verbose]
+  $ objectified completion [--api-key <value>] [--api-key-file <value>] [--base-url <value>] [--config <value>]
+    [--json] [--color] [--profile <value>] [-q] [--verbose]
 
 DESCRIPTION
   Install or print shell completion scripts for bash, zsh, fish, or PowerShell.
@@ -207,7 +264,9 @@ OUTPUT
       --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
 
 AUTH
-  --api-key=<value>  API key for direct authentication (bypasses login token).
+  --api-key=<value>       [env: OBJECTIFIED_API_KEY] API key for direct authentication (OBJECTIFIED_API_KEY). Not
+                          persisted unless you run `auth login --api-key`.
+  --api-key-file=<value>  Read API key from a file (single line; avoids shell history).
 
 SEE ALSO
   objectified docs completions
@@ -223,8 +282,8 @@ Append shell completion glue to the right startup file for your shell.
 
 ```
 USAGE
-  $ objectified completion install [SHELL] [--api-key <value>] [--base-url <value>] [--config <value>] [--json]
-    [--color] [--profile <value>] [-q] [--verbose]
+  $ objectified completion install [SHELL] [--api-key <value>] [--api-key-file <value>] [--base-url <value>] [--config
+    <value>] [--json] [--color] [--profile <value>] [-q] [--verbose]
 
 ARGUMENTS
   [SHELL]  (bash|zsh|fish|powershell) Shell to install for (default: inferred from $SHELL / OS)
@@ -252,7 +311,9 @@ OUTPUT
       --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
 
 AUTH
-  --api-key=<value>  API key for direct authentication (bypasses login token).
+  --api-key=<value>       [env: OBJECTIFIED_API_KEY] API key for direct authentication (OBJECTIFIED_API_KEY). Not
+                          persisted unless you run `auth login --api-key`.
+  --api-key-file=<value>  Read API key from a file (single line; avoids shell history).
 
 SEE ALSO
   objectified completion show
@@ -268,8 +329,8 @@ Print shell completion glue (with marker comments) to stdout.
 
 ```
 USAGE
-  $ objectified completion show [SHELL] [--api-key <value>] [--base-url <value>] [--config <value>] [--json]
-    [--color] [--profile <value>] [-q] [--verbose]
+  $ objectified completion show [SHELL] [--api-key <value>] [--api-key-file <value>] [--base-url <value>] [--config
+    <value>] [--json] [--color] [--profile <value>] [-q] [--verbose]
 
 ARGUMENTS
   [SHELL]  (bash|zsh|fish|powershell) Shell to generate
@@ -297,7 +358,9 @@ OUTPUT
       --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
 
 AUTH
-  --api-key=<value>  API key for direct authentication (bypasses login token).
+  --api-key=<value>       [env: OBJECTIFIED_API_KEY] API key for direct authentication (OBJECTIFIED_API_KEY). Not
+                          persisted unless you run `auth login --api-key`.
+  --api-key-file=<value>  Read API key from a file (single line; avoids shell history).
 
 SEE ALSO
   objectified completion install
@@ -311,8 +374,8 @@ Remove Objectified completion blocks added by `completion install`.
 
 ```
 USAGE
-  $ objectified completion uninstall [--api-key <value>] [--base-url <value>] [--config <value>] [--json] [--color]
-    [--profile <value>] [-q] [--verbose]
+  $ objectified completion uninstall [--api-key <value>] [--api-key-file <value>] [--base-url <value>] [--config <value>]
+    [--json] [--color] [--profile <value>] [-q] [--verbose]
 
 DESCRIPTION
   Remove Objectified completion blocks added by `completion install`.
@@ -335,7 +398,9 @@ OUTPUT
       --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
 
 AUTH
-  --api-key=<value>  API key for direct authentication (bypasses login token).
+  --api-key=<value>       [env: OBJECTIFIED_API_KEY] API key for direct authentication (OBJECTIFIED_API_KEY). Not
+                          persisted unless you run `auth login --api-key`.
+  --api-key-file=<value>  Read API key from a file (single line; avoids shell history).
 
 SEE ALSO
   objectified completion install
@@ -349,8 +414,8 @@ Print a single config value by dotted key
 
 ```
 USAGE
-  $ objectified config get KEY [--api-key <value>] [--base-url <value>] [--config <value>] [--json] [--color]
-    [--profile <value>] [-q] [--verbose]
+  $ objectified config get KEY [--api-key <value>] [--api-key-file <value>] [--base-url <value>] [--config
+    <value>] [--json] [--color] [--profile <value>] [-q] [--verbose]
 
 ARGUMENTS
   KEY  Dotted path (e.g. default_profile, profile.prod.base_url)
@@ -378,7 +443,9 @@ OUTPUT
       --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
 
 AUTH
-  --api-key=<value>  API key for direct authentication (bypasses login token).
+  --api-key=<value>       [env: OBJECTIFIED_API_KEY] API key for direct authentication (OBJECTIFIED_API_KEY). Not
+                          persisted unless you run `auth login --api-key`.
+  --api-key-file=<value>  Read API key from a file (single line; avoids shell history).
 
 SEE ALSO
   objectified config set
@@ -392,8 +459,8 @@ Print the entire config file (stable JSON with --json, otherwise TOML)
 
 ```
 USAGE
-  $ objectified config list [--api-key <value>] [--base-url <value>] [--config <value>] [--json] [--color]
-    [--profile <value>] [-q] [--verbose]
+  $ objectified config list [--api-key <value>] [--api-key-file <value>] [--base-url <value>] [--config <value>]
+    [--json] [--color] [--profile <value>] [-q] [--verbose]
 
 DESCRIPTION
   Print the entire config file (stable JSON with --json, otherwise TOML)
@@ -418,7 +485,9 @@ OUTPUT
       --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
 
 AUTH
-  --api-key=<value>  API key for direct authentication (bypasses login token).
+  --api-key=<value>       [env: OBJECTIFIED_API_KEY] API key for direct authentication (OBJECTIFIED_API_KEY). Not
+                          persisted unless you run `auth login --api-key`.
+  --api-key-file=<value>  Read API key from a file (single line; avoids shell history).
 
 SEE ALSO
   objectified config path
@@ -432,8 +501,8 @@ Print the resolved config.toml path
 
 ```
 USAGE
-  $ objectified config path [--api-key <value>] [--base-url <value>] [--config <value>] [--json] [--color]
-    [--profile <value>] [-q] [--verbose]
+  $ objectified config path [--api-key <value>] [--api-key-file <value>] [--base-url <value>] [--config <value>]
+    [--json] [--color] [--profile <value>] [-q] [--verbose]
 
 DESCRIPTION
   Print the resolved config.toml path
@@ -458,7 +527,9 @@ OUTPUT
       --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
 
 AUTH
-  --api-key=<value>  API key for direct authentication (bypasses login token).
+  --api-key=<value>       [env: OBJECTIFIED_API_KEY] API key for direct authentication (OBJECTIFIED_API_KEY). Not
+                          persisted unless you run `auth login --api-key`.
+  --api-key-file=<value>  Read API key from a file (single line; avoids shell history).
 
 SEE ALSO
   objectified config get
@@ -472,8 +543,8 @@ Set a config value by dotted key and persist config.toml
 
 ```
 USAGE
-  $ objectified config set KEY VALUE [--api-key <value>] [--base-url <value>] [--config <value>] [--json]
-    [--color] [--profile <value>] [-q] [--verbose]
+  $ objectified config set KEY VALUE [--api-key <value>] [--api-key-file <value>] [--base-url <value>] [--config
+    <value>] [--json] [--color] [--profile <value>] [-q] [--verbose]
 
 ARGUMENTS
   KEY    Dotted path (e.g. default_profile, profile.prod.tenant_slug)
@@ -502,7 +573,9 @@ OUTPUT
       --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
 
 AUTH
-  --api-key=<value>  API key for direct authentication (bypasses login token).
+  --api-key=<value>       [env: OBJECTIFIED_API_KEY] API key for direct authentication (OBJECTIFIED_API_KEY). Not
+                          persisted unless you run `auth login --api-key`.
+  --api-key-file=<value>  Read API key from a file (single line; avoids shell history).
 
 SEE ALSO
   objectified config get
@@ -516,8 +589,8 @@ List documentation topics (`objectified docs`) or open one with `objectified doc
 
 ```
 USAGE
-  $ objectified docs [--api-key <value>] [--base-url <value>] [--config <value>] [--json] [--color]
-    [--profile <value>] [-q] [--verbose]
+  $ objectified docs [--api-key <value>] [--api-key-file <value>] [--base-url <value>] [--config <value>]
+    [--json] [--color] [--profile <value>] [-q] [--verbose]
 
 DESCRIPTION
   List documentation topics (`objectified docs`) or open one with `objectified docs <topic>`.
@@ -542,7 +615,9 @@ OUTPUT
       --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
 
 AUTH
-  --api-key=<value>  API key for direct authentication (bypasses login token).
+  --api-key=<value>       [env: OBJECTIFIED_API_KEY] API key for direct authentication (OBJECTIFIED_API_KEY). Not
+                          persisted unless you run `auth login --api-key`.
+  --api-key-file=<value>  Read API key from a file (single line; avoids shell history).
 
 SEE ALSO
   objectified docs errors
@@ -558,8 +633,8 @@ Shell completions (install/show/uninstall, static manifest + cached REST suggest
 
 ```
 USAGE
-  $ objectified docs completions [--api-key <value>] [--base-url <value>] [--config <value>] [--json] [--color]
-    [--profile <value>] [-q] [--verbose]
+  $ objectified docs completions [--api-key <value>] [--api-key-file <value>] [--base-url <value>] [--config <value>]
+    [--json] [--color] [--profile <value>] [-q] [--verbose]
 
 DESCRIPTION
   Shell completions (install/show/uninstall, static manifest + cached REST suggestions)
@@ -584,7 +659,9 @@ OUTPUT
       --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
 
 AUTH
-  --api-key=<value>  API key for direct authentication (bypasses login token).
+  --api-key=<value>       [env: OBJECTIFIED_API_KEY] API key for direct authentication (OBJECTIFIED_API_KEY). Not
+                          persisted unless you run `auth login --api-key`.
+  --api-key-file=<value>  Read API key from a file (single line; avoids shell history).
 
 SEE ALSO
   objectified completion install
@@ -598,8 +675,8 @@ Exit codes, hints, and error-handling reference
 
 ```
 USAGE
-  $ objectified docs errors [--api-key <value>] [--base-url <value>] [--config <value>] [--json] [--color]
-    [--profile <value>] [-q] [--verbose]
+  $ objectified docs errors [--api-key <value>] [--api-key-file <value>] [--base-url <value>] [--config <value>]
+    [--json] [--color] [--profile <value>] [-q] [--verbose]
 
 DESCRIPTION
   Exit codes, hints, and error-handling reference
@@ -624,7 +701,9 @@ OUTPUT
       --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
 
 AUTH
-  --api-key=<value>  API key for direct authentication (bypasses login token).
+  --api-key=<value>       [env: OBJECTIFIED_API_KEY] API key for direct authentication (OBJECTIFIED_API_KEY). Not
+                          persisted unless you run `auth login --api-key`.
+  --api-key-file=<value>  Read API key from a file (single line; avoids shell history).
 
 SEE ALSO
   objectified docs
@@ -640,8 +719,8 @@ TTY vs JSON output, quiet mode, verbose logs, and color
 
 ```
 USAGE
-  $ objectified docs output [--api-key <value>] [--base-url <value>] [--config <value>] [--json] [--color]
-    [--profile <value>] [-q] [--verbose]
+  $ objectified docs output [--api-key <value>] [--api-key-file <value>] [--base-url <value>] [--config <value>]
+    [--json] [--color] [--profile <value>] [-q] [--verbose]
 
 DESCRIPTION
   TTY vs JSON output, quiet mode, verbose logs, and color
@@ -666,7 +745,9 @@ OUTPUT
       --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
 
 AUTH
-  --api-key=<value>  API key for direct authentication (bypasses login token).
+  --api-key=<value>       [env: OBJECTIFIED_API_KEY] API key for direct authentication (OBJECTIFIED_API_KEY). Not
+                          persisted unless you run `auth login --api-key`.
+  --api-key-file=<value>  Read API key from a file (single line; avoids shell history).
 
 SEE ALSO
   objectified docs
@@ -682,8 +763,8 @@ Future oclif plugin extensibility for Objectified
 
 ```
 USAGE
-  $ objectified docs plugins [--api-key <value>] [--base-url <value>] [--config <value>] [--json] [--color]
-    [--profile <value>] [-q] [--verbose]
+  $ objectified docs plugins [--api-key <value>] [--api-key-file <value>] [--base-url <value>] [--config <value>]
+    [--json] [--color] [--profile <value>] [-q] [--verbose]
 
 DESCRIPTION
   Future oclif plugin extensibility for Objectified
@@ -708,7 +789,9 @@ OUTPUT
       --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
 
 AUTH
-  --api-key=<value>  API key for direct authentication (bypasses login token).
+  --api-key=<value>       [env: OBJECTIFIED_API_KEY] API key for direct authentication (OBJECTIFIED_API_KEY). Not
+                          persisted unless you run `auth login --api-key`.
+  --api-key-file=<value>  Read API key from a file (single line; avoids shell history).
 
 SEE ALSO
   objectified docs
@@ -722,8 +805,8 @@ config.toml profiles, defaults, and precedence rules
 
 ```
 USAGE
-  $ objectified docs profiles [--api-key <value>] [--base-url <value>] [--config <value>] [--json] [--color]
-    [--profile <value>] [-q] [--verbose]
+  $ objectified docs profiles [--api-key <value>] [--api-key-file <value>] [--base-url <value>] [--config <value>]
+    [--json] [--color] [--profile <value>] [-q] [--verbose]
 
 DESCRIPTION
   config.toml profiles, defaults, and precedence rules
@@ -748,7 +831,9 @@ OUTPUT
       --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
 
 AUTH
-  --api-key=<value>  API key for direct authentication (bypasses login token).
+  --api-key=<value>       [env: OBJECTIFIED_API_KEY] API key for direct authentication (OBJECTIFIED_API_KEY). Not
+                          persisted unless you run `auth login --api-key`.
+  --api-key-file=<value>  Read API key from a file (single line; avoids shell history).
 
 SEE ALSO
   objectified docs
@@ -764,8 +849,8 @@ Telemetry posture and safe verbose debugging
 
 ```
 USAGE
-  $ objectified docs telemetry [--api-key <value>] [--base-url <value>] [--config <value>] [--json] [--color]
-    [--profile <value>] [-q] [--verbose]
+  $ objectified docs telemetry [--api-key <value>] [--api-key-file <value>] [--base-url <value>] [--config <value>]
+    [--json] [--color] [--profile <value>] [-q] [--verbose]
 
 DESCRIPTION
   Telemetry posture and safe verbose debugging
@@ -791,7 +876,9 @@ OUTPUT
       --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
 
 AUTH
-  --api-key=<value>  API key for direct authentication (bypasses login token).
+  --api-key=<value>       [env: OBJECTIFIED_API_KEY] API key for direct authentication (OBJECTIFIED_API_KEY). Not
+                          persisted unless you run `auth login --api-key`.
+  --api-key-file=<value>  Read API key from a file (single line; avoids shell history).
 
 SEE ALSO
   objectified docs errors
@@ -805,8 +892,8 @@ Smoke-test greeting for the Objectified CLI
 
 ```
 USAGE
-  $ objectified hello [NAME] [--api-key <value>] [--base-url <value>] [--config <value>] [--json] [--color]
-    [--profile <value>] [-q] [--verbose]
+  $ objectified hello [NAME] [--api-key <value>] [--api-key-file <value>] [--base-url <value>] [--config
+    <value>] [--json] [--color] [--profile <value>] [-q] [--verbose]
 
 ARGUMENTS
   [NAME]  Who to greet
@@ -834,7 +921,9 @@ OUTPUT
       --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
 
 AUTH
-  --api-key=<value>  API key for direct authentication (bypasses login token).
+  --api-key=<value>       [env: OBJECTIFIED_API_KEY] API key for direct authentication (OBJECTIFIED_API_KEY). Not
+                          persisted unless you run `auth login --api-key`.
+  --api-key-file=<value>  Read API key from a file (single line; avoids shell history).
 
 SEE ALSO
   objectified docs output
@@ -868,8 +957,8 @@ List Objectified projects
 
 ```
 USAGE
-  $ objectified projects list [--api-key <value>] [--base-url <value>] [--config <value>] [--json] [--color]
-    [--profile <value>] [-q] [--verbose]
+  $ objectified projects list [--api-key <value>] [--api-key-file <value>] [--base-url <value>] [--config <value>]
+    [--json] [--color] [--profile <value>] [-q] [--verbose]
 
 DESCRIPTION
   List Objectified projects
@@ -894,7 +983,9 @@ OUTPUT
       --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
 
 AUTH
-  --api-key=<value>  API key for direct authentication (bypasses login token).
+  --api-key=<value>       [env: OBJECTIFIED_API_KEY] API key for direct authentication (OBJECTIFIED_API_KEY). Not
+                          persisted unless you run `auth login --api-key`.
+  --api-key-file=<value>  Read API key from a file (single line; avoids shell history).
 
 SEE ALSO
   objectified config path

--- a/objectified-cli/bin/dev.js
+++ b/objectified-cli/bin/dev.js
@@ -5,16 +5,13 @@ import { ExitError } from "@oclif/core/errors";
 import { run } from "@oclif/core/run";
 import { settings } from "@oclif/core/settings";
 
-import { promoteLeadingGlobalFlags } from "../src/lib/normalize-argv.js";
-import {
-  formatAndReportCliFailure,
-  resolveDebugStacks,
-} from "../src/lib/handle-error.js";
+import { normalizeCliArgv } from "../src/lib/normalize-argv.js";
+import { formatAndReportCliFailure, resolveDebugStacks } from "../src/lib/handle-error.js";
 
 process.env.NODE_ENV = "development";
 settings.debug = true;
 
-const argv = promoteLeadingGlobalFlags(process.argv.slice(2));
+const argv = normalizeCliArgv(process.argv.slice(2));
 
 try {
   await run(argv, import.meta.url);

--- a/objectified-cli/bin/run.js
+++ b/objectified-cli/bin/run.js
@@ -4,13 +4,10 @@ import { flush } from "@oclif/core/flush";
 import { ExitError } from "@oclif/core/errors";
 import { run } from "@oclif/core/run";
 
-import { promoteLeadingGlobalFlags } from "../dist/lib/normalize-argv.js";
-import {
-  formatAndReportCliFailure,
-  resolveDebugStacks,
-} from "../dist/lib/handle-error.js";
+import { normalizeCliArgv } from "../dist/lib/normalize-argv.js";
+import { formatAndReportCliFailure, resolveDebugStacks } from "../dist/lib/handle-error.js";
 
-const argv = promoteLeadingGlobalFlags(process.argv.slice(2));
+const argv = normalizeCliArgv(process.argv.slice(2));
 
 try {
   await run(argv, import.meta.url);

--- a/objectified-cli/man/man1/objectified-auth-login.1
+++ b/objectified-cli/man/man1/objectified-auth-login.1
@@ -1,15 +1,16 @@
 .TH OBJECTIFIED\-AUTH\-LOGIN 1 "" "" "User Commands"
 .SH NAME
-objectified auth login \- Sign in via PKCE browser flow (stores tokens in the OS keychain).
+objectified auth login \- Sign in via PKCE browser flow or store an API key in the OS keychain (`--api-key`).
 .SH DESCRIPTION
 .nf
 USAGE
-  $ objectified auth login [--api-key <value>] [--base-url <value>]
-    [--config <value>] [--json] [--color] [--profile <value>] [-q] [--verbose]
-    [--no-browser]
+  $ objectified auth login [--api-key <value>] [--api-key-file
+    <value>] [--base-url <value>] [--config <value>] [--json] [--color]
+    [--profile <value>] [-q] [--verbose] [--no-browser]
 
 DESCRIPTION
-  Sign in via PKCE browser flow (stores tokens in the OS keychain).
+  Sign in via PKCE browser flow or store an API key in the OS keychain
+  (`--api-key`).
 
 EXAMPLES
   $ objectified auth login
@@ -17,6 +18,10 @@ EXAMPLES
   $ objectified --profile staging auth login
 
   $ objectified auth login --no-browser
+
+  $ objectified auth login --api-key
+
+  $ objectified auth login --api-key sk_live_…
 
   $ objectified --json auth login
 
@@ -37,7 +42,11 @@ OUTPUT
       --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
 
 AUTH
-  --api-key=<value>  API key for direct authentication (bypasses login token).
+  --api-key=<value>       [env: OBJECTIFIED_API_KEY] API key for direct
+                          authentication (OBJECTIFIED_API_KEY). Not persisted
+                          unless you run `auth login --api-key`.
+  --api-key-file=<value>  Read API key from a file (single line; avoids shell
+                          history).
 
 OTHER
   --no-browser  Do not launch a browser; print the login URL and read the
@@ -45,6 +54,8 @@ OTHER
 
 SEE ALSO
   objectified auth logout
+
+  objectified auth status
 
   objectified docs profiles
 .fi

--- a/objectified-cli/man/man1/objectified-auth-logout.1
+++ b/objectified-cli/man/man1/objectified-auth-logout.1
@@ -1,16 +1,16 @@
 .TH OBJECTIFIED\-AUTH\-LOGOUT 1 "" "" "User Commands"
 .SH NAME
-objectified auth logout \- Revoke CLI refresh token at the API and remove OAuth credentials from the OS keychain.
+objectified auth logout \- Revoke CLI refresh token at the API (OAuth profiles) and remove stored credentials from the OS keychain.
 .SH DESCRIPTION
 .nf
 USAGE
-  $ objectified auth logout [--api-key <value>] [--base-url <value>]
-    [--config <value>] [--json] [--color] [--profile <value>] [-q] [--verbose]
-    [--all-profiles]
+  $ objectified auth logout [--api-key <value>] [--api-key-file
+    <value>] [--base-url <value>] [--config <value>] [--json] [--color]
+    [--profile <value>] [-q] [--verbose] [--all-profiles]
 
 DESCRIPTION
-  Revoke CLI refresh token at the API and remove OAuth credentials from the OS
-  keychain.
+  Revoke CLI refresh token at the API (OAuth profiles) and remove stored
+  credentials from the OS keychain.
 
 EXAMPLES
   $ objectified auth logout
@@ -38,7 +38,11 @@ OUTPUT
       --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
 
 AUTH
-  --api-key=<value>  API key for direct authentication (bypasses login token).
+  --api-key=<value>       [env: OBJECTIFIED_API_KEY] API key for direct
+                          authentication (OBJECTIFIED_API_KEY). Not persisted
+                          unless you run `auth login --api-key`.
+  --api-key-file=<value>  Read API key from a file (single line; avoids shell
+                          history).
 
 OTHER
   --all-profiles  Revoke and clear stored OAuth credentials for every profile
@@ -46,6 +50,8 @@ OTHER
 
 SEE ALSO
   objectified auth login
+
+  objectified auth status
 
   objectified docs profiles
 .fi

--- a/objectified-cli/man/man1/objectified-auth-status.1
+++ b/objectified-cli/man/man1/objectified-auth-status.1
@@ -1,22 +1,23 @@
-.TH OBJECTIFIED\-DOCS\-PROFILES 1 "" "" "User Commands"
+.TH OBJECTIFIED\-AUTH\-STATUS 1 "" "" "User Commands"
 .SH NAME
-objectified docs profiles \- config.toml profiles, defaults, and precedence rules
+objectified auth status \- Show the active profile, base URL, and whether you are using an API key or OAuth token.
 .SH DESCRIPTION
 .nf
 USAGE
-  $ objectified docs profiles [--api-key <value>] [--api-key-file
+  $ objectified auth status [--api-key <value>] [--api-key-file
     <value>] [--base-url <value>] [--config <value>] [--json] [--color]
     [--profile <value>] [-q] [--verbose]
 
 DESCRIPTION
-  config.toml profiles, defaults, and precedence rules
+  Show the active profile, base URL, and whether you are using an API key or
+  OAuth token.
 
 EXAMPLES
-  $ objectified docs profiles
+  $ objectified auth status
 
-  $ objectified --profile staging config path
+  $ objectified --profile staging auth status
 
-  $ objectified docs profiles | sed -n '1,12p'
+  $ objectified --json auth status
 
 COMMON
   --base-url=<value>  Root REST API URL.
@@ -42,9 +43,9 @@ AUTH
                           history).
 
 SEE ALSO
-  objectified docs
+  objectified auth login
 
-  objectified config path
+  objectified auth logout
 
-  objectified config get
+  objectified docs profiles
 .fi

--- a/objectified-cli/man/man1/objectified-completion-install.1
+++ b/objectified-cli/man/man1/objectified-completion-install.1
@@ -4,9 +4,9 @@ objectified completion install \- Append shell completion glue to the right star
 .SH DESCRIPTION
 .nf
 USAGE
-  $ objectified completion install [SHELL] [--api-key <value>] [--base-url
-    <value>] [--config <value>] [--json] [--color] [--profile <value>] [-q]
-    [--verbose]
+  $ objectified completion install [SHELL] [--api-key <value>] [--api-key-file
+    <value>] [--base-url <value>] [--config <value>] [--json] [--color]
+    [--profile <value>] [-q] [--verbose]
 
 ARGUMENTS
   [SHELL]  (bash|zsh|fish|powershell) Shell to install for (default: inferred
@@ -39,7 +39,11 @@ OUTPUT
       --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
 
 AUTH
-  --api-key=<value>  API key for direct authentication (bypasses login token).
+  --api-key=<value>       [env: OBJECTIFIED_API_KEY] API key for direct
+                          authentication (OBJECTIFIED_API_KEY). Not persisted
+                          unless you run `auth login --api-key`.
+  --api-key-file=<value>  Read API key from a file (single line; avoids shell
+                          history).
 
 SEE ALSO
   objectified completion show

--- a/objectified-cli/man/man1/objectified-completion-show.1
+++ b/objectified-cli/man/man1/objectified-completion-show.1
@@ -4,9 +4,9 @@ objectified completion show \- Print shell completion glue (with marker comments
 .SH DESCRIPTION
 .nf
 USAGE
-  $ objectified completion show [SHELL] [--api-key <value>] [--base-url
-    <value>] [--config <value>] [--json] [--color] [--profile <value>] [-q]
-    [--verbose]
+  $ objectified completion show [SHELL] [--api-key <value>] [--api-key-file
+    <value>] [--base-url <value>] [--config <value>] [--json] [--color]
+    [--profile <value>] [-q] [--verbose]
 
 ARGUMENTS
   [SHELL]  (bash|zsh|fish|powershell) Shell to generate
@@ -38,7 +38,11 @@ OUTPUT
       --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
 
 AUTH
-  --api-key=<value>  API key for direct authentication (bypasses login token).
+  --api-key=<value>       [env: OBJECTIFIED_API_KEY] API key for direct
+                          authentication (OBJECTIFIED_API_KEY). Not persisted
+                          unless you run `auth login --api-key`.
+  --api-key-file=<value>  Read API key from a file (single line; avoids shell
+                          history).
 
 SEE ALSO
   objectified completion install

--- a/objectified-cli/man/man1/objectified-completion-uninstall.1
+++ b/objectified-cli/man/man1/objectified-completion-uninstall.1
@@ -4,8 +4,9 @@ objectified completion uninstall \- Remove Objectified completion blocks added b
 .SH DESCRIPTION
 .nf
 USAGE
-  $ objectified completion uninstall [--api-key <value>] [--base-url <value>]
-    [--config <value>] [--json] [--color] [--profile <value>] [-q] [--verbose]
+  $ objectified completion uninstall [--api-key <value>] [--api-key-file
+    <value>] [--base-url <value>] [--config <value>] [--json] [--color]
+    [--profile <value>] [-q] [--verbose]
 
 DESCRIPTION
   Remove Objectified completion blocks added by `completion install`.
@@ -32,7 +33,11 @@ OUTPUT
       --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
 
 AUTH
-  --api-key=<value>  API key for direct authentication (bypasses login token).
+  --api-key=<value>       [env: OBJECTIFIED_API_KEY] API key for direct
+                          authentication (OBJECTIFIED_API_KEY). Not persisted
+                          unless you run `auth login --api-key`.
+  --api-key-file=<value>  Read API key from a file (single line; avoids shell
+                          history).
 
 SEE ALSO
   objectified completion install

--- a/objectified-cli/man/man1/objectified-completion.1
+++ b/objectified-cli/man/man1/objectified-completion.1
@@ -4,8 +4,9 @@ objectified completion \- Install or print shell completion scripts for bash, zs
 .SH DESCRIPTION
 .nf
 USAGE
-  $ objectified completion [--api-key <value>] [--base-url <value>]
-    [--config <value>] [--json] [--color] [--profile <value>] [-q] [--verbose]
+  $ objectified completion [--api-key <value>] [--api-key-file
+    <value>] [--base-url <value>] [--config <value>] [--json] [--color]
+    [--profile <value>] [-q] [--verbose]
 
 DESCRIPTION
   Install or print shell completion scripts for bash, zsh, fish, or
@@ -37,7 +38,11 @@ OUTPUT
       --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
 
 AUTH
-  --api-key=<value>  API key for direct authentication (bypasses login token).
+  --api-key=<value>       [env: OBJECTIFIED_API_KEY] API key for direct
+                          authentication (OBJECTIFIED_API_KEY). Not persisted
+                          unless you run `auth login --api-key`.
+  --api-key-file=<value>  Read API key from a file (single line; avoids shell
+                          history).
 
 SEE ALSO
   objectified docs completions

--- a/objectified-cli/man/man1/objectified-config-get.1
+++ b/objectified-cli/man/man1/objectified-config-get.1
@@ -4,9 +4,9 @@ objectified config get \- Print a single config value by dotted key
 .SH DESCRIPTION
 .nf
 USAGE
-  $ objectified config get KEY [--api-key <value>] [--base-url
-    <value>] [--config <value>] [--json] [--color] [--profile <value>] [-q]
-    [--verbose]
+  $ objectified config get KEY [--api-key <value>] [--api-key-file
+    <value>] [--base-url <value>] [--config <value>] [--json] [--color]
+    [--profile <value>] [-q] [--verbose]
 
 ARGUMENTS
   KEY  Dotted path (e.g. default_profile, profile.prod.base_url)
@@ -38,7 +38,11 @@ OUTPUT
       --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
 
 AUTH
-  --api-key=<value>  API key for direct authentication (bypasses login token).
+  --api-key=<value>       [env: OBJECTIFIED_API_KEY] API key for direct
+                          authentication (OBJECTIFIED_API_KEY). Not persisted
+                          unless you run `auth login --api-key`.
+  --api-key-file=<value>  Read API key from a file (single line; avoids shell
+                          history).
 
 SEE ALSO
   objectified config set

--- a/objectified-cli/man/man1/objectified-config-list.1
+++ b/objectified-cli/man/man1/objectified-config-list.1
@@ -4,8 +4,9 @@ objectified config list \- Print the entire config file (stable JSON with --json
 .SH DESCRIPTION
 .nf
 USAGE
-  $ objectified config list [--api-key <value>] [--base-url <value>]
-    [--config <value>] [--json] [--color] [--profile <value>] [-q] [--verbose]
+  $ objectified config list [--api-key <value>] [--api-key-file
+    <value>] [--base-url <value>] [--config <value>] [--json] [--color]
+    [--profile <value>] [-q] [--verbose]
 
 DESCRIPTION
   Print the entire config file (stable JSON with --json, otherwise TOML)
@@ -34,7 +35,11 @@ OUTPUT
       --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
 
 AUTH
-  --api-key=<value>  API key for direct authentication (bypasses login token).
+  --api-key=<value>       [env: OBJECTIFIED_API_KEY] API key for direct
+                          authentication (OBJECTIFIED_API_KEY). Not persisted
+                          unless you run `auth login --api-key`.
+  --api-key-file=<value>  Read API key from a file (single line; avoids shell
+                          history).
 
 SEE ALSO
   objectified config path

--- a/objectified-cli/man/man1/objectified-config-path.1
+++ b/objectified-cli/man/man1/objectified-config-path.1
@@ -4,8 +4,9 @@ objectified config path \- Print the resolved config.toml path
 .SH DESCRIPTION
 .nf
 USAGE
-  $ objectified config path [--api-key <value>] [--base-url <value>]
-    [--config <value>] [--json] [--color] [--profile <value>] [-q] [--verbose]
+  $ objectified config path [--api-key <value>] [--api-key-file
+    <value>] [--base-url <value>] [--config <value>] [--json] [--color]
+    [--profile <value>] [-q] [--verbose]
 
 DESCRIPTION
   Print the resolved config.toml path
@@ -34,7 +35,11 @@ OUTPUT
       --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
 
 AUTH
-  --api-key=<value>  API key for direct authentication (bypasses login token).
+  --api-key=<value>       [env: OBJECTIFIED_API_KEY] API key for direct
+                          authentication (OBJECTIFIED_API_KEY). Not persisted
+                          unless you run `auth login --api-key`.
+  --api-key-file=<value>  Read API key from a file (single line; avoids shell
+                          history).
 
 SEE ALSO
   objectified config get

--- a/objectified-cli/man/man1/objectified-config-set.1
+++ b/objectified-cli/man/man1/objectified-config-set.1
@@ -4,9 +4,9 @@ objectified config set \- Set a config value by dotted key and persist config.to
 .SH DESCRIPTION
 .nf
 USAGE
-  $ objectified config set KEY VALUE [--api-key <value>] [--base-url
-    <value>] [--config <value>] [--json] [--color] [--profile <value>] [-q]
-    [--verbose]
+  $ objectified config set KEY VALUE [--api-key <value>]
+    [--api-key-file <value>] [--base-url <value>] [--config <value>] [--json]
+    [--color] [--profile <value>] [-q] [--verbose]
 
 ARGUMENTS
   KEY    Dotted path (e.g. default_profile, profile.prod.tenant_slug)
@@ -39,7 +39,11 @@ OUTPUT
       --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
 
 AUTH
-  --api-key=<value>  API key for direct authentication (bypasses login token).
+  --api-key=<value>       [env: OBJECTIFIED_API_KEY] API key for direct
+                          authentication (OBJECTIFIED_API_KEY). Not persisted
+                          unless you run `auth login --api-key`.
+  --api-key-file=<value>  Read API key from a file (single line; avoids shell
+                          history).
 
 SEE ALSO
   objectified config get

--- a/objectified-cli/man/man1/objectified-docs-completions.1
+++ b/objectified-cli/man/man1/objectified-docs-completions.1
@@ -4,8 +4,9 @@ objectified docs completions \- Shell completions (install/show/uninstall, stati
 .SH DESCRIPTION
 .nf
 USAGE
-  $ objectified docs completions [--api-key <value>] [--base-url <value>]
-    [--config <value>] [--json] [--color] [--profile <value>] [-q] [--verbose]
+  $ objectified docs completions [--api-key <value>] [--api-key-file
+    <value>] [--base-url <value>] [--config <value>] [--json] [--color]
+    [--profile <value>] [-q] [--verbose]
 
 DESCRIPTION
   Shell completions (install/show/uninstall, static manifest + cached REST
@@ -35,7 +36,11 @@ OUTPUT
       --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
 
 AUTH
-  --api-key=<value>  API key for direct authentication (bypasses login token).
+  --api-key=<value>       [env: OBJECTIFIED_API_KEY] API key for direct
+                          authentication (OBJECTIFIED_API_KEY). Not persisted
+                          unless you run `auth login --api-key`.
+  --api-key-file=<value>  Read API key from a file (single line; avoids shell
+                          history).
 
 SEE ALSO
   objectified completion install

--- a/objectified-cli/man/man1/objectified-docs-errors.1
+++ b/objectified-cli/man/man1/objectified-docs-errors.1
@@ -4,8 +4,9 @@ objectified docs errors \- Exit codes, hints, and error-handling reference
 .SH DESCRIPTION
 .nf
 USAGE
-  $ objectified docs errors [--api-key <value>] [--base-url <value>]
-    [--config <value>] [--json] [--color] [--profile <value>] [-q] [--verbose]
+  $ objectified docs errors [--api-key <value>] [--api-key-file
+    <value>] [--base-url <value>] [--config <value>] [--json] [--color]
+    [--profile <value>] [-q] [--verbose]
 
 DESCRIPTION
   Exit codes, hints, and error-handling reference
@@ -34,7 +35,11 @@ OUTPUT
       --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
 
 AUTH
-  --api-key=<value>  API key for direct authentication (bypasses login token).
+  --api-key=<value>       [env: OBJECTIFIED_API_KEY] API key for direct
+                          authentication (OBJECTIFIED_API_KEY). Not persisted
+                          unless you run `auth login --api-key`.
+  --api-key-file=<value>  Read API key from a file (single line; avoids shell
+                          history).
 
 SEE ALSO
   objectified docs

--- a/objectified-cli/man/man1/objectified-docs-output.1
+++ b/objectified-cli/man/man1/objectified-docs-output.1
@@ -4,8 +4,9 @@ objectified docs output \- TTY vs JSON output, quiet mode, verbose logs, and col
 .SH DESCRIPTION
 .nf
 USAGE
-  $ objectified docs output [--api-key <value>] [--base-url <value>]
-    [--config <value>] [--json] [--color] [--profile <value>] [-q] [--verbose]
+  $ objectified docs output [--api-key <value>] [--api-key-file
+    <value>] [--base-url <value>] [--config <value>] [--json] [--color]
+    [--profile <value>] [-q] [--verbose]
 
 DESCRIPTION
   TTY vs JSON output, quiet mode, verbose logs, and color
@@ -34,7 +35,11 @@ OUTPUT
       --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
 
 AUTH
-  --api-key=<value>  API key for direct authentication (bypasses login token).
+  --api-key=<value>       [env: OBJECTIFIED_API_KEY] API key for direct
+                          authentication (OBJECTIFIED_API_KEY). Not persisted
+                          unless you run `auth login --api-key`.
+  --api-key-file=<value>  Read API key from a file (single line; avoids shell
+                          history).
 
 SEE ALSO
   objectified docs

--- a/objectified-cli/man/man1/objectified-docs-plugins.1
+++ b/objectified-cli/man/man1/objectified-docs-plugins.1
@@ -4,8 +4,9 @@ objectified docs plugins \- Future oclif plugin extensibility for Objectified
 .SH DESCRIPTION
 .nf
 USAGE
-  $ objectified docs plugins [--api-key <value>] [--base-url <value>]
-    [--config <value>] [--json] [--color] [--profile <value>] [-q] [--verbose]
+  $ objectified docs plugins [--api-key <value>] [--api-key-file
+    <value>] [--base-url <value>] [--config <value>] [--json] [--color]
+    [--profile <value>] [-q] [--verbose]
 
 DESCRIPTION
   Future oclif plugin extensibility for Objectified
@@ -34,7 +35,11 @@ OUTPUT
       --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
 
 AUTH
-  --api-key=<value>  API key for direct authentication (bypasses login token).
+  --api-key=<value>       [env: OBJECTIFIED_API_KEY] API key for direct
+                          authentication (OBJECTIFIED_API_KEY). Not persisted
+                          unless you run `auth login --api-key`.
+  --api-key-file=<value>  Read API key from a file (single line; avoids shell
+                          history).
 
 SEE ALSO
   objectified docs

--- a/objectified-cli/man/man1/objectified-docs-telemetry.1
+++ b/objectified-cli/man/man1/objectified-docs-telemetry.1
@@ -4,8 +4,9 @@ objectified docs telemetry \- Telemetry posture and safe verbose debugging
 .SH DESCRIPTION
 .nf
 USAGE
-  $ objectified docs telemetry [--api-key <value>] [--base-url <value>]
-    [--config <value>] [--json] [--color] [--profile <value>] [-q] [--verbose]
+  $ objectified docs telemetry [--api-key <value>] [--api-key-file
+    <value>] [--base-url <value>] [--config <value>] [--json] [--color]
+    [--profile <value>] [-q] [--verbose]
 
 DESCRIPTION
   Telemetry posture and safe verbose debugging
@@ -35,7 +36,11 @@ OUTPUT
       --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
 
 AUTH
-  --api-key=<value>  API key for direct authentication (bypasses login token).
+  --api-key=<value>       [env: OBJECTIFIED_API_KEY] API key for direct
+                          authentication (OBJECTIFIED_API_KEY). Not persisted
+                          unless you run `auth login --api-key`.
+  --api-key-file=<value>  Read API key from a file (single line; avoids shell
+                          history).
 
 SEE ALSO
   objectified docs errors

--- a/objectified-cli/man/man1/objectified-docs.1
+++ b/objectified-cli/man/man1/objectified-docs.1
@@ -4,8 +4,9 @@ objectified docs \- List documentation topics (`objectified docs`) or open one w
 .SH DESCRIPTION
 .nf
 USAGE
-  $ objectified docs [--api-key <value>] [--base-url <value>]
-    [--config <value>] [--json] [--color] [--profile <value>] [-q] [--verbose]
+  $ objectified docs [--api-key <value>] [--api-key-file
+    <value>] [--base-url <value>] [--config <value>] [--json] [--color]
+    [--profile <value>] [-q] [--verbose]
 
 DESCRIPTION
   List documentation topics (`objectified docs`) or open one with `objectified
@@ -35,7 +36,11 @@ OUTPUT
       --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
 
 AUTH
-  --api-key=<value>  API key for direct authentication (bypasses login token).
+  --api-key=<value>       [env: OBJECTIFIED_API_KEY] API key for direct
+                          authentication (OBJECTIFIED_API_KEY). Not persisted
+                          unless you run `auth login --api-key`.
+  --api-key-file=<value>  Read API key from a file (single line; avoids shell
+                          history).
 
 SEE ALSO
   objectified docs errors

--- a/objectified-cli/man/man1/objectified-hello.1
+++ b/objectified-cli/man/man1/objectified-hello.1
@@ -4,9 +4,9 @@ objectified hello \- Smoke-test greeting for the Objectified CLI
 .SH DESCRIPTION
 .nf
 USAGE
-  $ objectified hello [NAME] [--api-key <value>] [--base-url
-    <value>] [--config <value>] [--json] [--color] [--profile <value>] [-q]
-    [--verbose]
+  $ objectified hello [NAME] [--api-key <value>] [--api-key-file
+    <value>] [--base-url <value>] [--config <value>] [--json] [--color]
+    [--profile <value>] [-q] [--verbose]
 
 ARGUMENTS
   [NAME]  Who to greet
@@ -38,7 +38,11 @@ OUTPUT
       --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
 
 AUTH
-  --api-key=<value>  API key for direct authentication (bypasses login token).
+  --api-key=<value>       [env: OBJECTIFIED_API_KEY] API key for direct
+                          authentication (OBJECTIFIED_API_KEY). Not persisted
+                          unless you run `auth login --api-key`.
+  --api-key-file=<value>  Read API key from a file (single line; avoids shell
+                          history).
 
 SEE ALSO
   objectified docs output

--- a/objectified-cli/man/man1/objectified-projects-list.1
+++ b/objectified-cli/man/man1/objectified-projects-list.1
@@ -4,8 +4,9 @@ objectified projects list \- List Objectified projects
 .SH DESCRIPTION
 .nf
 USAGE
-  $ objectified projects list [--api-key <value>] [--base-url <value>]
-    [--config <value>] [--json] [--color] [--profile <value>] [-q] [--verbose]
+  $ objectified projects list [--api-key <value>] [--api-key-file
+    <value>] [--base-url <value>] [--config <value>] [--json] [--color]
+    [--profile <value>] [-q] [--verbose]
 
 DESCRIPTION
   List Objectified projects
@@ -34,7 +35,11 @@ OUTPUT
       --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
 
 AUTH
-  --api-key=<value>  API key for direct authentication (bypasses login token).
+  --api-key=<value>       [env: OBJECTIFIED_API_KEY] API key for direct
+                          authentication (OBJECTIFIED_API_KEY). Not persisted
+                          unless you run `auth login --api-key`.
+  --api-key-file=<value>  Read API key from a file (single line; avoids shell
+                          history).
 
 SEE ALSO
   objectified config path

--- a/objectified-cli/man/man1/objectified.1
+++ b/objectified-cli/man/man1/objectified.1
@@ -6,7 +6,7 @@ objectified \- Objectified command-line interface
 Objectified command-line interface
 
 VERSION
-  objectified-cli/0.1.8 linux-x64 node-v24.14.1
+  objectified-cli/0.1.9 linux-x64 node-v24.14.1
 
 USAGE
   $ objectified [COMMAND]
@@ -15,7 +15,9 @@ GLOBAL FLAGS
   Global flags apply to every command:
 
   --api-key       OBJECTIFIED_API_KEY       Direct API-key auth (not read from
-  config.toml)
+  config.toml; never persisted unless auth login --api-key)
+  --api-key-file                            Read API key from a file (single
+  line)
   --base-url      OBJECTIFIED_BASE_URL      Root REST endpoint (built-in
   default: https://api.objectified.dev)
   --config        OBJECTIFIED_CONFIG        config.toml (default: XDG config
@@ -36,8 +38,9 @@ GLOBAL FLAGS
   4. Config [default]              (base_url=…)
   5. Built-in default              (https://api.objectified.dev)
 
-  Resolution order for API key: --api-key, then OBJECTIFIED_API_KEY (never
-  from config file; see #3188).
+  Resolution order for API key: --api-key, then OBJECTIFIED_API_KEY, then
+  --api-key-file (never from config file; see #3188). Stored keys follow
+  explicit auth login --api-key (#3195).
   Resolution order for tenant slug: OBJECTIFIED_TENANT, then config profile /
   [default] (tenant_slug).
 .fi

--- a/objectified-cli/package.json
+++ b/objectified-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-cli",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Objectified command-line interface",
   "author": "Objectified",
   "type": "module",
@@ -75,6 +75,7 @@
   "man": [
     "./man/man1/objectified-auth-login.1",
     "./man/man1/objectified-auth-logout.1",
+    "./man/man1/objectified-auth-status.1",
     "./man/man1/objectified-completion-install.1",
     "./man/man1/objectified-completion-show.1",
     "./man/man1/objectified-completion-uninstall.1",

--- a/objectified-cli/src/base-command.ts
+++ b/objectified-cli/src/base-command.ts
@@ -5,14 +5,18 @@ import { ExitError } from "@oclif/core/errors";
 import type { CommandError } from "@oclif/core/interfaces";
 import supportsColor from "supports-color";
 
+import { describeActiveCredential, type ActiveCredential } from "./lib/active-credential.js";
+import { readApiKeyFromFile } from "./lib/api-key-file.js";
 import { createApiClient, type ApiAuthSnapshot, type ObjectifiedApi } from "./lib/client.js";
-import { loadCliOAuthCredentials } from "./lib/credentials/store.js";
 import {
   buildObjectifiedContext,
   type GlobalCliFlags,
   type ObjectifiedContext,
   resolveAllowColor,
 } from "./lib/cli-context.js";
+import { loadCliStoredAuth } from "./lib/credentials/store.js";
+import { ObjectifiedCliError } from "./lib/errors.js";
+import { EXIT_CODES } from "./lib/exit-codes.js";
 import {
   ensureDefaultConfigFile,
   loadTomlConfigFile,
@@ -26,11 +30,18 @@ import {
   resolveEffectiveExitCode,
 } from "./lib/handle-error.js";
 import { createCliOutput, localePrefersAsciiTable, type CliOutput } from "./lib/output.js";
+import { normalizeCliArgv } from "./lib/normalize-argv.js";
 
 export abstract class BaseCommand extends Command {
   static baseFlags = {
     "api-key": Flags.string({
-      description: "API key for direct authentication (bypasses login token).",
+      description:
+        "API key for direct authentication (OBJECTIFIED_API_KEY). Not persisted unless you run `auth login --api-key`.",
+      helpGroup: "Auth",
+      env: "OBJECTIFIED_API_KEY",
+    }),
+    "api-key-file": Flags.string({
+      description: "Read API key from a file (single line; avoids shell history).",
       helpGroup: "Auth",
     }),
     "base-url": Flags.string({
@@ -93,6 +104,15 @@ export abstract class BaseCommand extends Command {
   /** Resolved API/client context (flag > env > profile config > [default] > built-ins). */
   context!: ObjectifiedContext;
 
+  /** argv after global promotion + auth login sentinel normalization (matches oclif input). */
+  protected normalizedArgv!: string[];
+
+  /** API key from flags/env/file only (before OS keychain merge). */
+  protected transientApiKey!: string | undefined;
+
+  /** Effective credential classification for `auth status` and UX. */
+  protected activeCredential!: ActiveCredential;
+
   /** Parsed config document after loading `config.toml`. */
   protected configDoc!: ParsedTomlConfig;
 
@@ -118,10 +138,27 @@ export abstract class BaseCommand extends Command {
     const parsed = await this.parse(Cmd);
     const parsedFlags = parsed.flags as Record<string, unknown>;
     // Keep camelCase fallback for compatibility while normalize-argv continues accepting legacy aliases.
+    const apiKeyFlag =
+      (parsedFlags["api-key"] as string | undefined) ?? (parsedFlags.apiKey as string | undefined);
+    const apiKeyFileFlag =
+      (parsedFlags["api-key-file"] as string | undefined) ??
+      (parsedFlags.apiKeyFile as string | undefined);
+
+    let apiKey = apiKeyFlag;
+    if (
+      (apiKey === undefined || apiKey === "") &&
+      apiKeyFileFlag !== undefined &&
+      apiKeyFileFlag.trim() !== ""
+    ) {
+      apiKey = readApiKeyFromFile(apiKeyFileFlag.trim());
+    }
+
     const globalPart: GlobalCliFlags = {
-      apiKey: (parsedFlags["api-key"] as string | undefined) ?? (parsedFlags.apiKey as string | undefined),
+      apiKey,
+      apiKeyFile: apiKeyFileFlag,
       baseUrl:
-        (parsedFlags["base-url"] as string | undefined) ?? (parsedFlags.baseUrl as string | undefined),
+        (parsedFlags["base-url"] as string | undefined) ??
+        (parsedFlags.baseUrl as string | undefined),
       config: parsedFlags.config as string | undefined,
       json: parsedFlags.json as boolean | undefined,
       color: parsedFlags.color as boolean | undefined,
@@ -131,6 +168,7 @@ export abstract class BaseCommand extends Command {
     };
     this.parsedGlobalFlags = globalPart;
     this.commandArgs = parsed.args as Record<string, unknown>;
+    this.normalizedArgv = normalizeCliArgv(process.argv.slice(2));
 
     this.resolvedConfigPath = resolveConfigFilePath(globalPart.config, process.env, os.homedir);
     await ensureDefaultConfigFile(this.resolvedConfigPath);
@@ -151,25 +189,51 @@ export abstract class BaseCommand extends Command {
       ...parsed.flags,
       verboseEffective: built.verboseEffective,
     } as BaseCommand["flags"];
-    this.apiAuth.apiKey = this.context.apiKey;
-    this.apiAuth.bearer = this.context.accessToken;
-    if (!this.apiAuth.apiKey && !this.apiAuth.bearer) {
-      try {
-        const oauth = await loadCliOAuthCredentials(this.context.profile);
-        if (oauth?.accessToken) this.apiAuth.bearer = oauth.accessToken;
-      } catch (err: unknown) {
-        if (this.verboseEffective) {
-          const msg = err instanceof Error ? err.message : String(err);
-          process.stderr.write(`objectified: could not read CLI credentials: ${msg}\n`);
-        }
+    this.transientApiKey = this.context.apiKey;
+
+    let storedApiKey: string | undefined;
+    let storedBearer: string | undefined;
+    try {
+      const stored = await loadCliStoredAuth(this.context.profile);
+      if (stored?.kind === "api_key") storedApiKey = stored.apiKey;
+      else if (stored?.kind === "oauth") storedBearer = stored.accessToken;
+    } catch (err: unknown) {
+      if (this.verboseEffective) {
+        const msg = err instanceof Error ? err.message : String(err);
+        process.stderr.write(`objectified: could not read CLI credentials: ${msg}\n`);
       }
     }
+
+    this.apiAuth.apiKey = this.context.apiKey ?? storedApiKey;
+    this.apiAuth.bearer = this.context.accessToken ?? storedBearer;
+    if (this.apiAuth.apiKey) this.apiAuth.bearer = undefined;
+
+    this.activeCredential = describeActiveCredential({
+      argv: this.normalizedArgv,
+      env: process.env,
+      transientApiKey: this.transientApiKey,
+      effectiveApiKey: this.apiAuth.apiKey,
+      effectiveBearer: this.apiAuth.bearer,
+    });
+
     this.api = createApiClient({
       baseUrl: this.context.baseUrl,
       auth: this.apiAuth,
       verbose: this.verboseEffective,
       stderrWrite: (line) => process.stderr.write(`${line}\n`),
     });
+  }
+
+  /** Throws exit code 3 when no API key or bearer is available (#3195). */
+  protected ensureAuthenticated(): void {
+    if (!this.apiAuth.apiKey && !this.apiAuth.bearer) {
+      throw new ObjectifiedCliError({
+        message: "No API key or OAuth token available for this command.",
+        exitCode: EXIT_CODES.NOT_AUTHENTICATED,
+        title: "Not authenticated",
+        hint: "Run `objectified auth login`, set OBJECTIFIED_API_KEY, or pass --api-key / --api-key-file.",
+      });
+    }
   }
 
   protected override catch(err: CommandError): Promise<void> {

--- a/objectified-cli/src/commands/auth/login.ts
+++ b/objectified-cli/src/commands/auth/login.ts
@@ -1,21 +1,28 @@
 import { Flags } from "@oclif/core";
 
 import { BaseCommand } from "../../base-command.js";
+import { readApiKeyInteractively } from "../../lib/auth/read-secret-api-key.js";
 import { runCliPkceLogin } from "../../lib/auth/cli-login-flow.js";
-import { DEFAULT_CLI_WEB_LOGIN_URL } from "../../lib/constants.js";
-import { saveCliOAuthCredentials } from "../../lib/credentials/store.js";
+import { API_KEY_PROMPT_SENTINEL, DEFAULT_CLI_WEB_LOGIN_URL } from "../../lib/constants.js";
+import { saveCliApiKeyCredentials, saveCliOAuthCredentials } from "../../lib/credentials/store.js";
+import { ObjectifiedCliError } from "../../lib/errors.js";
+import { EXIT_CODES } from "../../lib/exit-codes.js";
+import { authLoginIntendsApiKeyStore } from "../../lib/normalize-argv.js";
 
 export default class AuthLogin extends BaseCommand {
-  static description = "Sign in via PKCE browser flow (stores tokens in the OS keychain).";
+  static description =
+    "Sign in via PKCE browser flow or store an API key in the OS keychain (`--api-key`).";
 
   static examples = [
     "<%= config.bin %> <%= command.id %>",
     "<%= config.bin %> --profile staging <%= command.id %>",
     "<%= config.bin %> <%= command.id %> --no-browser",
+    "<%= config.bin %> <%= command.id %> --api-key",
+    "<%= config.bin %> <%= command.id %> --api-key sk_live_…",
     "<%= config.bin %> --json <%= command.id %>",
   ];
 
-  static seeAlso = ["auth logout", "docs profiles"];
+  static seeAlso = ["auth logout", "auth status", "docs profiles"];
 
   static flags = {
     ...BaseCommand.baseFlags,
@@ -36,6 +43,47 @@ export default class AuthLogin extends BaseCommand {
       else process.stderr.write(`${line}\n`);
     };
 
+    const storeApiKey = authLoginIntendsApiKeyStore(this.normalizedArgv);
+
+    if (storeApiKey) {
+      let rawKey = this.flags["api-key"] as string | undefined;
+      if (rawKey === API_KEY_PROMPT_SENTINEL) {
+        rawKey = await readApiKeyInteractively();
+      }
+      const trimmed = rawKey?.trim();
+      if (trimmed === undefined || trimmed === "") {
+        throw new ObjectifiedCliError({
+          message: "API key is required.",
+          exitCode: EXIT_CODES.MISUSE,
+          title: "Invalid usage",
+          hint: "Pass `--api-key <key>`, pipe stdin for non-TTY sessions, or omit the value for an interactive prompt.",
+        });
+      }
+
+      await saveCliApiKeyCredentials(this.context.profile, trimmed);
+      this.apiAuth.apiKey = trimmed;
+      this.apiAuth.bearer = undefined;
+      this.activeCredential = {
+        kind: "api_key_keychain",
+        authenticated: true,
+      };
+
+      if (this.context.json) {
+        this.output.json({
+          ok: true,
+          profile: this.context.profile,
+          credential: "api_key",
+        });
+        return;
+      }
+
+      this.output.success(`API key stored for profile '${this.context.profile}'`);
+      this.output.hint(
+        "Per-invocation keys (`OBJECTIFIED_API_KEY`) still override the stored key.",
+      );
+      return;
+    }
+
     const bundle = await runCliPkceLogin({
       apiBaseUrl: this.context.baseUrl,
       webLoginUrl: DEFAULT_CLI_WEB_LOGIN_URL,
@@ -49,6 +97,7 @@ export default class AuthLogin extends BaseCommand {
       accessToken: bundle.accessToken,
       refreshToken: bundle.refreshToken,
     });
+    this.apiAuth.apiKey = undefined;
     this.apiAuth.bearer = bundle.accessToken;
 
     const tenant = this.context.tenantSlug;
@@ -60,6 +109,7 @@ export default class AuthLogin extends BaseCommand {
         profile: this.context.profile,
         email: bundle.displayEmail ?? null,
         tenant_slug: tenant ?? null,
+        credential: "oauth",
       });
       return;
     }

--- a/objectified-cli/src/commands/auth/logout.ts
+++ b/objectified-cli/src/commands/auth/logout.ts
@@ -2,18 +2,12 @@ import { Flags } from "@oclif/core";
 
 import { BaseCommand } from "../../base-command.js";
 import { revokeCliRefreshToken } from "../../lib/auth/cli-oauth.js";
-import {
-  deleteCliOAuthCredentials,
-  loadCliOAuthCredentials,
-} from "../../lib/credentials/store.js";
-import {
-  listAvailableProfileNames,
-  resolveProfileConfigBaseUrl,
-} from "../../lib/cli-context.js";
+import { deleteCliOAuthCredentials, loadCliStoredAuth } from "../../lib/credentials/store.js";
+import { listAvailableProfileNames, resolveProfileConfigBaseUrl } from "../../lib/cli-context.js";
 
 export default class AuthLogout extends BaseCommand {
   static description =
-    "Revoke CLI refresh token at the API and remove OAuth credentials from the OS keychain.";
+    "Revoke CLI refresh token at the API (OAuth profiles) and remove stored credentials from the OS keychain.";
 
   static examples = [
     "<%= config.bin %> <%= command.id %>",
@@ -22,7 +16,7 @@ export default class AuthLogout extends BaseCommand {
     "<%= config.bin %> --json <%= command.id %>",
   ];
 
-  static seeAlso = ["auth login", "docs profiles"];
+  static seeAlso = ["auth login", "auth status", "docs profiles"];
 
   static flags = {
     ...BaseCommand.baseFlags,
@@ -47,12 +41,12 @@ export default class AuthLogout extends BaseCommand {
       const baseUrl = allProfiles
         ? resolveProfileConfigBaseUrl(this.configDoc, profile)
         : this.context.baseUrl;
-      const bundle = await loadCliOAuthCredentials(profile);
-      if (bundle?.refreshToken) {
+      const stored = await loadCliStoredAuth(profile);
+      if (stored?.kind === "oauth") {
         try {
           await revokeCliRefreshToken({
             apiBaseUrl: baseUrl,
-            refreshToken: bundle.refreshToken,
+            refreshToken: stored.refreshToken,
           });
         } catch {
           revokeFailures.push(profile);

--- a/objectified-cli/src/commands/auth/status.ts
+++ b/objectified-cli/src/commands/auth/status.ts
@@ -1,0 +1,49 @@
+import { BaseCommand } from "../../base-command.js";
+import { credentialKindLabel } from "../../lib/active-credential.js";
+import { ObjectifiedCliError } from "../../lib/errors.js";
+import { EXIT_CODES } from "../../lib/exit-codes.js";
+
+export default class AuthStatus extends BaseCommand {
+  static description =
+    "Show the active profile, base URL, and whether you are using an API key or OAuth token.";
+
+  static examples = [
+    "<%= config.bin %> <%= command.id %>",
+    "<%= config.bin %> --profile staging <%= command.id %>",
+    "<%= config.bin %> --json <%= command.id %>",
+  ];
+
+  static seeAlso = ["auth login", "auth logout", "docs profiles"];
+
+  run(): Promise<void> {
+    if (!this.activeCredential.authenticated) {
+      throw new ObjectifiedCliError({
+        message: "No credentials configured for this invocation.",
+        exitCode: EXIT_CODES.NOT_AUTHENTICATED,
+        title: "Not authenticated",
+        hint: "Run `objectified auth login`, set OBJECTIFIED_API_KEY, or pass --api-key / --api-key-file.",
+      });
+    }
+
+    if (this.context.json) {
+      this.output.json({
+        profile: this.context.profile,
+        base_url: this.context.baseUrl,
+        tenant_slug: this.context.tenantSlug ?? null,
+        credential_kind: this.activeCredential.kind,
+        authenticated: true,
+      });
+      return Promise.resolve();
+    }
+
+    this.output.text(`Profile:    ${this.context.profile}`);
+    this.output.text(`Base URL:   ${this.context.baseUrl}`);
+    const tenant =
+      this.context.tenantSlug !== undefined && this.context.tenantSlug !== ""
+        ? this.context.tenantSlug
+        : "(not set)";
+    this.output.text(`Tenant:     ${tenant}`);
+    this.output.text(`Credential: ${credentialKindLabel(this.activeCredential.kind)}`);
+    return Promise.resolve();
+  }
+}

--- a/objectified-cli/src/commands/projects/list.ts
+++ b/objectified-cli/src/commands/projects/list.ts
@@ -26,6 +26,8 @@ export default class ProjectsList extends BaseCommand {
       });
     }
 
+    this.ensureAuthenticated();
+
     const projects = await this.api.listProjects(tenant);
     const payload = { projects };
 

--- a/objectified-cli/src/help.ts
+++ b/objectified-cli/src/help.ts
@@ -10,7 +10,8 @@ const DEFAULT_BASE_URL = "https://api.objectified.dev";
 const GLOBAL_FLAGS_BODY = [
   "Global flags apply to every command:",
   "",
-  `  --api-key       OBJECTIFIED_API_KEY       Direct API-key auth (not read from config.toml)`,
+  `  --api-key       OBJECTIFIED_API_KEY       Direct API-key auth (not read from config.toml; never persisted unless auth login --api-key)`,
+  `  --api-key-file                            Read API key from a file (single line)`,
   `  --base-url      OBJECTIFIED_BASE_URL      Root REST endpoint (built-in default: ${DEFAULT_BASE_URL})`,
   `  --config        OBJECTIFIED_CONFIG        config.toml (default: XDG config dir, or %APPDATA%\\Objectified on Windows)`,
   `  --json          OBJECTIFIED_JSON=1        Machine-readable JSON (auto when stdout is not a TTY)`,
@@ -26,7 +27,7 @@ const GLOBAL_FLAGS_BODY = [
   "  4. Config [default]              (base_url=…)",
   `  5. Built-in default              (${DEFAULT_BASE_URL})`,
   "",
-  "Resolution order for API key: --api-key, then OBJECTIFIED_API_KEY (never from config file; see #3188).",
+  "Resolution order for API key: --api-key, then OBJECTIFIED_API_KEY, then --api-key-file (never from config file; see #3188). Stored keys follow explicit auth login --api-key (#3195).",
   "Resolution order for tenant slug: OBJECTIFIED_TENANT, then config profile / [default] (tenant_slug).",
 ].join("\n");
 

--- a/objectified-cli/src/lib/active-credential.ts
+++ b/objectified-cli/src/lib/active-credential.ts
@@ -1,0 +1,97 @@
+import { API_KEY_PROMPT_SENTINEL } from "./constants.js";
+
+export type ActiveCredentialKind =
+  | "none"
+  | "api_key_flag"
+  | "api_key_env"
+  | "api_key_file"
+  | "api_key_keychain"
+  | "oauth_keychain"
+  | "bearer_env";
+
+export type ActiveCredential = {
+  kind: ActiveCredentialKind;
+  /** True when an API request would send credentials (API key or bearer). */
+  authenticated: boolean;
+};
+
+function readExplicitApiKeyFromArgv(argv: string[]): string | undefined {
+  for (let i = 0; i < argv.length; i++) {
+    const t = argv[i];
+    if (t?.startsWith("--api-key=")) {
+      const v = t.slice("--api-key=".length);
+      if (v !== "" && v !== API_KEY_PROMPT_SENTINEL) return v;
+      continue;
+    }
+    if (t === "--api-key") {
+      const next = argv[i + 1];
+      if (next !== undefined && !next.startsWith("-") && next !== API_KEY_PROMPT_SENTINEL) {
+        return next;
+      }
+    }
+  }
+  return undefined;
+}
+
+function argvReferencesApiKeyFile(argv: string[]): boolean {
+  return argv.some((t) => t === "--api-key-file" || t.startsWith("--api-key-file="));
+}
+
+/** Describes how the CLI is authenticated after BaseCommand.init(). */
+export function describeActiveCredential(opts: {
+  argv: string[];
+  env: NodeJS.ProcessEnv;
+  /** Transient API key from flags/env/file before keychain merge (undefined if none). */
+  transientApiKey?: string;
+  effectiveApiKey?: string;
+  effectiveBearer?: string;
+}): ActiveCredential {
+  const { argv, env, transientApiKey, effectiveApiKey, effectiveBearer } = opts;
+
+  if (effectiveApiKey) {
+    const explicitFlag = readExplicitApiKeyFromArgv(argv);
+    if (explicitFlag !== undefined && explicitFlag === effectiveApiKey) {
+      return { kind: "api_key_flag", authenticated: true };
+    }
+    if (
+      transientApiKey &&
+      env.OBJECTIFIED_API_KEY &&
+      env.OBJECTIFIED_API_KEY === transientApiKey &&
+      transientApiKey === effectiveApiKey
+    ) {
+      return { kind: "api_key_env", authenticated: true };
+    }
+    if (transientApiKey && argvReferencesApiKeyFile(argv) && transientApiKey === effectiveApiKey) {
+      return { kind: "api_key_file", authenticated: true };
+    }
+    return { kind: "api_key_keychain", authenticated: true };
+  }
+
+  if (effectiveBearer) {
+    if (env.OBJECTIFIED_ACCESS_TOKEN && env.OBJECTIFIED_ACCESS_TOKEN === effectiveBearer) {
+      return { kind: "bearer_env", authenticated: true };
+    }
+    return { kind: "oauth_keychain", authenticated: true };
+  }
+
+  return { kind: "none", authenticated: false };
+}
+
+export function credentialKindLabel(kind: ActiveCredentialKind): string {
+  switch (kind) {
+    case "api_key_flag":
+      return "API key (--api-key)";
+    case "api_key_env":
+      return "API key (OBJECTIFIED_API_KEY)";
+    case "api_key_file":
+      return "API key (--api-key-file)";
+    case "api_key_keychain":
+      return "API key (stored for profile)";
+    case "oauth_keychain":
+      return "OAuth token (stored for profile)";
+    case "bearer_env":
+      return "Bearer token (OBJECTIFIED_ACCESS_TOKEN)";
+    default:
+      return "none";
+  }
+}

--- a/objectified-cli/src/lib/api-key-file.ts
+++ b/objectified-cli/src/lib/api-key-file.ts
@@ -1,0 +1,31 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { ObjectifiedCliError } from "./errors.js";
+import { EXIT_CODES } from "./exit-codes.js";
+
+export function readApiKeyFromFile(filePath: string): string {
+  const resolved = path.resolve(process.cwd(), filePath);
+  let raw: string;
+  try {
+    raw = fs.readFileSync(resolved, "utf8");
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    throw new ObjectifiedCliError({
+      message: `Could not read API key file (${msg}).`,
+      exitCode: EXIT_CODES.MISUSE,
+      title: "Invalid usage",
+      hint: "Check --api-key-file path permissions and that the file exists.",
+    });
+  }
+  const key = raw.replace(/^\uFEFF/, "").trim();
+  if (key === "") {
+    throw new ObjectifiedCliError({
+      message: "API key file is empty.",
+      exitCode: EXIT_CODES.MISUSE,
+      title: "Invalid usage",
+      hint: "Put the API key on a single line in the file, or use --api-key / OBJECTIFIED_API_KEY.",
+    });
+  }
+  return key;
+}

--- a/objectified-cli/src/lib/auth/read-secret-api-key.ts
+++ b/objectified-cli/src/lib/auth/read-secret-api-key.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 
-import { stdin as input, stdout as stderr } from "node:process";
+import { stdin as input, stderr } from "node:process";
 
 import { ObjectifiedCliError } from "../errors.js";
 import { EXIT_CODES } from "../exit-codes.js";

--- a/objectified-cli/src/lib/auth/read-secret-api-key.ts
+++ b/objectified-cli/src/lib/auth/read-secret-api-key.ts
@@ -1,0 +1,61 @@
+import fs from "node:fs";
+
+import { stdin as input, stdout as stderr } from "node:process";
+
+import { ObjectifiedCliError } from "../errors.js";
+import { EXIT_CODES } from "../exit-codes.js";
+
+/**
+ * Reads an API key without echoing input on TTYs (#3195).
+ * Falls back to stdin pipe when not a TTY (CI / scripting).
+ */
+export async function readApiKeyInteractively(): Promise<string> {
+  if (!input.isTTY) {
+    return fs.readFileSync(0, "utf8").trim();
+  }
+
+  stderr.write("Paste your API key (input hidden): ");
+
+  return await new Promise((resolve, reject) => {
+    const chars: string[] = [];
+    input.setRawMode(true);
+    input.resume();
+    input.setEncoding("utf8");
+
+    const cleanup = (): void => {
+      input.setRawMode(false);
+      input.removeListener("data", onData);
+      input.pause();
+    };
+
+    const onData = (buf: Buffer | string): void => {
+      const s = typeof buf === "string" ? buf : buf.toString("utf8");
+      for (const ch of s) {
+        if (ch === "\n" || ch === "\r") {
+          cleanup();
+          stderr.write("\n");
+          resolve(chars.join("").trim());
+          return;
+        }
+        if (ch === "\u0003") {
+          cleanup();
+          stderr.write("\n");
+          reject(
+            new ObjectifiedCliError({
+              message: "Interrupted.",
+              exitCode: EXIT_CODES.GENERIC,
+            }),
+          );
+          return;
+        }
+        if (ch === "\u007f" || ch === "\b") {
+          chars.pop();
+          continue;
+        }
+        chars.push(ch);
+      }
+    };
+
+    input.on("data", onData);
+  });
+}

--- a/objectified-cli/src/lib/cli-context.ts
+++ b/objectified-cli/src/lib/cli-context.ts
@@ -5,6 +5,7 @@ import { DEFAULT_BASE_URL } from "./constants.js";
 /** Parsed global flags (oclif uses camelCase keys). */
 export type GlobalCliFlags = {
   apiKey?: string;
+  apiKeyFile?: string;
   baseUrl?: string;
   config?: string;
   json?: boolean;

--- a/objectified-cli/src/lib/client.ts
+++ b/objectified-cli/src/lib/client.ts
@@ -13,11 +13,8 @@ import {
 } from "../generated/operations.js";
 
 import { EXIT_CODES } from "./exit-codes.js";
-import {
-  httpStatusToCliError,
-  networkErrnoToCliError,
-  ObjectifiedCliError,
-} from "./errors.js";
+import { httpStatusToCliError, networkErrnoToCliError, ObjectifiedCliError } from "./errors.js";
+import { redactApiKeyForLogs } from "./redact-api-key.js";
 
 /** Mutable auth fields read on every request (supports 401 refresh hook). */
 export type ApiAuthSnapshot = {
@@ -34,6 +31,8 @@ export type CreateApiClientOptions = {
   /** Invoked once after a 401 before retrying the same request. */
   onUnauthorized?: () => Promise<void>;
 };
+
+type RequestAuthMeta = { hadCredentials: boolean };
 
 export type ObjectifiedApi = {
   readonly lastRequestId: string | undefined;
@@ -57,10 +56,14 @@ function trimTrailingSlash(url: string): string {
 
 function mergeAuthHeaders(request: Request, auth: ApiAuthSnapshot): Request {
   const headers = new Headers(request.headers);
-  if (auth.apiKey) headers.set("X-API-Key", auth.apiKey);
-  else headers.delete("X-API-Key");
-  if (auth.bearer) headers.set("Authorization", `Bearer ${auth.bearer}`);
-  else headers.delete("Authorization");
+  if (auth.apiKey) {
+    headers.set("X-API-Key", auth.apiKey);
+    headers.delete("Authorization");
+  } else {
+    headers.delete("X-API-Key");
+    if (auth.bearer) headers.set("Authorization", `Bearer ${auth.bearer}`);
+    else headers.delete("Authorization");
+  }
   return new Request(request, { headers });
 }
 
@@ -156,11 +159,7 @@ function parseProjectsPayload(data: unknown): ProjectSchema[] {
         hint: "Required project fields were missing or mistyped.",
       });
     }
-    if (
-      p.enabled !== undefined &&
-      p.enabled !== null &&
-      typeof p.enabled !== "boolean"
-    ) {
+    if (p.enabled !== undefined && p.enabled !== null && typeof p.enabled !== "boolean") {
       throw new ObjectifiedCliError({
         message: "Invalid project fields in response.",
         exitCode: EXIT_CODES.VALIDATION,
@@ -180,6 +179,7 @@ function unwrapSdkGet(
   rawUnknown: unknown,
   lastRequestId: string | undefined,
   lastRetriesAttempted: number,
+  requestMeta: RequestAuthMeta,
 ): unknown {
   const rawBundle =
     rawUnknown && typeof rawUnknown === "object"
@@ -208,6 +208,7 @@ function unwrapSdkGet(
     throw httpStatusToCliError(status, formatApiError(rawBundle.error), {
       requestId: hdrId ?? lastRequestId,
       retriesAttempted: lastRetriesAttempted,
+      credentialsWereSent: requestMeta.hadCredentials,
     });
   }
 
@@ -320,11 +321,13 @@ function createInstrumentedFetch(opts: {
   stderrWrite?: (line: string) => void;
   onUnauthorized?: () => Promise<void>;
   onRetryStats?: (count: number) => void;
+  requestMeta: RequestAuthMeta;
 }): typeof fetch {
   const log = opts.stderrWrite ?? ((line: string) => process.stderr.write(`${line}\n`));
 
   return async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
     const baseReq = input instanceof Request ? input : new Request(input, init);
+    opts.requestMeta.hadCredentials = Boolean(opts.auth.apiKey || opts.auth.bearer);
     let req = mergeAuthHeaders(baseReq, opts.auth);
     let transientRetries = 0;
     let didReauth = false;
@@ -340,6 +343,14 @@ function createInstrumentedFetch(opts: {
       const response = await opts.inner(req);
       const rid = response.headers.get("x-request-id") ?? response.headers.get("X-Request-Id");
       if (opts.verbose && rid !== null && rid !== "") log(`objectified: request-id=${rid}`);
+      if (opts.verbose) {
+        const mode = opts.auth.apiKey
+          ? `api-key=${redactApiKeyForLogs(opts.auth.apiKey)}`
+          : opts.auth.bearer
+            ? "bearer=***"
+            : "none";
+        log(`objectified: auth=${mode}`);
+      }
 
       if (response.status === 401 && opts.onUnauthorized !== undefined && !didReauth) {
         didReauth = true;
@@ -351,10 +362,7 @@ function createInstrumentedFetch(opts: {
       const idem = methodIsIdempotent(req.method);
       const attemptNumber = transientRetries + 1;
 
-      if (
-        attemptNumber < MAX_TRANSIENT_ATTEMPTS &&
-        shouldRetryStatus(response.status, idem)
-      ) {
+      if (attemptNumber < MAX_TRANSIENT_ATTEMPTS && shouldRetryStatus(response.status, idem)) {
         if (!idem && response.status !== 429) {
           return response;
         }
@@ -382,6 +390,7 @@ export function createApiClient(options: CreateApiClientOptions): ObjectifiedApi
   const innerFetch = globalThis.fetch.bind(globalThis);
   let lastRequestId: string | undefined;
   let lastRetriesAttempted = 0;
+  const requestMeta: RequestAuthMeta = { hadCredentials: false };
 
   const instrumented = createInstrumentedFetch({
     inner: async (input, init) => {
@@ -401,6 +410,7 @@ export function createApiClient(options: CreateApiClientOptions): ObjectifiedApi
     verbose: options.verbose,
     stderrWrite: options.stderrWrite,
     onUnauthorized: options.onUnauthorized,
+    requestMeta,
     onRetryStats: (n) => {
       lastRetriesAttempted = n;
     },
@@ -435,7 +445,9 @@ export function createApiClient(options: CreateApiClientOptions): ObjectifiedApi
         throw e;
       }
 
-      return parseProjectsPayload(unwrapSdkGet(rawUnknown, lastRequestId, lastRetriesAttempted));
+      return parseProjectsPayload(
+        unwrapSdkGet(rawUnknown, lastRequestId, lastRetriesAttempted, requestMeta),
+      );
     },
 
     async listVersions(tenantSlug: string, projectId: string): Promise<VersionSchema[]> {
@@ -453,7 +465,9 @@ export function createApiClient(options: CreateApiClientOptions): ObjectifiedApi
         }
         throw e;
       }
-      return parseVersionsPayload(unwrapSdkGet(rawUnknown, lastRequestId, lastRetriesAttempted));
+      return parseVersionsPayload(
+        unwrapSdkGet(rawUnknown, lastRequestId, lastRetriesAttempted, requestMeta),
+      );
     },
 
     async listClasses(tenantSlug: string, versionId?: string): Promise<ClassSchema[]> {
@@ -472,7 +486,9 @@ export function createApiClient(options: CreateApiClientOptions): ObjectifiedApi
         }
         throw e;
       }
-      return parseClassesPayload(unwrapSdkGet(rawUnknown, lastRequestId, lastRetriesAttempted));
+      return parseClassesPayload(
+        unwrapSdkGet(rawUnknown, lastRequestId, lastRetriesAttempted, requestMeta),
+      );
     },
 
     async listPrimitives(tenantSlug: string): Promise<PrimitiveSchema[]> {
@@ -490,7 +506,9 @@ export function createApiClient(options: CreateApiClientOptions): ObjectifiedApi
         }
         throw e;
       }
-      return parsePrimitivesPayload(unwrapSdkGet(rawUnknown, lastRequestId, lastRetriesAttempted));
+      return parsePrimitivesPayload(
+        unwrapSdkGet(rawUnknown, lastRequestId, lastRetriesAttempted, requestMeta),
+      );
     },
   };
 }

--- a/objectified-cli/src/lib/completion/candidates-logic.ts
+++ b/objectified-cli/src/lib/completion/candidates-logic.ts
@@ -12,6 +12,7 @@ import { extractProfileFromWords, matchesPrefix, splitCommandTokens } from "./pa
 
 const GLOBAL_FLAG_TOKENS = [
   "--api-key",
+  "--api-key-file",
   "--base-url",
   "--config",
   "--json",
@@ -111,10 +112,14 @@ async function loadProjectSlugIdRows(
   profileCacheKey: string,
   tenantSlug: string,
 ): Promise<Array<{ slug: string; id: string }>> {
-  const rows = await withCompletionCache(profileCacheKey, ["projects-map", tenantSlug], async () => {
-    const list = await api.listProjects(tenantSlug);
-    return list.map((p) => `${p.slug}\t${p.id}`);
-  });
+  const rows = await withCompletionCache(
+    profileCacheKey,
+    ["projects-map", tenantSlug],
+    async () => {
+      const list = await api.listProjects(tenantSlug);
+      return list.map((p) => `${p.slug}\t${p.id}`);
+    },
+  );
   const out: Array<{ slug: string; id: string }> = [];
   for (const row of rows) {
     const tab = row.indexOf("\t");
@@ -154,18 +159,12 @@ async function tryDynamicCandidates(opts: {
 
   if (cmdParts[0] === "projects" && cmdParts[1] === "show" && cmdParts.length === 2) {
     const rows = await loadProjectSlugIdRows(api, profileCacheKey, tenantSlug);
-    return filterByPrefix(
-      uniqSorted(rows.map((r) => r.slug)),
-      current,
-    );
+    return filterByPrefix(uniqSorted(rows.map((r) => r.slug)), current);
   }
 
   if (cmdParts[0] === "versions" && cmdParts[1] === "list" && cmdParts.length === 2) {
     const rows = await loadProjectSlugIdRows(api, profileCacheKey, tenantSlug);
-    return filterByPrefix(
-      uniqSorted(rows.map((r) => r.slug)),
-      current,
-    );
+    return filterByPrefix(uniqSorted(rows.map((r) => r.slug)), current);
   }
 
   if (cmdParts[0] === "versions" && cmdParts[1] === "list" && cmdParts.length === 3) {
@@ -187,10 +186,7 @@ async function tryDynamicCandidates(opts: {
 
   if (cmdParts[0] === "versions" && cmdParts[1] === "show" && cmdParts.length === 2) {
     const rows = await loadProjectSlugIdRows(api, profileCacheKey, tenantSlug);
-    return filterByPrefix(
-      uniqSorted(rows.map((r) => r.slug)),
-      current,
-    );
+    return filterByPrefix(uniqSorted(rows.map((r) => r.slug)), current);
   }
 
   if (cmdParts[0] === "versions" && cmdParts[1] === "show" && cmdParts.length === 3) {
@@ -219,10 +215,14 @@ async function tryDynamicCandidates(opts: {
   }
 
   if (cmdParts[0] === "primitives" && cmdParts[1] === "show" && cmdParts.length === 2) {
-    const values = await withCompletionCache(profileCacheKey, ["primitives", tenantSlug], async () => {
-      const rows = await api.listPrimitives(tenantSlug);
-      return uniqSorted(rows.map((p) => p.name));
-    });
+    const values = await withCompletionCache(
+      profileCacheKey,
+      ["primitives", tenantSlug],
+      async () => {
+        const rows = await api.listPrimitives(tenantSlug);
+        return uniqSorted(rows.map((p) => p.name));
+      },
+    );
     return filterByPrefix(values, current);
   }
 

--- a/objectified-cli/src/lib/completion/parse-line.ts
+++ b/objectified-cli/src/lib/completion/parse-line.ts
@@ -1,6 +1,9 @@
 /** Split CLI words (from the shell driver) into profile override and command tokens. */
 
-export function extractProfileFromWords(words: string[], uptoInclusive: number): string | undefined {
+export function extractProfileFromWords(
+  words: string[],
+  uptoInclusive: number,
+): string | undefined {
   const hi = Math.min(uptoInclusive, words.length - 1);
   for (let i = 1; i <= hi; i++) {
     const w = words[i];
@@ -45,6 +48,11 @@ export function splitCommandTokens(words: string[], cword: number): SplitWordsRe
       }
       if (w === "--api-key" || w.startsWith("--api-key=")) {
         if (w === "--api-key") i += 2;
+        else i += 1;
+        continue;
+      }
+      if (w === "--api-key-file" || w.startsWith("--api-key-file=")) {
+        if (w === "--api-key-file") i += 2;
         else i += 1;
         continue;
       }

--- a/objectified-cli/src/lib/constants.ts
+++ b/objectified-cli/src/lib/constants.ts
@@ -2,3 +2,6 @@ export const DEFAULT_BASE_URL = "https://api.objectified.dev";
 
 /** Web UI entry for CLI OAuth (PKCE); opened by `objectified auth login`. */
 export const DEFAULT_CLI_WEB_LOGIN_URL = "https://app.objectified.dev/cli/login";
+
+/** Injected before oclif parse when `auth login --api-key` has no value (#3195). */
+export const API_KEY_PROMPT_SENTINEL = "__OBJECTIFIED_API_KEY_PROMPT__";

--- a/objectified-cli/src/lib/credentials/store.ts
+++ b/objectified-cli/src/lib/credentials/store.ts
@@ -13,18 +13,23 @@ export type CliOAuthBundle = {
   refreshToken: string;
 };
 
-const memoryBackends = new Map<string, CliOAuthBundle>();
+export type StoredCliCredential =
+  | ({ kind?: "oauth" } & CliOAuthBundle)
+  | { kind: "api_key"; apiKey: string };
+
+export type LoadedCliAuth =
+  | { kind: "oauth"; accessToken: string; refreshToken: string }
+  | { kind: "api_key"; apiKey: string };
+
+const memoryBackends = new Map<string, StoredCliCredential>();
 let keytarPromise: Promise<KeytarModule> | null = null;
 
 function useMemoryBackend(): boolean {
   return process.env.OBJECTIFIED_CLI_CREDENTIAL_BACKEND === "memory";
 }
 
-function toStoredBundle(bundle: CliOAuthBundle): CliOAuthBundle {
-  return {
-    accessToken: bundle.accessToken,
-    refreshToken: bundle.refreshToken,
-  };
+function toStoredOAuth(bundle: CliOAuthBundle): StoredCliCredential {
+  return { kind: "oauth", accessToken: bundle.accessToken, refreshToken: bundle.refreshToken };
 }
 
 async function loadKeytar() {
@@ -36,8 +41,7 @@ async function loadKeytar() {
       throw new ObjectifiedCliError({
         message: `OS keychain is unavailable for CLI credentials (${detail}).`,
         exitCode: EXIT_CODES.GENERIC,
-        hint:
-          "Install the required system keychain libraries (for example, libsecret on Linux) or set OBJECTIFIED_CLI_CREDENTIAL_BACKEND=memory for environments without a keychain.",
+        hint: "Install the required system keychain libraries (for example, libsecret on Linux) or set OBJECTIFIED_CLI_CREDENTIAL_BACKEND=memory for environments without a keychain.",
       });
     });
   return keytarPromise;
@@ -48,11 +52,31 @@ export function resetMemoryCredentialBackend(): void {
   memoryBackends.clear();
 }
 
+function parseStoredCredential(raw: string): LoadedCliAuth | null {
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== "object") return null;
+    const rec = parsed as Record<string, unknown>;
+    if (rec.kind === "api_key" && typeof rec.apiKey === "string")
+      return { kind: "api_key", apiKey: rec.apiKey };
+    if (
+      typeof rec.accessToken === "string" &&
+      typeof rec.refreshToken === "string" &&
+      (rec.kind === undefined || rec.kind === "oauth")
+    ) {
+      return { kind: "oauth", accessToken: rec.accessToken, refreshToken: rec.refreshToken };
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
 export async function saveCliOAuthCredentials(
   profile: string,
   bundle: CliOAuthBundle,
 ): Promise<void> {
-  const stored = toStoredBundle(bundle);
+  const stored = toStoredOAuth(bundle);
   if (useMemoryBackend()) {
     memoryBackends.set(profile, stored);
     return;
@@ -61,27 +85,34 @@ export async function saveCliOAuthCredentials(
   await keytar.setPassword(SERVICE_NAME, profile, JSON.stringify(stored));
 }
 
-export async function loadCliOAuthCredentials(profile: string): Promise<CliOAuthBundle | null> {
+export async function saveCliApiKeyCredentials(profile: string, apiKey: string): Promise<void> {
+  const stored: StoredCliCredential = { kind: "api_key", apiKey };
   if (useMemoryBackend()) {
-    return memoryBackends.get(profile) ?? null;
+    memoryBackends.set(profile, stored);
+    return;
+  }
+  const keytar = await loadKeytar();
+  await keytar.setPassword(SERVICE_NAME, profile, JSON.stringify(stored));
+}
+
+/** Loads OAuth tokens only (legacy helper for callers that ignore API keys). */
+export async function loadCliOAuthCredentials(profile: string): Promise<CliOAuthBundle | null> {
+  const auth = await loadCliStoredAuth(profile);
+  if (auth?.kind !== "oauth") return null;
+  return { accessToken: auth.accessToken, refreshToken: auth.refreshToken };
+}
+
+export async function loadCliStoredAuth(profile: string): Promise<LoadedCliAuth | null> {
+  if (useMemoryBackend()) {
+    const hit = memoryBackends.get(profile);
+    if (!hit) return null;
+    if (hit.kind === "api_key") return { kind: "api_key", apiKey: hit.apiKey };
+    return { kind: "oauth", accessToken: hit.accessToken, refreshToken: hit.refreshToken };
   }
   const keytar = await loadKeytar();
   const raw = await keytar.getPassword(SERVICE_NAME, profile);
   if (raw === null) return null;
-  try {
-    const parsed = JSON.parse(raw) as unknown;
-    if (
-      !parsed ||
-      typeof parsed !== "object" ||
-      typeof (parsed as CliOAuthBundle).accessToken !== "string" ||
-      typeof (parsed as CliOAuthBundle).refreshToken !== "string"
-    ) {
-      return null;
-    }
-    return parsed as CliOAuthBundle;
-  } catch {
-    return null;
-  }
+  return parseStoredCredential(raw);
 }
 
 export async function deleteCliOAuthCredentials(profile: string): Promise<void> {

--- a/objectified-cli/src/lib/docs-content.ts
+++ b/objectified-cli/src/lib/docs-content.ts
@@ -29,7 +29,7 @@ default_profile
   default_profile selects which profile is active when --profile is omitted. Use objectified config get default_profile or objectified config set default_profile staging.
 
 Resolution order
-  Base URL and tenant slug resolve per profile: explicit flags and env vars override profile values, which override [default]. API keys are never read from the file (#3188); use --api-key or OBJECTIFIED_API_KEY.
+  Base URL and tenant slug resolve per profile: explicit flags and env vars override profile values, which override [default]. API keys are never read from config.toml (#3188); use --api-key, OBJECTIFIED_API_KEY, --api-key-file, or store one with objectified auth login --api-key (#3195).
 
 Switching profiles
   Pass --profile <name> for a single invocation or change default_profile for every command.

--- a/objectified-cli/src/lib/errors.ts
+++ b/objectified-cli/src/lib/errors.ts
@@ -39,6 +39,8 @@ export class CliError extends ObjectifiedCliError {
 export type HttpErrorContext = {
   requestId?: string;
   retriesAttempted?: number;
+  /** True when the CLI attached X-API-Key or Authorization on the failing request (#3195). */
+  credentialsWereSent?: boolean;
 };
 
 function retryHint(ctx: HttpErrorContext): string | undefined {
@@ -62,11 +64,27 @@ export function httpStatusToCliError(
   const rHint = retryHint(ctx);
 
   if (status === 401) {
+    if (ctx.credentialsWereSent) {
+      return new ObjectifiedCliError({
+        message: base,
+        exitCode: EXIT_CODES.FORBIDDEN,
+        title: "Invalid credentials",
+        hint: mergeHints(
+          "Verify your API key or OAuth token, or run `objectified auth login`.",
+          rHint,
+        ),
+        requestId: ctx.requestId,
+        retriesAttempted: ctx.retriesAttempted,
+      });
+    }
     return new ObjectifiedCliError({
       message: base,
       exitCode: EXIT_CODES.NOT_AUTHENTICATED,
       title: "Not authenticated",
-      hint: mergeHints("Run `objectified auth login` or set OBJECTIFIED_API_KEY.", rHint),
+      hint: mergeHints(
+        "Run `objectified auth login`, set OBJECTIFIED_API_KEY, or use --api-key / --api-key-file.",
+        rHint,
+      ),
       requestId: ctx.requestId,
       retriesAttempted: ctx.retriesAttempted,
     });
@@ -156,8 +174,7 @@ export function httpStatusToCliError(
   }
 
   if (status >= 500 && status <= 599) {
-    const exit =
-      status === 504 ? EXIT_CODES.NETWORK : EXIT_CODES.SERVER_ERROR;
+    const exit = status === 504 ? EXIT_CODES.NETWORK : EXIT_CODES.SERVER_ERROR;
     const title = status === 504 ? "Gateway timeout" : "Server error";
     return new ObjectifiedCliError({
       message: base,
@@ -212,13 +229,15 @@ export function networkErrnoToCliError(err: NodeJS.ErrnoException): ObjectifiedC
   const baseHint =
     "Check VPN / firewall / DNS; verify `--base-url` or OBJECTIFIED_BASE_URL reaches the API.";
   const specifics: Record<string, string> = {
-    ECONNREFUSED: "Connection refused — nothing is listening at this host/port or a firewall blocked it.",
+    ECONNREFUSED:
+      "Connection refused — nothing is listening at this host/port or a firewall blocked it.",
     ENOTFOUND: "DNS lookup failed — check the hostname in `--base-url`.",
     EAI_AGAIN: "Temporary DNS failure — retry or check resolver / VPN.",
     ETIMEDOUT: "Connection timed out — host may be down or blocked.",
     EPIPE: "Connection closed unexpectedly — retry or verify `--base-url`.",
     CERT_HAS_EXPIRED: "TLS certificate expired — update server or trust store.",
-    UNABLE_TO_VERIFY_LEAF_SIGNATURE: "TLS verification failed — check corporate proxy or `--base-url`.",
+    UNABLE_TO_VERIFY_LEAF_SIGNATURE:
+      "TLS verification failed — check corporate proxy or `--base-url`.",
   };
   const detail = specifics[code];
   return new ObjectifiedCliError({

--- a/objectified-cli/src/lib/exit-codes.ts
+++ b/objectified-cli/src/lib/exit-codes.ts
@@ -24,17 +24,33 @@ export type ExitCodeRow = {
 
 export const EXIT_CODE_TABLE: ExitCodeRow[] = [
   { code: 0, label: "success", hint: "Command completed normally." },
-  { code: 1, label: "generic failure", hint: "Unexpected error; see message and retry with OBJECTIFIED_DEBUG=1." },
+  {
+    code: 1,
+    label: "generic failure",
+    hint: "Unexpected error; see message and retry with OBJECTIFIED_DEBUG=1.",
+  },
   { code: 2, label: "misuse", hint: "Fix flags or arguments; try --help on the command." },
   {
     code: 3,
     label: "not authenticated",
     hint: "Run `objectified auth login` or set OBJECTIFIED_API_KEY / bearer token.",
   },
-  { code: 4, label: "forbidden", hint: "Switch tenant or API key; check permissions for this resource." },
-  { code: 5, label: "not found", hint: "Check spelling of slugs and IDs; see suggestions when available." },
+  {
+    code: 4,
+    label: "forbidden / invalid credentials",
+    hint: "Invalid API key or OAuth token (401 with credentials), or insufficient permissions (403).",
+  },
+  {
+    code: 5,
+    label: "not found",
+    hint: "Check spelling of slugs and IDs; see suggestions when available.",
+  },
   { code: 6, label: "conflict", hint: "Pull remote changes or fork before retrying." },
-  { code: 7, label: "validation", hint: "Fix request payload; use --dry-run where supported to preview changes." },
+  {
+    code: 7,
+    label: "validation",
+    hint: "Fix request payload; use --dry-run where supported to preview changes.",
+  },
   {
     code: 8,
     label: "server error",
@@ -50,7 +66,11 @@ export const EXIT_CODE_TABLE: ExitCodeRow[] = [
     label: "rate limited",
     hint: "Wait for Retry-After (shown when present), then retry with backoff.",
   },
-  { code: 11, label: "config error", hint: "Run `objectified config path` and fix config.toml / profile entries." },
+  {
+    code: 11,
+    label: "config error",
+    hint: "Run `objectified config path` and fix config.toml / profile entries.",
+  },
 ];
 
 export function formatExitCodeDocs(): string {

--- a/objectified-cli/src/lib/normalize-argv.ts
+++ b/objectified-cli/src/lib/normalize-argv.ts
@@ -3,6 +3,64 @@
  * that appear before the command to the tail so `objectified --json hello` works like `hello --json`.
  */
 
+import { API_KEY_PROMPT_SENTINEL } from "./constants.js";
+
+function indexOfSubcommand(argv: string[], parts: string[]): number {
+  outer: for (let i = 0; i <= argv.length - parts.length; i++) {
+    for (let j = 0; j < parts.length; j++) {
+      if (argv[i + j] !== parts[j]) continue outer;
+    }
+    return i;
+  }
+  return -1;
+}
+
+/** True when normalized argv has `auth login … --api-key …` (explicit store / prompt flow). */
+export function authLoginIntendsApiKeyStore(argv: string[]): boolean {
+  const loginAt = indexOfSubcommand(argv, ["auth", "login"]);
+  if (loginAt === -1) return false;
+  const afterLogin = loginAt + 2;
+  for (let i = afterLogin; i < argv.length; i++) {
+    const t = argv[i];
+    if (t === "--api-key") return true;
+    if (t?.startsWith("--api-key=")) return true;
+  }
+  return false;
+}
+
+/** Ensures `auth login --api-key` without a value parses by inserting a sentinel token. */
+export function normalizeAuthLoginApiKeyPrompt(argv: string[]): string[] {
+  const loginAt = indexOfSubcommand(argv, ["auth", "login"]);
+  if (loginAt === -1) return argv;
+  const afterLogin = loginAt + 2;
+  for (let i = afterLogin; i < argv.length; i++) {
+    const t = argv[i];
+    if (t === "--api-key") {
+      const next = argv[i + 1];
+      if (next === undefined || next.startsWith("-")) {
+        const out = [...argv];
+        out.splice(i + 1, 0, API_KEY_PROMPT_SENTINEL);
+        return out;
+      }
+      return argv;
+    }
+    if (t?.startsWith("--api-key=")) {
+      const rest = t.slice("--api-key=".length);
+      if (rest === "") {
+        const out = [...argv];
+        out[i] = `--api-key=${API_KEY_PROMPT_SENTINEL}`;
+        return out;
+      }
+      return argv;
+    }
+  }
+  return argv;
+}
+
+export function normalizeCliArgv(argv: string[]): string[] {
+  return normalizeAuthLoginApiKeyPrompt(promoteLeadingGlobalFlags(argv));
+}
+
 const BOOL_GLOBALS = new Set([
   "--json",
   "--no-json",
@@ -16,7 +74,13 @@ const BOOL_GLOBALS = new Set([
   "--version",
 ]);
 
-const VALUE_GLOBALS = new Set(["--api-key", "--base-url", "--config", "--profile"]);
+const VALUE_GLOBALS = new Set([
+  "--api-key",
+  "--api-key-file",
+  "--base-url",
+  "--config",
+  "--profile",
+]);
 
 function valueFlagName(token: string): string | undefined {
   const eq = token.indexOf("=");

--- a/objectified-cli/src/lib/redact-api-key.ts
+++ b/objectified-cli/src/lib/redact-api-key.ts
@@ -1,0 +1,8 @@
+/** Redacts API keys for stderr / verbose output (#3195). */
+export function redactApiKeyForLogs(key: string): string {
+  const t = key.trim();
+  if (t === "") return "***";
+  const prefixMatch = /^(sk_|pk_)/.exec(t);
+  if (prefixMatch?.[1] !== undefined) return `${prefixMatch[1]}***`;
+  return "***";
+}

--- a/objectified-cli/test/__snapshots__/handle-error.snap.test.ts.snap
+++ b/objectified-cli/test/__snapshots__/handle-error.snap.test.ts.snap
@@ -31,6 +31,14 @@ Request-Id: 7f2c…cafe
 Exit code:  1"
 `;
 
+exports[`handleError snapshots by category > invalid credentials (401 with auth headers) 1`] = `
+"✖ Invalid credentials
+Reason: Invalid API key
+Hint:   Verify your API key or OAuth token, or run \`objectified auth login\`.
+Request-Id: rid-401b
+Exit code:  4"
+`;
+
 exports[`handleError snapshots by category > misuse (oclif unknown flag) 1`] = `
 "✖ Invalid usage
 Reason: Unexpected flag --frobnitz
@@ -49,7 +57,7 @@ Exit code:  9"
 exports[`handleError snapshots by category > not authenticated 1`] = `
 "✖ Not authenticated
 Reason: Missing bearer token
-Hint:   Run \`objectified auth login\` or set OBJECTIFIED_API_KEY.
+Hint:   Run \`objectified auth login\`, set OBJECTIFIED_API_KEY, or use --api-key / --api-key-file.
 Request-Id: rid-401
 Exit code:  3"
 `;

--- a/objectified-cli/test/api-client.test.ts
+++ b/objectified-cli/test/api-client.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { createApiClient } from "../src/lib/client.js";
+import { redactApiKeyForLogs } from "../src/lib/redact-api-key.js";
 
 describe("createApiClient + generated SDK", () => {
   const originalFetch = globalThis.fetch;
@@ -9,6 +10,53 @@ describe("createApiClient + generated SDK", () => {
     vi.useRealTimers();
     globalThis.fetch = originalFetch;
     vi.restoreAllMocks();
+  });
+
+  it("does not send Authorization when an API key is set (API key wins)", async () => {
+    const mockFetch = vi.fn(async (input: RequestInfo | URL) => {
+      const request = input instanceof Request ? input : new Request(input);
+      expect(request.headers.get("x-api-key")).toBe("sk_live_abc");
+      expect(request.headers.get("authorization")).toBeNull();
+      return new Response(JSON.stringify([]), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+    globalThis.fetch = mockFetch as typeof fetch;
+
+    const auth: { apiKey?: string; bearer?: string } = {
+      apiKey: "sk_live_abc",
+      bearer: "should-not-send",
+    };
+    const api = createApiClient({
+      baseUrl: "http://127.0.0.1:9",
+      auth,
+    });
+
+    await expect(api.listProjects("acme-corp")).resolves.toEqual([]);
+  });
+
+  it("verbose logs redact API keys (#3195)", async () => {
+    const lines: string[] = [];
+    const mockFetch = vi.fn(async () => {
+      return new Response(JSON.stringify([]), {
+        status: 200,
+        headers: { "Content-Type": "application/json", "x-request-id": "r1" },
+      });
+    });
+    globalThis.fetch = mockFetch as typeof fetch;
+
+    const api = createApiClient({
+      baseUrl: "http://127.0.0.1:9",
+      auth: { apiKey: "sk_live_secret_suffix" },
+      verbose: true,
+      stderrWrite: (line) => lines.push(line),
+    });
+
+    await api.listProjects("acme-corp");
+    const joined = lines.join("\n");
+    expect(joined).not.toContain("secret_suffix");
+    expect(joined).toContain(`api-key=${redactApiKeyForLogs("sk_live_secret_suffix")}`);
   });
 
   it("listProjects performs GET /v1/projects/{tenant_slug}", async () => {

--- a/objectified-cli/test/cli.integration.test.ts
+++ b/objectified-cli/test/cli.integration.test.ts
@@ -1,5 +1,6 @@
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawn, spawnSync } from "node:child_process";
 import fs from "node:fs";
+import http from "node:http";
 import os from "node:os";
 import { performance } from "node:perf_hooks";
 import path from "node:path";
@@ -10,7 +11,12 @@ import { describe, expect, it } from "vitest";
 const pkgRoot = path.join(path.dirname(fileURLToPath(import.meta.url)), "..");
 
 function run(args: string[], extraEnv: Record<string, string> = {}): string {
-  const env = { ...process.env, FORCE_COLOR: "0", ...extraEnv };
+  const env = {
+    ...process.env,
+    FORCE_COLOR: "0",
+    OBJECTIFIED_CLI_CREDENTIAL_BACKEND: "memory",
+    ...extraEnv,
+  };
   delete env.NODE_OPTIONS;
   return execFileSync("node", [path.join(pkgRoot, "bin/run.js"), ...args], {
     cwd: pkgRoot,
@@ -32,8 +38,74 @@ function runExpectFailure(args: string[], extraEnv: Record<string, string> = {})
   }
 }
 
+function runExitAsync(
+  args: string[],
+  extraEnv: Record<string, string> = {},
+  timeoutMs = 20_000,
+): Promise<number> {
+  const env = {
+    ...process.env,
+    FORCE_COLOR: "0",
+    OBJECTIFIED_CLI_CREDENTIAL_BACKEND: "memory",
+    ...extraEnv,
+  };
+  delete env.NODE_OPTIONS;
+
+  return new Promise((resolve, reject) => {
+    const child = spawn("node", [path.join(pkgRoot, "bin/run.js"), ...args], {
+      cwd: pkgRoot,
+      env,
+      stdio: "inherit",
+    });
+
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      child.kill("SIGKILL");
+      reject(new Error(`CLI subprocess timed out after ${String(timeoutMs)}ms: ${args.join(" ")}`));
+    }, timeoutMs);
+
+    child.on("error", (err) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      reject(err);
+    });
+
+    child.on("exit", (code) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(code ?? 1);
+    });
+  });
+}
+
+function runExit(args: string[], extraEnv: Record<string, string> = {}): number {
+  const env = {
+    ...process.env,
+    FORCE_COLOR: "0",
+    OBJECTIFIED_CLI_CREDENTIAL_BACKEND: "memory",
+    ...extraEnv,
+  };
+  delete env.NODE_OPTIONS;
+  const r = spawnSync("node", [path.join(pkgRoot, "bin/run.js"), ...args], {
+    cwd: pkgRoot,
+    encoding: "utf8",
+    env,
+  });
+  if (r.error) throw r.error;
+  return r.status ?? 1;
+}
+
 function runStdin(args: string[], stdin: string, extraEnv: Record<string, string> = {}): string {
-  const env = { ...process.env, FORCE_COLOR: "0", ...extraEnv };
+  const env = {
+    ...process.env,
+    FORCE_COLOR: "0",
+    OBJECTIFIED_CLI_CREDENTIAL_BACKEND: "memory",
+    ...extraEnv,
+  };
   delete env.NODE_OPTIONS;
   return execFileSync("node", [path.join(pkgRoot, "bin/run.js"), ...args], {
     cwd: pkgRoot,
@@ -125,6 +197,161 @@ describe("objectified CLI", () => {
     const out = run(["auth", "login", "--help"]);
     expect(out).toMatch(/PKCE/i);
     expect(out).toMatch(/--no-browser/);
+    expect(out).toMatch(/--api-key/);
+  });
+
+  it("auth status exits 3 without credentials", () => {
+    expect(runExit(["--no-json", "auth", "status"])).toBe(3);
+  });
+
+  it("auth status exits 0 with OBJECTIFIED_API_KEY", () => {
+    expect(runExit(["--no-json", "auth", "status"], { OBJECTIFIED_API_KEY: "sk_live_test" })).toBe(
+      0,
+    );
+  });
+
+  it("projects list exits 3 when tenant is set but credentials are missing", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "obj-cli-auth-"));
+    const cfg = path.join(dir, "config.toml");
+    fs.writeFileSync(
+      cfg,
+      `
+[default]
+tenant_slug = "acme"
+`,
+      "utf8",
+    );
+    expect(runExit(["--no-json", "--config", cfg, "projects", "list"])).toBe(3);
+  });
+
+  it("projects list sends X-API-Key to a mock API (#3195)", async () => {
+    const server = http.createServer((req, res) => {
+      res.setHeader("Connection", "close");
+      if (!req.url?.startsWith("/v1/projects/acme")) {
+        res.statusCode = 404;
+        res.end();
+        return;
+      }
+      if (req.headers["x-api-key"] !== "good-key") {
+        res.statusCode = 401;
+        res.setHeader("Content-Type", "application/json");
+        res.end(JSON.stringify({ detail: "Authentication required" }));
+        return;
+      }
+      res.setHeader("Content-Type", "application/json");
+      res.end(
+        JSON.stringify([
+          { id: "p1", tenant_id: "t1", name: "Payments", slug: "payments", enabled: true },
+        ]),
+      );
+    });
+
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", () => resolve()));
+    const addr = server.address();
+    if (addr === null || typeof addr === "string") throw new Error("expected AddressInfo");
+
+    try {
+      const code = await runExitAsync(
+        [
+          "--base-url",
+          `http://127.0.0.1:${addr.port}`,
+          "--api-key",
+          "good-key",
+          "--no-json",
+          "projects",
+          "list",
+        ],
+        { OBJECTIFIED_TENANT: "acme" },
+      );
+      expect(code).toBe(0);
+    } finally {
+      server.closeAllConnections?.();
+      await new Promise<void>((resolve, reject) =>
+        server.close((err) => (err !== undefined ? reject(err) : resolve())),
+      );
+    }
+  });
+
+  it("projects list exits 4 when the API rejects the API key", async () => {
+    const server = http.createServer((req, res) => {
+      res.setHeader("Connection", "close");
+      res.statusCode = 401;
+      res.setHeader("Content-Type", "application/json");
+      res.end(JSON.stringify({ detail: "Invalid API key" }));
+    });
+
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", () => resolve()));
+    const addr = server.address();
+    if (addr === null || typeof addr === "string") throw new Error("expected AddressInfo");
+
+    try {
+      const code = await runExitAsync(
+        [
+          "--base-url",
+          `http://127.0.0.1:${addr.port}`,
+          "--api-key",
+          "bad-key",
+          "--no-json",
+          "projects",
+          "list",
+        ],
+        { OBJECTIFIED_TENANT: "acme" },
+      );
+      expect(code).toBe(4);
+    } finally {
+      server.closeAllConnections?.();
+      await new Promise<void>((resolve, reject) =>
+        server.close((err) => (err !== undefined ? reject(err) : resolve())),
+      );
+    }
+  });
+
+  it("projects list reads API key from --api-key-file", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "obj-cli-keyfile-"));
+    const keyPath = path.join(dir, "apikey.txt");
+    fs.writeFileSync(keyPath, "good-key\n", "utf8");
+
+    const server = http.createServer((req, res) => {
+      res.setHeader("Connection", "close");
+      if (!req.url?.startsWith("/v1/projects/acme")) {
+        res.statusCode = 404;
+        res.end();
+        return;
+      }
+      if (req.headers["x-api-key"] !== "good-key") {
+        res.statusCode = 401;
+        res.setHeader("Content-Type", "application/json");
+        res.end(JSON.stringify({ detail: "no" }));
+        return;
+      }
+      res.setHeader("Content-Type", "application/json");
+      res.end(JSON.stringify([]));
+    });
+
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", () => resolve()));
+    const addr = server.address();
+    if (addr === null || typeof addr === "string") throw new Error("expected AddressInfo");
+
+    try {
+      const code = await runExitAsync(
+        [
+          "--base-url",
+          `http://127.0.0.1:${addr.port}`,
+          "--api-key-file",
+          keyPath,
+          "--no-json",
+          "projects",
+          "list",
+        ],
+        { OBJECTIFIED_TENANT: "acme" },
+      );
+      expect(code).toBe(0);
+    } finally {
+      server.closeAllConnections?.();
+      await new Promise<void>((resolve, reject) =>
+        server.close((err) => (err !== undefined ? reject(err) : resolve())),
+      );
+    }
   });
 
   it("unknown command suggests typo fix when close match", () => {

--- a/objectified-cli/test/credentials-store.test.ts
+++ b/objectified-cli/test/credentials-store.test.ts
@@ -9,11 +9,8 @@ afterEach(() => {
 describe("CLI credential store", () => {
   it("stores only oauth tokens in the memory backend", async () => {
     process.env.OBJECTIFIED_CLI_CREDENTIAL_BACKEND = "memory";
-    const {
-      loadCliOAuthCredentials,
-      resetMemoryCredentialBackend,
-      saveCliOAuthCredentials,
-    } = await import("../src/lib/credentials/store.js");
+    const { loadCliOAuthCredentials, resetMemoryCredentialBackend, saveCliOAuthCredentials } =
+      await import("../src/lib/credentials/store.js");
 
     resetMemoryCredentialBackend();
     const bundleWithDisplayEmail: Parameters<typeof saveCliOAuthCredentials>[1] & {
@@ -23,14 +20,25 @@ describe("CLI credential store", () => {
       refreshToken: "refresh",
       displayEmail: "user@example.com",
     };
-    await saveCliOAuthCredentials(
-      "default",
-      bundleWithDisplayEmail,
-    );
+    await saveCliOAuthCredentials("default", bundleWithDisplayEmail);
 
     await expect(loadCliOAuthCredentials("default")).resolves.toEqual({
       accessToken: "access",
       refreshToken: "refresh",
+    });
+  });
+
+  it("stores API keys in the memory backend (#3195)", async () => {
+    process.env.OBJECTIFIED_CLI_CREDENTIAL_BACKEND = "memory";
+    const { loadCliStoredAuth, resetMemoryCredentialBackend, saveCliApiKeyCredentials } =
+      await import("../src/lib/credentials/store.js");
+
+    resetMemoryCredentialBackend();
+    await saveCliApiKeyCredentials("default", "sk_live_unit_test_12345");
+
+    await expect(loadCliStoredAuth("default")).resolves.toEqual({
+      kind: "api_key",
+      apiKey: "sk_live_unit_test_12345",
     });
   });
 

--- a/objectified-cli/test/handle-error.snap.test.ts
+++ b/objectified-cli/test/handle-error.snap.test.ts
@@ -2,7 +2,11 @@ import { CLIError } from "@oclif/core/errors";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { EXIT_CODES } from "../src/lib/exit-codes.js";
-import { httpStatusToCliError, networkErrnoToCliError, ObjectifiedCliError } from "../src/lib/errors.js";
+import {
+  httpStatusToCliError,
+  networkErrnoToCliError,
+  ObjectifiedCliError,
+} from "../src/lib/errors.js";
 import {
   formatAndReportCliFailure,
   handleError,
@@ -45,7 +49,22 @@ describe("handleError snapshots by category", () => {
 
   it("not authenticated", () => {
     expect(
-      handleError(httpStatusToCliError(401, "Missing bearer token", { requestId: "rid-401" }), noColor),
+      handleError(
+        httpStatusToCliError(401, "Missing bearer token", { requestId: "rid-401" }),
+        noColor,
+      ),
+    ).toMatchSnapshot();
+  });
+
+  it("invalid credentials (401 with auth headers)", () => {
+    expect(
+      handleError(
+        httpStatusToCliError(401, "Invalid API key", {
+          requestId: "rid-401b",
+          credentialsWereSent: true,
+        }),
+        noColor,
+      ),
     ).toMatchSnapshot();
   });
 
@@ -63,7 +82,10 @@ describe("handleError snapshots by category", () => {
 
   it("conflict", () => {
     expect(
-      handleError(httpStatusToCliError(409, "Version already exists", { requestId: "rid-409" }), noColor),
+      handleError(
+        httpStatusToCliError(409, "Version already exists", { requestId: "rid-409" }),
+        noColor,
+      ),
     ).toMatchSnapshot();
   });
 

--- a/objectified-cli/test/http-status-mapping.test.ts
+++ b/objectified-cli/test/http-status-mapping.test.ts
@@ -12,6 +12,9 @@ describe("httpStatusToCliError", () => {
 
   it("maps representative statuses", () => {
     expect(httpStatusToCliError(401, "nope", ctx).exitCode).toBe(EXIT_CODES.NOT_AUTHENTICATED);
+    expect(httpStatusToCliError(401, "nope", { ...ctx, credentialsWereSent: true }).exitCode).toBe(
+      EXIT_CODES.FORBIDDEN,
+    );
     expect(httpStatusToCliError(403, "nope", ctx).exitCode).toBe(EXIT_CODES.FORBIDDEN);
     expect(httpStatusToCliError(404, "nope", ctx).exitCode).toBe(EXIT_CODES.NOT_FOUND);
     expect(httpStatusToCliError(409, "nope", ctx).exitCode).toBe(EXIT_CODES.CONFLICT);

--- a/objectified-cli/test/normalize-argv.test.ts
+++ b/objectified-cli/test/normalize-argv.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 
-import { promoteLeadingGlobalFlags } from "../src/lib/normalize-argv.js";
+import {
+  authLoginIntendsApiKeyStore,
+  normalizeAuthLoginApiKeyPrompt,
+  normalizeCliArgv,
+  promoteLeadingGlobalFlags,
+} from "../src/lib/normalize-argv.js";
+import { API_KEY_PROMPT_SENTINEL } from "../src/lib/constants.js";
 
 describe("promoteLeadingGlobalFlags", () => {
   it("moves leading globals after the command", () => {
@@ -42,5 +48,43 @@ describe("promoteLeadingGlobalFlags", () => {
 
   it("stops at unknown leading flags", () => {
     expect(promoteLeadingGlobalFlags(["--unknown", "hello"])).toEqual(["--unknown", "hello"]);
+  });
+});
+
+describe("normalizeAuthLoginApiKeyPrompt", () => {
+  it("inserts a sentinel when auth login --api-key has no value", () => {
+    expect(normalizeAuthLoginApiKeyPrompt(["auth", "login", "--api-key"])).toEqual([
+      "auth",
+      "login",
+      "--api-key",
+      API_KEY_PROMPT_SENTINEL,
+    ]);
+  });
+
+  it("does not insert when a value follows --api-key", () => {
+    const argv = ["auth", "login", "--api-key", "sk_test_123"];
+    expect(normalizeAuthLoginApiKeyPrompt(argv)).toEqual(argv);
+  });
+});
+
+describe("authLoginIntendsApiKeyStore", () => {
+  it("is true when --api-key follows auth login", () => {
+    expect(authLoginIntendsApiKeyStore(["auth", "login", "--api-key"])).toBe(true);
+  });
+
+  it("is false when --api-key appears only before auth login", () => {
+    expect(authLoginIntendsApiKeyStore(["--api-key", "x", "auth", "login"])).toBe(false);
+  });
+});
+
+describe("normalizeCliArgv", () => {
+  it("composes promotion and auth login prompt fix", () => {
+    expect(normalizeCliArgv(["--json", "auth", "login", "--api-key"])).toEqual([
+      "auth",
+      "login",
+      "--api-key",
+      API_KEY_PROMPT_SENTINEL,
+      "--json",
+    ]);
   });
 });

--- a/objectified-cli/test/redact-api-key.test.ts
+++ b/objectified-cli/test/redact-api-key.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+
+import { redactApiKeyForLogs } from "../src/lib/redact-api-key.js";
+
+describe("redactApiKeyForLogs", () => {
+  it("redacts sk_ and pk_ prefixes", () => {
+    expect(redactApiKeyForLogs("sk_live_abcdef")).toBe("sk_***");
+    expect(redactApiKeyForLogs("pk_test_xyz")).toBe("pk_***");
+  });
+
+  it("redacts unknown shapes", () => {
+    expect(redactApiKeyForLogs("opaque")).toBe("***");
+  });
+});

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.93",
+  "version": "0.11.94",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -8,6 +8,7 @@ We continue to improve the platform based on your feedback with improvements and
 - MCP service is now live
 
 ## CLI
+- **`objectified-cli`**: API-key auth (`--api-key`, `OBJECTIFIED_API_KEY`, `--api-key-file`), keychain storage via `auth login --api-key`, `auth status`, API-key precedence over OAuth, redacted verbose logging, and exit **4** for rejected credentials on authenticated requests (#3195).
 - **`objectified-cli`**: `objectified auth login` (PKCE loopback + browser or `--no-browser` / headless stdin code) and `objectified auth logout` (`--all-profiles`); tokens stored per profile in the OS keychain via `keytar`, bearer hydration for API calls (#3194).
 - **`objectified-cli`**: `objectified completion install|show|uninstall` for bash, zsh, fish, and PowerShell; manifest-backed static completions plus REST-backed suggestions cached five minutes under `~/.cache/objectified/completion/` (#3193).
 - **`objectified-cli`**: rich `--help` (≥2 examples per command, flag groups **COMMON** / **OUTPUT** / **AUTH**, **SEE ALSO** links), `objectified docs` topic browser + prose topics, troff **man** pages under `man/man1/`, `oclif readme`-synced **README.md**, and CI guard for generated artifacts (#3192).


### PR DESCRIPTION
## Summary
Implements headless-friendly API-key authentication for `objectified-cli`: `--api-key`, `OBJECTIFIED_API_KEY` (oclif flag env), `--api-key-file`, optional persistence via `auth login --api-key`, `auth status` for credential kind, API key precedence over bearer tokens on outbound requests, redacted `--verbose` logging, and clearer exit codes for missing vs rejected credentials.

## How to test
1. **Env-only key**: `OBJECTIFIED_API_KEY=sk_test_dummy objectified --no-json auth status` — expect exit **0** and credential line mentioning `OBJECTIFIED_API_KEY`.
2. **Flag override**: `objectified --api-key sk_test_dummy --no-json auth status` — expect exit **0**.
3. **File**: put a key in `/tmp/key.txt`, run `objectified --api-key-file /tmp/key.txt --no-json auth status`.
4. **Store in keychain**: `objectified auth login --api-key` (interactive prompt) or `objectified auth login --api-key sk_live_…`.
5. **Network**: with tenant set, `objectified projects list` with a valid key succeeds; invalid key yields exit **4**.
6. **Verbose**: `objectified --verbose --api-key sk_live_longsecret …` — stderr must show `sk_***` only, not the full secret.

Automated: `yarn workspace objectified-cli test` (includes loopback HTTP stub for `X-API-Key`).

## Risks / notes
- HTTP **401** responses map to exit **4** when the CLI attached credentials, and exit **3** when none were sent (per issue acceptance criteria).
- `auth login --api-key` is detected via argv; `OBJECTIFIED_API_KEY` alone still runs OAuth login unless `--api-key` is passed.

Closes #3195


Made with [Cursor](https://cursor.com)