### PR TITLE
fix: pin @xyflow/react to 12.10.2 to fix UI Docker build

### DIFF
--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -61,7 +61,7 @@
     "@radix-ui/react-tooltip": "^1.2.8",
     "@radix-ui/themes": "^3.3.0",
     "@seriousme/openapi-schema-validator": "^2.8.0",
-    "@xyflow/react": "^12.10.2",
+    "@xyflow/react": "12.10.2",
     "ajv": "^8.18.0",
     "ajv-formats": "^3.0.1",
     "bcrypt": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7096,7 +7096,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xyflow/react@npm:^12.10.2":
+"@xyflow/react@npm:12.10.2, @xyflow/react@npm:^12.10.2":
   version: 12.10.2
   resolution: "@xyflow/react@npm:12.10.2"
   dependencies:
@@ -14390,7 +14390,7 @@ __metadata:
     "@types/react": "npm:^19.2.14"
     "@types/react-dom": "npm:^19.2.3"
     "@types/uuid": "npm:^11.0.0"
-    "@xyflow/react": "npm:^12.10.2"
+    "@xyflow/react": "npm:12.10.2"
     ajv: "npm:^8.18.0"
     ajv-formats: "npm:^3.0.1"
     babel-plugin-react-compiler: "npm:^1.0.0"


### PR DESCRIPTION
## Problem
The **Objectified UI Publish** build fails at the `next build` type-check ([run](https://github.com/objectified-project/objectified/actions/runs/27894404801/job/82543372207)):

```
src/app/ade/studio/editor/page.tsx:8658
Type '(event: React.MouseEvent, node: Node) => void' is not assignable to type 'OnNodeDrag<Node>'.
  Type 'MouseEvent | TouchEvent' is not assignable to type 'MouseEvent<Element, MouseEvent>'.
```

## Root cause
`objectified-ui/Dockerfile` copies **only `package.json`** (not the lockfile) and runs `npm install`, so the `"@xyflow/react": "^12.10.2"` range floats to the latest 12.x in CI. A newer `@xyflow/react` changed the `OnNodeDrag` callback type from `ReactMouseEvent` to `MouseEvent | TouchEvent`, which is incompatible with the studio editor's `handleNodeDrag` / `handleNodeDragStop` handlers (typed `React.MouseEvent`).

Locally and in `package-lock.json` it's `12.10.2` (which still uses `ReactMouseEvent` and matches the handlers) — that's why it only fails in CI. Not caused by the dev-mode revert; that merge just triggered the first main build to hit the drift.

## Fix
Pin `@xyflow/react` to the exact `12.10.2` the code is written against (and that the lockfile records). Deterministic, code unchanged.

```diff
- "@xyflow/react": "^12.10.2",
+ "@xyflow/react": "12.10.2",
```

## Follow-up (not in this PR)
The real fragility is that the UI Docker build ignores the lockfile (`npm install` on `package.json` only), so **any** `^` dependency can float and break a future build. Hardening to copy a lockfile and use `npm ci` would make builds reproducible. Happy to do that separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
