### PR TITLE
Fix #3303 - Decouple importer engine behind TransactionalClient

### DIFF
--- a/objectified-importer/package.json
+++ b/objectified-importer/package.json
@@ -17,8 +17,12 @@
     "build": "tsc --project tsconfig.json --noEmit",
     "test": "vitest run"
   },
+  "dependencies": {
+    "pg": "^8.20.0"
+  },
   "devDependencies": {
     "@types/node": "^22.10.0",
+    "@types/pg": "^8.15.5",
     "typescript": "^5.9.3",
     "vitest": "^3.2.4"
   }

--- a/objectified-importer/src/engine/import-helper.ts
+++ b/objectified-importer/src/engine/import-helper.ts
@@ -1,25 +1,7 @@
-import {
-  PoolClient,
-  getTransactionClient,
-  beginTransaction,
-  commitTransaction,
-  rollbackTransaction,
-  releaseClient,
-  createProjectTx,
-  createVersionTx,
-  createPropertyTx,
-  createClassTx,
-  addPropertyToClassTx,
-  getClassesWithPropertiesAndTagsTx,
-  getLatestVersionUuidForProjectTx,
-  listProjectLibraryPropertiesTx,
-} from './import-transaction';
+import type { ImportEngineDeps, TransactionHandle } from './transactional-client';
 import { ImportSourceKind, getImporter, NormalizedClass, NormalizedProperty } from '../parsers/index';
 import { withRetry } from '../../../objectified-ui/lib/retry';
-import { permanentDeleteProject } from '../../../objectified-ui/lib/db/helper';
 import { extractPaths, extractSecuritySchemes } from '../../../objectified-ui/src/app/utils/openapi-import';
-import { importOpenAPIPathsAndSecurity } from './import-openapi-paths-security';
-import { recordTenantRepositoryImport } from '../../../objectified-ui/lib/db/repository-import-metrics';
 
 export type ImportJobState = 'queued' | 'running' | 'pending-approval' | 'committing' | 'completed' | 'failed' | 'canceled' | 'rolled-back';
 
@@ -106,6 +88,8 @@ export interface ImportJobInput {
   };
 }
 
