### PR TITLE
Fix #3204 - objectified projects create (interactive + CI)

### DIFF
--- a/docs/PLANNED_ROADMAP_CLI.md
+++ b/docs/PLANNED_ROADMAP_CLI.md
@@ -407,7 +407,6 @@ Part of Epic: Authentication & Tenant Context (#3175)
 
 | #         | Title                                | Description                                          | Labels                                | MVP | Parallel |
 |-----------|--------------------------------------|------------------------------------------------------|---------------------------------------|-----|----------|
-| 3.3 (#3204) | `projects create`                  | Interactive + non-interactive + `--from-file`         | `enhancement`, `mvp`, `cli`, `roadmap-cli` | Yes | Yes      |
 | 3.4 (#3205) | `projects update`                  | Partial update with diff renderer + concurrency check | `enhancement`, `cli`, `roadmap-cli`   | No  | Yes      |
 | 3.5 (#3206) | `projects delete`                  | Typed confirmation, refuses on published versions     | `enhancement`, `cli`, `roadmap-cli`   | No  | Yes      |
 | 3.6 (#3207) | `projects export`                  | Deterministic full project dump (JSON or YAML)        | `enhancement`, `cli`, `roadmap-cli`, `export` | No  | Yes      |
@@ -762,12 +761,11 @@ The `NPM_REGISTRY` env var lets us point at npmjs.com, GitHub Packages, JFrog Ar
 
 ## MVP Release — Ticket Bundle
 
-The MVP delivers an installable, useful CLI focused on _read_ and _publish_ for a single project's lifecycle. Total: **16 open sub-tickets** across 5 epics (plus completed foundation items such as #3186, #3187, #3188, #3189, #3190, #3191, #3192, #3193, #3194, #3195, #3202, and #3203).
+The MVP delivers an installable, useful CLI focused on _read_ and _publish_ for a single project's lifecycle. Total: **15 open sub-tickets** across 4 epics (plus completed foundation items such as #3186, #3187, #3188, #3189, #3190, #3191, #3192, #3193, #3194, #3195, #3202, #3203, and #3204).
 
 | Epic     | Tickets                                                                                                   | Count |
 |----------|-----------------------------------------------------------------------------------------------------------|-------|
 | 2 (#3175) | #3196, #3197, #3198, #3199                                                                                | 4     |
-| 3 (#3176) | #3204                                                                                                      | 1     |
 | 4 (#3177) | #3208, #3209, #3210, #3212                                                                                | 4     |
 | 9 (#3182) | #3244, #3245, #3246, #3247, #3248                                                                          | 5     |
 | 12 (#3185) | #3267, #3268                                                                                               | 2     |
@@ -855,7 +853,7 @@ The tickets were created in the order below — that is also the recommended **e
 
 1. **Epic 1 — Foundation** (#3174: #3186, #3187, #3188, #3189, #3190, #3191, #3192, and #3193 landed). Without the scaffold, no other command can exist.
 2. **Epic 2 — Auth & Tenants** (#3175; #3194–#3197 shipped — continue #3198 → #3201). Required for any tenant-scoped command.
-3. **Epic 3 — Projects** (#3176 then #3204 → #3207; #3203 shipped). The first useful read/write surface.
+3. **Epic 3 — Projects** (#3176 then #3205 → #3207; #3203 and #3204 shipped). The first useful read/write surface.
 4. **Epic 4 — Versions** (#3177 then #3208 → #3216). The publish flow that makes the CLI valuable in CI.
 5. **Epic 9 — Browse & Schema Export** (#3182 then #3244 → #3252). The most-used consumer surface; lands early because it works without auth.
 6. **Epic 12 — Distribution (CI + NPM publish only)** (#3185 then #3267, #3268). Ship MVP — `npm i -g objectified-cli` works.

--- a/objectified-cli/README.md
+++ b/objectified-cli/README.md
@@ -50,7 +50,7 @@ $ npm install -g objectified-cli
 $ objectified COMMAND
 running command...
 $ objectified (--version)
-objectified-cli/0.1.15 <platform> node-v<major.minor.patch>
+objectified-cli/0.1.16 <platform> node-v<major.minor.patch>
 $ objectified --help [COMMAND]
 USAGE
   $ objectified COMMAND
@@ -81,6 +81,7 @@ USAGE
 * [`objectified docs telemetry`](#objectified-docs-telemetry)
 * [`objectified hello [NAME]`](#objectified-hello-name)
 * [`objectified help [COMMAND]`](#objectified-help-command)
+* [`objectified projects create`](#objectified-projects-create)
 * [`objectified projects list`](#objectified-projects-list)
 * [`objectified projects show REF`](#objectified-projects-show-ref)
 * [`objectified tenants info SLUG`](#objectified-tenants-info-slug)
@@ -999,6 +1000,68 @@ OTHER
 ```
 
 _See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/6.2.46/src/commands/help.ts)_
+
+## `objectified projects create`
+
+Create a project for the active tenant (POST /v1/projects/{tenant_slug}); interactive or CI flags.
+
+```
+USAGE
+  $ objectified projects create [--api-key <value>] [--api-key-file <value>] [--base-url <value>] [--config <value>]
+    [--json] [--color] [--profile <value>] [--tenant <value>] [-q] [--verbose] [--name <value>] [--slug <value>]
+    [--description <value>] [--domain <value>] [--visibility private|public] [--from-file <value>] [--yes] [--dry-run]
+
+DESCRIPTION
+  Create a project for the active tenant (POST /v1/projects/{tenant_slug}); interactive or CI flags.
+
+EXAMPLES
+  $ objectified projects create
+
+  $ objectified projects create --name 'Payments API' --slug payments-api --yes
+
+  $ objectified projects create --from-file ./project.yaml --yes
+
+  $ objectified projects create --dry-run --name 'Payments API' --slug payments-api
+
+COMMON
+  --base-url=<value>  Root REST API URL.
+  --config=<value>    Path to config file (default: XDG config dir / Objectified AppData on Windows — see `objectified
+                      config path`).
+  --profile=<value>   Named credentials profile (OBJECTIFIED_PROFILE); falls back to default_profile in config.
+  --tenant=<value>    [env: OBJECTIFIED_TENANT] Tenant slug for this run only (overrides OBJECTIFIED_TENANT and config
+                      tenant_slug).
+
+OUTPUT
+  --[no-]color  Enable/disable ANSI colors (--no-color sets NO_COLOR; colors are off when stdout is not a TTY).
+      --[no-]json   Emit machine-readable JSON (OBJECTIFIED_JSON=1; auto-enabled when stdout is not a TTY).
+  -q, --quiet       Suppress non-error stdout (spinners, banners, tips).
+      --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
+
+AUTH
+  --api-key=<value>       [env: OBJECTIFIED_API_KEY] API key for direct authentication (OBJECTIFIED_API_KEY). Not
+                          persisted unless you run `auth login --api-key`.
+  --api-key-file=<value>  Read API key from a file (single line; avoids shell history).
+
+OTHER
+  --description=<value>  Optional description.
+  --domain=<value>       Domain category id (metadata domainCategory). Validated against GET …/domains when available.
+  --dry-run              Print the POST JSON body and exit without calling the API.
+  --from-file=<value>    Load fields from JSON or YAML (validated JSON Schema).
+  --name=<value>         Project display name.
+  --slug=<value>         URL-safe slug (^[a-z][a-z0-9-]{1,62}$).
+  --visibility=<option>  Stored in project metadata: private or public.
+                         <options: private|public>
+  --yes                  Skip confirmation prompts (CI guard).
+
+SEE ALSO
+  objectified projects list
+
+  objectified projects show
+
+  objectified tenants use
+
+  objectified docs errors
+```
 
 ## `objectified projects list`
 

--- a/objectified-cli/man/man1/objectified-projects-create.1
+++ b/objectified-cli/man/man1/objectified-projects-create.1
@@ -1,0 +1,73 @@
+.TH OBJECTIFIED\-PROJECTS\-CREATE 1 "" "" "User Commands"
+.SH NAME
+objectified projects create \- Create a project for the active tenant (POST /v1/projects/{tenant_slug}); interactive or CI flags.
+.SH DESCRIPTION
+.nf
+USAGE
+  $ objectified projects create [--api-key <value>] [--api-key-file
+    <value>] [--base-url <value>] [--config <value>] [--json] [--color]
+    [--profile <value>] [--tenant <value>] [-q] [--verbose] [--name <value>]
+    [--slug <value>] [--description <value>] [--domain <value>] [--visibility
+    private|public] [--from-file <value>] [--yes] [--dry-run]
+
+DESCRIPTION
+  Create a project for the active tenant (POST /v1/projects/{tenant_slug});
+  interactive or CI flags.
+
+EXAMPLES
+  $ objectified projects create
+
+  $ objectified projects create --name 'Payments API' --slug payments-api --yes
+
+  $ objectified projects create --from-file ./project.yaml --yes
+
+  $ objectified projects create --dry-run --name 'Payments API' --slug payments-api
+
+COMMON
+  --base-url=<value>  Root REST API URL.
+  --config=<value>    Path to config file (default: XDG config dir /
+                      Objectified AppData on Windows — see `objectified config
+                      path`).
+  --profile=<value>   Named credentials profile (OBJECTIFIED_PROFILE); falls
+                      back to default_profile in config.
+  --tenant=<value>    [env: OBJECTIFIED_TENANT] Tenant slug for this run only
+                      (overrides OBJECTIFIED_TENANT and config tenant_slug).
+
+OUTPUT
+  --[no-]color  Enable/disable ANSI colors (--no-color sets NO_COLOR;
+                    colors are off when stdout is not a TTY).
+      --[no-]json   Emit machine-readable JSON (OBJECTIFIED_JSON=1;
+                    auto-enabled when stdout is not a TTY).
+  -q, --quiet       Suppress non-error stdout (spinners, banners, tips).
+      --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
+
+AUTH
+  --api-key=<value>       [env: OBJECTIFIED_API_KEY] API key for direct
+                          authentication (OBJECTIFIED_API_KEY). Not persisted
+                          unless you run `auth login --api-key`.
+  --api-key-file=<value>  Read API key from a file (single line; avoids shell
+                          history).
+
+OTHER
+  --description=<value>  Optional description.
+  --domain=<value>       Domain category id (metadata domainCategory).
+                         Validated against GET …/domains when available.
+  --dry-run              Print the POST JSON body and exit without calling the
+                         API.
+  --from-file=<value>    Load fields from JSON or YAML (validated JSON
+                         Schema).
+  --name=<value>         Project display name.
+  --slug=<value>         URL-safe slug (^[a-z][a-z0-9-]{1,62}$).
+  --visibility=<option>  Stored in project metadata: private or public.
+                         <options: private|public>
+  --yes                  Skip confirmation prompts (CI guard).
+
+SEE ALSO
+  objectified projects list
+
+  objectified projects show
+
+  objectified tenants use
+
+  objectified docs errors
+.fi

--- a/objectified-cli/man/man1/objectified.1
+++ b/objectified-cli/man/man1/objectified.1
@@ -6,7 +6,7 @@ objectified \- Objectified command-line interface
 Objectified command-line interface
 
 VERSION
-  objectified-cli/0.1.15 linux-x64 node-v24.14.1
+  objectified-cli/0.1.16 linux-x64 node-v24.14.1
 
 USAGE
   $ objectified [COMMAND]

--- a/objectified-cli/package.json
+++ b/objectified-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-cli",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "Objectified command-line interface",
   "author": "Objectified",
   "type": "module",
@@ -42,9 +42,11 @@
   },
   "dependencies": {
     "@iarna/toml": "^2.2.5",
+    "@inquirer/prompts": "^8.4.2",
     "@oclif/core": "^4.11.0",
     "@oclif/plugin-help": "^6.2.46",
     "@oclif/plugin-version": "^2.2.43",
+    "ajv": "^8.20.0",
     "chalk": "^5.6.2",
     "cli-table3": "^0.6.5",
     "env-paths": "^4.0.0",
@@ -93,6 +95,7 @@
     "./man/man1/objectified-docs.1",
     "./man/man1/objectified-hello.1",
     "./man/man1/objectified-help.1",
+    "./man/man1/objectified-projects-create.1",
     "./man/man1/objectified-projects-list.1",
     "./man/man1/objectified-projects-show.1",
     "./man/man1/objectified-tenants-info.1",

--- a/objectified-cli/src/commands/projects/create.ts
+++ b/objectified-cli/src/commands/projects/create.ts
@@ -32,7 +32,17 @@ function loadStructuredFile(filePath: string): unknown {
   const raw = fs.readFileSync(abs, "utf8");
   const lower = abs.toLowerCase();
   if (lower.endsWith(".yaml") || lower.endsWith(".yml")) {
-    return YAML.parse(raw) as unknown;
+    try {
+      return YAML.parse(raw) as unknown;
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      throw new ObjectifiedCliError({
+        message: `Invalid YAML in project file: ${msg}`,
+        exitCode: EXIT_CODES.VALIDATION,
+        title: "Validation failed",
+        hint: "Fix the file syntax or use .json for JSON.",
+      });
+    }
   }
   try {
     return JSON.parse(raw) as unknown;
@@ -123,7 +133,18 @@ export default class ProjectsCreate extends BaseCommand {
 
     if (fromFileRaw !== "") {
       const rawFile = loadStructuredFile(fromFileRaw);
-      const validated = validateProjectCreateFileJson(rawFile);
+      let validated: ReturnType<typeof validateProjectCreateFileJson>;
+      try {
+        validated = validateProjectCreateFileJson(rawFile);
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        throw new ObjectifiedCliError({
+          message: msg,
+          exitCode: EXIT_CODES.VALIDATION,
+          title: "Validation failed",
+          hint: "Fix the project file fields and retry.",
+        });
+      }
       name = validated.name;
       slug = validated.slug;
       description = validated.description ?? "";

--- a/objectified-cli/src/commands/projects/create.ts
+++ b/objectified-cli/src/commands/projects/create.ts
@@ -1,0 +1,349 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { Flags } from "@oclif/core";
+import YAML from "yaml";
+
+import { BaseCommand } from "../../base-command.js";
+import { ObjectifiedCliError } from "../../lib/errors.js";
+import { EXIT_CODES } from "../../lib/exit-codes.js";
+import { localePrefersAsciiTable } from "../../lib/output.js";
+import { PROJECT_DOMAIN_CATEGORY_NONE } from "../../lib/projects/domain-categories.js";
+import type { Visibility } from "../../lib/projects/project-create-body.js";
+import { buildProjectCreateRequest } from "../../lib/projects/project-create-body.js";
+import { validateProjectCreateFileJson } from "../../lib/projects/project-create-file-schema.js";
+import { normalizeSlugInput, validateProjectSlug } from "../../lib/projects/project-slug.js";
+
+function argvHasFlag(argv: string[], name: string): boolean {
+  const prefixed = `--${name}`;
+  return argv.some((a) => a === prefixed || a.startsWith(`${prefixed}=`));
+}
+
+function loadStructuredFile(filePath: string): unknown {
+  const abs = path.resolve(process.cwd(), filePath);
+  if (!fs.existsSync(abs)) {
+    throw new ObjectifiedCliError({
+      message: `Project file not found: ${abs}`,
+      exitCode: EXIT_CODES.MISUSE,
+      title: "Invalid usage",
+      hint: "Pass a path to an existing JSON or YAML file.",
+    });
+  }
+  const raw = fs.readFileSync(abs, "utf8");
+  const lower = abs.toLowerCase();
+  if (lower.endsWith(".yaml") || lower.endsWith(".yml")) {
+    return YAML.parse(raw) as unknown;
+  }
+  try {
+    return JSON.parse(raw) as unknown;
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    throw new ObjectifiedCliError({
+      message: `Invalid JSON in project file: ${msg}`,
+      exitCode: EXIT_CODES.VALIDATION,
+      title: "Validation failed",
+      hint: "Fix the file syntax or use .yaml / .yml for YAML.",
+    });
+  }
+}
+
+function normalizeDomainCategory(raw: string | undefined): string | undefined {
+  if (raw === undefined) return undefined;
+  const t = raw.trim();
+  if (t === "" || t === PROJECT_DOMAIN_CATEGORY_NONE) return undefined;
+  return t;
+}
+
+export default class ProjectsCreate extends BaseCommand {
+  static description =
+    "Create a project for the active tenant (POST /v1/projects/{tenant_slug}); interactive or CI flags.";
+
+  static examples = [
+    "<%= config.bin %> <%= command.id %>",
+    "<%= config.bin %> <%= command.id %> --name 'Payments API' --slug payments-api --yes",
+    "<%= config.bin %> <%= command.id %> --from-file ./project.yaml --yes",
+    "<%= config.bin %> <%= command.id %> --dry-run --name 'Payments API' --slug payments-api",
+  ];
+
+  static seeAlso = ["projects list", "projects show", "tenants use", "docs errors"];
+
+  static flags = {
+    name: Flags.string({ description: "Project display name." }),
+    slug: Flags.string({ description: "URL-safe slug (^[a-z][a-z0-9-]{1,62}$)." }),
+    description: Flags.string({ description: "Optional description." }),
+    domain: Flags.string({
+      description:
+        "Domain category id (metadata domainCategory). Validated against GET …/domains when available.",
+    }),
+    visibility: Flags.string({
+      description: "Stored in project metadata: private or public.",
+      options: ["private", "public"],
+    }),
+    "from-file": Flags.string({
+      description: "Load fields from JSON or YAML (validated JSON Schema).",
+    }),
+    yes: Flags.boolean({
+      description: "Skip confirmation prompts (CI guard).",
+      default: false,
+    }),
+    "dry-run": Flags.boolean({
+      description: "Print the POST JSON body and exit without calling the API.",
+      default: false,
+    }),
+  };
+
+  async run(): Promise<void> {
+    const tenant = this.context.tenantSlug;
+    if (tenant === undefined || tenant === "") {
+      throw new ObjectifiedCliError({
+        message:
+          "Tenant slug is required for this command. Pass --tenant, set OBJECTIFIED_TENANT, or configure tenant_slug for your profile.",
+        exitCode: EXIT_CODES.CONFIG,
+        title: "Configuration error",
+        hint: "Run `objectified tenants use <slug>` to save a default tenant.",
+      });
+    }
+
+    const argv = this.normalizedArgv;
+    const fromFileRaw =
+      typeof this.flags["from-file"] === "string" ? this.flags["from-file"].trim() : "";
+    const dryRun = this.flags["dry-run"] === true;
+    const yes = this.flags["yes"] === true;
+    const quiet = this.flags.quiet === true;
+
+    let name: string | undefined;
+    let slug: string | undefined;
+    let description: string | undefined;
+    let domainCategoryStr: string | undefined;
+
+    let baseMetadata: Record<string, unknown> | undefined;
+    let fileVisibility: Visibility | undefined;
+    let descriptionFromFileDoc = false;
+    let domainFromFileDoc = false;
+
+    if (fromFileRaw !== "") {
+      const rawFile = loadStructuredFile(fromFileRaw);
+      const validated = validateProjectCreateFileJson(rawFile);
+      name = validated.name;
+      slug = validated.slug;
+      description = validated.description ?? "";
+      if (
+        validated.description !== undefined &&
+        validated.description !== null &&
+        typeof validated.description === "string" &&
+        validated.description.trim() !== ""
+      ) {
+        descriptionFromFileDoc = true;
+      }
+      domainCategoryStr = validated.domainCategory?.trim() || validated.domain?.trim() || "";
+      if (normalizeDomainCategory(domainCategoryStr) !== undefined) {
+        domainFromFileDoc = true;
+      }
+      if (validated.visibility !== undefined) {
+        fileVisibility = validated.visibility;
+      }
+      baseMetadata =
+        validated.metadata !== undefined && typeof validated.metadata === "object"
+          ? { ...validated.metadata }
+          : undefined;
+    }
+
+    if (typeof this.flags.name === "string") name = this.flags.name;
+    if (typeof this.flags.slug === "string") slug = this.flags.slug;
+    if (typeof this.flags.description === "string") description = this.flags.description;
+    if (typeof this.flags.domain === "string") domainCategoryStr = this.flags.domain;
+
+    const visibilityFlag = this.flags.visibility as Visibility | undefined;
+
+    const missingCore =
+      name === undefined || name.trim() === "" || slug === undefined || slug.trim() === "";
+
+    let tty = false;
+    if (process.stdin.isTTY && process.stdout.isTTY) {
+      tty = true;
+    }
+    const useInteractive = !quiet && tty && fromFileRaw === "" && missingCore && !dryRun;
+
+    const partialNonInteractive =
+      !tty &&
+      fromFileRaw === "" &&
+      ((name !== undefined && name.trim() !== "" && (slug === undefined || slug.trim() === "")) ||
+        (slug !== undefined && slug.trim() !== "" && (name === undefined || name.trim() === "")));
+
+    if (partialNonInteractive) {
+      throw new ObjectifiedCliError({
+        message:
+          "Incomplete non-interactive invocation: pass both --name and --slug, or use `objectified projects create` from a TTY.",
+        exitCode: EXIT_CODES.MISUSE,
+        title: "Invalid usage",
+        hint: "Example: `objectified projects create --name 'My API' --slug my-api --yes`",
+      });
+    }
+
+    if (quiet && missingCore && fromFileRaw === "") {
+      throw new ObjectifiedCliError({
+        message: "Quiet mode requires explicit fields or --from-file.",
+        exitCode: EXIT_CODES.MISUSE,
+        title: "Invalid usage",
+        hint: "Provide --name and --slug (and usually --yes), or drop --quiet.",
+      });
+    }
+
+    this.ensureAuthenticated();
+
+    const allowlistArr = await this.api.fetchProjectDomainsAllowlist(tenant);
+    const allowlist = new Set(allowlistArr);
+
+    let finalName = name ?? "";
+    let finalSlug = slug ?? "";
+    let finalDescription = description ?? "";
+    let finalDomainStr = domainCategoryStr ?? "";
+    let visibilityResolved: Visibility = visibilityFlag ?? fileVisibility ?? "private";
+
+    if (useInteractive) {
+      const { promptProjectCreateInteractive } =
+        await import("../../lib/projects/create-interactive.js");
+      const interactiveDraft = await promptProjectCreateInteractive({
+        draft: {
+          name: finalName,
+          slug: finalSlug,
+          description: finalDescription,
+          domainCategory: finalDomainStr,
+          visibility: visibilityFlag,
+        },
+        domainAllowlist: allowlist,
+        skipFinalConfirm: yes,
+        promptDescription: !argvHasFlag(argv, "description") && !descriptionFromFileDoc,
+        promptDomain: !argvHasFlag(argv, "domain") && !domainFromFileDoc,
+        promptVisibility: !argvHasFlag(argv, "visibility") && fileVisibility === undefined,
+      });
+      finalName = interactiveDraft.name;
+      finalSlug = interactiveDraft.slug;
+      finalDescription = interactiveDraft.description;
+      finalDomainStr = interactiveDraft.domainCategory;
+      visibilityResolved = interactiveDraft.visibility;
+    } else {
+      if (missingCore) {
+        throw new ObjectifiedCliError({
+          message:
+            "Project name and slug are required. Pass --from-file, use interactive mode from a TTY, or provide --name and --slug.",
+          exitCode: EXIT_CODES.MISUSE,
+          title: "Invalid usage",
+        });
+      }
+      finalName = name ?? "";
+      finalSlug = slug ?? "";
+      finalDescription = description ?? "";
+
+      if (!dryRun && !yes && tty && fromFileRaw === "") {
+        const { confirm } = await import("@inquirer/prompts");
+        const ok = await confirm({ message: "Create now?", default: true });
+        if (!ok) {
+          throw new ObjectifiedCliError({
+            message: "Project creation aborted.",
+            exitCode: EXIT_CODES.MISUSE,
+            title: "Aborted",
+          });
+        }
+      }
+
+      if (!dryRun && !yes && tty && fromFileRaw !== "") {
+        const { confirm } = await import("@inquirer/prompts");
+        const ok = await confirm({ message: "Create project from file?", default: true });
+        if (!ok) {
+          throw new ObjectifiedCliError({
+            message: "Project creation aborted.",
+            exitCode: EXIT_CODES.MISUSE,
+            title: "Aborted",
+          });
+        }
+      }
+
+      if (!dryRun && !yes && !tty && fromFileRaw !== "") {
+        throw new ObjectifiedCliError({
+          message: "When stdin is not a TTY, pass --yes to create from a file.",
+          exitCode: EXIT_CODES.MISUSE,
+          title: "Invalid usage",
+          hint: "Example: `objectified projects create --from-file ./p.json --yes`",
+        });
+      }
+
+      if (!dryRun && !yes && !tty && fromFileRaw === "") {
+        throw new ObjectifiedCliError({
+          message: "When stdin is not a TTY, pass --yes to create a project.",
+          exitCode: EXIT_CODES.MISUSE,
+          title: "Invalid usage",
+          hint: "Example: `objectified projects create --name 'My API' --slug my-api --yes`",
+        });
+      }
+
+      visibilityResolved = visibilityFlag ?? fileVisibility ?? "private";
+    }
+
+    const slugCheck = validateProjectSlug(finalSlug);
+    if (!slugCheck.ok) {
+      throw new ObjectifiedCliError({
+        message: slugCheck.message,
+        exitCode: EXIT_CODES.VALIDATION,
+        title: "Validation failed",
+        hint:
+          slugCheck.suggestion !== undefined
+            ? `Try slug \`${slugCheck.suggestion}\`.`
+            : "Slug must match ^[a-z][a-z0-9-]{1,62}$.",
+      });
+    }
+    finalSlug = slugCheck.slug;
+
+    const domainNorm = normalizeDomainCategory(finalDomainStr);
+    if (domainNorm !== undefined && !allowlist.has(domainNorm)) {
+      throw new ObjectifiedCliError({
+        message: `Unknown domain category '${domainNorm}'.`,
+        exitCode: EXIT_CODES.VALIDATION,
+        title: "Validation failed",
+        hint: `Choose one of: ${Array.from(allowlist).sort().join(", ")}`,
+      });
+    }
+
+    const body = buildProjectCreateRequest({
+      name: finalName,
+      slug: finalSlug,
+      description: finalDescription === "" ? null : finalDescription,
+      domainCategory: domainNorm ?? null,
+      visibility: visibilityResolved,
+      baseMetadata,
+    });
+
+    if (dryRun) {
+      if (this.context.json) {
+        this.output.json(body);
+      } else {
+        this.output.text(JSON.stringify(body, null, 2));
+      }
+      return;
+    }
+
+    const existing = await this.api.listProjects(tenant);
+    const taken = existing.some((p) => normalizeSlugInput(p.slug) === finalSlug);
+    if (taken) {
+      throw new ObjectifiedCliError({
+        message: `Project slug '${finalSlug}' is already in use for this tenant.`,
+        exitCode: EXIT_CODES.CONFLICT,
+        title: "Conflict",
+        hint: "Pick another slug or delete the existing project first.",
+      });
+    }
+
+    const created = await this.api.createProject(tenant, body);
+
+    if (this.context.json) {
+      this.output.json(created);
+      return;
+    }
+
+    const langAscii = localePrefersAsciiTable(process.env);
+    const mark = langAscii ? "[ok]" : "✔";
+    const id = created.id;
+    const idShort = id.length <= 14 ? id : `${id.slice(0, 8)}…`;
+    this.output.text(`${mark} Created project '${created.slug}' (${idShort})`);
+  }
+}

--- a/objectified-cli/src/lib/client.ts
+++ b/objectified-cli/src/lib/client.ts
@@ -2,6 +2,7 @@ import { createClient, type Client } from "../generated/client.js";
 import type {
   ClassSchema,
   PrimitiveSchema,
+  ProjectCreateRequest,
   ProjectSchema,
   TenantInfoResponse,
   TenantsMeResponse,
@@ -10,6 +11,7 @@ import type {
   WorkflowAuditPageResponse,
 } from "../generated/models.js";
 import {
+  createProjectV1ProjectsTenantSlugPost,
   getProjectBySlugV1ProjectsTenantSlugBySlugProjectSlugGet,
   getProjectV1ProjectsTenantSlugProjectIdGet,
   getTenantInfoV1TenantsTenantSlugGet,
@@ -23,11 +25,15 @@ import {
   verifyTenantAccessV1TenantsTenantSlugHead,
 } from "../generated/operations.js";
 
+import { PROJECT_DOMAIN_FALLBACK_IDS } from "./projects/domain-categories.js";
+import { normalizeProjectDomainsApiPayload } from "./projects/domains-payload.js";
+
 import { EXIT_CODES } from "./exit-codes.js";
 import { httpStatusToCliError, networkErrnoToCliError, ObjectifiedCliError } from "./errors.js";
 import { redactApiKeyForLogs } from "./redact-api-key.js";
 
 export type {
+  ProjectCreateRequest,
   ProjectSchema,
   VersionSchema,
   VersionTagSchema,
@@ -63,6 +69,12 @@ export type ObjectifiedApi = {
   /** Transient HTTP retries consumed on the last instrumented request (429 / 5xx policy). */
   readonly lastRetriesAttempted: number;
   listProjects(tenantSlug: string, options?: ListProjectsOptions): Promise<ProjectSchema[]>;
+  /**
+   * Domain ids allowed for project metadata (`domainCategory`), from GET …/domains when deployed,
+   * else cached fallback ids (#3204).
+   */
+  fetchProjectDomainsAllowlist(tenantSlug: string): Promise<string[]>;
+  createProject(tenantSlug: string, body: ProjectCreateRequest): Promise<ProjectSchema>;
   getProject(tenantSlug: string, projectId: string): Promise<ProjectSchema>;
   getProjectBySlug(tenantSlug: string, projectSlug: string): Promise<ProjectSchema>;
   listVersions(tenantSlug: string, projectId: string): Promise<VersionSchema[]>;
@@ -82,6 +94,8 @@ export type ObjectifiedApi = {
 
 const MAX_RETRY_AFTER_MS = 120_000;
 export const MAX_TRANSIENT_ATTEMPTS = 4;
+
+const PROJECT_DOMAINS_CACHE_TTL_MS = 5 * 60 * 1000;
 
 const IDEMPOTENT_METHODS = new Set(["GET", "HEAD", "PUT", "DELETE"]);
 const BACKOFF_MS = [250, 500, 1000, 2000];
@@ -635,8 +649,11 @@ export function createApiClient(options: CreateApiClientOptions): ObjectifiedApi
     },
   });
 
+  const baseUrlNorm = trimTrailingSlash(options.baseUrl);
+  const domainsAllowlistCache = new Map<string, { ids: string[]; expiresAt: number }>();
+
   const hey: Client = createClient({
-    baseUrl: trimTrailingSlash(options.baseUrl),
+    baseUrl: baseUrlNorm,
     fetch: instrumented,
   });
 
@@ -646,6 +663,99 @@ export function createApiClient(options: CreateApiClientOptions): ObjectifiedApi
     },
     get lastRetriesAttempted() {
       return lastRetriesAttempted;
+    },
+
+    async fetchProjectDomainsAllowlist(tenantSlug: string): Promise<string[]> {
+      const cacheKey = `${baseUrlNorm}|${tenantSlug}`;
+      const now = Date.now();
+      const hit = domainsAllowlistCache.get(cacheKey);
+      if (hit !== undefined && hit.expiresAt > now) {
+        return hit.ids;
+      }
+
+      const tryUrls = [
+        `${baseUrlNorm}/v1/projects/${encodeURIComponent(tenantSlug)}/domains`,
+        `${baseUrlNorm}/v1/projects/domains`,
+      ];
+
+      for (const url of tryUrls) {
+        const res = await instrumented(
+          new Request(url, { method: "GET", headers: { Accept: "application/json" } }),
+        );
+        if (res.status === 404) continue;
+
+        const text = await res.text();
+        const hdrId =
+          res.headers.get("x-request-id") ?? res.headers.get("X-Request-Id") ?? undefined;
+
+        if (!res.ok) {
+          let apiMessage = text.slice(0, 800);
+          try {
+            apiMessage = formatApiError(JSON.parse(text) as unknown);
+          } catch {
+            /* keep truncated body */
+          }
+          throw httpStatusToCliError(res.status, apiMessage, {
+            requestId: hdrId ?? lastRequestId,
+            retriesAttempted: lastRetriesAttempted,
+            credentialsWereSent: requestMeta.hadCredentials,
+          });
+        }
+
+        let parsed: unknown = null;
+        if (text.trim() !== "") {
+          try {
+            parsed = JSON.parse(text) as unknown;
+          } catch {
+            throw new ObjectifiedCliError({
+              message: "Project domains response was not valid JSON.",
+              exitCode: EXIT_CODES.VALIDATION,
+              title: "Validation failed",
+              hint: "Expected JSON from GET /v1/projects/{tenant}/domains (or /v1/projects/domains).",
+              requestId: hdrId ?? lastRequestId,
+              retriesAttempted: lastRetriesAttempted,
+            });
+          }
+        }
+
+        const ids = normalizeProjectDomainsApiPayload(parsed);
+        if (ids.length > 0) {
+          domainsAllowlistCache.set(cacheKey, {
+            ids,
+            expiresAt: now + PROJECT_DOMAINS_CACHE_TTL_MS,
+          });
+          return ids;
+        }
+      }
+
+      const fallback = [...PROJECT_DOMAIN_FALLBACK_IDS];
+      domainsAllowlistCache.set(cacheKey, {
+        ids: fallback,
+        expiresAt: now + PROJECT_DOMAINS_CACHE_TTL_MS,
+      });
+      return fallback;
+    },
+
+    async createProject(tenantSlug: string, body: ProjectCreateRequest): Promise<ProjectSchema> {
+      let rawUnknown: unknown;
+      try {
+        rawUnknown = await createProjectV1ProjectsTenantSlugPost({
+          client: hey,
+          path: { tenant_slug: tenantSlug },
+          body,
+          throwOnError: false,
+        });
+      } catch (e) {
+        if (e instanceof ObjectifiedCliError) throw e;
+        if (e !== null && typeof e === "object" && "code" in e) {
+          throw networkErrnoToCliError(e as NodeJS.ErrnoException);
+        }
+        throw e;
+      }
+
+      return parseProjectPayload(
+        unwrapSdkGet(rawUnknown, lastRequestId, lastRetriesAttempted, requestMeta),
+      );
     },
 
     async listProjects(

--- a/objectified-cli/src/lib/projects/create-interactive.ts
+++ b/objectified-cli/src/lib/projects/create-interactive.ts
@@ -58,12 +58,20 @@ export async function promptProjectCreateInteractive(opts: {
   }
 
   if (opts.promptDomain && out.domainCategory.trim() === "") {
+    const knownIds = new Set(PROJECT_DOMAIN_CHOICES.map((c) => c.id));
+    // Any ids returned by the API that are not in the static catalog are shown
+    // using just the id as the label — they have no local descriptive text.
+    const extraChoices = Array.from(opts.domainAllowlist)
+      .filter((id) => !knownIds.has(id))
+      .sort()
+      .map((id) => ({ value: id, name: id }));
     const choices = [
       { value: PROJECT_DOMAIN_CATEGORY_NONE, name: "(none)" },
       ...PROJECT_DOMAIN_CHOICES.filter((c) => opts.domainAllowlist.has(c.id)).map((c) => ({
         value: c.id,
         name: `${c.id} — ${c.label}`,
       })),
+      ...extraChoices,
     ];
     const picked = await select({
       message: "Domain:",

--- a/objectified-cli/src/lib/projects/create-interactive.ts
+++ b/objectified-cli/src/lib/projects/create-interactive.ts
@@ -1,0 +1,102 @@
+import { confirm, input, select } from "@inquirer/prompts";
+
+import { ObjectifiedCliError } from "../errors.js";
+import { EXIT_CODES } from "../exit-codes.js";
+
+import { PROJECT_DOMAIN_CATEGORY_NONE, PROJECT_DOMAIN_CHOICES } from "./domain-categories.js";
+import type { Visibility } from "./project-create-body.js";
+import { suggestSlugFromName, validateProjectSlug } from "./project-slug.js";
+
+export type InteractiveProjectDraft = {
+  name: string;
+  slug: string;
+  description: string;
+  domainCategory: string;
+  /** Set only when the user passed `--visibility` on the CLI. */
+  visibility?: Visibility;
+};
+
+export async function promptProjectCreateInteractive(opts: {
+  draft: InteractiveProjectDraft;
+  domainAllowlist: Set<string>;
+  skipFinalConfirm: boolean;
+  promptDescription: boolean;
+  promptDomain: boolean;
+  promptVisibility: boolean;
+}): Promise<InteractiveProjectDraft & { visibility: Visibility }> {
+  const out: InteractiveProjectDraft = { ...opts.draft };
+
+  if (out.name.trim() === "") {
+    const v = await input({
+      message: "Name:",
+      validate: (x) => (x.trim() === "" ? "Name is required" : true),
+    });
+    out.name = v.trim();
+  }
+
+  if (out.slug.trim() === "") {
+    const defaultSlug = suggestSlugFromName(out.name);
+    const raw = await input({
+      message: "Slug:",
+      default: defaultSlug,
+      validate: (x) => {
+        const r = validateProjectSlug(x);
+        if (r.ok) return true;
+        return r.suggestion !== undefined ? `${r.message} Suggested: ${r.suggestion}` : r.message;
+      },
+    });
+    const again = validateProjectSlug(raw);
+    out.slug = again.ok ? again.slug : suggestSlugFromName(out.name);
+  }
+
+  if (opts.promptDescription) {
+    const v = await input({
+      message: "Description:",
+      default: out.description,
+    });
+    out.description = v;
+  }
+
+  if (opts.promptDomain && out.domainCategory.trim() === "") {
+    const choices = [
+      { value: PROJECT_DOMAIN_CATEGORY_NONE, name: "(none)" },
+      ...PROJECT_DOMAIN_CHOICES.filter((c) => opts.domainAllowlist.has(c.id)).map((c) => ({
+        value: c.id,
+        name: `${c.id} — ${c.label}`,
+      })),
+    ];
+    const picked = await select({
+      message: "Domain:",
+      choices,
+    });
+    out.domainCategory = picked;
+  }
+
+  let visibility: Visibility = opts.draft.visibility ?? "private";
+  if (opts.promptVisibility) {
+    visibility = await select({
+      message: "Visibility:",
+      choices: [
+        { value: "private" as const, name: "private" },
+        { value: "public" as const, name: "public" },
+      ],
+      default: "private",
+    });
+  }
+
+  if (!opts.skipFinalConfirm) {
+    const ok = await confirm({
+      message: "Create now?",
+      default: true,
+    });
+    if (!ok) {
+      throw new ObjectifiedCliError({
+        message: "Project creation aborted.",
+        exitCode: EXIT_CODES.MISUSE,
+        title: "Aborted",
+      });
+    }
+  }
+
+  return { ...out, visibility };
+}

--- a/objectified-cli/src/lib/projects/domain-categories.ts
+++ b/objectified-cli/src/lib/projects/domain-categories.ts
@@ -1,0 +1,31 @@
+/**
+ * Domain category ids for projects (#243 / objectified-ui `project-domain-categories.ts`).
+ * Used when GET …/domains is unavailable and for interactive labels.
+ */
+export type ProjectDomainChoice = { id: string; label: string };
+
+export const PROJECT_DOMAIN_CATEGORY_NONE = "none";
+
+export const PROJECT_DOMAIN_CHOICES: readonly ProjectDomainChoice[] = [
+  { id: "iot", label: "IoT device schemas" },
+  { id: "social", label: "Social media entities" },
+  { id: "gaming", label: "Gaming (Player, Match, Leaderboard)" },
+  { id: "travel", label: "Travel & hospitality" },
+  { id: "media", label: "Media & entertainment" },
+  { id: "ecommerce", label: "E-commerce (Product, Cart, Order, Payment, Shipping)" },
+  { id: "healthcare", label: "Healthcare (Patient, Appointment, Medication, Insurance)" },
+  { id: "finance", label: "Finance (Account, Transaction, Investment, Loan)" },
+  { id: "saas", label: "SaaS (Tenant, User, Subscription, Usage)" },
+  { id: "education", label: "Education (Course, Student, Assignment, Grade)" },
+  { id: "realestate", label: "Real Estate (Property, Listing, Agent, Transaction)" },
+  { id: "logistics", label: "Logistics (Shipment, Route, Warehouse, Delivery)" },
+];
+
+const ids = PROJECT_DOMAIN_CHOICES.map((c) => c.id);
+
+/** Fallback allowlist when the projects domains API is not deployed (#3204). */
+export const PROJECT_DOMAIN_FALLBACK_IDS: readonly string[] = ids;
+
+export function domainChoiceLabel(id: string): string | undefined {
+  return PROJECT_DOMAIN_CHOICES.find((c) => c.id === id)?.label;
+}

--- a/objectified-cli/src/lib/projects/domains-payload.ts
+++ b/objectified-cli/src/lib/projects/domains-payload.ts
@@ -1,0 +1,30 @@
+/** Normalize GET /v1/projects/…/domains (or similar) JSON into id strings (#3204). */
+export function normalizeProjectDomainsApiPayload(data: unknown): string[] {
+  if (Array.isArray(data)) {
+    if (data.every((x) => typeof x === "string")) {
+      return data.filter((s) => s.trim() !== "");
+    }
+    const ids: string[] = [];
+    for (const row of data) {
+      if (row && typeof row === "object" && typeof (row as { id?: unknown }).id === "string") {
+        const id = (row as { id: string }).id.trim();
+        if (id !== "") ids.push(id);
+      }
+    }
+    return ids;
+  }
+
+  if (data && typeof data === "object") {
+    const o = data as Record<string, unknown>;
+    const domains = o.domains;
+    if (Array.isArray(domains) && domains.every((x) => typeof x === "string")) {
+      return domains.map((s) => s.trim()).filter((s) => s !== "");
+    }
+    const items = o.items;
+    if (Array.isArray(items)) {
+      return normalizeProjectDomainsApiPayload(items);
+    }
+  }
+
+  return [];
+}

--- a/objectified-cli/src/lib/projects/format.ts
+++ b/objectified-cli/src/lib/projects/format.ts
@@ -96,6 +96,8 @@ export function latestColumnDisplay(p: ProjectSchema, nowMs: number): string {
 export function domainDisplay(p: ProjectSchema): string {
   const meta = readMetaString(p.metadata, "domain");
   if (meta !== undefined && meta !== "") return meta;
+  const category = readMetaString(p.metadata, "domainCategory");
+  if (category !== undefined && category !== "" && category !== "none") return category;
   const top = (p as Record<string, unknown>).domain;
   return typeof top === "string" && top !== "" ? top : "—";
 }
@@ -135,10 +137,11 @@ function cellForColumn(key: string, p: ProjectSchema, nowMs: number): string {
       return versionsCountDisplay(p);
     case "latest":
       return latestColumnDisplay(p, nowMs);
-    case "latest_published_at": {
-      const iso = latestPublishedIso(p);
-      return iso !== undefined ? iso.slice(0, 19) : ""; // YYYY-MM-DDTHH:MM:SS
-    }
+    case "latest_published_at":
+      {
+        const iso = latestPublishedIso(p);
+        return iso !== undefined ? iso.slice(0, 19) : ""; // YYYY-MM-DDTHH:MM:SS
+      }
       return p.description ?? "";
     case "id":
       return p.id;

--- a/objectified-cli/src/lib/projects/format.ts
+++ b/objectified-cli/src/lib/projects/format.ts
@@ -137,11 +137,11 @@ function cellForColumn(key: string, p: ProjectSchema, nowMs: number): string {
       return versionsCountDisplay(p);
     case "latest":
       return latestColumnDisplay(p, nowMs);
-    case "latest_published_at":
-      {
-        const iso = latestPublishedIso(p);
-        return iso !== undefined ? iso.slice(0, 19) : ""; // YYYY-MM-DDTHH:MM:SS
-      }
+    case "latest_published_at": {
+      const iso = latestPublishedIso(p);
+      return iso !== undefined ? iso.slice(0, 19) : ""; // YYYY-MM-DDTHH:MM:SS
+    }
+    case "description":
       return p.description ?? "";
     case "id":
       return p.id;

--- a/objectified-cli/src/lib/projects/project-create-body.ts
+++ b/objectified-cli/src/lib/projects/project-create-body.ts
@@ -1,0 +1,49 @@
+import type { ProjectCreateRequest } from "../client.js";
+
+import { PROJECT_DOMAIN_CATEGORY_NONE } from "./domain-categories.js";
+
+export type Visibility = "private" | "public";
+
+export type NormalizedProjectCreateFields = {
+  name: string;
+  slug: string;
+  description?: string | null;
+  /** Empty / none → omit domainCategory in metadata. */
+  domainCategory?: string | null;
+  visibility: Visibility;
+  /** Merged into metadata after domain + visibility (caller strips conflicting keys if needed). */
+  baseMetadata?: Record<string, unknown> | null;
+};
+
+export function buildProjectCreateRequest(
+  input: NormalizedProjectCreateFields,
+): ProjectCreateRequest {
+  const description =
+    typeof input.description === "string" && input.description.trim() !== ""
+      ? input.description.trim()
+      : null;
+
+  const meta: Record<string, unknown> = {};
+  if (input.baseMetadata && typeof input.baseMetadata === "object") {
+    for (const [k, v] of Object.entries(input.baseMetadata)) {
+      meta[k] = v;
+    }
+  }
+
+  const domainRaw = input.domainCategory?.trim() ?? "";
+  const domain =
+    domainRaw === "" || domainRaw === PROJECT_DOMAIN_CATEGORY_NONE ? undefined : domainRaw;
+
+  if (domain !== undefined) {
+    meta.domainCategory = domain;
+  }
+
+  meta.visibility = input.visibility;
+
+  return {
+    name: input.name.trim(),
+    slug: input.slug.trim().toLowerCase(),
+    description,
+    metadata: Object.keys(meta).length > 0 ? meta : null,
+  };
+}

--- a/objectified-cli/src/lib/projects/project-create-file-schema.ts
+++ b/objectified-cli/src/lib/projects/project-create-file-schema.ts
@@ -1,0 +1,50 @@
+import { Ajv, type ErrorObject } from "ajv";
+
+/**
+ * JSON Schema for `objectified projects create --from-file` (#3204).
+ * Top-level `domain` is an alias of `domainCategory` (UI metadata key).
+ */
+export const PROJECT_CREATE_FILE_SCHEMA = {
+  type: "object",
+  required: ["name", "slug"],
+  additionalProperties: false,
+  properties: {
+    name: { type: "string", minLength: 1 },
+    slug: { type: "string", minLength: 1 },
+    description: { type: ["string", "null"] },
+    domain: { type: "string" },
+    domainCategory: { type: "string" },
+    visibility: { type: "string", enum: ["private", "public"] },
+    metadata: { type: "object", additionalProperties: true },
+  },
+} as const;
+
+const ajv = new Ajv({ allErrors: true, strict: false });
+const validateCompiled = ajv.compile(PROJECT_CREATE_FILE_SCHEMA);
+
+export type ProjectCreateFileShape = {
+  name: string;
+  slug: string;
+  description?: string | null;
+  domain?: string;
+  domainCategory?: string;
+  visibility?: "private" | "public";
+  metadata?: Record<string, unknown>;
+};
+
+function formatAjvErrors(errors: ErrorObject[] | undefined | null): string {
+  if (!errors?.length) return "Invalid project file.";
+  return errors
+    .map((e) => {
+      const path = e.instancePath === "" ? "(root)" : e.instancePath;
+      return `${path}: ${e.message ?? "invalid"}`;
+    })
+    .join("; ");
+}
+
+export function validateProjectCreateFileJson(data: unknown): ProjectCreateFileShape {
+  if (!validateCompiled(data)) {
+    throw new Error(formatAjvErrors(validateCompiled.errors));
+  }
+  return data as ProjectCreateFileShape;
+}

--- a/objectified-cli/src/lib/projects/project-slug.ts
+++ b/objectified-cli/src/lib/projects/project-slug.ts
@@ -1,0 +1,67 @@
+/** #3204 acceptance: `^[a-z][a-z0-9-]{1,62}$` → length 2–63 inclusive. */
+export const PROJECT_SLUG_PATTERN = /^[a-z][a-z0-9-]{1,62}$/;
+
+export type SlugValidationResult =
+  | { ok: true; slug: string }
+  | { ok: false; message: string; suggestion?: string };
+
+export function normalizeSlugInput(raw: string): string {
+  return raw.trim().toLowerCase();
+}
+
+/**
+ * Derives a slug suggestion from a display name (does not guarantee pattern match if name is empty).
+ */
+export function suggestSlugFromName(name: string): string {
+  let s = name
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-+/, "")
+    .replace(/-+$/, "");
+
+  if (s.length === 0) return "project";
+
+  if (!/^[a-z]/.test(s)) {
+    s = `p-${s}`;
+  }
+
+  s = s.replace(/_/g, "-");
+
+  if (s.length > 63) {
+    s = s.slice(0, 63).replace(/-+$/, "");
+    if (s.length < 2) s = "pr";
+  }
+
+  if (s.length < 2) {
+    s = `${s}x`;
+  }
+
+  if (!PROJECT_SLUG_PATTERN.test(s)) {
+    return "project";
+  }
+
+  return s;
+}
+
+export function validateProjectSlug(raw: string): SlugValidationResult {
+  const slug = normalizeSlugInput(raw);
+  if (slug === "") {
+    return { ok: false, message: "Project slug is required.", suggestion: "project" };
+  }
+  if (PROJECT_SLUG_PATTERN.test(slug)) {
+    return { ok: true, slug };
+  }
+
+  const suggestion = suggestSlugFromName(slug.replace(/_/g, "-"));
+  let hint = `Slug must match ${PROJECT_SLUG_PATTERN.source}.`;
+  if (slug.includes("_")) {
+    hint += " Underscores are not allowed; use hyphens.";
+  }
+  return {
+    ok: false,
+    message: hint,
+    suggestion: PROJECT_SLUG_PATTERN.test(suggestion) ? suggestion : undefined,
+  };
+}

--- a/objectified-cli/test/domains-payload.test.ts
+++ b/objectified-cli/test/domains-payload.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeProjectDomainsApiPayload } from "../src/lib/projects/domains-payload.js";
+
+describe("normalizeProjectDomainsApiPayload (#3204)", () => {
+  it("parses string arrays", () => {
+    expect(normalizeProjectDomainsApiPayload(["finance", "saas"])).toEqual(["finance", "saas"]);
+  });
+
+  it("parses objects with id", () => {
+    expect(
+      normalizeProjectDomainsApiPayload([{ id: "finance" }, { id: "iot", label: "x" }]),
+    ).toEqual(["finance", "iot"]);
+  });
+
+  it("parses domains wrapper", () => {
+    expect(normalizeProjectDomainsApiPayload({ domains: ["a", "b"] })).toEqual(["a", "b"]);
+  });
+
+  it("parses items wrapper", () => {
+    expect(normalizeProjectDomainsApiPayload({ items: [{ id: "media" }] })).toEqual(["media"]);
+  });
+});

--- a/objectified-cli/test/project-create-file-schema.test.ts
+++ b/objectified-cli/test/project-create-file-schema.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import { validateProjectCreateFileJson } from "../src/lib/projects/project-create-file-schema.js";
+
+describe("project create file JSON Schema (#3204)", () => {
+  it("accepts minimal valid documents", () => {
+    const v = validateProjectCreateFileJson({
+      name: "X",
+      slug: "x-api",
+    });
+    expect(v.name).toBe("X");
+    expect(v.slug).toBe("x-api");
+  });
+
+  it("rejects unknown top-level keys", () => {
+    expect(() =>
+      validateProjectCreateFileJson({
+        name: "X",
+        slug: "x-api",
+        extra: true,
+      }),
+    ).toThrow(/additional properties/i);
+  });
+
+  it("accepts domain alias and visibility", () => {
+    const v = validateProjectCreateFileJson({
+      name: "Shop",
+      slug: "shop-api",
+      domain: "finance",
+      visibility: "private",
+      metadata: { foo: "bar" },
+    });
+    expect(v.domain).toBe("finance");
+    expect(v.visibility).toBe("private");
+    expect(v.metadata).toEqual({ foo: "bar" });
+  });
+});

--- a/objectified-cli/test/project-slug.test.ts
+++ b/objectified-cli/test/project-slug.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  PROJECT_SLUG_PATTERN,
+  suggestSlugFromName,
+  validateProjectSlug,
+} from "../src/lib/projects/project-slug.js";
+
+describe("project slug helpers (#3204)", () => {
+  it("accepts slugs matching the ticket regex", () => {
+    expect(PROJECT_SLUG_PATTERN.test("ab")).toBe(true);
+    expect(PROJECT_SLUG_PATTERN.test("payments-api")).toBe(true);
+    expect(PROJECT_SLUG_PATTERN.test(`a${"b".repeat(61)}`)).toBe(true);
+  });
+
+  it("rejects underscore and lowercases input", () => {
+    expect(validateProjectSlug("pay_api").ok).toBe(false);
+    const r = validateProjectSlug("Pay-api");
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.slug).toBe("pay-api");
+  });
+
+  it("suggestSlugFromName produces a valid slug for typical titles", () => {
+    const s = suggestSlugFromName("Payments API");
+    expect(PROJECT_SLUG_PATTERN.test(s)).toBe(true);
+    expect(s).toBe("payments-api");
+  });
+});

--- a/objectified-cli/test/projects-create.integration.test.ts
+++ b/objectified-cli/test/projects-create.integration.test.ts
@@ -1,0 +1,330 @@
+import { spawn } from "node:child_process";
+import http from "node:http";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const pkgRoot = path.join(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+async function runCliCaptureAsync(
+  args: string[],
+  extraEnv: Record<string, string> = {},
+  timeoutMs = 20_000,
+): Promise<{ code: number; stdout: string }> {
+  const env = {
+    ...process.env,
+    FORCE_COLOR: "0",
+    OBJECTIFIED_CLI_CREDENTIAL_BACKEND: "memory",
+    ...extraEnv,
+  };
+  delete env.NODE_OPTIONS;
+
+  return await new Promise((resolve, reject) => {
+    const child = spawn("node", [path.join(pkgRoot, "bin/run.js"), ...args], {
+      cwd: pkgRoot,
+      env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    const outChunks: Buffer[] = [];
+    child.stdout?.on("data", (c: Buffer | string) => {
+      outChunks.push(Buffer.isBuffer(c) ? c : Buffer.from(c));
+    });
+
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      child.kill("SIGKILL");
+      reject(new Error(`CLI timed out after ${String(timeoutMs)}ms: ${args.join(" ")}`));
+    }, timeoutMs);
+
+    child.on("error", (err) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      reject(err);
+    });
+
+    child.on("close", (code) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve({
+        code: code ?? 1,
+        stdout: Buffer.concat(outChunks).toString("utf8"),
+      });
+    });
+  });
+}
+
+describe("projects create CLI (#3204)", () => {
+  it("dry-run prints POST JSON body", async () => {
+    const server = http.createServer((req, res) => {
+      res.setHeader("Connection", "close");
+      const url = new URL(req.url ?? "/", "http://127.0.0.1");
+      if (
+        req.method === "GET" &&
+        (url.pathname === "/v1/projects/acme/domains" || url.pathname === "/v1/projects/domains")
+      ) {
+        res.statusCode = 404;
+        res.end();
+        return;
+      }
+      res.statusCode = 500;
+      res.end("unexpected request");
+    });
+
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", () => resolve()));
+    const addr = server.address();
+    if (addr === null || typeof addr === "string") throw new Error("expected AddressInfo");
+
+    try {
+      const base = `http://127.0.0.1:${String(addr.port)}`;
+      const { code, stdout } = await runCliCaptureAsync([
+        "--base-url",
+        base,
+        "--api-key",
+        "k",
+        "--tenant",
+        "acme",
+        "--no-json",
+        "projects",
+        "create",
+        "--dry-run",
+        "--yes",
+        "--name",
+        "Payments API",
+        "--slug",
+        "payments-api",
+        "--description",
+        "Inbound charges.",
+        "--domain",
+        "finance",
+        "--visibility",
+        "private",
+      ]);
+      expect(code).toBe(0);
+      const body = JSON.parse(stdout.trim()) as Record<string, unknown>;
+      expect(body.name).toBe("Payments API");
+      expect(body.slug).toBe("payments-api");
+      expect(body.metadata).toEqual(
+        expect.objectContaining({
+          domainCategory: "finance",
+          visibility: "private",
+        }),
+      );
+    } finally {
+      server.closeAllConnections?.();
+      await new Promise<void>((resolve, reject) =>
+        server.close((err) => (err !== undefined ? reject(err) : resolve())),
+      );
+    }
+  });
+
+  it("exits 7 when slug violates regex", async () => {
+    const server = http.createServer((req, res) => {
+      res.setHeader("Connection", "close");
+      const url = new URL(req.url ?? "/", "http://127.0.0.1");
+      if (
+        req.method === "GET" &&
+        (url.pathname === "/v1/projects/acme/domains" || url.pathname === "/v1/projects/domains")
+      ) {
+        res.statusCode = 404;
+        res.end();
+        return;
+      }
+      res.statusCode = 500;
+      res.end();
+    });
+
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", () => resolve()));
+    const addr = server.address();
+    if (addr === null || typeof addr === "string") throw new Error("expected AddressInfo");
+
+    try {
+      const { code } = await runCliCaptureAsync([
+        "--base-url",
+        `http://127.0.0.1:${String(addr.port)}`,
+        "--api-key",
+        "k",
+        "--tenant",
+        "acme",
+        "--no-json",
+        "projects",
+        "create",
+        "--yes",
+        "--name",
+        "X",
+        "--slug",
+        "bad_slug",
+      ]);
+      expect(code).toBe(7);
+    } finally {
+      server.closeAllConnections?.();
+      await new Promise<void>((resolve, reject) =>
+        server.close((err) => (err !== undefined ? reject(err) : resolve())),
+      );
+    }
+  });
+
+  it("exits 6 when slug already exists (pre-check)", async () => {
+    const server = http.createServer((req, res) => {
+      res.setHeader("Connection", "close");
+      const url = new URL(req.url ?? "/", "http://127.0.0.1");
+      if (
+        req.method === "GET" &&
+        (url.pathname === "/v1/projects/acme/domains" || url.pathname === "/v1/projects/domains")
+      ) {
+        res.statusCode = 404;
+        res.end();
+        return;
+      }
+      if (req.method === "GET" && url.pathname === "/v1/projects/acme") {
+        res.setHeader("Content-Type", "application/json");
+        res.end(
+          JSON.stringify([
+            {
+              id: "p-existing",
+              tenant_id: "t1",
+              name: "Existing",
+              slug: "taken-slug",
+              enabled: true,
+            },
+          ]),
+        );
+        return;
+      }
+      res.statusCode = 500;
+      res.end();
+    });
+
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", () => resolve()));
+    const addr = server.address();
+    if (addr === null || typeof addr === "string") throw new Error("expected AddressInfo");
+
+    try {
+      const { code } = await runCliCaptureAsync([
+        "--base-url",
+        `http://127.0.0.1:${String(addr.port)}`,
+        "--api-key",
+        "k",
+        "--tenant",
+        "acme",
+        "--no-json",
+        "projects",
+        "create",
+        "--yes",
+        "--name",
+        "Dup",
+        "--slug",
+        "taken-slug",
+      ]);
+      expect(code).toBe(6);
+    } finally {
+      server.closeAllConnections?.();
+      await new Promise<void>((resolve, reject) =>
+        server.close((err) => (err !== undefined ? reject(err) : resolve())),
+      );
+    }
+  });
+
+  it("POST creates project then DELETE rolls back on mock API", async () => {
+    let deleted: string | undefined;
+    const server = http.createServer((req, res) => {
+      res.setHeader("Connection", "close");
+      const url = new URL(req.url ?? "/", "http://127.0.0.1");
+      if (
+        req.method === "GET" &&
+        (url.pathname === "/v1/projects/acme/domains" || url.pathname === "/v1/projects/domains")
+      ) {
+        res.statusCode = 404;
+        res.end();
+        return;
+      }
+      if (req.method === "GET" && url.pathname === "/v1/projects/acme") {
+        res.setHeader("Content-Type", "application/json");
+        res.end(JSON.stringify([]));
+        return;
+      }
+      if (req.method === "POST" && url.pathname === "/v1/projects/acme") {
+        res.setHeader("Content-Type", "application/json");
+        res.end(
+          JSON.stringify({
+            id: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+            tenant_id: "t1",
+            name: "Tmp",
+            slug: "tmp-create-cli",
+            enabled: true,
+          }),
+        );
+        return;
+      }
+      if (
+        req.method === "DELETE" &&
+        url.pathname === "/v1/projects/acme/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+      ) {
+        deleted = "ok";
+        res.statusCode = 200;
+        res.setHeader("Content-Type", "application/json");
+        res.end(JSON.stringify({ ok: true }));
+        return;
+      }
+      res.statusCode = 500;
+      res.end();
+    });
+
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", () => resolve()));
+    const addr = server.address();
+    if (addr === null || typeof addr === "string") throw new Error("expected AddressInfo");
+
+    try {
+      const base = `http://127.0.0.1:${String(addr.port)}`;
+      const { code, stdout } = await runCliCaptureAsync([
+        "--base-url",
+        base,
+        "--api-key",
+        "k",
+        "--tenant",
+        "acme",
+        "--json",
+        "projects",
+        "create",
+        "--yes",
+        "--name",
+        "Tmp",
+        "--slug",
+        "tmp-create-cli",
+      ]);
+      expect(code).toBe(0);
+      const proj = JSON.parse(stdout.trim()) as { id: string; slug: string };
+      expect(proj.slug).toBe("tmp-create-cli");
+
+      const deleteStatus = await new Promise<number>((resolve, reject) => {
+        const req = http.request(
+          {
+            hostname: "127.0.0.1",
+            port: addr.port,
+            path: `/v1/projects/acme/${encodeURIComponent(proj.id)}`,
+            method: "DELETE",
+            headers: { "X-API-Key": "k" },
+          },
+          (res) => {
+            res.resume();
+            res.on("end", () => resolve(res.statusCode ?? 0));
+          },
+        );
+        req.on("error", reject);
+        req.end();
+      });
+      expect(deleteStatus).toBe(200);
+      expect(deleted).toBe("ok");
+    } finally {
+      server.closeAllConnections?.();
+      await new Promise<void>((resolve, reject) =>
+        server.close((err) => (err !== undefined ? reject(err) : resolve())),
+      );
+    }
+  });
+});

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -8,6 +8,7 @@ We continue to improve the platform based on your feedback with improvements and
 - MCP service is now live
 
 ## CLI
+- **`objectified-cli`**: `objectified projects create` adds projects via `POST /v1/projects/{tenant_slug}`—interactive `@inquirer/prompts` wizard on a TTY, or CI flags (`--name`, `--slug`, `--description`, `--domain`, `--visibility`, `--yes`); `--from-file` JSON/YAML validated with JSON Schema; `--dry-run` prints the POST body; domain ids validated against cached `GET …/domains` (fallback catalog); slug format + pre-create uniqueness (exit **6** conflict, **7** validation) (#3204).
 - **`objectified-cli`**: `objectified projects show <slug-or-id>` resolves UUID vs slug (`GET /v1/projects/{tenant}/by-slug/{slug}` or `GET /v1/projects/{tenant}/{id}`), prints rich detail with version/tag summaries and up to **10** workflow-audit rows; `--json` returns the project object plus `activity[]` (#3203).
 - **`objectified-cli`**: `objectified projects list` calls `GET /v1/projects/{tenant_slug}` with an 80-column table (slug, name, domain, versions, latest published), `--limit` / `--all`, `--sort`, `--filter`, `--search`, `--columns`, `--include-deleted`, and top-level `--json` array output (#3202).
 - **`objectified-cli`**: `objectified tenants list` and `objectified tenants info <slug>` call `GET /v1/tenants/me` and `GET /v1/tenants/{slug}` (REST support in `objectified-rest`); stable `--json`; active profile tenant marker; `--limit` / `--offset` pagination for large tenant lists (#3198).

--- a/yarn.lock
+++ b/yarn.lock
@@ -2101,6 +2101,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@inquirer/ansi@npm:^2.0.5":
+  version: 2.0.5
+  resolution: "@inquirer/ansi@npm:2.0.5"
+  checksum: 10c0/ad61532e5bb47473e3d987c32d4015499a8ce5f4f86e46467e8e672fc52670beb303905d6b324e453935a61671f59f3b9b1b6a1edbbe1f64085e2bb87735e295
+  languageName: node
+  linkType: hard
+
 "@inquirer/checkbox@npm:^4.3.2":
   version: 4.3.2
   resolution: "@inquirer/checkbox@npm:4.3.2"
@@ -2116,6 +2123,23 @@ __metadata:
     "@types/node":
       optional: true
   checksum: 10c0/771d23bc6b16cd5c21a4f1073e98e306147f90c0e2487fe887ee054b8bf86449f1f9e6e6f9c218c1aa45ae3be2533197d53654abe9c0545981aebb0920d5f471
+  languageName: node
+  linkType: hard
+
+"@inquirer/checkbox@npm:^5.1.4":
+  version: 5.1.4
+  resolution: "@inquirer/checkbox@npm:5.1.4"
+  dependencies:
+    "@inquirer/ansi": "npm:^2.0.5"
+    "@inquirer/core": "npm:^11.1.9"
+    "@inquirer/figures": "npm:^2.0.5"
+    "@inquirer/type": "npm:^4.0.5"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10c0/38d6c8b49c392307c29fbb252d5dd09a819aecc34c83f01a7652efa09d7b8b901c448216496eda3962e319209243297ec575eff4e081a758bb08adb805f7e3d4
   languageName: node
   linkType: hard
 
@@ -2144,6 +2168,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@inquirer/confirm@npm:^6.0.12":
+  version: 6.0.12
+  resolution: "@inquirer/confirm@npm:6.0.12"
+  dependencies:
+    "@inquirer/core": "npm:^11.1.9"
+    "@inquirer/type": "npm:^4.0.5"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10c0/36e9b1ef60e08562f07bcbcd78ba0a681b2fa3e5f54fa5e12303fc5982e8ba875ed782c24161e2295028b2b404ba690e841837303d16eeeb28df7aa9eb8aa835
+  languageName: node
+  linkType: hard
+
 "@inquirer/core@npm:^10.3.2":
   version: 10.3.2
   resolution: "@inquirer/core@npm:10.3.2"
@@ -2162,6 +2201,26 @@ __metadata:
     "@types/node":
       optional: true
   checksum: 10c0/f0f27e07fe288e01e3949b4ad216c19751f025ce77c610366e08d8b0f7a135d064dc074732031d251584b454c576f1e5c849e4abe259186dd5d4974c8f85c13e
+  languageName: node
+  linkType: hard
+
+"@inquirer/core@npm:^11.1.9":
+  version: 11.1.9
+  resolution: "@inquirer/core@npm:11.1.9"
+  dependencies:
+    "@inquirer/ansi": "npm:^2.0.5"
+    "@inquirer/figures": "npm:^2.0.5"
+    "@inquirer/type": "npm:^4.0.5"
+    cli-width: "npm:^4.1.0"
+    fast-wrap-ansi: "npm:^0.2.0"
+    mute-stream: "npm:^3.0.0"
+    signal-exit: "npm:^4.1.0"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10c0/f7b162ce5f67fb75aab00a3668fdd8c8629aec790087840ea66ee8ead6009ab2066bec9cbf5bcc394ccdf130e6139051d6bace334b3a66c4f05349585213172c
   languageName: node
   linkType: hard
 
@@ -2201,6 +2260,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@inquirer/editor@npm:^5.1.1":
+  version: 5.1.1
+  resolution: "@inquirer/editor@npm:5.1.1"
+  dependencies:
+    "@inquirer/core": "npm:^11.1.9"
+    "@inquirer/external-editor": "npm:^3.0.0"
+    "@inquirer/type": "npm:^4.0.5"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10c0/d9506fc4d16362ee060df0c8aa722ee85eae79e0be373253ecc49d0f51569f886bf0d09da9ae9910e3d5f79dca10767a5c1711c799af41c668b2a97866470221
+  languageName: node
+  linkType: hard
+
 "@inquirer/expand@npm:^4.0.23":
   version: 4.0.23
   resolution: "@inquirer/expand@npm:4.0.23"
@@ -2214,6 +2289,21 @@ __metadata:
     "@types/node":
       optional: true
   checksum: 10c0/294c92652760c3d1a46c4b900a99fd553ea9e5734ba261d4e71d7b8499d86a8b15e38a2467ddb7c95c197daf7e472bdab209fc3f7c38cbc70842cd291f4ce39d
+  languageName: node
+  linkType: hard
+
+"@inquirer/expand@npm:^5.0.13":
+  version: 5.0.13
+  resolution: "@inquirer/expand@npm:5.0.13"
+  dependencies:
+    "@inquirer/core": "npm:^11.1.9"
+    "@inquirer/type": "npm:^4.0.5"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10c0/108055f24dc4348a4981003003ca41fe793c7b3292ff80f583a1e1f1097bee64a0c2e5795cae969bcf77d4f34f03a3feeaa6315363eb01554f1c1eae6769c9f5
   languageName: node
   linkType: hard
 
@@ -2232,10 +2322,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@inquirer/external-editor@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@inquirer/external-editor@npm:3.0.0"
+  dependencies:
+    chardet: "npm:^2.1.1"
+    iconv-lite: "npm:^0.7.2"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10c0/120910c954869c73c54aee825abef6f4c4aa8620cafa831d56b218586b1ee02c12ad0a17b8d701784fb9d33fa8fd63ee155d9c718c90533ff4d8086b99986e1d
+  languageName: node
+  linkType: hard
+
 "@inquirer/figures@npm:^1.0.15, @inquirer/figures@npm:^1.0.5, @inquirer/figures@npm:^1.0.6":
   version: 1.0.15
   resolution: "@inquirer/figures@npm:1.0.15"
   checksum: 10c0/6e39a040d260ae234ae220180b7994ff852673e20be925f8aa95e78c7934d732b018cbb4d0ec39e600a410461bcb93dca771e7de23caa10630d255692e440f69
+  languageName: node
+  linkType: hard
+
+"@inquirer/figures@npm:^2.0.5":
+  version: 2.0.5
+  resolution: "@inquirer/figures@npm:2.0.5"
+  checksum: 10c0/139671b88f33f059aec85ed3fdf464999115573350c6dea61141adc1cfd43d14742b6cb68150c2ca9baf5a1bae618f990ed89b4430ae768d415bbd19944c56df
   languageName: node
   linkType: hard
 
@@ -2264,6 +2376,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@inquirer/input@npm:^5.0.12":
+  version: 5.0.12
+  resolution: "@inquirer/input@npm:5.0.12"
+  dependencies:
+    "@inquirer/core": "npm:^11.1.9"
+    "@inquirer/type": "npm:^4.0.5"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10c0/bb8273925c774bc5dffd93d6edc9e24391ab03c3ddd0c604987abbb74a7efcf03ca10b3bd0607ccf6613369e004417b14cf3c031327601118cff2cc98c5098e6
+  languageName: node
+  linkType: hard
+
 "@inquirer/number@npm:^3.0.23":
   version: 3.0.23
   resolution: "@inquirer/number@npm:3.0.23"
@@ -2276,6 +2403,21 @@ __metadata:
     "@types/node":
       optional: true
   checksum: 10c0/3944a524be2a2e0834822a0e483f2e2fd56ad597b5feeca2155b956821f88e22e07ce3816f66113b040601636ed7146865aee7d7afb2a06939acc77491330ccc
+  languageName: node
+  linkType: hard
+
+"@inquirer/number@npm:^4.0.12":
+  version: 4.0.12
+  resolution: "@inquirer/number@npm:4.0.12"
+  dependencies:
+    "@inquirer/core": "npm:^11.1.9"
+    "@inquirer/type": "npm:^4.0.5"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10c0/e933967d9879792775d4ac8f4abcc9c2f263107a1e3c1cdd5ce85dd446a03bed2f6cb01c41ed1a3b45b80f385eb3a991d1442703d9816416c79c0ca6f20e57f3
   languageName: node
   linkType: hard
 
@@ -2292,6 +2434,22 @@ __metadata:
     "@types/node":
       optional: true
   checksum: 10c0/9fd3d0462d02735bb1521c4e221d057a94d9aaac308e9a192e59d6c1e8efc707c2376ab627151d589bc3633f6b14b74b60b91c3d473a32adfd100ef1f6cfdef7
+  languageName: node
+  linkType: hard
+
+"@inquirer/password@npm:^5.0.12":
+  version: 5.0.12
+  resolution: "@inquirer/password@npm:5.0.12"
+  dependencies:
+    "@inquirer/ansi": "npm:^2.0.5"
+    "@inquirer/core": "npm:^11.1.9"
+    "@inquirer/type": "npm:^4.0.5"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10c0/e1399196f01ff5fadc1d3e1bc6946a4f53a5753ccf8e39b2f11f1dae5c51fdb85e33ef44760d83c5b58dacc442de603f32e9c991b2e5f2f8a2a451ff62e1fe48
   languageName: node
   linkType: hard
 
@@ -2318,6 +2476,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@inquirer/prompts@npm:^8.4.2":
+  version: 8.4.2
+  resolution: "@inquirer/prompts@npm:8.4.2"
+  dependencies:
+    "@inquirer/checkbox": "npm:^5.1.4"
+    "@inquirer/confirm": "npm:^6.0.12"
+    "@inquirer/editor": "npm:^5.1.1"
+    "@inquirer/expand": "npm:^5.0.13"
+    "@inquirer/input": "npm:^5.0.12"
+    "@inquirer/number": "npm:^4.0.12"
+    "@inquirer/password": "npm:^5.0.12"
+    "@inquirer/rawlist": "npm:^5.2.8"
+    "@inquirer/search": "npm:^4.1.8"
+    "@inquirer/select": "npm:^5.1.4"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10c0/0519d6a52e195e24b03949afda1ad7fc2ae752c72a7ba554d4bdbbac844fd47dc83d79e67f732c6bf3c56a407e3171b92bd3b0dc334fd35eea446a889d1100f7
+  languageName: node
+  linkType: hard
+
 "@inquirer/rawlist@npm:^4.1.11":
   version: 4.1.11
   resolution: "@inquirer/rawlist@npm:4.1.11"
@@ -2331,6 +2512,21 @@ __metadata:
     "@types/node":
       optional: true
   checksum: 10c0/33792b40cd0fbf77f547c9c4805087dd1188342c6a5ca512c73b0b6c4d132225fc5ae8bc4fd5035309484da3698a90fcef17aad100b9ae57624fda7b07d92227
+  languageName: node
+  linkType: hard
+
+"@inquirer/rawlist@npm:^5.2.8":
+  version: 5.2.8
+  resolution: "@inquirer/rawlist@npm:5.2.8"
+  dependencies:
+    "@inquirer/core": "npm:^11.1.9"
+    "@inquirer/type": "npm:^4.0.5"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10c0/35b0a9e29972342669365af70ea8feebc4e13ce688ce53c1fae723cbd02a7082294553eeb49ee443f5e993c1a97be31fcbe366f7cb573c075557316717792527
   languageName: node
   linkType: hard
 
@@ -2348,6 +2544,22 @@ __metadata:
     "@types/node":
       optional: true
   checksum: 10c0/e7849663a51fe95e3ce99d274c815b8dc8933d6a5ddcaaf6130bf43f5f10316062c9f7a37c2923a14b8dcd09d202b0bb9cc3eaf0adb0336f6a704ea52e03ef8c
+  languageName: node
+  linkType: hard
+
+"@inquirer/search@npm:^4.1.8":
+  version: 4.1.8
+  resolution: "@inquirer/search@npm:4.1.8"
+  dependencies:
+    "@inquirer/core": "npm:^11.1.9"
+    "@inquirer/figures": "npm:^2.0.5"
+    "@inquirer/type": "npm:^4.0.5"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10c0/7281c59e8953aa4663c5afe3d6a3b558ec3e97867569f29dcc0a67e89ff05b37f374ac34ebc7356a7137f76a5172d52c60469cadcc323cc733b4d635b5cf3334
   languageName: node
   linkType: hard
 
@@ -2382,6 +2594,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@inquirer/select@npm:^5.1.4":
+  version: 5.1.4
+  resolution: "@inquirer/select@npm:5.1.4"
+  dependencies:
+    "@inquirer/ansi": "npm:^2.0.5"
+    "@inquirer/core": "npm:^11.1.9"
+    "@inquirer/figures": "npm:^2.0.5"
+    "@inquirer/type": "npm:^4.0.5"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10c0/30b6b061acd08f3f4cfde08a626446d308271e32569acec03f8c87a17e04c21aeccbecf354c8b254a2decfbe7d2189d8ae4443bf10d0be4a2aedeb4e850574c2
+  languageName: node
+  linkType: hard
+
 "@inquirer/type@npm:^1.5.3":
   version: 1.5.5
   resolution: "@inquirer/type@npm:1.5.5"
@@ -2409,6 +2638,18 @@ __metadata:
     "@types/node":
       optional: true
   checksum: 10c0/a846c7a570e3bf2657d489bcc5dcdc3179d24c7323719de1951dcdb722400ac76e5b2bfe9765d0a789bc1921fac810983d7999f021f30a78a6a174c23fc78dc9
+  languageName: node
+  linkType: hard
+
+"@inquirer/type@npm:^4.0.5":
+  version: 4.0.5
+  resolution: "@inquirer/type@npm:4.0.5"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10c0/390edb0fd1f027f9c8dc26bac28486d38bbde6c19974ef1588ea187f54a2cb58db639ebca31fa81a8fe4a4e84c2f0953ab3f5a6768ba86649368c5e806148a6f
   languageName: node
   linkType: hard
 
@@ -6921,6 +7162,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ajv@npm:^8.20.0":
+  version: 8.20.0
+  resolution: "ajv@npm:8.20.0"
+  dependencies:
+    fast-deep-equal: "npm:^3.1.3"
+    fast-uri: "npm:^3.0.1"
+    json-schema-traverse: "npm:^1.0.0"
+    require-from-string: "npm:^2.0.2"
+  checksum: 10c0/5df9a1c8f83863cde1bd3a9ddb426f599718f88e3dc9153616c79fb28e0be455335830d7f21d745576519f057b371352daa31047b6a33d7036fe08777d60cf2a
+  languageName: node
+  linkType: hard
+
 "ansi-colors@npm:4.1.3":
   version: 4.1.3
   resolution: "ansi-colors@npm:4.1.3"
@@ -9750,10 +10003,35 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fast-string-truncated-width@npm:^3.0.2":
+  version: 3.0.3
+  resolution: "fast-string-truncated-width@npm:3.0.3"
+  checksum: 10c0/043b8663397d14a3880ce4f3407bcda60b40db9bbeafe62863a35d1f9c69ea17c8da3fcd72de235553e6c9cd053128cde9e24ca0d4a7463208f48db3cd23d981
+  languageName: node
+  linkType: hard
+
+"fast-string-width@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "fast-string-width@npm:3.0.2"
+  dependencies:
+    fast-string-truncated-width: "npm:^3.0.2"
+  checksum: 10c0/c8822d175315bb353ebe782b65214ac53b13e3bf704e03b132ea7bdfa8de6a636375b3ab7a4097545393d109381c37c4f387c72a462c90b61412dbc4632f39a7
+  languageName: node
+  linkType: hard
+
 "fast-uri@npm:^3.0.1":
   version: 3.1.0
   resolution: "fast-uri@npm:3.1.0"
   checksum: 10c0/44364adca566f70f40d1e9b772c923138d47efeac2ae9732a872baafd77061f26b097ba2f68f0892885ad177becd065520412b8ffeec34b16c99433c5b9e2de7
+  languageName: node
+  linkType: hard
+
+"fast-wrap-ansi@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "fast-wrap-ansi@npm:0.2.0"
+  dependencies:
+    fast-string-width: "npm:^3.0.2"
+  checksum: 10c0/c0eb6debee565c5dbb9132dddff5c4d4aba5eb02185ae4dab285acd6186018cffca04264e92f373cbf592a9bcd1c33d65dba036030a8f3baeff1169969a1b59b
   languageName: node
   linkType: hard
 
@@ -10697,7 +10975,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"iconv-lite@npm:^0.7.0":
+"iconv-lite@npm:^0.7.0, iconv-lite@npm:^0.7.2":
   version: 0.7.2
   resolution: "iconv-lite@npm:0.7.2"
   dependencies:
@@ -13455,6 +13733,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mute-stream@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "mute-stream@npm:3.0.0"
+  checksum: 10c0/12cdb36a101694c7a6b296632e6d93a30b74401873cf7507c88861441a090c71c77a58f213acadad03bc0c8fa186639dec99d68a14497773a8744320c136e701
+  languageName: node
+  linkType: hard
+
 "nanoid@npm:^3.3.11, nanoid@npm:^3.3.6":
   version: 3.3.11
   resolution: "nanoid@npm:3.3.11"
@@ -13892,12 +14177,14 @@ __metadata:
     "@eslint/js": "npm:^9.39.4"
     "@hey-api/openapi-ts": "npm:^0.74"
     "@iarna/toml": "npm:^2.2.5"
+    "@inquirer/prompts": "npm:^8.4.2"
     "@oclif/core": "npm:^4.11.0"
     "@oclif/plugin-help": "npm:^6.2.46"
     "@oclif/plugin-version": "npm:^2.2.43"
     "@types/fs-extra": "npm:^11.0.4"
     "@types/node": "npm:^22.10.0"
     "@types/supports-color": "npm:^10.0.0"
+    ajv: "npm:^8.20.0"
     chalk: "npm:^5.6.2"
     cli-table3: "npm:^0.6.5"
     env-paths: "npm:^4.0.0"


### PR DESCRIPTION
## Summary
- Adds `objectified projects create` for `POST /v1/projects/{tenant_slug}` with the same JSON body for interactive (`@inquirer/prompts`, loaded only when needed) and flag/`--from-file` flows.
- Validates slug with `^[a-z][a-z0-9-]{1,62}$`, checks uniqueness via `listProjects` before POST (exit **6**), maps API/payload issues to **7** where applicable.
- Domain category: validates against cached `GET /v1/projects/{tenant}/domains` then `GET /v1/projects/domains`; falls back to the UI-aligned catalog. Stored as `metadata.domainCategory`; visibility as `metadata.visibility`.
- `--from-file` supports JSON/YAML with AJV JSON Schema; `--dry-run` prints the POST body; `--yes` skips confirmations for CI/non-TTY.

## How to test
- **Dry-run**: From `objectified-cli/`, run `yarn build`, then `node bin/run.js --base-url <api> --api-key <key> --tenant <slug> projects create --dry-run --yes --name 'Payments API' --slug payments-api --domain finance --visibility private` and confirm printed JSON matches the POST body.
- **Mock API**: Run `yarn test` (includes `test/projects-create.integration.test.ts` against a local HTTP server).
- **Interactive**: On a TTY, run `objectified projects create` and complete prompts; use `--yes` to skip the final confirm.

## Risks / notes
- REST `ProjectCreateRequest` remains name/slug/description/metadata; domain and visibility are carried in metadata to match the studio UI (`domainCategory`).
- Underscores in slugs are rejected by the CLI regex even though the API allows them today.

Closes #3204

Made with [Cursor](https://cursor.com)