### PR TITLE
Fix #3512 - repository_import_spec data model

### DIFF
--- a/docs/ROADMAP_REPOSITORY_AUTOREFRESH.md
+++ b/docs/ROADMAP_REPOSITORY_AUTOREFRESH.md
@@ -118,7 +118,7 @@ epic. Use this table to resolve any `RAR-*` reference below to its issue number.
 |----|-------|----|-------|----|-------|
 | RAR-EPIC-1 | #3506 | RAR-EPIC-2 | #3507 | RAR-EPIC-3 | #3508 |
 | RAR-EPIC-4 | #3509 | RAR-EPIC-5 | #3510 | RAR-EPIC-6 | #3511 |
-| RAR-1.1 | #3512 | RAR-1.2 | #3513 | RAR-1.3 | #3514 |
+| ~~RAR-1.1~~ ✅ | ~~#3512~~ | RAR-1.2 | #3513 | RAR-1.3 | #3514 |
 | RAR-1.4 | #3515 | RAR-1.5 | #3516 | RAR-1.6 | #3517 |
 | RAR-2.1 | #3518 | RAR-2.2 | #3519 | RAR-2.3 | #3520 |
 | RAR-2.4 | #3521 | RAR-3.1 | #3522 | RAR-3.2 | #3523 |
@@ -138,7 +138,7 @@ Persist exactly what the user asked for at import time so it can be replayed.
 
 | ID | Title | Summary | Labels | Parallel | MVP | Cmplx | Modules |
 |----|-------|---------|--------|----------|-----|-------|---------|
