### PR TITLE
Fix #3203 - projects show (slug or UUID, activity, JSON)

### DIFF
--- a/docs/PLANNED_ROADMAP_CLI.md
+++ b/docs/PLANNED_ROADMAP_CLI.md
@@ -407,7 +407,6 @@ Part of Epic: Authentication & Tenant Context (#3175)
 
 | #         | Title                                | Description                                          | Labels                                | MVP | Parallel |
 |-----------|--------------------------------------|------------------------------------------------------|---------------------------------------|-----|----------|
-| 3.2 (#3203) | `projects show <slug-or-id>`       | Slug resolution; rich detail + recent activity        | `enhancement`, `mvp`, `cli`, `roadmap-cli` | Yes | Yes      |
 | 3.3 (#3204) | `projects create`                  | Interactive + non-interactive + `--from-file`         | `enhancement`, `mvp`, `cli`, `roadmap-cli` | Yes | Yes      |
 | 3.4 (#3205) | `projects update`                  | Partial update with diff renderer + concurrency check | `enhancement`, `cli`, `roadmap-cli`   | No  | Yes      |
 | 3.5 (#3206) | `projects delete`                  | Typed confirmation, refuses on published versions     | `enhancement`, `cli`, `roadmap-cli`   | No  | Yes      |
@@ -763,12 +762,12 @@ The `NPM_REGISTRY` env var lets us point at npmjs.com, GitHub Packages, JFrog Ar
 
 ## MVP Release — Ticket Bundle
 
-The MVP delivers an installable, useful CLI focused on _read_ and _publish_ for a single project's lifecycle. Total: **17 open sub-tickets** across 5 epics (plus completed foundation items such as #3186, #3187, #3188, #3189, #3190, #3191, #3192, #3193, #3194, #3195, and #3202).
+The MVP delivers an installable, useful CLI focused on _read_ and _publish_ for a single project's lifecycle. Total: **16 open sub-tickets** across 5 epics (plus completed foundation items such as #3186, #3187, #3188, #3189, #3190, #3191, #3192, #3193, #3194, #3195, #3202, and #3203).
 
 | Epic     | Tickets                                                                                                   | Count |
 |----------|-----------------------------------------------------------------------------------------------------------|-------|
 | 2 (#3175) | #3196, #3197, #3198, #3199                                                                                | 4     |
-| 3 (#3176) | #3203, #3204                                                                                               | 2     |
+| 3 (#3176) | #3204                                                                                                      | 1     |
 | 4 (#3177) | #3208, #3209, #3210, #3212                                                                                | 4     |
 | 9 (#3182) | #3244, #3245, #3246, #3247, #3248                                                                          | 5     |
 | 12 (#3185) | #3267, #3268                                                                                               | 2     |
@@ -856,7 +855,7 @@ The tickets were created in the order below — that is also the recommended **e
 
 1. **Epic 1 — Foundation** (#3174: #3186, #3187, #3188, #3189, #3190, #3191, #3192, and #3193 landed). Without the scaffold, no other command can exist.
 2. **Epic 2 — Auth & Tenants** (#3175; #3194–#3197 shipped — continue #3198 → #3201). Required for any tenant-scoped command.
-3. **Epic 3 — Projects** (#3176 then #3203 → #3207). The first useful read/write surface.
+3. **Epic 3 — Projects** (#3176 then #3204 → #3207; #3203 shipped). The first useful read/write surface.
 4. **Epic 4 — Versions** (#3177 then #3208 → #3216). The publish flow that makes the CLI valuable in CI.
 5. **Epic 9 — Browse & Schema Export** (#3182 then #3244 → #3252). The most-used consumer surface; lands early because it works without auth.
 6. **Epic 12 — Distribution (CI + NPM publish only)** (#3185 then #3267, #3268). Ship MVP — `npm i -g objectified-cli` works.

--- a/objectified-cli/README.md
+++ b/objectified-cli/README.md
@@ -50,7 +50,7 @@ $ npm install -g objectified-cli
 $ objectified COMMAND
 running command...
 $ objectified (--version)
-objectified-cli/0.1.14 <platform> node-v<major.minor.patch>
+objectified-cli/0.1.15 <platform> node-v<major.minor.patch>
 $ objectified --help [COMMAND]
 USAGE
   $ objectified COMMAND
@@ -82,6 +82,7 @@ USAGE
 * [`objectified hello [NAME]`](#objectified-hello-name)
 * [`objectified help [COMMAND]`](#objectified-help-command)
 * [`objectified projects list`](#objectified-projects-list)
+* [`objectified projects show REF`](#objectified-projects-show-ref)
 * [`objectified tenants info SLUG`](#objectified-tenants-info-slug)
 * [`objectified tenants list`](#objectified-tenants-list)
 * [`objectified tenants use [SLUG]`](#objectified-tenants-use-slug)
@@ -1057,6 +1058,57 @@ SEE ALSO
   objectified tenants use
 
   objectified config path
+
+  objectified docs errors
+```
+
+## `objectified projects show REF`
+
+Show one project by slug or UUID (GET /v1/projects/{tenant}/{id} or …/by-slug/{slug})
+
+```
+USAGE
+  $ objectified projects show REF [--api-key <value>] [--api-key-file <value>] [--base-url <value>] [--config
+    <value>] [--json] [--color] [--profile <value>] [--tenant <value>] [-q] [--verbose]
+
+ARGUMENTS
+  REF  Project slug or project UUID (uuid-shaped refs resolve as id first)
+
+DESCRIPTION
+  Show one project by slug or UUID (GET /v1/projects/{tenant}/{id} or …/by-slug/{slug})
+
+EXAMPLES
+  $ objectified projects show payments-api
+
+  $ objectified --json projects show payments-api
+
+  $ objectified projects show 33333333-4444-5555-6666-777777777777
+
+  $ objectified --profile staging projects show my-project
+
+COMMON
+  --base-url=<value>  Root REST API URL.
+  --config=<value>    Path to config file (default: XDG config dir / Objectified AppData on Windows — see `objectified
+                      config path`).
+  --profile=<value>   Named credentials profile (OBJECTIFIED_PROFILE); falls back to default_profile in config.
+  --tenant=<value>    [env: OBJECTIFIED_TENANT] Tenant slug for this run only (overrides OBJECTIFIED_TENANT and config
+                      tenant_slug).
+
+OUTPUT
+  --[no-]color  Enable/disable ANSI colors (--no-color sets NO_COLOR; colors are off when stdout is not a TTY).
+      --[no-]json   Emit machine-readable JSON (OBJECTIFIED_JSON=1; auto-enabled when stdout is not a TTY).
+  -q, --quiet       Suppress non-error stdout (spinners, banners, tips).
+      --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
+
+AUTH
+  --api-key=<value>       [env: OBJECTIFIED_API_KEY] API key for direct authentication (OBJECTIFIED_API_KEY). Not
+                          persisted unless you run `auth login --api-key`.
+  --api-key-file=<value>  Read API key from a file (single line; avoids shell history).
+
+SEE ALSO
+  objectified projects list
+
+  objectified tenants use
 
   objectified docs errors
 ```

--- a/objectified-cli/man/man1/objectified-projects-show.1
+++ b/objectified-cli/man/man1/objectified-projects-show.1
@@ -1,0 +1,58 @@
+.TH OBJECTIFIED\-PROJECTS\-SHOW 1 "" "" "User Commands"
+.SH NAME
+objectified projects show \- Show one project by slug or UUID (GET /v1/projects/{tenant}/{id} or …/by-slug/{slug})
+.SH DESCRIPTION
+.nf
+USAGE
+  $ objectified projects show REF [--api-key <value>] [--api-key-file
+    <value>] [--base-url <value>] [--config <value>] [--json] [--color]
+    [--profile <value>] [--tenant <value>] [-q] [--verbose]
+
+ARGUMENTS
+  REF  Project slug or project UUID (uuid-shaped refs resolve as id first)
+
+DESCRIPTION
+  Show one project by slug or UUID (GET /v1/projects/{tenant}/{id} or
+  …/by-slug/{slug})
+
+EXAMPLES
+  $ objectified projects show payments-api
+
+  $ objectified --json projects show payments-api
+
+  $ objectified projects show 33333333-4444-5555-6666-777777777777
+
+  $ objectified --profile staging projects show my-project
+
+COMMON
+  --base-url=<value>  Root REST API URL.
+  --config=<value>    Path to config file (default: XDG config dir /
+                      Objectified AppData on Windows — see `objectified config
+                      path`).
+  --profile=<value>   Named credentials profile (OBJECTIFIED_PROFILE); falls
+                      back to default_profile in config.
+  --tenant=<value>    [env: OBJECTIFIED_TENANT] Tenant slug for this run only
+                      (overrides OBJECTIFIED_TENANT and config tenant_slug).
+
+OUTPUT
+  --[no-]color  Enable/disable ANSI colors (--no-color sets NO_COLOR;
+                    colors are off when stdout is not a TTY).
+      --[no-]json   Emit machine-readable JSON (OBJECTIFIED_JSON=1;
+                    auto-enabled when stdout is not a TTY).
+  -q, --quiet       Suppress non-error stdout (spinners, banners, tips).
+      --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
+
+AUTH
+  --api-key=<value>       [env: OBJECTIFIED_API_KEY] API key for direct
+                          authentication (OBJECTIFIED_API_KEY). Not persisted
+                          unless you run `auth login --api-key`.
+  --api-key-file=<value>  Read API key from a file (single line; avoids shell
+                          history).
+
+SEE ALSO
+  objectified projects list
+
+  objectified tenants use
+
+  objectified docs errors
+.fi

--- a/objectified-cli/man/man1/objectified.1
+++ b/objectified-cli/man/man1/objectified.1
@@ -6,7 +6,7 @@ objectified \- Objectified command-line interface
 Objectified command-line interface
 
 VERSION
-  objectified-cli/0.1.14 linux-x64 node-v24.14.1
+  objectified-cli/0.1.15 linux-x64 node-v24.14.1
 
 USAGE
   $ objectified [COMMAND]

--- a/objectified-cli/package.json
+++ b/objectified-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-cli",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "Objectified command-line interface",
   "author": "Objectified",
   "type": "module",
@@ -94,6 +94,7 @@
     "./man/man1/objectified-hello.1",
     "./man/man1/objectified-help.1",
     "./man/man1/objectified-projects-list.1",
+    "./man/man1/objectified-projects-show.1",
     "./man/man1/objectified-tenants-info.1",
     "./man/man1/objectified-tenants-list.1",
     "./man/man1/objectified-tenants-use.1",

--- a/objectified-cli/src/commands/projects/show.ts
+++ b/objectified-cli/src/commands/projects/show.ts
@@ -1,0 +1,91 @@
+import { Args } from "@oclif/core";
+
+import { BaseCommand } from "../../base-command.js";
+import { ObjectifiedCliError } from "../../lib/errors.js";
+import { EXIT_CODES } from "../../lib/exit-codes.js";
+import { formatProjectsShowHumanLines } from "../../lib/projects/show-format.js";
+import { chalkForContext, localePrefersAsciiTable, stableDeepSort } from "../../lib/output.js";
+import { completionProfileCacheKey, resolveProjectForTenant } from "../../lib/resolve.js";
+
+export default class ProjectsShow extends BaseCommand {
+  static description =
+    "Show one project by slug or UUID (GET /v1/projects/{tenant}/{id} or …/by-slug/{slug})";
+
+  static examples = [
+    "<%= config.bin %> <%= command.id %> payments-api",
+    "<%= config.bin %> --json <%= command.id %> payments-api",
+    "<%= config.bin %> <%= command.id %> 33333333-4444-5555-6666-777777777777",
+    "<%= config.bin %> --profile staging <%= command.id %> my-project",
+  ];
+
+  static seeAlso = ["projects list", "tenants use", "docs errors"];
+
+  static args = {
+    ref: Args.string({
+      description: "Project slug or project UUID (uuid-shaped refs resolve as id first)",
+      required: true,
+    }),
+  };
+
+  async run(): Promise<void> {
+    const tenant = this.context.tenantSlug;
+    if (tenant === undefined || tenant === "") {
+      throw new ObjectifiedCliError({
+        message:
+          "Tenant slug is required for this command. Pass --tenant, set OBJECTIFIED_TENANT, or configure tenant_slug for your profile.",
+        exitCode: EXIT_CODES.CONFIG,
+        title: "Configuration error",
+        hint: "Run `objectified tenants use <slug>` to save a default tenant, or `objectified tenants list` to see accessible tenants.",
+      });
+    }
+
+    const rawRef = this.commandArgs.ref;
+    const ref = typeof rawRef === "string" ? rawRef : "";
+
+    this.ensureAuthenticated();
+
+    const profileKey = completionProfileCacheKey({
+      baseUrl: this.context.baseUrl,
+      profile: this.context.profile,
+      tenantSlug: tenant,
+    });
+
+    const project = await resolveProjectForTenant(this.api, tenant, ref, profileKey);
+
+    const [versions, tags, auditPage] = await Promise.all([
+      this.api.listVersions(tenant, project.id),
+      this.api.listVersionTags(tenant, project.id),
+      this.api.listWorkflowAudit({
+        tenantSlug: tenant,
+        projectId: project.id,
+        limit: 10,
+        offset: 0,
+      }),
+    ]);
+
+    const activity = auditPage.items.slice(0, 10);
+
+    if (this.context.json) {
+      const composite = { ...(project as Record<string, unknown>), activity };
+      this.output.json(stableDeepSort(composite));
+      return;
+    }
+
+    const c = chalkForContext(this.context.color);
+    const langAscii = localePrefersAsciiTable(process.env);
+    const separator = langAscii ? "-".repeat(61) : "─".repeat(61);
+
+    const lines = formatProjectsShowHumanLines({
+      project,
+      tenantSlug: tenant,
+      versions,
+      tags,
+      activity,
+      titleBold: (s) => c.bold(s),
+      separator,
+    });
+    for (const line of lines) {
+      this.output.text(line);
+    }
+  }
+}

--- a/objectified-cli/src/lib/client.ts
+++ b/objectified-cli/src/lib/client.ts
@@ -6,14 +6,20 @@ import type {
   TenantInfoResponse,
   TenantsMeResponse,
   VersionSchema,
+  VersionTagSchema,
+  WorkflowAuditPageResponse,
 } from "../generated/models.js";
 import {
+  getProjectBySlugV1ProjectsTenantSlugBySlugProjectSlugGet,
+  getProjectV1ProjectsTenantSlugProjectIdGet,
   getTenantInfoV1TenantsTenantSlugGet,
   listClassesV1ClassesTenantSlugGet,
   listMyTenantsV1TenantsMeGet,
   listPrimitivesV1PrimitivesTenantSlugGet,
   listProjectsV1ProjectsTenantSlugGet,
+  listVersionTagsV1VersionTagsTenantSlugProjectIdGet,
   listVersionsV1VersionsTenantSlugProjectIdGet,
+  listWorkflowAuditV1VersionsTenantSlugWorkflowAuditGet,
   verifyTenantAccessV1TenantsTenantSlugHead,
 } from "../generated/operations.js";
 
@@ -21,7 +27,13 @@ import { EXIT_CODES } from "./exit-codes.js";
 import { httpStatusToCliError, networkErrnoToCliError, ObjectifiedCliError } from "./errors.js";
 import { redactApiKeyForLogs } from "./redact-api-key.js";
 
-export type { ProjectSchema };
+export type {
+  ProjectSchema,
+  VersionSchema,
+  VersionTagSchema,
+  WorkflowAuditEntryOut,
+  WorkflowAuditPageResponse,
+} from "../generated/models.js";
 
 /** Mutable auth fields read on every request (supports 401 refresh hook). */
 export type ApiAuthSnapshot = {
@@ -51,7 +63,16 @@ export type ObjectifiedApi = {
   /** Transient HTTP retries consumed on the last instrumented request (429 / 5xx policy). */
   readonly lastRetriesAttempted: number;
   listProjects(tenantSlug: string, options?: ListProjectsOptions): Promise<ProjectSchema[]>;
+  getProject(tenantSlug: string, projectId: string): Promise<ProjectSchema>;
+  getProjectBySlug(tenantSlug: string, projectSlug: string): Promise<ProjectSchema>;
   listVersions(tenantSlug: string, projectId: string): Promise<VersionSchema[]>;
+  listVersionTags(tenantSlug: string, projectId: string): Promise<VersionTagSchema[]>;
+  listWorkflowAudit(opts: {
+    tenantSlug: string;
+    projectId?: string;
+    limit?: number;
+    offset?: number;
+  }): Promise<WorkflowAuditPageResponse>;
   listClasses(tenantSlug: string, versionId?: string): Promise<ClassSchema[]>;
   listPrimitives(tenantSlug: string): Promise<PrimitiveSchema[]>;
   listMyTenantsPage(limit: number, offset: number): Promise<TenantsMeResponse>;
@@ -140,6 +161,43 @@ function shouldRetryStatus(status: number, idempotent: boolean): boolean {
   return false;
 }
 
+function parseProjectRecord(raw: unknown, ctx: string): ProjectSchema {
+  if (!raw || typeof raw !== "object") {
+    throw new ObjectifiedCliError({
+      message: `Invalid project entry in ${ctx}.`,
+      exitCode: EXIT_CODES.VALIDATION,
+      title: "Validation failed",
+      hint: "The API returned an unexpected JSON shape; include request-id when reporting.",
+    });
+  }
+  const p = raw as Record<string, unknown>;
+  if (
+    typeof p.id !== "string" ||
+    typeof p.tenant_id !== "string" ||
+    typeof p.name !== "string" ||
+    typeof p.slug !== "string"
+  ) {
+    throw new ObjectifiedCliError({
+      message: "Invalid project fields in response.",
+      exitCode: EXIT_CODES.VALIDATION,
+      title: "Validation failed",
+      hint: "Required project fields were missing or mistyped.",
+    });
+  }
+  if (p.enabled !== undefined && p.enabled !== null && typeof p.enabled !== "boolean") {
+    throw new ObjectifiedCliError({
+      message: "Invalid project fields in response.",
+      exitCode: EXIT_CODES.VALIDATION,
+      title: "Validation failed",
+      hint: "`enabled` must be boolean when present.",
+    });
+  }
+  return {
+    ...(raw as ProjectSchema),
+    enabled: typeof p.enabled === "boolean" ? p.enabled : true,
+  };
+}
+
 /** Validates the list endpoint payload enough for CLI rendering (required OpenAPI fields). */
 function parseProjectsPayload(data: unknown): ProjectSchema[] {
   if (!Array.isArray(data)) {
@@ -152,42 +210,85 @@ function parseProjectsPayload(data: unknown): ProjectSchema[] {
   }
   const projects: ProjectSchema[] = [];
   for (const raw of data) {
-    if (!raw || typeof raw !== "object") {
-      throw new ObjectifiedCliError({
-        message: "Invalid project entry in response.",
-        exitCode: EXIT_CODES.VALIDATION,
-        title: "Validation failed",
-        hint: "The API returned invalid project rows; include request-id when reporting.",
-      });
-    }
-    const p = raw as Record<string, unknown>;
-    if (
-      typeof p.id !== "string" ||
-      typeof p.tenant_id !== "string" ||
-      typeof p.name !== "string" ||
-      typeof p.slug !== "string"
-    ) {
-      throw new ObjectifiedCliError({
-        message: "Invalid project fields in response.",
-        exitCode: EXIT_CODES.VALIDATION,
-        title: "Validation failed",
-        hint: "Required project fields were missing or mistyped.",
-      });
-    }
-    if (p.enabled !== undefined && p.enabled !== null && typeof p.enabled !== "boolean") {
-      throw new ObjectifiedCliError({
-        message: "Invalid project fields in response.",
-        exitCode: EXIT_CODES.VALIDATION,
-        title: "Validation failed",
-        hint: "`enabled` must be boolean when present.",
-      });
-    }
-    projects.push({
-      ...(raw as ProjectSchema),
-      enabled: typeof p.enabled === "boolean" ? p.enabled : true,
-    });
+    projects.push(parseProjectRecord(raw, "projects list"));
   }
   return projects;
+}
+
+function parseProjectPayload(data: unknown): ProjectSchema {
+  return parseProjectRecord(data, "project response");
+}
+
+function parseVersionTagsPayload(data: unknown): VersionTagSchema[] {
+  if (!Array.isArray(data)) {
+    throw new ObjectifiedCliError({
+      message: "Unexpected response shape for version tags list.",
+      exitCode: EXIT_CODES.VALIDATION,
+      title: "Validation failed",
+      hint: "The API returned an unexpected JSON shape; try again or upgrade the CLI.",
+    });
+  }
+  const tags: VersionTagSchema[] = [];
+  for (const raw of data) {
+    if (!raw || typeof raw !== "object") {
+      throw new ObjectifiedCliError({
+        message: "Invalid version tag entry in response.",
+        exitCode: EXIT_CODES.VALIDATION,
+        title: "Validation failed",
+        hint: "The API returned invalid tag rows.",
+      });
+    }
+    const t = raw as Record<string, unknown>;
+    if (
+      typeof t.id !== "string" ||
+      typeof t.project_id !== "string" ||
+      typeof t.version_id !== "string" ||
+      typeof t.name !== "string"
+    ) {
+      throw new ObjectifiedCliError({
+        message: "Invalid version tag fields in response.",
+        exitCode: EXIT_CODES.VALIDATION,
+        title: "Validation failed",
+        hint: "Required tag fields were missing or mistyped.",
+      });
+    }
+    tags.push(raw as VersionTagSchema);
+  }
+  return tags;
+}
+
+function parseWorkflowAuditPayload(data: unknown): WorkflowAuditPageResponse {
+  if (!data || typeof data !== "object") {
+    throw new ObjectifiedCliError({
+      message: "Unexpected response shape for workflow audit.",
+      exitCode: EXIT_CODES.VALIDATION,
+      title: "Validation failed",
+      hint: "The API returned an unexpected JSON shape; try again or upgrade the CLI.",
+    });
+  }
+  const o = data as Record<string, unknown>;
+  if (!Array.isArray(o.items) || !o.pagination || typeof o.pagination !== "object") {
+    throw new ObjectifiedCliError({
+      message: "Unexpected response shape for workflow audit.",
+      exitCode: EXIT_CODES.VALIDATION,
+      title: "Validation failed",
+      hint: "Expected items and pagination from GET .../workflow-audit.",
+    });
+  }
+  const pag = o.pagination as Record<string, unknown>;
+  if (
+    typeof pag.limit !== "number" ||
+    typeof pag.total !== "number" ||
+    typeof pag.hasMore !== "boolean"
+  ) {
+    throw new ObjectifiedCliError({
+      message: "Invalid pagination fields in workflow audit response.",
+      exitCode: EXIT_CODES.VALIDATION,
+      title: "Validation failed",
+      hint: "Expected numeric limit, total, and boolean hasMore.",
+    });
+  }
+  return data as WorkflowAuditPageResponse;
 }
 
 function unwrapSdkGet(
@@ -572,6 +673,46 @@ export function createApiClient(options: CreateApiClientOptions): ObjectifiedApi
       );
     },
 
+    async getProject(tenantSlug: string, projectId: string): Promise<ProjectSchema> {
+      let rawUnknown: unknown;
+      try {
+        rawUnknown = await getProjectV1ProjectsTenantSlugProjectIdGet({
+          client: hey,
+          path: { tenant_slug: tenantSlug, project_id: projectId },
+          throwOnError: false,
+        });
+      } catch (e) {
+        if (e instanceof ObjectifiedCliError) throw e;
+        if (e !== null && typeof e === "object" && "code" in e) {
+          throw networkErrnoToCliError(e as NodeJS.ErrnoException);
+        }
+        throw e;
+      }
+      return parseProjectPayload(
+        unwrapSdkGet(rawUnknown, lastRequestId, lastRetriesAttempted, requestMeta),
+      );
+    },
+
+    async getProjectBySlug(tenantSlug: string, projectSlug: string): Promise<ProjectSchema> {
+      let rawUnknown: unknown;
+      try {
+        rawUnknown = await getProjectBySlugV1ProjectsTenantSlugBySlugProjectSlugGet({
+          client: hey,
+          path: { tenant_slug: tenantSlug, project_slug: projectSlug },
+          throwOnError: false,
+        });
+      } catch (e) {
+        if (e instanceof ObjectifiedCliError) throw e;
+        if (e !== null && typeof e === "object" && "code" in e) {
+          throw networkErrnoToCliError(e as NodeJS.ErrnoException);
+        }
+        throw e;
+      }
+      return parseProjectPayload(
+        unwrapSdkGet(rawUnknown, lastRequestId, lastRetriesAttempted, requestMeta),
+      );
+    },
+
     async listVersions(tenantSlug: string, projectId: string): Promise<VersionSchema[]> {
       let rawUnknown: unknown;
       try {
@@ -588,6 +729,56 @@ export function createApiClient(options: CreateApiClientOptions): ObjectifiedApi
         throw e;
       }
       return parseVersionsPayload(
+        unwrapSdkGet(rawUnknown, lastRequestId, lastRetriesAttempted, requestMeta),
+      );
+    },
+
+    async listVersionTags(tenantSlug: string, projectId: string): Promise<VersionTagSchema[]> {
+      let rawUnknown: unknown;
+      try {
+        rawUnknown = await listVersionTagsV1VersionTagsTenantSlugProjectIdGet({
+          client: hey,
+          path: { tenant_slug: tenantSlug, project_id: projectId },
+          throwOnError: false,
+        });
+      } catch (e) {
+        if (e instanceof ObjectifiedCliError) throw e;
+        if (e !== null && typeof e === "object" && "code" in e) {
+          throw networkErrnoToCliError(e as NodeJS.ErrnoException);
+        }
+        throw e;
+      }
+      return parseVersionTagsPayload(
+        unwrapSdkGet(rawUnknown, lastRequestId, lastRetriesAttempted, requestMeta),
+      );
+    },
+
+    async listWorkflowAudit(opts: {
+      tenantSlug: string;
+      projectId?: string;
+      limit?: number;
+      offset?: number;
+    }): Promise<WorkflowAuditPageResponse> {
+      let rawUnknown: unknown;
+      try {
+        rawUnknown = await listWorkflowAuditV1VersionsTenantSlugWorkflowAuditGet({
+          client: hey,
+          path: { tenant_slug: opts.tenantSlug },
+          query: {
+            projectId: opts.projectId ?? undefined,
+            limit: opts.limit ?? undefined,
+            offset: opts.offset ?? undefined,
+          },
+          throwOnError: false,
+        });
+      } catch (e) {
+        if (e instanceof ObjectifiedCliError) throw e;
+        if (e !== null && typeof e === "object" && "code" in e) {
+          throw networkErrnoToCliError(e as NodeJS.ErrnoException);
+        }
+        throw e;
+      }
+      return parseWorkflowAuditPayload(
         unwrapSdkGet(rawUnknown, lastRequestId, lastRetriesAttempted, requestMeta),
       );
     },

--- a/objectified-cli/src/lib/completion/candidates-logic.ts
+++ b/objectified-cli/src/lib/completion/candidates-logic.ts
@@ -32,7 +32,6 @@ const GLOBAL_FLAG_TOKENS = [
 
 /** Roadmap commands not yet registered — still complete for power users (#3193). */
 const EXTRA_SUBCOMMANDS: Record<string, string[]> = {
-  projects: ["show"],
   versions: ["list", "show"],
   classes: ["show"],
   primitives: ["show"],

--- a/objectified-cli/src/lib/projects/show-format.ts
+++ b/objectified-cli/src/lib/projects/show-format.ts
@@ -1,0 +1,253 @@
+import type {
+  ProjectSchema,
+  VersionSchema,
+  VersionTagSchema,
+  WorkflowAuditEntryOut,
+} from "../client.js";
+
+import {
+  domainDisplay,
+  ellipsizeMiddle,
+  formatRelativeAgo,
+  latestPublishedIso,
+  versionsCountDisplay,
+} from "./format.js";
+
+function kv(label: string, value: string): string {
+  const lc = `${label}:`;
+  return `  ${lc.padEnd(14)} ${value}`;
+}
+
+function isoDateOnly(iso: string | null | undefined): string {
+  if (!iso) return "—";
+  const d = Date.parse(iso);
+  if (Number.isNaN(d)) return "—";
+  return iso.slice(0, 10);
+}
+
+export type VersionLifecycleSummary = {
+  total: number;
+  published: number;
+  draft: number;
+  archived: number;
+  latestPublished?: { versionLabel: string; publishedAt: string };
+};
+
+export function summarizeVersionLifecycle(versions: VersionSchema[]): VersionLifecycleSummary {
+  let published = 0;
+  let draft = 0;
+  let archived = 0;
+  let latestPublished: { versionLabel: string; publishedAt: string } | undefined;
+
+  for (const v of versions) {
+    const isArchived = v.lifecycle === "archived" || v.enabled === false;
+    if (isArchived) {
+      archived++;
+      continue;
+    }
+    if (v.published === true) {
+      published++;
+      const at = v.published_at ?? "";
+      if (at !== "" && (!latestPublished || at > latestPublished.publishedAt)) {
+        const raw = v.version_id.trim();
+        const versionLabel = raw.startsWith("v") ? raw : `v${raw}`;
+        latestPublished = { versionLabel, publishedAt: at };
+      }
+    } else {
+      draft++;
+    }
+  }
+
+  return {
+    total: versions.length,
+    published,
+    draft,
+    archived,
+    latestPublished,
+  };
+}
+
+export function revisionToVersionDisplayMap(versions: VersionSchema[]): Map<string, string> {
+  const m = new Map<string, string>();
+  for (const v of versions) {
+    const raw = v.version_id.trim();
+    const label = raw.startsWith("v") ? raw : `v${raw}`;
+    m.set(v.id, label);
+  }
+  return m;
+}
+
+function formatTagArrow(
+  tag: VersionTagSchema,
+  revisionToLabel: Map<string, string>,
+): string {
+  const target =
+    (tag.target_version_string !== undefined &&
+      tag.target_version_string !== null &&
+      tag.target_version_string !== "" &&
+      tag.target_version_string) ||
+    revisionToLabel.get(tag.version_id) ||
+    tag.version_id.slice(0, 8);
+  return `${tag.name} → ${target}`;
+}
+
+function readDetailString(detail: WorkflowAuditEntryOut["detail"], key: string): string | undefined {
+  if (!detail || typeof detail !== "object") return undefined;
+  const v = (detail as Record<string, unknown>)[key];
+  return typeof v === "string" && v !== "" ? v : undefined;
+}
+
+function actorDisplay(entry: WorkflowAuditEntryOut): string {
+  const detail = entry.detail;
+  const email =
+    readDetailString(detail, "actorEmail") ??
+    readDetailString(detail, "actor_email") ??
+    readDetailString(detail, "email");
+  if (email !== undefined) {
+    return email.includes("@") ? ellipsizeMiddle(email, 22) : email;
+  }
+  if (entry.actorId !== undefined && entry.actorId !== null && entry.actorId !== "") {
+    return ellipsizeMiddle(entry.actorId, 22);
+  }
+  return "—";
+}
+
+function actionDisplay(action: string): string {
+  const parts = action.split(".").filter((p) => p !== "");
+  if (parts.length === 0) return action;
+  const [head, verb, ...rest] = parts;
+  const topic =
+    head === "version"
+      ? "versions"
+      : head === "schema"
+        ? "schema"
+        : head === "repository"
+          ? "repository"
+          : head ?? action;
+  const tail = rest.length > 0 ? ` ${rest.join(" ")}` : "";
+  return verb !== undefined ? `${topic} ${verb}${tail}` : `${topic}${tail}`;
+}
+
+function versionTokenForAudit(
+  entry: WorkflowAuditEntryOut,
+  revisionToLabel: Map<string, string>,
+): string {
+  const fromDetail =
+    readDetailString(entry.detail, "versionLine") ??
+    readDetailString(entry.detail, "version_id") ??
+    readDetailString(entry.detail, "versionId");
+  if (fromDetail !== undefined) {
+    const t = fromDetail.trim();
+    return t.startsWith("v") || !/\d+\.\d+/.test(t) ? t : `v${t}`;
+  }
+  if (entry.versionId !== undefined && entry.versionId !== null && entry.versionId !== "") {
+    return revisionToLabel.get(entry.versionId) ?? ellipsizeMiddle(entry.versionId, 14);
+  }
+  return "";
+}
+
+export function formatWorkflowAuditActivityLine(
+  entry: WorkflowAuditEntryOut,
+  revisionToLabel: Map<string, string>,
+  nowMs: number,
+): string {
+  const rel = formatRelativeAgo(entry.createdAt, nowMs).padEnd(8);
+  const verb = actionDisplay(entry.action);
+  const ver = versionTokenForAudit(entry, revisionToLabel);
+  const outcome = entry.outcome !== "success" ? ` (${entry.outcome})` : "";
+  const middle = [verb, ver !== "" ? ver : undefined].filter(Boolean).join(" ");
+  const actor = actorDisplay(entry);
+  return `    ${rel} ${middle}${outcome}  ${actor}`;
+}
+
+export function formatProjectsShowHumanLines(opts: {
+  project: ProjectSchema;
+  tenantSlug: string;
+  versions: VersionSchema[];
+  tags: VersionTagSchema[];
+  activity: WorkflowAuditEntryOut[];
+  titleBold: (s: string) => string;
+  separator: string;
+  now?: Date;
+}): string[] {
+  const nowMs = (opts.now ?? new Date()).getTime();
+  const p = opts.project;
+  const summary = summarizeVersionLifecycle(opts.versions);
+  const revisionToLabel = revisionToVersionDisplayMap(opts.versions);
+
+  const versionsLine = versionsLineFromProjectOrVersions(p, summary);
+  const latestLine = latestLineFromProjectOrVersions(p, summary);
+
+  const tagsSorted = [...opts.tags].sort((a, b) => a.name.localeCompare(b.name));
+  const tagsLine =
+    tagsSorted.length === 0
+      ? "—"
+      : tagsSorted.map((t) => formatTagArrow(t, revisionToLabel)).join(", ");
+
+  const createdEmail = p.creator_email ?? "";
+  const createdIso = p.created_at ?? "";
+  const created =
+    createdIso !== ""
+      ? `${isoDateOnly(createdIso)}${createdEmail !== "" ? ` by ${createdEmail}` : ""}`
+      : "—";
+
+  const desc = (p.description ?? "").trim();
+  const descDisp = desc !== "" ? desc : "—";
+
+  const lines: string[] = [
+    "",
+    `  ${opts.titleBold(`${p.name}  (${p.slug})`)}`,
+    `  ${opts.separator}`,
+    kv("ID", ellipsizeMiddle(p.id, 36)),
+    kv("Tenant", opts.tenantSlug),
+    kv("Domain", domainDisplay(p)),
+    kv("Description", descDisp),
+    kv("Created", created),
+    kv("Updated", isoDateOnly(p.updated_at ?? null)),
+    kv("Versions", versionsLine),
+    kv("Latest", latestLine),
+    kv("Tags (latest)", tagsLine),
+    "",
+    "  Recent activity:",
+    ...opts.activity.map((e) => formatWorkflowAuditActivityLine(e, revisionToLabel, nowMs)),
+  ];
+
+  if (opts.activity.length === 0) {
+    lines.push("    —");
+  }
+
+  lines.push("");
+  return lines;
+}
+
+/** Uses aggregate counts from API/project payload when version list is empty (same helpers as list view). */
+export function versionsLineFromProjectOrVersions(
+  project: ProjectSchema,
+  summary: VersionLifecycleSummary,
+): string {
+  const listed = summary.total;
+  if (listed > 0) {
+    return `${String(summary.total)}  (${String(summary.published)} published, ${String(summary.draft)} draft, ${String(summary.archived)} archived)`;
+  }
+  const vc = versionsCountDisplay(project);
+  return vc === "—" ? "0" : vc;
+}
+
+export function latestLineFromProjectOrVersions(
+  project: ProjectSchema,
+  summary: VersionLifecycleSummary,
+): string {
+  if (summary.latestPublished !== undefined) {
+    const pubDate = isoDateOnly(summary.latestPublished.publishedAt);
+    return `${summary.latestPublished.versionLabel}   published ${pubDate}`;
+  }
+  const iso = latestPublishedIso(project);
+  if (iso !== undefined) {
+    const top = (project as Record<string, unknown>).latest_published_version;
+    const raw = typeof top === "string" ? top.trim() : "";
+    const ver = raw !== "" ? (raw.startsWith("v") ? raw : `v${raw}`) : undefined;
+    const pubDate = isoDateOnly(iso);
+    return ver !== undefined ? `${ver}   published ${pubDate}` : `published ${pubDate}`;
+  }
+  return "—";
+}

--- a/objectified-cli/src/lib/resolve.ts
+++ b/objectified-cli/src/lib/resolve.ts
@@ -1,0 +1,128 @@
+import leven from "leven";
+
+import type { ObjectifiedApi, ProjectSchema } from "./client.js";
+import { readCompletionCache } from "./completion/cache.js";
+import { ObjectifiedCliError } from "./errors.js";
+import { EXIT_CODES } from "./exit-codes.js";
+
+/** Lowercase UUID string with hyphens (36 chars), per #3203 — ambiguous slug-as-UUID resolves as UUID first. */
+const PROJECT_UUID_REF_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+export function normalizeProjectRef(raw: string): string {
+  return raw.trim();
+}
+
+export function projectRefLooksLikeUuid(ref: string): boolean {
+  return PROJECT_UUID_REF_RE.test(ref.toLowerCase());
+}
+
+/** Same cache key shape as completion candidates (`baseUrl|profile|tenantSlug`). */
+export function completionProfileCacheKey(parts: {
+  baseUrl: string;
+  profile: string;
+  tenantSlug: string | undefined;
+}): string {
+  return `${parts.baseUrl}|${parts.profile}|${parts.tenantSlug ?? ""}`;
+}
+
+export async function loadCachedProjectSlugs(
+  profileCacheKey: string,
+  tenantSlug: string,
+): Promise<string[]> {
+  const rows = await readCompletionCache(profileCacheKey, ["projects-map", tenantSlug]);
+  if (rows === undefined) return [];
+  const slugs: string[] = [];
+  for (const row of rows) {
+    const tab = row.indexOf("\t");
+    if (tab <= 0) continue;
+    const slug = row.slice(0, tab);
+    if (slug !== "") slugs.push(slug);
+  }
+  return slugs;
+}
+
+const DID_YOU_MEAN_MAX = 3;
+const DID_YOU_MEAN_MAX_DISTANCE = 8;
+
+/** Closest slugs by Levenshtein distance (used after cache miss / 404). */
+export function didYouMeanSlugs(ref: string, slugs: string[]): string[] {
+  const needle = ref.trim().toLowerCase();
+  if (needle === "") return [];
+  const uniq = [...new Set(slugs.map((s) => s.trim()).filter((s) => s !== ""))];
+  const scored = uniq
+    .filter((s) => s.toLowerCase() !== needle)
+    .map((s) => ({ s, d: leven(needle, s.toLowerCase()) }))
+    .filter((x) => x.d > 0 && x.d <= DID_YOU_MEAN_MAX_DISTANCE)
+    .sort((a, b) => a.d - b.d || a.s.localeCompare(b.s));
+  const out: string[] = [];
+  for (const row of scored) {
+    if (out.length >= DID_YOU_MEAN_MAX) break;
+    out.push(row.s);
+  }
+  return out;
+}
+
+async function enrichNotFoundHint(opts: {
+  ref: string;
+  tenantSlug: string;
+  profileCacheKey: string;
+  baseHint?: string | undefined;
+}): Promise<string | undefined> {
+  const base =
+    opts.baseHint ??
+    "Check slugs, IDs, and tenant scope. Run `objectified projects list` to refresh suggestions.";
+  if (projectRefLooksLikeUuid(opts.ref)) {
+    return base;
+  }
+  const cached = await loadCachedProjectSlugs(opts.profileCacheKey, opts.tenantSlug);
+  const picks = didYouMeanSlugs(opts.ref, cached);
+  if (picks.length === 0) return base;
+  return `${base} Did you mean: ${picks.join(", ")}?`;
+}
+
+/**
+ * Resolve `projects show`-style ref: UUID → GET /v1/projects/{tenant}/{id}; else → …/by-slug/{slug}.
+ * On 404, exit **5** with optional Levenshtein hints from cached `projects list` slugs (#3203).
+ */
+export async function resolveProjectForTenant(
+  api: ObjectifiedApi,
+  tenantSlug: string,
+  rawRef: string,
+  profileCacheKey: string,
+): Promise<ProjectSchema> {
+  const ref = normalizeProjectRef(rawRef);
+  if (ref === "") {
+    throw new ObjectifiedCliError({
+      message: "Project slug or id is required.",
+      exitCode: EXIT_CODES.MISUSE,
+      title: "Missing argument",
+      hint: "Run `objectified projects show <slug-or-id>`.",
+    });
+  }
+
+  try {
+    if (projectRefLooksLikeUuid(ref)) {
+      return await api.getProject(tenantSlug, ref.toLowerCase());
+    }
+    return await api.getProjectBySlug(tenantSlug, ref);
+  } catch (e) {
+    if (!(e instanceof ObjectifiedCliError) || e.exitCode !== EXIT_CODES.NOT_FOUND) {
+      throw e;
+    }
+    const hint = await enrichNotFoundHint({
+      ref,
+      tenantSlug,
+      profileCacheKey,
+      baseHint: e.hint,
+    });
+    throw new ObjectifiedCliError({
+      message: `Project not found: ${ref}`,
+      exitCode: EXIT_CODES.NOT_FOUND,
+      title: "Not found",
+      hint,
+      requestId: e.requestId,
+      retriesAttempted: e.retriesAttempted,
+    });
+  }
+}

--- a/objectified-cli/test/cli.integration.test.ts
+++ b/objectified-cli/test/cli.integration.test.ts
@@ -825,6 +825,103 @@ tenant_slug = "acme"
     }
   });
 
+  it("projects show resolves by slug and returns composite json (#3203)", async () => {
+    const PROJ = "33333333-4444-5555-6666-777777777777";
+    const projectBody = {
+      id: PROJ,
+      tenant_id: "t1",
+      name: "Showcase",
+      slug: "showcase",
+      enabled: true,
+      description: "Demo",
+      creator_email: "u@example.com",
+      created_at: "2024-08-19T10:00:00Z",
+      updated_at: "2026-04-02T15:00:00Z",
+      metadata: { domain: "finance" },
+    };
+
+    const server = http.createServer((req, res) => {
+      res.setHeader("Connection", "close");
+      if (req.headers["x-api-key"] !== "good-key") {
+        res.statusCode = 401;
+        res.setHeader("Content-Type", "application/json");
+        res.end(JSON.stringify({ detail: "Authentication required" }));
+        return;
+      }
+
+      const urlRaw = req.url ?? "";
+      const url = new URL(urlRaw, "http://127.0.0.1");
+
+      if (req.method === "GET" && url.pathname === "/v1/projects/acme/by-slug/showcase") {
+        res.setHeader("Content-Type", "application/json");
+        res.end(JSON.stringify(projectBody));
+        return;
+      }
+
+      if (req.method === "GET" && url.pathname === `/v1/versions/acme/${PROJ}`) {
+        res.setHeader("Content-Type", "application/json");
+        res.end(JSON.stringify([]));
+        return;
+      }
+
+      if (req.method === "GET" && url.pathname === `/v1/version-tags/acme/${PROJ}`) {
+        res.setHeader("Content-Type", "application/json");
+        res.end(JSON.stringify([]));
+        return;
+      }
+
+      if (req.method === "GET" && url.pathname === "/v1/versions/acme/workflow-audit") {
+        if (url.searchParams.get("projectId") !== PROJ || url.searchParams.get("limit") !== "10") {
+          res.statusCode = 400;
+          res.end();
+          return;
+        }
+        res.setHeader("Content-Type", "application/json");
+        res.end(
+          JSON.stringify({
+            schemaVersion: 1,
+            items: [],
+            pagination: { limit: 10, total: 0, hasMore: false, offset: 0 },
+          }),
+        );
+        return;
+      }
+
+      res.statusCode = 404;
+      res.end();
+    });
+
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", () => resolve()));
+    const addr = server.address();
+    if (addr === null || typeof addr === "string") throw new Error("expected AddressInfo");
+
+    try {
+      const { code, stdout } = await spawnCliCaptureAsync(
+        [
+          "--base-url",
+          `http://127.0.0.1:${String(addr.port)}`,
+          "--api-key",
+          "good-key",
+          "--json",
+          "projects",
+          "show",
+          "showcase",
+        ],
+        { OBJECTIFIED_TENANT: "acme" },
+      );
+      expect(code).toBe(0);
+      const parsed = JSON.parse(stdout.trim()) as { slug?: string; activity?: unknown[] };
+      expect(parsed.slug).toBe("showcase");
+      expect(Array.isArray(parsed.activity)).toBe(true);
+      expect(parsed.activity).toHaveLength(0);
+    } finally {
+      server.closeAllConnections?.();
+      await new Promise<void>((resolve, reject) =>
+        server.close((err) => (err !== undefined ? reject(err) : resolve())),
+      );
+    }
+  });
+
   it("projects list rejects --all with --limit before calling the API (#3202)", async () => {
     const { code, stderr } = await spawnCliCaptureAsync(
       [

--- a/objectified-cli/test/project-ref-resolve.test.ts
+++ b/objectified-cli/test/project-ref-resolve.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  didYouMeanSlugs,
+  normalizeProjectRef,
+  projectRefLooksLikeUuid,
+} from "../src/lib/resolve.js";
+
+describe("project ref resolution helpers (#3203)", () => {
+  it("normalizes whitespace", () => {
+    expect(normalizeProjectRef("  payments-api \n")).toBe("payments-api");
+  });
+
+  it("detects canonical lowercase UUIDs", () => {
+    expect(projectRefLooksLikeUuid("33333333-4444-5555-6666-777777777777")).toBe(true);
+    expect(projectRefLooksLikeUuid("payments-api")).toBe(false);
+    expect(projectRefLooksLikeUuid("not-a-uuid")).toBe(false);
+  });
+
+  it("ranks slug suggestions by Levenshtein distance", () => {
+    const slugs = ["payments-api", "pets-api", "billing-portal"];
+    const paySuggest = didYouMeanSlugs("payment-api", slugs);
+    expect(paySuggest[0]).toBe("payments-api");
+    expect(paySuggest.length).toBeGreaterThanOrEqual(1);
+    expect(didYouMeanSlugs("pets-ap", slugs)).toContain("pets-api");
+  });
+});

--- a/objectified-cli/test/projects-show-format.test.ts
+++ b/objectified-cli/test/projects-show-format.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+
+import type { ProjectSchema, VersionSchema, WorkflowAuditEntryOut } from "../src/lib/client.js";
+
+import {
+  formatProjectsShowHumanLines,
+  formatWorkflowAuditActivityLine,
+  revisionToVersionDisplayMap,
+  summarizeVersionLifecycle,
+} from "../src/lib/projects/show-format.js";
+
+describe("projects show formatting (#3203)", () => {
+  const project: ProjectSchema = {
+    id: "33333333-4444-5555-6666-777777777777",
+    tenant_id: "t1",
+    name: "Payments API",
+    slug: "payments-api",
+    enabled: true,
+    description: "Inbound charges.",
+    creator_email: "kenji@objectified.dev",
+    created_at: "2024-08-19T10:00:00Z",
+    updated_at: "2026-04-02T15:00:00Z",
+    metadata: { domain: "finance" },
+  };
+
+  it("summarizes lifecycle buckets", () => {
+    const versions: VersionSchema[] = [
+      {
+        id: "r1",
+        project_id: project.id,
+        version_id: "2.1.0",
+        published: true,
+        published_at: "2026-05-04T12:00:00Z",
+        enabled: true,
+      },
+      {
+        id: "r2",
+        project_id: project.id,
+        version_id: "2.2.0-rc.1",
+        published: false,
+        enabled: true,
+      },
+      {
+        id: "r3",
+        project_id: project.id,
+        version_id: "1.0.0",
+        lifecycle: "archived",
+        published: true,
+        enabled: true,
+      },
+    ];
+    const s = summarizeVersionLifecycle(versions);
+    expect(s.total).toBe(3);
+    expect(s.published).toBe(1);
+    expect(s.draft).toBe(1);
+    expect(s.archived).toBe(1);
+    expect(s.latestPublished?.versionLabel).toBe("v2.1.0");
+  });
+
+  it("renders workflow audit lines using revision map", () => {
+    const versions: VersionSchema[] = [
+      {
+        id: "rev-aaa",
+        project_id: project.id,
+        version_id: "2.1.0",
+        published: true,
+        enabled: true,
+      },
+    ];
+    const map = revisionToVersionDisplayMap(versions);
+    const entry: WorkflowAuditEntryOut = {
+      id: "a",
+      tenantId: "t",
+      projectId: project.id,
+      versionId: "rev-aaa",
+      action: "version.push",
+      outcome: "success",
+      actorId: "11111111-2222-3333-4444-555555555555",
+      createdAt: "2026-05-06T12:00:00Z",
+      detail: null,
+    };
+    const line = formatWorkflowAuditActivityLine(entry, map, Date.parse("2026-05-08T12:00:00Z"));
+    expect(line).toContain("versions push");
+    expect(line).toContain("v2.1.0");
+  });
+
+  it("includes title and key rows in human output", () => {
+    const lines = formatProjectsShowHumanLines({
+      project,
+      tenantSlug: "acme-corp",
+      versions: [],
+      tags: [],
+      activity: [],
+      titleBold: (s) => s,
+      separator: "-".repeat(61),
+      now: new Date("2026-05-08T12:00:00Z"),
+    });
+    expect(lines.some((l) => l.includes("Payments API") && l.includes("payments-api"))).toBe(true);
+    expect(lines.some((l) => l.includes("Tenant") && l.includes("acme-corp"))).toBe(true);
+    expect(lines.some((l) => l.includes("finance"))).toBe(true);
+  });
+});

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.96",
+  "version": "0.11.97",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -8,6 +8,7 @@ We continue to improve the platform based on your feedback with improvements and
 - MCP service is now live
 
 ## CLI
+- **`objectified-cli`**: `objectified projects show <slug-or-id>` resolves UUID vs slug (`GET /v1/projects/{tenant}/by-slug/{slug}` or `GET /v1/projects/{tenant}/{id}`), prints rich detail with version/tag summaries and up to **10** workflow-audit rows; `--json` returns the project object plus `activity[]` (#3203).
 - **`objectified-cli`**: `objectified projects list` calls `GET /v1/projects/{tenant_slug}` with an 80-column table (slug, name, domain, versions, latest published), `--limit` / `--all`, `--sort`, `--filter`, `--search`, `--columns`, `--include-deleted`, and top-level `--json` array output (#3202).
 - **`objectified-cli`**: `objectified tenants list` and `objectified tenants info <slug>` call `GET /v1/tenants/me` and `GET /v1/tenants/{slug}` (REST support in `objectified-rest`); stable `--json`; active profile tenant marker; `--limit` / `--offset` pagination for large tenant lists (#3198).
 - **`objectified-cli`**: `objectified tenants use <slug>` validates access with `HEAD /v1/tenants/{slug}`, writes `tenant_slug` under `profile.<name>` in config.toml, supports `--clear`, global `--tenant` (over `OBJECTIFIED_TENANT` then config), exit **4**/**5** with hints and typo suggestions (#3199).


### PR DESCRIPTION
## What changed
- Added `objectified projects show <slug-or-id>` with UUID-first resolution (`GET /v1/projects/{tenant}/{id}` vs `GET /v1/projects/{tenant}/by-slug/{slug}`).
- Centralized ref handling in `objectified-cli/src/lib/resolve.ts`: cached slug list (same keys as shell completion) plus Levenshtein **did-you-mean** on **404** for non-UUID refs.
- Extended `lib/client.ts` with `getProject`, `getProjectBySlug`, `listVersionTags`, `listWorkflowAudit`, plus validators for tags and audit payloads.
- Human output: domain, description, version lifecycle breakdown, latest published line, version tags, and up to **10** workflow-audit rows (newest first via API `limit`).
- `--json`: `{ ...projectFields, activity: WorkflowAuditEntryOut[] }` via `stableDeepSort`.

## How to test
1. **Authenticate** (`objectified auth login` or `--api-key`).
2. **Set tenant** (`objectified tenants use <slug>` or `--tenant`).
3. Run **`objectified projects show <slug>`** and confirm detail sections and **Recent activity**.
4. Run **`objectified projects show <uuid>`** for the same project; output should match.
5. Run **`objectified --json projects show <slug>`** and verify top-level **`activity`** array (≤10 items).

## Risk / notes
- Activity depends on workflow-audit rows for `projectId`; empty API → section shows **—**.
- Did-you-mean uses completion cache; run **`objectified projects list`** to populate cache when needed.

Closes #3203

Made with [Cursor](https://cursor.com)