### PR TITLE
Fix #3208 - versions list command

### DIFF
--- a/docs/PLANNED_ROADMAP_CLI.md
+++ b/docs/PLANNED_ROADMAP_CLI.md
@@ -86,7 +86,7 @@ Every command lives in one of three connection modes:
 | 1   | [CLI Foundation & DevEx](https://github.com/KenSuenobu/objectified-commercial/issues/3174)                 | #3174   | 8           | All 8        |
 | 2   | [Authentication & Tenant Context](https://github.com/KenSuenobu/objectified-commercial/issues/3175)        | #3175   | 8           | 6 of 8       |
 | 3   | [Projects (CLI)](https://github.com/KenSuenobu/objectified-commercial/issues/3176)                         | #3176   | 6           | 3 of 6       |
-| 4   | [Versions (CLI)](https://github.com/KenSuenobu/objectified-commercial/issues/3177)                         | #3177   | 9           | 3 of 9       |
+| 4   | [Versions (CLI)](https://github.com/KenSuenobu/objectified-commercial/issues/3177)                         | #3177   | 9           | 4 of 9       |
 | 5   | [Primitives (CLI)](https://github.com/KenSuenobu/objectified-commercial/issues/3178)                       | #3178   | 6           | 0 (v2)       |
 | 6   | [Properties (CLI)](https://github.com/KenSuenobu/objectified-commercial/issues/3179)                       | #3179   | 6           | 0 (v2)       |
 | 7   | [Classes (CLI)](https://github.com/KenSuenobu/objectified-commercial/issues/3180)                          | #3180   | 8           | 0 (v2)       |

--- a/docs/PLANNED_ROADMAP_CLI.md
+++ b/docs/PLANNED_ROADMAP_CLI.md
@@ -86,7 +86,7 @@ Every command lives in one of three connection modes:
 | 1   | [CLI Foundation & DevEx](https://github.com/KenSuenobu/objectified-commercial/issues/3174)                 | #3174   | 8           | All 8        |
 | 2   | [Authentication & Tenant Context](https://github.com/KenSuenobu/objectified-commercial/issues/3175)        | #3175   | 8           | 6 of 8       |
 | 3   | [Projects (CLI)](https://github.com/KenSuenobu/objectified-commercial/issues/3176)                         | #3176   | 6           | 3 of 6       |
-| 4   | [Versions (CLI)](https://github.com/KenSuenobu/objectified-commercial/issues/3177)                         | #3177   | 9           | 4 of 9       |
+| 4   | [Versions (CLI)](https://github.com/KenSuenobu/objectified-commercial/issues/3177)                         | #3177   | 9           | 3 of 9       |
 | 5   | [Primitives (CLI)](https://github.com/KenSuenobu/objectified-commercial/issues/3178)                       | #3178   | 6           | 0 (v2)       |
 | 6   | [Properties (CLI)](https://github.com/KenSuenobu/objectified-commercial/issues/3179)                       | #3179   | 6           | 0 (v2)       |
 | 7   | [Classes (CLI)](https://github.com/KenSuenobu/objectified-commercial/issues/3180)                          | #3180   | 8           | 0 (v2)       |
@@ -421,7 +421,6 @@ See each ticket on GitHub for the full description, acceptance criteria, ASCII d
 
 | #         | Title                              | Description                                                        | Labels                                          | MVP | Parallel |
 |-----------|------------------------------------|--------------------------------------------------------------------|-------------------------------------------------|-----|----------|
-| 4.1 (#3208) | `versions list`                  | List versions with state, tags, publish date, author               | `enhancement`, `mvp`, `cli`, `roadmap-cli`, `versions` | Yes | Yes      |
 | 4.2 (#3209) | `versions show`                  | Single-version detail; resolves semver/UUID/tag-name               | `enhancement`, `mvp`, `cli`, `roadmap-cli`, `versions` | Yes | Yes      |
 | 4.3 (#3210) | `versions create`                | Create draft; supports `--base` (copy from existing)               | `enhancement`, `mvp`, `cli`, `roadmap-cli`, `versions` | Yes | Yes      |
 | 4.4 (#3211) | `versions fork`                  | Fork existing version into a new semver                            | `enhancement`, `cli`, `roadmap-cli`, `versions`, `git-behavior` | No  | Yes |
@@ -430,6 +429,10 @@ See each ticket on GitHub for the full description, acceptance criteria, ASCII d
 | 4.7 (#3214) | `versions freeze`                | Immutable schema snapshot; `--unfreeze` allowed pre-download       | `enhancement`, `cli`, `roadmap-cli`, `versions` | No  | Yes      |
 | 4.8 (#3215) | `versions compatibility`         | Backward-compat check; SARIF + CI exit codes                       | `enhancement`, `cli`, `roadmap-cli`, `versions`, `validation` | No  | Yes |
 | 4.9 (#3216) | `versions delete`                | Delete draft/archived; refuses published without `--force`         | `enhancement`, `cli`, `roadmap-cli`, `versions` | No  | Yes      |
+
+#### 4.1 (#3208) — `versions list` (**done**)
+
+Shipped `objectified versions list <project>`: table columns for version label, state (draft / published / archived, with frozen marker), tags joined from `version_tags`, publish date, author; `--state`, `--limit` / `--all`, `--sort`, `--reverse`, `--json`; defaults to latest **10** rows in descending semver order (#3208).
 
 ### Notable Detail — 4.5 (#3212) `versions publish`
 
@@ -761,12 +764,12 @@ The `NPM_REGISTRY` env var lets us point at npmjs.com, GitHub Packages, JFrog Ar
 
 ## MVP Release — Ticket Bundle
 
-The MVP delivers an installable, useful CLI focused on _read_ and _publish_ for a single project's lifecycle. Total: **15 open sub-tickets** across 4 epics (plus completed foundation items such as #3186, #3187, #3188, #3189, #3190, #3191, #3192, #3193, #3194, #3195, #3202, #3203, and #3204).
+The MVP delivers an installable, useful CLI focused on _read_ and _publish_ for a single project's lifecycle. Total: **14 open sub-tickets** across 4 epics (plus completed foundation items such as #3186, #3187, #3188, #3189, #3190, #3191, #3192, #3193, #3194, #3195, #3202, #3203, #3204, and #3208).
 
 | Epic     | Tickets                                                                                                   | Count |
 |----------|-----------------------------------------------------------------------------------------------------------|-------|
 | 2 (#3175) | #3196, #3197, #3198, #3199                                                                                | 4     |
-| 4 (#3177) | #3208, #3209, #3210, #3212                                                                                | 4     |
+| 4 (#3177) | #3209, #3210, #3212                                                                                       | 3     |
 | 9 (#3182) | #3244, #3245, #3246, #3247, #3248                                                                          | 5     |
 | 12 (#3185) | #3267, #3268                                                                                               | 2     |
 
@@ -854,7 +857,7 @@ The tickets were created in the order below — that is also the recommended **e
 1. **Epic 1 — Foundation** (#3174: #3186, #3187, #3188, #3189, #3190, #3191, #3192, and #3193 landed). Without the scaffold, no other command can exist.
 2. **Epic 2 — Auth & Tenants** (#3175; #3194–#3197 shipped — continue #3198 → #3201). Required for any tenant-scoped command.
 3. **Epic 3 — Projects** (#3176 then #3205 → #3207; #3203 and #3204 shipped). The first useful read/write surface.
-4. **Epic 4 — Versions** (#3177 then #3208 → #3216). The publish flow that makes the CLI valuable in CI.
+4. **Epic 4 — Versions** (#3177 then #3209 → #3216; #3208 `versions list` shipped). The publish flow that makes the CLI valuable in CI.
 5. **Epic 9 — Browse & Schema Export** (#3182 then #3244 → #3252). The most-used consumer surface; lands early because it works without auth.
 6. **Epic 12 — Distribution (CI + NPM publish only)** (#3185 then #3267, #3268). Ship MVP — `npm i -g objectified-cli` works.
 7. **Epic 5 — Primitives** (#3178 then #3217 → #3222). v2 schema-modeling surface starts here.

--- a/objectified-cli/README.md
+++ b/objectified-cli/README.md
@@ -50,7 +50,7 @@ $ npm install -g objectified-cli
 $ objectified COMMAND
 running command...
 $ objectified (--version)
-objectified-cli/0.1.16 <platform> node-v<major.minor.patch>
+objectified-cli/0.1.17 <platform> node-v<major.minor.patch>
 $ objectified --help [COMMAND]
 USAGE
   $ objectified COMMAND
@@ -88,6 +88,7 @@ USAGE
 * [`objectified tenants list`](#objectified-tenants-list)
 * [`objectified tenants use [SLUG]`](#objectified-tenants-use-slug)
 * [`objectified version`](#objectified-version)
+* [`objectified versions list PROJECT`](#objectified-versions-list-project)
 * [`objectified whoami`](#objectified-whoami)
 
 ## `objectified auth login`
@@ -1351,6 +1352,69 @@ FLAG DESCRIPTIONS
 ```
 
 _See code: [@oclif/plugin-version](https://github.com/oclif/plugin-version/blob/2.2.43/src/commands/version.ts)_
+
+## `objectified versions list PROJECT`
+
+List schema versions for a project (GET /v1/versions/{tenant_slug}/{project_id}; tags joined from version tags)
+
+```
+USAGE
+  $ objectified versions list PROJECT [--api-key <value>] [--api-key-file <value>] [--base-url <value>] [--config
+    <value>] [--json] [--color] [--profile <value>] [--tenant <value>] [-q] [--verbose] [--state <value>] [--limit
+    <value>] [--all] [--sort <value>] [--reverse]
+
+ARGUMENTS
+  PROJECT  Project slug or UUID (uuid-shaped refs resolve as id first)
+
+DESCRIPTION
+  List schema versions for a project (GET /v1/versions/{tenant_slug}/{project_id}; tags joined from version tags)
+
+EXAMPLES
+  $ objectified versions list payments-api
+
+  $ objectified --json versions list payments-api
+
+  $ objectified versions list payments-api --state draft,published --limit 25
+
+  $ objectified versions list payments-api --sort published_at --reverse
+
+  $ objectified --profile staging versions list my-api --all
+
+COMMON
+  --base-url=<value>  Root REST API URL.
+  --config=<value>    Path to config file (default: XDG config dir / Objectified AppData on Windows — see `objectified
+                      config path`).
+  --profile=<value>   Named credentials profile (OBJECTIFIED_PROFILE); falls back to default_profile in config.
+  --tenant=<value>    [env: OBJECTIFIED_TENANT] Tenant slug for this run only (overrides OBJECTIFIED_TENANT and config
+                      tenant_slug).
+
+OUTPUT
+  --[no-]color  Enable/disable ANSI colors (--no-color sets NO_COLOR; colors are off when stdout is not a TTY).
+      --[no-]json   Emit machine-readable JSON (OBJECTIFIED_JSON=1; auto-enabled when stdout is not a TTY).
+  -q, --quiet       Suppress non-error stdout (spinners, banners, tips).
+      --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
+
+AUTH
+  --api-key=<value>       [env: OBJECTIFIED_API_KEY] API key for direct authentication (OBJECTIFIED_API_KEY). Not
+                          persisted unless you run `auth login --api-key`.
+  --api-key-file=<value>  Read API key from a file (single line; avoids shell history).
+
+OTHER
+  --all            List every matching version after sort/filter (no --limit cap).
+  --limit=<value>  [default: 10] Maximum rows after sort/filter (1–500; default 10). Ignored with --all.
+  --reverse        Reverse the default sort direction (defaults are descending).
+  --sort=<value>   Sort by version, published_at, or created_at (default: version).
+  --state=<value>  Comma-separated filters (OR): draft, published, archived, frozen. Matches CLI-derived states.
+
+SEE ALSO
+  objectified projects show
+
+  objectified projects list
+
+  objectified tenants use
+
+  objectified docs errors
+```
 
 ## `objectified whoami`
 

--- a/objectified-cli/man/man1/objectified-versions-list.1
+++ b/objectified-cli/man/man1/objectified-versions-list.1
@@ -1,0 +1,75 @@
+.TH OBJECTIFIED\-VERSIONS\-LIST 1 "" "" "User Commands"
+.SH NAME
+objectified versions list \- List schema versions for a project (GET /v1/versions/{tenant_slug}/{project_id}; tags joined from version tags)
+.SH DESCRIPTION
+.nf
+USAGE
+  $ objectified versions list PROJECT [--api-key <value>] [--api-key-file
+    <value>] [--base-url <value>] [--config <value>] [--json] [--color]
+    [--profile <value>] [--tenant <value>] [-q] [--verbose] [--state <value>]
+    [--limit <value>] [--all] [--sort <value>] [--reverse]
+
+ARGUMENTS
+  PROJECT  Project slug or UUID (uuid-shaped refs resolve as id first)
+
+DESCRIPTION
+  List schema versions for a project (GET
+  /v1/versions/{tenant_slug}/{project_id}; tags joined from version tags)
+
+EXAMPLES
+  $ objectified versions list payments-api
+
+  $ objectified --json versions list payments-api
+
+  $ objectified versions list payments-api --state draft,published --limit 25
+
+  $ objectified versions list payments-api --sort published_at --reverse
+
+  $ objectified --profile staging versions list my-api --all
+
+COMMON
+  --base-url=<value>  Root REST API URL.
+  --config=<value>    Path to config file (default: XDG config dir /
+                      Objectified AppData on Windows — see `objectified config
+                      path`).
+  --profile=<value>   Named credentials profile (OBJECTIFIED_PROFILE); falls
+                      back to default_profile in config.
+  --tenant=<value>    [env: OBJECTIFIED_TENANT] Tenant slug for this run only
+                      (overrides OBJECTIFIED_TENANT and config tenant_slug).
+
+OUTPUT
+  --[no-]color  Enable/disable ANSI colors (--no-color sets NO_COLOR;
+                    colors are off when stdout is not a TTY).
+      --[no-]json   Emit machine-readable JSON (OBJECTIFIED_JSON=1;
+                    auto-enabled when stdout is not a TTY).
+  -q, --quiet       Suppress non-error stdout (spinners, banners, tips).
+      --verbose     Verbose logging on stderr (OBJECTIFIED_VERBOSE=1).
+
+AUTH
+  --api-key=<value>       [env: OBJECTIFIED_API_KEY] API key for direct
+                          authentication (OBJECTIFIED_API_KEY). Not persisted
+                          unless you run `auth login --api-key`.
+  --api-key-file=<value>  Read API key from a file (single line; avoids shell
+                          history).
+
+OTHER
+  --all            List every matching version after sort/filter (no --limit
+                   cap).
+  --limit=<value>  [default: 10] Maximum rows after sort/filter (1–500;
+                   default 10). Ignored with --all.
+  --reverse        Reverse the default sort direction (defaults are
+                   descending).
+  --sort=<value>   Sort by version, published_at, or created_at (default:
+                   version).
+  --state=<value>  Comma-separated filters (OR): draft, published, archived,
+                   frozen. Matches CLI-derived states.
+
+SEE ALSO
+  objectified projects show
+
+  objectified projects list
+
+  objectified tenants use
+
+  objectified docs errors
+.fi

--- a/objectified-cli/man/man1/objectified.1
+++ b/objectified-cli/man/man1/objectified.1
@@ -6,7 +6,7 @@ objectified \- Objectified command-line interface
 Objectified command-line interface
 
 VERSION
-  objectified-cli/0.1.16 linux-x64 node-v24.14.1
+  objectified-cli/0.1.17 linux-x64 node-v24.14.1
 
 USAGE
   $ objectified [COMMAND]

--- a/objectified-cli/package.json
+++ b/objectified-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-cli",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "Objectified command-line interface",
   "author": "Objectified",
   "type": "module",
@@ -102,6 +102,7 @@
     "./man/man1/objectified-tenants-list.1",
     "./man/man1/objectified-tenants-use.1",
     "./man/man1/objectified-version.1",
+    "./man/man1/objectified-versions-list.1",
     "./man/man1/objectified-whoami.1",
     "./man/man1/objectified.1"
   ]

--- a/objectified-cli/src/commands/versions/list.ts
+++ b/objectified-cli/src/commands/versions/list.ts
@@ -1,0 +1,174 @@
+import { Args, Flags } from "@oclif/core";
+
+import { BaseCommand } from "../../base-command.js";
+import { ObjectifiedCliError } from "../../lib/errors.js";
+import { EXIT_CODES } from "../../lib/exit-codes.js";
+import { chalkForContext } from "../../lib/output.js";
+import { completionProfileCacheKey, resolveProjectForTenant } from "../../lib/resolve.js";
+import {
+  applyVersionsListPipeline,
+  parseVersionsSortField,
+  parseVersionStateFilter,
+} from "../../lib/versions/list-query.js";
+import {
+  buildTagsByRevisionId,
+  formatVersionsListHumanLines,
+} from "../../lib/versions/list-format.js";
+
+const LIMIT_MAX = 500;
+const DEFAULT_LIMIT = 10;
+
+export default class VersionsList extends BaseCommand {
+  static description =
+    "List schema versions for a project (GET /v1/versions/{tenant_slug}/{project_id}; tags joined from version tags)";
+
+  static examples = [
+    "<%= config.bin %> <%= command.id %> payments-api",
+    "<%= config.bin %> --json <%= command.id %> payments-api",
+    "<%= config.bin %> <%= command.id %> payments-api --state draft,published --limit 25",
+    "<%= config.bin %> <%= command.id %> payments-api --sort published_at --reverse",
+    "<%= config.bin %> --profile staging <%= command.id %> my-api --all",
+  ];
+
+  static seeAlso = ["projects show", "projects list", "tenants use", "docs errors"];
+
+  static args = {
+    project: Args.string({
+      description: "Project slug or UUID (uuid-shaped refs resolve as id first)",
+      required: true,
+    }),
+  };
+
+  static flags = {
+    state: Flags.string({
+      description:
+        "Comma-separated filters (OR): draft, published, archived, frozen. Matches CLI-derived states.",
+    }),
+    limit: Flags.integer({
+      description: `Maximum rows after sort/filter (1–${String(LIMIT_MAX)}; default ${String(DEFAULT_LIMIT)}). Ignored with --all.`,
+      min: 1,
+      max: LIMIT_MAX,
+      default: DEFAULT_LIMIT,
+    }),
+    all: Flags.boolean({
+      description: "List every matching version after sort/filter (no --limit cap).",
+      default: false,
+    }),
+    sort: Flags.string({
+      description: "Sort by version, published_at, or created_at (default: version).",
+    }),
+    reverse: Flags.boolean({
+      description: "Reverse the default sort direction (defaults are descending).",
+      default: false,
+    }),
+  };
+
+  async run(): Promise<void> {
+    const tenant = this.context.tenantSlug;
+    if (tenant === undefined || tenant === "") {
+      throw new ObjectifiedCliError({
+        message:
+          "Tenant slug is required for this command. Pass --tenant, set OBJECTIFIED_TENANT, or configure tenant_slug for your profile.",
+        exitCode: EXIT_CODES.CONFIG,
+        title: "Configuration error",
+        hint: "Run `objectified tenants use <slug>` to save a default tenant, or `objectified tenants list` to see accessible tenants.",
+      });
+    }
+
+    const argv = this.normalizedArgv;
+    const hasAllFlag = argv.some((a) => a === "--all" || a.startsWith("--all="));
+    const hasLimitFlag = argv.some((a) => a === "--limit" || a.startsWith("--limit="));
+    if (hasAllFlag && hasLimitFlag) {
+      throw new ObjectifiedCliError({
+        message: "Cannot use --all together with --limit.",
+        exitCode: EXIT_CODES.MISUSE,
+        title: "Invalid usage",
+        hint: "Pass only one of --all or --limit.",
+      });
+    }
+
+    let stateFilter;
+    let sortField;
+    try {
+      stateFilter = parseVersionStateFilter(this.flags.state as string | undefined);
+      sortField = parseVersionsSortField(this.flags.sort as string | undefined);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      throw new ObjectifiedCliError({
+        message: msg,
+        exitCode: EXIT_CODES.MISUSE,
+        title: "Invalid usage",
+        hint: "Run `objectified versions list --help` for flag syntax.",
+      });
+    }
+
+    const rawProjectArg = this.commandArgs.project;
+    const projectArg = typeof rawProjectArg === "string" ? rawProjectArg : "";
+
+    this.ensureAuthenticated();
+
+    const profileKey = completionProfileCacheKey({
+      baseUrl: this.context.baseUrl,
+      profile: this.context.profile,
+      tenantSlug: tenant,
+    });
+
+    const project = await resolveProjectForTenant(this.api, tenant, projectArg, profileKey);
+
+    const [versions, tags] = await Promise.all([
+      this.api.listVersions(tenant, project.id),
+      this.api.listVersionTags(tenant, project.id),
+    ]);
+
+    const tagsByRevisionId = buildTagsByRevisionId(tags);
+
+    const pipeline = applyVersionsListPipeline(versions, {
+      stateFilter,
+      sortField,
+      reverse: this.flags.reverse === true,
+    });
+
+    const useAll = Boolean(this.flags.all);
+    const limitRaw = this.flags.limit as number | undefined;
+    const limit = Math.min(LIMIT_MAX, Math.max(1, limitRaw ?? DEFAULT_LIMIT));
+    const displayed = useAll ? pipeline : pipeline.slice(0, limit);
+    const truncated = !useAll && pipeline.length > displayed.length;
+
+    const projectLabel = project.slug;
+
+    if (this.context.json) {
+      this.output.json(displayed);
+      return;
+    }
+
+    const c = chalkForContext(this.context.color);
+
+    if (versions.length === 0) {
+      this.output.text(`${c.bold("No versions yet.")} Project '${projectLabel}' has no schema revisions.`);
+      return;
+    }
+
+    if (pipeline.length === 0) {
+      this.output.text("No versions match your --state filter.");
+      return;
+    }
+
+    const useGlyphForFrozen = this.context.color;
+    const freezeGlyph = useGlyphForFrozen ? c.cyan("❄") : "";
+    const freezeBracket = " [frozen]";
+
+    const lines = formatVersionsListHumanLines({
+      versions: displayed,
+      tagsByRevisionId,
+      projectLabel,
+      truncated,
+      totalAfterPipeline: pipeline.length,
+      useGlyphForFrozen,
+      freezeGlyph,
+      freezeBracket,
+    });
+    for (const line of lines) {
+      this.output.text(line);
+    }
+  }
+}

--- a/objectified-cli/src/lib/versions/list-format.ts
+++ b/objectified-cli/src/lib/versions/list-format.ts
@@ -8,8 +8,8 @@ const versionW = 14;
 /** Fits `published [frozen]` (ASCII) or `published ❄` (glyph). */
 const stateW = 18;
 const tagsW = 14;
-const publishedW = 11;
-const authorW = 19;
+const publishedW = 10;
+const authorW = 18;
 
 export function formatVersionLabel(versionId: string): string {
   const raw = versionId.trim();
@@ -73,7 +73,7 @@ export function formatVersionsListHumanLines(opts: VersionsListFormatOpts): stri
       const w = widths[i] ?? 0;
       return ellipsizeEnd(h, w).padEnd(w);
     })
-    .join(" ")}`.slice(0, 80);
+    .join(" ")}`;
 
   const lines: string[] = [headerLine];
 
@@ -85,7 +85,7 @@ export function formatVersionsListHumanLines(opts: VersionsListFormatOpts): stri
     if (frozen) {
       stateText =
         opts.useGlyphForFrozen && opts.freezeGlyph !== ""
-          ? `${stateText} ${opts.freezeGlyph}`
+          ? `${stateText} ❄`
           : `${stateText}${opts.freezeBracket}`;
     }
     const stateCell = ellipsizeEnd(stateText, stateW).padEnd(stateW);
@@ -94,16 +94,22 @@ export function formatVersionsListHumanLines(opts: VersionsListFormatOpts): stri
     const tagsCell = ellipsizeEnd(tagsRaw, tagsW).padEnd(tagsW);
     const pubCell = ellipsizeEnd(publishedDateDisplay(v), publishedW).padEnd(publishedW);
     const authCell = ellipsizeEnd(authorDisplay(v), authorW).padEnd(authorW);
-    lines.push(`  ${verCell.padEnd(versionW)} ${stateCell} ${tagsCell} ${pubCell} ${authCell}`.slice(0, 80));
+    let row = `  ${verCell.padEnd(versionW)} ${stateCell} ${tagsCell} ${pubCell} ${authCell}`;
+    if (frozen && opts.useGlyphForFrozen && opts.freezeGlyph !== "") {
+      row = row.replace("❄", opts.freezeGlyph);
+    }
+    lines.push(row);
   }
 
   lines.push("");
   const total = opts.totalAfterPipeline;
   const showing = opts.versions.length;
   const noun = total === 1 ? "version" : "versions";
-  let summary = `${String(total)} ${noun} in '${opts.projectLabel}'.`;
+  let summary = `${String(total)} ${noun} in '${opts.projectLabel}'`;
   if (opts.truncated && total > showing) {
     summary += ` (showing latest ${String(showing)} of ${String(total)}). Use --all to list all.`;
+  } else {
+    summary += ".";
   }
   lines.push(summary);
 

--- a/objectified-cli/src/lib/versions/list-format.ts
+++ b/objectified-cli/src/lib/versions/list-format.ts
@@ -1,0 +1,111 @@
+import type { VersionSchema, VersionTagSchema } from "../client.js";
+
+import { ellipsizeEnd, ellipsizeMiddle } from "../projects/format.js";
+
+import { versionIsArchived } from "./list-query.js";
+
+const versionW = 14;
+/** Fits `published [frozen]` (ASCII) or `published ❄` (glyph). */
+const stateW = 18;
+const tagsW = 14;
+const publishedW = 11;
+const authorW = 19;
+
+export function formatVersionLabel(versionId: string): string {
+  const raw = versionId.trim();
+  return raw.startsWith("v") || raw.startsWith("V") ? raw : `v${raw}`;
+}
+
+/** Map revision id (`versions.id`) → distinct tag names pointing at that revision (API iteration order). */
+export function buildTagsByRevisionId(tags: VersionTagSchema[]): Map<string, string[]> {
+  const m = new Map<string, string[]>();
+  for (const t of tags) {
+    const rev = t.version_id;
+    const name = t.name.trim();
+    if (rev === "" || name === "") continue;
+    const cur = m.get(rev) ?? [];
+    if (!cur.includes(name)) cur.push(name);
+    m.set(rev, cur);
+  }
+  return m;
+}
+
+function primaryStateWord(v: VersionSchema): string {
+  if (versionIsArchived(v)) return "archived";
+  if (v.published === true) return "published";
+  return "draft";
+}
+
+function publishedDateDisplay(v: VersionSchema): string {
+  const iso = v.published_at;
+  if (!iso || iso === "") return "—";
+  return iso.slice(0, 10);
+}
+
+function authorDisplay(v: VersionSchema): string {
+  const a = v.author?.trim();
+  if (a !== undefined && a !== "") return a;
+  const email = v.creator_email?.trim();
+  if (email !== undefined && email !== "") return email;
+  const name = v.creator_name?.trim();
+  if (name !== undefined && name !== "") return name;
+  return "—";
+}
+
+export type VersionsListFormatOpts = {
+  versions: VersionSchema[];
+  tagsByRevisionId: Map<string, string[]>;
+  /** Project slug for footer messaging (human output). */
+  projectLabel: string;
+  truncated: boolean;
+  totalAfterPipeline: number;
+  /** When false, frozen revisions use `[frozen]` instead of a snowflake glyph. */
+  useGlyphForFrozen: boolean;
+  freezeGlyph: string;
+  freezeBracket: string;
+};
+
+export function formatVersionsListHumanLines(opts: VersionsListFormatOpts): string[] {
+  const headers = ["VERSION", "STATE", "TAGS", "PUBLISHED", "AUTHOR"];
+  const widths = [versionW, stateW, tagsW, publishedW, authorW];
+  const headerLine = `  ${headers
+    .map((h, i) => {
+      const w = widths[i] ?? 0;
+      return ellipsizeEnd(h, w).padEnd(w);
+    })
+    .join(" ")}`.slice(0, 80);
+
+  const lines: string[] = [headerLine];
+
+  for (const v of opts.versions) {
+    const verCell = ellipsizeMiddle(formatVersionLabel(v.version_id), versionW);
+    const archived = versionIsArchived(v);
+    const frozen = !archived && Boolean(v.published) && v.publishedImmutable === true;
+    let stateText = primaryStateWord(v);
+    if (frozen) {
+      stateText =
+        opts.useGlyphForFrozen && opts.freezeGlyph !== ""
+          ? `${stateText} ${opts.freezeGlyph}`
+          : `${stateText}${opts.freezeBracket}`;
+    }
+    const stateCell = ellipsizeEnd(stateText, stateW).padEnd(stateW);
+    const tagNames = opts.tagsByRevisionId.get(v.id) ?? [];
+    const tagsRaw = tagNames.join(", ");
+    const tagsCell = ellipsizeEnd(tagsRaw, tagsW).padEnd(tagsW);
+    const pubCell = ellipsizeEnd(publishedDateDisplay(v), publishedW).padEnd(publishedW);
+    const authCell = ellipsizeEnd(authorDisplay(v), authorW).padEnd(authorW);
+    lines.push(`  ${verCell.padEnd(versionW)} ${stateCell} ${tagsCell} ${pubCell} ${authCell}`.slice(0, 80));
+  }
+
+  lines.push("");
+  const total = opts.totalAfterPipeline;
+  const showing = opts.versions.length;
+  const noun = total === 1 ? "version" : "versions";
+  let summary = `${String(total)} ${noun} in '${opts.projectLabel}'.`;
+  if (opts.truncated && total > showing) {
+    summary += ` (showing latest ${String(showing)} of ${String(total)}). Use --all to list all.`;
+  }
+  lines.push(summary);
+
+  return lines;
+}

--- a/objectified-cli/src/lib/versions/list-query.ts
+++ b/objectified-cli/src/lib/versions/list-query.ts
@@ -1,0 +1,162 @@
+import type { VersionSchema } from "../client.js";
+
+export type VersionListState = "draft" | "published" | "archived" | "frozen";
+
+export type VersionsSortField = "version" | "published_at" | "created_at";
+
+const STATE_WORDS: VersionListState[] = ["draft", "published", "archived", "frozen"];
+
+/** Whether this revision counts as archived for list/filter semantics (matches projects show). */
+export function versionIsArchived(v: VersionSchema): boolean {
+  return v.lifecycle === "archived" || v.enabled === false;
+}
+
+/** States a version matches for `--state` filtering (OR semantics across selected states). */
+export function versionStateMembership(v: VersionSchema): Set<VersionListState> {
+  const s = new Set<VersionListState>();
+  if (versionIsArchived(v)) {
+    s.add("archived");
+    return s;
+  }
+  const pub = Boolean(v.published);
+  const frozen = pub && v.publishedImmutable === true;
+  if (frozen) s.add("frozen");
+  if (pub) s.add("published");
+  else s.add("draft");
+  return s;
+}
+
+export function parseVersionStateFilter(raw: string | undefined): Set<VersionListState> | undefined {
+  if (raw === undefined || raw.trim() === "") return undefined;
+  const parts = raw.split(",").map((p) => p.trim().toLowerCase());
+  const out = new Set<VersionListState>();
+  for (const p of parts) {
+    if (p === "") continue;
+    if (!STATE_WORDS.includes(p as VersionListState)) {
+      throw new Error(
+        `Invalid --state value "${p}". Expected one of: ${STATE_WORDS.join(", ")} (comma-separated).`,
+      );
+    }
+    out.add(p as VersionListState);
+  }
+  if (out.size === 0) return undefined;
+  return out;
+}
+
+export function parseVersionsSortField(raw: string | undefined): VersionsSortField {
+  if (raw === undefined || raw.trim() === "") return "version";
+  const v = raw.trim().toLowerCase();
+  if (v === "version" || v === "published_at" || v === "created_at") return v;
+  throw new Error(
+    `Invalid --sort field "${raw}". Expected version, published_at, or created_at.`,
+  );
+}
+
+function stripLeadingV(id: string): string {
+  const t = id.trim();
+  if (t.startsWith("v") || t.startsWith("V")) return t.slice(1);
+  return t;
+}
+
+function splitPreRelease(core: string): [string, string] {
+  const i = core.indexOf("-");
+  if (i <= 0) return [core, ""];
+  return [core.slice(0, i), core.slice(i + 1)];
+}
+
+function compareDotSegments(a: string, b: string): number {
+  const pa = a.split(".");
+  const pb = b.split(".");
+  const n = Math.max(pa.length, pb.length);
+  for (let i = 0; i < n; i++) {
+    const sa = pa[i] ?? "";
+    const sb = pb[i] ?? "";
+    const na = parseInt(sa, 10);
+    const nb = parseInt(sb, 10);
+    const aNum = !Number.isNaN(na) && String(na) === sa;
+    const bNum = !Number.isNaN(nb) && String(nb) === sb;
+    if (aNum && bNum) {
+      if (na !== nb) return na < nb ? -1 : 1;
+    } else {
+      const c = sa.localeCompare(sb);
+      if (c !== 0) return c;
+    }
+  }
+  return 0;
+}
+
+/** Ascending semver-ish order on `version_id` (v-prefix ignored). */
+export function compareSemverVersionIdsAsc(a: string, b: string): number {
+  const ca = stripLeadingV(a);
+  const cb = stripLeadingV(b);
+  const [coreA, preA] = splitPreRelease(ca);
+  const [coreB, preB] = splitPreRelease(cb);
+  const cmp = compareDotSegments(coreA, coreB);
+  if (cmp !== 0) return cmp;
+  if (preA === "" && preB !== "") return 1;
+  if (preA !== "" && preB === "") return -1;
+  if (preA === preB) return 0;
+  return preA.localeCompare(preB);
+}
+
+function compareIsoNullable(a: string | null | undefined, b: string | null | undefined): number {
+  const sa = a ?? "";
+  const sb = b ?? "";
+  if (sa === sb) return 0;
+  if (sa === "") return -1;
+  if (sb === "") return 1;
+  if (sa < sb) return -1;
+  if (sa > sb) return 1;
+  return 0;
+}
+
+function sortComparator(
+  field: VersionsSortField,
+  descending: boolean,
+): (x: VersionSchema, y: VersionSchema) => number {
+  return (x, y) => {
+    let cmp = 0;
+    switch (field) {
+      case "version":
+        cmp = compareSemverVersionIdsAsc(x.version_id, y.version_id);
+        break;
+      case "published_at":
+        cmp = compareIsoNullable(x.published_at, y.published_at);
+        break;
+      case "created_at":
+        cmp = compareIsoNullable(x.created_at, y.created_at);
+        break;
+      default:
+        cmp = 0;
+    }
+    if (cmp !== 0) return descending ? -cmp : cmp;
+    return compareSemverVersionIdsAsc(x.version_id, y.version_id);
+  };
+}
+
+export function applyVersionsListPipeline(
+  versions: VersionSchema[],
+  opts: {
+    stateFilter: Set<VersionListState> | undefined;
+    sortField: VersionsSortField;
+    /** When true, reverse the default direction (defaults are descending). */
+    reverse: boolean;
+  },
+): VersionSchema[] {
+  let rows = versions;
+  const wantedStates = opts.stateFilter;
+  if (wantedStates !== undefined && wantedStates.size > 0) {
+    rows = rows.filter((v) => {
+      const mem = versionStateMembership(v);
+      for (const wanted of wantedStates) {
+        if (mem.has(wanted)) return true;
+      }
+      return false;
+    });
+  }
+
+  const descendingDefault = true;
+  const descending = opts.reverse ? !descendingDefault : descendingDefault;
+  const cmp = sortComparator(opts.sortField, descending);
+  return [...rows].sort(cmp);
+}

--- a/objectified-cli/src/lib/versions/list-query.ts
+++ b/objectified-cli/src/lib/versions/list-query.ts
@@ -130,7 +130,8 @@ function sortComparator(
         cmp = 0;
     }
     if (cmp !== 0) return descending ? -cmp : cmp;
-    return compareSemverVersionIdsAsc(x.version_id, y.version_id);
+    const tie = compareSemverVersionIdsAsc(x.version_id, y.version_id);
+    return descending ? -tie : tie;
   };
 }
 

--- a/objectified-cli/test/__snapshots__/versions-list.snap.test.ts.snap
+++ b/objectified-cli/test/__snapshots__/versions-list.snap.test.ts.snap
@@ -1,0 +1,11 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`versions list human table snapshots (#3208) > matches issue-style columns (80 cols) with tags joined client-side 1`] = `
+"  VERSION        STATE              TAGS           PUBLISHED   AUTHOR           
+  v2.2.0-rc.1    draft              next           —           morgan@example.co
+  v2.1.0         published          stable, latest 2026-05-04  kenji@example.com
+  v2.0.0         published [frozen]                2026-02-18  kenji@example.com
+  v1.4.0         archived                          2025-11-02  —                
+
+8 versions in 'payments-api'. (showing latest 4 of 8). Use --all to list all."
+`;

--- a/objectified-cli/test/__snapshots__/versions-list.snap.test.ts.snap
+++ b/objectified-cli/test/__snapshots__/versions-list.snap.test.ts.snap
@@ -1,11 +1,11 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`versions list human table snapshots (#3208) > matches issue-style columns (80 cols) with tags joined client-side 1`] = `
-"  VERSION        STATE              TAGS           PUBLISHED   AUTHOR           
-  v2.2.0-rc.1    draft              next           —           morgan@example.co
-  v2.1.0         published          stable, latest 2026-05-04  kenji@example.com
-  v2.0.0         published [frozen]                2026-02-18  kenji@example.com
-  v1.4.0         archived                          2025-11-02  —                
+"  VERSION        STATE              TAGS           PUBLISHED  AUTHOR            
+  v2.2.0-rc.1    draft              next           —          morgan@example.com
+  v2.1.0         published          stable, latest 2026-05-04 kenji@example.com 
+  v2.0.0         published [frozen]                2026-02-18 kenji@example.com 
+  v1.4.0         archived                          2025-11-02 —                 
 
-8 versions in 'payments-api'. (showing latest 4 of 8). Use --all to list all."
+8 versions in 'payments-api' (showing latest 4 of 8). Use --all to list all."
 `;

--- a/objectified-cli/test/versions-list-query.test.ts
+++ b/objectified-cli/test/versions-list-query.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from "vitest";
+
+import type { VersionSchema } from "../src/generated/models.js";
+import {
+  applyVersionsListPipeline,
+  compareSemverVersionIdsAsc,
+  parseVersionStateFilter,
+  parseVersionsSortField,
+  versionStateMembership,
+} from "../src/lib/versions/list-query.js";
+
+function V(partial: Partial<VersionSchema> & Pick<VersionSchema, "id" | "project_id" | "version_id">): VersionSchema {
+  return {
+    enabled: true,
+    published: false,
+    ...partial,
+  };
+}
+
+describe("versions list semver sort (#3208)", () => {
+  it("orders semver ids ascending", () => {
+    expect(compareSemverVersionIdsAsc("1.0.0", "2.0.0")).toBeLessThan(0);
+    expect(compareSemverVersionIdsAsc("v2.1.0", "2.0.9")).toBeGreaterThan(0);
+    expect(compareSemverVersionIdsAsc("2.2.0-rc.1", "2.2.0")).toBeLessThan(0);
+  });
+
+  it("defaults to version descending (newest semver first)", () => {
+    const rows = [
+      V({ id: "a", project_id: "p", version_id: "1.0.0" }),
+      V({ id: "b", project_id: "p", version_id: "2.0.0" }),
+      V({ id: "c", project_id: "p", version_id: "1.5.0" }),
+    ];
+    const out = applyVersionsListPipeline(rows, {
+      stateFilter: undefined,
+      sortField: "version",
+      reverse: false,
+    });
+    expect(out.map((x) => x.version_id)).toEqual(["2.0.0", "1.5.0", "1.0.0"]);
+  });
+
+  it("--reverse flips version order", () => {
+    const rows = [
+      V({ id: "a", project_id: "p", version_id: "1.0.0" }),
+      V({ id: "b", project_id: "p", version_id: "2.0.0" }),
+    ];
+    const out = applyVersionsListPipeline(rows, {
+      stateFilter: undefined,
+      sortField: "version",
+      reverse: true,
+    });
+    expect(out.map((x) => x.version_id)).toEqual(["1.0.0", "2.0.0"]);
+  });
+});
+
+describe("versions list state filter (#3208)", () => {
+  it("parses comma-separated states", () => {
+    const s = parseVersionStateFilter(" draft , FROZEN ");
+    expect(s?.has("draft")).toBe(true);
+    expect(s?.has("frozen")).toBe(true);
+    expect(s?.size).toBe(2);
+  });
+
+  it("rejects unknown state tokens", () => {
+    expect(() => parseVersionStateFilter("draft,solid")).toThrow(/Invalid --state/);
+  });
+
+  it("infers archived from lifecycle or disabled flag", () => {
+    const a = V({
+      id: "1",
+      project_id: "p",
+      version_id: "1.0.0",
+      lifecycle: "archived",
+    });
+    expect(versionStateMembership(a)).toEqual(new Set(["archived"]));
+    const b = V({ id: "2", project_id: "p", version_id: "2.0.0", enabled: false });
+    expect(versionStateMembership(b)).toEqual(new Set(["archived"]));
+  });
+
+  it("frozen published rows match frozen and published", () => {
+    const v = V({
+      id: "x",
+      project_id: "p",
+      version_id: "2.1.0",
+      published: true,
+      publishedImmutable: true,
+    });
+    const m = versionStateMembership(v);
+    expect(m.has("frozen")).toBe(true);
+    expect(m.has("published")).toBe(true);
+  });
+
+  it("filters with OR semantics", () => {
+    const rows = [
+      V({ id: "d", project_id: "p", version_id: "0.9.0", published: false }),
+      V({ id: "p", project_id: "p", version_id: "1.0.0", published: true }),
+      V({ id: "a", project_id: "p", version_id: "0.5.0", lifecycle: "archived" }),
+    ];
+    const draftOrPub = parseVersionStateFilter("draft,published");
+    if (draftOrPub === undefined) throw new Error("expected filter");
+    const out = applyVersionsListPipeline(rows, {
+      stateFilter: draftOrPub,
+      sortField: "version",
+      reverse: false,
+    });
+    expect(out.map((x) => x.id).sort()).toEqual(["d", "p"]);
+  });
+});
+
+describe("versions list sort fields (#3208)", () => {
+  it("parses sort flag", () => {
+    expect(parseVersionsSortField(undefined)).toBe("version");
+    expect(parseVersionsSortField("published_at")).toBe("published_at");
+    expect(() => parseVersionsSortField("semver")).toThrow(/Invalid --sort/);
+  });
+
+  it("sorts by published_at descending by default", () => {
+    const rows = [
+      V({
+        id: "a",
+        project_id: "p",
+        version_id: "1.0.0",
+        published: true,
+        published_at: "2026-02-18T00:00:00Z",
+      }),
+      V({
+        id: "b",
+        project_id: "p",
+        version_id: "2.0.0",
+        published: true,
+        published_at: "2026-05-04T00:00:00Z",
+      }),
+    ];
+    const out = applyVersionsListPipeline(rows, {
+      stateFilter: undefined,
+      sortField: "published_at",
+      reverse: false,
+    });
+    expect(out.map((x) => x.version_id)).toEqual(["2.0.0", "1.0.0"]);
+  });
+});

--- a/objectified-cli/test/versions-list-query.test.ts
+++ b/objectified-cli/test/versions-list-query.test.ts
@@ -137,4 +137,37 @@ describe("versions list sort fields (#3208)", () => {
     });
     expect(out.map((x) => x.version_id)).toEqual(["2.0.0", "1.0.0"]);
   });
+
+  it("applies tie-breaker direction with the primary sort", () => {
+    const rows = [
+      V({
+        id: "a",
+        project_id: "p",
+        version_id: "1.0.0",
+        published: true,
+        published_at: "2026-05-04T00:00:00Z",
+      }),
+      V({
+        id: "b",
+        project_id: "p",
+        version_id: "2.0.0",
+        published: true,
+        published_at: "2026-05-04T00:00:00Z",
+      }),
+    ];
+
+    const outDesc = applyVersionsListPipeline(rows, {
+      stateFilter: undefined,
+      sortField: "published_at",
+      reverse: false,
+    });
+    expect(outDesc.map((x) => x.version_id)).toEqual(["2.0.0", "1.0.0"]);
+
+    const outAsc = applyVersionsListPipeline(rows, {
+      stateFilter: undefined,
+      sortField: "published_at",
+      reverse: true,
+    });
+    expect(outAsc.map((x) => x.version_id)).toEqual(["1.0.0", "2.0.0"]);
+  });
 });

--- a/objectified-cli/test/versions-list.snap.test.ts
+++ b/objectified-cli/test/versions-list.snap.test.ts
@@ -94,4 +94,32 @@ describe("versions list human table snapshots (#3208)", () => {
     });
     expect(lines.join("\n")).toMatchSnapshot();
   });
+
+  it("keeps columns stable when frozen glyph is ANSI-colored", () => {
+    const revPubFrozen = "33333333-3333-3333-3333-333333333333";
+    const versions: VersionSchema[] = [
+      V({
+        id: revPubFrozen,
+        project_id: "p1",
+        version_id: "2.0.0",
+        published: true,
+        publishedImmutable: true,
+        published_at: "2026-02-18T08:00:00.000Z",
+        author: "morgan@example.com",
+      }),
+    ];
+    const lines = formatVersionsListHumanLines({
+      versions,
+      tagsByRevisionId: new Map(),
+      projectLabel: "payments-api",
+      truncated: false,
+      totalAfterPipeline: 1,
+      useGlyphForFrozen: true,
+      freezeGlyph: "\u001b[36m❄\u001b[39m",
+      freezeBracket: " [frozen]",
+    });
+
+    expect(lines[1]).toContain("\u001b[36m❄\u001b[39m");
+    expect(lines[1]).toContain("morgan@example.com");
+  });
 });

--- a/objectified-cli/test/versions-list.snap.test.ts
+++ b/objectified-cli/test/versions-list.snap.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+
+import type { VersionSchema } from "../src/generated/models.js";
+import { buildTagsByRevisionId, formatVersionsListHumanLines } from "../src/lib/versions/list-format.js";
+
+function V(partial: Partial<VersionSchema> & Pick<VersionSchema, "id" | "project_id" | "version_id">): VersionSchema {
+  return {
+    enabled: true,
+    published: false,
+    ...partial,
+  };
+}
+
+describe("versions list human table snapshots (#3208)", () => {
+  it("matches issue-style columns (80 cols) with tags joined client-side", () => {
+    const revDraft = "11111111-1111-1111-1111-111111111111";
+    const revPub = "22222222-2222-2222-2222-222222222222";
+    const revPubFrozen = "33333333-3333-3333-3333-333333333333";
+    const revArchived = "44444444-4444-4444-4444-444444444444";
+
+    const versions: VersionSchema[] = [
+      V({
+        id: revDraft,
+        project_id: "p1",
+        version_id: "2.2.0-rc.1",
+        published: false,
+        published_at: null,
+        author: "morgan@example.com",
+      }),
+      V({
+        id: revPub,
+        project_id: "p1",
+        version_id: "2.1.0",
+        published: true,
+        published_at: "2026-05-04T12:00:00.000Z",
+        author: "kenji@example.com",
+      }),
+      V({
+        id: revPubFrozen,
+        project_id: "p1",
+        version_id: "2.0.0",
+        published: true,
+        publishedImmutable: true,
+        published_at: "2026-02-18T08:00:00.000Z",
+        author: "kenji@example.com",
+      }),
+      V({
+        id: revArchived,
+        project_id: "p1",
+        version_id: "1.4.0",
+        published: true,
+        published_at: "2025-11-02T00:00:00.000Z",
+        lifecycle: "archived",
+        author: null,
+      }),
+    ];
+
+    const tagsByRevisionId = buildTagsByRevisionId([
+      {
+        id: "t1",
+        project_id: "p1",
+        version_id: revDraft,
+        name: "next",
+        immutable: false,
+        protected: false,
+      },
+      {
+        id: "t2",
+        project_id: "p1",
+        version_id: revPub,
+        name: "stable",
+        immutable: false,
+        protected: false,
+      },
+      {
+        id: "t3",
+        project_id: "p1",
+        version_id: revPub,
+        name: "latest",
+        immutable: false,
+        protected: false,
+      },
+    ]);
+
+    const lines = formatVersionsListHumanLines({
+      versions,
+      tagsByRevisionId,
+      projectLabel: "payments-api",
+      truncated: true,
+      totalAfterPipeline: 8,
+      useGlyphForFrozen: false,
+      freezeGlyph: "",
+      freezeBracket: " [frozen]",
+    });
+    expect(lines.join("\n")).toMatchSnapshot();
+  });
+});

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.97",
+  "version": "0.11.98",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -8,6 +8,7 @@ We continue to improve the platform based on your feedback with improvements and
 - MCP service is now live
 
 ## CLI
+- **`objectified-cli`**: `objectified versions list <project>` lists schema revisions from `GET /v1/versions/{tenant}/{project_id}` with tags merged from version tags, `--state` / `--limit` / `--all` / `--sort` / `--reverse`, frozen revisions marked (`❄` with color or `[frozen]` with `--no-color`), and `--json` for the filtered slice (#3208).
 - **`objectified-cli`**: `objectified projects create` adds projects via `POST /v1/projects/{tenant_slug}`—interactive `@inquirer/prompts` wizard on a TTY, or CI flags (`--name`, `--slug`, `--description`, `--domain`, `--visibility`, `--yes`); `--from-file` JSON/YAML validated with JSON Schema; `--dry-run` prints the POST body; domain ids validated against cached `GET …/domains` (fallback catalog); slug format + pre-create uniqueness (exit **6** conflict, **7** validation) (#3204).
 - **`objectified-cli`**: `objectified projects show <slug-or-id>` resolves UUID vs slug (`GET /v1/projects/{tenant}/by-slug/{slug}` or `GET /v1/projects/{tenant}/{id}`), prints rich detail with version/tag summaries and up to **10** workflow-audit rows; `--json` returns the project object plus `activity[]` (#3203).
 - **`objectified-cli`**: `objectified projects list` calls `GET /v1/projects/{tenant_slug}` with an 80-column table (slug, name, domain, versions, latest published), `--limit` / `--all`, `--sort`, `--filter`, `--search`, `--columns`, `--include-deleted`, and top-level `--json` array output (#3202).


### PR DESCRIPTION
## What changed
Implements `objectified versions list <project>` per Epic 4.1: fetches versions from `GET /v1/versions/{tenant}/{project_id}` and version tags, renders an 80-column table (version label, state, tags, publish date, author), supports `--state` (comma-separated OR filter), `--limit` (default 10) / `--all`, `--sort` (`version` | `published_at` | `created_at`), `--reverse`, and `--json` for the filtered slice. Frozen published revisions show a cyan snowflake when color is on, or `[frozen]` with `--no-color`.

## How to test
1. **Authenticate** (`objectified auth login` or API key) and **select a tenant** (`objectified tenants use <slug>`).
2. Run **`objectified versions list <project-slug>`** and confirm the table matches API data (states, tags, dates, authors).
3. Try **`--state draft,frozen`**, **`--sort published_at --reverse`**, **`--limit 5`**, and **`--all`**.
4. Run **`objectified versions list <project> --json | jq`** and confirm you get a JSON array of version objects.

## Risk / notes
- State (`draft` / `published` / `archived` / `frozen`) is derived client-side from `VersionSchema` fields (aligned with `projects show` lifecycle summaries). Tag names preserve API iteration order when merged by revision id.

Closes #3208

Made with [Cursor](https://cursor.com)