### PR TITLE
Fix #3514 - Capture source descriptor on import

### DIFF
--- a/docs/ROADMAP_REPOSITORY_AUTOREFRESH.md
+++ b/docs/ROADMAP_REPOSITORY_AUTOREFRESH.md
@@ -118,7 +118,7 @@ epic. Use this table to resolve any `RAR-*` reference below to its issue number.
 |----|-------|----|-------|----|-------|
 | RAR-EPIC-1 | #3506 | RAR-EPIC-2 | #3507 | RAR-EPIC-3 | #3508 |
 | RAR-EPIC-4 | #3509 | RAR-EPIC-5 | #3510 | RAR-EPIC-6 | #3511 |
-| ~~RAR-1.1~~ ✅ | ~~#3512~~ | ~~RAR-1.2~~ ✅ | ~~#3513~~ | RAR-1.3 | #3514 |
+| ~~RAR-1.1~~ ✅ | ~~#3512~~ | ~~RAR-1.2~~ ✅ | ~~#3513~~ | ~~RAR-1.3~~ ✅ | ~~#3514~~ |
 | RAR-1.4 | #3515 | RAR-1.5 | #3516 | RAR-1.6 | #3517 |
 | RAR-2.1 | #3518 | RAR-2.2 | #3519 | RAR-2.3 | #3520 |
 | RAR-2.4 | #3521 | RAR-3.1 | #3522 | RAR-3.2 | #3523 |
