### PR TITLE
Add import options form to repository file import

### DIFF
--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.116",
+  "version": "0.11.117",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/src/app/components/ade/dashboard/ImportOptionsForm.tsx
+++ b/objectified-ui/src/app/components/ade/dashboard/ImportOptionsForm.tsx
@@ -1,0 +1,182 @@
+'use client';
+
+import type { ImportNamingConvention, ImportOptions } from './PreviewPanel';
+
+/**
+ * Which option groups to render.
+ * - `naming`: apply-naming-convention toggle, class/property convention selects, class prefix/suffix.
+ * - `flags`: generate-examples, dry-run, incremental-mode checkboxes.
+ */
+export type ImportOptionsSection = 'naming' | 'flags';
+
+interface ImportOptionsFormProps {
+  /** Current import options being edited. */
+  options: ImportOptions;
+  /** Apply a single option change. Mirrors PreviewPanel's handleOptionChange(key, value). */
+  onOptionChange: <K extends keyof ImportOptions>(key: K, value: ImportOptions[K]) => void;
+  /** Option groups to render, in order. Defaults to both `naming` then `flags`. */
+  sections?: ImportOptionsSection[];
+  /** Hide the dry-run checkbox (e.g. when the caller drives dry-run separately). */
+  showDryRun?: boolean;
+  /** Hide the incremental-mode checkbox. */
+  showIncrementalMode?: boolean;
+}
+
+/**
+ * Shared import-options editor used by both the Projects dashboard import dialog
+ * (`PreviewPanel`) and the repository file import flow (`RepositoryFileImportMapping`).
+ *
+ * It owns no state: the parent holds the `ImportOptions` and applies each change
+ * via `onOptionChange`, keeping a single source of truth. Markup/classes mirror
+ * the original PreviewPanel layout so the dashboard import is visually unchanged.
+ */
+export function ImportOptionsForm({
+  options,
+  onOptionChange,
+  sections = ['naming', 'flags'],
+  showDryRun = true,
+  showIncrementalMode = true,
+}: ImportOptionsFormProps) {
+  return (
+    <>
+      {sections.includes('naming') && (
+        /* Naming convention enforcement (#581) */
+        <div className="col-span-4 flex flex-col gap-3 pt-2">
+          <label className="flex items-center gap-2 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={options.applyNamingConvention ?? true}
+              onChange={(e) => onOptionChange('applyNamingConvention', e.target.checked)}
+              className="w-4 h-4 rounded border-gray-300 dark:border-gray-600 text-indigo-600 focus:ring-2 focus:ring-indigo-500 bg-white dark:bg-gray-700"
+            />
+            <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
+              Apply naming convention
+            </span>
+          </label>
+          <p className="text-xs text-gray-500 dark:text-gray-400">
+            Convert class and property names to match your chosen conventions (e.g. PascalCase for classes, camelCase for properties).
+          </p>
+          {(options.applyNamingConvention ?? true) && (
+            <div className="flex flex-wrap gap-4 pl-6">
+              <div>
+                <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">Classes</label>
+                <select
+                  value={options.classNamingConvention ?? 'PascalCase'}
+                  onChange={(e) => onOptionChange('classNamingConvention', e.target.value as ImportNamingConvention)}
+                  className="px-3 py-1.5 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
+                >
+                  <option value="PascalCase">PascalCase</option>
+                  <option value="camelCase">camelCase</option>
+                  <option value="snake_case">snake_case</option>
+                  <option value="kebab-case">kebab-case</option>
+                  <option value="none">None (keep original)</option>
+                </select>
+              </div>
+              <div>
+                <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">Properties</label>
+                <select
+                  value={options.propertyNamingConvention ?? 'camelCase'}
+                  onChange={(e) => onOptionChange('propertyNamingConvention', e.target.value as ImportNamingConvention)}
+                  className="px-3 py-1.5 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
+                >
+                  <option value="PascalCase">PascalCase</option>
+                  <option value="camelCase">camelCase</option>
+                  <option value="snake_case">snake_case</option>
+                  <option value="kebab-case">kebab-case</option>
+                  <option value="none">None (keep original)</option>
+                </select>
+              </div>
+            </div>
+          )}
+          <div className="flex flex-wrap gap-4 pl-6 pt-2 border-t border-gray-100 dark:border-gray-700 mt-3 pt-3">
+            <div className="flex-1 min-w-[140px]">
+              <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">Class name prefix</label>
+              <input
+                type="text"
+                value={options.classPrefix ?? ''}
+                onChange={(e) => onOptionChange('classPrefix', e.target.value)}
+                placeholder="e.g. Api"
+                className="w-full px-3 py-1.5 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500"
+              />
+            </div>
+            <div className="flex-1 min-w-[140px]">
+              <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">Class name suffix</label>
+              <input
+                type="text"
+                value={options.classSuffix ?? ''}
+                onChange={(e) => onOptionChange('classSuffix', e.target.value)}
+                placeholder="e.g. Dto"
+                className="w-full px-3 py-1.5 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500"
+              />
+            </div>
+          </div>
+          <p className="text-xs text-gray-500 dark:text-gray-400 pl-6 mt-1">
+            Prefix and suffix are applied to every imported class name (e.g. Api + User + Dto → ApiUserDto).
+          </p>
+        </div>
+      )}
+
+      {sections.includes('flags') && (
+        <>
+          {/* Generate examples for properties without examples (#761) */}
+          <div className="col-span-4 flex items-start gap-3 pt-2">
+            <label className="flex items-center gap-2 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={options.generateExamples ?? false}
+                onChange={(e) => onOptionChange('generateExamples', e.target.checked)}
+                className="w-4 h-4 rounded border-gray-300 dark:border-gray-600 text-indigo-600 focus:ring-2 focus:ring-indigo-500 bg-white dark:bg-gray-700"
+              />
+              <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                Generate examples
+              </span>
+            </label>
+            <p className="text-xs text-gray-500 dark:text-gray-400">
+              Auto-generate example values for properties that don&apos;t have one (string, number, date, etc.).
+            </p>
+          </div>
+
+          {showDryRun && (
+            /* Dry run: preview without committing */
+            <div className="col-span-4 flex items-start gap-3 pt-2">
+              <label className="flex items-center gap-2 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={options.dryRun ?? false}
+                  onChange={(e) => onOptionChange('dryRun', e.target.checked)}
+                  className="w-4 h-4 rounded border-gray-300 dark:border-gray-600 text-indigo-600 focus:ring-2 focus:ring-indigo-500 bg-white dark:bg-gray-700"
+                />
+                <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                  Dry run (preview only)
+                </span>
+              </label>
+              <p className="text-xs text-gray-500 dark:text-gray-400">
+                Simulate the import and show what would be created. No project or data is saved.
+              </p>
+            </div>
+          )}
+
+          {showIncrementalMode && (
+            /* Incremental mode: skip failures */
+            <div className="col-span-4 flex items-start gap-3 pt-2">
+              <label className="flex items-center gap-2 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={options.incrementalMode ?? false}
+                  onChange={(e) => onOptionChange('incrementalMode', e.target.checked)}
+                  className="w-4 h-4 rounded border-gray-300 dark:border-gray-600 text-indigo-600 focus:ring-2 focus:ring-indigo-500 bg-white dark:bg-gray-700"
+                />
+                <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                  Incremental mode (skip failures)
+                </span>
+              </label>
+              <p className="text-xs text-gray-500 dark:text-gray-400">
+                Import all available classes and skip any that fail. Changes are saved as each class is imported; no single transaction.
+              </p>
+            </div>
+          )}
+        </>
+      )}
+    </>
+  );
+}

