### PR TITLE
Fix #3197 - Secure credential storage (keytar + encrypted file fallback)

### DIFF
--- a/.github/workflows/objectified-cli.yml
+++ b/.github/workflows/objectified-cli.yml
@@ -26,8 +26,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
-          cache: yarn
-          cache-dependency-path: yarn.lock
       - run: corepack enable
       - run: yarn install --immutable
       - run: yarn workspace objectified-cli test

--- a/.github/workflows/objectified-cli.yml
+++ b/.github/workflows/objectified-cli.yml
@@ -16,7 +16,11 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/docs/PLANNED_ROADMAP_CLI.md
+++ b/docs/PLANNED_ROADMAP_CLI.md
@@ -252,7 +252,7 @@ Part of Epic: CLI Foundation & DevEx (#3174)
 | #         | Title                                                  | Description                                                       | Labels                                                  | MVP | Parallel |
 |-----------|--------------------------------------------------------|-------------------------------------------------------------------|---------------------------------------------------------|-----|----------|
 | 2.3 (#3196) | `auth status` / `whoami` — **COMPLETE** | Show profile, base-url, tenant, user, expiry, plan via `GET /v1/auth/cli/whoami`; OAuth silent refresh on 401 | `enhancement`, `mvp`, `cli`, `roadmap-cli`, `auth`     | Yes | Yes      |
-| 2.4 (#3197) | Secure credential storage (keytar + encrypted fallback) | OS keychain primary, AES-GCM file fallback for headless           | `enhancement`, `mvp`, `cli`, `roadmap-cli`, `auth`, `security` | Yes | No       |
+| 2.4 (#3197) | Secure credential storage (keytar + encrypted fallback) — **COMPLETE** | OS keychain primary, AES-GCM file fallback for headless           | `enhancement`, `mvp`, `cli`, `roadmap-cli`, `auth`, `security` | Yes | No       |
 | 2.5 (#3198) | `tenants list` / `tenants info`                      | Enumerate user's tenants and inspect one                          | `enhancement`, `mvp`, `cli`, `roadmap-cli`, `tenancy`  | Yes | Yes      |
 | 2.6 (#3199) | `tenants use <slug>`                                 | Set default tenant per profile                                    | `enhancement`, `mvp`, `cli`, `roadmap-cli`, `tenancy`  | Yes | No       |
 | 2.7 (#3200) | Multi-profile management                             | `auth profiles list/add/remove/set-default`                       | `enhancement`, `cli`, `roadmap-cli`, `auth`            | No  | Yes      |
@@ -308,9 +308,9 @@ Part of Epic: Authentication & Tenant Context (#3175)
 
 ---
 
-#### 2.4 (#3197) — Secure credential storage
+#### 2.4 (#3197) — Secure credential storage — **COMPLETE**
 
-`keytar` (Keychain / libsecret / Credential Vault). Encrypted file fallback at `~/.config/objectified/credentials.enc` (AES-256-GCM) for headless Linux containers.
+Landed: `keytar` primary (Keychain / libsecret / Windows Credential Vault); AES-256-GCM encrypted vault at `credentials.enc` with machine-bound PBKDF2 + one-time passphrase file when the keychain is unavailable; stderr warning when fallback is used (suppressed when `VITEST` is set); per-profile merge and delete; `auth logout` clears keychain and vault entries; OAuth wire format includes `type`, `access_token`, `refresh_token`, optional `expires_at` / `tenant_slug`; resolution order flag → env → keychain → file; `docs/cli-security.md` threat model; CI matrix ubuntu / macOS / Windows for native `keytar` builds.
 
 ```
 ┌────────────────────────────────────────────────────────┐
@@ -852,7 +852,7 @@ v2 fills out the writable surface for primitives, properties, classes, paths, da
 The tickets were created in the order below — that is also the recommended **execution** order. Earlier epics provide primitives that later epics rely on.
 
 1. **Epic 1 — Foundation** (#3174: #3186, #3187, #3188, #3189, #3190, #3191, #3192, and #3193 landed). Without the scaffold, no other command can exist.
-2. **Epic 2 — Auth & Tenants** (#3175; #3194, #3195, and #3196 shipped — continue #3197 → #3201). Required for any tenant-scoped command.
+2. **Epic 2 — Auth & Tenants** (#3175; #3194–#3197 shipped — continue #3198 → #3201). Required for any tenant-scoped command.
 3. **Epic 3 — Projects** (#3176 then #3202 → #3207). The first useful read/write surface.
 4. **Epic 4 — Versions** (#3177 then #3208 → #3216). The publish flow that makes the CLI valuable in CI.
 5. **Epic 9 — Browse & Schema Export** (#3182 then #3244 → #3252). The most-used consumer surface; lands early because it works without auth.

--- a/objectified-cli/README.md
+++ b/objectified-cli/README.md
@@ -50,7 +50,7 @@ $ npm install -g objectified-cli
 $ objectified COMMAND
 running command...
 $ objectified (--version)
-objectified-cli/0.1.10 <platform> node-v<major.minor.patch>
+objectified-cli/0.1.11 <platform> node-v<major.minor.patch>
 $ objectified --help [COMMAND]
 USAGE
   $ objectified COMMAND
@@ -140,7 +140,7 @@ SEE ALSO
 
 ## `objectified auth logout`
 
-Revoke CLI refresh token at the API (OAuth profiles) and remove stored credentials from the OS keychain.
+Revoke CLI refresh token at the API (OAuth profiles) and remove stored credentials from the OS keychain and any encrypted file fallback.
 
 ```
 USAGE
@@ -148,7 +148,8 @@ USAGE
     [--json] [--color] [--profile <value>] [-q] [--verbose] [--all-profiles]
 
 DESCRIPTION
-  Revoke CLI refresh token at the API (OAuth profiles) and remove stored credentials from the OS keychain.
+  Revoke CLI refresh token at the API (OAuth profiles) and remove stored credentials from the OS keychain and any
+  encrypted file fallback.
 
 EXAMPLES
   $ objectified auth logout

--- a/objectified-cli/docs/cli-security.md
+++ b/objectified-cli/docs/cli-security.md
@@ -1,0 +1,77 @@
+# CLI credential security
+
+This document describes how the `objectified` CLI handles API keys and OAuth tokens, and what it does **not** guarantee.
+
+## Storage layers
+
+1. **Primary — OS secret service (`keytar`)**
+   - **macOS:** Keychain
+   - **Linux:** libsecret (GNOME Keyring / KWallet, when a secret service is available)
+   - **Windows:** Credential Vault
+
+   Each profile has one entry: service name `objectified-cli`, account name equal to the profile name (for example `default` or `staging`). The stored value is JSON (never printed by the CLI in normal operation).
+
+2. **Fallback — encrypted file**  
+   When `keytar` cannot load or use the system store (common in containers or minimal Linux images without libsecret), credentials are written under the same config directory as `config.toml`:
+   - `credentials.enc` — AES-256-GCM ciphertext (format version 1, IV prepended, PBKDF2-derived key).
+   - `.cli-credential-passphrase` — a one-time random passphrase used only with PBKDF2 together with a **machine binding** (for example Linux `/etc/machine-id` when present).
+
+   Both files are created with mode **0600** on Unix. The CLI prints a **one-time warning on stderr** when this fallback is used (suppressed under Vitest when `VITEST` is set).
+
+3. **In-memory test backend**  
+   Set `OBJECTIFIED_CLI_CREDENTIAL_BACKEND=memory` so Vitest and CI never touch the real keychain or vault files.
+
+## Resolution order (per invocation)
+
+Credentials used for HTTP requests are resolved as documented in the product issue pack:
+
+1. `--api-key`
+2. `OBJECTIFIED_API_KEY`
+3. Stored credentials: keychain first, then encrypted file for the active profile
+4. None → unauthenticated commands exit with code **3** and a login hint
+
+`OBJECTIFIED_ACCESS_TOKEN` is still evaluated for bearer-in-env flows; it does not use the vault.
+
+## Log safety
+
+- Verbose HTTP logging uses **redacted** API keys (`sk_***` / `pk_***`) and **never** prints bearer tokens (only `bearer=***`).
+- Tokens are not passed on the process command line after login (use stored credentials or env as above).
+
+## Profile isolation
+
+Updates are **per profile**. Saving or deleting profile `staging` does not remove credentials for `prod` or `default`. The encrypted vault file holds a JSON map of profile name → credential payload; deleting one profile rewrites the vault without dropping others.
+
+## Recovery and overrides
+
+| Variable                                           | Purpose                                                                                                                                                                                                |
+| -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `OBJECTIFIED_CLI_CREDENTIAL_VAULT_DIR`             | Store `credentials.enc` and passphrase in this directory (absolute path). Intended for tests; must remain private.                                                                                     |
+| `OBJECTIFIED_CLI_CREDENTIAL_VAULT_RESET`           | When set to `1`/`true`/`yes`, the next vault operation **deletes** the vault files so a fresh vault can be created. Use after backup if you treat this as destructive logout for file-backed profiles. |
+| `OBJECTIFIED_CLI_CREDENTIAL_DISABLE_FILE_FALLBACK` | When `1`/`true`/`yes`, a missing or broken keychain surfaces an error instead of silently using the file vault.                                                                                        |
+
+## Threat model (pragmatic)
+
+**Mitigates**
+
+- **Casual leakage** from world-readable files: vault and passphrase are private to the user (`0600`), not world-readable.
+- **Accidental git commits:** paths are under the user config dir, not the project tree.
+- **Shell history:** login avoids putting secrets on the command line when using browser / stdin flows; API keys can still be passed explicitly—prefer `--api-key-file` or piping.
+- **Cross-profile mistakes:** operations are scoped by profile name.
+
+**Does not mitigate**
+
+- **Malware or a compromised user account** with your UID can read `credentials.enc`, the passphrase file, memory, or attach a debugger. This is the same class of threat as any other local secret.
+- **Root on the machine** can read all user files.
+- **File backup tools** that copy `~/.config/objectified/` copy ciphertext **and** the passphrase file; treat backups like secrets.
+- **Shared development machines:** anyone with your login session can use stored credentials.
+
+**Operational guidance**
+
+- Prefer the OS keychain on workstations.
+- On servers, prefer short-lived tokens, `OBJECTIFIED_API_KEY` from a secret manager, or CI `memory` backend over long-lived file vaults on shared disks.
+- Rotate API keys and run `objectified auth logout` when a machine is decommissioned.
+
+## Related
+
+- `objectified docs profiles` — config vs secrets.
+- `objectified docs output` — verbose and redaction rules.

--- a/objectified-cli/man/man1/objectified-auth-logout.1
+++ b/objectified-cli/man/man1/objectified-auth-logout.1
@@ -1,6 +1,6 @@
 .TH OBJECTIFIED\-AUTH\-LOGOUT 1 "" "" "User Commands"
 .SH NAME
-objectified auth logout \- Revoke CLI refresh token at the API (OAuth profiles) and remove stored credentials from the OS keychain.
+objectified auth logout \- Revoke CLI refresh token at the API (OAuth profiles) and remove stored credentials from the OS keychain and any encrypted file fallback.
 .SH DESCRIPTION
 .nf
 USAGE
@@ -10,7 +10,7 @@ USAGE
 
 DESCRIPTION
   Revoke CLI refresh token at the API (OAuth profiles) and remove stored
-  credentials from the OS keychain.
+  credentials from the OS keychain and any encrypted file fallback.
 
 EXAMPLES
   $ objectified auth logout

--- a/objectified-cli/man/man1/objectified.1
+++ b/objectified-cli/man/man1/objectified.1
@@ -6,7 +6,7 @@ objectified \- Objectified command-line interface
 Objectified command-line interface
 
 VERSION
-  objectified-cli/0.1.10 linux-x64 node-v24.14.1
+  objectified-cli/0.1.11 linux-x64 node-v24.14.1
 
 USAGE
   $ objectified [COMMAND]

--- a/objectified-cli/package.json
+++ b/objectified-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-cli",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "Objectified command-line interface",
   "author": "Objectified",
   "type": "module",

--- a/objectified-cli/src/commands/auth/login.ts
+++ b/objectified-cli/src/commands/auth/login.ts
@@ -9,6 +9,11 @@ import { ObjectifiedCliError } from "../../lib/errors.js";
 import { EXIT_CODES } from "../../lib/exit-codes.js";
 import { authLoginIntendsApiKeyStore } from "../../lib/normalize-argv.js";
 
+function expiresAtFromExpiresIn(expiresIn: number | undefined): string | undefined {
+  if (expiresIn === undefined || !Number.isFinite(expiresIn)) return undefined;
+  return new Date(Date.now() + expiresIn * 1000).toISOString();
+}
+
 export default class AuthLogin extends BaseCommand {
   static description =
     "Sign in via PKCE browser flow or store an API key in the OS keychain (`--api-key`).";
@@ -96,6 +101,8 @@ export default class AuthLogin extends BaseCommand {
     await saveCliOAuthCredentials(this.context.profile, {
       accessToken: bundle.accessToken,
       refreshToken: bundle.refreshToken,
+      expiresAt: expiresAtFromExpiresIn(bundle.expiresIn),
+      tenantSlug: this.context.tenantSlug ?? undefined,
     });
     this.apiAuth.apiKey = undefined;
     this.apiAuth.bearer = bundle.accessToken;

--- a/objectified-cli/src/commands/auth/logout.ts
+++ b/objectified-cli/src/commands/auth/logout.ts
@@ -7,7 +7,7 @@ import { listAvailableProfileNames, resolveProfileConfigBaseUrl } from "../../li
 
 export default class AuthLogout extends BaseCommand {
   static description =
-    "Revoke CLI refresh token at the API (OAuth profiles) and remove stored credentials from the OS keychain.";
+    "Revoke CLI refresh token at the API (OAuth profiles) and remove stored credentials from the OS keychain and any encrypted file fallback.";
 
   static examples = [
     "<%= config.bin %> <%= command.id %>",

--- a/objectified-cli/src/commands/auth/status.ts
+++ b/objectified-cli/src/commands/auth/status.ts
@@ -40,10 +40,12 @@ export default class AuthStatus extends BaseCommand {
       stored?.kind === "oauth" && this.activeCredential.kind === "oauth_keychain"
         ? {
             refreshToken: stored.refreshToken,
-            onRotated: async (accessToken: string, refreshToken: string) => {
+            onRotated: async (accessToken: string, refreshToken: string, expiresAt?: string) => {
               await saveCliOAuthCredentials(this.context.profile, {
                 accessToken,
                 refreshToken,
+                expiresAt,
+                tenantSlug: this.context.tenantSlug ?? undefined,
               });
             },
           }

--- a/objectified-cli/src/lib/auth/cli-login-flow.ts
+++ b/objectified-cli/src/lib/auth/cli-login-flow.ts
@@ -35,6 +35,8 @@ export type RunCliPkceLoginOpts = {
 
 export type RunCliPkceLoginResult = CliOAuthBundle & {
   displayEmail?: string;
+  /** Seconds until access token expiry when the token endpoint returned `expires_in`. */
+  expiresIn?: number;
 };
 
 function shouldUseLoopbackBrowserFlow(opts: RunCliPkceLoginOpts): boolean {
@@ -76,7 +78,9 @@ export async function runCliPkceLogin(opts: RunCliPkceLoginOpts): Promise<RunCli
     } else {
       const waitForCode = lb?.waitForCode;
       if (!waitForCode) {
-        throw new Error("internal error: browser auth flow expected a loopback server, but none was started");
+        throw new Error(
+          "internal error: browser auth flow expected a loopback server, but none was started",
+        );
       }
       opts.stdoutLine(`Opening ${opts.webLoginUrl.replace(/\?.*$/, "")} in your browser…`);
       opts.stderrLine("Waiting for browser… (Ctrl+C to cancel)");
@@ -113,5 +117,6 @@ export async function runCliPkceLogin(opts: RunCliPkceLoginOpts): Promise<RunCli
     accessToken: tokens.access_token,
     refreshToken: tokens.refresh_token,
     displayEmail,
+    expiresIn: tokens.expires_in,
   };
 }

--- a/objectified-cli/src/lib/auth/cli-whoami.ts
+++ b/objectified-cli/src/lib/auth/cli-whoami.ts
@@ -290,7 +290,7 @@ export type FetchCliWhoamiOptions = {
   activeCredentialKind: ActiveCredentialKind;
   oauthRefresh?: {
     refreshToken: string;
-    onRotated: (accessToken: string, refreshToken: string) => Promise<void>;
+    onRotated: (accessToken: string, refreshToken: string, expiresAt?: string) => Promise<void>;
   };
   fetchImpl?: typeof fetch;
 };
@@ -319,7 +319,11 @@ export async function fetchCliWhoami(opts: FetchCliWhoamiOptions): Promise<CliWh
     });
     opts.auth.apiKey = undefined;
     opts.auth.bearer = tokens.access_token;
-    await opts.oauthRefresh.onRotated(tokens.access_token, tokens.refresh_token);
+    const rotatedExpires =
+      typeof tokens.expires_in === "number" && Number.isFinite(tokens.expires_in)
+        ? new Date(Date.now() + tokens.expires_in * 1000).toISOString()
+        : undefined;
+    await opts.oauthRefresh.onRotated(tokens.access_token, tokens.refresh_token, rotatedExpires);
     res = await getOnce();
   }
 

--- a/objectified-cli/src/lib/config.ts
+++ b/objectified-cli/src/lib/config.ts
@@ -207,7 +207,7 @@ export function assertWritableConfigKey(dottedKey: string): void {
   );
   if (isSecret) {
     throw new CliError(
-      "Secrets are not stored in config.toml; use the OS keychain when implemented (see roadmap).",
+      "Secrets are not stored in config.toml; use `objectified auth login` to store credentials in the OS keychain or the encrypted file fallback (see `docs/cli-security.md`).",
       11,
     );
   }

--- a/objectified-cli/src/lib/config.ts
+++ b/objectified-cli/src/lib/config.ts
@@ -207,7 +207,7 @@ export function assertWritableConfigKey(dottedKey: string): void {
   );
   if (isSecret) {
     throw new CliError(
-      "Secrets are not stored in config.toml; use `objectified auth login` to store credentials in the OS keychain or the encrypted file fallback (see `docs/cli-security.md`).",
+      "Secrets are not stored in config.toml; use `objectified auth login` to store credentials in the OS keychain or the encrypted file fallback (see `objectified docs profiles`).",
       11,
     );
   }

--- a/objectified-cli/src/lib/credentials/file-vault.ts
+++ b/objectified-cli/src/lib/credentials/file-vault.ts
@@ -265,7 +265,7 @@ export async function writeVaultDocument(doc: VaultPlainV1, deps: VaultDeps): Pr
   await removeVaultFilesIfResetRequested(deps);
   const enc = credentialEncPath(deps);
   await fse.ensureDir(path.dirname(enc));
-  const tmp = `${enc}.tmp.${String(process.pid)}.${deps.randomBytes(6).toString("hex")}`;
+  const tmp = `${enc}.tmp.${String(process.pid)}.${deps.randomBytes(16).toString("hex")}`;
   const payload = await encryptVaultJson(doc, deps);
   let moved = false;
   try {

--- a/objectified-cli/src/lib/credentials/file-vault.ts
+++ b/objectified-cli/src/lib/credentials/file-vault.ts
@@ -1,0 +1,324 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createHash, randomBytes as nodeRandomBytes } from "node:crypto";
+
+import fse from "fs-extra";
+
+import { defaultConfigDirectory } from "../config.js";
+import { ObjectifiedCliError } from "../errors.js";
+import { EXIT_CODES } from "../exit-codes.js";
+
+const MAGIC = Buffer.from("OBJF", "utf8");
+const FORMAT_VERSION = 1;
+const PBKDF2_ITERATIONS = 210_000;
+
+export type VaultDeps = {
+  homedir: () => string;
+  env: NodeJS.ProcessEnv;
+  subtle: SubtleCrypto;
+  randomBytes: (n: number) => Buffer;
+};
+
+export const defaultVaultDeps: VaultDeps = {
+  homedir: os.homedir,
+  env: process.env,
+  subtle: globalThis.crypto.subtle,
+  randomBytes: (n) => nodeRandomBytes(n),
+};
+
+function vaultRootDir(deps: VaultDeps): string {
+  const override = deps.env.OBJECTIFIED_CLI_CREDENTIAL_VAULT_DIR?.trim();
+  if (override !== undefined && override !== "") return path.resolve(override);
+  return defaultConfigDirectory(deps.env, deps.homedir);
+}
+
+export function credentialEncPath(deps: VaultDeps): string {
+  const root = vaultRootDir(deps);
+  return path.join(root, "credentials.enc");
+}
+
+export function credentialPassphrasePath(deps: VaultDeps): string {
+  const root = vaultRootDir(deps);
+  return path.join(root, ".cli-credential-passphrase");
+}
+
+function resolveMachineBinding(deps: VaultDeps): string {
+  if (process.platform === "linux") {
+    for (const p of ["/etc/machine-id", "/var/lib/dbus/machine-id"]) {
+      try {
+        const s = fs.readFileSync(p, "utf8").trim();
+        if (s.length > 0) return `linux:${s}`;
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+  const home = deps.homedir();
+  const tail = createHash("sha256").update(home).digest("hex").slice(0, 16);
+  return `${process.platform}:${os.hostname()}:${tail}`;
+}
+
+async function deriveAesKey(
+  passphrase: string,
+  machineBinding: string,
+  subtle: SubtleCrypto,
+): Promise<CryptoKey> {
+  const enc = new TextEncoder();
+  const saltBytes = new Uint8Array(
+    await subtle.digest(
+      "SHA-256",
+      enc.encode(`objectified-cli/v1/credential-vault|${machineBinding}`),
+    ),
+  );
+  const passBytes = enc.encode(passphrase);
+  const keyMaterial = await subtle.importKey("raw", passBytes, "PBKDF2", false, ["deriveKey"]);
+  return subtle.deriveKey(
+    {
+      name: "PBKDF2",
+      salt: saltBytes,
+      iterations: PBKDF2_ITERATIONS,
+      hash: "SHA-256",
+    },
+    keyMaterial,
+    { name: "AES-GCM", length: 256 },
+    false,
+    ["encrypt", "decrypt"],
+  );
+}
+
+function chmod600(filePath: string): void {
+  if (process.platform === "win32") return;
+  try {
+    fs.chmodSync(filePath, 0o600);
+  } catch {
+    /* ignore */
+  }
+}
+
+async function readOrCreatePassphrase(deps: VaultDeps): Promise<string> {
+  const passPath = credentialPassphrasePath(deps);
+  if (await fse.pathExists(passPath)) {
+    const existing = (await fse.readFile(passPath, "utf8")).trim();
+    if (existing !== "") return existing;
+  }
+  await fse.ensureDir(path.dirname(passPath));
+  const raw = deps.randomBytes(48).toString("base64url");
+  await fse.writeFile(passPath, `${raw}\n`, { encoding: "utf8", mode: 0o600 });
+  chmod600(passPath);
+  return raw;
+}
+
+export type VaultPlainV1 = {
+  version: 1;
+  profiles: Record<string, unknown>;
+};
+
+async function encryptVaultJson(plain: VaultPlainV1, deps: VaultDeps): Promise<Buffer> {
+  const machineBinding = resolveMachineBinding(deps);
+  const passphrase = await readOrCreatePassphrase(deps);
+  const key = await deriveAesKey(passphrase, machineBinding, deps.subtle);
+  const iv = deps.randomBytes(12);
+  const body = new TextEncoder().encode(JSON.stringify(plain));
+  const cipherBuf = new Uint8Array(
+    await deps.subtle.encrypt({ name: "AES-GCM", iv: new Uint8Array(iv) }, key, body),
+  );
+  const header = Buffer.alloc(4 + 1 + 12);
+  MAGIC.copy(header, 0);
+  header.writeUInt8(FORMAT_VERSION, 4);
+  iv.copy(header, 5);
+  return Buffer.concat([header, Buffer.from(cipherBuf)]);
+}
+
+async function decryptVaultToPlain(encPath: string, deps: VaultDeps): Promise<VaultPlainV1> {
+  const buf = await fse.readFile(encPath);
+  if (buf.length < 4 + 1 + 12 + 16) {
+    throw new ObjectifiedCliError({
+      message: "Credential vault file is too small or corrupt.",
+      exitCode: EXIT_CODES.GENERIC,
+      title: "Credential vault",
+      hint: vaultCorruptHint(deps),
+    });
+  }
+  if (!buf.subarray(0, 4).equals(MAGIC)) {
+    throw new ObjectifiedCliError({
+      message: "Credential vault file has an unexpected format.",
+      exitCode: EXIT_CODES.GENERIC,
+      title: "Credential vault",
+      hint: vaultCorruptHint(deps),
+    });
+  }
+  const ver = buf.readUInt8(4);
+  if (ver !== FORMAT_VERSION) {
+    throw new ObjectifiedCliError({
+      message: `Credential vault format version ${String(ver)} is not supported.`,
+      exitCode: EXIT_CODES.GENERIC,
+      title: "Credential vault",
+      hint: "Upgrade the CLI or reset the vault with the documented environment variable.",
+    });
+  }
+  const iv = buf.subarray(5, 17);
+  const ciphertext = buf.subarray(17);
+  const machineBinding = resolveMachineBinding(deps);
+  const passPath = credentialPassphrasePath(deps);
+  if (!(await fse.pathExists(passPath))) {
+    throw new ObjectifiedCliError({
+      message: "Credential vault passphrase file is missing.",
+      exitCode: EXIT_CODES.GENERIC,
+      title: "Credential vault",
+      hint: vaultCorruptHint(deps),
+    });
+  }
+  const passphrase = (await fse.readFile(passPath, "utf8")).trim();
+  if (passphrase === "") {
+    throw new ObjectifiedCliError({
+      message: "Credential vault passphrase file is empty.",
+      exitCode: EXIT_CODES.GENERIC,
+      title: "Credential vault",
+      hint: vaultCorruptHint(deps),
+    });
+  }
+  const key = await deriveAesKey(passphrase, machineBinding, deps.subtle);
+  let plainBytes: ArrayBuffer;
+  try {
+    plainBytes = await deps.subtle.decrypt(
+      { name: "AES-GCM", iv: new Uint8Array(iv) },
+      key,
+      ciphertext,
+    );
+  } catch {
+    throw new ObjectifiedCliError({
+      message:
+        "Could not decrypt the credential vault (wrong key, corrupt data, or different machine).",
+      exitCode: EXIT_CODES.GENERIC,
+      title: "Credential vault",
+      hint: vaultCorruptHint(deps),
+    });
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(new TextDecoder().decode(new Uint8Array(plainBytes))) as unknown;
+  } catch {
+    throw new ObjectifiedCliError({
+      message: "Credential vault decrypted to invalid JSON.",
+      exitCode: EXIT_CODES.GENERIC,
+      title: "Credential vault",
+      hint: vaultCorruptHint(deps),
+    });
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new ObjectifiedCliError({
+      message: "Credential vault JSON has an invalid shape.",
+      exitCode: EXIT_CODES.GENERIC,
+      title: "Credential vault",
+      hint: vaultCorruptHint(deps),
+    });
+  }
+  const rec = parsed as Record<string, unknown>;
+  if (
+    rec.version !== 1 ||
+    typeof rec.profiles !== "object" ||
+    rec.profiles === null ||
+    Array.isArray(rec.profiles)
+  ) {
+    throw new ObjectifiedCliError({
+      message: "Credential vault JSON is missing version or profiles.",
+      exitCode: EXIT_CODES.GENERIC,
+      title: "Credential vault",
+      hint: vaultCorruptHint(deps),
+    });
+  }
+  return { version: 1, profiles: rec.profiles as Record<string, unknown> };
+}
+
+function vaultCorruptHint(deps: VaultDeps): string {
+  const enc = credentialEncPath(deps);
+  return `If you intentionally removed or rotated secrets, delete "${enc}" and "${credentialPassphrasePath(deps)}" or set OBJECTIFIED_CLI_CREDENTIAL_VAULT_RESET=1 once to remove the vault files (this logs you out of file-backed profiles).`;
+}
+
+function resetEnvTruthy(env: NodeJS.ProcessEnv): boolean {
+  const v = env.OBJECTIFIED_CLI_CREDENTIAL_VAULT_RESET?.trim().toLowerCase();
+  return v === "1" || v === "true" || v === "yes";
+}
+
+export async function removeVaultFilesIfResetRequested(deps: VaultDeps): Promise<void> {
+  if (!resetEnvTruthy(deps.env)) return;
+  const enc = credentialEncPath(deps);
+  const pass = credentialPassphrasePath(deps);
+  await fse.remove(enc).catch(() => undefined);
+  await fse.remove(pass).catch(() => undefined);
+}
+
+export async function readVaultDocument(deps: VaultDeps): Promise<VaultPlainV1 | null> {
+  await removeVaultFilesIfResetRequested(deps);
+  const enc = credentialEncPath(deps);
+  if (!(await fse.pathExists(enc))) return null;
+  const st = await fse.stat(enc);
+  if (!st.isFile() || st.size === 0) {
+    await fse.remove(enc).catch(() => undefined);
+    return null;
+  }
+  return decryptVaultToPlain(enc, deps);
+}
+
+export async function writeVaultDocument(doc: VaultPlainV1, deps: VaultDeps): Promise<void> {
+  await removeVaultFilesIfResetRequested(deps);
+  const enc = credentialEncPath(deps);
+  await fse.ensureDir(path.dirname(enc));
+  const tmp = `${enc}.tmp.${String(process.pid)}`;
+  const payload = await encryptVaultJson(doc, deps);
+  await fse.writeFile(tmp, payload, { mode: 0o600 });
+  chmod600(tmp);
+  await fse.move(tmp, enc, { overwrite: true });
+  chmod600(enc);
+}
+
+export async function mergeProfileIntoVault(
+  profile: string,
+  wireCredential: Record<string, unknown>,
+  deps: VaultDeps,
+): Promise<void> {
+  await removeVaultFilesIfResetRequested(deps);
+  const enc = credentialEncPath(deps);
+  let base: VaultPlainV1 = { version: 1, profiles: {} };
+  if (await fse.pathExists(enc)) {
+    const st = await fse.stat(enc);
+    if (st.isFile() && st.size > 0) {
+      try {
+        base = await decryptVaultToPlain(enc, deps);
+      } catch (err) {
+        if (resetEnvTruthy(deps.env)) {
+          await fse.remove(enc).catch(() => undefined);
+          await fse.remove(credentialPassphrasePath(deps)).catch(() => undefined);
+          base = { version: 1, profiles: {} };
+        } else {
+          throw err;
+        }
+      }
+    }
+  }
+  base.profiles[profile] = wireCredential;
+  await writeVaultDocument(base, deps);
+}
+
+export async function removeProfileFromVault(profile: string, deps: VaultDeps): Promise<void> {
+  await removeVaultFilesIfResetRequested(deps);
+  const enc = credentialEncPath(deps);
+  if (!(await fse.pathExists(enc))) return;
+  let doc: VaultPlainV1;
+  try {
+    doc = await decryptVaultToPlain(enc, deps);
+  } catch {
+    return;
+  }
+  const nextProfiles: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(doc.profiles)) {
+    if (k !== profile) nextProfiles[k] = v;
+  }
+  doc.profiles = nextProfiles;
+  if (Object.keys(doc.profiles).length === 0) {
+    await fse.remove(enc).catch(() => undefined);
+    return;
+  }
+  await writeVaultDocument(doc, deps);
+}

--- a/objectified-cli/src/lib/credentials/file-vault.ts
+++ b/objectified-cli/src/lib/credentials/file-vault.ts
@@ -265,12 +265,18 @@ export async function writeVaultDocument(doc: VaultPlainV1, deps: VaultDeps): Pr
   await removeVaultFilesIfResetRequested(deps);
   const enc = credentialEncPath(deps);
   await fse.ensureDir(path.dirname(enc));
-  const tmp = `${enc}.tmp.${String(process.pid)}`;
+  const tmp = `${enc}.tmp.${String(process.pid)}.${deps.randomBytes(6).toString("hex")}`;
   const payload = await encryptVaultJson(doc, deps);
-  await fse.writeFile(tmp, payload, { mode: 0o600 });
-  chmod600(tmp);
-  await fse.move(tmp, enc, { overwrite: true });
-  chmod600(enc);
+  let moved = false;
+  try {
+    await fse.writeFile(tmp, payload, { mode: 0o600 });
+    chmod600(tmp);
+    await fse.move(tmp, enc, { overwrite: true });
+    moved = true;
+    chmod600(enc);
+  } finally {
+    if (!moved) await fse.remove(tmp).catch(() => undefined);
+  }
 }
 
 export async function mergeProfileIntoVault(
@@ -318,6 +324,7 @@ export async function removeProfileFromVault(profile: string, deps: VaultDeps): 
   doc.profiles = nextProfiles;
   if (Object.keys(doc.profiles).length === 0) {
     await fse.remove(enc).catch(() => undefined);
+    await fse.remove(credentialPassphrasePath(deps)).catch(() => undefined);
     return;
   }
   await writeVaultDocument(doc, deps);

--- a/objectified-cli/src/lib/credentials/store.ts
+++ b/objectified-cli/src/lib/credentials/store.ts
@@ -1,4 +1,5 @@
 import os from "node:os";
+import { inspect } from "node:util";
 
 import { ObjectifiedCliError } from "../errors.js";
 import { EXIT_CODES } from "../exit-codes.js";
@@ -301,6 +302,6 @@ export async function deleteCliOAuthCredentials(profile: string): Promise<void> 
   if (keychainError !== undefined) {
     if (keychainError instanceof Error) throw keychainError;
     if (typeof keychainError === "string") throw new Error(keychainError);
-    throw new Error("Could not delete credentials from OS keychain.");
+    throw new Error(`Could not delete credentials from OS keychain: ${inspect(keychainError)}`);
   }
 }

--- a/objectified-cli/src/lib/credentials/store.ts
+++ b/objectified-cli/src/lib/credentials/store.ts
@@ -1,7 +1,17 @@
+import os from "node:os";
+
 import { ObjectifiedCliError } from "../errors.js";
 import { EXIT_CODES } from "../exit-codes.js";
+import {
+  defaultVaultDeps,
+  mergeProfileIntoVault,
+  readVaultDocument,
+  removeProfileFromVault,
+  type VaultDeps,
+} from "./file-vault.js";
 
 const SERVICE_NAME = "objectified-cli";
+
 type KeytarModule = {
   setPassword: (service: string, account: string, password: string) => Promise<void>;
   getPassword: (service: string, account: string) => Promise<string | null>;
@@ -11,6 +21,8 @@ type KeytarModule = {
 export type CliOAuthBundle = {
   accessToken: string;
   refreshToken: string;
+  expiresAt?: string | null;
+  tenantSlug?: string | null;
 };
 
 export type StoredCliCredential =
@@ -24,15 +36,60 @@ export type LoadedCliAuth =
 const memoryBackends = new Map<string, StoredCliCredential>();
 let keytarPromise: Promise<KeytarModule> | null = null;
 
+let warnedFileBackend = false;
+
+function stderrWarnFileBackend(): void {
+  if (process.env.VITEST !== undefined) return;
+  if (warnedFileBackend) return;
+  warnedFileBackend = true;
+  process.stderr.write(
+    "objectified: warning: OS keychain is unavailable; using encrypted file credential storage under your Objectified config directory (credentials.enc). Prefer libsecret / a desktop keyring on Linux when available.\n",
+  );
+}
+
 function useMemoryBackend(): boolean {
   return process.env.OBJECTIFIED_CLI_CREDENTIAL_BACKEND === "memory";
 }
 
-function toStoredOAuth(bundle: CliOAuthBundle): StoredCliCredential {
-  return { kind: "oauth", accessToken: bundle.accessToken, refreshToken: bundle.refreshToken };
+function fileFallbackDisabled(): boolean {
+  const v = process.env.OBJECTIFIED_CLI_CREDENTIAL_DISABLE_FILE_FALLBACK?.trim().toLowerCase();
+  return v === "1" || v === "true" || v === "yes";
 }
 
-async function loadKeytar() {
+function vaultDeps(): VaultDeps {
+  return { ...defaultVaultDeps, homedir: os.homedir, env: process.env };
+}
+
+function toStoredOAuth(bundle: CliOAuthBundle): StoredCliCredential {
+  return {
+    kind: "oauth",
+    accessToken: bundle.accessToken,
+    refreshToken: bundle.refreshToken,
+    expiresAt: bundle.expiresAt,
+    tenantSlug: bundle.tenantSlug,
+  };
+}
+
+function oauthWire(bundle: CliOAuthBundle): Record<string, unknown> {
+  const o: Record<string, unknown> = {
+    type: "oauth",
+    access_token: bundle.accessToken,
+    refresh_token: bundle.refreshToken,
+  };
+  if (bundle.expiresAt !== undefined && bundle.expiresAt !== null && bundle.expiresAt !== "") {
+    o.expires_at = bundle.expiresAt;
+  }
+  if (bundle.tenantSlug !== undefined && bundle.tenantSlug !== null && bundle.tenantSlug !== "") {
+    o.tenant_slug = bundle.tenantSlug;
+  }
+  return o;
+}
+
+function apiKeyWire(apiKey: string): Record<string, unknown> {
+  return { type: "api_key", api_key: apiKey };
+}
+
+async function loadKeytarOrThrow(): Promise<KeytarModule> {
   keytarPromise ??= import("keytar")
     .then((mod) => mod.default)
     .catch((err: unknown) => {
@@ -41,10 +98,20 @@ async function loadKeytar() {
       throw new ObjectifiedCliError({
         message: `OS keychain is unavailable for CLI credentials (${detail}).`,
         exitCode: EXIT_CODES.GENERIC,
-        hint: "Install the required system keychain libraries (for example, libsecret on Linux) or set OBJECTIFIED_CLI_CREDENTIAL_BACKEND=memory for environments without a keychain.",
+        hint: "Install the required system keychain libraries (for example, libsecret on Linux), use encrypted file fallback (default when keychain is missing), set OBJECTIFIED_CLI_CREDENTIAL_BACKEND=memory for tests, or set OBJECTIFIED_CLI_CREDENTIAL_DISABLE_FILE_FALLBACK=1 to surface this error instead of falling back.",
       });
     });
   return keytarPromise;
+}
+
+async function tryKeytar<T>(fn: (k: KeytarModule) => Promise<T>): Promise<T | "fail"> {
+  if (useMemoryBackend()) return "fail";
+  try {
+    const k = await import("keytar").then((m) => m.default);
+    return await fn(k);
+  } catch {
+    return "fail";
+  }
 }
 
 /** Test helper: clears the in-memory credential map when backend is `memory`. */
@@ -52,24 +119,72 @@ export function resetMemoryCredentialBackend(): void {
   memoryBackends.clear();
 }
 
-function parseStoredCredential(raw: string): LoadedCliAuth | null {
+export function resetFileBackendWarningForTests(): void {
+  warnedFileBackend = false;
+}
+
+export function parseStoredCredential(raw: string): LoadedCliAuth | null {
   try {
     const parsed = JSON.parse(raw) as unknown;
     if (!parsed || typeof parsed !== "object") return null;
     const rec = parsed as Record<string, unknown>;
-    if (rec.kind === "api_key" && typeof rec.apiKey === "string")
-      return { kind: "api_key", apiKey: rec.apiKey };
+    const typeField = rec.type;
+    if (typeField === "api_key" || rec.kind === "api_key") {
+      const key =
+        typeof rec.api_key === "string"
+          ? rec.api_key
+          : typeof rec.apiKey === "string"
+            ? rec.apiKey
+            : undefined;
+      if (key !== undefined) return { kind: "api_key", apiKey: key };
+      return null;
+    }
+    const accessToken =
+      typeof rec.access_token === "string"
+        ? rec.access_token
+        : typeof rec.accessToken === "string"
+          ? rec.accessToken
+          : undefined;
+    const refreshToken =
+      typeof rec.refresh_token === "string"
+        ? rec.refresh_token
+        : typeof rec.refreshToken === "string"
+          ? rec.refreshToken
+          : undefined;
     if (
-      typeof rec.accessToken === "string" &&
-      typeof rec.refreshToken === "string" &&
+      typeof accessToken === "string" &&
+      typeof refreshToken === "string" &&
+      (typeField === "oauth" || typeField === undefined) &&
       (rec.kind === undefined || rec.kind === "oauth")
     ) {
-      return { kind: "oauth", accessToken: rec.accessToken, refreshToken: rec.refreshToken };
+      return { kind: "oauth", accessToken, refreshToken };
     }
     return null;
   } catch {
     return null;
   }
+}
+
+async function loadFromFileVault(profile: string): Promise<LoadedCliAuth | null> {
+  if (useMemoryBackend() || fileFallbackDisabled()) return null;
+  try {
+    const doc = await readVaultDocument(vaultDeps());
+    if (!doc) return null;
+    const row = doc.profiles[profile];
+    if (!row || typeof row !== "object") return null;
+    return parseStoredCredential(JSON.stringify(row));
+  } catch (e: unknown) {
+    if (e instanceof ObjectifiedCliError) throw e;
+    return null;
+  }
+}
+
+function keychainUnavailableError(cause: string): ObjectifiedCliError {
+  return new ObjectifiedCliError({
+    message: `Could not store CLI credentials (${cause}).`,
+    exitCode: EXIT_CODES.GENERIC,
+    hint: "Install a system keychain (libsecret on Linux), unset OBJECTIFIED_CLI_CREDENTIAL_DISABLE_FILE_FALLBACK if set, or use OBJECTIFIED_CLI_CREDENTIAL_BACKEND=memory in CI.",
+  });
 }
 
 export async function saveCliOAuthCredentials(
@@ -81,8 +196,22 @@ export async function saveCliOAuthCredentials(
     memoryBackends.set(profile, stored);
     return;
   }
-  const keytar = await loadKeytar();
-  await keytar.setPassword(SERVICE_NAME, profile, JSON.stringify(stored));
+  const wire = oauthWire(bundle);
+  const json = JSON.stringify(wire);
+  const kt = await tryKeytar((k) => k.setPassword(SERVICE_NAME, profile, json));
+  if (kt !== "fail") return;
+  if (fileFallbackDisabled()) {
+    const k = await loadKeytarOrThrow();
+    await k.setPassword(SERVICE_NAME, profile, json);
+    return;
+  }
+  stderrWarnFileBackend();
+  try {
+    await mergeProfileIntoVault(profile, wire, vaultDeps());
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw keychainUnavailableError(msg);
+  }
 }
 
 export async function saveCliApiKeyCredentials(profile: string, apiKey: string): Promise<void> {
@@ -91,8 +220,22 @@ export async function saveCliApiKeyCredentials(profile: string, apiKey: string):
     memoryBackends.set(profile, stored);
     return;
   }
-  const keytar = await loadKeytar();
-  await keytar.setPassword(SERVICE_NAME, profile, JSON.stringify(stored));
+  const wire = apiKeyWire(apiKey);
+  const json = JSON.stringify(wire);
+  const kt = await tryKeytar((k) => k.setPassword(SERVICE_NAME, profile, json));
+  if (kt !== "fail") return;
+  if (fileFallbackDisabled()) {
+    const k = await loadKeytarOrThrow();
+    await k.setPassword(SERVICE_NAME, profile, json);
+    return;
+  }
+  stderrWarnFileBackend();
+  try {
+    await mergeProfileIntoVault(profile, wire, vaultDeps());
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw keychainUnavailableError(msg);
+  }
 }
 
 /** Loads OAuth tokens only (legacy helper for callers that ignore API keys). */
@@ -109,10 +252,29 @@ export async function loadCliStoredAuth(profile: string): Promise<LoadedCliAuth 
     if (hit.kind === "api_key") return { kind: "api_key", apiKey: hit.apiKey };
     return { kind: "oauth", accessToken: hit.accessToken, refreshToken: hit.refreshToken };
   }
-  const keytar = await loadKeytar();
-  const raw = await keytar.getPassword(SERVICE_NAME, profile);
-  if (raw === null) return null;
-  return parseStoredCredential(raw);
+  const kt = await tryKeytar((k) => k.getPassword(SERVICE_NAME, profile));
+  if (kt !== "fail") {
+    if (kt !== null && kt !== "") {
+      return parseStoredCredential(kt);
+    }
+    const fromFile = await loadFromFileVault(profile);
+    if (fromFile) stderrWarnFileBackend();
+    return fromFile;
+  }
+  if (!fileFallbackDisabled()) {
+    const fromFile = await loadFromFileVault(profile);
+    if (fromFile) stderrWarnFileBackend();
+    return fromFile;
+  }
+  try {
+    const k = await loadKeytarOrThrow();
+    const raw = await k.getPassword(SERVICE_NAME, profile);
+    if (raw === null || raw === "") return null;
+    return parseStoredCredential(raw);
+  } catch (e: unknown) {
+    if (e instanceof ObjectifiedCliError) throw e;
+    return null;
+  }
 }
 
 export async function deleteCliOAuthCredentials(profile: string): Promise<void> {
@@ -120,6 +282,12 @@ export async function deleteCliOAuthCredentials(profile: string): Promise<void> 
     memoryBackends.delete(profile);
     return;
   }
-  const keytar = await loadKeytar();
-  await keytar.deletePassword(SERVICE_NAME, profile);
+  await tryKeytar((k) => k.deletePassword(SERVICE_NAME, profile));
+  if (!fileFallbackDisabled()) {
+    try {
+      await removeProfileFromVault(profile, vaultDeps());
+    } catch {
+      /* ignore vault cleanup failures */
+    }
+  }
 }

--- a/objectified-cli/src/lib/credentials/store.ts
+++ b/objectified-cli/src/lib/credentials/store.ts
@@ -282,12 +282,25 @@ export async function deleteCliOAuthCredentials(profile: string): Promise<void> 
     memoryBackends.delete(profile);
     return;
   }
-  await tryKeytar((k) => k.deletePassword(SERVICE_NAME, profile));
-  if (!fileFallbackDisabled()) {
+  let keychainError: unknown;
+  if (fileFallbackDisabled()) {
     try {
-      await removeProfileFromVault(profile, vaultDeps());
-    } catch {
-      /* ignore vault cleanup failures */
+      const k = await loadKeytarOrThrow();
+      await k.deletePassword(SERVICE_NAME, profile);
+    } catch (err: unknown) {
+      keychainError = err;
     }
+  } else {
+    await tryKeytar((k) => k.deletePassword(SERVICE_NAME, profile));
+  }
+  try {
+    await removeProfileFromVault(profile, vaultDeps());
+  } catch {
+    /* ignore vault cleanup failures */
+  }
+  if (keychainError !== undefined) {
+    if (keychainError instanceof Error) throw keychainError;
+    if (typeof keychainError === "string") throw new Error(keychainError);
+    throw new Error("Could not delete credentials from OS keychain.");
   }
 }

--- a/objectified-cli/src/lib/credentials/store.ts
+++ b/objectified-cli/src/lib/credentials/store.ts
@@ -188,6 +188,14 @@ function keychainUnavailableError(cause: string): ObjectifiedCliError {
   });
 }
 
+function keychainDeleteError(cause: string): ObjectifiedCliError {
+  return new ObjectifiedCliError({
+    message: `Could not delete CLI credentials from OS keychain (${cause}).`,
+    exitCode: EXIT_CODES.GENERIC,
+    hint: "Install a system keychain (libsecret on Linux), unset OBJECTIFIED_CLI_CREDENTIAL_DISABLE_FILE_FALLBACK if set, or use OBJECTIFIED_CLI_CREDENTIAL_BACKEND=memory in CI.",
+  });
+}
+
 export async function saveCliOAuthCredentials(
   profile: string,
   bundle: CliOAuthBundle,
@@ -300,8 +308,12 @@ export async function deleteCliOAuthCredentials(profile: string): Promise<void> 
     /* ignore vault cleanup failures */
   }
   if (keychainError !== undefined) {
-    if (keychainError instanceof Error) throw keychainError;
-    if (typeof keychainError === "string") throw new Error(keychainError);
-    throw new Error(`Could not delete credentials from OS keychain: ${inspect(keychainError)}`);
+    const detail =
+      keychainError instanceof Error
+        ? keychainError.message
+        : typeof keychainError === "string"
+          ? keychainError
+          : inspect(keychainError);
+    throw keychainDeleteError(detail);
   }
 }

--- a/objectified-cli/src/lib/docs-content.ts
+++ b/objectified-cli/src/lib/docs-content.ts
@@ -34,6 +34,9 @@ default_profile
 Resolution order
   Base URL and tenant slug resolve per profile: explicit flags and env vars override profile values, which override [default]. API keys are never read from config.toml (#3188); use --api-key, OBJECTIFIED_API_KEY, --api-key-file, or store one with objectified auth login --api-key (#3195).
 
+Stored credentials (#3197)
+  OAuth and API keys from auth login are stored in the OS keychain when available; otherwise in an AES-256-GCM encrypted file next to config (see repository file docs/cli-security.md). Environment overrides: OBJECTIFIED_CLI_CREDENTIAL_VAULT_DIR, OBJECTIFIED_CLI_CREDENTIAL_VAULT_RESET, OBJECTIFIED_CLI_CREDENTIAL_DISABLE_FILE_FALLBACK.
+
 Switching profiles
   Pass --profile <name> for a single invocation or change default_profile for every command.
 `.trim();

--- a/objectified-cli/src/lib/docs-content.ts
+++ b/objectified-cli/src/lib/docs-content.ts
@@ -35,7 +35,7 @@ Resolution order
   Base URL and tenant slug resolve per profile: explicit flags and env vars override profile values, which override [default]. API keys are never read from config.toml (#3188); use --api-key, OBJECTIFIED_API_KEY, --api-key-file, or store one with objectified auth login --api-key (#3195).
 
 Stored credentials (#3197)
-  OAuth and API keys from auth login are stored in the OS keychain when available; otherwise in an AES-256-GCM encrypted file next to config (see repository file docs/cli-security.md). Environment overrides: OBJECTIFIED_CLI_CREDENTIAL_VAULT_DIR, OBJECTIFIED_CLI_CREDENTIAL_VAULT_RESET, OBJECTIFIED_CLI_CREDENTIAL_DISABLE_FILE_FALLBACK.
+  OAuth and API keys from auth login are stored in the OS keychain when available; otherwise in an AES-256-GCM encrypted file next to config (threat model: https://github.com/KenSuenobu/objectified-commercial/blob/main/objectified-cli/docs/cli-security.md). Environment overrides: OBJECTIFIED_CLI_CREDENTIAL_VAULT_DIR, OBJECTIFIED_CLI_CREDENTIAL_VAULT_RESET, OBJECTIFIED_CLI_CREDENTIAL_DISABLE_FILE_FALLBACK.
 
 Switching profiles
   Pass --profile <name> for a single invocation or change default_profile for every command.

--- a/objectified-cli/test/credentials-store.test.ts
+++ b/objectified-cli/test/credentials-store.test.ts
@@ -130,7 +130,14 @@ describe("CLI credential store", () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "obj-cli-vault-"));
     process.env.OBJECTIFIED_CLI_CREDENTIAL_VAULT_DIR = dir;
     vi.doMock("keytar", () => {
-      throw new Error("no native keychain");
+      const noNative = async () => Promise.reject(new Error("no native keychain"));
+      return {
+        default: {
+          deletePassword: noNative,
+          getPassword: noNative,
+          setPassword: noNative,
+        },
+      };
     });
 
     const { deleteCliOAuthCredentials, saveCliOAuthCredentials } = await import(
@@ -145,7 +152,7 @@ describe("CLI credential store", () => {
     process.env.OBJECTIFIED_CLI_CREDENTIAL_DISABLE_FILE_FALLBACK = "1";
     await expect(deleteCliOAuthCredentials("default")).rejects.toMatchObject({
       name: "ObjectifiedCliError",
-      message: expect.stringContaining("OS keychain is unavailable for CLI credentials"),
+      message: expect.stringContaining("Could not delete CLI credentials from OS keychain"),
     });
     expect(fs.existsSync(path.join(dir, "credentials.enc"))).toBe(false);
     expect(fs.existsSync(path.join(dir, ".cli-credential-passphrase"))).toBe(false);

--- a/objectified-cli/test/credentials-store.test.ts
+++ b/objectified-cli/test/credentials-store.test.ts
@@ -120,5 +120,34 @@ describe("CLI credential store", () => {
     await expect(loadCliStoredAuth("staging")).resolves.toMatchObject({
       accessToken: "access-two",
     });
+
+    await deleteCliOAuthCredentials("staging");
+    expect(fs.existsSync(enc)).toBe(false);
+    expect(fs.existsSync(path.join(dir, ".cli-credential-passphrase"))).toBe(false);
+  });
+
+  it("cleans file-vault credentials on logout even when fallback is disabled", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "obj-cli-vault-"));
+    process.env.OBJECTIFIED_CLI_CREDENTIAL_VAULT_DIR = dir;
+    vi.doMock("keytar", () => {
+      throw new Error("no native keychain");
+    });
+
+    const { deleteCliOAuthCredentials, saveCliOAuthCredentials } = await import(
+      "../src/lib/credentials/store.js"
+    );
+
+    await saveCliOAuthCredentials("default", {
+      accessToken: "access-one",
+      refreshToken: "refresh-one",
+    });
+
+    process.env.OBJECTIFIED_CLI_CREDENTIAL_DISABLE_FILE_FALLBACK = "1";
+    await expect(deleteCliOAuthCredentials("default")).rejects.toMatchObject({
+      name: "ObjectifiedCliError",
+      message: expect.stringContaining("OS keychain is unavailable for CLI credentials"),
+    });
+    expect(fs.existsSync(path.join(dir, "credentials.enc"))).toBe(false);
+    expect(fs.existsSync(path.join(dir, ".cli-credential-passphrase"))).toBe(false);
   });
 });

--- a/objectified-cli/test/credentials-store.test.ts
+++ b/objectified-cli/test/credentials-store.test.ts
@@ -4,7 +4,16 @@ import path from "node:path";
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+const tempDirs: string[] = [];
+
+function makeTempVaultDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "obj-cli-vault-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
 afterEach(() => {
+  for (const dir of tempDirs.splice(0)) fs.rmSync(dir, { force: true, recursive: true });
   delete process.env.OBJECTIFIED_CLI_CREDENTIAL_BACKEND;
   delete process.env.OBJECTIFIED_CLI_CREDENTIAL_VAULT_DIR;
   delete process.env.OBJECTIFIED_CLI_CREDENTIAL_DISABLE_FILE_FALLBACK;
@@ -70,7 +79,7 @@ describe("CLI credential store", () => {
   });
 
   it("persists OAuth in encrypted file vault when keytar is unavailable (#3197)", async () => {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "obj-cli-vault-"));
+    const dir = makeTempVaultDir();
     process.env.OBJECTIFIED_CLI_CREDENTIAL_VAULT_DIR = dir;
     vi.doMock("keytar", () => {
       throw new Error("no native keychain");
@@ -127,7 +136,7 @@ describe("CLI credential store", () => {
   });
 
   it("cleans file-vault credentials on logout even when fallback is disabled", async () => {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "obj-cli-vault-"));
+    const dir = makeTempVaultDir();
     process.env.OBJECTIFIED_CLI_CREDENTIAL_VAULT_DIR = dir;
     vi.doMock("keytar", () => {
       const noNative = async () => Promise.reject(new Error("no native keychain"));

--- a/objectified-cli/test/credentials-store.test.ts
+++ b/objectified-cli/test/credentials-store.test.ts
@@ -1,7 +1,14 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 afterEach(() => {
   delete process.env.OBJECTIFIED_CLI_CREDENTIAL_BACKEND;
+  delete process.env.OBJECTIFIED_CLI_CREDENTIAL_VAULT_DIR;
+  delete process.env.OBJECTIFIED_CLI_CREDENTIAL_DISABLE_FILE_FALLBACK;
+  delete process.env.OBJECTIFIED_CLI_CREDENTIAL_VAULT_RESET;
   vi.resetModules();
   vi.doUnmock("keytar");
 });
@@ -42,7 +49,8 @@ describe("CLI credential store", () => {
     });
   });
 
-  it("wraps keytar load failures with an actionable error", async () => {
+  it("wraps keytar load failures with an actionable error when file fallback is disabled", async () => {
+    process.env.OBJECTIFIED_CLI_CREDENTIAL_DISABLE_FILE_FALLBACK = "1";
     vi.doMock("keytar", () => {
       throw new Error("libsecret missing");
     });
@@ -57,7 +65,60 @@ describe("CLI credential store", () => {
     ).rejects.toMatchObject({
       name: "ObjectifiedCliError",
       message: expect.stringContaining("OS keychain is unavailable for CLI credentials"),
-      hint: expect.stringContaining("OBJECTIFIED_CLI_CREDENTIAL_BACKEND=memory"),
+      hint: expect.stringMatching(/libsecret|memory|FILE_FALLBACK/),
+    });
+  });
+
+  it("persists OAuth in encrypted file vault when keytar is unavailable (#3197)", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "obj-cli-vault-"));
+    process.env.OBJECTIFIED_CLI_CREDENTIAL_VAULT_DIR = dir;
+    vi.doMock("keytar", () => {
+      throw new Error("no native keychain");
+    });
+
+    const {
+      deleteCliOAuthCredentials,
+      loadCliStoredAuth,
+      resetFileBackendWarningForTests,
+      saveCliOAuthCredentials,
+    } = await import("../src/lib/credentials/store.js");
+    resetFileBackendWarningForTests();
+
+    await saveCliOAuthCredentials("default", {
+      accessToken: "access-one",
+      refreshToken: "refresh-one",
+      tenantSlug: "acme",
+    });
+    await expect(loadCliStoredAuth("default")).resolves.toEqual({
+      kind: "oauth",
+      accessToken: "access-one",
+      refreshToken: "refresh-one",
+    });
+
+    const enc = path.join(dir, "credentials.enc");
+    expect(fs.existsSync(enc)).toBe(true);
+    if (process.platform !== "win32") {
+      expect(fs.statSync(enc).mode & 0o777).toBe(0o600);
+      const passPath = path.join(dir, ".cli-credential-passphrase");
+      expect(fs.existsSync(passPath)).toBe(true);
+      expect(fs.statSync(passPath).mode & 0o777).toBe(0o600);
+    }
+
+    await saveCliOAuthCredentials("staging", {
+      accessToken: "access-two",
+      refreshToken: "refresh-two",
+    });
+    await expect(loadCliStoredAuth("default")).resolves.toMatchObject({
+      accessToken: "access-one",
+    });
+    await expect(loadCliStoredAuth("staging")).resolves.toMatchObject({
+      accessToken: "access-two",
+    });
+
+    await deleteCliOAuthCredentials("default");
+    await expect(loadCliStoredAuth("default")).resolves.toBeNull();
+    await expect(loadCliStoredAuth("staging")).resolves.toMatchObject({
+      accessToken: "access-two",
     });
   });
 });

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -8,6 +8,7 @@ We continue to improve the platform based on your feedback with improvements and
 - MCP service is now live
 
 ## CLI
+- **`objectified-cli`**: secure credential storage — `keytar` OS keychain first, AES-256-GCM encrypted file fallback (`credentials.enc`) when libsecret/keychain is missing; profile-scoped vault merge/delete; `auth logout` clears both stores; optional `expires_at` / `tenant_slug` on stored OAuth; documented threat model in `objectified-cli/docs/cli-security.md`; CI builds `keytar` on Linux, macOS, and Windows (#3197).
 - **`objectified-cli`**: `objectified auth status` / `whoami` calls `GET /v1/auth/cli/whoami` for tenant, user, plan, and token metadata; stable `--json` schema; stored OAuth silently refreshes on 401 before retrying whoami (#3196).
 - **`objectified-cli`**: API-key auth (`--api-key`, `OBJECTIFIED_API_KEY`, `--api-key-file`), keychain storage via `auth login --api-key`, `auth status`, API-key precedence over OAuth, redacted verbose logging, and exit **4** for rejected credentials on authenticated requests (#3195).
 - **`objectified-cli`**: `objectified auth login` (PKCE loopback + browser or `--no-browser` / headless stdin code) and `objectified auth logout` (`--all-profiles`); tokens stored per profile in the OS keychain via `keytar`, bearer hydration for API calls (#3194).


### PR DESCRIPTION
## Summary
Implements issue **#3197**: primary storage remains `keytar` (Keychain / libsecret / Windows Credential Vault). When the native store cannot be used, credentials are merged into an **AES-256-GCM** encrypted vault (`credentials.enc`) with a **PBKDF2**-derived key (machine binding + one-time passphrase file), **0600** Unix permissions, and a **stderr warning** once per process (suppressed when `VITEST` is set).

- **Resolution order** unchanged at the HTTP layer: `--api-key` → `OBJECTIFIED_API_KEY` → stored credentials (keychain, then vault).
- **OAuth JSON** on disk uses `type`, `access_token`, `refresh_token`, optional `expires_at` / `tenant_slug`; legacy camelCase still loads.
- **`auth logout`** clears keychain entries and removes the profile from the encrypted vault.
- **Threat model** documented in `objectified-cli/docs/cli-security.md`.
- **CI**: `objectified-cli` workflow matrix **ubuntu-latest**, **macos-latest**, **windows-latest** so `keytar` native builds are exercised.

## How to test
- **Normal path**: Run `objectified auth login` on a machine with a working keychain; confirm `objectified auth status` works after login.
- **Fallback path**: On Linux without libsecret (or with `keytar` mocked to fail in a scratch env), set `OBJECTIFIED_CLI_CREDENTIAL_VAULT_DIR` to a temp directory, run login, confirm `credentials.enc` and `.cli-credential-passphrase` exist with mode **0600**, and `objectified auth logout` removes the profile from the vault.
- **Force reset corrupt vault**: Set `OBJECTIFIED_CLI_CREDENTIAL_VAULT_RESET=1` and run a credential write; confirm vault files are recreated.
- **Disable fallback**: `OBJECTIFIED_CLI_CREDENTIAL_DISABLE_FILE_FALLBACK=1` reproduces the previous hard error when `keytar` is missing.
- **Automated**: `yarn workspace objectified-cli test` (includes new vault tests).

## Risks / notes
- File vault security is **host-user** scoped; backups of `~/.config/objectified/` include ciphertext **and** the passphrase file—treat as secrets.
- `VITEST` suppresses the fallback warning to keep test output clean.

Closes #3197

Made with [Cursor](https://cursor.com)