### PR TITLE
Fix #3515 - Versioned spec envelope (spec_schema_version) upgrade-on-read

### DIFF
--- a/docs/ROADMAP_REPOSITORY_AUTOREFRESH.md
+++ b/docs/ROADMAP_REPOSITORY_AUTOREFRESH.md
@@ -119,7 +119,7 @@ epic. Use this table to resolve any `RAR-*` reference below to its issue number.
 | RAR-EPIC-1 | #3506 | RAR-EPIC-2 | #3507 | RAR-EPIC-3 | #3508 |
 | RAR-EPIC-4 | #3509 | RAR-EPIC-5 | #3510 | RAR-EPIC-6 | #3511 |
 | ~~RAR-1.1~~ ✅ | ~~#3512~~ | ~~RAR-1.2~~ ✅ | ~~#3513~~ | ~~RAR-1.3~~ ✅ | ~~#3514~~ |
-| RAR-1.4 | #3515 | RAR-1.5 | #3516 | RAR-1.6 | #3517 |
+| ~~RAR-1.4~~ ✅ | ~~#3515~~ | RAR-1.5 | #3516 | RAR-1.6 | #3517 |
 | RAR-2.1 | #3518 | RAR-2.2 | #3519 | RAR-2.3 | #3520 |
 | RAR-2.4 | #3521 | RAR-3.1 | #3522 | RAR-3.2 | #3523 |
 | RAR-3.3 | #3524 | RAR-3.4 | #3525 | RAR-3.5 | #3526 |
