### PR TITLE
Fix #3305 - CLI-IMPORT T4: import_jobs DB migration and fixtures

### DIFF
--- a/objectified-db/fixtures/import_jobs_terminal_states.sql
+++ b/objectified-db/fixtures/import_jobs_terminal_states.sql
@@ -1,0 +1,121 @@
+-- Fixture: one import_jobs row per terminal state for REST/UI harnesses (#3305).
+-- Apply after migrations including 20260508-120000.sql. Idempotent for these UUIDs.
+--
+-- Expect:
+--   SELECT state, count(*) FROM odb.import_jobs
+--   WHERE tenant_id = 'a3305305-0001-4000-8000-000000000001'::uuid
+--   GROUP BY state ORDER BY state;
+--   → four rows: canceled, completed, failed, rolled-back
+--
+SET search_path TO odb, public;
+
+BEGIN;
+
+DELETE FROM odb.import_jobs
+WHERE tenant_id = 'a3305305-0001-4000-8000-000000000001'::uuid;
+
+DELETE FROM odb.tenant_users
+WHERE tenant_id = 'a3305305-0001-4000-8000-000000000001'::uuid
+  AND user_id = 'a3305305-0002-4000-8000-000000000002'::uuid;
+
+DELETE FROM odb.tenants WHERE id = 'a3305305-0001-4000-8000-000000000001'::uuid;
+DELETE FROM odb.users WHERE id = 'a3305305-0002-4000-8000-000000000002'::uuid;
+
+INSERT INTO odb.users (id, name, email, password)
+VALUES (
+    'a3305305-0002-4000-8000-000000000002',
+    'Import Jobs Fixture User',
+    'import-jobs-fixture-3305@objectified.local',
+    '$2b$04$fixture-not-a-real-hash-used-for-dev-only'
+);
+
+INSERT INTO odb.tenants (id, name, slug)
+VALUES (
+    'a3305305-0001-4000-8000-000000000001',
+    'Import Jobs Fixture Tenant',
+    'import-jobs-fixture-tenant-3305'
+);
+
+INSERT INTO odb.tenant_users (tenant_id, user_id)
+VALUES (
+    'a3305305-0001-4000-8000-000000000001',
+    'a3305305-0002-4000-8000-000000000002'
+);
+
+INSERT INTO odb.import_jobs (
+    job_id,
+    tenant_id,
+    project_id,
+    state,
+    source_kind,
+    input,
+    events,
+    percent,
+    result,
+    error,
+    created_by,
+    finished_at,
+    expires_at
+)
+VALUES (
+    'a3305305-1001-4000-8000-000000000001',
+    'a3305305-0001-4000-8000-000000000001',
+    NULL,
+    'completed',
+    'openapi',
+    '{"fixture": true, "kind": "terminal-completed"}'::jsonb,
+    '[{"type": "completed", "at": "fixture"}]'::jsonb,
+    100,
+    '{"projectId": "b3305305-0001-4000-8000-000000000001", "versionId": "b3305305-0002-4000-8000-000000000002"}'::jsonb,
+    NULL,
+    'a3305305-0002-4000-8000-000000000002',
+    now() - INTERVAL '1 hour',
+    now() + INTERVAL '7 days'
+),
+(
+    'a3305305-1002-4000-8000-000000000002',
+    'a3305305-0001-4000-8000-000000000001',
+    NULL,
+    'failed',
+    'swagger',
+    '{"fixture": true, "kind": "terminal-failed"}'::jsonb,
+    '[{"type": "failed", "at": "fixture"}]'::jsonb,
+    40,
+    NULL,
+    '{"code": "fixture_error", "message": "Harness terminal failed state"}'::jsonb,
+    'a3305305-0002-4000-8000-000000000002',
+    now() - INTERVAL '2 hours',
+    now() + INTERVAL '7 days'
+),
+(
+    'a3305305-1003-4000-8000-000000000003',
+    'a3305305-0001-4000-8000-000000000001',
+    NULL,
+    'canceled',
+    'arazzo',
+    '{"fixture": true, "kind": "terminal-canceled"}'::jsonb,
+    '[{"type": "canceled", "at": "fixture"}]'::jsonb,
+    10,
+    NULL,
+    NULL,
+    'a3305305-0002-4000-8000-000000000002',
+    now() - INTERVAL '3 hours',
+    now() + INTERVAL '7 days'
+),
+(
+    'a3305305-1004-4000-8000-000000000004',
+    'a3305305-0001-4000-8000-000000000001',
+    NULL,
+    'rolled-back',
+    'openapi',
+    '{"fixture": true, "kind": "terminal-rolled-back"}'::jsonb,
+    '[{"type": "rolled-back", "at": "fixture"}]'::jsonb,
+    0,
+    NULL,
+    NULL,
+    'a3305305-0002-4000-8000-000000000002',
+    now() - INTERVAL '4 hours',
+    now() + INTERVAL '7 days'
+);
+
+COMMIT;

--- a/objectified-db/scripts/20260508-120000.sql
+++ b/objectified-db/scripts/20260508-120000.sql
@@ -1,0 +1,43 @@
+-- CLI import job persistence: odb.import_jobs (#3305, T4)
+SET search_path TO odb, public;
+
+CREATE TABLE odb.import_jobs (
+    job_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id UUID NOT NULL REFERENCES odb.tenants(id) ON DELETE CASCADE,
+    project_id UUID NULL REFERENCES odb.projects(id) ON DELETE SET NULL,
+    state TEXT NOT NULL CHECK (state IN (
+        'queued', 'running', 'pending-approval', 'committing',
+        'completed', 'failed', 'canceled', 'rolled-back')),
+    source_kind TEXT NOT NULL CHECK (source_kind IN ('openapi', 'swagger', 'arazzo')),
+    blob_sha TEXT NULL,
+    repository_source JSONB NULL,
+    input JSONB NOT NULL,
+    events JSONB NOT NULL DEFAULT '[]'::jsonb,
+    progress JSONB NULL,
+    summary JSONB NULL,
+    result JSONB NULL,
+    percent SMALLINT NOT NULL DEFAULT 0,
+    error JSONB NULL,
+    created_by UUID NOT NULL REFERENCES odb.users(id),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    finished_at TIMESTAMPTZ NULL,
+    expires_at TIMESTAMPTZ NOT NULL DEFAULT (now() + INTERVAL '7 days')
+);
+
+CREATE INDEX import_jobs_tenant_id_idx ON odb.import_jobs (tenant_id);
+CREATE INDEX import_jobs_tenant_state_idx ON odb.import_jobs (tenant_id, state);
+CREATE INDEX import_jobs_created_at_idx ON odb.import_jobs (created_at DESC);
+CREATE INDEX import_jobs_expires_at_idx ON odb.import_jobs (expires_at)
+    WHERE state IN ('completed', 'failed', 'canceled', 'rolled-back');
+
+COMMENT ON TABLE odb.import_jobs IS
+    'Persisted spec-import job state for REST workers and importer sidecar (#3305); input is redacted (no credentials)';
+
+COMMENT ON COLUMN odb.import_jobs.input IS 'Redacted ImportJobInput JSON for audit and retry';
+COMMENT ON COLUMN odb.import_jobs.events IS 'Append-only event log JSON array; orchestrator caps length (e.g. last 1000)';
+COMMENT ON COLUMN odb.import_jobs.result IS 'On success: { projectId, versionId }';
+
+-- DOWN
+-- Rollback (#3305): drops table and all attached indexes (no orphans)
+-- DROP TABLE IF EXISTS odb.import_jobs CASCADE;

--- a/objectified-db/scripts/20260508-120000.sql
+++ b/objectified-db/scripts/20260508-120000.sql
@@ -1,8 +1,8 @@
 -- CLI import job persistence: odb.import_jobs (#3305, T4)
 SET search_path TO odb, public;
 
-CREATE TABLE odb.import_jobs (
-    job_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+CREATE TABLE IF NOT EXISTS odb.import_jobs (
+    job_id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
     tenant_id UUID NOT NULL REFERENCES odb.tenants(id) ON DELETE CASCADE,
     project_id UUID NULL REFERENCES odb.projects(id) ON DELETE SET NULL,
     state TEXT NOT NULL CHECK (state IN (
@@ -25,10 +25,10 @@ CREATE TABLE odb.import_jobs (
     expires_at TIMESTAMPTZ NOT NULL DEFAULT (now() + INTERVAL '7 days')
 );
 
-CREATE INDEX import_jobs_tenant_id_idx ON odb.import_jobs (tenant_id);
-CREATE INDEX import_jobs_tenant_state_idx ON odb.import_jobs (tenant_id, state);
-CREATE INDEX import_jobs_created_at_idx ON odb.import_jobs (created_at DESC);
-CREATE INDEX import_jobs_expires_at_idx ON odb.import_jobs (expires_at)
+CREATE INDEX IF NOT EXISTS import_jobs_tenant_id_idx ON odb.import_jobs (tenant_id);
+CREATE INDEX IF NOT EXISTS import_jobs_tenant_state_idx ON odb.import_jobs (tenant_id, state);
+CREATE INDEX IF NOT EXISTS import_jobs_created_at_idx ON odb.import_jobs (created_at DESC);
+CREATE INDEX IF NOT EXISTS import_jobs_expires_at_idx ON odb.import_jobs (expires_at)
     WHERE state IN ('completed', 'failed', 'canceled', 'rolled-back');
 
 COMMENT ON TABLE odb.import_jobs IS

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.108",
+  "version": "0.11.109",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -37,6 +37,7 @@ We continue to improve the platform based on your feedback with improvements and
 - **`objectified-cli`**: shared output layer (`lib/output.ts`) with `this.output` on `BaseCommand` — tables (`cli-table3`), stable sorted JSON/YAML, ora spinners, stderr warnings/errors, and TTY / `--json` / `--quiet` / `--no-color` / `LANG=C` behavior; Vitest snapshots cover render modes (#3189).
 
 ## Import
+- **Database**: `odb.import_jobs` migration (`objectified-db/scripts/20260508-120000.sql`) persists REST/import job state for multi-worker and sidecar restarts; `objectified-db/fixtures/import_jobs_terminal_states.sql` seeds one row per terminal state for harnesses (#3305).
 - Race condition fixed in 3.0.1 specification imports
 - Import supports Swagger 2.0 format
 - Adds the ability to import multiple versions of the same project 


### PR DESCRIPTION
## What / why
Adds `odb.import_jobs` so REST import job state can live in Postgres for multi-worker REST and importer-sidecar restarts (epic #3301). Includes an idempotent fixture with one row per **terminal** state for downstream harnesses.

## Changes
- `objectified-db/scripts/20260508-120000.sql`: table, four indexes (including partial `expires_at`), FKs, comments; `-- DOWN` rollback instructions (commented `DROP TABLE`, matching repo convention).
- `objectified-db/fixtures/import_jobs_terminal_states.sql`: fixture tenant/user + rows for `completed`, `failed`, `canceled`, `rolled-back`.
- `objectified-ui/public/WHATS_NEW.md` + patch bump `objectified-ui/package.json`.

## How to test
1. **Apply migrations** (e.g. docker compose `migrate` service or `sem-apply` / ordered `psql -f scripts/*.sql` per `objectified-db/docs`).
2. **Verify schema**: `\d odb.import_jobs` — expect PK, four secondary indexes (partial index on finished states), CHECKs on `state` and `source_kind`.
3. **Load fixture**: `psql ... -f objectified-db/fixtures/import_jobs_terminal_states.sql`, then `SELECT state FROM odb.import_jobs WHERE tenant_id = 'a3305305-0001-4000-8000-000000000001'::uuid ORDER BY state;` — four rows.
4. **Rollback (manual)**: uncomment and run the `DROP TABLE IF EXISTS odb.import_jobs CASCADE;` line under `-- DOWN` in the migration file.

## Risk / notes
- No app code changes yet; **T5/T6** will wire REST/orchestrator to this table.
- `created_by` has no `ON DELETE`; deleting users while jobs reference them will fail (intended for audit).

Closes #3305

Made with [Cursor](https://cursor.com)