### PR TITLE
Fix #3307 - Import orchestrator: spawn importer, stream NDJSON, tenant_repository_imports

### DIFF
--- a/objectified-importer/src/runner/index.ts
+++ b/objectified-importer/src/runner/index.ts
@@ -32,6 +32,12 @@ function sleep(ms: number): Promise<void> {
   return new Promise((r) => setTimeout(r, ms));
 }
 
+/** When set, auto-commit after preview so REST orchestrator sees a single process reach `completed`. */
+function orchestratorAutoCommitEnabled(): boolean {
+  const v = process.env.OBJECTIFIED_IMPORTER_ORCHESTRATOR;
+  return v === '1' || v === 'true';
+}
+
 function readPositiveIntFromEnv(name: string, fallback: number): number {
   const raw = process.env[name];
   if (!raw) return fallback;
@@ -169,6 +175,7 @@ async function streamUntilTerminal(engine: ImportEngine, jobId: string, stdout: 
         type: 'result',
         state: mapCliResultState(status),
         summary: status.summary,
+        result: status.result,
       });
 
       return status.state;
@@ -206,7 +213,20 @@ export async function runImportWithEngine(
       await engine.cancelImport(envelope.jobId);
     }
 
-    await streamUntilTerminal(engine, envelope.jobId, stdout);
+    let state = await streamUntilTerminal(engine, envelope.jobId, stdout);
+    if (orchestratorAutoCommitEnabled() && state === 'pending-approval') {
+      const commitRes = await engine.commitImport(envelope.jobId);
+      if (!commitRes.success) {
+        await writeNdjsonLine(stdout, {
+          type: 'error',
+          code: 'COMMIT_FAILED',
+          message: commitRes.error || 'commitImport failed',
+        });
+        await writeNdjsonLine(stdout, { type: 'result', state: 'failed', summary: undefined });
+        return 0;
+      }
+      state = await streamUntilTerminal(engine, envelope.jobId, stdout);
+    }
     return 0;
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);

--- a/objectified-importer/src/runner/stdio-events.ts
+++ b/objectified-importer/src/runner/stdio-events.ts
@@ -7,7 +7,13 @@ import type { ImportEvent, ProgressEvent } from '../engine/import-helper';
 export type RunnerNdjsonLine =
   | { type: 'event'; event: ImportEvent }
   | { type: 'progress'; progress: ProgressEvent }