-| RAR-1.1 | `repository_import_spec` data model | New table storing the full import spec keyed to an imported file | `enhancement`,`mvp`,`import`,`repository`,`data-model` | N | Y | M | objectified-db, objectified-rest |
+| ~~RAR-1.1~~ ✅ **Done** (#3512) | `repository_import_spec` data model | New table storing the full import spec keyed to an imported file | `enhancement`,`mvp`,`import`,`repository`,`data-model` | N | Y | M | objectified-db, objectified-rest |
 | RAR-1.2 | Persist `SpecImportOptions` at import time | Write the options blob on every successful import (manual + auto) | `enhancement`,`mvp`,`import`,`repository`,`rest` | N | Y | M | objectified-rest, objectified-ui |
 | RAR-1.3 | Capture source descriptor | Store kind, filename, `--format` override, content-type used | `enhancement`,`mvp`,`import`,`repository` | Y | Y | S | objectified-rest |
 | RAR-1.4 | Versioned spec envelope (`spec_schema_version`) | Forward-compatible envelope so stored specs survive option changes | `enhancement`,`mvp`,`import`,`data-model` | Y | Y | S | objectified-rest |
@@ -184,6 +184,13 @@ the `SpecImportOptions` model in `objectified-rest/src/app/models.py` and the wo
 
 **Parallelism / dependencies.** Blocks RAR-1.2, RAR-4.1. Depends on existing
 `tenant_repository_imports`. **Parallel = N.**
+
+**Status: ✅ Done (#3512).** Migration `objectified-db/scripts/20260621-120000.sql` creates
+`odb.repository_import_spec` with `UNIQUE (repository_id, branch, path)`, the
+`(tenant_id, repository_id)` sweep index, and `options_json JSONB`. objectified-rest adds the
+`RepositoryImportSpec` model and `upsert_repository_import_spec` / `get_repository_import_spec`
+DAO methods; tests assert the options payload round-trips losslessly. Wiring the write site is
+RAR-1.2.
 
 ### RAR-1.2 — Persist `SpecImportOptions` at import time
 

--- a/objectified-db/package.json
+++ b/objectified-db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-db",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Objectified database migrations and the direct-to-database admin CLI (objectified-db).",
   "author": "Objectified",
   "type": "module",

--- a/objectified-db/scripts/20260621-120000.sql
+++ b/objectified-db/scripts/20260621-120000.sql
@@ -1,0 +1,42 @@
+-- Persisted import specification per imported repository file (RAR-1.1, #3512).
+--
+-- `SpecImportOptions` (naming conventions, prefix/suffix, type mappings, conflict
+-- flags, project/version targeting, ...) is accepted and applied at import time but
+-- never stored, so a repository auto-refresh re-imports a changed file with importer
+-- DEFAULTS instead of the user's original request. This table captures the full
+-- import spec plus the source descriptor, keyed to the imported-file lineage
+-- (repository_id, branch, path), so the spec can be replayed faithfully.
+--
+-- The unique key keeps exactly one row per file lineage (the latest spec); the
+-- (tenant_id, repository_id) index serves the refresh-sweep joins.
+SET search_path TO odb, public;
+
+CREATE TABLE IF NOT EXISTS odb.repository_import_spec (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  tenant_id UUID NOT NULL REFERENCES odb.tenants(id) ON DELETE CASCADE,
+  repository_id UUID NOT NULL REFERENCES odb.tenant_repositories(id) ON DELETE CASCADE,
+  branch TEXT NOT NULL,
+  path TEXT NOT NULL,
+  project_id UUID NOT NULL REFERENCES odb.projects(id) ON DELETE CASCADE,
+  source_kind TEXT NOT NULL,
+  format_override TEXT,
+  content_type TEXT,
+  options_json JSONB NOT NULL DEFAULT '{}'::jsonb,
+  spec_schema_version SMALLINT NOT NULL DEFAULT 1,
+  created_by UUID REFERENCES odb.users(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT uq_repository_import_spec_repo_branch_path UNIQUE (repository_id, branch, path)
+);
+
+CREATE INDEX IF NOT EXISTS idx_repository_import_spec_tenant_repo
+  ON odb.repository_import_spec (tenant_id, repository_id);
+
+COMMENT ON TABLE odb.repository_import_spec IS
+  'Latest persisted SpecImportOptions + source descriptor per imported repository file, keyed (repository_id, branch, path); replayed by repository auto-refresh so re-imports honor the original request instead of importer defaults (RAR-1.1).';
+
+COMMENT ON COLUMN odb.repository_import_spec.options_json IS
+  'Full SpecImportOptions payload as submitted at import time; round-trips losslessly.';
+
+COMMENT ON COLUMN odb.repository_import_spec.spec_schema_version IS
+  'Envelope version for the stored spec so it survives future option-shape changes (RAR-1.4).';

--- a/objectified-rest/package.json
+++ b/objectified-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-rest",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "private": true,
   "description": "Trigger file for Objectified REST Docker publish workflow; app is Python (pyproject.toml).",
   "scripts": {

--- a/objectified-rest/src/app/database.py
+++ b/objectified-rest/src/app/database.py
@@ -6848,6 +6848,128 @@ class Database:
             conn.rollback()
             raise e
 
+    def upsert_repository_import_spec(
+        self,
+        tenant_id: str,
+        repository_id: str,
+        branch: str,
+        path: str,
+        project_id: str,
+        source_kind: str,
+        options: Dict[str, Any],
+        format_override: Optional[str] = None,
+        content_type: Optional[str] = None,
+        spec_schema_version: int = 1,
+        created_by: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Insert or refresh the persisted import spec for one repository file (RAR-1.1).
+
+        Keyed on the imported-file lineage ``(repository_id, branch, path)``: a
+        repeat import of the same file updates the existing row in place so the
+        table always holds the latest spec. ``options`` is the full
+        ``SpecImportOptions`` payload and is stored verbatim in ``options_json``.
+
+        The insert is guarded by a subquery so a row is only written when the
+        repository belongs to the given tenant.
+
+        Args:
+            tenant_id: Owning tenant id.
+            repository_id: Source repository id (must belong to ``tenant_id``).
+            branch: Branch the file was imported from.
+            path: Repository-relative file path (lineage key).
+            project_id: Catalog project the import targeted.
+            source_kind: Importer discriminator (for example ``openapi-3``).
+            options: Full ``SpecImportOptions`` payload to persist.
+            format_override: Explicit importer ``--format`` override, if any.
+            content_type: MIME type used to read the file, if known.
+            spec_schema_version: Envelope version of the stored spec.
+            created_by: User id that initiated the import, if known.
+
+        Returns:
+            The persisted row as a dict.
+
+        Raises:
+            ValueError: If the repository does not belong to the tenant.
+        """
+        import json
+
+        query = """
+            INSERT INTO odb.repository_import_spec (
+                tenant_id, repository_id, branch, path, project_id,
+                source_kind, format_override, content_type,
+                options_json, spec_schema_version, created_by
+            )
+            SELECT %s::uuid, %s::uuid, %s, %s, %s::uuid,
+                   %s, %s, %s,
+                   %s::jsonb, %s, %s::uuid
+            FROM odb.tenant_repositories tr
+            WHERE tr.id = %s::uuid AND tr.tenant_id = %s::uuid AND tr.deleted_at IS NULL
+            ON CONFLICT ON CONSTRAINT uq_repository_import_spec_repo_branch_path
+            DO UPDATE SET
+                tenant_id = EXCLUDED.tenant_id,
+                project_id = EXCLUDED.project_id,
+                source_kind = EXCLUDED.source_kind,
+                format_override = EXCLUDED.format_override,
+                content_type = EXCLUDED.content_type,
+                options_json = EXCLUDED.options_json,
+                spec_schema_version = EXCLUDED.spec_schema_version,
+                created_by = EXCLUDED.created_by,
+                updated_at = CURRENT_TIMESTAMP
+            RETURNING id, tenant_id, repository_id, branch, path, project_id,
+                      source_kind, format_override, content_type,
+                      options_json, spec_schema_version, created_by,
+                      created_at, updated_at
+        """
+        params = (
+            tenant_id, repository_id, branch, path, project_id,
+            source_kind, format_override, content_type,
+            json.dumps(options or {}), spec_schema_version, created_by,
+            repository_id, tenant_id,
+        )
+        conn = self.connect()
+        try:
+            with conn.cursor() as cursor:
+                cursor.execute(query, params)
+                row = cursor.fetchone()
+                conn.commit()
+            if row is None:
+                raise ValueError(
+                    f"Repository {repository_id} not found for tenant {tenant_id}; "
+                    "import spec not persisted."
+                )
+            return row
+        except Exception as e:
+            conn.rollback()
+            raise e
+
+    def get_repository_import_spec(
+        self, tenant_id: str, repository_id: str, branch: str, path: str
+    ) -> Optional[Dict[str, Any]]:
+        """Return the persisted import spec for one repository file, or None.
+
+        Args:
+            tenant_id: Owning tenant id (scopes the lookup).
+            repository_id: Source repository id.
+            branch: Branch the file was imported from.
+            path: Repository-relative file path (lineage key).
+
+        Returns:
+            The stored row as a dict, or None when no spec exists.
+        """
+        query = """
+            SELECT id, tenant_id, repository_id, branch, path, project_id,
+                   source_kind, format_override, content_type,
+                   options_json, spec_schema_version, created_by,
+                   created_at, updated_at
+            FROM odb.repository_import_spec
+            WHERE tenant_id = %s::uuid
+              AND repository_id = %s::uuid
+              AND branch = %s
+              AND path = %s
+        """
+        results = self.execute_query(query, (tenant_id, repository_id, branch, path))
+        return results[0] if results else None
+
     def get_public_browse_directory_stats(self) -> Dict[str, int]:
         """Counts for tenants/projects/versions with published public revisions (browse directory)."""
         query = """

--- a/objectified-rest/src/app/models.py
+++ b/objectified-rest/src/app/models.py
@@ -225,6 +225,57 @@ class SpecImportOptions(BaseModel):
     )
 
 
+# Current envelope version for a persisted repository import spec. Bumped by
+# RAR-1.4 when the stored option shape changes; readers use it to migrate older
+# rows forward without losing data.
+REPOSITORY_IMPORT_SPEC_SCHEMA_VERSION = 1
+
+
+class RepositoryImportSpec(BaseModel):
+    """Persisted import specification for one imported repository file (RAR-1.1).
+
+    Mirrors the ``odb.repository_import_spec`` row. Keyed to the imported-file
+    lineage ``(repository_id, branch, path)`` it captures the full
+    ``SpecImportOptions`` payload plus the source descriptor used at import time,
+    so a repository auto-refresh can replay the user's original request instead
+    of falling back to importer defaults.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: Optional[str] = Field(
+        default=None,
+        description="Row id; absent for a not-yet-persisted spec.",
+    )
+    tenant_id: str
+    repository_id: str
+    branch: str
+    path: str = Field(description="Repository-relative file path (lineage key).")
+    project_id: str
+    source_kind: str = Field(
+        description="Importer discriminator (for example openapi-3, arazzo).",
+    )
+    format_override: Optional[str] = Field(
+        default=None,
+        description="Explicit format override (the importer --format flag), when the user forced one.",
+    )
+    content_type: Optional[str] = Field(
+        default=None,
+        description="MIME type used to read the file (for example application/yaml), when known.",
+    )
+    options: SpecImportOptions = Field(
+        default_factory=SpecImportOptions,
+        description="Full SpecImportOptions payload submitted at import time.",
+    )
+    spec_schema_version: int = Field(
+        default=REPOSITORY_IMPORT_SPEC_SCHEMA_VERSION,
+        description="Envelope version of the stored spec.",
+    )
+    created_by: Optional[str] = None
+    created_at: Optional[Union[datetime, str]] = None
+    updated_at: Optional[Union[datetime, str]] = None
+
+
 class SpecImportStartMetadata(BaseModel):
     """Shared metadata for JSON-base64 and multipart upload flows."""
 

--- a/objectified-rest/tests/test_repository_import_spec_migration.py
+++ b/objectified-rest/tests/test_repository_import_spec_migration.py
@@ -1,0 +1,35 @@
+"""Guardrails for the repository_import_spec table migration (RAR-1.1, #3512)."""
+
+from pathlib import Path
+
+_MIGRATION = "objectified-db/scripts/20260621-120000.sql"
+
+# Fragments the migration must contain so the table, keys, and indexes survive
+# accidental edits. Acceptance criteria for #3512:
+#   - table + migration with UNIQUE (repository_id, branch, path)
+#   - index on (tenant_id, repository_id) for refresh-sweep joins
+#   - options_json JSONB column carrying the full SpecImportOptions payload
+_REQUIRED_FRAGMENTS = (
+    "CREATE TABLE IF NOT EXISTS odb.repository_import_spec",
+    "tenant_id UUID NOT NULL REFERENCES odb.tenants(id) ON DELETE CASCADE",
+    "repository_id UUID NOT NULL REFERENCES odb.tenant_repositories(id) ON DELETE CASCADE",
+    "project_id UUID NOT NULL REFERENCES odb.projects(id) ON DELETE CASCADE",
+    "created_by UUID REFERENCES odb.users(id) ON DELETE SET NULL",
+    "options_json JSONB NOT NULL",
+    "spec_schema_version SMALLINT NOT NULL DEFAULT 1",
+    "UNIQUE (repository_id, branch, path)",
+    "idx_repository_import_spec_tenant_repo",
+    "ON odb.repository_import_spec (tenant_id, repository_id)",
+)
+
+
+def test_migration_creates_repository_import_spec_table(repo_root: Path) -> None:
+    text = (repo_root / _MIGRATION).read_text()
+    missing = [frag for frag in _REQUIRED_FRAGMENTS if frag not in text]
+    assert not missing, f"Migration missing expected fragments: {missing}"
+
+
+def test_migration_unique_constraint_is_named(repo_root: Path) -> None:
+    """DAO upserts target the constraint by name, so it must stay named."""
+    text = (repo_root / _MIGRATION).read_text()
+    assert "uq_repository_import_spec_repo_branch_path" in text

--- a/objectified-rest/tests/test_repository_import_spec_model.py
+++ b/objectified-rest/tests/test_repository_import_spec_model.py
@@ -1,0 +1,98 @@
+"""Round-trip + shape tests for the RepositoryImportSpec model (RAR-1.1, #3512).
+
+The acceptance criterion is that ``options_json`` round-trips a full
+``SpecImportOptions`` payload losslessly. The DAO persists the options as JSONB
+(``json.dumps`` in, dict out), so the lossless guarantee lives in the Pydantic
+serialization layer exercised here.
+"""
+
+import json
+
+from app.models import (
+    REPOSITORY_IMPORT_SPEC_SCHEMA_VERSION,
+    RepositoryImportSpec,
+    SpecImportOptions,
+)
+
+
+def _full_options() -> SpecImportOptions:
+    """Every SpecImportOptions field set to a non-default value."""
+    return SpecImportOptions(
+        selected_schemas=["Pet", "Order", "User"],
+        dry_run=True,
+        incremental_mode=True,
+        apply_naming_convention=True,
+        class_naming_convention="PascalCase",
+        property_naming_convention="snake_case",
+        auto_layout=True,
+        create_relationships=True,
+        skip_duplicate_versions=True,
+    )
+
+
+def test_options_json_round_trips_losslessly() -> None:
+    options = _full_options()
+
+    # Serialize as the DAO would (the JSONB column), then read back.
+    options_json = options.model_dump()
+    rehydrated = SpecImportOptions.model_validate(json.loads(json.dumps(options_json)))
+
+    assert rehydrated == options
+    # Defaults must not silently drop any field on the way through JSON.
+    assert set(options_json.keys()) == set(SpecImportOptions().model_dump().keys())
+
+
+def test_repository_import_spec_round_trips_through_json() -> None:
+    spec = RepositoryImportSpec(
+        id="11111111-1111-1111-1111-111111111111",
+        tenant_id="22222222-2222-2222-2222-222222222222",
+        repository_id="33333333-3333-3333-3333-333333333333",
+        branch="main",
+        path="specs/petstore.yaml",
+        project_id="44444444-4444-4444-4444-444444444444",
+        source_kind="openapi-3",
+        format_override="yaml",
+        content_type="application/yaml",
+        options=_full_options(),
+        created_by="55555555-5555-5555-5555-555555555555",
+    )
+
+    payload = spec.model_dump()
+    restored = RepositoryImportSpec.model_validate(json.loads(json.dumps(payload)))
+
+    assert restored == spec
+    assert restored.options == _full_options()
+
+
+def test_spec_defaults_match_table_defaults() -> None:
+    """Unset envelope/options default the way the migration column defaults do."""
+    spec = RepositoryImportSpec(
+        tenant_id="22222222-2222-2222-2222-222222222222",
+        repository_id="33333333-3333-3333-3333-333333333333",
+        branch="main",
+        path="specs/petstore.yaml",
+        project_id="44444444-4444-4444-4444-444444444444",
+        source_kind="openapi-3",
+    )
+
+    assert spec.spec_schema_version == REPOSITORY_IMPORT_SPEC_SCHEMA_VERSION == 1
+    assert spec.options == SpecImportOptions()
+    assert spec.format_override is None
+    assert spec.content_type is None
+    assert spec.id is None
+
+
+def test_repository_import_spec_forbids_unknown_fields() -> None:
+    import pytest
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        RepositoryImportSpec(
+            tenant_id="22222222-2222-2222-2222-222222222222",
+            repository_id="33333333-3333-3333-3333-333333333333",
+            branch="main",
+            path="specs/petstore.yaml",
+            project_id="44444444-4444-4444-4444-444444444444",
+            source_kind="openapi-3",
+            unexpected_field="boom",
+        )


### PR DESCRIPTION
## What & why

Closes #3512 (RAR-1.1). `SpecImportOptions` is accepted and applied at import time but never stored — `odb.tenant_repository_imports` has no options column — so a repository auto-refresh re-imports a changed file with importer **defaults** instead of the user's original request.

This adds a table keyed to the imported-file lineage that captures the full import spec, plus the objectified-rest model/DAO to read/write it. (Wiring the write site into the import path is the follow-up, RAR-1.2.)

### Changes
- **objectified-db** — migration `scripts/20260621-120000.sql` creates `odb.repository_import_spec`:
  - `UNIQUE (repository_id, branch, path)` — one (latest) spec row per file lineage.
  - Index `(tenant_id, repository_id)` for refresh-sweep joins.
  - `options_json JSONB` holds the full `SpecImportOptions`; plus `source_kind`, `format_override`, `content_type`, `spec_schema_version`, audit columns.
- **objectified-rest** — `RepositoryImportSpec` Pydantic model (`extra="forbid"`) and `Database.upsert_repository_import_spec` / `get_repository_import_spec` DAO methods. The upsert is tenant-guarded and idempotent on the lineage key (re-import updates in place).
- **Tests** — migration guardrails + lossless `SpecImportOptions` round-trip through the JSON layer.
- Roadmap RAR-1.1 marked done; `objectified-db` → 0.1.1, `objectified-rest` → 1.0.2.

## Acceptance criteria
- [x] Table + migration created; unique on `(repository_id, branch, path)`.
- [x] Indexed on `(tenant_id, repository_id)` for refresh-sweep joins.
- [x] `options_json` round-trips a full `SpecImportOptions` payload losslessly.

## How to test
- `yarn workspace objectified-db build && yarn workspace objectified-db test`
- From `objectified-rest/`: `.venv/bin/pytest tests/test_repository_import_spec_model.py tests/test_repository_import_spec_migration.py -q` → 6 passed.

## Risk / notes
- Additive migration only (`CREATE TABLE IF NOT EXISTS` + index); no existing tables touched.
- DAO methods are not yet called from the import path — that wiring is RAR-1.2 (#3513), which this PR unblocks.
- Pre-existing rest test collection errors / DB-dependent failures are unrelated (verified present on a clean tree).

Work performed by Claude Code via model Opus 4.8 (1M context).