@@ -141,7 +141,7 @@ Persist exactly what the user asked for at import time so it can be replayed.
 | ~~RAR-1.1~~ ✅ **Done** (#3512) | `repository_import_spec` data model | New table storing the full import spec keyed to an imported file | `enhancement`,`mvp`,`import`,`repository`,`data-model` | N | Y | M | objectified-db, objectified-rest |
 | ~~RAR-1.2~~ ✅ **Done** (#3513) | Persist `SpecImportOptions` at import time | Write the options blob on every successful import (manual + auto) | `enhancement`,`mvp`,`import`,`repository`,`rest` | N | Y | M | objectified-rest, objectified-ui |
 | ~~RAR-1.3~~ ✅ **Done** (#3514) | Capture source descriptor | Store kind, filename, `--format` override, content-type used | `enhancement`,`mvp`,`import`,`repository` | Y | Y | S | objectified-ui |
-| RAR-1.4 | Versioned spec envelope (`spec_schema_version`) | Forward-compatible envelope so stored specs survive option changes | `enhancement`,`mvp`,`import`,`data-model` | Y | Y | S | objectified-rest |
+| ~~RAR-1.4~~ ✅ **Done** (#3515) | Versioned spec envelope (`spec_schema_version`) | Forward-compatible envelope so stored specs survive option changes | `enhancement`,`mvp`,`import`,`data-model` | Y | Y | S | objectified-rest |
 | RAR-1.5 | REST: read stored import spec | `GET …/repository-imports/{id}/spec` returns the captured spec | `enhancement`,`mvp`,`import`,`rest` | Y | Y | S | objectified-rest |
 | RAR-1.6 | Backfill best-effort specs for historical imports | Migration seeds a default spec for pre-existing imports | `enhancement`,`import`,`repository`,`data-model` | Y | N | M | objectified-db, objectified-rest |
 

--- a/objectified-rest/pyproject.toml
+++ b/objectified-rest/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "objectified-rest"
-version = "1.0.61"
+version = "1.0.62"
 description = "REST API for serving OpenAPI specifications from the Objectified database"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/objectified-rest/src/app/database.py
+++ b/objectified-rest/src/app/database.py
@@ -6970,6 +6970,34 @@ class Database:
         results = self.execute_query(query, (tenant_id, repository_id, branch, path))
         return results[0] if results else None
 
+    def get_repository_import_options(
+        self, tenant_id: str, repository_id: str, branch: str, path: str
+    ) -> Optional[Dict[str, Any]]:
+        """Return the stored import options for one file, migrated to the current shape.
+
+        Reads the persisted envelope and applies the versioned upgrade path
+        (RAR-1.4): if the row's ``spec_schema_version`` is older than the current
+        envelope version, the stored ``options_json`` blob is migrated forward so
+        the caller always receives a current-shape options dictionary, regardless
+        of when the spec was written. Used by repository auto-refresh to replay
+        the user's original request.
+
+        Args:
+            tenant_id: Owning tenant id (scopes the lookup).
+            repository_id: Source repository id.
+            branch: Branch the file was imported from.
+            path: Repository-relative file path (lineage key).
+
+        Returns:
+            The current-shape options as a dict, or None when no spec exists.
+        """
+        from .models import load_repository_import_options
+
+        row = self.get_repository_import_spec(tenant_id, repository_id, branch, path)
+        if row is None:
+            return None
+        return load_repository_import_options(row).model_dump()
+
     def get_public_browse_directory_stats(self) -> Dict[str, int]:
         """Counts for tenants/projects/versions with published public revisions (browse directory)."""
         query = """

--- a/objectified-rest/src/app/models.py
+++ b/objectified-rest/src/app/models.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from pydantic import BaseModel, Field, AliasChoices, ConfigDict, model_validator
-from typing import Optional, Dict, Any, List, Union, Literal
+from typing import Callable, Optional, Dict, Any, List, Union, Literal
 
 
 class TagSchema(BaseModel):
@@ -274,6 +274,141 @@ class RepositoryImportSpec(BaseModel):
     created_by: Optional[str] = None
     created_at: Optional[Union[datetime, str]] = None
     updated_at: Optional[Union[datetime, str]] = None
+
+
+# --- Versioned spec envelope upgrade path (RAR-1.4, #3515) -------------------
+#
+# A persisted import spec is a forward-compatible envelope:
+# ``{ spec_schema_version, options }``. When the ``SpecImportOptions`` shape
+# changes (a renamed or dropped field, a new default), the envelope version is
+# bumped and a single-step upgrader is registered below so that *reads* of an
+# older row migrate the stored ``options`` blob forward to the current shape
+# before it is validated. Without this, a raw blob with no version marker — or
+# one written under an older shape — would be impossible to interpret safely and
+# would break replay of old imports.
+#
+# An upgrader migrates an ``options`` dict from version N to version N+1. The
+# registry is keyed by the *source* version N; ``upgrade_repository_import_options``
+# walks it one step at a time up to ``REPOSITORY_IMPORT_SPEC_SCHEMA_VERSION``.
+RepositoryImportOptionsUpgrader = Callable[[Dict[str, Any]], Dict[str, Any]]
+
+
+def _upgrade_repository_import_options_v0_to_v1(
+    options: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Migrate a pre-envelope (version 0) options blob to the version 1 shape.
+
+    Version 0 is the legacy "raw ``options_json`` blob with no ``spec_schema_version``
+    marker" described in the ticket: a spec persisted before the versioned
+    envelope existed (or one whose marker is missing/``NULL``). It may carry keys
+    that are no longer part of ``SpecImportOptions``. This upgrader keeps only the
+    keys the current model recognizes, so the result validates under the
+    ``extra="forbid"`` model; fields absent from the legacy blob fall back to
+    their current defaults at validation time.
+
+    Args:
+        options: The legacy version-0 options dictionary.
+
+    Returns:
+        A new dictionary containing only keys valid for the version-1 shape.
+    """
+    known_fields = set(SpecImportOptions.model_fields.keys())
+    return {key: value for key, value in options.items() if key in known_fields}
+
+
+# Single-step upgraders keyed by the source envelope version they migrate *from*.
+# To add a v1 -> v2 migration: bump ``REPOSITORY_IMPORT_SPEC_SCHEMA_VERSION`` to
+# 2 and register ``1: _upgrade_..._v1_to_v2`` here. No read site changes.
+_REPOSITORY_IMPORT_OPTIONS_UPGRADERS: Dict[int, RepositoryImportOptionsUpgrader] = {
+    0: _upgrade_repository_import_options_v0_to_v1,
+}
+
+
+def upgrade_repository_import_options(
+    options: Optional[Dict[str, Any]],
+    from_version: Optional[int],
+) -> Dict[str, Any]:
+    """Migrate a stored options dict forward to the current envelope shape.
+
+    Applies the registered single-step upgraders in order, starting at
+    ``from_version`` and stopping at ``REPOSITORY_IMPORT_SPEC_SCHEMA_VERSION``.
+    A missing/``None`` version is treated as the unversioned legacy shape
+    (version 0). When ``from_version`` already equals the current version the
+    options are returned as a shallow copy, untouched.
+
+    Args:
+        options: The stored options dictionary (may be ``None`` or empty).
+        from_version: The envelope version the options were stored under;
+            ``None`` is interpreted as version 0 (legacy, unmarked).
+
+    Returns:
+        The options dictionary migrated to the current envelope shape.
+
+    Raises:
+        ValueError: If ``from_version`` is newer than this code understands
+            (a downgrade), or if no upgrader is registered for an intermediate
+            version (a gap in the migration chain).
+    """
+    version = 0 if from_version is None else int(from_version)
+    if version > REPOSITORY_IMPORT_SPEC_SCHEMA_VERSION:
+        raise ValueError(
+            "Stored import spec envelope version "
+            f"{version} is newer than the supported version "
+            f"{REPOSITORY_IMPORT_SPEC_SCHEMA_VERSION}; cannot downgrade."
+        )
+
+    migrated: Dict[str, Any] = dict(options or {})
+    while version < REPOSITORY_IMPORT_SPEC_SCHEMA_VERSION:
+        upgrader = _REPOSITORY_IMPORT_OPTIONS_UPGRADERS.get(version)
+        if upgrader is None:
+            raise ValueError(
+                "No upgrader registered for repository import options envelope "
+                f"version {version}; cannot migrate to version "
+                f"{REPOSITORY_IMPORT_SPEC_SCHEMA_VERSION}."
+            )
+        migrated = upgrader(migrated)
+        version += 1
+    return migrated
+
+
+def load_repository_import_options(
+    envelope: Optional[Dict[str, Any]],
+) -> SpecImportOptions:
+    """Read a stored import-spec envelope and return current-shape options.
+
+    This is the read entry point for persisted specs: it pulls the stored
+    options blob and ``spec_schema_version`` out of a DAO row (or any
+    envelope-shaped dict), migrates the blob forward with
+    ``upgrade_repository_import_options``, and validates it into a current
+    ``SpecImportOptions``. Repository auto-refresh uses it to replay the user's
+    original request regardless of when the spec was written.
+
+    The options blob is read from ``options_json`` (the DAO/JSONB column name)
+    or, failing that, ``options`` (the model field name); a JSON-encoded string
+    is decoded transparently for cursors that return JSONB as text.
+
+    Args:
+        envelope: A stored import-spec row or envelope dict, or ``None``.
+
+    Returns:
+        A validated, current-shape ``SpecImportOptions`` (defaults when the
+        envelope is ``None`` or carries no options).
+    """
+    if not envelope:
+        return SpecImportOptions()
+
+    raw = envelope.get("options_json")
+    if raw is None:
+        raw = envelope.get("options")
+    if isinstance(raw, str):
+        import json
+
+        raw = json.loads(raw) if raw.strip() else {}
+    if raw is None:
+        raw = {}
+
+    migrated = upgrade_repository_import_options(raw, envelope.get("spec_schema_version"))
+    return SpecImportOptions.model_validate(migrated)
 
 
 class SpecImportStartMetadata(BaseModel):

--- a/objectified-rest/tests/test_repository_import_spec_upgrade.py
+++ b/objectified-rest/tests/test_repository_import_spec_upgrade.py
@@ -1,0 +1,135 @@
+"""Versioned spec envelope upgrade-on-read tests (RAR-1.4, #3515).
+
+The persisted import spec is a forward-compatible envelope
+``{ spec_schema_version, options }``. A read of an older-version envelope must
+migrate the stored options blob forward to the current shape via the registered
+upgrade path. These tests cover the version-0 (legacy, unmarked) -> version-1
+upgrade and the read entry points that apply it.
+"""
+
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from app.models import (
+    REPOSITORY_IMPORT_SPEC_SCHEMA_VERSION,
+    SpecImportOptions,
+    load_repository_import_options,
+    upgrade_repository_import_options,
+)
+
+
+def test_legacy_v0_blob_upgrades_to_current_shape() -> None:
+    """A version-0 blob with a removed legacy key upgrades to valid current options.
+
+    The legacy key (``legacy_flatten``, no longer part of ``SpecImportOptions``)
+    is dropped by the v0 -> v1 upgrader so the result validates under the current
+    ``extra="forbid"`` model, while recognized keys survive.
+    """
+    legacy_blob = {
+        "legacy_flatten": True,  # removed field — must be dropped on upgrade
+        "apply_naming_convention": True,
+        "class_naming_convention": "PascalCase",
+        "selected_schemas": ["Pet", "Order"],
+    }
+
+    migrated = upgrade_repository_import_options(legacy_blob, from_version=0)
+
+    assert "legacy_flatten" not in migrated
+    # Recognized values carry through the upgrade unchanged.
+    assert migrated["apply_naming_convention"] is True
+    assert migrated["class_naming_convention"] == "PascalCase"
+    assert migrated["selected_schemas"] == ["Pet", "Order"]
+
+    # The migrated dict validates and missing fields fall back to defaults.
+    options = SpecImportOptions.model_validate(migrated)
+    assert options.class_naming_convention == "PascalCase"
+    assert options.skip_duplicate_versions is False
+
+
+def test_missing_version_treated_as_legacy_v0() -> None:
+    """A ``None`` version is treated as the unversioned legacy shape (v0)."""
+    migrated = upgrade_repository_import_options(
+        {"legacy_flatten": True, "dry_run": True}, from_version=None
+    )
+    assert migrated == {"dry_run": True}
+
+
+def test_current_version_is_passthrough_copy() -> None:
+    """Options already at the current version are returned unchanged (a copy)."""
+    options = {"dry_run": True, "auto_layout": True}
+    migrated = upgrade_repository_import_options(
+        options, from_version=REPOSITORY_IMPORT_SPEC_SCHEMA_VERSION
+    )
+    assert migrated == options
+    assert migrated is not options  # shallow copy, not the original reference
+
+
+def test_none_options_upgrades_to_empty_dict() -> None:
+    """A ``None`` options blob migrates to an empty (all-defaults) dict."""
+    assert upgrade_repository_import_options(None, from_version=0) == {}
+
+
+def test_future_version_rejected() -> None:
+    """A version newer than this code understands raises (no silent downgrade)."""
+    with pytest.raises(ValueError, match="newer than the supported version"):
+        upgrade_repository_import_options(
+            {}, from_version=REPOSITORY_IMPORT_SPEC_SCHEMA_VERSION + 1
+        )
+
+
+def test_load_from_dao_row_applies_upgrade() -> None:
+    """``load_repository_import_options`` upgrades a DAO-shaped row on read."""
+    row = {
+        "spec_schema_version": 0,
+        "options_json": {
+            "legacy_flatten": True,
+            "incremental_mode": True,
+            "property_naming_convention": "snake_case",
+        },
+    }
+
+    options = load_repository_import_options(row)
+
+    assert isinstance(options, SpecImportOptions)
+    assert options.incremental_mode is True
+    assert options.property_naming_convention == "snake_case"
+
+
+def test_load_decodes_jsonb_text_column() -> None:
+    """A JSONB column returned as a JSON string is decoded transparently."""
+    row = {
+        "spec_schema_version": 1,
+        "options_json": json.dumps({"dry_run": True}),
+    }
+    options = load_repository_import_options(row)
+    assert options.dry_run is True
+
+
+def test_load_accepts_model_field_name() -> None:
+    """The options blob may live under ``options`` (model field) not ``options_json``."""
+    row = {"spec_schema_version": 1, "options": {"auto_layout": True}}
+    options = load_repository_import_options(row)
+    assert options.auto_layout is True
+
+
+def test_load_none_and_empty_envelopes_default() -> None:
+    """A ``None`` or empty envelope yields default options, never an error."""
+    assert load_repository_import_options(None) == SpecImportOptions()
+    assert load_repository_import_options({}) == SpecImportOptions()
+    assert load_repository_import_options(
+        {"spec_schema_version": 1}
+    ) == SpecImportOptions()
+
+
+def test_load_rejects_unknown_field_at_current_version() -> None:
+    """An unknown key in a *current*-version row is not silently stripped.
+
+    The upgrade path only rewrites *older* envelopes; a current-version row with
+    an unexpected key is a genuine error and must fail validation rather than be
+    quietly accepted.
+    """
+    row = {"spec_schema_version": 1, "options_json": {"bogus_key": 1}}
+    with pytest.raises(ValidationError):
+        load_repository_import_options(row)


### PR DESCRIPTION
## What & why
`RAR-1.1` (#3514) already persists each repository import spec as a forward-compatible envelope `{ spec_schema_version, options }`. This ticket (`RAR-1.4`) adds the **upgrade-on-read** path so that when the `SpecImportOptions` shape changes, a read of an older-version envelope is migrated forward to the current shape instead of failing or being misinterpreted — preserving faithful replay of old imports.

### Changes (`objectified-rest`, Python only)
- `upgrade_repository_import_options(options, from_version)` — walks a registry of single-step upgraders from the stored version up to `REPOSITORY_IMPORT_SPEC_SCHEMA_VERSION`. Rejects future/downgrade versions and any gap in the migration chain (fails loudly rather than returning a stale shape).
- `_upgrade_repository_import_options_v0_to_v1()` — migrates a legacy **unmarked** blob (version 0, the "raw `options_json` with no version marker" the ticket calls out) to v1 by dropping keys the current model no longer recognizes, so it validates under `extra="forbid"`.
- `load_repository_import_options(envelope)` — read entry point: pulls `options_json` + `spec_schema_version` from a DAO row (decodes JSONB-as-text), upgrades, and validates into a current `SpecImportOptions`.
- `Database.get_repository_import_options(...)` — DAO convenience returning current-shape options for one file (the entry repository auto-refresh / `RAR-4.*` will call).
- Adding a future `v1 -> v2` migration is one registry entry + a version bump; no read sites change.

### Acceptance criteria
- [x] All persisted specs carry `spec_schema_version` (existing column, default 1).
- [x] A read of an older-version envelope returns a current-shape options object via an upgrade function.
- [x] Unit tests cover at least one version upgrade (v0 → v1, plus read entry points).

## How to test
```
cd objectified-rest
.venv/bin/python -m pytest tests/test_repository_import_spec_upgrade.py tests/test_repository_import_spec_model.py -q
```
All 16 pass. Example: a legacy v0 blob `{ "legacy_flatten": true, "apply_naming_convention": true }` read back yields a valid current `SpecImportOptions` with the removed `legacy_flatten` key dropped.

## Risk / notes
- Pure additive change confined to the Python REST service; no DB migration (the `spec_schema_version` column already exists from `RAR-1.1`). Current envelope version stays `1`.
- The 18 unrelated failures in the rest test suite (merge/publish/version APIs) are pre-existing on `main` and not touched here.

Closes #3515

Work performed by Claude Code via model claude-opus-4-8[1m]