+export type { ImportEngineDeps, RepositoryImportLink } from './transactional-client';
+
 interface JobState {
   input: ImportJobInput;
   state: ImportJobState;
@@ -115,7 +99,7 @@ interface JobState {
   result?: { projectId?: string; versionId?: string };
   canceled?: boolean;
   // Transaction state
-  transactionClient?: PoolClient;
+  transactionClient?: TransactionHandle;
   transactionPending?: boolean;
   summary?: {
     classesCreated: number;
@@ -146,6 +130,36 @@ interface JobState {
   };
 }
 
+export interface ImportEngine {
+  startImport(input: ImportJobInput): Promise<{ jobId: string }>;
+  getImportStatus(jobId: string): Promise<{
+    jobId: string;
+    state: ImportJobState;
+    percent: number;
+    events: ImportEvent[];
+    progress?: ProgressEvent;
+    summary?: JobState['summary'];
+    transactionPending?: boolean;
+    result?: { projectId?: string; versionId?: string };
+  }>;
+  cancelImport(jobId: string): Promise<{ success: boolean }>;
+  commitImport(jobId: string): Promise<{ success: boolean; error?: string }>;
+  rollbackImport(jobId: string): Promise<{ success: boolean; error?: string }>;
+  rollbackCompletedImport(jobId: string): Promise<{ success: boolean; error?: string }>;
+  retryImport(jobId: string): Promise<{ success: boolean; jobId?: string; error?: string }>;
+}
+
+let activeImportDeps: ImportEngineDeps | null = null;
+
+function importDeps(): ImportEngineDeps {
+  if (!activeImportDeps) {
+    throw new Error(
+      'Import engine dependencies not configured. Call createImportEngine() from the application bootstrap.'
+    );
+  }
+  return activeImportDeps;
+}
+
 const jobs = new Map<string, JobState>();
 
 async function recordRepositoryImportMetricIfApplicable(job: JobState): Promise<void> {
@@ -154,21 +168,42 @@ async function recordRepositoryImportMetricIfApplicable(job: JobState): Promise<
   const projectId = job.result?.projectId;
   const versionUuid = job.result?.versionId;
   if (!projectId || !versionUuid) return;
+  const recordFn = importDeps().recordRepositoryImport;
+  if (!recordFn) return;
   try {
-    await recordTenantRepositoryImport({
-      tenantId: job.input.tenantId,
-      repositorySource: {
-        repositoryId: src.repositoryId.trim(),
-        branch: src.branch,
-        path: src.path,
-        blobSha: src.blobSha ?? null,
-      },
-      projectId,
-      versionUuid,
-      importedByUserId: job.input.userId,
-    });
+    await recordFn({
+        tenantId: job.input.tenantId,
+        repositorySource: {
+          repositoryId: src.repositoryId.trim(),
+          branch: src.branch,
+          path: src.path,
+          blobSha: src.blobSha ?? null,
+        },
+        projectId,
+        versionUuid,
+        importedByUserId: job.input.userId,
+      });
   } catch (err) {
-    console.error('[import-helper] recordTenantRepositoryImport failed:', err);
+    console.error('[import-helper] recordRepositoryImport failed:', err);
+  }
+}
+
+async function maybeImportOpenApiPaths(
+  versionId: string,
+  paths: ReturnType<typeof extractPaths>,
+  securitySchemes: ReturnType<typeof extractSecuritySchemes>,
+  job: JobState
+): Promise<void> {
+  const run = importDeps().importOpenApiPathsAndSecurity;
+  if (!run) {
+    emit(job, 'warn', 'PATHS_SKIP', 'OpenAPI paths import not configured for this engine instance.');
+    return;
+  }
+  const pathResult = await run(versionId, paths, securitySchemes);
+  if (pathResult.success) {
+    emit(job, 'info', 'PATHS_IMPORTED', 'Paths and security schemes imported.');
+  } else {
+    emit(job, 'warn', 'PATHS_IMPORT_WARN', `Paths/security import had issues: ${pathResult.error}`);
   }
 }
 
@@ -203,7 +238,7 @@ function stableStringify(obj: any): string {
 type NormalizedModel = { classes: NormalizedClass[] };
 
 async function buildPropertyIdMapForImport(
-  client: PoolClient,
+  tx: TransactionHandle,
   projectId: string,
   norm: NormalizedModel,
   job: JobState,
@@ -234,7 +269,7 @@ async function buildPropertyIdMapForImport(
   const sigToLibraryId = new Map<string, string>();
 
   if (reuseLibraryFromProject) {
-    const rows = await listProjectLibraryPropertiesTx(client, projectId);
+    const rows = await tx.listProjectLibraryPropertiesTx(projectId);
     for (const row of rows) {
       usedNames.add(row.name);
       const sig = stableStringify(row.data);
@@ -277,7 +312,7 @@ async function buildPropertyIdMapForImport(
     });
 
     const resProp = JSON.parse(
-      await createPropertyTx(client, projectId, propName, payload.description || null, payload.data)
+      await tx.createPropertyTx(projectId, propName, payload.description || null, payload.data)
     );
     if (!resProp.success) {
       emit(job, 'warn', 'PROPERTY_CREATE_WARN', `Could not create property "${propName}": ${resProp.error}`);
@@ -417,7 +452,7 @@ function verifyClass(
 
 // Main verification function - verifies imported data matches the original schema
 async function verifyImport(
-  client: PoolClient,
+  tx: TransactionHandle,
   versionId: string,
   normalizedClasses: NormalizedClass[],
   job: JobState
@@ -434,7 +469,7 @@ async function verifyImport(
   emit(job, 'info', 'VERIFY_START', `Starting import verification for ${normalizedClasses.length} classes`);
 
   // Fetch all classes with properties from database using transaction client
-  const dbClassesJson = await getClassesWithPropertiesAndTagsTx(client, versionId);
+  const dbClassesJson = await tx.getClassesWithPropertiesAndTagsTx(versionId);
   const dbClasses = JSON.parse(dbClassesJson);
 
   // Build a map of database classes by name
@@ -508,14 +543,14 @@ async function verifyImport(
 }
 
 async function writeClassWithProperties(
-  client: PoolClient,
+  tx: TransactionHandle,
   projectId: string,
   versionId: string,
   cls: NormalizedClass,
   job: JobState,
   propertyIdMap: Map<string, string>
 ) {
-  const resClass = JSON.parse(await createClassTx(client, versionId, cls.name, cls.description || null, cls.schema || { type: 'object' }));
+  const resClass = JSON.parse(await tx.createClassTx(versionId, cls.name, cls.description || null, cls.schema || { type: 'object' }));
   if (!resClass.success) throw new Error(resClass.error || 'Failed to create class');
   const classId = resClass.class.id as string;
 
@@ -550,7 +585,7 @@ async function writeClassWithProperties(
         parentId
       });
       const addRes = JSON.parse(
-        await addPropertyToClassTx(client, classId, propertyId, p.name, p.description || null, p.data, parentId)
+        await tx.addPropertyToClassTx(classId, propertyId, p.name, p.description || null, p.data, parentId)
       );
       if (!addRes.success) {
         // Graceful degradation: log and continue with remaining properties
@@ -601,7 +636,7 @@ export async function startImport(input: ImportJobInput) {
   jobs.set(jobId, job);
 
   (async () => {
-    let client: PoolClient | null = null;
+    let tx: TransactionHandle | null = null;
     const isDryRun = input.options.dryRun === true;
 
     try {
@@ -702,12 +737,12 @@ export async function startImport(input: ImportJobInput) {
       const incrementalMode = input.options.incrementalMode === true;
 
       // Get a transaction client (with retry for transient connection errors)
-      client = await withRetry(() => getTransactionClient(), {
+      tx = await withRetry(() => importDeps().txClient.connect(), {
         maxAttempts: 3,
         initialDelayMs: 500,
-        label: 'getTransactionClient'
+        label: 'txClient.connect'
       });
-      job.transactionClient = client;
+      job.transactionClient = tx;
 
       if (incrementalMode) {
         // Incremental mode: no single transaction; commit as we go and skip failures
@@ -723,7 +758,7 @@ export async function startImport(input: ImportJobInput) {
         } else {
           const resProj = JSON.parse(
             await withRetry(
-              () => createProjectTx(client!, input.tenantId, input.userId, input.project.name, input.project.description || '', input.project.slug),
+              () => tx!.createProjectTx(input.tenantId, input.userId, input.project.name, input.project.description || '', input.project.slug),
               { maxAttempts: 3, initialDelayMs: 500, label: 'createProject' }
             )
           );
@@ -735,13 +770,12 @@ export async function startImport(input: ImportJobInput) {
         setProgress(job, 'creating-version', 2, 1, input.version.versionId);
         const reuseLibraryInc = Boolean(existingInc);
         const parentVersionUuidInc = reuseLibraryInc
-          ? await getLatestVersionUuidForProjectTx(client!, projectId)
+          ? await tx!.getLatestVersionUuidForProjectTx(projectId)
           : null;
         const resVer = JSON.parse(
           await withRetry(
             () =>
-              createVersionTx(
-                client!,
+              tx!.createVersionTx(
                 projectId,
                 input.userId,
                 input.version.versionId,
@@ -762,7 +796,7 @@ export async function startImport(input: ImportJobInput) {
         });
 
         const propertyIdMapInc = await buildPropertyIdMapForImport(
-          client!,
+          tx!,
           projectId,
           norm,
           job,
@@ -775,9 +809,9 @@ export async function startImport(input: ImportJobInput) {
           if (job.canceled) throw new Error('Import canceled');
           setProgress(job, 'creating-classes', 2 + norm.classes.length, 2 + classCountInc, cls.name);
           try {
-            await beginTransaction(client!);
-            await writeClassWithProperties(client!, projectId, versionId, cls, job, propertyIdMapInc);
-            await commitTransaction(client!);
+            await tx!.begin();
+            await writeClassWithProperties(tx!, projectId, versionId, cls, job, propertyIdMapInc);
+            await tx!.commit();
             emit(job, 'info', 'CLASS_CREATED', `Imported class: ${cls.name}`);
             if (job.summary) {
               job.summary.classesCreated++;
@@ -785,7 +819,7 @@ export async function startImport(input: ImportJobInput) {
             }
           } catch (classErr: any) {
             try {
-              await rollbackTransaction(client!);
+              await tx!.rollback();
             } catch (_) { /* ignore */ }
             emit(job, 'error', 'CLASS_FAILED', `Failed to create class ${cls.name}: ${classErr?.message}`);
             if (job.summary) {
@@ -798,7 +832,7 @@ export async function startImport(input: ImportJobInput) {
 
         if (job.canceled) throw new Error('Import canceled');
         setProgress(job, 'verifying', 3 + norm.classes.length, 2 + norm.classes.length, 'Verifying import...');
-        const verificationResultInc = await verifyImport(client!, versionId, norm.classes, job);
+        const verificationResultInc = await verifyImport(tx!, versionId, norm.classes, job);
         if (job.summary) job.summary.verification = verificationResultInc;
         if (!verificationResultInc.passed && job.summary) job.summary.warnings++;
 
@@ -807,12 +841,7 @@ export async function startImport(input: ImportJobInput) {
           const securitySchemes = extractSecuritySchemes(input.document);
           if (paths.length > 0 || securitySchemes.length > 0) {
             emit(job, 'info', 'IMPORTING_PATHS', `Importing ${paths.length} path(s) and ${securitySchemes.length} security scheme(s)...`);
-            const pathResult = await importOpenAPIPathsAndSecurity(versionId, paths, securitySchemes);
-            if (pathResult.success) {
-              emit(job, 'info', 'PATHS_IMPORTED', 'Paths and security schemes imported.');
-            } else {
-              emit(job, 'warn', 'PATHS_IMPORT_WARN', `Paths/security import had issues: ${pathResult.error}`);
-            }
+            await maybeImportOpenApiPaths(versionId, paths, securitySchemes, job);
           }
         }
 
@@ -826,16 +855,16 @@ export async function startImport(input: ImportJobInput) {
           job.summary.incrementalMode = true;
         }
         emit(job, 'info', 'INCREMENTAL_COMPLETE', 'Incremental import complete. Successful classes were saved; failed classes were skipped.', job.result);
-        await releaseClient(client!);
+        await tx!.release();
         job.transactionClient = undefined;
         return;
       }
 
       // Transaction mode: single transaction, pending-approval to commit or rollback
-      await withRetry(() => beginTransaction(client!), {
+      await withRetry(() => tx!.begin(), {
         maxAttempts: 3,
         initialDelayMs: 300,
-        label: 'beginTransaction'
+        label: 'transactionHandle.begin'
       });
       job.transactionPending = true;
       emit(job, 'info', 'TRANSACTION_STARTED', 'Database transaction started - changes will be committed only after approval');
@@ -851,7 +880,7 @@ export async function startImport(input: ImportJobInput) {
       } else {
         const resProj = JSON.parse(
           await withRetry(
-            () => createProjectTx(client!, input.tenantId, input.userId, input.project.name, input.project.description || '', input.project.slug),
+            () => tx!.createProjectTx(input.tenantId, input.userId, input.project.name, input.project.description || '', input.project.slug),
             { maxAttempts: 3, initialDelayMs: 500, label: 'createProject' }
           )
         );
@@ -865,13 +894,12 @@ export async function startImport(input: ImportJobInput) {
       setProgress(job, 'creating-version', 2, 1, input.version.versionId);
       const reuseLibraryTx = Boolean(existingTx);
       const parentVersionUuidTx = reuseLibraryTx
-        ? await getLatestVersionUuidForProjectTx(client!, projectId)
+        ? await tx!.getLatestVersionUuidForProjectTx(projectId)
         : null;
       const resVer = JSON.parse(
         await withRetry(
           () =>
-            createVersionTx(
-              client!,
+            tx!.createVersionTx(
               projectId,
               input.userId,
               input.version.versionId,
@@ -891,7 +919,7 @@ export async function startImport(input: ImportJobInput) {
         parentVersionUuid: parentVersionUuidTx ?? undefined,
       });
 
-      const propertyIdMap = await buildPropertyIdMapForImport(client, projectId, norm, job, reuseLibraryTx);
+      const propertyIdMap = await buildPropertyIdMapForImport(tx!, projectId, norm, job, reuseLibraryTx);
 
       // Create classes and link properties
       setProgress(job, 'creating-classes', 2 + norm.classes.length, 2);
@@ -900,7 +928,7 @@ export async function startImport(input: ImportJobInput) {
         if (job.canceled) throw new Error('Import canceled');
         setProgress(job, 'creating-classes', 2 + norm.classes.length, 2 + classCount, cls.name);
         try {
-          await writeClassWithProperties(client, projectId, versionId, cls, job, propertyIdMap);
+          await writeClassWithProperties(tx!, projectId, versionId, cls, job, propertyIdMap);
           emit(job, 'info', 'CLASS_CREATED', `Imported class: ${cls.name}`);
           if (job.summary) {
             job.summary.classesCreated++;
@@ -920,7 +948,7 @@ export async function startImport(input: ImportJobInput) {
       if (job.canceled) throw new Error('Import canceled');
       setProgress(job, 'verifying', 3 + norm.classes.length, 2 + norm.classes.length, 'Verifying import...');
 
-      const verificationResult = await verifyImport(client, versionId, norm.classes, job);
+      const verificationResult = await verifyImport(tx!, versionId, norm.classes, job);
 
       if (job.summary) {
         job.summary.verification = verificationResult;
@@ -949,9 +977,9 @@ export async function startImport(input: ImportJobInput) {
 
     } catch (err: any) {
       // Rollback transaction on any error
-      if (client && job.transactionPending) {
+      if (tx && job.transactionPending) {
         try {
-          await rollbackTransaction(client);
+          await tx.rollback();
           job.transactionPending = false;
           emit(job, 'info', 'TRANSACTION_ROLLED_BACK', 'Transaction rolled back due to error');
         } catch (rollbackErr) {
@@ -959,13 +987,13 @@ export async function startImport(input: ImportJobInput) {
         }
       }
 
-      // Release client on error
-      if (client) {
+      // Release pooled connection on error
+      if (tx) {
         try {
-          await releaseClient(client);
+          await tx.release();
           job.transactionClient = undefined;
         } catch (releaseErr) {
-          emit(job, 'error', 'RELEASE_FAILED', `Failed to release client: ${releaseErr}`);
+          emit(job, 'error', 'RELEASE_FAILED', `Failed to release connection: ${releaseErr}`);
         }
       }
 
@@ -1003,17 +1031,17 @@ export async function commitImport(jobId: string): Promise<{ success: boolean; e
     job.state = 'committing';
     emit(job, 'info', 'COMMITTING', 'Committing import transaction...');
 
-    await withRetry(() => commitTransaction(job.transactionClient!), {
+    await withRetry(() => job.transactionClient!.commit(), {
       maxAttempts: 3,
       initialDelayMs: 500,
-      label: 'commitTransaction'
+      label: 'transactionHandle.commit'
     });
     job.transactionPending = false;
 
     emit(job, 'info', 'COMMITTED', 'Import transaction committed successfully');
 
     // Release the client
-    await releaseClient(job.transactionClient);
+    await job.transactionClient.release();
     job.transactionClient = undefined;
 
     const versionId = job.result?.versionId as string | undefined;
@@ -1022,12 +1050,7 @@ export async function commitImport(jobId: string): Promise<{ success: boolean; e
       const securitySchemes = extractSecuritySchemes(job.input.document);
       if (paths.length > 0 || securitySchemes.length > 0) {
         emit(job, 'info', 'IMPORTING_PATHS', `Importing ${paths.length} path(s) and ${securitySchemes.length} security scheme(s)...`);
-        const pathResult = await importOpenAPIPathsAndSecurity(versionId, paths, securitySchemes);
-        if (pathResult.success) {
-          emit(job, 'info', 'PATHS_IMPORTED', 'Paths and security schemes imported.');
-        } else {
-          emit(job, 'warn', 'PATHS_IMPORT_WARN', `Paths/security import had issues: ${pathResult.error}`);
-        }
+        await maybeImportOpenApiPaths(versionId, paths, securitySchemes, job);
       }
     }
 
@@ -1044,7 +1067,7 @@ export async function commitImport(jobId: string): Promise<{ success: boolean; e
     // Try to release the client
     if (job.transactionClient) {
       try {
-        await releaseClient(job.transactionClient);
+        await job.transactionClient.release();
         job.transactionClient = undefined;
       } catch (releaseErr) {
         // Ignore release errors
@@ -1079,13 +1102,12 @@ export async function rollbackImport(jobId: string): Promise<{ success: boolean;
   try {
     emit(job, 'info', 'ROLLING_BACK', 'Rolling back import transaction...');
 
-    await rollbackTransaction(job.transactionClient);
+    await job.transactionClient.rollback();
     job.transactionPending = false;
 
     emit(job, 'info', 'ROLLED_BACK', 'Import transaction rolled back - no changes were saved');
 
-    // Release the client
-    await releaseClient(job.transactionClient);
+    await job.transactionClient.release();
     job.transactionClient = undefined;
 
     job.state = 'rolled-back';
@@ -1098,7 +1120,7 @@ export async function rollbackImport(jobId: string): Promise<{ success: boolean;
     // Try to release the client
     if (job.transactionClient) {
       try {
-        await releaseClient(job.transactionClient);
+        await job.transactionClient.release();
         job.transactionClient = undefined;
       } catch (releaseErr) {
         // Ignore release errors
@@ -1131,7 +1153,14 @@ export async function rollbackCompletedImport(jobId: string): Promise<{ success:
   try {
     emit(job, 'info', 'ROLLBACK_STARTED', 'Rolling back completed import - removing imported project and data...');
 
-    const raw = await permanentDeleteProject(projectId);
+    const deleteProject = importDeps().permanentDeleteProject;
+    if (!deleteProject) {
+      return {
+        success: false,
+        error: 'Rollback completed import requires permanentDeleteProject to be configured on the import engine.',
+      };
+    }
+    const raw = await deleteProject(projectId);
     const result = typeof raw === 'string' ? JSON.parse(raw) : raw;
     if (!result.success) {
       emit(job, 'error', 'ROLLBACK_FAILED', result.error || 'Failed to delete project');
@@ -1197,5 +1226,18 @@ export async function cancelImport(jobId: string) {
   }
 
   return { success: true };
+}
+
+export function createImportEngine(deps: ImportEngineDeps): ImportEngine {
+  activeImportDeps = deps;
+  return {
+    startImport,
+    getImportStatus,
+    cancelImport,
+    commitImport,
+    rollbackImport,
+    rollbackCompletedImport,
+    retryImport,
+  };
 }
 

--- a/objectified-importer/src/engine/import-helper.ts
+++ b/objectified-importer/src/engine/import-helper.ts
@@ -1,5 +1,6 @@
 import type { ImportEngineDeps, TransactionHandle } from './transactional-client';
-import { ImportSourceKind, getImporter, NormalizedClass, NormalizedProperty } from '../parsers/index';
+import { getImporter } from '../parsers/index';
+import type { ImportSourceKind, NormalizedClass, NormalizedProperty } from '../parsers/index';
 import { withRetry } from '../../../objectified-ui/lib/retry';
 import { extractPaths, extractSecuritySchemes } from '../../../objectified-ui/src/app/utils/openapi-import';
 

--- a/objectified-importer/src/engine/import-openapi-paths-security.ts
+++ b/objectified-importer/src/engine/import-openapi-paths-security.ts
@@ -3,7 +3,7 @@
  * Call after importProjectFromOpenAPI when the spec contains paths or components.securitySchemes.
  */
 
-import type { ParsedPath, ParsedSecurityScheme } from '../../../objectified-ui/src/app/utils/openapi-import';
+import type { ParsedPath, ParsedSecurityScheme } from './transactional-client';
 
 export type OpenApiPathsPgClient = {
   query: (text: string, params?: unknown[]) => Promise<unknown>;
@@ -322,6 +322,12 @@ export async function importOpenAPIPathsAndSecurityWithPool(
   paths: ParsedPath[],
   securitySchemes: ParsedSecurityScheme[]
 ): Promise<{ success: boolean; error?: string }> {
+  if (!versionId?.trim()) {
+    return { success: false, error: 'versionId is required' };
+  }
+  if (!paths?.length && !securitySchemes?.length) {
+    return { success: false, error: 'No paths or security schemes to import' };
+  }
   const client = await pool.connect();
   try {
     await client.query('BEGIN');

--- a/objectified-importer/src/engine/import-openapi-paths-security.ts
+++ b/objectified-importer/src/engine/import-openapi-paths-security.ts
@@ -4,10 +4,14 @@
  */
 
 import type { ParsedPath, ParsedSecurityScheme } from '../../../objectified-ui/src/app/utils/openapi-import';
-import { createImporterEngineRequire } from './importer-node-require';
 
-const nodeRequire = createImporterEngineRequire();
-const connectionPool = nodeRequire('../../../objectified-ui/lib/db/db');
+export type OpenApiPathsPgClient = {
+  query: (text: string, params?: unknown[]) => Promise<unknown>;
+};
+
+export type OpenApiPathsPgPool = {
+  connect: () => Promise<OpenApiPathsPgClient & { release: () => void }>;
+};
 
 function getRefSchemaName(ref: string | undefined): string | null {
   if (!ref || typeof ref !== 'string') return null;
@@ -15,11 +19,8 @@ function getRefSchemaName(ref: string | undefined): string | null {
   return m ? m[1] : null;
 }
 
-/**
- * Import security schemes into version_security_scheme for the given version.
- */
 async function importSecuritySchemes(
-  client: any,
+  client: OpenApiPathsPgClient,
   versionId: string,
   schemes: ParsedSecurityScheme[]
 ): Promise<void> {
@@ -52,284 +53,290 @@ async function importSecuritySchemes(
 }
 
 /**
- * Import paths, operations, parameters, request bodies, and responses.
- * Resolves $ref to class_id when the referenced class exists in the version.
+ * Core paths/security write logic (no transaction boundaries — caller wraps BEGIN/COMMIT).
  */
-export async function importOpenAPIPathsAndSecurity(
+export async function importOpenApiPathsCore(
+  client: OpenApiPathsPgClient,
   versionId: string,
   paths: ParsedPath[],
   securitySchemes: ParsedSecurityScheme[]
-): Promise<{ success: boolean; error?: string }> {
-  const client = await connectionPool.connect();
-  try {
-    await client.query('BEGIN');
+): Promise<void> {
+  if (securitySchemes.length > 0) {
+    await importSecuritySchemes(client, versionId, securitySchemes);
+  }
 
-    if (securitySchemes.length > 0) {
-      await importSecuritySchemes(client, versionId, securitySchemes);
-    }
+  const classRows = await client.query('SELECT id, name FROM odb.classes WHERE version_id = $1', [versionId]);
+  const rows = (classRows as { rows: Array<{ id: string; name: string }> }).rows;
+  const classNameToId = new Map<string, string>();
+  for (const r of rows) {
+    classNameToId.set(r.name, r.id);
+  }
 
-    const classRows = await client.query(
-      'SELECT id, name FROM odb.classes WHERE version_id = $1',
-      [versionId]
+  for (const pathItem of paths) {
+    const pathRes = await client.query(
+      `INSERT INTO odb.version_path (version_id, pathname, metadata)
+       VALUES ($1, $2, $3)
+       RETURNING id`,
+      [
+        versionId,
+        pathItem.path,
+        pathItem.summary || pathItem.description
+          ? JSON.stringify({ summary: pathItem.summary, description: pathItem.description })
+          : null,
+      ]
     );
-    const classNameToId = new Map<string, string>();
-    for (const r of classRows.rows) {
-      classNameToId.set(r.name, r.id);
+    const versionPathId = (pathRes as { rows: Array<{ id: string }> }).rows[0].id;
+
+    const paramIdsByKey = new Map<string, string>();
+    const buildParamData = (p: { schema?: Record<string, unknown>; required?: boolean }) => {
+      const base = p.schema && typeof p.schema === 'object' ? { ...p.schema } : { type: 'string' };
+      if (p.required === true) (base as Record<string, unknown>).required = true;
+      return base;
+    };
+    if (pathItem.parameters?.length) {
+      for (const p of pathItem.parameters) {
+        const inLoc = (p.in || 'query') as 'path' | 'query' | 'header' | 'cookie';
+        const key = `${p.name}:${inLoc}`;
+        const data = buildParamData(p);
+        const pr = await client.query(
+          `INSERT INTO odb.shared_path_parameter (version_path_id, name, in_location, summary, description, data)
+           VALUES ($1, $2, $3, $4, $5, $6)
+           ON CONFLICT (version_path_id, name, in_location) DO UPDATE SET description = EXCLUDED.description, data = EXCLUDED.data
+           RETURNING id`,
+          [versionPathId, p.name, inLoc, null, p.description || null, JSON.stringify(data)]
+        );
+        paramIdsByKey.set(key, (pr as { rows: Array<{ id: string }> }).rows[0].id);
+      }
     }
 
-    for (const pathItem of paths) {
-      const pathRes = await client.query(
-        `INSERT INTO odb.version_path (version_id, pathname, metadata)
+    for (const op of pathItem.operations) {
+      const opRes = await client.query(
+        `INSERT INTO odb.path_operation (version_path_id, operation, metadata)
          VALUES ($1, $2, $3)
          RETURNING id`,
-        [versionId, pathItem.path, pathItem.summary || pathItem.description ? JSON.stringify({ summary: pathItem.summary, description: pathItem.description }) : null]
+        [versionPathId, op.method, op.deprecated ? JSON.stringify({ deprecated: true }) : null]
       );
-      const versionPathId = pathRes.rows[0].id;
+      const pathOperationId = (opRes as { rows: Array<{ id: string }> }).rows[0].id;
 
-      const paramIdsByKey = new Map<string, string>();
-      const buildParamData = (p: { schema?: Record<string, unknown>; required?: boolean }) => {
-        const base = p.schema && typeof p.schema === 'object' ? { ...p.schema } : { type: 'string' };
-        if (p.required === true) (base as Record<string, unknown>).required = true;
-        return base;
-      };
-      if (pathItem.parameters?.length) {
-        for (const p of pathItem.parameters) {
-          const inLoc = (p.in || 'query') as 'path' | 'query' | 'header' | 'cookie';
-          const key = `${p.name}:${inLoc}`;
+      const descMetadata: Record<string, unknown> = {};
+      if (op.tags?.length) descMetadata.tags = op.tags;
+      if (op.deprecated === true) descMetadata.deprecated = true;
+      await client.query(
+        `INSERT INTO odb.path_operation_description (path_operation_id, summary, description, operation_id, metadata)
+         VALUES ($1, $2, $3, $4, $5)
+         ON CONFLICT (path_operation_id) DO UPDATE SET summary = EXCLUDED.summary, description = EXCLUDED.description, operation_id = EXCLUDED.operation_id, metadata = EXCLUDED.metadata`,
+        [
+          pathOperationId,
+          op.summary ?? null,
+          op.description ?? null,
+          op.operationId ?? null,
+          Object.keys(descMetadata).length > 0 ? JSON.stringify(descMetadata) : null,
+        ]
+      );
+
+      const allParams = op.parameters || [];
+      for (const p of allParams) {
+        const inLoc = (p.in || 'query') as 'path' | 'query' | 'header' | 'cookie';
+        const key = `${p.name}:${inLoc}`;
+        let paramId = paramIdsByKey.get(key);
+        if (!paramId) {
           const data = buildParamData(p);
           const pr = await client.query(
             `INSERT INTO odb.shared_path_parameter (version_path_id, name, in_location, summary, description, data)
              VALUES ($1, $2, $3, $4, $5, $6)
-             ON CONFLICT (version_path_id, name, in_location) DO UPDATE SET description = EXCLUDED.description, data = EXCLUDED.data
              RETURNING id`,
             [versionPathId, p.name, inLoc, null, p.description || null, JSON.stringify(data)]
           );
-          paramIdsByKey.set(key, pr.rows[0].id);
+          const insertedId = (pr as { rows: Array<{ id?: string }> }).rows[0]?.id;
+          if (typeof insertedId !== 'string') throw new Error('Insert shared_path_parameter failed');
+          paramId = insertedId;
+          paramIdsByKey.set(key, paramId);
         }
+        await client.query(
+          `INSERT INTO odb.path_operation_parameter_link (path_operation_id, shared_path_parameter_id, metadata)
+           VALUES ($1, $2, $3)
+           ON CONFLICT (path_operation_id, shared_path_parameter_id) DO NOTHING`,
+          [pathOperationId, paramId, null]
+        );
       }
 
-      for (const op of pathItem.operations) {
-        const opRes = await client.query(
-          `INSERT INTO odb.path_operation (version_path_id, operation, metadata)
-           VALUES ($1, $2, $3)
+      if (op.requestBody?.content && Object.keys(op.requestBody.content).length > 0) {
+        const rbName = op.operationId
+          ? op.operationId
+          : `RequestBody_${op.method}_${(pathItem.path.replace(/^\//, '').replace(/\//g, '_') || 'root')}`;
+        const rbRes = await client.query(
+          `INSERT INTO odb.shared_path_request_body (version_path_id, name, description, required)
+           VALUES ($1, $2, $3, $4)
            RETURNING id`,
-          [versionPathId, op.method, op.deprecated ? JSON.stringify({ deprecated: true }) : null]
-        );
-        const pathOperationId = opRes.rows[0].id;
-
-        const descMetadata: Record<string, unknown> = {};
-        if (op.tags?.length) descMetadata.tags = op.tags;
-        if (op.deprecated === true) descMetadata.deprecated = true;
-        await client.query(
-          `INSERT INTO odb.path_operation_description (path_operation_id, summary, description, operation_id, metadata)
-           VALUES ($1, $2, $3, $4, $5)
-           ON CONFLICT (path_operation_id) DO UPDATE SET summary = EXCLUDED.summary, description = EXCLUDED.description, operation_id = EXCLUDED.operation_id, metadata = EXCLUDED.metadata`,
           [
-            pathOperationId,
-            op.summary ?? null,
-            op.description ?? null,
-            op.operationId ?? null,
-            Object.keys(descMetadata).length > 0 ? JSON.stringify(descMetadata) : null,
+            versionPathId,
+            rbName,
+            op.requestBody.description ?? null,
+            op.requestBody.required === true,
           ]
         );
-
-        const allParams = op.parameters || [];
-        for (const p of allParams) {
-          const inLoc = (p.in || 'query') as 'path' | 'query' | 'header' | 'cookie';
-          const key = `${p.name}:${inLoc}`;
-          let paramId = paramIdsByKey.get(key);
-          if (!paramId) {
-            const data = buildParamData(p);
-            const pr = await client.query(
-              `INSERT INTO odb.shared_path_parameter (version_path_id, name, in_location, summary, description, data)
-               VALUES ($1, $2, $3, $4, $5, $6)
-               RETURNING id`,
-              [versionPathId, p.name, inLoc, null, p.description || null, JSON.stringify(data)]
+        const requestBodyId = (rbRes as { rows: Array<{ id: string }> }).rows[0].id;
+        for (const [mediaType, content] of Object.entries(op.requestBody!.content)) {
+          const refName = content.$ref ? getRefSchemaName(content.$ref) : null;
+          const classId = refName ? classNameToId.get(refName) ?? null : null;
+          const inlineSchema = !content.$ref && content.schema
+            ? content.schema.type === 'object' && content.schema.properties
+              ? {
+                  type: 'object',
+                  properties: Object.entries(content.schema.properties).map(([name, schema]: [string, unknown]) => ({
+                    id: `prop-${name}`,
+                    name,
+                    data: schema || { type: 'string' },
+                    parent_id: null,
+                  })),
+                }
+              : { type: (content.schema as { type?: string }).type || 'object', properties: [] }
+            : null;
+          if (classId || inlineSchema) {
+            await client.query(
+              `INSERT INTO odb.shared_path_request_body_content 
+               (shared_path_request_body_id, media_type, class_id, inline_schema)
+               VALUES ($1, $2, $3, $4)`,
+              [requestBodyId, mediaType, classId, inlineSchema ? JSON.stringify(inlineSchema) : null]
             );
-            const insertedId = pr.rows[0]?.id;
-            if (typeof insertedId !== 'string') throw new Error('Insert shared_path_parameter failed');
-            paramId = insertedId;
-            paramIdsByKey.set(key, paramId);
           }
-          await client.query(
-            `INSERT INTO odb.path_operation_parameter_link (path_operation_id, shared_path_parameter_id, metadata)
-             VALUES ($1, $2, $3)
-             ON CONFLICT (path_operation_id, shared_path_parameter_id) DO NOTHING`,
-            [pathOperationId, paramId, null]
-          );
         }
+        await client.query(
+          `INSERT INTO odb.path_operation_request_body_link (path_operation_id, shared_path_request_body_id, metadata)
+           VALUES ($1, $2, $3)
+           ON CONFLICT (path_operation_id) DO UPDATE SET shared_path_request_body_id = EXCLUDED.shared_path_request_body_id`,
+          [pathOperationId, requestBodyId, null]
+        );
+      }
 
-        if (op.requestBody?.content && Object.keys(op.requestBody.content).length > 0) {
-          const rbName = op.operationId
-            ? op.operationId
-            : `RequestBody_${op.method}_${(pathItem.path.replace(/^\//, '').replace(/\//g, '_') || 'root')}`;
-          const rbRes = await client.query(
-            `INSERT INTO odb.shared_path_request_body (version_path_id, name, description, required)
-             VALUES ($1, $2, $3, $4)
-             RETURNING id`,
-            [
-              versionPathId,
-              rbName,
-              op.requestBody.description ?? null,
-              op.requestBody.required === true,
-            ]
-          );
-          const requestBodyId = rbRes.rows[0].id;
-          for (const [mediaType, content] of Object.entries(op.requestBody!.content)) {
-            const refName = content.$ref ? getRefSchemaName(content.$ref) : null;
-            const classId = refName ? classNameToId.get(refName) ?? null : null;
-            const inlineSchema = !content.$ref && content.schema
-              ? (content.schema.type === 'object' && content.schema.properties
-                  ? { type: 'object', properties: Object.entries(content.schema.properties).map(([name, schema]: [string, any]) => ({
-                      id: `prop-${name}`,
-                      name,
-                      data: schema || { type: 'string' },
-                      parent_id: null,
-                    })) }
-                  : { type: (content.schema as any).type || 'object', properties: [] })
-              : null;
-            if (classId || inlineSchema) {
-              await client.query(
-                `INSERT INTO odb.shared_path_request_body_content 
-                 (shared_path_request_body_id, media_type, class_id, inline_schema)
-                 VALUES ($1, $2, $3, $4)`,
-                [
-                  requestBodyId,
-                  mediaType,
-                  classId,
-                  inlineSchema ? JSON.stringify(inlineSchema) : null,
-                ]
-              );
-            }
-          }
-          await client.query(
-            `INSERT INTO odb.path_operation_request_body_link (path_operation_id, shared_path_request_body_id, metadata)
-             VALUES ($1, $2, $3)
-             ON CONFLICT (path_operation_id) DO UPDATE SET shared_path_request_body_id = EXCLUDED.shared_path_request_body_id`,
-            [pathOperationId, requestBodyId, null]
-          );
-        }
-
-        if (op.responses && Object.keys(op.responses).length > 0) {
-          for (const [statusCode, res] of Object.entries(op.responses)) {
-            const hasContent = res.content && typeof res.content === 'object' && Object.keys(res.content).length > 0;
-            const contentEntries = hasContent ? Object.entries(res.content!) : [];
-            const dataObj: Record<string, unknown> = {};
-            if (res.headers && Object.keys(res.headers || {}).length > 0) dataObj.headers = res.headers;
-            if (res.links && Object.keys(res.links || {}).length > 0) dataObj.links = res.links;
-            let classId: string | null = null;
-            let inlineSchema: Record<string, unknown> | null = null;
-            let schemaMode: 'class' | 'object' = 'object';
-            if (contentEntries.length > 0) {
-              const [, firstMediaObj] = contentEntries[0];
-              const refName = firstMediaObj?.$ref ? getRefSchemaName(firstMediaObj.$ref) : null;
-              classId = refName ? classNameToId.get(refName) ?? null : null;
-              if (!firstMediaObj?.$ref && firstMediaObj?.schema) {
-                const s = firstMediaObj.schema as any;
-                inlineSchema = s.type === 'object' && s.properties
-                  ? { type: 'object', properties: Object.entries(s.properties).map(([name, schema]: [string, any]) => ({
-                      id: `prop-${name}`,
-                      name,
-                      data: schema || { type: 'string' },
-                      parent_id: null,
-                    })) }
-                  : { type: s?.type || 'object', properties: [] };
-              } else {
-                inlineSchema = { type: 'object', properties: [] };
-              }
-              schemaMode = classId ? 'class' : 'object';
-            }
-            const responseData = Object.keys(dataObj).length > 0 ? JSON.stringify(dataObj) : (hasContent ? null : '{}');
-            const responseClassId = classId ?? null;
-            const responseInlineSchema = classId ? null : (inlineSchema ? JSON.stringify(inlineSchema) : null);
-            const respRes = await client.query(
-              `INSERT INTO odb.shared_path_response (version_path_id, status_code, description, data, class_id, inline_schema, schema_mode)
-               VALUES ($1, $2, $3, $4, $5, $6, $7)
-               ON CONFLICT (version_path_id, status_code) DO UPDATE SET
-                 description = EXCLUDED.description,
-                 data = COALESCE(EXCLUDED.data, odb.shared_path_response.data),
-                 class_id = COALESCE(EXCLUDED.class_id, odb.shared_path_response.class_id),
-                 inline_schema = COALESCE(EXCLUDED.inline_schema, odb.shared_path_response.inline_schema),
-                 schema_mode = COALESCE(EXCLUDED.schema_mode, odb.shared_path_response.schema_mode)
-               RETURNING id`,
-              [
-                versionPathId,
-                statusCode,
-                res.description ?? null,
-                responseData,
-                responseClassId,
-                responseInlineSchema,
-                schemaMode,
-              ]
-            );
-            const responseId = respRes.rows[0].id;
-            for (const [mediaType, mediaObj] of contentEntries) {
-              const refName = mediaObj?.$ref ? getRefSchemaName(mediaObj.$ref) : null;
-              const ctClassId = refName ? classNameToId.get(refName) ?? null : null;
-              const ctInlineSchema = !mediaObj?.$ref && mediaObj?.schema
-                ? ((mediaObj.schema as any).type === 'object' && (mediaObj.schema as any).properties
-                    ? { type: 'object', properties: Object.entries((mediaObj.schema as any).properties).map(([name, schema]: [string, any]) => ({
+      if (op.responses && Object.keys(op.responses).length > 0) {
+        for (const [statusCode, res] of Object.entries(op.responses)) {
+          const hasContent = res.content && typeof res.content === 'object' && Object.keys(res.content).length > 0;
+          const contentEntries = hasContent ? Object.entries(res.content!) : [];
+          const dataObj: Record<string, unknown> = {};
+          if (res.headers && Object.keys(res.headers || {}).length > 0) dataObj.headers = res.headers;
+          if (res.links && Object.keys(res.links || {}).length > 0) dataObj.links = res.links;
+          let classId: string | null = null;
+          let inlineSchema: Record<string, unknown> | null = null;
+          let schemaMode: 'class' | 'object' = 'object';
+          if (contentEntries.length > 0) {
+            const [, firstMediaObj] = contentEntries[0];
+            const refName = firstMediaObj?.$ref ? getRefSchemaName(firstMediaObj.$ref) : null;
+            classId = refName ? classNameToId.get(refName) ?? null : null;
+            if (!firstMediaObj?.$ref && firstMediaObj?.schema) {
+              const s = firstMediaObj.schema as {
+                type?: string;
+                properties?: Record<string, unknown>;
+              };
+              inlineSchema =
+                s.type === 'object' && s.properties
+                  ? {
+                      type: 'object',
+                      properties: Object.entries(s.properties).map(([name, schema]: [string, unknown]) => ({
                         id: `prop-${name}`,
                         name,
                         data: schema || { type: 'string' },
                         parent_id: null,
-                      })) }
-                    : { type: (mediaObj.schema as any)?.type || 'object', properties: [] })
-                : { type: 'object', properties: [] };
-              const existingContent = await client.query(
-                'SELECT id FROM odb.shared_path_response_content WHERE shared_path_response_id = $1 AND media_type = $2',
-                [responseId, mediaType]
-              );
-              if (existingContent.rows.length === 0) {
-                await client.query(
-                  `INSERT INTO odb.shared_path_response_content (shared_path_response_id, media_type, class_id, inline_schema)
-                   VALUES ($1, $2, $3, $4)`,
-                  [
-                    responseId,
-                    mediaType,
-                    ctClassId,
-                    ctClassId ? null : JSON.stringify(ctInlineSchema),
-                  ]
-                );
-              }
+                      })),
+                    }
+                  : { type: s?.type || 'object', properties: [] };
+            } else {
+              inlineSchema = { type: 'object', properties: [] };
             }
-            await client.query(
-              `INSERT INTO odb.path_operation_response_link (path_operation_id, shared_path_response_id, metadata)
-               VALUES ($1, $2, $3)
-               ON CONFLICT (path_operation_id, shared_path_response_id) DO NOTHING`,
-              [pathOperationId, responseId, null]
-            );
+            schemaMode = classId ? 'class' : 'object';
           }
+          const responseData =
+            Object.keys(dataObj).length > 0 ? JSON.stringify(dataObj) : hasContent ? null : '{}';
+          const responseClassId = classId ?? null;
+          const responseInlineSchema = classId ? null : inlineSchema ? JSON.stringify(inlineSchema) : null;
+          const respRes = await client.query(
+            `INSERT INTO odb.shared_path_response (version_path_id, status_code, description, data, class_id, inline_schema, schema_mode)
+             VALUES ($1, $2, $3, $4, $5, $6, $7)
+             ON CONFLICT (version_path_id, status_code) DO UPDATE SET
+               description = EXCLUDED.description,
+               data = COALESCE(EXCLUDED.data, odb.shared_path_response.data),
+               class_id = COALESCE(EXCLUDED.class_id, odb.shared_path_response.class_id),
+               inline_schema = COALESCE(EXCLUDED.inline_schema, odb.shared_path_response.inline_schema),
+               schema_mode = COALESCE(EXCLUDED.schema_mode, odb.shared_path_response.schema_mode)
+             RETURNING id`,
+            [
+              versionPathId,
+              statusCode,
+              res.description ?? null,
+              responseData,
+              responseClassId,
+              responseInlineSchema,
+              schemaMode,
+            ]
+          );
+          const responseId = (respRes as { rows: Array<{ id: string }> }).rows[0].id;
+          for (const [mediaType, mediaObj] of contentEntries) {
+            const refName = mediaObj?.$ref ? getRefSchemaName(mediaObj.$ref) : null;
+            const ctClassId = refName ? classNameToId.get(refName) ?? null : null;
+            const ctInlineSchema = !mediaObj?.$ref && mediaObj?.schema
+              ? (mediaObj.schema as { type?: string; properties?: Record<string, unknown> }).type === 'object' &&
+                  (mediaObj.schema as { properties?: Record<string, unknown> }).properties
+                ? {
+                    type: 'object',
+                    properties: Object.entries(
+                      (mediaObj.schema as { properties: Record<string, unknown> }).properties
+                    ).map(([name, schema]: [string, unknown]) => ({
+                      id: `prop-${name}`,
+                      name,
+                      data: schema || { type: 'string' },
+                      parent_id: null,
+                    })),
+                  }
+                : {
+                    type: (mediaObj.schema as { type?: string })?.type || 'object',
+                    properties: [],
+                  }
+              : { type: 'object', properties: [] };
+            const existingContent = await client.query(
+              'SELECT id FROM odb.shared_path_response_content WHERE shared_path_response_id = $1 AND media_type = $2',
+              [responseId, mediaType]
+            );
+            if ((existingContent as { rows: unknown[] }).rows.length === 0) {
+              await client.query(
+                `INSERT INTO odb.shared_path_response_content (shared_path_response_id, media_type, class_id, inline_schema)
+                 VALUES ($1, $2, $3, $4)`,
+                [responseId, mediaType, ctClassId, ctClassId ? null : JSON.stringify(ctInlineSchema)]
+              );
+            }
+          }
+          await client.query(
+            `INSERT INTO odb.path_operation_response_link (path_operation_id, shared_path_response_id, metadata)
+             VALUES ($1, $2, $3)
+             ON CONFLICT (path_operation_id, shared_path_response_id) DO NOTHING`,
+            [pathOperationId, responseId, null]
+          );
         }
       }
     }
-
-    await client.query('COMMIT');
-    return { success: true };
-  } catch (err: any) {
-    try {
-      await client.query('ROLLBACK');
-    } catch {}
-    return { success: false, error: err?.message || 'Import paths/security failed' };
-  } finally {
-    client.release();
   }
 }
 
-/**
- * Server action: import paths and security schemes from OpenAPI into an existing version (#566).
- * Call from Paths Designer to capture paths from a pasted/uploaded spec.
- */
-export async function importPathsFromOpenAPIForVersion(
+export async function importOpenAPIPathsAndSecurityWithPool(
+  pool: OpenApiPathsPgPool,
   versionId: string,
   paths: ParsedPath[],
   securitySchemes: ParsedSecurityScheme[]
 ): Promise<{ success: boolean; error?: string }> {
-  if (!versionId) {
-    return { success: false, error: 'Version is required' };
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    await importOpenApiPathsCore(client, versionId, paths, securitySchemes);
+    await client.query('COMMIT');
+    return { success: true };
+  } catch (err: unknown) {
+    try {
+      await client.query('ROLLBACK');
+    } catch {
+      /* ignore */
+    }
+    const message = err instanceof Error ? err.message : String(err);
+    return { success: false, error: message || 'Import paths/security failed' };
+  } finally {
+    client.release();
   }
-  if (!paths?.length && !securitySchemes?.length) {
-    return { success: false, error: 'Spec has no paths or security schemes to import' };
-  }
-  return importOpenAPIPathsAndSecurity(versionId, paths || [], securitySchemes || []);
 }

--- a/objectified-importer/src/engine/import-transaction.ts
+++ b/objectified-importer/src/engine/import-transaction.ts
@@ -1,64 +1,50 @@
 /**
- * Transaction-aware database functions for imports.
- * These functions accept an optional client parameter to run within a transaction.
+ * Legacy transaction helpers bound to the UI pool singleton (dynamic require).
+ * Prefer {@link PgTransactionalClient} with an injected {@link Pool} for new code.
  */
 
-import { getPlanBlockMessageForNewProject, getPlanBlockMessageForNewVersion } from '../../../objectified-ui/lib/db/plan-entitlements';
 import { createImporterEngineRequire } from './importer-node-require';
+import type { PgQueryable } from './pg-client';
+import {
+  addPropertyToClassTx as pgAddPropertyToClassTx,
+  beginTransaction as pgBeginTransaction,
+  commitTransaction as pgCommitTransaction,
+  createClassTx as pgCreateClassTx,
+  createProjectTx as pgCreateProjectTx,
+  createPropertyTx as pgCreatePropertyTx,
+  createVersionTx as pgCreateVersionTx,
+  getClassesWithPropertiesAndTagsTx as pgGetClassesWithPropertiesAndTagsTx,
+  getLatestVersionUuidForProjectTx as pgGetLatestVersionUuidForProjectTx,
+  listProjectLibraryPropertiesTx as pgListProjectLibraryPropertiesTx,
+  releaseClient as pgReleaseClient,
+  rollbackTransaction as pgRollbackTransaction,
+} from './pg-client';
 
 const nodeRequire = createImporterEngineRequire();
 const connectionPool = nodeRequire('../../../objectified-ui/lib/db/db');
 
-// Type for a Postgres client (from pool)
-export type PoolClient = {
-  query: (text: string, params?: any[]) => Promise<any>;
-  release: () => void;
-};
+export type PoolClient = PgQueryable;
 
-// Helper to standardize responses
-const errorResponse = (error: string) => JSON.stringify({ success: false, error });
-const successResponse = (data: any = {}) => JSON.stringify({ success: true, ...data });
-
-// Get a new client from the pool for transaction use
 export async function getTransactionClient(): Promise<PoolClient> {
   return connectionPool.connect();
 }
 
-// Begin a transaction
 export async function beginTransaction(client: PoolClient): Promise<void> {
-  await client.query('BEGIN');
+  return pgBeginTransaction(client);
 }
 
-// Commit a transaction
 export async function commitTransaction(client: PoolClient): Promise<void> {
-  await client.query('COMMIT');
+  return pgCommitTransaction(client);
 }
 
-// Rollback a transaction
 export async function rollbackTransaction(client: PoolClient): Promise<void> {
-  await client.query('ROLLBACK');
+  return pgRollbackTransaction(client);
 }
 
-// Release client back to pool
 export async function releaseClient(client: PoolClient): Promise<void> {
-  client.release();
+  return pgReleaseClient(client);
 }
 
-// Slug validation helper
-function validateSlug(slug: string): string | null {
-  if (!slug) return 'Slug is required';
-  if (slug.length < 2) return 'Slug must be at least 2 characters';
-  if (slug.length > 100) return 'Slug must be 100 characters or less';
-  if (!/^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]$/.test(slug)) {
-    return 'Slug must start and end with a letter or number, and contain only lowercase letters, numbers, and hyphens';
-  }
-  if (/--/.test(slug)) return 'Slug cannot contain consecutive hyphens';
-  return null;
-}
-
-/**
- * Create a project within a transaction
- */
 export async function createProjectTx(
   client: PoolClient,
   tenantId: string,
@@ -66,42 +52,11 @@ export async function createProjectTx(
   name: string,
   description: string,
   slug: string,
-  metadata?: any
+  metadata?: unknown
 ): Promise<string> {
-  try {
-    if (!name?.trim()) return errorResponse('Project name is required');
-    if (!slug?.trim()) return errorResponse('Project slug is required');
-    const slugError = validateSlug(slug.trim());
-    if (slugError) return errorResponse(slugError);
-
-    const planErr = await getPlanBlockMessageForNewProject(creatorId, client);
-    if (planErr) return errorResponse(planErr);
-
-    const result = await client.query(
-      `INSERT INTO odb.projects (tenant_id, creator_id, name, description, slug, metadata) 
-       VALUES ($1, $2, $3, $4, $5, $6) RETURNING *`,
-      [tenantId, creatorId, name.trim(), description?.trim() || null, slug.trim().toLowerCase(), metadata ? JSON.stringify(metadata) : '{}']
-    );
-    return successResponse({ project: result.rows[0] });
-  } catch (error: any) {
-    if (error.code === '23505') return errorResponse('A project with this slug already exists in this tenant');
-    if (error.code === '23503') {
-      // Foreign key constraint violation
-      if (error.constraint === 'projects_tenant_id_fkey') {
-        return errorResponse('Invalid tenant ID. The tenant may no longer exist or you may need to switch to a valid tenant.');
-      }
-      if (error.constraint === 'projects_creator_id_fkey') {
-        return errorResponse('Invalid user ID. Please try logging out and back in.');
-      }
-      return errorResponse(`Database constraint error: ${error.detail || error.message}`);
-    }
-    return errorResponse(error.message);
-  }
+  return pgCreateProjectTx(client, tenantId, creatorId, name, description, slug, metadata);
 }
 
-/**
- * Create a version within a transaction
- */
 export async function createVersionTx(
   client: PoolClient,
   projectId: string,
@@ -111,259 +66,55 @@ export async function createVersionTx(
   changeLog: string,
   opts?: { parentVersionUuid?: string | null }
 ): Promise<string> {
-  try {
-    if (!versionId?.trim()) return errorResponse('Version ID is required');
-
-    const planErr = await getPlanBlockMessageForNewVersion(creatorId, client);
-    if (planErr) return errorResponse(planErr);
-
-    const parentUuid = opts?.parentVersionUuid?.trim() || null;
-    const result = parentUuid
-      ? await client.query(
-          `INSERT INTO odb.versions (project_id, creator_id, version_id, description, change_log, parent_version_id) 
-           VALUES ($1, $2, $3, $4, $5, $6) RETURNING *`,
-          [
-            projectId,
-            creatorId,
-            versionId.trim(),
-            description?.trim() || null,
-            changeLog?.trim() || null,
-            parentUuid,
-          ]
-        )
-      : await client.query(
-          `INSERT INTO odb.versions (project_id, creator_id, version_id, description, change_log) 
-           VALUES ($1, $2, $3, $4, $5) RETURNING *`,
-          [projectId, creatorId, versionId.trim(), description?.trim() || null, changeLog?.trim() || null]
-        );
-    return successResponse({ version: result.rows[0] });
-  } catch (error: any) {
-    if (error.code === '23505') return errorResponse('A version with this ID already exists in this project');
-    return errorResponse(error.message);
-  }
+  return pgCreateVersionTx(client, projectId, creatorId, versionId, description, changeLog, opts);
 }
 
-/** Latest non-deleted revision (versions.id) for a project — used as parent for incremental catalog imports. */
 export async function getLatestVersionUuidForProjectTx(
   client: PoolClient,
   projectId: string
 ): Promise<string | null> {
-  const result = await client.query(
-    `SELECT id FROM odb.versions
-     WHERE project_id = $1 AND deleted_at IS NULL
-     ORDER BY created_at DESC NULLS LAST, id DESC
-     LIMIT 1`,
-    [projectId]
-  );
-  const row = result.rows[0];
-  return row?.id ? (row.id as string) : null;
+  return pgGetLatestVersionUuidForProjectTx(client, projectId);
 }
 
-/** Property library rows for reuse when importing another revision into the same project. */
 export async function listProjectLibraryPropertiesTx(
   client: PoolClient,
   projectId: string
-): Promise<Array<{ id: string; name: string; description: string | null; data: any }>> {
-  const result = await client.query(
-    `SELECT id, name, description, data
-     FROM odb.properties
-     WHERE project_id = $1 AND deleted_at IS NULL`,
-    [projectId]
-  );
-  return result.rows as Array<{ id: string; name: string; description: string | null; data: any }>;
+): Promise<Array<{ id: string; name: string; description: string | null; data: unknown }>> {
+  return pgListProjectLibraryPropertiesTx(client, projectId);
 }
 
-/**
- * Create a property within a transaction
- */
 export async function createPropertyTx(
   client: PoolClient,
   projectId: string,
   name: string,
   description: string | null,
-  data: any
+  data: unknown
 ): Promise<string> {
-  try {
-    if (!name || name.trim().length === 0) {
-      return errorResponse('Property name is required');
-    }
-
-    if (!data) {
-      return errorResponse('Property data is required');
-    }
-
-    const result = await client.query(
-      `INSERT INTO odb.properties (project_id, name, description, data)
-       VALUES ($1, $2, $3, $4)
-       RETURNING *`,
-      [projectId, name.trim(), description, JSON.stringify(data)]
-    );
-
-    return successResponse({ property: result.rows[0] });
-  } catch (error: any) {
-    // Handle unique constraint violation (duplicate name in same project)
-    if (error.code === '23505') {
-      return errorResponse('A property with this name already exists in this project');
-    }
-    return errorResponse(error.message);
-  }
+  return pgCreatePropertyTx(client, projectId, name, description, data);
 }
 
-/**
- * Create a class within a transaction
- */
 export async function createClassTx(
   client: PoolClient,
   versionId: string,
   name: string,
   description: string | null,
-  schema: any
+  schema: unknown
 ): Promise<string> {
-  try {
-    if (!name || name.trim().length === 0) {
-      return errorResponse('Class name is required');
-    }
-
-    if (!schema) {
-      return errorResponse('Class schema is required');
-    }
-
-    const result = await client.query(
-      `INSERT INTO odb.classes (version_id, name, description, schema)
-       VALUES ($1, $2, $3, $4)
-       RETURNING *`,
-      [versionId, name.trim(), description, JSON.stringify(schema)]
-    );
-
-    return successResponse({ class: result.rows[0] });
-  } catch (error: any) {
-    // Handle unique constraint violation (duplicate name in same version)
-    if (error.code === '23505') {
-      return errorResponse('A class with this name already exists in this version');
-    }
-    return errorResponse(error.message);
-  }
+  return pgCreateClassTx(client, versionId, name, description, schema);
 }
 
-/**
- * Add a property to a class within a transaction
- */
 export async function addPropertyToClassTx(
   client: PoolClient,
   classId: string,
   propertyId: string | null,
   name: string,
   description: string | null,
-  data: any,
+  data: unknown,
   parentId: string | null = null
 ): Promise<string> {
-  try {
-    if (!name || name.trim().length === 0) {
-      return errorResponse('Property name is required');
-    }
-
-    // Validate: either propertyId must be set, or data must contain $ref
-    const hasRef = data && (data.$ref || (data.type === 'array' && data.items?.$ref));
-    if (!propertyId && !hasRef) {
-      return errorResponse('Property must have either a library reference (propertyId) or a schema $ref');
-    }
-
-    const result = await client.query(
-      `INSERT INTO odb.class_properties (class_id, property_id, name, description, data, parent_id)
-       VALUES ($1, $2, $3, $4, $5, $6)
-       RETURNING *`,
-      [classId, propertyId, name.trim(), description, JSON.stringify(data), parentId]
-    );
-
-    return successResponse({ classProperty: result.rows[0] });
-  } catch (error: any) {
-    // Handle unique constraint violation (duplicate name in same class under same parent)
-    if (error.code === '23505') {
-      return errorResponse('A property with this name already exists in this class');
-    }
-    return errorResponse(error.message);
-  }
+  return pgAddPropertyToClassTx(client, classId, propertyId, name, description, data, parentId);
 }
 
-/**
- * Get classes with properties and tags for a version (for verification)
- */
-export async function getClassesWithPropertiesAndTagsTx(
-  client: PoolClient,
-  versionId: string
-): Promise<string> {
-  try {
-    // Query 1: Get all classes for the version
-    const classesResult = await client.query(
-      `SELECT id, version_id, name, description, schema, enabled, canvas_metadata, created_at, updated_at
-       FROM odb.classes
-       WHERE version_id = $1 AND deleted_at IS NULL
-       ORDER BY name ASC`,
-      [versionId]
-    );
-
-    const classes = classesResult.rows;
-
-    if (classes.length === 0) {
-      return JSON.stringify([]);
-    }
-
-    const classIds = classes.map((c: any) => c.id);
-
-    // Query 2: Get all properties for all classes in one query
-    const propertiesResult = await client.query(
-      `SELECT cp.id, cp.class_id, cp.property_id, cp.name, cp.description, cp.data, cp.parent_id,
-              p.id as property_source_id, p.name as property_source_name
-       FROM odb.class_properties cp
-       LEFT JOIN odb.properties p ON cp.property_id = p.id
-       WHERE cp.class_id = ANY($1)
-       ORDER BY cp.class_id, cp.parent_id NULLS FIRST, cp.name ASC`,
-      [classIds]
-    );
-
-    // Query 3: Get all tags for all classes in one query
-    const tagsResult = await client.query(
-      `SELECT ct.id, ct.class_id, ct.tag_id, ct.created_at,
-              t.name as tag_name, t.color as tag_color, t.description as tag_description,
-              t.project_id
-       FROM odb.class_tags ct
-       JOIN odb.tags t ON ct.tag_id = t.id
-       WHERE ct.class_id = ANY($1)
-       ORDER BY ct.class_id, t.name ASC`,
-      [classIds]
-    );
-
-    // Group properties by class_id
-    const propertiesByClass = new Map<string, any[]>();
-    for (const prop of propertiesResult.rows) {
-      const classId = prop.class_id;
-      if (!propertiesByClass.has(classId)) {
-        propertiesByClass.set(classId, []);
-      }
-      propertiesByClass.get(classId)!.push(prop);
-    }
-
-    // Group tags by class_id
-    const tagsByClass = new Map<string, any[]>();
-    for (const tag of tagsResult.rows) {
-      const classId = tag.class_id;
-      if (!tagsByClass.has(classId)) {
-        tagsByClass.set(classId, []);
-      }
-      tagsByClass.get(classId)!.push(tag);
-    }
-
-    // Combine classes with their properties and tags
-    const classesWithData = classes.map((cls: any) => ({
-      ...cls,
-      properties: propertiesByClass.get(cls.id) || [],
-      tags: tagsByClass.get(cls.id) || []
-    }));
-
-    return JSON.stringify(classesWithData);
-  } catch (error: any) {
-    console.error('Error bulk loading classes with properties and tags:', error);
-    return JSON.stringify([]);
-  }
+export async function getClassesWithPropertiesAndTagsTx(client: PoolClient, versionId: string): Promise<string> {
+  return pgGetClassesWithPropertiesAndTagsTx(client, versionId);
 }
-

--- a/objectified-importer/src/engine/pg-client.ts
+++ b/objectified-importer/src/engine/pg-client.ts
@@ -10,9 +10,17 @@ import type { TransactionHandle, TransactionalClient } from './transactional-cli
  * Keeping these out of the constructor's required args avoids importing UI DB modules here.
  */
 export type PgClientPlanChecks = {
-  /** Returns a block-error message when the user cannot create a new project, or null if allowed. */
+  /**
+   * Returns a block-error message when the user cannot create a new project, or null if allowed.
+   * @param userId - The ID of the user creating the project.
+   * @param client - The active Postgres queryable (pool or transaction client).
+   */
   checkPlanForNewProject?: (userId: string, client: PgQueryable) => Promise<string | null>;
-  /** Returns a block-error message when the user cannot create a new version, or null if allowed. */
+  /**
+   * Returns a block-error message when the user cannot create a new version, or null if allowed.
+   * @param userId - The ID of the user creating the version.
+   * @param client - The active Postgres queryable (pool or transaction client).
+   */
   checkPlanForNewVersion?: (userId: string, client: PgQueryable) => Promise<string | null>;
 };
 

--- a/objectified-importer/src/engine/pg-client.ts
+++ b/objectified-importer/src/engine/pg-client.ts
@@ -3,8 +3,18 @@
  */
 
 import type { Pool, PoolClient } from 'pg';
-import { getPlanBlockMessageForNewProject, getPlanBlockMessageForNewVersion } from '../../../objectified-ui/lib/db/plan-entitlements';
 import type { TransactionHandle, TransactionalClient } from './transactional-client';
+
+/**
+ * Optional plan/entitlement check callbacks injected into {@link PgTransactionalClient}.
+ * Keeping these out of the constructor's required args avoids importing UI DB modules here.
+ */
+export type PgClientPlanChecks = {
+  /** Returns a block-error message when the user cannot create a new project, or null if allowed. */
+  checkPlanForNewProject?: (userId: string, client: PgQueryable) => Promise<string | null>;
+  /** Returns a block-error message when the user cannot create a new version, or null if allowed. */
+  checkPlanForNewVersion?: (userId: string, client: PgQueryable) => Promise<string | null>;
+};
 
 export type PgQueryable = Pick<PoolClient, 'query' | 'release'>;
 
@@ -45,7 +55,8 @@ async function createProjectTxImpl(
   name: string,
   description: string,
   slug: string,
-  metadata?: unknown
+  metadata?: unknown,
+  planChecks?: PgClientPlanChecks
 ): Promise<string> {
   try {
     if (!name?.trim()) return errorResponse('Project name is required');
@@ -53,8 +64,10 @@ async function createProjectTxImpl(
     const slugError = validateSlug(slug.trim());
     if (slugError) return errorResponse(slugError);
 
-    const planErr = await getPlanBlockMessageForNewProject(creatorId, client);
-    if (planErr) return errorResponse(planErr);
+    if (planChecks?.checkPlanForNewProject) {
+      const planErr = await planChecks.checkPlanForNewProject(creatorId, client);
+      if (planErr) return errorResponse(planErr);
+    }
 
     const result = await client.query(
       `INSERT INTO odb.projects (tenant_id, creator_id, name, description, slug, metadata) 
@@ -104,13 +117,16 @@ async function createVersionTxImpl(
   versionId: string,
   description: string,
   changeLog: string,
-  opts?: { parentVersionUuid?: string | null }
+  opts?: { parentVersionUuid?: string | null },
+  planChecks?: PgClientPlanChecks
 ): Promise<string> {
   try {
     if (!versionId?.trim()) return errorResponse('Version ID is required');
 
-    const planErr = await getPlanBlockMessageForNewVersion(creatorId, client);
-    if (planErr) return errorResponse(planErr);
+    if (planChecks?.checkPlanForNewVersion) {
+      const planErr = await planChecks.checkPlanForNewVersion(creatorId, client);
+      if (planErr) return errorResponse(planErr);
+    }
 
     const parentUuid = opts?.parentVersionUuid?.trim() || null;
     const result = parentUuid
@@ -400,7 +416,10 @@ export async function getClassesWithPropertiesAndTagsTx(client: PgQueryable, ver
 }
 
 class PgTransactionHandle implements TransactionHandle {
-  constructor(private readonly client: PoolClient) {}
+  constructor(
+    private readonly client: PoolClient,
+    private readonly planChecks?: PgClientPlanChecks
+  ) {}
 
   begin(): Promise<void> {
     return beginTransaction(this.client);
@@ -423,7 +442,7 @@ class PgTransactionHandle implements TransactionHandle {
     slug: string,
     metadata?: unknown
   ): Promise<string> {
-    return createProjectTxImpl(this.client, tenantId, creatorId, name, description, slug, metadata);
+    return createProjectTxImpl(this.client, tenantId, creatorId, name, description, slug, metadata, this.planChecks);
   }
 
   createVersionTx(
@@ -434,7 +453,7 @@ class PgTransactionHandle implements TransactionHandle {
     changeLog: string,
     opts?: { parentVersionUuid?: string | null }
   ): Promise<string> {
-    return createVersionTxImpl(this.client, projectId, creatorId, versionId, description, changeLog, opts);
+    return createVersionTxImpl(this.client, projectId, creatorId, versionId, description, changeLog, opts, this.planChecks);
   }
 
   getLatestVersionUuidForProjectTx(projectId: string): Promise<string | null> {
@@ -472,10 +491,13 @@ class PgTransactionHandle implements TransactionHandle {
 }
 
 export class PgTransactionalClient implements TransactionalClient {
-  constructor(private readonly pool: Pool) {}
+  constructor(
+    private readonly pool: Pool,
+    private readonly planChecks?: PgClientPlanChecks
+  ) {}
 
   async connect(): Promise<TransactionHandle> {
     const client = await this.pool.connect();
-    return new PgTransactionHandle(client);
+    return new PgTransactionHandle(client, this.planChecks);
   }
 }

--- a/objectified-importer/src/engine/pg-client.ts
+++ b/objectified-importer/src/engine/pg-client.ts
@@ -1,0 +1,481 @@
+/**
+ * Postgres-backed {@link TransactionalClient} for the import engine.
+ */
+
+import type { Pool, PoolClient } from 'pg';
+import { getPlanBlockMessageForNewProject, getPlanBlockMessageForNewVersion } from '../../../objectified-ui/lib/db/plan-entitlements';
+import type { TransactionHandle, TransactionalClient } from './transactional-client';
+
+export type PgQueryable = Pick<PoolClient, 'query' | 'release'>;
+
+const errorResponse = (error: string) => JSON.stringify({ success: false, error });
+const successResponse = (data: Record<string, unknown> = {}) => JSON.stringify({ success: true, ...data });
+
+function validateSlug(slug: string): string | null {
+  if (!slug) return 'Slug is required';
+  if (slug.length < 2) return 'Slug must be at least 2 characters';
+  if (slug.length > 100) return 'Slug must be 100 characters or less';
+  if (!/^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]$/.test(slug)) {
+    return 'Slug must start and end with a letter or number, and contain only lowercase letters, numbers, and hyphens';
+  }
+  if (/--/.test(slug)) return 'Slug cannot contain consecutive hyphens';
+  return null;
+}
+
+export async function beginTransaction(client: PgQueryable): Promise<void> {
+  await client.query('BEGIN');
+}
+
+export async function commitTransaction(client: PgQueryable): Promise<void> {
+  await client.query('COMMIT');
+}
+
+export async function rollbackTransaction(client: PgQueryable): Promise<void> {
+  await client.query('ROLLBACK');
+}
+
+export async function releaseClient(client: PgQueryable): Promise<void> {
+  client.release();
+}
+
+async function createProjectTxImpl(
+  client: PgQueryable,
+  tenantId: string,
+  creatorId: string,
+  name: string,
+  description: string,
+  slug: string,
+  metadata?: unknown
+): Promise<string> {
+  try {
+    if (!name?.trim()) return errorResponse('Project name is required');
+    if (!slug?.trim()) return errorResponse('Project slug is required');
+    const slugError = validateSlug(slug.trim());
+    if (slugError) return errorResponse(slugError);
+
+    const planErr = await getPlanBlockMessageForNewProject(creatorId, client);
+    if (planErr) return errorResponse(planErr);
+
+    const result = await client.query(
+      `INSERT INTO odb.projects (tenant_id, creator_id, name, description, slug, metadata) 
+       VALUES ($1, $2, $3, $4, $5, $6) RETURNING *`,
+      [
+        tenantId,
+        creatorId,
+        name.trim(),
+        description?.trim() || null,
+        slug.trim().toLowerCase(),
+        metadata ? JSON.stringify(metadata) : '{}',
+      ]
+    );
+    return successResponse({ project: result.rows[0] });
+  } catch (error: unknown) {
+    const err = error as { code?: string; constraint?: string; detail?: string; message?: string };
+    if (err.code === '23505') return errorResponse('A project with this slug already exists in this tenant');
+    if (err.code === '23503') {
+      if (err.constraint === 'projects_tenant_id_fkey') {
+        return errorResponse('Invalid tenant ID. The tenant may no longer exist or you may need to switch to a valid tenant.');
+      }
+      if (err.constraint === 'projects_creator_id_fkey') {
+        return errorResponse('Invalid user ID. Please try logging out and back in.');
+      }
+      return errorResponse(`Database constraint error: ${err.detail || err.message}`);
+    }
+    return errorResponse(err.message || String(error));
+  }
+}
+
+export async function createProjectTx(
+  client: PgQueryable,
+  tenantId: string,
+  creatorId: string,
+  name: string,
+  description: string,
+  slug: string,
+  metadata?: unknown
+): Promise<string> {
+  return createProjectTxImpl(client, tenantId, creatorId, name, description, slug, metadata);
+}
+
+async function createVersionTxImpl(
+  client: PgQueryable,
+  projectId: string,
+  creatorId: string,
+  versionId: string,
+  description: string,
+  changeLog: string,
+  opts?: { parentVersionUuid?: string | null }
+): Promise<string> {
+  try {
+    if (!versionId?.trim()) return errorResponse('Version ID is required');
+
+    const planErr = await getPlanBlockMessageForNewVersion(creatorId, client);
+    if (planErr) return errorResponse(planErr);
+
+    const parentUuid = opts?.parentVersionUuid?.trim() || null;
+    const result = parentUuid
+      ? await client.query(
+          `INSERT INTO odb.versions (project_id, creator_id, version_id, description, change_log, parent_version_id) 
+           VALUES ($1, $2, $3, $4, $5, $6) RETURNING *`,
+          [
+            projectId,
+            creatorId,
+            versionId.trim(),
+            description?.trim() || null,
+            changeLog?.trim() || null,
+            parentUuid,
+          ]
+        )
+      : await client.query(
+          `INSERT INTO odb.versions (project_id, creator_id, version_id, description, change_log) 
+           VALUES ($1, $2, $3, $4, $5) RETURNING *`,
+          [projectId, creatorId, versionId.trim(), description?.trim() || null, changeLog?.trim() || null]
+        );
+    return successResponse({ version: result.rows[0] });
+  } catch (error: unknown) {
+    const err = error as { code?: string; message?: string };
+    if (err.code === '23505') return errorResponse('A version with this ID already exists in this project');
+    return errorResponse(err.message || String(error));
+  }
+}
+
+export async function createVersionTx(
+  client: PgQueryable,
+  projectId: string,
+  creatorId: string,
+  versionId: string,
+  description: string,
+  changeLog: string,
+  opts?: { parentVersionUuid?: string | null }
+): Promise<string> {
+  return createVersionTxImpl(client, projectId, creatorId, versionId, description, changeLog, opts);
+}
+
+async function queryLatestVersionUuidForProject(client: PgQueryable, projectId: string): Promise<string | null> {
+  const result = await client.query(
+    `SELECT id FROM odb.versions
+     WHERE project_id = $1 AND deleted_at IS NULL
+     ORDER BY created_at DESC NULLS LAST, id DESC
+     LIMIT 1`,
+    [projectId]
+  );
+  const row = result.rows[0];
+  return row?.id ? (row.id as string) : null;
+}
+
+export async function getLatestVersionUuidForProjectTx(
+  client: PgQueryable,
+  projectId: string
+): Promise<string | null> {
+  return queryLatestVersionUuidForProject(client, projectId);
+}
+
+async function queryListProjectLibraryProperties(
+  client: PgQueryable,
+  projectId: string
+): Promise<Array<{ id: string; name: string; description: string | null; data: unknown }>> {
+  const result = await client.query(
+    `SELECT id, name, description, data
+     FROM odb.properties
+     WHERE project_id = $1 AND deleted_at IS NULL`,
+    [projectId]
+  );
+  return result.rows as Array<{ id: string; name: string; description: string | null; data: unknown }>;
+}
+
+export async function listProjectLibraryPropertiesTx(
+  client: PgQueryable,
+  projectId: string
+): Promise<Array<{ id: string; name: string; description: string | null; data: unknown }>> {
+  return queryListProjectLibraryProperties(client, projectId);
+}
+
+async function createPropertyTxImpl(
+  client: PgQueryable,
+  projectId: string,
+  name: string,
+  description: string | null,
+  data: unknown
+): Promise<string> {
+  try {
+    if (!name || name.trim().length === 0) {
+      return errorResponse('Property name is required');
+    }
+
+    if (!data) {
+      return errorResponse('Property data is required');
+    }
+
+    const result = await client.query(
+      `INSERT INTO odb.properties (project_id, name, description, data)
+       VALUES ($1, $2, $3, $4)
+       RETURNING *`,
+      [projectId, name.trim(), description, JSON.stringify(data)]
+    );
+
+    return successResponse({ property: result.rows[0] });
+  } catch (error: unknown) {
+    const err = error as { code?: string; message?: string };
+    if (err.code === '23505') {
+      return errorResponse('A property with this name already exists in this project');
+    }
+    return errorResponse(err.message || String(error));
+  }
+}
+
+export async function createPropertyTx(
+  client: PgQueryable,
+  projectId: string,
+  name: string,
+  description: string | null,
+  data: unknown
+): Promise<string> {
+  return createPropertyTxImpl(client, projectId, name, description, data);
+}
+
+async function createClassTxImpl(
+  client: PgQueryable,
+  versionId: string,
+  name: string,
+  description: string | null,
+  schema: unknown
+): Promise<string> {
+  try {
+    if (!name || name.trim().length === 0) {
+      return errorResponse('Class name is required');
+    }
+
+    if (!schema) {
+      return errorResponse('Class schema is required');
+    }
+
+    const result = await client.query(
+      `INSERT INTO odb.classes (version_id, name, description, schema)
+       VALUES ($1, $2, $3, $4)
+       RETURNING *`,
+      [versionId, name.trim(), description, JSON.stringify(schema)]
+    );
+
+    return successResponse({ class: result.rows[0] });
+  } catch (error: unknown) {
+    const err = error as { code?: string; message?: string };
+    if (err.code === '23505') {
+      return errorResponse('A class with this name already exists in this version');
+    }
+    return errorResponse(err.message || String(error));
+  }
+}
+
+export async function createClassTx(
+  client: PgQueryable,
+  versionId: string,
+  name: string,
+  description: string | null,
+  schema: unknown
+): Promise<string> {
+  return createClassTxImpl(client, versionId, name, description, schema);
+}
+
+async function addPropertyToClassTxImpl(
+  client: PgQueryable,
+  classId: string,
+  propertyId: string | null,
+  name: string,
+  description: string | null,
+  data: unknown,
+  parentId: string | null = null
+): Promise<string> {
+  try {
+    if (!name || name.trim().length === 0) {
+      return errorResponse('Property name is required');
+    }
+
+    const d = data as { $ref?: string; type?: string; items?: { $ref?: string } };
+    const hasRef = data && (d.$ref || (d.type === 'array' && d.items?.$ref));
+    if (!propertyId && !hasRef) {
+      return errorResponse('Property must have either a library reference (propertyId) or a schema $ref');
+    }
+
+    const result = await client.query(
+      `INSERT INTO odb.class_properties (class_id, property_id, name, description, data, parent_id)
+       VALUES ($1, $2, $3, $4, $5, $6)
+       RETURNING *`,
+      [classId, propertyId, name.trim(), description, JSON.stringify(data), parentId]
+    );
+
+    return successResponse({ classProperty: result.rows[0] });
+  } catch (error: unknown) {
+    const err = error as { code?: string; message?: string };
+    if (err.code === '23505') {
+      return errorResponse('A property with this name already exists in this class');
+    }
+    return errorResponse(err.message || String(error));
+  }
+}
+
+export async function addPropertyToClassTx(
+  client: PgQueryable,
+  classId: string,
+  propertyId: string | null,
+  name: string,
+  description: string | null,
+  data: unknown,
+  parentId: string | null = null
+): Promise<string> {
+  return addPropertyToClassTxImpl(client, classId, propertyId, name, description, data, parentId);
+}
+
+async function getClassesWithPropertiesAndTagsTxImpl(client: PgQueryable, versionId: string): Promise<string> {
+  try {
+    const classesResult = await client.query(
+      `SELECT id, version_id, name, description, schema, enabled, canvas_metadata, created_at, updated_at
+       FROM odb.classes
+       WHERE version_id = $1 AND deleted_at IS NULL
+       ORDER BY name ASC`,
+      [versionId]
+    );
+
+    const classes = classesResult.rows;
+
+    if (classes.length === 0) {
+      return JSON.stringify([]);
+    }
+
+    const classIds = classes.map((c: { id: string }) => c.id);
+
+    const propertiesResult = await client.query(
+      `SELECT cp.id, cp.class_id, cp.property_id, cp.name, cp.description, cp.data, cp.parent_id,
+              p.id as property_source_id, p.name as property_source_name
+       FROM odb.class_properties cp
+       LEFT JOIN odb.properties p ON cp.property_id = p.id
+       WHERE cp.class_id = ANY($1)
+       ORDER BY cp.class_id, cp.parent_id NULLS FIRST, cp.name ASC`,
+      [classIds]
+    );
+
+    const tagsResult = await client.query(
+      `SELECT ct.id, ct.class_id, ct.tag_id, ct.created_at,
+              t.name as tag_name, t.color as tag_color, t.description as tag_description,
+              t.project_id
+       FROM odb.class_tags ct
+       JOIN odb.tags t ON ct.tag_id = t.id
+       WHERE ct.class_id = ANY($1)
+       ORDER BY ct.class_id, t.name ASC`,
+      [classIds]
+    );
+
+    const propertiesByClass = new Map<string, unknown[]>();
+    for (const prop of propertiesResult.rows) {
+      const classId = prop.class_id as string;
+      if (!propertiesByClass.has(classId)) {
+        propertiesByClass.set(classId, []);
+      }
+      propertiesByClass.get(classId)!.push(prop);
+    }
+
+    const tagsByClass = new Map<string, unknown[]>();
+    for (const tag of tagsResult.rows) {
+      const classId = tag.class_id as string;
+      if (!tagsByClass.has(classId)) {
+        tagsByClass.set(classId, []);
+      }
+      tagsByClass.get(classId)!.push(tag);
+    }
+
+    const classesWithData = classes.map((cls: Record<string, unknown>) => ({
+      ...cls,
+      properties: propertiesByClass.get(cls.id as string) || [],
+      tags: tagsByClass.get(cls.id as string) || [],
+    }));
+
+    return JSON.stringify(classesWithData);
+  } catch (error: unknown) {
+    console.error('Error bulk loading classes with properties and tags:', error);
+    return JSON.stringify([]);
+  }
+}
+
+export async function getClassesWithPropertiesAndTagsTx(client: PgQueryable, versionId: string): Promise<string> {
+  return getClassesWithPropertiesAndTagsTxImpl(client, versionId);
+}
+
+class PgTransactionHandle implements TransactionHandle {
+  constructor(private readonly client: PoolClient) {}
+
+  begin(): Promise<void> {
+    return beginTransaction(this.client);
+  }
+  commit(): Promise<void> {
+    return commitTransaction(this.client);
+  }
+  rollback(): Promise<void> {
+    return rollbackTransaction(this.client);
+  }
+  release(): Promise<void> {
+    return Promise.resolve(this.client.release());
+  }
+
+  createProjectTx(
+    tenantId: string,
+    creatorId: string,
+    name: string,
+    description: string,
+    slug: string,
+    metadata?: unknown
+  ): Promise<string> {
+    return createProjectTxImpl(this.client, tenantId, creatorId, name, description, slug, metadata);
+  }
+
+  createVersionTx(
+    projectId: string,
+    creatorId: string,
+    versionId: string,
+    description: string,
+    changeLog: string,
+    opts?: { parentVersionUuid?: string | null }
+  ): Promise<string> {
+    return createVersionTxImpl(this.client, projectId, creatorId, versionId, description, changeLog, opts);
+  }
+
+  getLatestVersionUuidForProjectTx(projectId: string): Promise<string | null> {
+    return queryLatestVersionUuidForProject(this.client, projectId);
+  }
+
+  listProjectLibraryPropertiesTx(
+    projectId: string
+  ): Promise<Array<{ id: string; name: string; description: string | null; data: unknown }>> {
+    return queryListProjectLibraryProperties(this.client, projectId);
+  }
+
+  createPropertyTx(projectId: string, name: string, description: string | null, data: unknown): Promise<string> {
+    return createPropertyTxImpl(this.client, projectId, name, description, data);
+  }
+
+  createClassTx(versionId: string, name: string, description: string | null, schema: unknown): Promise<string> {
+    return createClassTxImpl(this.client, versionId, name, description, schema);
+  }
+
+  addPropertyToClassTx(
+    classId: string,
+    propertyId: string | null,
+    name: string,
+    description: string | null,
+    data: unknown,
+    parentId?: string | null
+  ): Promise<string> {
+    return addPropertyToClassTxImpl(this.client, classId, propertyId, name, description, data, parentId ?? null);
+  }
+
+  getClassesWithPropertiesAndTagsTx(versionId: string): Promise<string> {
+    return getClassesWithPropertiesAndTagsTxImpl(this.client, versionId);
+  }
+}
+
+export class PgTransactionalClient implements TransactionalClient {
+  constructor(private readonly pool: Pool) {}
+
+  async connect(): Promise<TransactionHandle> {
+    const client = await this.pool.connect();
+    return new PgTransactionHandle(client);
+  }
+}

--- a/objectified-importer/src/engine/transactional-client.ts
+++ b/objectified-importer/src/engine/transactional-client.ts
@@ -1,4 +1,40 @@
-import type { ParsedPath, ParsedSecurityScheme } from '../../../objectified-ui/src/app/utils/openapi-import';
+/** Parsed OpenAPI operation (get, post, etc.) */
+export interface ParsedOperation {
+  method: string;
+  operationId?: string;
+  summary?: string;
+  description?: string;
+  tags?: string[];
+  deprecated?: boolean;
+  parameters: Array<{ name: string; in: string; required?: boolean; description?: string; schema?: Record<string, unknown> }>;
+  requestBody?: {
+    required?: boolean;
+    description?: string;
+    content: Record<string, { schema?: Record<string, unknown>; $ref?: string }>;
+  };
+  responses: Record<string, { description?: string; content?: Record<string, { schema?: Record<string, unknown>; $ref?: string }>; headers?: Record<string, unknown>; links?: Record<string, unknown> }>;
+  security?: Record<string, string[]>;
+}
+
+/** Parsed OpenAPI path item. */
+export interface ParsedPath {
+  path: string;
+  summary?: string;
+  description?: string;
+  parameters?: Array<{ name: string; in: string; required?: boolean; description?: string; schema?: Record<string, unknown> }>;
+  operations: ParsedOperation[];
+}
+
+/** Parsed OpenAPI security scheme (components.securitySchemes). */
+export interface ParsedSecurityScheme {
+  scheme_name: string;
+  scheme_type: 'apiKey' | 'http' | 'oauth2' | 'openIdConnect' | 'mutualTLS';
+  in_location?: 'header' | 'query' | 'cookie';
+  param_name?: string;
+  http_scheme?: string;
+  description?: string;
+  data?: Record<string, unknown>;
+}
 
 /** Payload for optional repository-import linkage after a successful import (UI records metrics). */
 export type RepositoryImportLink = {

--- a/objectified-importer/src/engine/transactional-client.ts
+++ b/objectified-importer/src/engine/transactional-client.ts
@@ -1,0 +1,87 @@
+import type { ParsedPath, ParsedSecurityScheme } from '../../../objectified-ui/src/app/utils/openapi-import';
+
+/** Payload for optional repository-import linkage after a successful import (UI records metrics). */
+export type RepositoryImportLink = {
+  tenantId: string;
+  repositorySource: {
+    repositoryId: string;
+    branch: string;
+    path: string;
+    blobSha?: string | null;
+  };
+  projectId: string;
+  versionUuid: string;
+  importedByUserId: string;
+};
+
+/**
+ * Active pooled connection used by the import engine. Supports multiple BEGIN/COMMIT cycles (incremental mode).
+ */
+export interface TransactionHandle {
+  begin(): Promise<void>;
+  commit(): Promise<void>;
+  rollback(): Promise<void>;
+  release(): Promise<void>;
+
+  createProjectTx(
+    tenantId: string,
+    creatorId: string,
+    name: string,
+    description: string,
+    slug: string,
+    metadata?: unknown
+  ): Promise<string>;
+
+  createVersionTx(
+    projectId: string,
+    creatorId: string,
+    versionId: string,
+    description: string,
+    changeLog: string,
+    opts?: { parentVersionUuid?: string | null }
+  ): Promise<string>;
+
+  getLatestVersionUuidForProjectTx(projectId: string): Promise<string | null>;
+
+  listProjectLibraryPropertiesTx(
+    projectId: string
+  ): Promise<Array<{ id: string; name: string; description: string | null; data: unknown }>>;
+
+  createPropertyTx(
+    projectId: string,
+    name: string,
+    description: string | null,
+    data: unknown
+  ): Promise<string>;
+
+  createClassTx(versionId: string, name: string, description: string | null, schema: unknown): Promise<string>;
+
+  addPropertyToClassTx(
+    classId: string,
+    propertyId: string | null,
+    name: string,
+    description: string | null,
+    data: unknown,
+    parentId?: string | null
+  ): Promise<string>;
+
+  getClassesWithPropertiesAndTagsTx(versionId: string): Promise<string>;
+}
+
+export interface TransactionalClient {
+  connect(): Promise<TransactionHandle>;
+}
+
+export type ImportOpenApiPathsFn = (
+  versionId: string,
+  paths: ParsedPath[],
+  securitySchemes: ParsedSecurityScheme[]
+) => Promise<{ success: boolean; error?: string }>;
+
+export interface ImportEngineDeps {
+  txClient: TransactionalClient;
+  recordRepositoryImport?: (input: RepositoryImportLink) => Promise<void>;
+  permanentDeleteProject?: (projectId: string) => Promise<{ success: boolean; error?: string }>;
+  /** OpenAPI paths/security import (standalone transaction). Omit or no-op in tests. */
+  importOpenApiPathsAndSecurity?: ImportOpenApiPathsFn;
+}

--- a/objectified-importer/src/server.ts
+++ b/objectified-importer/src/server.ts
@@ -1,5 +1,4 @@
-import type { ParsedPath, ParsedSecurityScheme } from '../../objectified-ui/src/app/utils/openapi-import';
-import type { ImportEngineDeps } from './engine/transactional-client';
+import type { ParsedPath, ParsedSecurityScheme, ImportEngineDeps } from './engine/transactional-client';
 export * from './browser';
 import { createImporterEngineRequire } from './engine/importer-node-require';
 import {
@@ -61,7 +60,16 @@ export { importOpenAPIPathsAndSecurityWithPool } from './engine/import-openapi-p
 
 function buildDefaultImportEngineDeps(): ImportEngineDeps {
   return {
-    txClient: new PgTransactionalClient(uiConnectionPool()),
+    txClient: new PgTransactionalClient(uiConnectionPool(), {
+      checkPlanForNewProject: async (userId, client) => {
+        const { getPlanBlockMessageForNewProject } = nodeRequire('../../../objectified-ui/lib/db/plan-entitlements');
+        return getPlanBlockMessageForNewProject(userId, client);
+      },
+      checkPlanForNewVersion: async (userId, client) => {
+        const { getPlanBlockMessageForNewVersion } = nodeRequire('../../../objectified-ui/lib/db/plan-entitlements');
+        return getPlanBlockMessageForNewVersion(userId, client);
+      },
+    }),
     recordRepositoryImport: async link => {
       const { recordTenantRepositoryImport } = nodeRequire('../../../objectified-ui/lib/db/repository-import-metrics');
       await recordTenantRepositoryImport(link);
@@ -76,7 +84,14 @@ function buildDefaultImportEngineDeps(): ImportEngineDeps {
   };
 }
 
-createImportEngine(buildDefaultImportEngineDeps());
+/**
+ * Wire the import engine with UI-backed Postgres dependencies.
+ * Call this once from the UI server bootstrap before any import functions are used.
+ * Idempotent: subsequent calls replace the current engine configuration.
+ */
+export function configureUiImportEngine(): void {
+  createImportEngine(buildDefaultImportEngineDeps());
+}
 
 export { startImport, getImportStatus, cancelImport, commitImport, rollbackImport, rollbackCompletedImport, retryImport };
 

--- a/objectified-importer/src/server.ts
+++ b/objectified-importer/src/server.ts
@@ -1,5 +1,9 @@
+import type { ParsedPath, ParsedSecurityScheme } from '../../objectified-ui/src/app/utils/openapi-import';
+import type { ImportEngineDeps } from './engine/transactional-client';
 export * from './browser';
-export {
+import { createImporterEngineRequire } from './engine/importer-node-require';
+import {
+  createImportEngine,
   startImport,
   getImportStatus,
   cancelImport,
@@ -8,6 +12,9 @@ export {
   rollbackCompletedImport,
   retryImport,
 } from './engine/import-helper';
+import { importOpenAPIPathsAndSecurityWithPool } from './engine/import-openapi-paths-security';
+import { PgTransactionalClient } from './engine/pg-client';
+
 export type {
   ImportJobState,
   ImportLogLevel,
@@ -15,11 +22,64 @@ export type {
   ProgressEvent,
   ImportStatus,
   ImportJobInput,
+  ImportEngine,
+  ImportEngineDeps,
+  RepositoryImportLink,
 } from './engine/import-helper';
-export {
-  importOpenAPIPathsAndSecurity,
-  importPathsFromOpenAPIForVersion,
-} from './engine/import-openapi-paths-security';
+export { createImportEngine } from './engine/import-helper';
+export { PgTransactionalClient } from './engine/pg-client';
+
+const nodeRequire = createImporterEngineRequire();
+
+function uiConnectionPool() {
+  return nodeRequire('../../../objectified-ui/lib/db/db');
+}
+
+export async function importOpenAPIPathsAndSecurity(
+  versionId: string,
+  paths: ParsedPath[],
+  securitySchemes: ParsedSecurityScheme[]
+): Promise<{ success: boolean; error?: string }> {
+  return importOpenAPIPathsAndSecurityWithPool(uiConnectionPool(), versionId, paths, securitySchemes);
+}
+
+export async function importPathsFromOpenAPIForVersion(
+  versionId: string,
+  paths: ParsedPath[],
+  securitySchemes: ParsedSecurityScheme[]
+): Promise<{ success: boolean; error?: string }> {
+  if (!versionId) {
+    return { success: false, error: 'Version is required' };
+  }
+  if (!paths?.length && !securitySchemes?.length) {
+    return { success: false, error: 'Spec has no paths or security schemes to import' };
+  }
+  return importOpenAPIPathsAndSecurityWithPool(uiConnectionPool(), versionId, paths || [], securitySchemes || []);
+}
+
+export { importOpenAPIPathsAndSecurityWithPool } from './engine/import-openapi-paths-security';
+
+function buildDefaultImportEngineDeps(): ImportEngineDeps {
+  return {
+    txClient: new PgTransactionalClient(uiConnectionPool()),
+    recordRepositoryImport: async link => {
+      const { recordTenantRepositoryImport } = nodeRequire('../../../objectified-ui/lib/db/repository-import-metrics');
+      await recordTenantRepositoryImport(link);
+    },
+    permanentDeleteProject: async projectId => {
+      const { permanentDeleteProject } = nodeRequire('../../../objectified-ui/lib/db/helper');
+      const raw = await permanentDeleteProject(projectId);
+      return typeof raw === 'string' ? JSON.parse(raw) : raw;
+    },
+    importOpenApiPathsAndSecurity: (versionId, paths, schemes) =>
+      importOpenAPIPathsAndSecurityWithPool(uiConnectionPool(), versionId, paths, schemes),
+  };
+}
+
+createImportEngine(buildDefaultImportEngineDeps());
+
+export { startImport, getImportStatus, cancelImport, commitImport, rollbackImport, rollbackCompletedImport, retryImport };
+
 export type { PoolClient } from './engine/import-transaction';
 export {
   getTransactionClient,

--- a/objectified-importer/src/server.ts
+++ b/objectified-importer/src/server.ts
@@ -59,16 +59,13 @@ export async function importPathsFromOpenAPIForVersion(
 export { importOpenAPIPathsAndSecurityWithPool } from './engine/import-openapi-paths-security';
 
 function buildDefaultImportEngineDeps(): ImportEngineDeps {
+  const planEntitlements = nodeRequire('../../../objectified-ui/lib/db/plan-entitlements');
   return {
     txClient: new PgTransactionalClient(uiConnectionPool(), {
-      checkPlanForNewProject: async (userId, client) => {
-        const { getPlanBlockMessageForNewProject } = nodeRequire('../../../objectified-ui/lib/db/plan-entitlements');
-        return getPlanBlockMessageForNewProject(userId, client);
-      },
-      checkPlanForNewVersion: async (userId, client) => {
-        const { getPlanBlockMessageForNewVersion } = nodeRequire('../../../objectified-ui/lib/db/plan-entitlements');
-        return getPlanBlockMessageForNewVersion(userId, client);
-      },
+      checkPlanForNewProject: async (userId, client) =>
+        planEntitlements.getPlanBlockMessageForNewProject(userId, client),
+      checkPlanForNewVersion: async (userId, client) =>
+        planEntitlements.getPlanBlockMessageForNewVersion(userId, client),
     }),
     recordRepositoryImport: async link => {
       const { recordTenantRepositoryImport } = nodeRequire('../../../objectified-ui/lib/db/repository-import-metrics');

--- a/objectified-importer/tests/engine-with-mock-tx.test.ts
+++ b/objectified-importer/tests/engine-with-mock-tx.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Engine wiring: TransactionHandle used via injected mock client (#3303).
+ *
+ * Avoid vi.mock('../src/parsers/index') here — Vitest hoists it and can overwrite
+ * other test files' parser mocks in the same worker.
+ */
+
+import { describe, test, expect, beforeEach, vi } from 'vitest';
+import { createImportEngine } from '../src/engine/import-helper';
+import { mockTxConnect, buildDefaultMockTransactionHandle } from './import-test-mocks';
+
+/** Minimal OpenAPI document so the real OpenAPI importer yields one class (no parser mock). */
+const openapiOneWidget = {
+  openapi: '3.1.0',
+  info: { title: 'TxEngineTest', version: '1.0.0' },
+  paths: {},
+  components: {
+    schemas: {
+      Widget: {
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+        },
+      },
+    },
+  },
+};
+
+async function waitForPendingApproval(
+  getImportStatus: (jobId: string) => Promise<{ state: string }>,
+  jobId: string,
+  maxMs = 5000
+): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < maxMs) {
+    const status = await getImportStatus(jobId);
+    if (status.state === 'pending-approval') return;
+    if (status.state !== 'queued' && status.state !== 'running') {
+      throw new Error(`Expected pending-approval, got ${status.state}`);
+    }
+    await new Promise((r) => setTimeout(r, 30));
+  }
+  throw new Error(`Job ${jobId} did not reach pending-approval within ${maxMs}ms`);
+}
+
+describe('createImportEngine with mock TransactionalClient', () => {
+  const input = {
+    tenantId: 't1',
+    userId: 'u1',
+    sourceKind: 'openapi' as const,
+    document: openapiOneWidget,
+    project: { name: 'P', slug: 'p', description: null },
+    version: { versionId: '1.0.0', description: null },
+    options: { selectedSchemas: ['Widget'] },
+  };
+
+  beforeEach(() => {
+    mockTxConnect.mockClear();
+    mockTxConnect.mockImplementation(async () => buildDefaultMockTransactionHandle());
+    createImportEngine({
+      txClient: { connect: () => mockTxConnect() },
+      recordRepositoryImport: vi.fn(async () => {}),
+      permanentDeleteProject: vi.fn(async () => ({ success: true })),
+      importOpenApiPathsAndSecurity: vi.fn(async () => ({ success: true })),
+    });
+  });
+
+  test('transaction mode reaches pending-approval and calls connect and begin on the handle', async () => {
+    const handle = buildDefaultMockTransactionHandle();
+    mockTxConnect.mockImplementation(async () => handle);
+
+    const { startImport, getImportStatus } = await import('../src/engine/import-helper');
+    const { jobId } = await startImport(input);
+    await waitForPendingApproval(getImportStatus, jobId);
+
+    expect(mockTxConnect).toHaveBeenCalled();
+    expect(handle.begin).toHaveBeenCalled();
+  });
+
+  test('rollbackImport invokes rollback on the open transaction handle', async () => {
+    const handle = buildDefaultMockTransactionHandle();
+    mockTxConnect.mockImplementation(async () => handle);
+
+    const { startImport, getImportStatus, rollbackImport } = await import('../src/engine/import-helper');
+    const { jobId } = await startImport(input);
+    await waitForPendingApproval(getImportStatus, jobId);
+
+    await rollbackImport(jobId);
+
+    expect(handle.rollback).toHaveBeenCalled();
+    const st = await getImportStatus(jobId);
+    expect(st.state).toBe('rolled-back');
+  });
+
+  test('commit failure marks job failed and releases the handle', async () => {
+    const handle = buildDefaultMockTransactionHandle();
+    handle.commit = vi.fn(async () => {
+      throw new Error('commit rejected');
+    });
+    mockTxConnect.mockImplementation(async () => handle);
+
+    const { startImport, getImportStatus, commitImport } = await import('../src/engine/import-helper');
+    const { jobId } = await startImport(input);
+    await waitForPendingApproval(getImportStatus, jobId);
+
+    const res = await commitImport(jobId);
+    expect(res.success).toBe(false);
+
+    const st = await getImportStatus(jobId);
+    expect(st.state).toBe('failed');
+    expect(handle.release).toHaveBeenCalled();
+  });
+});

--- a/objectified-importer/tests/import-dry-run.test.ts
+++ b/objectified-importer/tests/import-dry-run.test.ts
@@ -5,29 +5,11 @@
  * - When options.dryRun === true, no DB transaction or writes occur
  * - Job completes with state 'completed', summary.dryRun === true, no result.projectId/versionId
  * - Log events include DRY_RUN and DRY_RUN_COMPLETE
- * - getTransactionClient and beginTransaction are never called
+ * - txClient.connect is never called
  */
 
-
-const mockGetTransactionClient = vi.fn();
-const mockBeginTransaction = vi.fn();
-const mockClient = { query: vi.fn(), release: vi.fn() };
-
-vi.mock('../src/engine/import-transaction', () => ({
-  getTransactionClient: (...args: any[]) => mockGetTransactionClient(...args),
-  beginTransaction: (...args: any[]) => mockBeginTransaction(...args),
-  commitTransaction: vi.fn(),
-  rollbackTransaction: vi.fn(),
-  releaseClient: vi.fn(),
-  createProjectTx: vi.fn(),
-  createVersionTx: vi.fn(),
-  createPropertyTx: vi.fn(),
-  createClassTx: vi.fn(),
-  addPropertyToClassTx: vi.fn(),
-  getClassesWithPropertiesAndTagsTx: vi.fn(),
-  getLatestVersionUuidForProjectTx: vi.fn(() => Promise.resolve(null)),
-  listProjectLibraryPropertiesTx: vi.fn(() => Promise.resolve([])),
-}));
+import { createImportEngine } from '../src/engine/import-helper';
+import { mockTxConnect } from './import-test-mocks';
 
 const mockNormalizeResult = {
   classes: [
@@ -94,14 +76,13 @@ describe('Import Dry Run (#729)', () => {
   };
 
   beforeEach(() => {
-    mockGetTransactionClient.mockReset();
-    mockBeginTransaction.mockReset();
-    mockGetTransactionClient.mockResolvedValue(mockClient);
-    mockBeginTransaction.mockResolvedValue(undefined);
-  });
-
-  afterEach(() => {
-    vi.resetModules();
+    mockTxConnect.mockClear();
+    createImportEngine({
+      txClient: { connect: () => mockTxConnect() },
+      recordRepositoryImport: vi.fn(async () => {}),
+      permanentDeleteProject: vi.fn(async () => ({ success: true })),
+      importOpenApiPathsAndSecurity: vi.fn(async () => ({ success: true })),
+    });
   });
 
   test('dry run completes with state completed and summary.dryRun true', async () => {
@@ -126,14 +107,13 @@ describe('Import Dry Run (#729)', () => {
     expect(status.summary?.versionId).toBe(dryRunInput.version.versionId);
   });
 
-  test('dry run does not call getTransactionClient or beginTransaction', async () => {
+  test('dry run does not call txClient.connect', async () => {
     const { startImport, getImportStatus } = await import('../src/engine/import-helper');
     const { jobId } = await startImport(dryRunInput);
 
     await waitForJobEnd(getImportStatus, jobId);
 
-    expect(mockGetTransactionClient).not.toHaveBeenCalled();
-    expect(mockBeginTransaction).not.toHaveBeenCalled();
+    expect(mockTxConnect).not.toHaveBeenCalled();
   });
 
   test('dry run emits DRY_RUN and DRY_RUN_COMPLETE events', async () => {
@@ -162,7 +142,6 @@ describe('Import Dry Run (#729)', () => {
     expect(status.summary?.classes?.map((c: any) => c.name)).toEqual(
       expect.arrayContaining(['User', 'Product'])
     );
-    // Unique properties by JSON signature (id/email/name may share type → 1 or more)
     expect(status.summary?.propertiesCreated).toBeGreaterThanOrEqual(1);
     expect(status.summary?.totalTime).toBeDefined();
     expect(typeof status.summary?.totalTime).toBe('number');
@@ -186,7 +165,7 @@ describe('Import Dry Run (#729)', () => {
 
     expect(status.state).toBe('completed');
     expect(status.summary?.dryRun).toBe(true);
-    expect(mockGetTransactionClient).not.toHaveBeenCalled();
+    expect(mockTxConnect).not.toHaveBeenCalled();
   });
 
   test('ImportJobInput allows dryRun in options', () => {

--- a/objectified-importer/tests/import-graceful-degradation.test.ts
+++ b/objectified-importer/tests/import-graceful-degradation.test.ts
@@ -1,73 +1,60 @@
 /**
  * Import Graceful Degradation Tests (#733)
- *
- * Unit tests for "continue on non-critical errors" during import execution:
- * - Property link failure: addPropertyToClassTx fails → emit PROPERTY_LINK_FAILED warn, continue, reach pending-approval
- * - Verification failure: verification mismatches → do not throw, emit VERIFY_MISMATCHES warn, reach pending-approval
  */
 
+import { createImportEngine } from '../src/engine/import-helper';
+import { mockTxConnect } from './import-test-mocks';
 
-// Track addPropertyToClassTx call count for "fail on Nth call" behavior
 let addPropertyToClassTxCallCount = 0;
 let addPropertyToClassTxFailOnCall: number | null = null;
-
-// Control getClassesWithPropertiesAndTagsTx response for verification tests
 let getClassesWithPropertiesAndTagsTxReturnsMismatch = false;
 
-const mockClient = { query: vi.fn(), release: vi.fn() };
+const mockBeginTransaction = vi.fn();
+const mockCommitTransaction = vi.fn();
+const mockRollbackTransaction = vi.fn();
+const mockReleaseClient = vi.fn();
+const mockCreateProjectTx = vi.fn(() =>
+  Promise.resolve(JSON.stringify({ success: true, project: { id: 'proj-1' } }))
+);
+const mockCreateVersionTx = vi.fn(() =>
+  Promise.resolve(JSON.stringify({ success: true, version: { id: 'ver-1' } }))
+);
+const mockCreatePropertyTx = vi.fn((_projectId: string, _name: string, _desc: any, data: any) => {
+  const id = 'prop-' + JSON.stringify(data).length;
+  return Promise.resolve(JSON.stringify({ success: true, property: { id } }));
+});
+const mockCreateClassTx = vi.fn(() =>
+  Promise.resolve(JSON.stringify({ success: true, class: { id: 'class-1' } }))
+);
+const mockAddPropertyToClassTx = vi.fn(async () => {
+  addPropertyToClassTxCallCount++;
+  if (addPropertyToClassTxFailOnCall !== null && addPropertyToClassTxCallCount === addPropertyToClassTxFailOnCall) {
+    return Promise.resolve(JSON.stringify({ success: false, error: 'Constraint violation (simulated)' }));
+  }
+  return Promise.resolve(
+    JSON.stringify({ success: true, classProperty: { id: 'cp-' + addPropertyToClassTxCallCount } })
+  );
+});
+const mockGetClassesWithPropertiesAndTagsTx = vi.fn(async () => {
+  if (getClassesWithPropertiesAndTagsTxReturnsMismatch) {
+    return Promise.resolve(JSON.stringify([]));
+  }
+  return Promise.resolve(
+    JSON.stringify([
+      {
+        name: 'TestClass',
+        schema: {},
+        properties: [
+          { id: 'p1', name: 'id', data: { type: 'string' }, children: [] },
+          { id: 'p2', name: 'name', data: { type: 'number' }, children: [] },
+        ],
+      },
+    ])
+  );
+});
+const mockGetLatestVersionUuidForProjectTx = vi.fn(() => Promise.resolve(null));
+const mockListProjectLibraryPropertiesTx = vi.fn(() => Promise.resolve([]));
 
-vi.mock('../src/engine/import-transaction', () => ({
-  getTransactionClient: vi.fn(() => Promise.resolve(mockClient)),
-  beginTransaction: vi.fn(() => Promise.resolve()),
-  commitTransaction: vi.fn(() => Promise.resolve()),
-  rollbackTransaction: vi.fn(() => Promise.resolve()),
-  releaseClient: vi.fn(() => Promise.resolve()),
-  createProjectTx: vi.fn(() =>
-    Promise.resolve(JSON.stringify({ success: true, project: { id: 'proj-1' } }))
-  ),
-  createVersionTx: vi.fn(() =>
-    Promise.resolve(JSON.stringify({ success: true, version: { id: 'ver-1' } }))
-  ),
-  createPropertyTx: vi.fn((_client: any, _projectId: string, _name: string, _desc: any, data: any) => {
-    const id = 'prop-' + JSON.stringify(data).length;
-    return Promise.resolve(JSON.stringify({ success: true, property: { id } }));
-  }),
-  createClassTx: vi.fn(() =>
-    Promise.resolve(JSON.stringify({ success: true, class: { id: 'class-1' } }))
-  ),
-  addPropertyToClassTx: vi.fn(async () => {
-    addPropertyToClassTxCallCount++;
-    if (addPropertyToClassTxFailOnCall !== null && addPropertyToClassTxCallCount === addPropertyToClassTxFailOnCall) {
-      return Promise.resolve(
-        JSON.stringify({ success: false, error: 'Constraint violation (simulated)' })
-      );
-    }
-    return Promise.resolve(
-      JSON.stringify({ success: true, classProperty: { id: 'cp-' + addPropertyToClassTxCallCount } })
-    );
-  }),
-  getClassesWithPropertiesAndTagsTx: vi.fn(async () => {
-    if (getClassesWithPropertiesAndTagsTxReturnsMismatch) {
-      return Promise.resolve(JSON.stringify([])); // No classes → verification will find missing_class
-    }
-    return Promise.resolve(
-      JSON.stringify([
-        {
-          name: 'TestClass',
-          schema: {},
-          properties: [
-            { id: 'p1', name: 'id', data: { type: 'string' }, children: [] },
-            { id: 'p2', name: 'name', data: { type: 'number' }, children: [] }
-          ]
-        }
-      ])
-    );
-  }),
-  getLatestVersionUuidForProjectTx: vi.fn(() => Promise.resolve(null)),
-  listProjectLibraryPropertiesTx: vi.fn(() => Promise.resolve([])),
-}));
-
-// Normalized class: two properties with different types so we get two addPropertyToClassTx calls
 const mockNormalizeResult = {
   classes: [
     {
@@ -76,19 +63,19 @@ const mockNormalizeResult = {
       schema: { type: 'object' },
       properties: [
         { name: 'id', data: { type: 'string' }, description: null },
-        { name: 'count', data: { type: 'number' }, description: null }
-      ]
-    }
+        { name: 'count', data: { type: 'number' }, description: null },
+      ],
+    },
   ],
-  warnings: [] as string[]
+  warnings: [] as string[],
 };
 
 vi.mock('../src/parsers/index', () => ({
   getImporter: vi.fn(() => ({
     kind: 'openapi',
-    normalize: () => mockNormalizeResult
+    normalize: () => mockNormalizeResult,
   })),
-  ImportSourceKind: { openapi: 'openapi', arazzo: 'arazzo', unknown: 'unknown' }
+  ImportSourceKind: { openapi: 'openapi', arazzo: 'arazzo', unknown: 'unknown' },
 }));
 
 async function waitForJobEnd(
@@ -115,23 +102,45 @@ describe('Import Graceful Degradation (#733)', () => {
     document: { openapi: '3.1.0' },
     project: { name: 'Test', slug: 'test', description: null },
     version: { versionId: '1.0.0', description: null },
-    options: { selectedSchemas: [] }
+    options: { selectedSchemas: [] },
   };
 
   beforeEach(() => {
     addPropertyToClassTxCallCount = 0;
     addPropertyToClassTxFailOnCall = null;
     getClassesWithPropertiesAndTagsTxReturnsMismatch = false;
-    mockClient.query.mockReset();
-    mockClient.release.mockReset();
-  });
+    mockTxConnect.mockReset();
 
-  afterEach(() => {
-    vi.resetModules();
+    mockBeginTransaction.mockResolvedValue(undefined);
+    mockCommitTransaction.mockResolvedValue(undefined);
+    mockRollbackTransaction.mockResolvedValue(undefined);
+    mockReleaseClient.mockResolvedValue(undefined);
+
+    mockTxConnect.mockImplementation(async () => ({
+      begin: mockBeginTransaction,
+      commit: mockCommitTransaction,
+      rollback: mockRollbackTransaction,
+      release: mockReleaseClient,
+      createProjectTx: mockCreateProjectTx,
+      createVersionTx: mockCreateVersionTx,
+      createPropertyTx: mockCreatePropertyTx,
+      createClassTx: mockCreateClassTx,
+      addPropertyToClassTx: mockAddPropertyToClassTx,
+      getClassesWithPropertiesAndTagsTx: mockGetClassesWithPropertiesAndTagsTx,
+      getLatestVersionUuidForProjectTx: mockGetLatestVersionUuidForProjectTx,
+      listProjectLibraryPropertiesTx: mockListProjectLibraryPropertiesTx,
+    }));
+
+    createImportEngine({
+      txClient: { connect: () => mockTxConnect() },
+      recordRepositoryImport: vi.fn(async () => {}),
+      permanentDeleteProject: vi.fn(async () => ({ success: true })),
+      importOpenApiPathsAndSecurity: vi.fn(async () => ({ success: true })),
+    });
   });
 
   test('when addPropertyToClassTx fails for one property: emits PROPERTY_LINK_FAILED warn and reaches pending-approval', async () => {
-    addPropertyToClassTxFailOnCall = 2; // Fail on second property link
+    addPropertyToClassTxFailOnCall = 2;
 
     const { startImport, getImportStatus } = await import('../src/engine/import-helper');
     const { jobId } = await startImport(validInput);
@@ -149,7 +158,7 @@ describe('Import Graceful Degradation (#733)', () => {
   });
 
   test('when verification fails (mismatches): does not throw, emits VERIFY_MISMATCHES warn and reaches pending-approval', async () => {
-    getClassesWithPropertiesAndTagsTxReturnsMismatch = true; // DB "returns" no classes → verification finds missing_class
+    getClassesWithPropertiesAndTagsTxReturnsMismatch = true;
 
     const { startImport, getImportStatus } = await import('../src/engine/import-helper');
     const { jobId } = await startImport(validInput);
@@ -182,8 +191,6 @@ describe('Import Graceful Degradation (#733)', () => {
   test('critical error (missing tenantId) throws and does not start job', async () => {
     const { startImport } = await import('../src/engine/import-helper');
 
-    await expect(
-      startImport({ ...validInput, tenantId: '' })
-    ).rejects.toThrow('Tenant ID is required');
+    await expect(startImport({ ...validInput, tenantId: '' })).rejects.toThrow('Tenant ID is required');
   });
 });

--- a/objectified-importer/tests/import-helper.test.ts
+++ b/objectified-importer/tests/import-helper.test.ts
@@ -20,8 +20,11 @@ import type {
 } from '../src/engine/import-helper';
 
 vi.mock('../src/parsers/index', () => ({
-  getImporter: vi.fn(),
-  ImportSourceKind: 'openapi',
+  getImporter: vi.fn(() => ({
+    kind: 'openapi',
+    normalize: () => ({ classes: [], warnings: [] as string[] }),
+  })),
+  ImportSourceKind: { openapi: 'openapi', arazzo: 'arazzo', unknown: 'unknown' },
 }));
 
 describe('Import Helper - Type Definitions', () => {

--- a/objectified-importer/tests/import-incremental-mode.test.ts
+++ b/objectified-importer/tests/import-incremental-mode.test.ts
@@ -1,16 +1,10 @@
 /**
  * Import Incremental Mode Tests (#730)
- *
- * Unit tests for incremental mode: import all available, skip failures.
- * - When options.incrementalMode === true, no single transaction; each class is committed separately
- * - Failed classes are skipped and the job still completes with state 'completed'
- * - summary.incrementalMode === true, result has projectId/versionId
- * - Events include INCREMENTAL_MODE and INCREMENTAL_COMPLETE
- * - transactionPending remains false (no pending-approval step)
  */
 
+import { createImportEngine } from '../src/engine/import-helper';
+import { mockTxConnect } from './import-test-mocks';
 
-const mockGetTransactionClient = vi.fn();
 const mockBeginTransaction = vi.fn();
 const mockCommitTransaction = vi.fn();
 const mockRollbackTransaction = vi.fn();
@@ -24,29 +18,7 @@ const mockGetClassesWithPropertiesAndTagsTx = vi.fn();
 const mockGetLatestVersionUuidForProjectTx = vi.fn(() => Promise.resolve(null));
 const mockListProjectLibraryPropertiesTx = vi.fn(() => Promise.resolve([]));
 
-// When set, createClassTx will return failure for this class name (simulate one class failing)
 let createClassTxFailForClassName: string | null = null;
-
-const mockClient = { query: vi.fn(), release: vi.fn() };
-
-vi.mock('../src/engine/import-transaction', () => ({
-  getTransactionClient: (...args: any[]) => mockGetTransactionClient(...args),
-  beginTransaction: (...args: any[]) => mockBeginTransaction(...args),
-  commitTransaction: (...args: any[]) => mockCommitTransaction(...args),
-  rollbackTransaction: (...args: any[]) => mockRollbackTransaction(...args),
-  releaseClient: (...args: any[]) => mockReleaseClient(...args),
-  createProjectTx: (...args: any[]) => mockCreateProjectTx(...args),
-  createVersionTx: (...args: any[]) => mockCreateVersionTx(...args),
-  createPropertyTx: (...args: any[]) => mockCreatePropertyTx(...args),
-  createClassTx: async (...args: any[]) => {
-    const result = await mockCreateClassTx(...args);
-    return result;
-  },
-  addPropertyToClassTx: (...args: any[]) => mockAddPropertyToClassTx(...args),
-  getClassesWithPropertiesAndTagsTx: (...args: any[]) => mockGetClassesWithPropertiesAndTagsTx(...args),
-  getLatestVersionUuidForProjectTx: (...args: any[]) => mockGetLatestVersionUuidForProjectTx(...args),
-  listProjectLibraryPropertiesTx: (...args: any[]) => mockListProjectLibraryPropertiesTx(...args),
-}));
 
 const mockNormalizeResult = {
   classes: [
@@ -114,7 +86,6 @@ describe('Import Incremental Mode (#730)', () => {
 
   beforeEach(() => {
     createClassTxFailForClassName = null;
-    mockGetTransactionClient.mockReset();
     mockBeginTransaction.mockReset();
     mockCommitTransaction.mockReset();
     mockRollbackTransaction.mockReset();
@@ -127,8 +98,8 @@ describe('Import Incremental Mode (#730)', () => {
     mockGetClassesWithPropertiesAndTagsTx.mockReset();
     mockGetLatestVersionUuidForProjectTx.mockReset();
     mockListProjectLibraryPropertiesTx.mockReset();
+    mockTxConnect.mockReset();
 
-    mockGetTransactionClient.mockResolvedValue(mockClient);
     mockBeginTransaction.mockResolvedValue(undefined);
     mockCommitTransaction.mockResolvedValue(undefined);
     mockRollbackTransaction.mockResolvedValue(undefined);
@@ -139,13 +110,12 @@ describe('Import Incremental Mode (#730)', () => {
     mockCreateVersionTx.mockResolvedValue(
       JSON.stringify({ success: true, version: { id: 'ver-incremental' } })
     );
-    mockCreatePropertyTx.mockImplementation(
-      (_c: any, _pid: string, name: string, _desc: any, data: any) =>
-        Promise.resolve(
-          JSON.stringify({ success: true, property: { id: `prop-${name}-${JSON.stringify(data).length}` } })
-        )
+    mockCreatePropertyTx.mockImplementation((_pid: string, name: string, _desc: any, data: any) =>
+      Promise.resolve(
+        JSON.stringify({ success: true, property: { id: `prop-${name}-${JSON.stringify(data).length}` } })
+      )
     );
-    mockCreateClassTx.mockImplementation((_c: any, _vid: string, name: string) => {
+    mockCreateClassTx.mockImplementation((_vid: string, name: string) => {
       if (createClassTxFailForClassName !== null && name === createClassTxFailForClassName) {
         return Promise.resolve(JSON.stringify({ success: false, error: 'Duplicate class (simulated)' }));
       }
@@ -162,10 +132,28 @@ describe('Import Incremental Mode (#730)', () => {
     );
     mockGetLatestVersionUuidForProjectTx.mockResolvedValue(null);
     mockListProjectLibraryPropertiesTx.mockResolvedValue([]);
-  });
 
-  afterEach(() => {
-    vi.resetModules();
+    mockTxConnect.mockImplementation(async () => ({
+      begin: mockBeginTransaction,
+      commit: mockCommitTransaction,
+      rollback: mockRollbackTransaction,
+      release: mockReleaseClient,
+      createProjectTx: mockCreateProjectTx,
+      createVersionTx: mockCreateVersionTx,
+      createPropertyTx: mockCreatePropertyTx,
+      createClassTx: mockCreateClassTx,
+      addPropertyToClassTx: mockAddPropertyToClassTx,
+      getClassesWithPropertiesAndTagsTx: mockGetClassesWithPropertiesAndTagsTx,
+      getLatestVersionUuidForProjectTx: mockGetLatestVersionUuidForProjectTx,
+      listProjectLibraryPropertiesTx: mockListProjectLibraryPropertiesTx,
+    }));
+
+    createImportEngine({
+      txClient: { connect: () => mockTxConnect() },
+      recordRepositoryImport: vi.fn(async () => {}),
+      permanentDeleteProject: vi.fn(async () => ({ success: true })),
+      importOpenApiPathsAndSecurity: vi.fn(async () => ({ success: true })),
+    });
   });
 
   test('incremental mode completes with state completed and summary.incrementalMode true', async () => {
@@ -216,13 +204,13 @@ describe('Import Incremental Mode (#730)', () => {
     expect(completeEvent?.message).toMatch(/complete|skipped/i);
   });
 
-  test('incremental mode calls getTransactionClient and releaseClient', async () => {
+  test('incremental mode connects once and releases', async () => {
     const { startImport, getImportStatus } = await import('../src/engine/import-helper');
     const { jobId } = await startImport(incrementalInput);
 
     await waitForJobEnd(getImportStatus, jobId);
 
-    expect(mockGetTransactionClient).toHaveBeenCalled();
+    expect(mockTxConnect).toHaveBeenCalled();
     expect(mockReleaseClient).toHaveBeenCalled();
   });
 
@@ -232,7 +220,6 @@ describe('Import Incremental Mode (#730)', () => {
 
     await waitForJobEnd(getImportStatus, jobId);
 
-    // Two classes → begin and commit each (no global begin at start in incremental path)
     expect(mockBeginTransaction).toHaveBeenCalled();
     expect(mockCommitTransaction).toHaveBeenCalled();
     expect(mockBeginTransaction.mock.calls.length).toBe(2);
@@ -277,9 +264,8 @@ describe('Import Incremental Mode (#730)', () => {
 
     await waitForJobEnd(getImportStatus, jobId);
 
-    // First class: begin, commit. Second class: begin, then createClassTx fails → rollback
     expect(mockRollbackTransaction).toHaveBeenCalled();
-    expect(mockCommitTransaction.mock.calls.length).toBe(1); // only User committed
+    expect(mockCommitTransaction.mock.calls.length).toBe(1);
   });
 
   test('when one class fails in incremental mode: CLASS_FAILED event emitted', async () => {
@@ -334,8 +320,7 @@ describe('Import Incremental Mode (#730)', () => {
 
     expect(status.state).toBe('completed');
     expect(status.summary?.dryRun).toBe(true);
-    expect(mockGetTransactionClient).not.toHaveBeenCalled();
-    // When dry run, incremental path is never hit
+    expect(mockTxConnect).not.toHaveBeenCalled();
     expect(status.summary?.incrementalMode).toBeFalsy();
   });
 
@@ -356,21 +341,14 @@ describe('Import Incremental Mode (#730)', () => {
     await waitForJobEnd(getImportStatus, jobId);
 
     expect(mockCreateProjectTx).not.toHaveBeenCalled();
-    expect(mockGetLatestVersionUuidForProjectTx).toHaveBeenCalledWith(
-      expect.anything(),
-      'already-created-project'
-    );
-    expect(mockListProjectLibraryPropertiesTx).toHaveBeenCalledWith(
-      expect.anything(),
-      'already-created-project'
-    );
+    expect(mockGetLatestVersionUuidForProjectTx).toHaveBeenCalledWith('already-created-project');
+    expect(mockListProjectLibraryPropertiesTx).toHaveBeenCalledWith('already-created-project');
 
-    // Normalized fixture uses only { type: 'string' } for scalars; one library row covers every occurrence.
     expect(mockCreatePropertyTx).not.toHaveBeenCalled();
 
     const versionCalls = mockCreateVersionTx.mock.calls;
     expect(versionCalls.length).toBeGreaterThanOrEqual(1);
     const lastCall = versionCalls[versionCalls.length - 1];
-    expect(lastCall[6]).toEqual({ parentVersionUuid: 'previous-version-uuid' });
+    expect(lastCall[5]).toEqual({ parentVersionUuid: 'previous-version-uuid' });
   });
 });

--- a/objectified-importer/tests/import-rollback-completed.test.ts
+++ b/objectified-importer/tests/import-rollback-completed.test.ts
@@ -1,53 +1,47 @@
 /**
  * Import Rollback Completed Tests (#735)
- *
- * Tests for rollbackCompletedImport: undo a completed import by removing
- * the created project and all its data. Only allowed when state === 'completed'.
  */
 
+import { createImportEngine } from '../src/engine/import-helper';
+import { mockTxConnect } from './import-test-mocks';
 
-import * as uiHelper from '../../objectified-ui/lib/db/helper';
+const mockPermanentDeleteProject = vi.fn();
 
-const mockClient = { query: vi.fn(), release: vi.fn() };
-
-vi.mock('../src/engine/import-transaction', () => ({
-  getTransactionClient: vi.fn(() => Promise.resolve(mockClient)),
-  beginTransaction: vi.fn(() => Promise.resolve()),
-  commitTransaction: vi.fn(() => Promise.resolve()),
-  rollbackTransaction: vi.fn(() => Promise.resolve()),
-  releaseClient: vi.fn(() => Promise.resolve()),
-  createProjectTx: vi.fn(() =>
-    Promise.resolve(JSON.stringify({ success: true, project: { id: 'proj-rollback-test' } }))
-  ),
-  createVersionTx: vi.fn(() =>
-    Promise.resolve(JSON.stringify({ success: true, version: { id: 'ver-rollback-test' } }))
-  ),
-  createPropertyTx: vi.fn((_client: any, _projectId: string, _name: string, _desc: any, data: any) =>
-    Promise.resolve(JSON.stringify({ success: true, property: { id: 'prop-' + JSON.stringify(data).length } }))
-  ),
-  createClassTx: vi.fn(() =>
-    Promise.resolve(JSON.stringify({ success: true, class: { id: 'class-1' } }))
-  ),
-  addPropertyToClassTx: vi.fn(() =>
-    Promise.resolve(JSON.stringify({ success: true, classProperty: { id: 'cp-1' } }))
-  ),
-  getClassesWithPropertiesAndTagsTx: vi.fn(() =>
-    Promise.resolve(
-      JSON.stringify([
-        {
-          name: 'TestClass',
-          schema: {},
-          properties: [
-            { id: 'p1', name: 'id', data: { type: 'string' }, children: [] },
-            { id: 'p2', name: 'name', data: { type: 'number' }, children: [] },
-          ],
-        },
-      ])
-    )
-  ),
-  getLatestVersionUuidForProjectTx: vi.fn(() => Promise.resolve(null)),
-  listProjectLibraryPropertiesTx: vi.fn(() => Promise.resolve([])),
-}));
+const mockBeginTransaction = vi.fn();
+const mockCommitTransaction = vi.fn();
+const mockRollbackTransaction = vi.fn();
+const mockReleaseClient = vi.fn();
+const mockCreateProjectTx = vi.fn(() =>
+  Promise.resolve(JSON.stringify({ success: true, project: { id: 'proj-rollback-test' } }))
+);
+const mockCreateVersionTx = vi.fn(() =>
+  Promise.resolve(JSON.stringify({ success: true, version: { id: 'ver-rollback-test' } }))
+);
+const mockCreatePropertyTx = vi.fn((_projectId: string, _name: string, _desc: any, data: any) =>
+  Promise.resolve(JSON.stringify({ success: true, property: { id: 'prop-' + JSON.stringify(data).length } }))
+);
+const mockCreateClassTx = vi.fn(() =>
+  Promise.resolve(JSON.stringify({ success: true, class: { id: 'class-1' } }))
+);
+const mockAddPropertyToClassTx = vi.fn(() =>
+  Promise.resolve(JSON.stringify({ success: true, classProperty: { id: 'cp-1' } }))
+);
+const mockGetClassesWithPropertiesAndTagsTx = vi.fn(() =>
+  Promise.resolve(
+    JSON.stringify([
+      {
+        name: 'TestClass',
+        schema: {},
+        properties: [
+          { id: 'p1', name: 'id', data: { type: 'string' }, children: [] },
+          { id: 'p2', name: 'name', data: { type: 'number' }, children: [] },
+        ],
+      },
+    ])
+  )
+);
+const mockGetLatestVersionUuidForProjectTx = vi.fn(() => Promise.resolve(null));
+const mockListProjectLibraryPropertiesTx = vi.fn(() => Promise.resolve([]));
 
 const mockNormalizeResult = {
   classes: [
@@ -100,14 +94,36 @@ describe('rollbackCompletedImport (#735)', () => {
   };
 
   beforeEach(() => {
-    vi.mocked(uiHelper.permanentDeleteProject).mockReset();
-    vi.mocked(uiHelper.permanentDeleteProject).mockResolvedValue(JSON.stringify({ success: true }));
-    mockClient.query.mockClear();
-    mockClient.release.mockClear();
-  });
+    mockPermanentDeleteProject.mockReset();
+    mockPermanentDeleteProject.mockResolvedValue({ success: true });
+    mockTxConnect.mockReset();
 
-  afterEach(() => {
-    vi.resetModules();
+    mockBeginTransaction.mockResolvedValue(undefined);
+    mockCommitTransaction.mockResolvedValue(undefined);
+    mockRollbackTransaction.mockResolvedValue(undefined);
+    mockReleaseClient.mockResolvedValue(undefined);
+
+    mockTxConnect.mockImplementation(async () => ({
+      begin: mockBeginTransaction,
+      commit: mockCommitTransaction,
+      rollback: mockRollbackTransaction,
+      release: mockReleaseClient,
+      createProjectTx: mockCreateProjectTx,
+      createVersionTx: mockCreateVersionTx,
+      createPropertyTx: mockCreatePropertyTx,
+      createClassTx: mockCreateClassTx,
+      addPropertyToClassTx: mockAddPropertyToClassTx,
+      getClassesWithPropertiesAndTagsTx: mockGetClassesWithPropertiesAndTagsTx,
+      getLatestVersionUuidForProjectTx: mockGetLatestVersionUuidForProjectTx,
+      listProjectLibraryPropertiesTx: mockListProjectLibraryPropertiesTx,
+    }));
+
+    createImportEngine({
+      txClient: { connect: () => mockTxConnect() },
+      recordRepositoryImport: vi.fn(async () => {}),
+      permanentDeleteProject: mockPermanentDeleteProject,
+      importOpenApiPathsAndSecurity: vi.fn(async () => ({ success: true })),
+    });
   });
 
   test('returns Job not found for unknown jobId', async () => {
@@ -117,7 +133,7 @@ describe('rollbackCompletedImport (#735)', () => {
 
     expect(result.success).toBe(false);
     expect(result.error).toBe('Job not found');
-    expect(uiHelper.permanentDeleteProject).not.toHaveBeenCalled();
+    expect(mockPermanentDeleteProject).not.toHaveBeenCalled();
   });
 
   test('returns error when job is pending-approval (not completed)', async () => {
@@ -132,7 +148,7 @@ describe('rollbackCompletedImport (#735)', () => {
     expect(result.success).toBe(false);
     expect(result.error).toContain('only allowed when the import has been committed');
     expect(result.error).toContain('pending-approval');
-    expect(uiHelper.permanentDeleteProject).not.toHaveBeenCalled();
+    expect(mockPermanentDeleteProject).not.toHaveBeenCalled();
   });
 
   test('calls permanentDeleteProject with projectId and sets state to rolled-back when job is completed', async () => {
@@ -151,8 +167,8 @@ describe('rollbackCompletedImport (#735)', () => {
     const rollbackResult = await rollbackCompletedImport(jobId);
 
     expect(rollbackResult.success).toBe(true);
-    expect(uiHelper.permanentDeleteProject).toHaveBeenCalledTimes(1);
-    expect(uiHelper.permanentDeleteProject).toHaveBeenCalledWith('proj-rollback-test');
+    expect(mockPermanentDeleteProject).toHaveBeenCalledTimes(1);
+    expect(mockPermanentDeleteProject).toHaveBeenCalledWith('proj-rollback-test');
 
     const afterStatus = await getImportStatus(jobId);
     expect(afterStatus.state).toBe('rolled-back');
@@ -176,9 +192,7 @@ describe('rollbackCompletedImport (#735)', () => {
   });
 
   test('returns error when permanentDeleteProject returns success: false', async () => {
-    vi.mocked(uiHelper.permanentDeleteProject).mockResolvedValue(
-      JSON.stringify({ success: false, error: 'Project in use' })
-    );
+    mockPermanentDeleteProject.mockResolvedValue({ success: false, error: 'Project in use' });
 
     const { startImport, getImportStatus, commitImport, rollbackCompletedImport } = await import(
       '../src/engine/import-helper'
@@ -192,7 +206,7 @@ describe('rollbackCompletedImport (#735)', () => {
 
     expect(result.success).toBe(false);
     expect(result.error).toBe('Project in use');
-    expect(uiHelper.permanentDeleteProject).toHaveBeenCalledWith('proj-rollback-test');
+    expect(mockPermanentDeleteProject).toHaveBeenCalledWith('proj-rollback-test');
 
     const status = await getImportStatus(jobId);
     expect(status.state).toBe('completed');
@@ -202,7 +216,7 @@ describe('rollbackCompletedImport (#735)', () => {
   });
 
   test('returns error when permanentDeleteProject throws', async () => {
-    vi.mocked(uiHelper.permanentDeleteProject).mockRejectedValue(new Error('Database connection lost'));
+    mockPermanentDeleteProject.mockRejectedValue(new Error('Database connection lost'));
 
     const { startImport, getImportStatus, commitImport, rollbackCompletedImport } = await import(
       '../src/engine/import-helper'
@@ -216,11 +230,11 @@ describe('rollbackCompletedImport (#735)', () => {
 
     expect(result.success).toBe(false);
     expect(result.error).toContain('Database connection lost');
-    expect(uiHelper.permanentDeleteProject).toHaveBeenCalledWith('proj-rollback-test');
+    expect(mockPermanentDeleteProject).toHaveBeenCalledWith('proj-rollback-test');
   });
 
   test('handles permanentDeleteProject returning object (not JSON string)', async () => {
-    vi.mocked(uiHelper.permanentDeleteProject).mockResolvedValue({ success: true });
+    mockPermanentDeleteProject.mockResolvedValue({ success: true });
 
     const { startImport, getImportStatus, commitImport, rollbackCompletedImport } = await import(
       '../src/engine/import-helper'
@@ -233,6 +247,6 @@ describe('rollbackCompletedImport (#735)', () => {
     const result = await rollbackCompletedImport(jobId);
 
     expect(result.success).toBe(true);
-    expect(uiHelper.permanentDeleteProject).toHaveBeenCalledWith('proj-rollback-test');
+    expect(mockPermanentDeleteProject).toHaveBeenCalledWith('proj-rollback-test');
   });
 });

--- a/objectified-importer/tests/import-test-mocks.ts
+++ b/objectified-importer/tests/import-test-mocks.ts
@@ -1,0 +1,34 @@
+import { vi } from 'vitest';
+import type { TransactionHandle } from '../src/engine/transactional-client';
+
+/** Spied by tests that assert no DB connection (e.g. dry run). */
+export const mockTxConnect = vi.fn();
+
+export function buildDefaultMockTransactionHandle(): TransactionHandle {
+  return {
+    begin: vi.fn(async () => {}),
+    commit: vi.fn(async () => {}),
+    rollback: vi.fn(async () => {}),
+    release: vi.fn(async () => {}),
+    createProjectTx: vi.fn(async () =>
+      JSON.stringify({ success: true, project: { id: 'mock-project-id' } })
+    ),
+    createVersionTx: vi.fn(async () =>
+      JSON.stringify({ success: true, version: { id: 'mock-version-id' } })
+    ),
+    getLatestVersionUuidForProjectTx: vi.fn(async () => null),
+    listProjectLibraryPropertiesTx: vi.fn(async () => []),
+    createPropertyTx: vi.fn(async () =>
+      JSON.stringify({ success: true, property: { id: 'mock-prop-id' } })
+    ),
+    createClassTx: vi.fn(async () =>
+      JSON.stringify({ success: true, class: { id: 'mock-class-id' } })
+    ),
+    addPropertyToClassTx: vi.fn(async () =>
+      JSON.stringify({ success: true, classProperty: { id: 'mock-cp-id' } })
+    ),
+    getClassesWithPropertiesAndTagsTx: vi.fn(async () => JSON.stringify([])),
+  };
+}
+
+mockTxConnect.mockImplementation(async () => buildDefaultMockTransactionHandle());

--- a/objectified-importer/tests/vitest-setup.ts
+++ b/objectified-importer/tests/vitest-setup.ts
@@ -1,26 +1,6 @@
 import { vi } from 'vitest';
 
-/** Avoid loading real plan-entitlements → `./db` under Vitest (no ts-jest require hook). */
 vi.mock('../../objectified-ui/lib/db/plan-entitlements', () => ({
   getPlanBlockMessageForNewProject: vi.fn(async () => null),
   getPlanBlockMessageForNewVersion: vi.fn(async () => null),
-}));
-
-vi.mock('../../objectified-ui/lib/db/repository-import-metrics', () => ({
-  recordTenantRepositoryImport: vi.fn(async () => true),
-}));
-
-/** import-helper only needs `permanentDeleteProject` from helper; loading real helper pulls auth → `./db`. */
-vi.mock('../../objectified-ui/lib/db/helper', () => ({
-  permanentDeleteProject: vi.fn(async () => JSON.stringify({ success: true })),
-  createProject: vi.fn(),
-  createVersion: vi.fn(),
-  createClass: vi.fn(),
-  createProperty: vi.fn(),
-  addPropertyToClass: vi.fn(),
-}));
-
-vi.mock('../src/engine/import-openapi-paths-security', () => ({
-  importOpenAPIPathsAndSecurity: vi.fn(async () => ({ success: true })),
-  importPathsFromOpenAPIForVersion: vi.fn(async () => ({ success: true })),
 }));

--- a/objectified-ui/lib/db/import-actions.ts
+++ b/objectified-ui/lib/db/import-actions.ts
@@ -2,6 +2,9 @@
 
 import * as importHelper from 'objectified-importer/server';
 
+// Wire UI-backed Postgres dependencies into the import engine at module load.
+importHelper.configureUiImportEngine();
+
 export async function startImport(input: importHelper.ImportJobInput) {
   return importHelper.startImport(input);
 }

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.106",
+  "version": "0.11.107",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -47,6 +47,7 @@ We continue to improve the platform based on your feedback with improvements and
 
 ## UI
 - Spec import engine and format parsers live in the **`objectified-importer`** workspace package (`objectified-importer` client-safe entry + `objectified-importer/server` for DB-backed import); the UI keeps thin server-action wrappers and the same import APIs (#3302).
+- **`objectified-importer`**: import engine depends on injected `TransactionalClient` / `TransactionHandle`, `ImportEngineDeps`, and `createImportEngine` (Postgres via `PgTransactionalClient`); repository metrics and completed rollback use injected helpers; Vitest setup no longer loads the engine before per-file `vi.mock` (#3303).
 - Adds the ability to view projects that were deleted (show deleted toggle)
 - Introduces undelete for soft deleted projects
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6542,7 +6542,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/pg@npm:^8.20.0":
+"@types/pg@npm:^8.15.5, @types/pg@npm:^8.20.0":
   version: 8.20.0
   resolution: "@types/pg@npm:8.20.0"
   dependencies:
@@ -14223,6 +14223,8 @@ __metadata:
   resolution: "objectified-importer@workspace:objectified-importer"
   dependencies:
     "@types/node": "npm:^22.10.0"
+    "@types/pg": "npm:^8.15.5"
+    pg: "npm:^8.20.0"
     typescript: "npm:^5.9.3"
     vitest: "npm:^3.2.4"
   languageName: unknown


### PR DESCRIPTION
## What / why
Introduces `TransactionalClient` / `TransactionHandle`, `ImportEngineDeps`, and `createImportEngine` so the import engine does not call Postgres or UI DB modules directly. Postgres is isolated in `PgTransactionalClient`; repository metrics and completed rollback deletion use injected callbacks. OpenAPI paths import is wired with an explicit pool at the boundary.

## How to test
- **Run** `yarn workspace objectified-importer build` and **run** `yarn workspace objectified-importer test` (includes **`tests/engine-with-mock-tx.test.ts`**).
- **Run** `yarn build` and **run** `yarn test` from repo root (includes **`yarn workspace objectified-ui test`**).
- **Smoke**: start an OpenAPI import in the UI and complete commit / rollback as before.

## Risk / notes
- Consumers must call `createImportEngine(deps)` before `startImport`; UI server bootstrap wires defaults.
- Vitest no longer imports `import-helper` in `vitest-setup.ts` (setup ran before per-file mocks and cached real parsers).

Closes #3303

Made with [Cursor](https://cursor.com)