--- a/objectified-ui/src/app/components/ade/dashboard/PreviewPanel.tsx
+++ b/objectified-ui/src/app/components/ade/dashboard/PreviewPanel.tsx
@@ -26,6 +26,7 @@ import {
 } from '@xyflow/react';
 import '@xyflow/react/dist/style.css';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '../../ui/Collapsible';
+import { ImportOptionsForm } from './ImportOptionsForm';
 
 interface PreviewPanelProps {
   analysis: AnalysisResult;
@@ -1505,80 +1506,8 @@ export function PreviewPanel({ analysis, onImportOptionsChange }: PreviewPanelPr
             </div>
           </div>
 
-          {/* Naming convention enforcement (#581) */}
-          <div className="col-span-4 flex flex-col gap-3 pt-2">
-            <label className="flex items-center gap-2 cursor-pointer">
-              <input
-                type="checkbox"
-                checked={importOptions.applyNamingConvention ?? true}
-                onChange={(e) => handleOptionChange('applyNamingConvention', e.target.checked)}
-                className="w-4 h-4 rounded border-gray-300 dark:border-gray-600 text-indigo-600 focus:ring-2 focus:ring-indigo-500 bg-white dark:bg-gray-700"
-              />
-              <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
-                Apply naming convention
-              </span>
-            </label>
-            <p className="text-xs text-gray-500 dark:text-gray-400">
-              Convert class and property names to match your chosen conventions (e.g. PascalCase for classes, camelCase for properties).
-            </p>
-            {(importOptions.applyNamingConvention ?? true) && (
-              <div className="flex flex-wrap gap-4 pl-6">
-                <div>
-                  <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">Classes</label>
-                  <select
-                    value={importOptions.classNamingConvention ?? 'PascalCase'}
-                    onChange={(e) => handleOptionChange('classNamingConvention', e.target.value as ImportNamingConvention)}
-                    className="px-3 py-1.5 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
-                  >
-                    <option value="PascalCase">PascalCase</option>
-                    <option value="camelCase">camelCase</option>
-                    <option value="snake_case">snake_case</option>
-                    <option value="kebab-case">kebab-case</option>
-                    <option value="none">None (keep original)</option>
-                  </select>
-                </div>
-                <div>
-                  <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">Properties</label>
-                  <select
-                    value={importOptions.propertyNamingConvention ?? 'camelCase'}
-                    onChange={(e) => handleOptionChange('propertyNamingConvention', e.target.value as ImportNamingConvention)}
-                    className="px-3 py-1.5 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
-                  >
-                    <option value="PascalCase">PascalCase</option>
-                    <option value="camelCase">camelCase</option>
-                    <option value="snake_case">snake_case</option>
-                    <option value="kebab-case">kebab-case</option>
-                    <option value="none">None (keep original)</option>
-                  </select>
-                </div>
-              </div>
-            )}
-            <div className="flex flex-wrap gap-4 pl-6 pt-2 border-t border-gray-100 dark:border-gray-700 mt-3 pt-3">
-              <div className="flex-1 min-w-[140px]">
-                <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">Class name prefix</label>
-                <input
-                  type="text"
-                  value={importOptions.classPrefix ?? ''}
-                  onChange={(e) => handleOptionChange('classPrefix', e.target.value)}
-                  placeholder="e.g. Api"
-                  className="w-full px-3 py-1.5 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500"
-                />
-              </div>
-              <div className="flex-1 min-w-[140px]">
-                <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">Class name suffix</label>
-                <input
-                  type="text"
-                  value={importOptions.classSuffix ?? ''}
-                  onChange={(e) => handleOptionChange('classSuffix', e.target.value)}
-                  placeholder="e.g. Dto"
-                  className="w-full px-3 py-1.5 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500"
-                />
-              </div>
-            </div>
-            <p className="text-xs text-gray-500 dark:text-gray-400 pl-6 mt-1">
-              Prefix and suffix are applied to every imported class name (e.g. Api + User + Dto → ApiUserDto).
-            </p>
-          </div>
+          {/* Naming convention enforcement (#581) — shared ImportOptionsForm */}
+          <ImportOptionsForm options={importOptions} onOptionChange={handleOptionChange} sections={['naming']} />
 
           {/* Property mapping: type mapping, default values, required override, description override (#757, #758, #759, #760) */}
           {(externalTypeKeys.length > 0 || requiredOverrideRows.length > 0 || descriptionOverrideRows.length > 0) && (
@@ -1842,59 +1771,8 @@ export function PreviewPanel({ analysis, onImportOptionsChange }: PreviewPanelPr
             </div>
           )}
 
-          {/* Generate examples for properties without examples (#761) */}
-          <div className="col-span-4 flex items-start gap-3 pt-2">
-            <label className="flex items-center gap-2 cursor-pointer">
-              <input
-                type="checkbox"
-                checked={importOptions.generateExamples ?? false}
-                onChange={(e) => handleOptionChange('generateExamples', e.target.checked)}
-                className="w-4 h-4 rounded border-gray-300 dark:border-gray-600 text-indigo-600 focus:ring-2 focus:ring-indigo-500 bg-white dark:bg-gray-700"
-              />
-              <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
-                Generate examples
-              </span>
-            </label>
-            <p className="text-xs text-gray-500 dark:text-gray-400">
-              Auto-generate example values for properties that don&apos;t have one (string, number, date, etc.).
-            </p>
-          </div>
-
-          {/* Dry run: preview without committing */}
-          <div className="col-span-4 flex items-start gap-3 pt-2">
-            <label className="flex items-center gap-2 cursor-pointer">
-              <input
-                type="checkbox"
-                checked={importOptions.dryRun ?? false}
-                onChange={(e) => handleOptionChange('dryRun', e.target.checked)}
-                className="w-4 h-4 rounded border-gray-300 dark:border-gray-600 text-indigo-600 focus:ring-2 focus:ring-indigo-500 bg-white dark:bg-gray-700"
-              />
-              <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
-                Dry run (preview only)
-              </span>
-            </label>
-            <p className="text-xs text-gray-500 dark:text-gray-400">
-              Simulate the import and show what would be created. No project or data is saved.
-            </p>
-          </div>
-
-          {/* Incremental mode: skip failures */}
-          <div className="col-span-4 flex items-start gap-3 pt-2">
-            <label className="flex items-center gap-2 cursor-pointer">
-              <input
-                type="checkbox"
-                checked={importOptions.incrementalMode ?? false}
-                onChange={(e) => handleOptionChange('incrementalMode', e.target.checked)}
-                className="w-4 h-4 rounded border-gray-300 dark:border-gray-600 text-indigo-600 focus:ring-2 focus:ring-indigo-500 bg-white dark:bg-gray-700"
-              />
-              <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
-                Incremental mode (skip failures)
-              </span>
-            </label>
-            <p className="text-xs text-gray-500 dark:text-gray-400">
-              Import all available classes and skip any that fail. Changes are saved as each class is imported; no single transaction.
-            </p>
-          </div>
+          {/* Generate examples / dry run / incremental mode — shared ImportOptionsForm */}
+          <ImportOptionsForm options={importOptions} onOptionChange={handleOptionChange} sections={['flags']} />
         </div>
       </div>
     </div>

--- a/objectified-ui/src/app/components/ade/dashboard/repositories/RepositoryFileImportMapping.tsx
+++ b/objectified-ui/src/app/components/ade/dashboard/repositories/RepositoryFileImportMapping.tsx
@@ -20,6 +20,7 @@ import { generateSlug } from '@/app/utils/slug';
 import ImportExecutionPanel from '@/app/components/ade/dashboard/ImportExecutionPanel';
 import ImportCompletePanel from '@/app/components/ade/dashboard/ImportCompletePanel';
 import type { ImportOptions } from '@/app/components/ade/dashboard/PreviewPanel';
+import { ImportOptionsForm } from '@/app/components/ade/dashboard/ImportOptionsForm';
 import { Button } from '@/app/components/ui/Button';
 import {
   Dialog,
@@ -240,6 +241,19 @@ export function RepositoryFileImportMapping({
   const [catalogImportSucceeded, setCatalogImportSucceeded] = useState(false);
   const dryRunRef = useRef(false);
 
+  // User-adjustable import options for this file. Initialized from the spec
+  // analysis once the file content loads and editable via the Import options card.
+  // Persisted with the import (RAR-1.2) so an auto-refresh can replay them.
+  const [importOptions, setImportOptions] = useState<ImportOptions | null>(null);
+  const importOptionsFilePathRef = useRef<string | null>(null);
+
+  const updateImportOption = useCallback(
+    <K extends keyof ImportOptions>(key: K, value: ImportOptions[K]) => {
+      setImportOptions((prev) => (prev ? { ...prev, [key]: value } : prev));
+    },
+    []
+  );
+
   const specMetadata = useMemo(
     () => parseRepositoryFileSpecMetadata(payload?.content ?? '', file.path),
     [payload?.content, file.path]
@@ -262,6 +276,33 @@ export function RepositoryFileImportMapping({
 
   const specVersionLabel = specMetadata.version?.trim() || null;
   const willCreateLabel = specVersionLabel ? `v${specVersionLabel}` : 'v… (set info.version in the spec)';
+
+  // Initialize the editable import options from the spec analysis once per loaded
+  // file. Re-analyzing only when the file path changes preserves the user's edits
+  // across unrelated re-renders.
+  useEffect(() => {
+    const content = payload?.content;
+    if (importableVerdict.status !== 'importable' || typeof content !== 'string' || !content.trim()) {
+      return;
+    }
+    if (importOptionsFilePathRef.current === file.path) {
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        const analysis = await analyzeSpecification(content, analysisFilenameForRepoImport(file.path));
+        if (cancelled) return;
+        importOptionsFilePathRef.current = file.path;
+        setImportOptions(defaultImportOptionsFromAnalysis(analysis));
+      } catch {
+        // Parsing problems are already surfaced via importableVerdict; leave options unset.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [payload?.content, file.path, importableVerdict.status]);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -544,16 +585,18 @@ export function RepositoryFileImportMapping({
           return;
         }
 
-        const importOptions = defaultImportOptionsFromAnalysis(analysis);
+        // Use the user-edited options when available, falling back to the spec
+        // defaults (e.g. if the file was submitted before analysis finished).
+        const effectiveOptions: ImportOptions = importOptions ?? defaultImportOptionsFromAnalysis(analysis);
         if (targetMode === 'existing' && stagedProject) {
-          importOptions.projectName = stagedProject.name;
-          importOptions.projectSlug = stagedProject.slug;
+          effectiveOptions.projectName = stagedProject.name;
+          effectiveOptions.projectSlug = stagedProject.slug;
         } else if (newProjectFormSnapshot) {
-          importOptions.projectName = newProjectFormSnapshot.projectName.trim();
-          importOptions.projectSlug = newProjectFormSnapshot.projectSlug.trim();
+          effectiveOptions.projectName = newProjectFormSnapshot.projectName.trim();
+          effectiveOptions.projectSlug = newProjectFormSnapshot.projectSlug.trim();
         }
 
-        dryRunRef.current = Boolean(importOptions.dryRun);
+        dryRunRef.current = Boolean(effectiveOptions.dryRun);
 
         const document = analysis.document;
         const sourceKind = analysis.format === 'arazzo' ? 'arazzo' : 'openapi';
@@ -570,38 +613,38 @@ export function RepositoryFileImportMapping({
             blobSha: payload?.blob_sha ?? file.blob_sha ?? null,
           },
           project: {
-            name: importOptions.projectName || (document?.info?.title || 'New Project'),
+            name: effectiveOptions.projectName || (document?.info?.title || 'New Project'),
             slug:
-              importOptions.projectSlug ||
+              effectiveOptions.projectSlug ||
               generateSlug(document?.info?.title || 'new-project') ||
               'imported-project',
             description: document?.info?.description || null,
           },
           version: {
-            versionId: importOptions.targetVersion || (document?.info?.version || '1.0.0'),
+            versionId: effectiveOptions.targetVersion || (document?.info?.version || '1.0.0'),
             description: 'Imported from OpenAPI specification',
           },
           options: {
-            selectedSchemas: importOptions.selectedSchemas,
-            applyNamingConvention: importOptions.applyNamingConvention ?? true,
-            classNamingConvention: importOptions.classNamingConvention ?? 'PascalCase',
-            propertyNamingConvention: importOptions.propertyNamingConvention ?? 'camelCase',
-            classNameMap: importOptions.classNameMap,
-            classPrefix: (importOptions.classPrefix ?? '').trim() || undefined,
-            classSuffix: (importOptions.classSuffix ?? '').trim() || undefined,
-            typeMapping: importOptions.typeMapping,
-            defaultValues: importOptions.defaultValues,
-            requiredOverrides: importOptions.requiredOverrides,
-            descriptionOverrides: importOptions.descriptionOverrides,
-            generateExamples: importOptions.generateExamples ?? false,
-            dryRun: importOptions.dryRun ?? false,
-            incrementalMode: importOptions.incrementalMode ?? false,
+            selectedSchemas: effectiveOptions.selectedSchemas,
+            applyNamingConvention: effectiveOptions.applyNamingConvention ?? true,
+            classNamingConvention: effectiveOptions.classNamingConvention ?? 'PascalCase',
+            propertyNamingConvention: effectiveOptions.propertyNamingConvention ?? 'camelCase',
+            classNameMap: effectiveOptions.classNameMap,
+            classPrefix: (effectiveOptions.classPrefix ?? '').trim() || undefined,
+            classSuffix: (effectiveOptions.classSuffix ?? '').trim() || undefined,
+            typeMapping: effectiveOptions.typeMapping,
+            defaultValues: effectiveOptions.defaultValues,
+            requiredOverrides: effectiveOptions.requiredOverrides,
+            descriptionOverrides: effectiveOptions.descriptionOverrides,
+            generateExamples: effectiveOptions.generateExamples ?? false,
+            dryRun: effectiveOptions.dryRun ?? false,
+            incrementalMode: effectiveOptions.incrementalMode ?? false,
           },
           existingProjectId: catalogProjectId,
         });
 
         setCatalogImportJobId(job.jobId);
-        setCatalogImportSchemas(importOptions.selectedSchemas);
+        setCatalogImportSchemas(effectiveOptions.selectedSchemas);
         setCatalogImportAnalysis(analysis);
         setCatalogImportExecutionComplete(false);
         setCatalogImportSucceeded(false);
@@ -1050,6 +1093,28 @@ export function RepositoryFileImportMapping({
                     </label>
                   </div>
                 </>
+              )}
+            </div>
+
+            <div className="rounded-xl border border-gray-200 bg-white p-5 dark:border-gray-700 dark:bg-gray-800">
+              <h3 className="mb-1 text-sm font-semibold text-gray-900 dark:text-gray-100">Import options</h3>
+              <p className="mb-3 text-xs text-gray-500 dark:text-gray-400">
+                How classes and properties are named and generated when this file is imported. These options are saved
+                with the import and replayed when the file is auto-refreshed.
+              </p>
+              {loading ? (
+                <div className="space-y-3" aria-hidden>
+                  <Skeleton className="h-10 w-full rounded-md" />
+                  <Skeleton className="h-10 w-full rounded-md" />
+                </div>
+              ) : importOptions ? (
+                <div className="flex flex-col gap-2" data-testid="repository-import-options">
+                  <ImportOptionsForm options={importOptions} onOptionChange={updateImportOption} />
+                </div>
+              ) : (
+                <p className="text-xs text-gray-500 dark:text-gray-400">
+                  Load an importable spec (OpenAPI, Swagger, JSON Schema, Arazzo, GraphQL SDL) to adjust import options.
+                </p>
               )}
             </div>
 

--- a/objectified-ui/tests/ImportOptionsForm.test.tsx
+++ b/objectified-ui/tests/ImportOptionsForm.test.tsx
@@ -1,0 +1,134 @@
+/**
+ * Unit tests for ImportOptionsForm — the shared import-options editor used by both
+ * the Projects dashboard import dialog (PreviewPanel) and the repository file import
+ * flow (RepositoryFileImportMapping).
+ *
+ * The component is controlled (parent owns the ImportOptions), so these tests assert
+ * the rendered controls and that each edit calls onOptionChange(key, value) correctly.
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { jest } from '@jest/globals';
+
+import { ImportOptionsForm } from '../src/app/components/ade/dashboard/ImportOptionsForm';
+import type { ImportOptions } from '../src/app/components/ade/dashboard/PreviewPanel';
+
+function baseOptions(overrides: Partial<ImportOptions> = {}): ImportOptions {
+  return {
+    projectName: 'Petstore',
+    projectSlug: 'petstore',
+    versionSource: 'spec',
+    targetVersion: '1.0.0',
+    selectedSchemas: ['Pet'],
+    applyNamingConvention: true,
+    classNamingConvention: 'PascalCase',
+    propertyNamingConvention: 'camelCase',
+    classPrefix: '',
+    classSuffix: '',
+    generateExamples: false,
+    dryRun: false,
+    incrementalMode: false,
+    ...overrides,
+  };
+}
+
+describe('ImportOptionsForm', () => {
+  it('renders naming and flag controls by default', () => {
+    render(<ImportOptionsForm options={baseOptions()} onOptionChange={jest.fn()} />);
+
+    expect(screen.getByRole('checkbox', { name: /apply naming convention/i })).toBeInTheDocument();
+    expect(screen.getByDisplayValue('PascalCase')).toBeInTheDocument(); // class convention select
+    expect(screen.getByDisplayValue('camelCase')).toBeInTheDocument(); // property convention select
+    expect(screen.getByPlaceholderText('e.g. Api')).toBeInTheDocument(); // prefix
+    expect(screen.getByPlaceholderText('e.g. Dto')).toBeInTheDocument(); // suffix
+    expect(screen.getByRole('checkbox', { name: /generate examples/i })).toBeInTheDocument();
+    expect(screen.getByRole('checkbox', { name: /dry run/i })).toBeInTheDocument();
+    expect(screen.getByRole('checkbox', { name: /incremental mode/i })).toBeInTheDocument();
+  });
+
+  it('toggling apply-naming-convention reports the negated value', () => {
+    const onOptionChange = jest.fn();
+    render(<ImportOptionsForm options={baseOptions({ applyNamingConvention: true })} onOptionChange={onOptionChange} />);
+
+    fireEvent.click(screen.getByRole('checkbox', { name: /apply naming convention/i }));
+    expect(onOptionChange).toHaveBeenCalledWith('applyNamingConvention', false);
+  });
+
+  it('hides the convention selects when naming convention is off', () => {
+    render(<ImportOptionsForm options={baseOptions({ applyNamingConvention: false })} onOptionChange={jest.fn()} />);
+
+    expect(screen.queryByDisplayValue('PascalCase')).not.toBeInTheDocument();
+    expect(screen.queryByDisplayValue('camelCase')).not.toBeInTheDocument();
+    // The prefix/suffix inputs remain available.
+    expect(screen.getByPlaceholderText('e.g. Api')).toBeInTheDocument();
+  });
+
+  it('reports class and property naming convention changes', () => {
+    const onOptionChange = jest.fn();
+    render(<ImportOptionsForm options={baseOptions()} onOptionChange={onOptionChange} />);
+
+    fireEvent.change(screen.getByDisplayValue('PascalCase'), { target: { value: 'snake_case' } });
+    expect(onOptionChange).toHaveBeenCalledWith('classNamingConvention', 'snake_case');
+
+    fireEvent.change(screen.getByDisplayValue('camelCase'), { target: { value: 'kebab-case' } });
+    expect(onOptionChange).toHaveBeenCalledWith('propertyNamingConvention', 'kebab-case');
+  });
+
+  it('reports class prefix and suffix edits', () => {
+    const onOptionChange = jest.fn();
+    render(<ImportOptionsForm options={baseOptions()} onOptionChange={onOptionChange} />);
+
+    fireEvent.change(screen.getByPlaceholderText('e.g. Api'), { target: { value: 'Api' } });
+    expect(onOptionChange).toHaveBeenCalledWith('classPrefix', 'Api');
+
+    fireEvent.change(screen.getByPlaceholderText('e.g. Dto'), { target: { value: 'Dto' } });
+    expect(onOptionChange).toHaveBeenCalledWith('classSuffix', 'Dto');
+  });
+
+  it('reports flag toggles', () => {
+    const onOptionChange = jest.fn();
+    render(<ImportOptionsForm options={baseOptions()} onOptionChange={onOptionChange} />);
+
+    fireEvent.click(screen.getByRole('checkbox', { name: /generate examples/i }));
+    expect(onOptionChange).toHaveBeenCalledWith('generateExamples', true);
+
+    fireEvent.click(screen.getByRole('checkbox', { name: /dry run/i }));
+    expect(onOptionChange).toHaveBeenCalledWith('dryRun', true);
+
+    fireEvent.click(screen.getByRole('checkbox', { name: /incremental mode/i }));
+    expect(onOptionChange).toHaveBeenCalledWith('incrementalMode', true);
+  });
+
+  it('renders only the naming section when requested', () => {
+    render(<ImportOptionsForm options={baseOptions()} onOptionChange={jest.fn()} sections={['naming']} />);
+
+    expect(screen.getByRole('checkbox', { name: /apply naming convention/i })).toBeInTheDocument();
+    expect(screen.queryByRole('checkbox', { name: /generate examples/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('checkbox', { name: /dry run/i })).not.toBeInTheDocument();
+  });
+
+  it('renders only the flags section when requested', () => {
+    render(<ImportOptionsForm options={baseOptions()} onOptionChange={jest.fn()} sections={['flags']} />);
+
+    expect(screen.queryByRole('checkbox', { name: /apply naming convention/i })).not.toBeInTheDocument();
+    expect(screen.getByRole('checkbox', { name: /generate examples/i })).toBeInTheDocument();
+  });
+
+  it('can hide the dry-run and incremental-mode flags', () => {
+    render(
+      <ImportOptionsForm
+        options={baseOptions()}
+        onOptionChange={jest.fn()}
+        sections={['flags']}
+        showDryRun={false}
+        showIncrementalMode={false}
+      />
+    );
+
+    expect(screen.getByRole('checkbox', { name: /generate examples/i })).toBeInTheDocument();
+    expect(screen.queryByRole('checkbox', { name: /dry run/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('checkbox', { name: /incremental mode/i })).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## What & why

The **repository file import** (ADE → Repositories → a file → Import) had **no options form** — it always used hardcoded defaults (`defaultImportOptionsFromAnalysis`: all schemas, PascalCase classes / camelCase properties, no prefix/suffix, no examples, no dry-run). Only the **Projects dashboard import** (upload/paste) exposed those controls, via `PreviewPanel`. This adds the same options UI to the repository flow.

This also makes the RAR-1.2 spec-capture meaningful for repository imports: previously the "user's original request" we persist was just defaults, because there was no way to choose anything.

### Changes
- **New `ImportOptionsForm.tsx`** — the import-options editor extracted out of `PreviewPanel` into a controlled, reusable component (naming convention toggle + class/property convention selects, class prefix/suffix, generate-examples, dry-run, incremental-mode). Props: `{ options, onOptionChange, sections?, showDryRun?, showIncrementalMode? }`. It owns no state — the parent holds `ImportOptions`.
- **`PreviewPanel.tsx`** — now renders `<ImportOptionsForm sections={['naming']}>` and `<ImportOptionsForm sections={['flags']}>` in place of the inline JSX, preserving the dashboard import layout/behavior exactly (markup and CSS classes unchanged; the advanced type-mapping/override tables stay in PreviewPanel between the two sections).
- **`RepositoryFileImportMapping.tsx`** — initializes editable options from the spec analysis once the file loads (preserving edits across re-renders), renders an **"Import options"** card in the mapping step, and submits the user-edited options (falling back to spec defaults). These flow into `startImport` and are persisted by RAR-1.2.
- **Tests** — `ImportOptionsForm.test.tsx` (9 tests: controls render; each edit reports the correct `(key, value)`; `sections`/`showDryRun`/`showIncrementalMode` behavior).

## How to test
From `objectified-ui/`:
- `npx jest ImportOptionsForm` → 9 passed.
- `npx jest PreviewPanel ImportDialog import-` → 415 passed (no regressions).
- `npx tsc --noEmit` → clean.

Manual:
1. **Go to ADE → Repositories → (a repo) → pick an OpenAPI/Swagger file → Import.**
2. In the **Map & import** step, the new **Import options** card appears. **Change the class naming convention** to `snake_case`, **set a class prefix** (e.g. `Api`), **toggle Generate examples**.
3. **Click Import** and confirm the created classes reflect those choices (e.g. `Api`-prefixed, snake_case names).
4. Re-open the same file — options re-initialize from the spec defaults for a fresh import.

## Risk / notes
- `PreviewPanel` refactor is markup-preserving; covered by the existing 415 import/preview tests.
- Advanced type-mapping/override tables were intentionally left in `PreviewPanel` (out of scope for the repo flow's first options form); the repo card covers the core transform options.
- No backend/schema changes.

Work performed by Claude Code via model Opus 4.8 (1M context).