### PR TITLE
Fix #3343 - Developer Mode entitlement and toggle

### DIFF
--- a/docs/FUTURE_FEATURE_ROADMAP_DEVELOPER_MODE.md
+++ b/docs/FUTURE_FEATURE_ROADMAP_DEVELOPER_MODE.md
@@ -31,7 +31,6 @@ Tickets were created from this roadmap with structured descriptions (problem, sc
 
 | ID | Issue |
 |----|------:|
-| 1.1 | [#3343](https://github.com/KenSuenobu/objectified-commercial/issues/3343) |
 | 1.2 | [#3344](https://github.com/KenSuenobu/objectified-commercial/issues/3344) |
 | 1.3 | [#3345](https://github.com/KenSuenobu/objectified-commercial/issues/3345) |
 | 1.4 | [#3346](https://github.com/KenSuenobu/objectified-commercial/issues/3346) |

--- a/objectified-db/scripts/20260511-162000.sql
+++ b/objectified-db/scripts/20260511-162000.sql
@@ -1,0 +1,8 @@
+-- Per-user JSON preferences (Developer Mode toggle, future settings) (#3343).
+SET search_path TO odb, public;
+
+ALTER TABLE odb.users
+  ADD COLUMN IF NOT EXISTS preferences JSONB NOT NULL DEFAULT '{}'::jsonb;
+
+COMMENT ON COLUMN odb.users.preferences IS
+  'User-level preferences merged by the API (e.g. developerModeEnabled for code-first Developer Mode).';

--- a/objectified-rest/pyproject.toml
+++ b/objectified-rest/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "objectified-rest"
-version = "1.0.61"
+version = "1.0.62"
 description = "REST API for serving OpenAPI specifications from the Objectified database"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/objectified-rest/src/app/database.py
+++ b/objectified-rest/src/app/database.py
@@ -7207,6 +7207,74 @@ class Database:
         """
         return self.execute_query(query, tuple(params))
 
+    def get_user_entitlements_row(self, user_id: str) -> Optional[Dict[str, Any]]:
+        rows = self.execute_query(
+            """
+            SELECT plan_code, license_id::text AS license_id
+            FROM odb.user_entitlements
+            WHERE user_id = %s
+            LIMIT 1
+            """,
+            (user_id,),
+        )
+        return rows[0] if rows else None
+
+    def is_developer_mode_entitled(self, user_id: str, row: Optional[Dict[str, Any]] = None) -> bool:
+        """
+        Developer Mode is a paid capability: free-tier rows (plan_code = free, no license) are excluded.
+        Users with no entitlements row are treated as not entitled (strict gate).
+        """
+        r = row if row is not None else self.get_user_entitlements_row(user_id)
+        if not r:
+            return False
+        pc = (r.get("plan_code") or "").strip().lower()
+        if pc != "free":
+            return True
+        lic = r.get("license_id")
+        return lic is not None and str(lic).strip() != ""
+
+    def get_user_preferences(self, user_id: str) -> Dict[str, Any]:
+        rows = self.execute_query(
+            """
+            SELECT COALESCE(preferences, '{}'::jsonb) AS preferences
+            FROM odb.users
+            WHERE id = %s AND deleted_at IS NULL
+            LIMIT 1
+            """,
+            (user_id,),
+        )
+        if not rows:
+            return {}
+        raw = rows[0].get("preferences")
+        if isinstance(raw, dict):
+            return raw
+        if isinstance(raw, str):
+            try:
+                parsed = json.loads(raw)
+                return parsed if isinstance(parsed, dict) else {}
+            except Exception:
+                return {}
+        return {}
+
+    def merge_user_preferences(self, user_id: str, patch: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Shallow-merge top-level keys into odb.users.preferences (jsonb ||).
+        """
+        rows = self.execute_query(
+            """
+            UPDATE odb.users
+            SET preferences = COALESCE(preferences, '{}'::jsonb) || %s::jsonb,
+                updated_at = CURRENT_TIMESTAMP
+            WHERE id = %s AND deleted_at IS NULL
+            RETURNING preferences
+            """,
+            (Json(patch), user_id),
+        )
+        if not rows:
+            raise ValueError("user not found or deleted")
+        out = rows[0].get("preferences")
+        return out if isinstance(out, dict) else {}
+
 
 # Global database instance
 db = Database()

--- a/objectified-rest/src/app/entitlements_routes.py
+++ b/objectified-rest/src/app/entitlements_routes.py
@@ -1,0 +1,50 @@
+"""
+Entitlement checks for product surfaces (Developer Mode, etc.).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from .auth import validate_session_credentials
+from .database import db
+
+router = APIRouter(prefix="/v1/entitlements", tags=["entitlements"])
+
+
+def _effective_user_id(session: Dict[str, Any]) -> Optional[str]:
+    if session.get("auth_method") == "jwt":
+        uid = session.get("user_id")
+        return str(uid) if uid else None
+    if session.get("auth_method") == "api_key":
+        uid = session.get("user_id")
+        if uid:
+            return str(uid)
+        tid = session.get("tenant_id")
+        if tid:
+            return db.get_fallback_creator_user_id_for_tenant(str(tid))
+    return None
+
+
+@router.get("/developer-mode")
+async def get_developer_mode_entitlement(
+    session: Dict[str, Any] = Depends(validate_session_credentials),
+) -> Dict[str, Any]:
+    """
+    Returns whether the current principal may use Developer Mode (Pro / paid license).
+
+    JWT: the signed-in user. API key: ``created_by_user_id`` for the key, or tenant fallback creator.
+    """
+    user_id = _effective_user_id(session)
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Missing user identifier for entitlement check")
+
+    row = db.get_user_entitlements_row(user_id)
+    plan_code = (row or {}).get("plan_code")
+    allowed = db.is_developer_mode_entitled(user_id, row)
+    return {
+        "allowed": allowed,
+        "planCode": str(plan_code) if plan_code is not None else None,
+    }

--- a/objectified-rest/src/app/main.py
+++ b/objectified-rest/src/app/main.py
@@ -36,12 +36,14 @@ from .tenant_repositories_routes import router as tenant_repositories_router
 from .tenants_session_routes import router as tenants_session_router
 from .browse_public_routes import router as browse_public_router
 from .spec_import_routes import router as spec_import_router
+from .entitlements_routes import router as entitlements_router
+from .users_preferences_routes import router as users_preferences_router
 
 # Create FastAPI app
 app = FastAPI(
     title="Objectified REST API",
     description="REST API for serving OpenAPI specifications from the Objectified database",
-    version="1.0.61"
+    version="1.0.62"
 )
 
 
@@ -111,6 +113,8 @@ app.include_router(change_report_router)
 app.include_router(version_change_report_router)
 app.include_router(change_report_template_router)
 app.include_router(tenants_session_router)
+app.include_router(entitlements_router)
+app.include_router(users_preferences_router)
 app.include_router(spec_import_router)
 app.include_router(tenant_repositories_router)
 

--- a/objectified-rest/src/app/users_preferences_routes.py
+++ b/objectified-rest/src/app/users_preferences_routes.py
@@ -1,0 +1,87 @@
+"""
+Current-user preferences (session-scoped, JWT-only writes).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, ConfigDict, Field
+
+from .auth import validate_session_credentials
+from .database import db
+
+router = APIRouter(prefix="/v1/users", tags=["users"])
+
+
+class UserPreferencesPatch(BaseModel):
+    """Subset of keys accepted on PUT; extend as new preferences ship."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    developer_mode_enabled: bool | None = Field(default=None, alias="developerModeEnabled")
+
+
+def _effective_user_id(session: Dict[str, Any]) -> str:
+    if session.get("auth_method") == "jwt":
+        uid = session.get("user_id")
+        if not uid:
+            raise HTTPException(status_code=401, detail="Missing user identifier")
+        return str(uid)
+    if session.get("auth_method") == "api_key":
+        uid = session.get("user_id")
+        if uid:
+            return str(uid)
+        tid = session.get("tenant_id")
+        if tid:
+            fb = db.get_fallback_creator_user_id_for_tenant(str(tid))
+            if fb:
+                return str(fb)
+        raise HTTPException(status_code=401, detail="Missing user identifier for API key session")
+    raise HTTPException(status_code=401, detail="Missing session")
+
+
+def _require_jwt_user_id(session: Dict[str, Any]) -> str:
+    if session.get("auth_method") != "jwt":
+        raise HTTPException(
+            status_code=403,
+            detail="Updating user preferences requires a browser session (JWT).",
+        )
+    uid = session.get("user_id")
+    if not uid:
+        raise HTTPException(status_code=401, detail="Missing user identifier")
+    return str(uid)
+
+
+@router.get("/me/preferences")
+async def get_my_preferences(
+    session: Dict[str, Any] = Depends(validate_session_credentials),
+) -> Dict[str, Any]:
+    user_id = _effective_user_id(session)
+    prefs = db.get_user_preferences(user_id)
+    return {"preferences": prefs}
+
+
+@router.put("/me/preferences")
+async def put_my_preferences(
+    body: UserPreferencesPatch,
+    session: Dict[str, Any] = Depends(validate_session_credentials),
+) -> Dict[str, Any]:
+    user_id = _require_jwt_user_id(session)
+    patch: Dict[str, Any] = body.model_dump(by_alias=True, exclude_none=True)
+    if not patch:
+        raise HTTPException(status_code=400, detail="No preference fields supplied")
+
+    if patch.get("developerModeEnabled") is True and not db.is_developer_mode_entitled(user_id):
+        raise HTTPException(
+            status_code=403,
+            detail="Developer Mode requires an eligible plan. Upgrade to enable this preference.",
+        )
+
+    try:
+        merged = db.merge_user_preferences(user_id, patch)
+    except ValueError:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    return {"preferences": merged}

--- a/objectified-rest/tests/test_developer_mode_and_preferences_api.py
+++ b/objectified-rest/tests/test_developer_mode_and_preferences_api.py
@@ -1,0 +1,87 @@
+"""Tests for Developer Mode entitlement and user preferences APIs (#3343)."""
+
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.auth import validate_session_credentials
+from app.main import app
+
+client = TestClient(app)
+
+_USER_ID = "660e8400-e29b-41d4-a716-446655440001"
+
+
+@pytest.fixture
+def jwt_session():
+    app.dependency_overrides[validate_session_credentials] = lambda: {
+        "auth_method": "jwt",
+        "user_id": _USER_ID,
+    }
+    yield
+    app.dependency_overrides.pop(validate_session_credentials, None)
+
+
+def test_get_developer_mode_entitlement_allowed(jwt_session):
+    with patch("app.entitlements_routes.db") as m:
+        m.get_user_entitlements_row.return_value = {"plan_code": "paid", "license_id": None}
+        m.is_developer_mode_entitled.return_value = True
+        r = client.get("/v1/entitlements/developer-mode")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["allowed"] is True
+    assert body["planCode"] == "paid"
+
+
+def test_get_developer_mode_entitlement_free_tier(jwt_session):
+    with patch("app.entitlements_routes.db") as m:
+        m.get_user_entitlements_row.return_value = {"plan_code": "free", "license_id": None}
+        m.is_developer_mode_entitled.return_value = False
+        r = client.get("/v1/entitlements/developer-mode")
+    assert r.status_code == 200
+    assert r.json() == {"allowed": False, "planCode": "free"}
+
+
+def test_put_preferences_blocks_dev_mode_without_entitlement(jwt_session):
+    with patch("app.users_preferences_routes.db") as m:
+        m.is_developer_mode_entitled.return_value = False
+        r = client.put(
+            "/v1/users/me/preferences",
+            json={"developerModeEnabled": True},
+        )
+        assert r.status_code == 403
+        m.merge_user_preferences.assert_not_called()
+
+
+def test_put_preferences_allows_dev_mode_when_entitled(jwt_session):
+    with patch("app.users_preferences_routes.db") as m:
+        m.is_developer_mode_entitled.return_value = True
+        m.merge_user_preferences.return_value = {"developerModeEnabled": True, "theme": "dark"}
+        r = client.put(
+            "/v1/users/me/preferences",
+            json={"developerModeEnabled": True},
+        )
+    assert r.status_code == 200
+    assert r.json()["preferences"]["developerModeEnabled"] is True
+    m.merge_user_preferences.assert_called_once()
+
+
+def test_put_preferences_can_disable_without_entitlement(jwt_session):
+    with patch("app.users_preferences_routes.db") as m:
+        m.is_developer_mode_entitled.return_value = False
+        m.merge_user_preferences.return_value = {"developerModeEnabled": False}
+        r = client.put(
+            "/v1/users/me/preferences",
+            json={"developerModeEnabled": False},
+        )
+    assert r.status_code == 200
+    m.merge_user_preferences.assert_called_once()
+
+
+def test_get_preferences_reads_db(jwt_session):
+    with patch("app.users_preferences_routes.db") as m:
+        m.get_user_preferences.return_value = {"developerModeEnabled": True}
+        r = client.get("/v1/users/me/preferences")
+    assert r.status_code == 200
+    assert r.json() == {"preferences": {"developerModeEnabled": True}}

--- a/objectified-rest/uv.lock
+++ b/objectified-rest/uv.lock
@@ -514,7 +514,7 @@ wheels = [
 
 [[package]]
 name = "objectified-rest"
-version = "1.0.61"
+version = "1.0.62"
 source = { editable = "." }
 dependencies = [
     { name = "bcrypt" },

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.112",
+  "version": "0.11.113",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -62,6 +62,7 @@ We continue to improve the platform based on your feedback with improvements and
 - Projects list includes a **Show deleted** switch; when on, soft-deleted projects appear with a **Deleted** badge and **Restore** or **permanent delete** in the row menu (#2981).
 
 ## Studio
+- **Developer Mode (foundation)**: Pro-gated **Developer Mode** preference with server-side entitlement (`GET /v1/entitlements/developer-mode`), persisted user settings (`PUT /v1/users/me/preferences`), **SSR-hydrated** toggle in the studio chrome and **Profile**, free-tier **Pro upsell** dialog, and authenticated telemetry `developer_mode.toggled` with `from` / `to` (`POST /api/v1/telemetry/events`) (#3343).
 - **Schema Metrics** includes **Canvas layout intelligence**: analyzes the live ReactFlow graph (strongly connected components, hubs, hierarchy roots, weakly connected islands), recommends **Top→Bottom** vs **Left→Right** auto-layout, adds matching **Suggestions**, and optional **AI narrative** via Ollama (`canvas_layout_recommendations`) (#623).
 - Property **Examples** (Advanced Constraints) supports **Generate example with AI** (Ollama): adds a realistic JSON example from the property name, optional description, schema snapshot, and nested member hints on class properties (#622).
 - **Paths** operation **Docs** tab supports **Generate summary & description** (Ollama): drafts OpenAPI **summary** and Markdown **description** from the HTTP method, path template, path parameters, and optional operationId (#621).

--- a/objectified-ui/src/app/ade/dashboard/profile/page.tsx
+++ b/objectified-ui/src/app/ade/dashboard/profile/page.tsx
@@ -23,6 +23,7 @@ import {
   dashboardMainClass,
   dashboardPanelClass,
 } from '@/app/components/ade/dashboard/dashboardScreenClasses';
+import { DeveloperModePreferenceControl } from '@/app/components/ade/DeveloperModePreferenceControl';
 import { cn } from '../../../../../lib/utils';
 
 const Profile = () => {
@@ -293,6 +294,8 @@ const Profile = () => {
             </Button>
           </CardFooter>
         </Card>
+
+        <DeveloperModePreferenceControl layout="profile" />
 
         {/* Security card */}
         <Card className={cn(dashboardPanelClass, 'shadow-none overflow-hidden')}>

--- a/objectified-ui/src/app/ade/layout.tsx
+++ b/objectified-ui/src/app/ade/layout.tsx
@@ -6,6 +6,8 @@ import AuthenticatedLayout from "@/app/components/auth/AuthenticatedLayout";
 import ConditionalHeader from '@/app/components/ade/ConditionalHeader';
 import { PushConflictBannerProvider } from '@/app/providers/PushConflictBannerProvider';
 import { ThemeProvider } from '@/app/providers/ThemeProvider';
+import { DeveloperModeProvider } from '@/app/providers/DeveloperModeProvider';
+import { fetchDeveloperModeServerSnapshot } from '@/lib/developer-mode-server';
 import { ThemeProvider as NextThemesProvider } from "next-themes";
 import { Theme as RadixTheme } from "@radix-ui/themes";
 import * as React from 'react';
@@ -15,11 +17,13 @@ export const metadata: Metadata = {
   description: "Objectified ADE Platform - Studio",
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const developerModeSnapshot = await fetchDeveloperModeServerSnapshot();
+
   return (
     <div className="antialiased">
       <NextThemesProvider
@@ -37,12 +41,14 @@ export default function RootLayout({
         >
           <ThemeProvider>
             <SessionWrapper>
-              <PushConflictBannerProvider>
-                <AuthenticatedLayout>
-                  <ConditionalHeader />
-                  {children}
-                </AuthenticatedLayout>
-              </PushConflictBannerProvider>
+              <DeveloperModeProvider initial={developerModeSnapshot}>
+                <PushConflictBannerProvider>
+                  <AuthenticatedLayout>
+                    <ConditionalHeader />
+                    {children}
+                  </AuthenticatedLayout>
+                </PushConflictBannerProvider>
+              </DeveloperModeProvider>
             </SessionWrapper>
           </ThemeProvider>
         </RadixTheme>

--- a/objectified-ui/src/app/api/v1/entitlements/developer-mode/route.ts
+++ b/objectified-ui/src/app/api/v1/entitlements/developer-mode/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '../../../auth/[...nextauth]/route';
+import { createRestAuthHeaders, REST_API_BASE_URL } from '@lib/rest-auth';
+
+type SessionUser = {
+  user_id?: string;
+  email?: string | null;
+  name?: string | null;
+  current_tenant_id?: string;
+};
+
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  const user = session?.user as SessionUser | undefined;
+  if (!user?.user_id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const headers = createRestAuthHeaders(user);
+  try {
+    const res = await fetch(`${REST_API_BASE_URL}/entitlements/developer-mode`, {
+      method: 'GET',
+      headers,
+      cache: 'no-store',
+    });
+    const body = await res.json().catch(() => ({}));
+    return NextResponse.json(body, { status: res.status });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : 'Upstream error';
+    return NextResponse.json({ error: msg }, { status: 502 });
+  }
+}

--- a/objectified-ui/src/app/api/v1/telemetry/events/route.ts
+++ b/objectified-ui/src/app/api/v1/telemetry/events/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '../../../auth/[...nextauth]/route';
+
+const ALLOWED = new Set(['developer_mode.toggled']);
+
+export async function POST(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  const user = session?.user as { user_id?: string } | undefined;
+  if (!user?.user_id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+  if (!body || typeof body !== 'object' || Array.isArray(body)) {
+    return NextResponse.json({ error: 'Invalid payload' }, { status: 400 });
+  }
+  const rec = body as Record<string, unknown>;
+  const event = rec.event;
+  const properties = rec.properties;
+  if (typeof event !== 'string' || !ALLOWED.has(event)) {
+    return NextResponse.json({ error: 'Unknown or missing event' }, { status: 400 });
+  }
+  if (properties !== undefined && (typeof properties !== 'object' || properties === null || Array.isArray(properties))) {
+    return NextResponse.json({ error: 'Invalid properties' }, { status: 400 });
+  }
+
+  const props = (properties ?? {}) as Record<string, unknown>;
+  if (event === 'developer_mode.toggled') {
+    const from = props.from;
+    const to = props.to;
+    if (from !== 'off' && from !== 'on') {
+      return NextResponse.json({ error: 'developer_mode.toggled requires properties.from' }, { status: 400 });
+    }
+    if (to !== 'off' && to !== 'on') {
+      return NextResponse.json({ error: 'developer_mode.toggled requires properties.to' }, { status: 400 });
+    }
+  }
+
+  console.info('[telemetry]', JSON.stringify({ userId: user.user_id, event, properties: props }));
+  return new NextResponse(null, { status: 204 });
+}

--- a/objectified-ui/src/app/api/v1/users/me/preferences/route.ts
+++ b/objectified-ui/src/app/api/v1/users/me/preferences/route.ts
@@ -1,0 +1,62 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '../../../../auth/[...nextauth]/route';
+import { createRestAuthHeaders, REST_API_BASE_URL } from '@lib/rest-auth';
+
+type SessionUser = {
+  user_id?: string;
+  email?: string | null;
+  name?: string | null;
+  current_tenant_id?: string;
+};
+
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  const user = session?.user as SessionUser | undefined;
+  if (!user?.user_id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const headers = createRestAuthHeaders(user);
+  try {
+    const res = await fetch(`${REST_API_BASE_URL}/users/me/preferences`, {
+      method: 'GET',
+      headers,
+      cache: 'no-store',
+    });
+    const body = await res.json().catch(() => ({}));
+    return NextResponse.json(body, { status: res.status });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : 'Upstream error';
+    return NextResponse.json({ error: msg }, { status: 502 });
+  }
+}
+
+export async function PUT(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  const user = session?.user as SessionUser | undefined;
+  if (!user?.user_id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  let json: unknown;
+  try {
+    json = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const headers = createRestAuthHeaders(user);
+  try {
+    const res = await fetch(`${REST_API_BASE_URL}/users/me/preferences`, {
+      method: 'PUT',
+      headers,
+      body: JSON.stringify(json ?? {}),
+    });
+    const body = await res.json().catch(() => ({}));
+    return NextResponse.json(body, { status: res.status });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : 'Upstream error';
+    return NextResponse.json({ error: msg }, { status: 502 });
+  }
+}

--- a/objectified-ui/src/app/components/ade/DeveloperModePreferenceControl.tsx
+++ b/objectified-ui/src/app/components/ade/DeveloperModePreferenceControl.tsx
@@ -1,0 +1,182 @@
+'use client';
+
+import React, { useState } from 'react';
+import Link from 'next/link';
+import * as Switch from '@radix-ui/react-switch';
+import { Code2 } from 'lucide-react';
+import { useDeveloperMode } from '@/app/providers/DeveloperModeProvider';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/app/components/ui/Dialog';
+import { Button, buttonVariants } from '@/app/components/ui/Button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/app/components/ui/Card';
+import { cn } from '@lib/utils';
+import { dashboardPanelClass } from '@/app/components/ade/dashboard/dashboardScreenClasses';
+
+type Layout = 'toolbar' | 'profile';
+
+function DeveloperModePaywallDialog({
+  open,
+  onOpenChange,
+  planCode,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  planCode: string | null;
+}) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Code2 className="h-5 w-5 text-indigo-600 dark:text-indigo-400" aria-hidden />
+            Developer Mode is a Pro feature
+          </DialogTitle>
+          <DialogDescription>
+            Code-first editing, unified workspace tools, and advanced schema surfaces are included with an eligible
+            plan. {planCode ? `Your current plan is ${planCode}.` : ''}
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter className="gap-2 sm:gap-0">
+          <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+            Not now
+          </Button>
+          <Link
+            href="/ade/dashboard/profile"
+            className={cn(buttonVariants({ variant: 'default', size: 'default' }))}
+            onClick={() => onOpenChange(false)}
+          >
+            View profile & billing
+          </Link>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export function DeveloperModePreferenceControl({ layout = 'toolbar' }: { layout?: Layout }) {
+  const ctx = useDeveloperMode();
+  const [paywallOpen, setPaywallOpen] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  if (!ctx?.signedIn) {
+    return null;
+  }
+
+  const { entitled, developerModeEnabled, setDeveloperModeEnabled, planCode } = ctx;
+
+  const onCheckedChange = async (checked: boolean) => {
+    if (!entitled && checked) {
+      setPaywallOpen(true);
+      return;
+    }
+    if (!entitled) {
+      return;
+    }
+    setSaving(true);
+    try {
+      await setDeveloperModeEnabled(checked);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const toolbarSwitch = (
+    <div className="hidden items-center gap-2 sm:flex">
+      <span className="whitespace-nowrap text-xs font-medium text-slate-600 dark:text-slate-300">Developer Mode</span>
+      {entitled ? (
+        <Switch.Root
+          checked={developerModeEnabled}
+          onCheckedChange={(v) => void onCheckedChange(v)}
+          disabled={saving}
+          aria-label="Developer Mode"
+          className={cn(
+            'relative h-6 w-11 shrink-0 cursor-pointer rounded-full border border-transparent bg-slate-300 outline-none transition-colors',
+            'data-[state=checked]:bg-indigo-600',
+            'disabled:cursor-wait disabled:opacity-60',
+            'dark:bg-slate-600 dark:data-[state=checked]:bg-indigo-500'
+          )}
+        >
+          <Switch.Thumb
+            className={cn(
+              'block h-5 w-5 translate-x-0.5 rounded-full bg-white shadow transition-transform will-change-transform',
+              'data-[state=checked]:translate-x-[1.375rem]'
+            )}
+          />
+        </Switch.Root>
+      ) : (
+        <button
+          type="button"
+          onClick={() => setPaywallOpen(true)}
+          className="rounded-full border border-amber-200 bg-amber-50 px-2.5 py-1 text-xs font-semibold text-amber-900 transition-colors hover:bg-amber-100 dark:border-amber-900/50 dark:bg-amber-950/40 dark:text-amber-100 dark:hover:bg-amber-900/30"
+        >
+          Pro
+        </button>
+      )}
+    </div>
+  );
+
+  if (layout === 'toolbar') {
+    return (
+      <>
+        {toolbarSwitch}
+        <DeveloperModePaywallDialog open={paywallOpen} onOpenChange={setPaywallOpen} planCode={planCode} />
+      </>
+    );
+  }
+
+  return (
+    <>
+      <Card className={cn(dashboardPanelClass, 'shadow-none overflow-hidden')}>
+        <CardHeader className="border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900">
+          <CardTitle className="flex items-center gap-2">
+            <Code2 className="h-5 w-5 text-indigo-500" />
+            Developer Mode
+          </CardTitle>
+          <CardDescription>
+            Prefer code-first editors for schemas and paths when this workspace ships the full Developer Mode
+            experience.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <p className="text-sm text-gray-600 dark:text-gray-400">
+            {entitled
+              ? 'Toggle code-first mode. Your choice is saved to your account and applies on every device.'
+              : 'Upgrade to a Pro-eligible plan to turn on Developer Mode.'}
+          </p>
+          {entitled ? (
+            <Switch.Root
+              checked={developerModeEnabled}
+              onCheckedChange={(v) => void onCheckedChange(v)}
+              disabled={saving}
+              aria-label="Developer Mode"
+              className={cn(
+                'relative h-7 w-12 shrink-0 cursor-pointer rounded-full border border-transparent bg-slate-300 outline-none transition-colors',
+                'data-[state=checked]:bg-indigo-600',
+                'disabled:cursor-wait disabled:opacity-60',
+                'dark:bg-slate-600 dark:data-[state=checked]:bg-indigo-500'
+              )}
+            >
+              <Switch.Thumb
+                className={cn(
+                  'block h-6 w-6 translate-x-0.5 rounded-full bg-white shadow transition-transform will-change-transform',
+                  'data-[state=checked]:translate-x-[1.5rem]'
+                )}
+              />
+            </Switch.Root>
+          ) : (
+            <Button type="button" variant="outline" size="sm" onClick={() => setPaywallOpen(true)}>
+              View Pro options
+            </Button>
+          )}
+        </CardContent>
+      </Card>
+      <DeveloperModePaywallDialog open={paywallOpen} onOpenChange={setPaywallOpen} planCode={planCode} />
+    </>
+  );
+}

--- a/objectified-ui/src/app/components/ade/TopHeader.tsx
+++ b/objectified-ui/src/app/components/ade/TopHeader.tsx
@@ -8,6 +8,7 @@ import { usePathname } from 'next/navigation';
 import { ChevronDown, Check, Shield } from 'lucide-react';
 import WhatsNewDialog from './WhatsNewDialog';
 import ThemeSelector from './ThemeSelector';
+import { DeveloperModePreferenceControl } from './DeveloperModePreferenceControl';
 import { useTheme } from '../../providers/ThemeProvider';
 import { useDarkMode } from '../../hooks/useDarkMode';
 import { getTenantsForUser, getTenantsAdministratedByUser } from '../../../../lib/db/helper';
@@ -215,6 +216,8 @@ const TopHeader = () => {
           })}
         </ul>
       </nav>
+
+      <DeveloperModePreferenceControl layout="toolbar" />
 
       {/* Tenant switcher */}
       {userTenants.length > 0 && (

--- a/objectified-ui/src/app/providers/DeveloperModeProvider.tsx
+++ b/objectified-ui/src/app/providers/DeveloperModeProvider.tsx
@@ -52,7 +52,12 @@ export function DeveloperModeProvider({ initial, children }: Props) {
         });
         if (!res.ok) {
           const err = await res.json().catch(() => ({}));
-          const msg = typeof err?.error === 'string' ? err.error : 'Failed to save preference';
+          const msg =
+            typeof err?.detail === 'string'
+              ? err.detail
+              : typeof err?.error === 'string'
+              ? err.error
+              : 'Failed to save preference';
           return { ok: false as const, error: msg };
         }
         setLocal(next);

--- a/objectified-ui/src/app/providers/DeveloperModeProvider.tsx
+++ b/objectified-ui/src/app/providers/DeveloperModeProvider.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import React, { createContext, useCallback, useContext, useMemo, useState } from 'react';
+import type { DeveloperModeServerSnapshot } from '@/lib/developer-mode-server';
+
+export type DeveloperModeContextValue = DeveloperModeServerSnapshot & {
+  setDeveloperModeEnabled: (next: boolean) => Promise<{ ok: boolean; error?: string }>;
+};
+
+const DeveloperModeContext = createContext<DeveloperModeContextValue | null>(null);
+
+type Props = {
+  initial: DeveloperModeServerSnapshot;
+  children: React.ReactNode;
+};
+
+async function postTelemetry(from: 'off' | 'on', to: 'off' | 'on') {
+  try {
+    await fetch('/api/v1/telemetry/events', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        event: 'developer_mode.toggled',
+        properties: { from, to },
+      }),
+    });
+  } catch {
+    /* non-blocking */
+  }
+}
+
+export function DeveloperModeProvider({ initial, children }: Props) {
+  const [entitled] = useState(initial.entitled);
+  const [planCode] = useState(initial.planCode);
+  const [signedIn] = useState(initial.signedIn);
+  const [developerModeEnabled, setLocal] = useState(initial.developerModeEnabled);
+
+  const setDeveloperModeEnabled = useCallback(
+    async (next: boolean) => {
+      const prev = developerModeEnabled;
+      if (next && !entitled) {
+        return { ok: false as const, error: 'not_entitled' };
+      }
+      if (next === prev) {
+        return { ok: true as const };
+      }
+      try {
+        const res = await fetch('/api/v1/users/me/preferences', {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ developerModeEnabled: next }),
+        });
+        if (!res.ok) {
+          const err = await res.json().catch(() => ({}));
+          const msg = typeof err?.error === 'string' ? err.error : 'Failed to save preference';
+          return { ok: false as const, error: msg };
+        }
+        setLocal(next);
+        const from: 'off' | 'on' = prev ? 'on' : 'off';
+        const to: 'off' | 'on' = next ? 'on' : 'off';
+        void postTelemetry(from, to);
+        return { ok: true as const };
+      } catch (e) {
+        return { ok: false as const, error: e instanceof Error ? e.message : 'Network error' };
+      }
+    },
+    [developerModeEnabled, entitled]
+  );
+
+  const value = useMemo<DeveloperModeContextValue>(
+    () => ({
+      signedIn,
+      entitled,
+      planCode,
+      developerModeEnabled,
+      setDeveloperModeEnabled,
+    }),
+    [signedIn, entitled, planCode, developerModeEnabled, setDeveloperModeEnabled]
+  );
+
+  return <DeveloperModeContext.Provider value={value}>{children}</DeveloperModeContext.Provider>;
+}
+
+export function useDeveloperMode(): DeveloperModeContextValue | null {
+  return useContext(DeveloperModeContext);
+}

--- a/objectified-ui/src/lib/developer-mode-server.ts
+++ b/objectified-ui/src/lib/developer-mode-server.ts
@@ -1,0 +1,66 @@
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/app/api/auth/[...nextauth]/route';
+import { createRestAuthHeaders, REST_API_BASE_URL } from '@lib/rest-auth';
+
+export type DeveloperModeServerSnapshot = {
+  signedIn: boolean;
+  entitled: boolean;
+  planCode: string | null;
+  developerModeEnabled: boolean;
+};
+
+function readEnabled(prefs: unknown): boolean {
+  if (!prefs || typeof prefs !== 'object' || Array.isArray(prefs)) return false;
+  const v = (prefs as Record<string, unknown>).developerModeEnabled;
+  return v === true;
+}
+
+export async function fetchDeveloperModeServerSnapshot(): Promise<DeveloperModeServerSnapshot> {
+  const session = await getServerSession(authOptions);
+  const user = session?.user as
+    | { user_id?: string; email?: string | null; name?: string | null; current_tenant_id?: string }
+    | undefined;
+  if (!session?.user || !user?.user_id) {
+    return { signedIn: false, entitled: false, planCode: null, developerModeEnabled: false };
+  }
+
+  const headers = createRestAuthHeaders({
+    user_id: user.user_id,
+    email: user.email,
+    name: user.name,
+    current_tenant_id: user.current_tenant_id,
+  });
+
+  try {
+    const [entRes, prefRes] = await Promise.all([
+      fetch(`${REST_API_BASE_URL}/entitlements/developer-mode`, { headers, cache: 'no-store' }),
+      fetch(`${REST_API_BASE_URL}/users/me/preferences`, { headers, cache: 'no-store' }),
+    ]);
+
+    let entitled = false;
+    let planCode: string | null = null;
+    if (entRes.ok) {
+      const ent = (await entRes.json().catch(() => null)) as Record<string, unknown> | null;
+      if (ent && typeof ent === 'object') {
+        entitled = ent.allowed === true;
+        const pc = ent.planCode;
+        planCode = typeof pc === 'string' ? pc : pc == null ? null : String(pc);
+      }
+    }
+
+    let developerModeEnabled = false;
+    if (prefRes.ok) {
+      const body = (await prefRes.json().catch(() => null)) as Record<string, unknown> | null;
+      const prefs = body && typeof body === 'object' && 'preferences' in body ? body.preferences : null;
+      developerModeEnabled = readEnabled(prefs);
+    }
+
+    if (!entitled && developerModeEnabled) {
+      developerModeEnabled = false;
+    }
+
+    return { signedIn: true, entitled, planCode, developerModeEnabled };
+  } catch {
+    return { signedIn: true, entitled: false, planCode: null, developerModeEnabled: false };
+  }
+}


### PR DESCRIPTION
## Summary
Implements [DevMode 1.1] Developer Mode entitlement and user preference from issue #3343: REST contract, DB column, Next.js BFF routes, SSR-hydrated chrome + profile UI, Pro paywall, and telemetry.

## What changed
- **objectified-db**: `odb.users.preferences` JSONB column for merged user settings.
- **objectified-rest** (v1.0.62): `GET /v1/entitlements/developer-mode` (allowed + planCode from `user_entitlements`); `GET|PUT /v1/users/me/preferences` (JWT for writes; shallow-merge `developerModeEnabled`; blocks enabling when not entitled). Pytest coverage in `test_developer_mode_and_preferences_api.py`.
- **objectified-ui**: Server snapshot in `ade/layout` (no client-only toggle flicker); `DeveloperModeProvider`; top bar + profile controls; `/api/v1/*` proxies; `POST /api/v1/telemetry/events` for `developer_mode.toggled` with `from` / `to` (`off` | `on`). WHATS_NEW + roadmap table + patch version bump.

## How to test
1. **Apply DB migration** `objectified-db/scripts/20260511-162000.sql` to your database.
2. Run **objectified-rest** with `NEXTAUTH_SECRET` aligned to the UI.
3. **Sign in** as a free-tier user: open any `/ade/...` page except `/ade` — **confirm** a **Pro** chip (not a live switch) and **click** it to open the upsell dialog.
4. **Sign in** as a paid / non-free `plan_code` user (or with a license row): **confirm** the **Radix switch** toggles, persists after **reload**, and **SSR** shows the same state on first paint.
5. **Profile**: **browse to** `/ade/dashboard/profile` — **confirm** the Developer Mode card matches entitlement (switch vs upsell).
6. Toggle on then off with devtools **Network** tab: **confirm** `PUT /api/v1/users/me/preferences` then `POST /api/v1/telemetry/events` with `developer_mode.toggled` and `properties.from` / `properties.to`.
7. **Server logs**: after telemetry POST, a line `[telemetry]` with JSON should appear.

## Risk / notes
- Users without `preferences` column until migration runs will get REST errors on preference routes.
- Entitlement treats **missing** `user_entitlements` row as **not** allowed (strict gate vs legacy unlimited quotas).

Closes #3343

Made with [Cursor](https://cursor.com)