-  | { type: 'result'; state: string; summary?: unknown }
+  | {
+      type: 'result';
+      state: string;
+      summary?: unknown;
+      /** Catalog UUIDs when the engine has committed import metadata (or dry-run completion). */
+      result?: { projectId?: string; versionId?: string };
+    }
   | { type: 'error'; code: string; message: string; context?: unknown };
 
 export async function writeNdjsonLine(stream: Writable, line: RunnerNdjsonLine): Promise<void> {

--- a/objectified-rest/pyproject.toml
+++ b/objectified-rest/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "objectified-rest"
-version = "1.0.61"
+version = "1.0.62"
 description = "REST API for serving OpenAPI specifications from the Objectified database"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/objectified-rest/src/app/database.py
+++ b/objectified-rest/src/app/database.py
@@ -1,6 +1,7 @@
 import psycopg2
 import json
 import logging
+import threading
 import hashlib
 from datetime import datetime
 import bcrypt
@@ -15,6 +16,28 @@ from .revision_lifecycle import prepare_version_metadata_update, sql_effective_l
 from .push_webhook_crypto import encrypt_signing_secret
 
 _logger = logging.getLogger(__name__)
+
+
+class ImportJobConcurrencyCaps:
+    """Shared limits for import orchestrator subprocess concurrency (#3307)."""
+
+    __slots__ = ("lock", "max_total", "max_per_tenant", "total_running", "per_tenant")
+
+    def __init__(self, max_total: int, max_per_tenant: int):
+        self.lock = threading.Lock()
+        self.max_total = max_total
+        self.max_per_tenant = max_per_tenant
+        self.total_running = 0
+        self.per_tenant: Dict[str, int] = {}
+
+    def release(self, tenant_id: str) -> None:
+        with self.lock:
+            self.total_running = max(0, self.total_running - 1)
+            cur = self.per_tenant.get(tenant_id, 0) - 1
+            if cur <= 0:
+                self.per_tenant.pop(tenant_id, None)
+            else:
+                self.per_tenant[tenant_id] = cur
 
 
 def _deep_equal(a: Any, b: Any) -> bool:
@@ -2689,6 +2712,248 @@ class Database:
                 row = cursor.fetchone()
                 conn.commit()
                 return dict(row) if row else None
+        except Exception as e:
+            conn.rollback()
+            raise e
+
+    def claim_import_job_with_caps(self, caps: ImportJobConcurrencyCaps) -> Optional[Dict[str, Any]]:
+        """
+        Atomically claim one queued job respecting per-process concurrency caps (#3307).
+
+        Uses FOR UPDATE SKIP LOCKED with an in-memory cap gate so tenant/total limits are enforced
+        before flipping queued → running.
+        """
+        conn = self.connect()
+        _upd = (
+            "UPDATE odb.import_jobs SET state = 'running', updated_at = NOW() "
+            "WHERE job_id = %s AND state = 'queued' "
+            "RETURNING job_id::text AS job_id, tenant_id::text AS tenant_id, "
+            "project_id::text AS project_id, state, source_kind, "
+            "blob_sha, repository_source, input, events, progress, summary, "
+            "result, percent, error, created_by::text AS created_by, "
+            "created_at, updated_at, finished_at, expires_at, idempotency_key"
+        )
+        with caps.lock:
+            if caps.total_running >= caps.max_total:
+                return None
+            try:
+                with conn.cursor() as cursor:
+                    cursor.execute(
+                        """
+                        SELECT job_id, tenant_id::text AS tenant_id
+                        FROM odb.import_jobs
+                        WHERE state = 'queued'
+                        ORDER BY created_at ASC
+                        FOR UPDATE SKIP LOCKED
+                        LIMIT 32
+                        """
+                    )
+                    candidates = cursor.fetchall()
+                    for cand in candidates:
+                        tid = str(cand["tenant_id"])
+                        if caps.per_tenant.get(tid, 0) >= caps.max_per_tenant:
+                            continue
+                        chosen_id = str(cand["job_id"])
+                        cursor.execute(_upd, (chosen_id,))
+                        row = cursor.fetchone()
+                        if row:
+                            caps.total_running += 1
+                            caps.per_tenant[tid] = caps.per_tenant.get(tid, 0) + 1
+                            conn.commit()
+                            return dict(row)
+                conn.rollback()
+                return None
+            except Exception:
+                conn.rollback()
+                raise
+
+    def import_job_append_events(
+        self,
+        tenant_id: str,
+        job_id: str,
+        fragments: List[Any],
+        *,
+        cap: int = 1000,
+    ) -> None:
+        if not fragments:
+            return
+        conn = self.connect()
+        try:
+            self._begin_tx(conn)
+            with conn.cursor() as cursor:
+                cursor.execute(
+                    "SELECT events FROM odb.import_jobs WHERE tenant_id = %s AND job_id = %s FOR UPDATE",
+                    (tenant_id, job_id),
+                )
+                one = cursor.fetchone()
+                if not one:
+                    conn.rollback()
+                    return
+                ev = one["events"]
+                events: List[Any] = list(ev) if isinstance(ev, list) else []
+                for frag in fragments:
+                    if isinstance(frag, dict):
+                        events.append(frag)
+                if len(events) > cap:
+                    events = events[-cap:]
+                cursor.execute(
+                    "UPDATE odb.import_jobs SET events = %s::jsonb, updated_at = NOW() "
+                    "WHERE tenant_id = %s AND job_id = %s",
+                    (Json(events), tenant_id, job_id),
+                )
+            conn.commit()
+        except Exception as e:
+            conn.rollback()
+            raise e
+
+    def import_job_set_progress(
+        self,
+        tenant_id: str,
+        job_id: str,
+        progress: Optional[Dict[str, Any]],
+        percent: int,
+    ) -> None:
+        conn = self.connect()
+        try:
+            with conn.cursor() as cursor:
+                cursor.execute(
+                    "UPDATE odb.import_jobs SET progress = %s::jsonb, percent = %s, updated_at = NOW() "
+                    "WHERE tenant_id = %s AND job_id = %s",
+                    (Json(progress) if progress is not None else None, percent, tenant_id, job_id),
+                )
+            conn.commit()
+        except Exception as e:
+            conn.rollback()
+            raise e
+
+    def import_job_touch_updated_at(self, tenant_id: str, job_id: str) -> None:
+        conn = self.connect()
+        try:
+            with conn.cursor() as cursor:
+                cursor.execute(
+                    "UPDATE odb.import_jobs SET updated_at = NOW() WHERE tenant_id = %s AND job_id = %s",
+                    (tenant_id, job_id),
+                )
+            conn.commit()
+        except Exception as e:
+            conn.rollback()
+            raise e
+
+    def import_job_apply_terminal(
+        self,
+        tenant_id: str,
+        job_id: str,
+        *,
+        state: str,
+        summary: Optional[Any] = None,
+        result: Optional[Any] = None,
+        error: Optional[Any] = None,
+        percent: Optional[int] = None,
+        finished_now: bool,
+        clear_error: bool = False,
+        clear_result: bool = False,
+    ) -> None:
+        conn = self.connect()
+        parts: List[str] = ["state = %s", "updated_at = NOW()"]
+        params: List[Any] = [state]
+        if summary is not None:
+            parts.append("summary = %s::jsonb")
+            params.append(Json(summary))
+        if result is not None:
+            parts.append("result = %s::jsonb")
+            params.append(Json(result))
+        elif clear_result:
+            parts.append("result = NULL")
+        if error is not None:
+            parts.append("error = %s::jsonb")
+            params.append(Json(error))
+        elif clear_error:
+            parts.append("error = NULL")
+        if percent is not None:
+            parts.append("percent = %s")
+            params.append(percent)
+        if finished_now:
+            parts.append("finished_at = NOW()")
+        sql = f"UPDATE odb.import_jobs SET {', '.join(parts)} WHERE tenant_id = %s AND job_id = %s"
+        params.extend([tenant_id, job_id])
+        try:
+            with conn.cursor() as cursor:
+                cursor.execute(sql, tuple(params))
+            conn.commit()
+        except Exception as e:
+            conn.rollback()
+            raise e
+
+    def mark_stale_running_import_jobs_failed(self, stale_after_seconds: int) -> int:
+        """Mark stuck running/committing jobs as failed (orchestrator restart / crash recovery)."""
+        err = Json({"code": "orchestrator-crash", "message": "Import worker lost contact with the orchestrator"})
+        conn = self.connect()
+        try:
+            with conn.cursor() as cursor:
+                cursor.execute(
+                    """
+                    UPDATE odb.import_jobs
+                    SET state = 'failed',
+                        error = %s::jsonb,
+                        finished_at = NOW(),
+                        updated_at = NOW()
+                    WHERE state IN ('running', 'committing')
+                      AND updated_at < NOW() - (%s * INTERVAL '1 second')
+                    """,
+                    (err, stale_after_seconds),
+                )
+                n = cursor.rowcount or 0
+            conn.commit()
+            return int(n)
+        except Exception as e:
+            conn.rollback()
+            raise e
+
+    def insert_tenant_repository_import_if_owned(
+        self,
+        *,
+        tenant_id: str,
+        repository_id: str,
+        branch: str,
+        path: str,
+        blob_sha: Optional[str],
+        project_id: str,
+        version_id: str,
+        imported_by: str,
+    ) -> bool:
+        """Mirror objectified-ui/lib/db/repository-import-metrics.ts insert (tenant-owned repo guard)."""
+        repo_id = repository_id.strip()
+        if not repo_id:
+            return False
+        conn = self.connect()
+        try:
+            with conn.cursor() as cursor:
+                cursor.execute(
+                    """
+                    INSERT INTO odb.tenant_repository_imports (
+                       tenant_id, repository_id, branch, path, blob_sha, project_id, version_id, imported_by
+                     )
+                     SELECT %s::uuid, %s::uuid, %s, %s, %s, %s::uuid, %s::uuid, %s::uuid
+                     FROM odb.tenant_repositories tr
+                     WHERE tr.id = %s::uuid AND tr.tenant_id = %s::uuid AND tr.deleted_at IS NULL
+                     RETURNING id
+                    """,
+                    (
+                        tenant_id,
+                        repo_id,
+                        branch,
+                        path,
+                        blob_sha.strip() if blob_sha and str(blob_sha).strip() else None,
+                        project_id,
+                        version_id,
+                        imported_by,
+                        repo_id,
+                        tenant_id,
+                    ),
+                )
+                ok = cursor.fetchone() is not None
+            conn.commit()
+            return ok
         except Exception as e:
             conn.rollback()
             raise e

--- a/objectified-rest/src/app/import_orchestrator.py
+++ b/objectified-rest/src/app/import_orchestrator.py
@@ -1,0 +1,534 @@
+"""
+Import job orchestrator: claim queued rows, spawn objectified-importer sidecar, stream NDJSON (#3307).
+
+Workers run as FastAPI startup tasks; configuration is read from environment at startup time.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import logging
+import os
+import shlex
+import signal
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+from .config import settings
+from .database import Database, ImportJobConcurrencyCaps
+
+_LOG = logging.getLogger(__name__)
+
+_EVENTS_CAP = 1000
+
+_active_tasks: List[asyncio.Task[Any]] = []
+_stop = asyncio.Event()
+_caps: Optional[ImportJobConcurrencyCaps] = None
+_active_subprocesses: Set[asyncio.subprocess.Process] = set()
+_subproc_lock = asyncio.Lock()
+
+
+def _repo_root() -> Path:
+    """Monorepo root (parent of ``objectified-rest``)."""
+    return Path(__file__).resolve().parent.parent.parent.parent
+
+
+def _default_run_js() -> Path:
+    return _repo_root() / "objectified-importer" / "bin" / "run.js"
+
+
+def _read_positive_int(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if raw is None or not str(raw).strip():
+        return default
+    try:
+        v = int(str(raw).strip(), 10)
+        return v if v >= 0 else default
+    except ValueError:
+        return default
+
+
+def orchestrator_worker_count() -> int:
+    """Concurrent asyncio worker loops (0 disables orchestrator tasks)."""
+    return _read_positive_int("OBJECTIFIED_IMPORT_WORKERS", 0)
+
+
+def orchestrator_stale_seconds() -> int:
+    return _read_positive_int("OBJECTIFIED_IMPORT_STALE_TIMEOUT", 600)
+
+
+def orchestrator_max_per_tenant() -> int:
+    v = _read_positive_int("OBJECTIFIED_IMPORT_MAX_PER_TENANT", 2)
+    return max(1, v)
+
+
+def orchestrator_max_total() -> int:
+    v = _read_positive_int("OBJECTIFIED_IMPORT_MAX_TOTAL", 8)
+    return max(1, v)
+
+
+def _runner_command() -> List[str]:
+    override = os.environ.get("OBJECTIFIED_IMPORT_RUNNER_CMD")
+    if override and override.strip():
+        return shlex.split(override)
+    run_js = Path(os.environ["OBJECTIFIED_IMPORT_RUN_JS"]) if os.environ.get("OBJECTIFIED_IMPORT_RUN_JS") else _default_run_js()
+    node = os.environ.get("OBJECTIFIED_IMPORT_NODE_BIN") or "node"
+    return [node, str(run_js)]
+
+
+def merge_job_input(row: Dict[str, Any]) -> Dict[str, Any]:
+    """Build ImportJobInput JSON for the sidecar from persisted REST row."""
+    raw = row.get("input")
+    if not isinstance(raw, dict):
+        raw = {}
+    out = dict(raw)
+    out["tenantId"] = str(row["tenant_id"])
+    out["userId"] = str(row["created_by"])
+    opts = out.get("options")
+    if not isinstance(opts, dict):
+        opts = {}
+        out["options"] = opts
+    if "selectedSchemas" not in opts:
+        doc = out.get("document") if isinstance(out.get("document"), dict) else {}
+        schemas = ((doc.get("components") or {}).get("schemas")) if isinstance(doc.get("components"), dict) else {}
+        if isinstance(schemas, dict) and schemas:
+            opts["selectedSchemas"] = list(schemas.keys())[:64]
+        else:
+            opts["selectedSchemas"] = []
+    return out
+
+
+def _percent_from_progress(progress: Dict[str, Any]) -> int:
+    total = int(progress.get("total") or 0)
+    completed = int(progress.get("completed") or 0)
+    if total <= 0:
+        return 0
+    return min(100, int(100 * completed / total))
+
+
+def _workflow_audit_job(
+    db: Database,
+    tenant_id: str,
+    project_id: Optional[str],
+    version_id: Optional[str],
+    action: str,
+    outcome: str,
+    actor_id: Optional[str],
+    detail: Optional[Dict[str, Any]],
+) -> None:
+    db.insert_workflow_audit(tenant_id, project_id, version_id, action, outcome, actor_id, detail)
+
+
+async def _register_subprocess(proc: asyncio.subprocess.Process) -> None:
+    async with _subproc_lock:
+        _active_subprocesses.add(proc)
+
+
+async def _unregister_subprocess(proc: asyncio.subprocess.Process) -> None:
+    async with _subproc_lock:
+        _active_subprocesses.discard(proc)
+
+
+async def _terminate_active_subprocesses() -> None:
+    async with _subproc_lock:
+        procs = list(_active_subprocesses)
+    for p in procs:
+        if p.returncode is None:
+            try:
+                p.send_signal(signal.SIGTERM)
+            except ProcessLookupError:
+                pass
+
+
+def _parse_ndjson_line(line: bytes) -> Optional[Dict[str, Any]]:
+    if not line.strip():
+        return None
+    try:
+        obj = json.loads(line.decode("utf-8"))
+    except json.JSONDecodeError:
+        return None
+    return obj if isinstance(obj, dict) else None
+
+
+async def _poll_cancel_requested(
+    db: Database,
+    tenant_id: str,
+    job_id: str,
+    proc: asyncio.subprocess.Process,
+    stop: asyncio.Event,
+) -> None:
+    while not stop.is_set() and proc.returncode is None:
+        await asyncio.sleep(0.3)
+        row = await asyncio.to_thread(db.get_import_job_row, tenant_id, job_id)
+        if row and str(row.get("state")) == "canceled":
+            _LOG.info(
+                "import cancel propagated",
+                extra={"job_id": job_id, "tenant_id": tenant_id, "phase": "cancel", "percent": row.get("percent")},
+            )
+            try:
+                proc.send_signal(signal.SIGTERM)
+            except ProcessLookupError:
+                pass
+            return
+
+
+async def run_import_sidecar(
+    db: Database,
+    row: Dict[str, Any],
+) -> Tuple[int, List[str]]:
+    """
+    Spawn importer subprocess; stream stdout NDJSON into ``db`` updates.
+
+    Returns (exit_code, stderr_lines).
+    """
+    job_id = str(row["job_id"])
+    tenant_id = str(row["tenant_id"])
+    cmd = _runner_command()
+    env = os.environ.copy()
+    env["OBJECTIFIED_IMPORTER_ORCHESTRATOR"] = "1"
+
+    inp = merge_job_input(row)
+    envelope = {
+        "schemaVersion": 1,
+        "jobId": job_id,
+        "input": inp,
+        "dbConfig": {"connectionString": settings.effective_database_url},
+    }
+    payload = json.dumps(envelope, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+
+    _LOG.info(
+        "import subprocess spawn",
+        extra={
+            "job_id": job_id,
+            "tenant_id": tenant_id,
+            "phase": "spawn",
+            "percent": row.get("percent"),
+            "subprocess_pid": None,
+        },
+    )
+
+    proc = await asyncio.create_subprocess_exec(
+        *cmd,
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        env=env,
+        cwd=str(_repo_root()),
+    )
+    await _register_subprocess(proc)
+    pid = proc.pid
+    _LOG.info(
+        "import subprocess started",
+        extra={"job_id": job_id, "tenant_id": tenant_id, "phase": "running", "percent": row.get("percent"), "subprocess_pid": pid},
+    )
+
+    stderr_tail: List[str] = []
+
+    async def _drain_stderr() -> None:
+        assert proc.stderr is not None
+        while True:
+            line = await proc.stderr.readline()
+            if not line:
+                break
+            try:
+                stderr_tail.append(line.decode("utf-8", errors="replace").rstrip())
+            except Exception:
+                continue
+
+    stderr_task = asyncio.create_task(_drain_stderr())
+
+    stop_watch = asyncio.Event()
+    watcher = asyncio.create_task(_poll_cancel_requested(db, tenant_id, job_id, proc, stop_watch))
+
+    assert proc.stdin is not None
+    proc.stdin.write(payload)
+    await proc.stdin.drain()
+    proc.stdin.close()
+
+    saw_terminal = False
+    terminal_state: Optional[str] = None
+
+    assert proc.stdout is not None
+    try:
+        while True:
+            line = await proc.stdout.readline()
+            if not line:
+                break
+            await asyncio.to_thread(db.import_job_touch_updated_at, tenant_id, job_id)
+            msg = _parse_ndjson_line(line)
+            if not msg:
+                continue
+            mtype = msg.get("type")
+            if mtype == "event" and isinstance(msg.get("event"), dict):
+                await asyncio.to_thread(db.import_job_append_events, tenant_id, job_id, [msg["event"]], cap=_EVENTS_CAP)
+                ev = msg["event"]
+                pct = ev.get("percent") if isinstance(ev.get("percent"), int) else None
+                extra = {"job_id": job_id, "tenant_id": tenant_id, "phase": "event", "percent": pct}
+                _LOG.info("import ndjson event", extra=extra)
+            elif mtype == "progress" and isinstance(msg.get("progress"), dict):
+                prog = msg["progress"]
+                pct = _percent_from_progress(prog)
+                await asyncio.to_thread(db.import_job_set_progress, tenant_id, job_id, prog, pct)
+                _LOG.info(
+                    "import ndjson progress",
+                    extra={
+                        "job_id": job_id,
+                        "tenant_id": tenant_id,
+                        "phase": prog.get("phase") or "progress",
+                        "percent": pct,
+                        "subprocess_pid": pid,
+                    },
+                )
+            elif mtype == "error" and isinstance(msg.get("code"), str):
+                cur_err = await asyncio.to_thread(db.get_import_job_row, tenant_id, job_id)
+                if cur_err and str(cur_err.get("state")) == "canceled":
+                    saw_terminal = True
+                    terminal_state = "canceled"
+                    break
+                err = {"code": msg["code"], "message": str(msg.get("message") or ""), "context": msg.get("context") or {}}
+                await asyncio.to_thread(
+                    db.import_job_apply_terminal,
+                    tenant_id,
+                    job_id,
+                    state="failed",
+                    error=err,
+                    finished_now=True,
+                )
+                _LOG.warning(
+                    "import ndjson error",
+                    extra={"job_id": job_id, "tenant_id": tenant_id, "phase": "error", "percent": row.get("percent")},
+                )
+            elif mtype == "result":
+                state = str(msg.get("state") or "failed")
+                summary = msg.get("summary")
+                result_payload = msg.get("result") if isinstance(msg.get("result"), dict) else None
+                finished = state in ("completed", "failed", "canceled", "rolled-back")
+                pct: Optional[int] = 100 if state == "completed" else None
+
+                cur = await asyncio.to_thread(db.get_import_job_row, tenant_id, job_id)
+                if cur and str(cur.get("state")) == "canceled":
+                    saw_terminal = True
+                    terminal_state = "canceled"
+                    break
+
+                if state == "pending-approval":
+                    summ = summary if isinstance(summary, dict) else {"raw": summary}
+                    await asyncio.to_thread(
+                        db.import_job_apply_terminal,
+                        tenant_id,
+                        job_id,
+                        state="pending-approval",
+                        summary=summ,
+                        result=result_payload,
+                        percent=None,
+                        finished_now=False,
+                        clear_error=True,
+                    )
+                    saw_terminal = False
+                    continue
+
+                await asyncio.to_thread(
+                    db.import_job_apply_terminal,
+                    tenant_id,
+                    job_id,
+                    state=state,
+                    summary=summary if isinstance(summary, dict) else {"raw": summary},
+                    result=result_payload,
+                    finished_now=finished,
+                    percent=pct,
+                    clear_error=state == "completed",
+                )
+                saw_terminal = finished
+                terminal_state = state
+
+                _LOG.info(
+                    "import ndjson result",
+                    extra={"job_id": job_id, "tenant_id": tenant_id, "phase": state, "percent": pct or 0, "subprocess_pid": pid},
+                )
+
+                actor_id = str(row.get("created_by")) if row.get("created_by") else None
+                project_uuid: Optional[str] = None
+                version_uuid: Optional[str] = None
+                if isinstance(result_payload, dict):
+                    project_uuid = result_payload.get("projectId") or result_payload.get("project_id")
+                    version_uuid = result_payload.get("versionId") or result_payload.get("version_id")
+
+                if state == "completed" and project_uuid and version_uuid:
+                    repo_src = row.get("repository_source")
+                    if isinstance(repo_src, dict):
+                        rid = str(repo_src.get("repositoryId") or repo_src.get("repository_id") or "").strip()
+                        branch = str(repo_src.get("branch") or "")
+                        path = str(repo_src.get("path") or "")
+                        blob = repo_src.get("blobSha") or repo_src.get("blob_sha")
+                        blob_s = str(blob).strip() if blob else None
+                        if rid:
+                            await asyncio.to_thread(
+                                db.insert_tenant_repository_import_if_owned,
+                                tenant_id=tenant_id,
+                                repository_id=rid,
+                                branch=branch,
+                                path=path,
+                                blob_sha=blob_s,
+                                project_id=str(project_uuid),
+                                version_id=str(version_uuid),
+                                imported_by=str(row.get("created_by")),
+                            )
+                    _workflow_audit_job(
+                        db,
+                        tenant_id,
+                        str(project_uuid),
+                        str(version_uuid),
+                        "import.job.complete",
+                        "success",
+                        actor_id,
+                        {"jobId": job_id, "projectId": str(project_uuid), "versionId": str(version_uuid)},
+                    )
+                elif state == "failed":
+                    _workflow_audit_job(
+                        db,
+                        tenant_id,
+                        row.get("project_id"),
+                        None,
+                        "import.job.failed",
+                        "failure",
+                        actor_id,
+                        {"jobId": job_id},
+                    )
+
+                if finished:
+                    break
+    finally:
+        stop_watch.set()
+        watcher.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await watcher
+        await stderr_task
+        await _unregister_subprocess(proc)
+
+    code = await proc.wait()
+    if not saw_terminal:
+        cur = await asyncio.to_thread(db.get_import_job_row, tenant_id, job_id)
+        if cur and str(cur.get("state")) == "canceled":
+            return code, stderr_tail
+        err = {"code": "subprocess-exit", "message": f"Importer exited without terminal NDJSON (code {code})"}
+        await asyncio.to_thread(
+            db.import_job_apply_terminal,
+            tenant_id,
+            job_id,
+            state="failed",
+            error=err,
+            finished_now=True,
+        )
+    elif terminal_state == "completed":
+        pass
+
+    return code, stderr_tail
+
+
+async def _run_single_job(caps: ImportJobConcurrencyCaps, row: Dict[str, Any]) -> None:
+    db = Database()
+    db.connect()
+    tenant_id = str(row["tenant_id"])
+    job_id = str(row["job_id"])
+    try:
+        await run_import_sidecar(db, row)
+    except asyncio.CancelledError:
+        raise
+    except Exception:
+        _LOG.exception("import job crashed job_id=%s tenant_id=%s", job_id, tenant_id)
+        err = {"code": "orchestrator-exception", "message": "Orchestrator crashed processing import"}
+        await asyncio.to_thread(
+            db.import_job_apply_terminal,
+            tenant_id,
+            job_id,
+            state="failed",
+            error=err,
+            finished_now=True,
+        )
+    finally:
+        caps.release(tenant_id)
+
+
+async def _worker_loop(worker_id: int, caps: ImportJobConcurrencyCaps) -> None:
+    log = _LOG
+    while not _stop.is_set():
+        db = Database()
+        db.connect()
+        row = await asyncio.to_thread(db.claim_import_job_with_caps, caps)
+        if row is None:
+            await asyncio.sleep(0.12)
+            continue
+        log.info("claimed import job worker=%s job_id=%s", worker_id, row.get("job_id"))
+        await _run_single_job(caps, row)
+
+
+async def _stale_sweep_loop() -> None:
+    while not _stop.is_set():
+        await asyncio.sleep(30)
+        if _stop.is_set():
+            break
+        stale_after = orchestrator_stale_seconds()
+        try:
+
+            def _sweep() -> int:
+                d = Database()
+                d.connect()
+                try:
+                    return d.mark_stale_running_import_jobs_failed(stale_after)
+                finally:
+                    d.close()
+
+            n = await asyncio.to_thread(_sweep)
+            if n:
+                _LOG.warning("marked stale import jobs failed count=%s", n)
+        except Exception:
+            _LOG.exception("stale import sweep failed")
+
+
+def start_import_orchestrator_tasks() -> None:
+    """Spawn worker tasks (call from FastAPI startup)."""
+    global _caps, _active_tasks
+    if _active_tasks:
+        _LOG.warning("import orchestrator start skipped: tasks already running")
+        return
+    n = orchestrator_worker_count()
+    if n <= 0:
+        _LOG.info("import orchestrator disabled (OBJECTIFIED_IMPORT_WORKERS=%s)", os.environ.get("OBJECTIFIED_IMPORT_WORKERS"))
+        return
+    _caps = ImportJobConcurrencyCaps(orchestrator_max_total(), orchestrator_max_per_tenant())
+    _active_tasks = [asyncio.create_task(_worker_loop(i, _caps), name=f"import-orchestrator-worker-{i}") for i in range(n)]
+    _active_tasks.append(asyncio.create_task(_stale_sweep_loop(), name="import-orchestrator-stale"))
+    _LOG.info(
+        "import orchestrator started workers=%s max_total=%s max_per_tenant=%s",
+        n,
+        orchestrator_max_total(),
+        orchestrator_max_per_tenant(),
+    )
+
+
+async def shutdown_import_orchestrator_tasks() -> None:
+    """Cancel workers and SIGTERM running importer children."""
+    global _stop
+    _stop.set()
+    await _terminate_active_subprocesses()
+    for t in _active_tasks:
+        t.cancel()
+    for t in _active_tasks:
+        with contextlib.suppress(asyncio.CancelledError):
+            await t
+    _active_tasks.clear()
+    _stop = asyncio.Event()
+
+
+async def run_standalone_orchestrator() -> None:
+    """Entry point for ``python -m app.import_runner`` (long-running worker only)."""
+    db = Database()
+    db.connect()
+    start_import_orchestrator_tasks()
+    try:
+        await asyncio.Future()
+    finally:
+        await shutdown_import_orchestrator_tasks()
+        db.close()

--- a/objectified-rest/src/app/import_orchestrator.py
+++ b/objectified-rest/src/app/import_orchestrator.py
@@ -247,7 +247,14 @@ async def run_import_sidecar(
 
     saw_terminal = False
     terminal_state: Optional[str] = None
-    last_touch_at = 0.0
+    last_touch_at = asyncio.get_running_loop().time()
+
+    async def _touch_if_due() -> None:
+        nonlocal last_touch_at
+        now = asyncio.get_running_loop().time()
+        if now - last_touch_at >= 5.0:
+            await asyncio.to_thread(_db_call, "import_job_touch_updated_at", tenant_id, job_id)
+            last_touch_at = now
 
     assert proc.stdout is not None
     try:
@@ -257,10 +264,7 @@ async def run_import_sidecar(
                 break
             msg = _parse_ndjson_line(line)
             if not msg:
-                now = asyncio.get_running_loop().time()
-                if now - last_touch_at >= 5.0:
-                    await asyncio.to_thread(_db_call, "import_job_touch_updated_at", tenant_id, job_id)
-                    last_touch_at = now
+                await _touch_if_due()
                 continue
             mtype = msg.get("type")
             if mtype == "event" and isinstance(msg.get("event"), dict):
@@ -415,10 +419,7 @@ async def run_import_sidecar(
                 if finished:
                     break
             else:
-                now = asyncio.get_running_loop().time()
-                if now - last_touch_at >= 5.0:
-                    await asyncio.to_thread(_db_call, "import_job_touch_updated_at", tenant_id, job_id)
-                    last_touch_at = now
+                await _touch_if_due()
     finally:
         stop_watch.set()
         watcher.cancel()

--- a/objectified-rest/src/app/import_orchestrator.py
+++ b/objectified-rest/src/app/import_orchestrator.py
@@ -22,6 +22,7 @@ from .database import Database, ImportJobConcurrencyCaps
 _LOG = logging.getLogger(__name__)
 
 _EVENTS_CAP = 1000
+_STDERR_TAIL_CAP = 200
 
 _active_tasks: List[asyncio.Task[Any]] = []
 _stop = asyncio.Event()
@@ -108,17 +109,14 @@ def _percent_from_progress(progress: Dict[str, Any]) -> int:
     return min(100, int(100 * completed / total))
 
 
-def _workflow_audit_job(
-    db: Database,
-    tenant_id: str,
-    project_id: Optional[str],
-    version_id: Optional[str],
-    action: str,
-    outcome: str,
-    actor_id: Optional[str],
-    detail: Optional[Dict[str, Any]],
-) -> None:
-    db.insert_workflow_audit(tenant_id, project_id, version_id, action, outcome, actor_id, detail)
+def _db_call(method: str, *args: Any, **kwargs: Any) -> Any:
+    db = Database()
+    db.connect()
+    try:
+        fn = getattr(db, method)
+        return fn(*args, **kwargs)
+    finally:
+        db.close()
 
 
 async def _register_subprocess(proc: asyncio.subprocess.Process) -> None:
@@ -153,7 +151,6 @@ def _parse_ndjson_line(line: bytes) -> Optional[Dict[str, Any]]:
 
 
 async def _poll_cancel_requested(
-    db: Database,
     tenant_id: str,
     job_id: str,
     proc: asyncio.subprocess.Process,
@@ -161,7 +158,7 @@ async def _poll_cancel_requested(
 ) -> None:
     while not stop.is_set() and proc.returncode is None:
         await asyncio.sleep(0.3)
-        row = await asyncio.to_thread(db.get_import_job_row, tenant_id, job_id)
+        row = await asyncio.to_thread(_db_call, "get_import_job_row", tenant_id, job_id)
         if row and str(row.get("state")) == "canceled":
             _LOG.info(
                 "import cancel propagated",
@@ -175,11 +172,10 @@ async def _poll_cancel_requested(
 
 
 async def run_import_sidecar(
-    db: Database,
     row: Dict[str, Any],
 ) -> Tuple[int, List[str]]:
     """
-    Spawn importer subprocess; stream stdout NDJSON into ``db`` updates.
+    Spawn importer subprocess; stream stdout NDJSON into DB updates.
 
     Returns (exit_code, stderr_lines).
     """
@@ -234,13 +230,15 @@ async def run_import_sidecar(
                 break
             try:
                 stderr_tail.append(line.decode("utf-8", errors="replace").rstrip())
+                if len(stderr_tail) > _STDERR_TAIL_CAP:
+                    del stderr_tail[:-_STDERR_TAIL_CAP]
             except Exception:
                 continue
 
     stderr_task = asyncio.create_task(_drain_stderr())
 
     stop_watch = asyncio.Event()
-    watcher = asyncio.create_task(_poll_cancel_requested(db, tenant_id, job_id, proc, stop_watch))
+    watcher = asyncio.create_task(_poll_cancel_requested(tenant_id, job_id, proc, stop_watch))
 
     assert proc.stdin is not None
     proc.stdin.write(payload)
@@ -249,6 +247,7 @@ async def run_import_sidecar(
 
     saw_terminal = False
     terminal_state: Optional[str] = None
+    last_touch_at = 0.0
 
     assert proc.stdout is not None
     try:
@@ -256,13 +255,23 @@ async def run_import_sidecar(
             line = await proc.stdout.readline()
             if not line:
                 break
-            await asyncio.to_thread(db.import_job_touch_updated_at, tenant_id, job_id)
             msg = _parse_ndjson_line(line)
             if not msg:
+                now = asyncio.get_running_loop().time()
+                if now - last_touch_at >= 5.0:
+                    await asyncio.to_thread(_db_call, "import_job_touch_updated_at", tenant_id, job_id)
+                    last_touch_at = now
                 continue
             mtype = msg.get("type")
             if mtype == "event" and isinstance(msg.get("event"), dict):
-                await asyncio.to_thread(db.import_job_append_events, tenant_id, job_id, [msg["event"]], cap=_EVENTS_CAP)
+                await asyncio.to_thread(
+                    _db_call,
+                    "import_job_append_events",
+                    tenant_id,
+                    job_id,
+                    [msg["event"]],
+                    cap=_EVENTS_CAP,
+                )
                 ev = msg["event"]
                 pct = ev.get("percent") if isinstance(ev.get("percent"), int) else None
                 extra = {"job_id": job_id, "tenant_id": tenant_id, "phase": "event", "percent": pct}
@@ -270,7 +279,7 @@ async def run_import_sidecar(
             elif mtype == "progress" and isinstance(msg.get("progress"), dict):
                 prog = msg["progress"]
                 pct = _percent_from_progress(prog)
-                await asyncio.to_thread(db.import_job_set_progress, tenant_id, job_id, prog, pct)
+                await asyncio.to_thread(_db_call, "import_job_set_progress", tenant_id, job_id, prog, pct)
                 _LOG.info(
                     "import ndjson progress",
                     extra={
@@ -282,14 +291,15 @@ async def run_import_sidecar(
                     },
                 )
             elif mtype == "error" and isinstance(msg.get("code"), str):
-                cur_err = await asyncio.to_thread(db.get_import_job_row, tenant_id, job_id)
+                cur_err = await asyncio.to_thread(_db_call, "get_import_job_row", tenant_id, job_id)
                 if cur_err and str(cur_err.get("state")) == "canceled":
                     saw_terminal = True
                     terminal_state = "canceled"
                     break
                 err = {"code": msg["code"], "message": str(msg.get("message") or ""), "context": msg.get("context") or {}}
                 await asyncio.to_thread(
-                    db.import_job_apply_terminal,
+                    _db_call,
+                    "import_job_apply_terminal",
                     tenant_id,
                     job_id,
                     state="failed",
@@ -307,7 +317,7 @@ async def run_import_sidecar(
                 finished = state in ("completed", "failed", "canceled", "rolled-back")
                 pct: Optional[int] = 100 if state == "completed" else None
 
-                cur = await asyncio.to_thread(db.get_import_job_row, tenant_id, job_id)
+                cur = await asyncio.to_thread(_db_call, "get_import_job_row", tenant_id, job_id)
                 if cur and str(cur.get("state")) == "canceled":
                     saw_terminal = True
                     terminal_state = "canceled"
@@ -316,7 +326,8 @@ async def run_import_sidecar(
                 if state == "pending-approval":
                     summ = summary if isinstance(summary, dict) else {"raw": summary}
                     await asyncio.to_thread(
-                        db.import_job_apply_terminal,
+                        _db_call,
+                        "import_job_apply_terminal",
                         tenant_id,
                         job_id,
                         state="pending-approval",
@@ -330,7 +341,8 @@ async def run_import_sidecar(
                     continue
 
                 await asyncio.to_thread(
-                    db.import_job_apply_terminal,
+                    _db_call,
+                    "import_job_apply_terminal",
                     tenant_id,
                     job_id,
                     state=state,
@@ -365,7 +377,8 @@ async def run_import_sidecar(
                         blob_s = str(blob).strip() if blob else None
                         if rid:
                             await asyncio.to_thread(
-                                db.insert_tenant_repository_import_if_owned,
+                                _db_call,
+                                "insert_tenant_repository_import_if_owned",
                                 tenant_id=tenant_id,
                                 repository_id=rid,
                                 branch=branch,
@@ -375,8 +388,9 @@ async def run_import_sidecar(
                                 version_id=str(version_uuid),
                                 imported_by=str(row.get("created_by")),
                             )
-                    _workflow_audit_job(
-                        db,
+                    await asyncio.to_thread(
+                        _db_call,
+                        "insert_workflow_audit",
                         tenant_id,
                         str(project_uuid),
                         str(version_uuid),
@@ -386,8 +400,9 @@ async def run_import_sidecar(
                         {"jobId": job_id, "projectId": str(project_uuid), "versionId": str(version_uuid)},
                     )
                 elif state == "failed":
-                    _workflow_audit_job(
-                        db,
+                    await asyncio.to_thread(
+                        _db_call,
+                        "insert_workflow_audit",
                         tenant_id,
                         row.get("project_id"),
                         None,
@@ -399,6 +414,11 @@ async def run_import_sidecar(
 
                 if finished:
                     break
+            else:
+                now = asyncio.get_running_loop().time()
+                if now - last_touch_at >= 5.0:
+                    await asyncio.to_thread(_db_call, "import_job_touch_updated_at", tenant_id, job_id)
+                    last_touch_at = now
     finally:
         stop_watch.set()
         watcher.cancel()
@@ -409,12 +429,13 @@ async def run_import_sidecar(
 
     code = await proc.wait()
     if not saw_terminal:
-        cur = await asyncio.to_thread(db.get_import_job_row, tenant_id, job_id)
+        cur = await asyncio.to_thread(_db_call, "get_import_job_row", tenant_id, job_id)
         if cur and str(cur.get("state")) == "canceled":
             return code, stderr_tail
         err = {"code": "subprocess-exit", "message": f"Importer exited without terminal NDJSON (code {code})"}
         await asyncio.to_thread(
-            db.import_job_apply_terminal,
+            _db_call,
+            "import_job_apply_terminal",
             tenant_id,
             job_id,
             state="failed",
@@ -428,19 +449,18 @@ async def run_import_sidecar(
 
 
 async def _run_single_job(caps: ImportJobConcurrencyCaps, row: Dict[str, Any]) -> None:
-    db = Database()
-    db.connect()
     tenant_id = str(row["tenant_id"])
     job_id = str(row["job_id"])
     try:
-        await run_import_sidecar(db, row)
+        await run_import_sidecar(row)
     except asyncio.CancelledError:
         raise
     except Exception:
         _LOG.exception("import job crashed job_id=%s tenant_id=%s", job_id, tenant_id)
         err = {"code": "orchestrator-exception", "message": "Orchestrator crashed processing import"}
         await asyncio.to_thread(
-            db.import_job_apply_terminal,
+            _db_call,
+            "import_job_apply_terminal",
             tenant_id,
             job_id,
             state="failed",
@@ -454,9 +474,7 @@ async def _run_single_job(caps: ImportJobConcurrencyCaps, row: Dict[str, Any]) -
 async def _worker_loop(worker_id: int, caps: ImportJobConcurrencyCaps) -> None:
     log = _LOG
     while not _stop.is_set():
-        db = Database()
-        db.connect()
-        row = await asyncio.to_thread(db.claim_import_job_with_caps, caps)
+        row = await asyncio.to_thread(_db_call, "claim_import_job_with_caps", caps)
         if row is None:
             await asyncio.sleep(0.12)
             continue

--- a/objectified-rest/src/app/import_runner.py
+++ b/objectified-rest/src/app/import_runner.py
@@ -1,0 +1,15 @@
+"""Long-running import orchestrator without HTTP (#3307). Run from ``objectified-rest`` with ``PYTHONPATH=src``."""
+
+from __future__ import annotations
+
+import asyncio
+
+from app.import_orchestrator import run_standalone_orchestrator
+
+
+def main() -> None:
+    asyncio.run(run_standalone_orchestrator())
+
+
+if __name__ == "__main__":
+    main()

--- a/objectified-rest/src/app/main.py
+++ b/objectified-rest/src/app/main.py
@@ -34,6 +34,10 @@ from .version_change_report_routes import router as version_change_report_router
 from .change_report_template_routes import router as change_report_template_router
 from .tenant_repositories_routes import router as tenant_repositories_router
 from .imports_routes import router as imports_router
+from .import_orchestrator import (
+    shutdown_import_orchestrator_tasks,
+    start_import_orchestrator_tasks,
+)
 from .tenants_session_routes import router as tenants_session_router
 from .browse_public_routes import router as browse_public_router
 
@@ -41,7 +45,7 @@ from .browse_public_routes import router as browse_public_router
 app = FastAPI(
     title="Objectified REST API",
     description="REST API for serving OpenAPI specifications from the Objectified database",
-    version="1.0.61"
+    version="1.0.62"
 )
 
 
@@ -195,10 +199,14 @@ async def startup_event():
     global _repository_file_scan_task
     _repository_file_scan_task = asyncio.create_task(_repository_file_scan_sweep())
 
+    start_import_orchestrator_tasks()
+
 
 @app.on_event("shutdown")
 async def shutdown_event():
     """Close database connection on shutdown."""
+    await shutdown_import_orchestrator_tasks()
+
     global _webhook_delivery_task
     if _webhook_delivery_task is not None:
         _webhook_delivery_task.cancel()

--- a/objectified-rest/tests/conftest.py
+++ b/objectified-rest/tests/conftest.py
@@ -1,8 +1,12 @@
 """Shared pytest fixtures for objectified-rest tests."""
 
+import os
 from pathlib import Path
 
 import pytest
+
+# Default-off import orchestrator subprocess workers so TestClient(app) does not spawn importers.
+os.environ.setdefault("OBJECTIFIED_IMPORT_WORKERS", "0")
 
 
 @pytest.fixture

--- a/objectified-rest/tests/test_import_orchestrator.py
+++ b/objectified-rest/tests/test_import_orchestrator.py
@@ -1,0 +1,292 @@
+"""Import orchestrator (#3307) — unit helpers and optional live-DB / Node checks."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import uuid
+from pathlib import Path
+import pytest
+
+from app.database import Database, ImportJobConcurrencyCaps
+from app.import_orchestrator import merge_job_input, orchestrator_worker_count, run_import_sidecar
+
+_requires_db = pytest.mark.skipif(not os.environ.get("DATABASE_URL"), reason="DATABASE_URL not set")
+_requires_node = pytest.mark.skipif(not shutil.which("node"), reason="node not on PATH")
+
+
+def test_merge_job_input_adds_ids_and_selected_schemas():
+    row = {
+        "tenant_id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+        "created_by": "11111111-2222-3333-4444-555555555555",
+        "input": {
+            "sourceKind": "openapi",
+            "document": {
+                "openapi": "3.0.0",
+                "components": {"schemas": {"Pet": {"type": "object"}}},
+            },
+            "project": {"name": "P", "slug": "p"},
+            "version": {"versionId": "1.0.0"},
+            "options": {},
+        },
+    }
+    out = merge_job_input(row)
+    assert out["tenantId"] == row["tenant_id"]
+    assert out["userId"] == row["created_by"]
+    assert out["options"]["selectedSchemas"] == ["Pet"]
+
+
+def test_orchestrator_worker_count_reads_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OBJECTIFIED_IMPORT_WORKERS", "3")
+    assert orchestrator_worker_count() == 3
+    monkeypatch.setenv("OBJECTIFIED_IMPORT_WORKERS", "0")
+    assert orchestrator_worker_count() == 0
+
+
+@_requires_db
+def test_mark_stale_running_import_jobs_failed():
+    db_url = os.environ["DATABASE_URL"]
+    psycopg2 = pytest.importorskip("psycopg2")
+    from psycopg2.extras import Json
+
+    db = Database()
+    db.connect()
+    members = db.execute_query(
+        "SELECT tenant_id::text AS tenant_id, user_id::text AS user_id FROM odb.tenant_users LIMIT 1"
+    )
+    if not members:
+        pytest.skip("no tenant_users row")
+
+    tenant_id = members[0]["tenant_id"]
+    user_id = members[0]["user_id"]
+    job_id = str(uuid.uuid4())
+
+    conn = psycopg2.connect(db_url)
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO odb.import_jobs (
+                    job_id, tenant_id, project_id, state, source_kind,
+                    blob_sha, repository_source, input, events,
+                    percent, created_by
+                )
+                VALUES (
+                    %s::uuid, %s::uuid, NULL, 'running', 'openapi',
+                    NULL, NULL, %s::jsonb, %s::jsonb,
+                    0, %s::uuid
+                )
+                """,
+                (
+                    job_id,
+                    tenant_id,
+                    Json(
+                        {
+                            "sourceKind": "openapi",
+                            "document": {"openapi": "3.0.0"},
+                            "project": {"name": "Stale", "slug": f"stale-{job_id[:8]}"},
+                            "version": {"versionId": "1.0.0"},
+                            "options": {"selectedSchemas": [], "dryRun": True},
+                        }
+                    ),
+                    Json([{"type": "queued", "at": "2026-05-09T00:00:00+00:00"}]),
+                    user_id,
+                ),
+            )
+            cur.execute(
+                """
+                UPDATE odb.import_jobs
+                SET updated_at = NOW() - INTERVAL '2 minutes'
+                WHERE job_id = %s::uuid
+                """,
+                (job_id,),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+    try:
+        n = db.mark_stale_running_import_jobs_failed(60)
+        assert n >= 1
+        row = db.get_import_job_row(tenant_id, job_id)
+        assert row is not None
+        assert row["state"] == "failed"
+        err = row.get("error")
+        assert isinstance(err, dict)
+        assert err.get("code") == "orchestrator-crash"
+    finally:
+        conn = psycopg2.connect(db_url)
+        try:
+            with conn.cursor() as cur:
+                cur.execute("DELETE FROM odb.import_jobs WHERE job_id = %s::uuid", (job_id,))
+            conn.commit()
+        finally:
+            conn.close()
+
+
+@_requires_db
+@_requires_node
+@pytest.mark.asyncio
+async def test_sidecar_dry_run_completes(repo_root: Path) -> None:
+    db_url = os.environ["DATABASE_URL"]
+    psycopg2 = pytest.importorskip("psycopg2")
+    from psycopg2.extras import Json
+
+    db = Database()
+    db.connect()
+    members = db.execute_query(
+        "SELECT tenant_id::text AS tenant_id, user_id::text AS user_id FROM odb.tenant_users LIMIT 1"
+    )
+    if not members:
+        pytest.skip("no tenant_users row")
+
+    tenant_id = members[0]["tenant_id"]
+    user_id = members[0]["user_id"]
+    job_id = str(uuid.uuid4())
+    slug = f"orch-test-{job_id[:8]}"
+
+    conn = psycopg2.connect(db_url)
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO odb.import_jobs (
+                    job_id, tenant_id, project_id, state, source_kind,
+                    blob_sha, repository_source, input, events,
+                    percent, created_by
+                )
+                VALUES (
+                    %s::uuid, %s::uuid, NULL, 'running', 'openapi',
+                    NULL, NULL, %s::jsonb, %s::jsonb,
+                    0, %s::uuid
+                )
+                """,
+                (
+                    job_id,
+                    tenant_id,
+                    Json(
+                        {
+                            "sourceKind": "openapi",
+                            "document": {
+                                "openapi": "3.1.0",
+                                "info": {"title": "Orch", "version": "1.0"},
+                                "paths": {},
+                                "components": {"schemas": {"Pet": {"type": "object", "properties": {"n": {"type": "string"}}}}},
+                            },
+                            "project": {"name": "Orch Test", "slug": slug},
+                            "version": {"versionId": "1.0.0"},
+                            "options": {"selectedSchemas": ["Pet"], "dryRun": True},
+                        }
+                    ),
+                    Json([{"type": "queued", "at": "2026-05-09T00:00:00+00:00"}]),
+                    user_id,
+                ),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+    row = db.get_import_job_row(tenant_id, job_id)
+    assert row is not None
+
+    try:
+        code, err_tail = await run_import_sidecar(db, row)
+        assert code == 0
+        updated = db.get_import_job_row(tenant_id, job_id)
+        assert updated is not None
+        assert updated["state"] == "completed"
+        if err_tail:
+            assert isinstance(err_tail, list)
+    finally:
+        conn = psycopg2.connect(db_url)
+        try:
+            with conn.cursor() as cur:
+                cur.execute("DELETE FROM odb.import_jobs WHERE job_id = %s::uuid", (job_id,))
+            conn.commit()
+        finally:
+            conn.close()
+
+
+def test_import_job_concurrency_caps_release_idempotent() -> None:
+    caps = ImportJobConcurrencyCaps(max_total=8, max_per_tenant=2)
+    caps.total_running = 2
+    caps.per_tenant["t"] = 2
+    caps.release("t")
+    assert caps.total_running == 1
+    assert caps.per_tenant.get("t") == 1
+    caps.release("t")
+    assert caps.total_running == 0
+    assert "t" not in caps.per_tenant
+
+
+@_requires_db
+def test_claim_skips_third_job_when_per_tenant_cap_reached():
+    """Third queued row for the same tenant is not claimed until a slot is released (#3307)."""
+    db_url = os.environ["DATABASE_URL"]
+    psycopg2 = pytest.importorskip("psycopg2")
+    from psycopg2.extras import Json
+
+    db = Database()
+    db.connect()
+    members = db.execute_query(
+        "SELECT tenant_id::text AS tenant_id, user_id::text AS user_id FROM odb.tenant_users LIMIT 1"
+    )
+    if not members:
+        pytest.skip("no tenant_users row")
+
+    tenant_id = members[0]["tenant_id"]
+    user_id = members[0]["user_id"]
+    job_ids = [str(uuid.uuid4()) for _ in range(3)]
+    payload = {
+        "sourceKind": "openapi",
+        "document": {"openapi": "3.0.0"},
+        "project": {"name": "Cap Test", "slug": f"cap-{job_ids[0][:8]}"},
+        "version": {"versionId": "1.0.0"},
+        "options": {"selectedSchemas": [], "dryRun": True},
+    }
+    events = [{"type": "queued", "at": "2026-05-09T00:00:00+00:00"}]
+
+    conn = psycopg2.connect(db_url)
+    try:
+        with conn.cursor() as cur:
+            for jid in job_ids:
+                cur.execute(
+                    """
+                    INSERT INTO odb.import_jobs (
+                        job_id, tenant_id, project_id, state, source_kind,
+                        blob_sha, repository_source, input, events,
+                        percent, created_by
+                    )
+                    VALUES (
+                        %s::uuid, %s::uuid, NULL, 'queued', 'openapi',
+                        NULL, NULL, %s::jsonb, %s::jsonb,
+                        0, %s::uuid
+                    )
+                    """,
+                    (jid, tenant_id, Json(payload), Json(events), user_id),
+                )
+        conn.commit()
+    finally:
+        conn.close()
+
+    caps = ImportJobConcurrencyCaps(max_total=8, max_per_tenant=2)
+    try:
+        r1 = db.claim_import_job_with_caps(caps)
+        r2 = db.claim_import_job_with_caps(caps)
+        r3 = db.claim_import_job_with_caps(caps)
+        assert r1 is not None and r2 is not None
+        assert r3 is None
+        tid = str(r1["tenant_id"])
+        caps.release(tid)
+        r4 = db.claim_import_job_with_caps(caps)
+        assert r4 is not None
+        assert str(r4["job_id"]) == job_ids[2]
+    finally:
+        conn = psycopg2.connect(db_url)
+        try:
+            with conn.cursor() as cur:
+                for jid in job_ids:
+                    cur.execute("DELETE FROM odb.import_jobs WHERE job_id = %s::uuid", (jid,))
+            conn.commit()
+        finally:
+            conn.close()

--- a/objectified-rest/tests/test_import_orchestrator.py
+++ b/objectified-rest/tests/test_import_orchestrator.py
@@ -51,77 +51,80 @@ def test_mark_stale_running_import_jobs_failed():
 
     db = Database()
     db.connect()
-    members = db.execute_query(
-        "SELECT tenant_id::text AS tenant_id, user_id::text AS user_id FROM odb.tenant_users LIMIT 1"
-    )
-    if not members:
-        pytest.skip("no tenant_users row")
-
-    tenant_id = members[0]["tenant_id"]
-    user_id = members[0]["user_id"]
-    job_id = str(uuid.uuid4())
-
-    conn = psycopg2.connect(db_url)
     try:
-        with conn.cursor() as cur:
-            cur.execute(
-                """
-                INSERT INTO odb.import_jobs (
-                    job_id, tenant_id, project_id, state, source_kind,
-                    blob_sha, repository_source, input, events,
-                    percent, created_by
-                )
-                VALUES (
-                    %s::uuid, %s::uuid, NULL, 'running', 'openapi',
-                    NULL, NULL, %s::jsonb, %s::jsonb,
-                    0, %s::uuid
-                )
-                """,
-                (
-                    job_id,
-                    tenant_id,
-                    Json(
-                        {
-                            "sourceKind": "openapi",
-                            "document": {"openapi": "3.0.0"},
-                            "project": {"name": "Stale", "slug": f"stale-{job_id[:8]}"},
-                            "version": {"versionId": "1.0.0"},
-                            "options": {"selectedSchemas": [], "dryRun": True},
-                        }
-                    ),
-                    Json([{"type": "queued", "at": "2026-05-09T00:00:00+00:00"}]),
-                    user_id,
-                ),
-            )
-            cur.execute(
-                """
-                UPDATE odb.import_jobs
-                SET updated_at = NOW() - INTERVAL '2 minutes'
-                WHERE job_id = %s::uuid
-                """,
-                (job_id,),
-            )
-        conn.commit()
-    finally:
-        conn.close()
+        members = db.execute_query(
+            "SELECT tenant_id::text AS tenant_id, user_id::text AS user_id FROM odb.tenant_users LIMIT 1"
+        )
+        if not members:
+            pytest.skip("no tenant_users row")
 
-    try:
-        n = db.mark_stale_running_import_jobs_failed(60)
-        assert n >= 1
-        row = db.get_import_job_row(tenant_id, job_id)
-        assert row is not None
-        assert row["state"] == "failed"
-        err = row.get("error")
-        assert isinstance(err, dict)
-        assert err.get("code") == "orchestrator-crash"
-    finally:
+        tenant_id = members[0]["tenant_id"]
+        user_id = members[0]["user_id"]
+        job_id = str(uuid.uuid4())
+
         conn = psycopg2.connect(db_url)
         try:
             with conn.cursor() as cur:
-                cur.execute("DELETE FROM odb.import_jobs WHERE job_id = %s::uuid", (job_id,))
+                cur.execute(
+                    """
+                    INSERT INTO odb.import_jobs (
+                        job_id, tenant_id, project_id, state, source_kind,
+                        blob_sha, repository_source, input, events,
+                        percent, created_by
+                    )
+                    VALUES (
+                        %s::uuid, %s::uuid, NULL, 'running', 'openapi',
+                        NULL, NULL, %s::jsonb, %s::jsonb,
+                        0, %s::uuid
+                    )
+                    """,
+                    (
+                        job_id,
+                        tenant_id,
+                        Json(
+                            {
+                                "sourceKind": "openapi",
+                                "document": {"openapi": "3.0.0"},
+                                "project": {"name": "Stale", "slug": f"stale-{job_id[:8]}"},
+                                "version": {"versionId": "1.0.0"},
+                                "options": {"selectedSchemas": [], "dryRun": True},
+                            }
+                        ),
+                        Json([{"type": "queued", "at": "2026-05-09T00:00:00+00:00"}]),
+                        user_id,
+                    ),
+                )
+                cur.execute(
+                    """
+                    UPDATE odb.import_jobs
+                    SET updated_at = NOW() - INTERVAL '2 minutes'
+                    WHERE job_id = %s::uuid
+                    """,
+                    (job_id,),
+                )
             conn.commit()
         finally:
             conn.close()
+
+        try:
+            n = db.mark_stale_running_import_jobs_failed(60)
+            assert n >= 1
+            row = db.get_import_job_row(tenant_id, job_id)
+            assert row is not None
+            assert row["state"] == "failed"
+            err = row.get("error")
+            assert isinstance(err, dict)
+            assert err.get("code") == "orchestrator-crash"
+        finally:
+            conn = psycopg2.connect(db_url)
+            try:
+                with conn.cursor() as cur:
+                    cur.execute("DELETE FROM odb.import_jobs WHERE job_id = %s::uuid", (job_id,))
+                conn.commit()
+            finally:
+                conn.close()
+    finally:
+        db.close()
 
 
 @_requires_db
@@ -134,80 +137,83 @@ async def test_sidecar_dry_run_completes(repo_root: Path) -> None:
 
     db = Database()
     db.connect()
-    members = db.execute_query(
-        "SELECT tenant_id::text AS tenant_id, user_id::text AS user_id FROM odb.tenant_users LIMIT 1"
-    )
-    if not members:
-        pytest.skip("no tenant_users row")
-
-    tenant_id = members[0]["tenant_id"]
-    user_id = members[0]["user_id"]
-    job_id = str(uuid.uuid4())
-    slug = f"orch-test-{job_id[:8]}"
-
-    conn = psycopg2.connect(db_url)
     try:
-        with conn.cursor() as cur:
-            cur.execute(
-                """
-                INSERT INTO odb.import_jobs (
-                    job_id, tenant_id, project_id, state, source_kind,
-                    blob_sha, repository_source, input, events,
-                    percent, created_by
-                )
-                VALUES (
-                    %s::uuid, %s::uuid, NULL, 'running', 'openapi',
-                    NULL, NULL, %s::jsonb, %s::jsonb,
-                    0, %s::uuid
-                )
-                """,
-                (
-                    job_id,
-                    tenant_id,
-                    Json(
-                        {
-                            "sourceKind": "openapi",
-                            "document": {
-                                "openapi": "3.1.0",
-                                "info": {"title": "Orch", "version": "1.0"},
-                                "paths": {},
-                                "components": {"schemas": {"Pet": {"type": "object", "properties": {"n": {"type": "string"}}}}},
-                            },
-                            "project": {"name": "Orch Test", "slug": slug},
-                            "version": {"versionId": "1.0.0"},
-                            "options": {"selectedSchemas": ["Pet"], "dryRun": True},
-                        }
-                    ),
-                    Json([{"type": "queued", "at": "2026-05-09T00:00:00+00:00"}]),
-                    user_id,
-                ),
-            )
-        conn.commit()
-    finally:
-        conn.close()
+        members = db.execute_query(
+            "SELECT tenant_id::text AS tenant_id, user_id::text AS user_id FROM odb.tenant_users LIMIT 1"
+        )
+        if not members:
+            pytest.skip("no tenant_users row")
 
-    row = db.get_import_job_row(tenant_id, job_id)
-    assert row is not None
+        tenant_id = members[0]["tenant_id"]
+        user_id = members[0]["user_id"]
+        job_id = str(uuid.uuid4())
+        slug = f"orch-test-{job_id[:8]}"
 
-    try:
-        code, err_tail = await run_import_sidecar(db, row)
-        assert code == 0
-        updated = db.get_import_job_row(tenant_id, job_id)
-        assert updated is not None
-        assert updated["state"] == "completed"
-        if err_tail:
-            assert isinstance(err_tail, list)
-    finally:
         conn = psycopg2.connect(db_url)
         try:
             with conn.cursor() as cur:
-                cur.execute("DELETE FROM odb.import_jobs WHERE job_id = %s::uuid", (job_id,))
+                cur.execute(
+                    """
+                    INSERT INTO odb.import_jobs (
+                        job_id, tenant_id, project_id, state, source_kind,
+                        blob_sha, repository_source, input, events,
+                        percent, created_by
+                    )
+                    VALUES (
+                        %s::uuid, %s::uuid, NULL, 'running', 'openapi',
+                        NULL, NULL, %s::jsonb, %s::jsonb,
+                        0, %s::uuid
+                    )
+                    """,
+                    (
+                        job_id,
+                        tenant_id,
+                        Json(
+                            {
+                                "sourceKind": "openapi",
+                                "document": {
+                                    "openapi": "3.1.0",
+                                    "info": {"title": "Orch", "version": "1.0"},
+                                    "paths": {},
+                                    "components": {"schemas": {"Pet": {"type": "object", "properties": {"n": {"type": "string"}}}}},
+                                },
+                                "project": {"name": "Orch Test", "slug": slug},
+                                "version": {"versionId": "1.0.0"},
+                                "options": {"selectedSchemas": ["Pet"], "dryRun": True},
+                            }
+                        ),
+                        Json([{"type": "queued", "at": "2026-05-09T00:00:00+00:00"}]),
+                        user_id,
+                    ),
+                )
             conn.commit()
         finally:
             conn.close()
 
+        row = db.get_import_job_row(tenant_id, job_id)
+        assert row is not None
 
-def test_import_job_concurrency_caps_release_idempotent() -> None:
+        try:
+            code, err_tail = await run_import_sidecar(row)
+            assert code == 0
+            updated = db.get_import_job_row(tenant_id, job_id)
+            assert updated is not None
+            assert updated["state"] == "completed"
+            if err_tail:
+                assert isinstance(err_tail, list)
+        finally:
+            conn = psycopg2.connect(db_url)
+            try:
+                with conn.cursor() as cur:
+                    cur.execute("DELETE FROM odb.import_jobs WHERE job_id = %s::uuid", (job_id,))
+                conn.commit()
+            finally:
+                conn.close()
+    finally:
+        db.close()
+
+
+def test_import_job_concurrency_caps_release_does_not_underflow() -> None:
     caps = ImportJobConcurrencyCaps(max_total=8, max_per_tenant=2)
     caps.total_running = 2
     caps.per_tenant["t"] = 2
@@ -228,65 +234,68 @@ def test_claim_skips_third_job_when_per_tenant_cap_reached():
 
     db = Database()
     db.connect()
-    members = db.execute_query(
-        "SELECT tenant_id::text AS tenant_id, user_id::text AS user_id FROM odb.tenant_users LIMIT 1"
-    )
-    if not members:
-        pytest.skip("no tenant_users row")
-
-    tenant_id = members[0]["tenant_id"]
-    user_id = members[0]["user_id"]
-    job_ids = [str(uuid.uuid4()) for _ in range(3)]
-    payload = {
-        "sourceKind": "openapi",
-        "document": {"openapi": "3.0.0"},
-        "project": {"name": "Cap Test", "slug": f"cap-{job_ids[0][:8]}"},
-        "version": {"versionId": "1.0.0"},
-        "options": {"selectedSchemas": [], "dryRun": True},
-    }
-    events = [{"type": "queued", "at": "2026-05-09T00:00:00+00:00"}]
-
-    conn = psycopg2.connect(db_url)
     try:
-        with conn.cursor() as cur:
-            for jid in job_ids:
-                cur.execute(
-                    """
-                    INSERT INTO odb.import_jobs (
-                        job_id, tenant_id, project_id, state, source_kind,
-                        blob_sha, repository_source, input, events,
-                        percent, created_by
-                    )
-                    VALUES (
-                        %s::uuid, %s::uuid, NULL, 'queued', 'openapi',
-                        NULL, NULL, %s::jsonb, %s::jsonb,
-                        0, %s::uuid
-                    )
-                    """,
-                    (jid, tenant_id, Json(payload), Json(events), user_id),
-                )
-        conn.commit()
-    finally:
-        conn.close()
+        members = db.execute_query(
+            "SELECT tenant_id::text AS tenant_id, user_id::text AS user_id FROM odb.tenant_users LIMIT 1"
+        )
+        if not members:
+            pytest.skip("no tenant_users row")
 
-    caps = ImportJobConcurrencyCaps(max_total=8, max_per_tenant=2)
-    try:
-        r1 = db.claim_import_job_with_caps(caps)
-        r2 = db.claim_import_job_with_caps(caps)
-        r3 = db.claim_import_job_with_caps(caps)
-        assert r1 is not None and r2 is not None
-        assert r3 is None
-        tid = str(r1["tenant_id"])
-        caps.release(tid)
-        r4 = db.claim_import_job_with_caps(caps)
-        assert r4 is not None
-        assert str(r4["job_id"]) == job_ids[2]
-    finally:
+        tenant_id = members[0]["tenant_id"]
+        user_id = members[0]["user_id"]
+        job_ids = [str(uuid.uuid4()) for _ in range(3)]
+        payload = {
+            "sourceKind": "openapi",
+            "document": {"openapi": "3.0.0"},
+            "project": {"name": "Cap Test", "slug": f"cap-{job_ids[0][:8]}"},
+            "version": {"versionId": "1.0.0"},
+            "options": {"selectedSchemas": [], "dryRun": True},
+        }
+        events = [{"type": "queued", "at": "2026-05-09T00:00:00+00:00"}]
+
         conn = psycopg2.connect(db_url)
         try:
             with conn.cursor() as cur:
                 for jid in job_ids:
-                    cur.execute("DELETE FROM odb.import_jobs WHERE job_id = %s::uuid", (jid,))
+                    cur.execute(
+                        """
+                        INSERT INTO odb.import_jobs (
+                            job_id, tenant_id, project_id, state, source_kind,
+                            blob_sha, repository_source, input, events,
+                            percent, created_by
+                        )
+                        VALUES (
+                            %s::uuid, %s::uuid, NULL, 'queued', 'openapi',
+                            NULL, NULL, %s::jsonb, %s::jsonb,
+                            0, %s::uuid
+                        )
+                        """,
+                        (jid, tenant_id, Json(payload), Json(events), user_id),
+                    )
             conn.commit()
         finally:
             conn.close()
+
+        caps = ImportJobConcurrencyCaps(max_total=8, max_per_tenant=2)
+        try:
+            r1 = db.claim_import_job_with_caps(caps)
+            r2 = db.claim_import_job_with_caps(caps)
+            r3 = db.claim_import_job_with_caps(caps)
+            assert r1 is not None and r2 is not None
+            assert r3 is None
+            tid = str(r1["tenant_id"])
+            caps.release(tid)
+            r4 = db.claim_import_job_with_caps(caps)
+            assert r4 is not None
+            assert str(r4["job_id"]) == job_ids[2]
+        finally:
+            conn = psycopg2.connect(db_url)
+            try:
+                with conn.cursor() as cur:
+                    for jid in job_ids:
+                        cur.execute("DELETE FROM odb.import_jobs WHERE job_id = %s::uuid", (jid,))
+                conn.commit()
+            finally:
+                conn.close()
+    finally:
+        db.close()

--- a/objectified-rest/uv.lock
+++ b/objectified-rest/uv.lock
@@ -514,7 +514,7 @@ wheels = [
 
 [[package]]
 name = "objectified-rest"
-version = "1.0.61"
+version = "1.0.62"
 source = { editable = "." }
 dependencies = [
     { name = "bcrypt" },

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.110",
+  "version": "0.11.111",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -8,6 +8,7 @@ We continue to improve the platform based on your feedback with improvements and
 - MCP service is now live
 
 ## REST
+- **`objectified-rest`**: import orchestrator (`import_orchestrator.py`) — FastAPI startup workers claim `queued` jobs, spawn **`objectified-importer`** (`OBJECTIFIED_IMPORT_RUNNER_CMD` or `node …/bin/run.js`), stream NDJSON into `import_jobs`, enforce tenant/total concurrency caps, stale-job recovery, cancel via **SIGTERM** when the row is **canceled**, optional standalone **`python -m app.import_runner`**; **`OBJECTIFIED_IMPORT_WORKERS`** defaults off in tests (**`0`** via pytest); production sets workers + caps (#3307).
 - **`objectified-rest`**: `/v1/imports/{tenant_slug}` spec-import jobs API (POST queue + optional **Idempotency-Key**, GET status with weak **ETag**, commit / cancel / rollback), workflow-audit on transitions, DB migration for idempotency keys; **`objectified-cli`** codegen updated (#3306).
 
 ## CLI


### PR DESCRIPTION
## What changed
- Added `objectified-rest/src/app/import_orchestrator.py`: FastAPI startup worker pool (`OBJECTIFIED_IMPORT_WORKERS`, default **0** so pytest/dev stay quiet; set **2+** in production), claims `queued` rows with `FOR UPDATE SKIP LOCKED` plus per-tenant (`OBJECTIFIED_IMPORT_MAX_PER_TENANT`, default 2) and global (`OBJECTIFIED_IMPORT_MAX_TOTAL`, default 8) caps, spawns `objectified-importer` (`OBJECTIFIED_IMPORT_RUNNER_CMD` or `node …/bin/run.js`), streams NDJSON `event` / `progress` / `result` / `error` into `odb.import_jobs`, caps event array at 1000, propagates cancel via **SIGTERM** when the row is **canceled**, inserts `odb.tenant_repository_imports` on **completed** when `repository_source` is set (same guard SQL as UI), emits workflow audit `import.job.complete` / `import.job.failed`, stale sweep every 30s (`OBJECTIFIED_IMPORT_STALE_TIMEOUT`, default 600s) marking stuck `running`/`committing` rows `failed` with `orchestrator-crash`.
- Added `objectified-rest/src/app/import_runner.py` for a worker-only process (`PYTHONPATH=src python -m app.import_runner`).
- Extended `database.py` with claim/append/progress/terminal/stale/repository-import helpers and `ImportJobConcurrencyCaps`.
- **Importer**: `OBJECTIFIED_IMPORTER_ORCHESTRATOR=1` auto-`commitImport` after `pending-approval` so one sidecar run reaches **completed**; NDJSON `result` lines now include engine `result` (project/version UUIDs).

## How to test
1. **Unit**: `cd objectified-rest && uv run pytest tests/test_import_orchestrator.py tests/test_imports_api.py -q`
2. **Integration** (needs **`DATABASE_URL`** and **Node**): same path — stale-mark, cap-claim, and dry-run sidecar tests run; others skip.
3. **Production-style**: set `OBJECTIFIED_IMPORT_WORKERS=2`, ensure `node` and `objectified-importer/bin/run.js` resolve, **POST** `/v1/imports/{tenant}`, poll GET until **completed**.

## Risk / notes
- Shared `Database` connection is not used across orchestrator worker threads; each claim/run uses a dedicated `Database()` connection.
- Default worker count **0** avoids spawning importers during existing pytest `TestClient` runs (`conftest.py` `setdefault`).
- Full cancel/SIGKILL timing assertions are environment-heavy; stale recovery is covered via `mark_stale_running_import_jobs_failed`.

Closes #3307

Made with [Cursor](https://cursor.com)