@@ -140,7 +140,7 @@ Persist exactly what the user asked for at import time so it can be replayed.
 |----|-------|---------|--------|----------|-----|-------|---------|
 | ~~RAR-1.1~~ ✅ **Done** (#3512) | `repository_import_spec` data model | New table storing the full import spec keyed to an imported file | `enhancement`,`mvp`,`import`,`repository`,`data-model` | N | Y | M | objectified-db, objectified-rest |
 | ~~RAR-1.2~~ ✅ **Done** (#3513) | Persist `SpecImportOptions` at import time | Write the options blob on every successful import (manual + auto) | `enhancement`,`mvp`,`import`,`repository`,`rest` | N | Y | M | objectified-rest, objectified-ui |
-| RAR-1.3 | Capture source descriptor | Store kind, filename, `--format` override, content-type used | `enhancement`,`mvp`,`import`,`repository` | Y | Y | S | objectified-rest |
+| ~~RAR-1.3~~ ✅ **Done** (#3514) | Capture source descriptor | Store kind, filename, `--format` override, content-type used | `enhancement`,`mvp`,`import`,`repository` | Y | Y | S | objectified-ui |
 | RAR-1.4 | Versioned spec envelope (`spec_schema_version`) | Forward-compatible envelope so stored specs survive option changes | `enhancement`,`mvp`,`import`,`data-model` | Y | Y | S | objectified-rest |
 | RAR-1.5 | REST: read stored import spec | `GET …/repository-imports/{id}/spec` returns the captured spec | `enhancement`,`mvp`,`import`,`rest` | Y | Y | S | objectified-rest |
 | RAR-1.6 | Backfill best-effort specs for historical imports | Migration seeds a default spec for pre-existing imports | `enhancement`,`import`,`repository`,`data-model` | Y | N | M | objectified-db, objectified-rest |
@@ -217,6 +217,16 @@ upsert; an integration test drives a full import and asserts persisted == submit
 - **1.5** expose `GET …/repository-imports/{id}/spec` (and a `?path=` variant) for UI/CLI.
 - **1.6** one-time backfill: derive a conservative default spec for historical imports so they become
   refresh-eligible (flagged `backfilled=true`).
+
+**Status of 1.3: ✅ Done (#3514).** The repository import path
+(`RepositoryFileImportMapping.tsx`) now derives the source descriptor the importer actually resolved
+and passes it into `startImport` → `upsertRepositoryImportSpec`: `format_override` = the resolved spec
+format (e.g. `swagger` for a Swagger 2.0 file routed through the OpenAPI importer), `content_type` =
+the syntax the document was parsed as (`application/json`, `application/yaml`, …). `source_kind` is the
+importer kind and the filename is the `path` lineage key, both already captured. The derivation lives in
+the pure, reusable `lib/repository-import-source-descriptor.ts` so the RAR-4.1 refresh worker can reuse
+it; unit tests pin the format/content-type mapping and a wiring test asserts the descriptor reaches the
+capture call.
 
 ---
 

--- a/objectified-ui/lib/repository-import-source-descriptor.ts
+++ b/objectified-ui/lib/repository-import-source-descriptor.ts
@@ -1,0 +1,91 @@
+/**
+ * Source-descriptor derivation for repository imports (RAR-1.3, #3514).
+ *
+ * A faithful auto-refresh must route and parse a repository file identically to
+ * its first import. To do that the refresh worker (RAR-4.1) needs the values the
+ * importer actually resolved the first time — not a fresh sniff that could detect
+ * the format or syntax differently. This module turns the spec analysis produced
+ * at import time into the persisted descriptor fields (`format_override`,
+ * `content_type`) so they can be stored alongside the import spec.
+ *
+ * `source_kind` and the filename are captured elsewhere (the importer kind and the
+ * `path` lineage key respectively); this helper covers only the two descriptor
+ * fields that are otherwise derived by sniffing.
+ */
+
+/** The subset of the spec analysis this descriptor is derived from. */
+export interface SourceDescriptorAnalysisInput {
+  /** Resolved spec format from sniffing (e.g. `openapi`, `swagger`, `arazzo`). */
+  format: string;
+  /** Concrete document syntax the spec was parsed as. */
+  syntax: string;
+}
+
+/** The persisted source-descriptor fields for a repository import. */
+export interface RepositoryImportSourceDescriptor {
+  /**
+   * The resolved spec format the importer routed on, captured so a refresh
+   * re-routes identically instead of re-sniffing. `null` when the format could
+   * not be determined (`unknown`).
+   */
+  formatOverride: string | null;
+  /**
+   * The content type the document was read/parsed as, derived from its syntax,
+   * so a refresh reads the bytes with the same parser. `null` when the syntax is
+   * not recognized.
+   */
+  contentType: string | null;
+}
+
+/** Document-syntax → content-type used to read the spec. */
+const SYNTAX_CONTENT_TYPES: Record<string, string> = {
+  json: 'application/json',
+  yaml: 'application/yaml',
+  graphql: 'application/graphql',
+  protobuf: 'application/x-protobuf',
+  thrift: 'application/x-thrift',
+};
+
+/**
+ * Map a document syntax to the content type used to read it. Returns `null` for
+ * an unrecognized or empty syntax so an unknown value is stored as "no content
+ * type" rather than a fabricated one.
+ *
+ * @param syntax the analysis `syntax` value (e.g. `json`, `yaml`).
+ * @returns the content type, or `null` when the syntax is not recognized.
+ */
+export function contentTypeForSyntax(syntax: string | null | undefined): string | null {
+  if (!syntax) return null;
+  return SYNTAX_CONTENT_TYPES[syntax.trim().toLowerCase()] ?? null;
+}
+
+/**
+ * Normalize the resolved spec format into the stored `format_override`. An
+ * `unknown` (or empty) format yields `null` so the descriptor records "no
+ * resolved format" instead of the literal sentinel.
+ *
+ * @param format the analysis `format` value.
+ * @returns the resolved format, or `null` when it could not be determined.
+ */
+export function formatOverrideForFormat(format: string | null | undefined): string | null {
+  if (!format) return null;
+  const trimmed = format.trim();
+  if (!trimmed || trimmed.toLowerCase() === 'unknown') return null;
+  return trimmed;
+}
+
+/**
+ * Derive the persisted source descriptor (`format_override`, `content_type`) from
+ * the spec analysis resolved at import time.
+ *
+ * @param analysis the resolved `format` and `syntax` from the import analysis.
+ * @returns the descriptor fields to persist with the import spec.
+ */
+export function deriveRepositoryImportSourceDescriptor(
+  analysis: SourceDescriptorAnalysisInput
+): RepositoryImportSourceDescriptor {
+  return {
+    formatOverride: formatOverrideForFormat(analysis.format),
+    contentType: contentTypeForSyntax(analysis.syntax),
+  };
+}

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.117",
+  "version": "0.11.118",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/src/app/components/ade/dashboard/repositories/RepositoryFileImportMapping.tsx
+++ b/objectified-ui/src/app/components/ade/dashboard/repositories/RepositoryFileImportMapping.tsx
@@ -45,6 +45,7 @@ import {
   getRepositoryFileImportableVerdict,
   parseRepositoryFileSpecMetadata,
 } from '@lib/repository-file-spec-metadata';
+import { deriveRepositoryImportSourceDescriptor } from '@lib/repository-import-source-descriptor';
 import {
   projectDraftFromRepositorySpec,
   type RepositorySpecProjectDraft,
@@ -601,6 +602,13 @@ export function RepositoryFileImportMapping({
         const document = analysis.document;
         const sourceKind = analysis.format === 'arazzo' ? 'arazzo' : 'openapi';
 
+        // Capture the source descriptor the importer actually resolved (RAR-1.3)
+        // so a future auto-refresh routes/parses this file identically instead of
+        // re-sniffing from scratch. `path` already carries the filename and
+        // `sourceKind` the importer kind; this adds the resolved format + the
+        // content type the document was read as.
+        const sourceDescriptor = deriveRepositoryImportSourceDescriptor(analysis);
+
         const job = await startImport({
           tenantId: currentTenantId,
           userId: currentUserId,
@@ -611,6 +619,8 @@ export function RepositoryFileImportMapping({
             branch,
             path: file.path,
             blobSha: payload?.blob_sha ?? file.blob_sha ?? null,
+            formatOverride: sourceDescriptor.formatOverride,
+            contentType: sourceDescriptor.contentType,
           },
           project: {
             name: effectiveOptions.projectName || (document?.info?.title || 'New Project'),

--- a/objectified-ui/tests/repository-import-source-descriptor.test.ts
+++ b/objectified-ui/tests/repository-import-source-descriptor.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Source-descriptor derivation tests (RAR-1.3, #3514)
+ *
+ * The descriptor (`format_override`, `content_type`) is persisted at import time
+ * so an auto-refresh routes/parses a repository file identically to the first
+ * import. These tests pin the format normalization and the syntax → content-type
+ * mapping that produce those stored values.
+ */
+
+import { describe, test, expect } from '@jest/globals';
+
+import {
+  contentTypeForSyntax,
+  formatOverrideForFormat,
+  deriveRepositoryImportSourceDescriptor,
+} from '../lib/repository-import-source-descriptor';
+
+describe('contentTypeForSyntax (RAR-1.3)', () => {
+  test.each([
+    ['json', 'application/json'],
+    ['yaml', 'application/yaml'],
+    ['graphql', 'application/graphql'],
+    ['protobuf', 'application/x-protobuf'],
+    ['thrift', 'application/x-thrift'],
+  ])('maps %s syntax to %s', (syntax, expected) => {
+    expect(contentTypeForSyntax(syntax)).toBe(expected);
+  });
+
+  test('is case- and whitespace-insensitive', () => {
+    expect(contentTypeForSyntax('  JSON ')).toBe('application/json');
+    expect(contentTypeForSyntax('Yaml')).toBe('application/yaml');
+  });
+
+  test('returns null for unrecognized, empty, or missing syntax', () => {
+    expect(contentTypeForSyntax('xml')).toBeNull();
+    expect(contentTypeForSyntax('')).toBeNull();
+    expect(contentTypeForSyntax(null)).toBeNull();
+    expect(contentTypeForSyntax(undefined)).toBeNull();
+  });
+});
+
+describe('formatOverrideForFormat (RAR-1.3)', () => {
+  test.each(['openapi', 'swagger', 'arazzo', 'jsonschema', 'asyncapi'])(
+    'keeps the resolved format %s',
+    (format) => {
+      expect(formatOverrideForFormat(format)).toBe(format);
+    }
+  );
+
+  test('trims surrounding whitespace', () => {
+    expect(formatOverrideForFormat('  swagger ')).toBe('swagger');
+  });
+
+  test('returns null when the format is unknown, empty, or missing', () => {
+    expect(formatOverrideForFormat('unknown')).toBeNull();
+    expect(formatOverrideForFormat('UNKNOWN')).toBeNull();
+    expect(formatOverrideForFormat('')).toBeNull();
+    expect(formatOverrideForFormat('   ')).toBeNull();
+    expect(formatOverrideForFormat(null)).toBeNull();
+    expect(formatOverrideForFormat(undefined)).toBeNull();
+  });
+});
+
+describe('deriveRepositoryImportSourceDescriptor (RAR-1.3)', () => {
+  test('derives both descriptor fields from a resolved analysis', () => {
+    expect(
+      deriveRepositoryImportSourceDescriptor({ format: 'openapi', syntax: 'yaml' })
+    ).toEqual({ formatOverride: 'openapi', contentType: 'application/yaml' });
+  });
+
+  test('captures the granular format distinct from the importer kind (swagger)', () => {
+    // A Swagger 2.0 file routes through the OpenAPI importer (source_kind=openapi)
+    // but its resolved format is swagger — the descriptor preserves that.
+    expect(
+      deriveRepositoryImportSourceDescriptor({ format: 'swagger', syntax: 'json' })
+    ).toEqual({ formatOverride: 'swagger', contentType: 'application/json' });
+  });
+
+  test('yields null fields when format/syntax are unresolved', () => {
+    expect(
+      deriveRepositoryImportSourceDescriptor({ format: 'unknown', syntax: '' })
+    ).toEqual({ formatOverride: null, contentType: null });
+  });
+});

--- a/objectified-ui/tests/repository-import-spec-capture.test.ts
+++ b/objectified-ui/tests/repository-import-spec-capture.test.ts
@@ -205,6 +205,37 @@ describe('Import-time spec capture (RAR-1.2, #3513)', () => {
     expect(mockUpsertRepositoryImportSpec).not.toHaveBeenCalled();
   });
 
+  test('the source descriptor (format/content-type) is forwarded to capture (RAR-1.3)', async () => {
+    const input = repositoryImportInput();
+    input.repositorySource = {
+      ...input.repositorySource,
+      formatOverride: 'swagger',
+      contentType: 'application/json',
+    } as typeof input.repositorySource;
+
+    const helper = await import('../lib/db/import-helper');
+    const { jobId } = await helper.startImport(input);
+
+    const status = await runImportToCompletion(helper, jobId);
+    expect(status.state).toBe('completed');
+
+    expect(mockUpsertRepositoryImportSpec).toHaveBeenCalledTimes(1);
+    const arg = mockUpsertRepositoryImportSpec.mock.calls[0][0] as any;
+    expect(arg.formatOverride).toBe('swagger');
+    expect(arg.contentType).toBe('application/json');
+  });
+
+  test('a missing source descriptor is captured as null (RAR-1.3)', async () => {
+    const helper = await import('../lib/db/import-helper');
+    const { jobId } = await helper.startImport(repositoryImportInput());
+
+    await runImportToCompletion(helper, jobId);
+
+    const arg = mockUpsertRepositoryImportSpec.mock.calls[0][0] as any;
+    expect(arg.formatOverride).toBeNull();
+    expect(arg.contentType).toBeNull();
+  });
+
   test('a spec-capture failure does not fail the import', async () => {
     mockUpsertRepositoryImportSpec.mockRejectedValueOnce(new Error('db down') as never);
 


### PR DESCRIPTION
## What & why

RAR-1.3 (epic #3506). A faithful auto-refresh must route and parse a repository file **identically to its first import**, but the resolved spec format and the content type used to read the file were never persisted — so a refresh could detect the format differently than the original run.

RAR-1.1 added the `format_override` / `content_type` columns and RAR-1.2 threaded them through `import-helper` as nullable slots, but no caller populated them. This wires the repository import path to capture the descriptor the importer actually resolved:

- **`source_kind`** — the importer kind (already captured).
- **`format_override`** — the resolved spec format, e.g. `swagger` for a Swagger 2.0 file that routes through the OpenAPI importer (more granular than `source_kind`).
- **`content_type`** — derived from the document syntax (`application/json`, `application/yaml`, …) so a refresh reads the bytes with the same parser.
- **filename** — already captured as the `path` lineage key.

Derivation lives in a pure, reusable module (`lib/repository-import-source-descriptor.ts`) so the future RAR-4.1 refresh worker can reuse it. Unknown/unrecognized format or syntax is stored as `null` rather than a fabricated value.

## Changes

- `objectified-ui/lib/repository-import-source-descriptor.ts` — new pure helper (`deriveRepositoryImportSourceDescriptor`, `contentTypeForSyntax`, `formatOverrideForFormat`).
- `RepositoryFileImportMapping.tsx` — derive the descriptor from the import analysis and pass `formatOverride`/`contentType` through `repositorySource`.
- Tests — unit-test the mapping; extend the capture test to assert the descriptor reaches `upsertRepositoryImportSpec` (and that a missing descriptor persists `null`).
- ROADMAP marked done; `objectified-ui` 0.11.117 → 0.11.118.

## How to test

1. **Open** a repository file (an OpenAPI/Swagger/Arazzo spec) in the Repositories dashboard and **start an import** into a project.
2. After it completes, **inspect** `odb.repository_import_spec` for that `(repository_id, branch, path)`:
   - `source_kind` is `openapi` or `arazzo`,
   - `format_override` is the resolved format (e.g. `swagger` for a Swagger 2.0 file, `openapi` for OpenAPI 3.x),
   - `content_type` is `application/json` for a `.json` spec or `application/yaml` for a `.yaml` spec,
   - `path` is the file path (filename).
3. Automated: `cd objectified-ui && yarn jest repository-import-source-descriptor repository-import-spec-capture`.

## Risk / notes

- Low risk: capture is best-effort (a failure logs but never fails the import — unchanged from RAR-1.2). The only behavioral change is that two previously-`null` columns are now populated.
- Full suite green: 3230 tests, `tsc --noEmit` clean, production files lint clean.

Closes #3514

Work performed by Claude Code via model Opus 4.8 (1M context)