### PR TITLE
Fix #3516 - REST: read stored import spec (RAR-1.5)

### DIFF
--- a/docs/ROADMAP_REPOSITORY_AUTOREFRESH.md
+++ b/docs/ROADMAP_REPOSITORY_AUTOREFRESH.md
@@ -119,7 +119,7 @@ epic. Use this table to resolve any `RAR-*` reference below to its issue number.
 | RAR-EPIC-1 | #3506 | RAR-EPIC-2 | #3507 | RAR-EPIC-3 | #3508 |
 | RAR-EPIC-4 | #3509 | RAR-EPIC-5 | #3510 | RAR-EPIC-6 | #3511 |
 | ~~RAR-1.1~~ ✅ | ~~#3512~~ | ~~RAR-1.2~~ ✅ | ~~#3513~~ | ~~RAR-1.3~~ ✅ | ~~#3514~~ |
-| ~~RAR-1.4~~ ✅ | ~~#3515~~ | RAR-1.5 | #3516 | RAR-1.6 | #3517 |
+| ~~RAR-1.4~~ ✅ | ~~#3515~~ | ~~RAR-1.5~~ ✅ | ~~#3516~~ | RAR-1.6 | #3517 |
 | RAR-2.1 | #3518 | RAR-2.2 | #3519 | RAR-2.3 | #3520 |
 | RAR-2.4 | #3521 | RAR-3.1 | #3522 | RAR-3.2 | #3523 |
 | RAR-3.3 | #3524 | RAR-3.4 | #3525 | RAR-3.5 | #3526 |
@@ -142,7 +142,7 @@ Persist exactly what the user asked for at import time so it can be replayed.
 | ~~RAR-1.2~~ ✅ **Done** (#3513) | Persist `SpecImportOptions` at import time | Write the options blob on every successful import (manual + auto) | `enhancement`,`mvp`,`import`,`repository`,`rest` | N | Y | M | objectified-rest, objectified-ui |
 | ~~RAR-1.3~~ ✅ **Done** (#3514) | Capture source descriptor | Store kind, filename, `--format` override, content-type used | `enhancement`,`mvp`,`import`,`repository` | Y | Y | S | objectified-ui |
 | ~~RAR-1.4~~ ✅ **Done** (#3515) | Versioned spec envelope (`spec_schema_version`) | Forward-compatible envelope so stored specs survive option changes | `enhancement`,`mvp`,`import`,`data-model` | Y | Y | S | objectified-rest |
-| RAR-1.5 | REST: read stored import spec | `GET …/repository-imports/{id}/spec` returns the captured spec | `enhancement`,`mvp`,`import`,`rest` | Y | Y | S | objectified-rest |
+| ~~RAR-1.5~~ ✅ **Done** (#3516) | REST: read stored import spec | `GET …/repository-imports/{id}/spec` returns the captured spec | `enhancement`,`mvp`,`import`,`rest` | Y | Y | S | objectified-rest |
 | RAR-1.6 | Backfill best-effort specs for historical imports | Migration seeds a default spec for pre-existing imports | `enhancement`,`import`,`repository`,`data-model` | Y | N | M | objectified-db, objectified-rest |
 
 ### RAR-1.1 — `repository_import_spec` data model
@@ -227,6 +227,16 @@ importer kind and the filename is the `path` lineage key, both already captured.
 the pure, reusable `lib/repository-import-source-descriptor.ts` so the RAR-4.1 refresh worker can reuse
 it; unit tests pin the format/content-type mapping and a wiring test asserts the descriptor reaches the
 capture call.
+
+**Status of 1.5: ✅ Done (#3516).** `GET /v1/tenants/{tenant_slug}/repository-imports/{id}/spec`
+returns the captured spec as `{ spec_schema_version, source_kind, format_override, content_type,
+options }`, upgraded on read to the current envelope shape (RAR-1.4) so `options` and
+`spec_schema_version` always reflect the current `SpecImportOptions`. The `?path=` variant
+reinterprets `{id}` as the repository id and resolves the latest spec for that repository / `branch`
+/ `path` (branch optional → most recently updated across branches). Both modes are tenant-scoped from
+the auth token (404 cross-tenant); backed by `Database.get_repository_import_spec_by_id` /
+`get_repository_import_spec_by_path`. The refresh worker (RAR-3.2/4.1), the Specs tab (RAR-5.1), and
+the CLI consume it. The OpenAPI contract is regenerated.
 
 ---
 

--- a/objectified-rest/openapi.json
+++ b/objectified-rest/openapi.json
@@ -2394,6 +2394,85 @@
         }
       }
     },
+    "/v1/projects/domains": {
+      "get": {
+        "tags": [
+          "projects"
+        ],
+        "summary": "List Project Domain Categories Global",
+        "description": "Allowlist of ``domainCategory`` ids for project metadata.\n\nPublic read (CLI prefetch uses no credentials). Register before ``/{tenant_slug}`` so\n``/v1/projects/domains`` is not captured as a tenant slug.",
+        "operationId": "list_project_domain_categories_global_v1_projects_domains_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "type": "object",
+                  "title": "Response List Project Domain Categories Global V1 Projects Domains Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/projects/{tenant_slug}/domains": {
+      "get": {
+        "tags": [
+          "projects"
+        ],
+        "summary": "List Project Domain Categories For Tenant",
+        "description": "Same allowlist under the tenant-scoped URL shape expected by the CLI.\n\nMust be registered before ``/{tenant_slug}/{project_id}`` so the final segment\n``domains`` is not interpreted as a project UUID.",
+        "operationId": "list_project_domain_categories_for_tenant_v1_projects__tenant_slug__domains_get",
+        "parameters": [
+          {
+            "name": "tenant_slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Tenant Slug"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "title": "Response List Project Domain Categories For Tenant V1 Projects  Tenant Slug  Domains Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/projects/{tenant_slug}": {
       "get": {
         "tags": [
@@ -12289,6 +12368,79 @@
       }
     },
     "/v1/tenants/{tenant_slug}/imports": {
+      "get": {
+        "tags": [
+          "spec-import"
+        ],
+        "summary": "List specification import jobs",
+        "description": "Jobs tracked in this API process for the tenant (in-memory). After restart the list is empty; use GET \u2026/imports/{job_id} for full event history.",
+        "operationId": "list_spec_import_jobs_v1_tenants__tenant_slug__imports_get",
+        "parameters": [
+          {
+            "name": "tenant_slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Tenant Slug"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "name": "X-API-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SpecImportJobListResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
       "post": {
         "tags": [
           "spec-import"
@@ -12356,21 +12508,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/SpecImportJobAccepted"
-                }
-              }
-            }
-          },
-          "501": {
-            "description": "Not Implemented \u2014 backend importer is not yet available.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "detail": {
-                      "type": "string"
-                    }
-                  }
                 }
               }
             }
@@ -12460,21 +12597,6 @@
               }
             }
           },
-          "501": {
-            "description": "Not Implemented \u2014 backend importer is not yet available.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "detail": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
-          },
           "422": {
             "description": "Validation Error",
             "content": {
@@ -12558,21 +12680,6 @@
               }
             }
           },
-          "501": {
-            "description": "Not Implemented \u2014 backend importer is not yet available.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "detail": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
-          },
           "422": {
             "description": "Validation Error",
             "content": {
@@ -12646,21 +12753,6 @@
         "responses": {
           "204": {
             "description": "Successful Response"
-          },
-          "501": {
-            "description": "Not Implemented \u2014 backend importer is not yet available.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "detail": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
           },
           "422": {
             "description": "Validation Error",
@@ -12745,21 +12837,6 @@
               }
             }
           },
-          "501": {
-            "description": "Not Implemented \u2014 backend importer is not yet available.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "detail": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
-          },
           "422": {
             "description": "Validation Error",
             "content": {
@@ -12839,21 +12916,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/SpecImportRollbackResponse"
-                }
-              }
-            }
-          },
-          "501": {
-            "description": "Not Implemented \u2014 backend importer is not yet available.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "detail": {
-                      "type": "string"
-                    }
-                  }
                 }
               }
             }
@@ -13489,6 +13551,123 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/TenantRepositoryFileContentResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/tenants/{tenant_slug}/repository-imports/{import_id}/spec": {
+      "get": {
+        "tags": [
+          "tenant-repositories"
+        ],
+        "summary": "Read Repository Import Spec",
+        "description": "Read the stored import spec for an imported repository file (RAR-1.5).\n\nTwo lookup modes share this route, mirroring the ticket's\n``GET \u2026/repository-imports/{id}/spec`` plus ``?path=`` variant:\n\n- **By import id (default).** ``import_id`` is the\n  ``odb.repository_import_spec`` row id; the spec for that file lineage is\n  returned. This is the \"read the spec for a file/import id\" path.\n- **By path (``?path=`` present).** ``import_id`` is reinterpreted as the\n  *repository* id and the latest spec for that repository / ``branch`` /\n  ``path`` lineage is resolved. ``branch`` is optional: when omitted the most\n  recently updated spec across branches for that path is returned.\n\nIn both modes the lookup is scoped to the caller's tenant (from the auth\ntoken), so a spec belonging to another tenant returns 404 rather than\nleaking. The returned ``options`` blob is upgraded on read to the current\nenvelope shape (RAR-1.4), and ``spec_schema_version`` reports that current\nversion.\n\nArgs:\n    tenant_slug: Tenant slug from the path (scoping comes from the token).\n    import_id: Import-spec row id, or repository id when ``path`` is given.\n    auth_data: Authenticated principal; supplies the tenant scope.\n    path: Repository-relative file path for the ``?path=`` lookup variant.\n    branch: Optional branch filter for the ``?path=`` lookup variant.\n\nReturns:\n    The current-shape import spec for the resolved file.\n\nRaises:\n    HTTPException: 404 when no spec exists for the id/path within the tenant.",
+        "operationId": "read_repository_import_spec_v1_tenants__tenant_slug__repository_imports__import_id__spec_get",
+        "parameters": [
+          {
+            "name": "tenant_slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Tenant Slug"
+            }
+          },
+          {
+            "name": "import_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Import Id"
+            }
+          },
+          {
+            "name": "path",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Path"
+            }
+          },
+          {
+            "name": "branch",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Branch"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "name": "X-API-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RepositoryImportSpecRead"
                 }
               }
             }
@@ -14232,7 +14411,7 @@
         "properties": {
           "file": {
             "type": "string",
-            "contentMediaType": "application/octet-stream",
+            "format": "binary",
             "title": "File",
             "description": "Raw specification file bytes."
           },
@@ -16727,6 +16906,56 @@
         "title": "PushWebhookSubscriptionUpdateRequest",
         "description": "Update URL, active flag, and/or rotate signing secret (#2587)."
       },
+      "RepositoryImportSpecRead": {
+        "properties": {
+          "spec_schema_version": {
+            "type": "integer",
+            "title": "Spec Schema Version",
+            "description": "Current envelope version the returned options conform to.",
+            "default": 1
+          },
+          "source_kind": {
+            "type": "string",
+            "title": "Source Kind",
+            "description": "Importer discriminator (for example openapi-3, arazzo)."
+          },
+          "format_override": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Format Override",
+            "description": "Explicit format override (the importer --format flag), when the user forced one."
+          },
+          "content_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Content Type",
+            "description": "MIME type used to read the file (for example application/yaml), when known."
+          },
+          "options": {
+            "$ref": "#/components/schemas/SpecImportOptions",
+            "description": "Full SpecImportOptions payload, upgraded to the current shape."
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "source_kind"
+        ],
+        "title": "RepositoryImportSpecRead",
+        "description": "Current-shape import spec returned by the read endpoint (RAR-1.5).\n\nThe response surface for ``GET \u2026/repository-imports/{id}/spec`` (and its\n``?path=`` lookup variant). It exposes the captured source descriptor and the\nfull ``SpecImportOptions`` payload, upgraded on read to the current envelope\nshape, so the refresh worker, the UI status surface, and the CLI can replay\nthe user's original import request. ``spec_schema_version`` always reports the\ncurrent envelope version because ``options`` has already been migrated forward."
+      },
       "RequestBodyContentTypeRequest": {
         "properties": {
           "media_type": {
@@ -17376,7 +17605,6 @@
             "title": "Version Record Id"
           }
         },
-        "additionalProperties": false,
         "type": "object",
         "required": [
           "job_id",
@@ -17452,7 +17680,6 @@
             "description": "Relative URL path for GET \u2026/imports/{job_id} until the job reaches a terminal state."
           }
         },
-        "additionalProperties": false,
         "type": "object",
         "required": [
           "job_id",
@@ -17460,6 +17687,87 @@
         ],
         "title": "SpecImportJobAccepted",
         "description": "Returned when a job is accepted (HTTP 202)."
+      },
+      "SpecImportJobListItem": {
+        "properties": {
+          "job_id": {
+            "type": "string",
+            "title": "Job Id"
+          },
+          "state": {
+            "type": "string",
+            "enum": [
+              "queued",
+              "running",
+              "pending-approval",
+              "committing",
+              "completed",
+              "failed",
+              "canceled",
+              "rolled-back"
+            ],
+            "title": "State"
+          },
+          "percent": {
+            "type": "integer",
+            "maximum": 100.0,
+            "minimum": 0.0,
+            "title": "Percent",
+            "default": 0
+          },
+          "status_path": {
+            "type": "string",
+            "title": "Status Path",
+            "description": "Relative URL for GET \u2026/imports/{job_id}."
+          },
+          "progress": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SpecImportProgress"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "result": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SpecImportJobResult"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "job_id",
+          "state",
+          "status_path"
+        ],
+        "title": "SpecImportJobListItem",
+        "description": "Summary row for GET \u2026/imports (no full event log)."
+      },
+      "SpecImportJobListResponse": {
+        "properties": {
+          "jobs": {
+            "items": {
+              "$ref": "#/components/schemas/SpecImportJobListItem"
+            },
+            "type": "array",
+            "title": "Jobs"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "jobs"
+        ],
+        "title": "SpecImportJobListResponse",
+        "description": "Tenant-scoped import jobs visible to this API process."
       },
       "SpecImportJobResult": {
         "properties": {
@@ -17580,7 +17888,6 @@
             ]
           }
         },
-        "additionalProperties": false,
         "type": "object",
         "required": [
           "job_id",
@@ -17657,6 +17964,12 @@
           "create_relationships": {
             "type": "boolean",
             "title": "Create Relationships",
+            "default": false
+          },
+          "skip_duplicate_versions": {
+            "type": "boolean",
+            "title": "Skip Duplicate Versions",
+            "description": "When true, if the target catalog version line already exists in the project, complete successfully without re-importing (idempotent no-op).",
             "default": false
           }
         },
@@ -17777,7 +18090,6 @@
             "title": "Version Record Id"
           }
         },
-        "additionalProperties": false,
         "type": "object",
         "required": [
           "job_id"
@@ -18704,13 +19016,6 @@
           "type": {
             "type": "string",
             "title": "Error Type"
-          },
-          "input": {
-            "title": "Input"
-          },
-          "ctx": {
-            "type": "object",
-            "title": "Context"
           }
         },
         "type": "object",

--- a/objectified-rest/openapi.yaml
+++ b/objectified-rest/openapi.yaml
@@ -1513,6 +1513,71 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /v1/projects/domains:
+    get:
+      tags:
+      - projects
+      summary: List Project Domain Categories Global
+      description: 'Allowlist of ``domainCategory`` ids for project metadata.
+
+
+        Public read (CLI prefetch uses no credentials). Register before ``/{tenant_slug}``
+        so
+
+        ``/v1/projects/domains`` is not captured as a tenant slug.'
+      operationId: list_project_domain_categories_global_v1_projects_domains_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                additionalProperties:
+                  items:
+                    type: string
+                  type: array
+                type: object
+                title: Response List Project Domain Categories Global V1 Projects
+                  Domains Get
+  /v1/projects/{tenant_slug}/domains:
+    get:
+      tags:
+      - projects
+      summary: List Project Domain Categories For Tenant
+      description: 'Same allowlist under the tenant-scoped URL shape expected by the
+        CLI.
+
+
+        Must be registered before ``/{tenant_slug}/{project_id}`` so the final segment
+
+        ``domains`` is not interpreted as a project UUID.'
+      operationId: list_project_domain_categories_for_tenant_v1_projects__tenant_slug__domains_get
+      parameters:
+      - name: tenant_slug
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Tenant Slug
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: array
+                  items:
+                    type: string
+                title: Response List Project Domain Categories For Tenant V1 Projects  Tenant
+                  Slug  Domains Get
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /v1/projects/{tenant_slug}:
     get:
       tags:
@@ -7757,8 +7822,8 @@ paths:
       tags:
       - spec-import
       summary: List specification import jobs
-      description: Returns import jobs for this tenant held in this API process (in-memory;
-        restart clears the list). Use GET …/imports/{job_id} for full events.
+      description: Jobs tracked in this API process for the tenant (in-memory). After
+        restart the list is empty; use GET …/imports/{job_id} for full event history.
       operationId: list_spec_import_jobs_v1_tenants__tenant_slug__imports_get
       parameters:
       - name: tenant_slug
@@ -7839,15 +7904,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SpecImportJobAccepted'
-        '501':
-          description: Not Implemented — backend importer is not yet available.
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  detail:
-                    type: string
         '422':
           description: Validation Error
           content:
@@ -7900,15 +7956,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SpecImportJobAccepted'
-        '501':
-          description: Not Implemented — backend importer is not yet available.
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  detail:
-                    type: string
         '422':
           description: Validation Error
           content:
@@ -7957,15 +8004,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SpecImportJobStatus'
-        '501':
-          description: Not Implemented — backend importer is not yet available.
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  detail:
-                    type: string
         '422':
           description: Validation Error
           content:
@@ -8009,15 +8047,6 @@ paths:
       responses:
         '204':
           description: Successful Response
-        '501':
-          description: Not Implemented — backend importer is not yet available.
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  detail:
-                    type: string
         '422':
           description: Validation Error
           content:
@@ -8066,15 +8095,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SpecImportCommitResponse'
-        '501':
-          description: Not Implemented — backend importer is not yet available.
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  detail:
-                    type: string
         '422':
           description: Validation Error
           content:
@@ -8123,15 +8143,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SpecImportRollbackResponse'
-        '501':
-          description: Not Implemented — backend importer is not yet available.
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  detail:
-                    type: string
         '422':
           description: Validation Error
           content:
@@ -8504,6 +8515,91 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/TenantRepositoryFileContentResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /v1/tenants/{tenant_slug}/repository-imports/{import_id}/spec:
+    get:
+      tags:
+      - tenant-repositories
+      summary: Read Repository Import Spec
+      description: "Read the stored import spec for an imported repository file (RAR-1.5).\n\
+        \nTwo lookup modes share this route, mirroring the ticket's\n``GET …/repository-imports/{id}/spec``\
+        \ plus ``?path=`` variant:\n\n- **By import id (default).** ``import_id``\
+        \ is the\n  ``odb.repository_import_spec`` row id; the spec for that file\
+        \ lineage is\n  returned. This is the \"read the spec for a file/import id\"\
+        \ path.\n- **By path (``?path=`` present).** ``import_id`` is reinterpreted\
+        \ as the\n  *repository* id and the latest spec for that repository / ``branch``\
+        \ /\n  ``path`` lineage is resolved. ``branch`` is optional: when omitted\
+        \ the most\n  recently updated spec across branches for that path is returned.\n\
+        \nIn both modes the lookup is scoped to the caller's tenant (from the auth\n\
+        token), so a spec belonging to another tenant returns 404 rather than\nleaking.\
+        \ The returned ``options`` blob is upgraded on read to the current\nenvelope\
+        \ shape (RAR-1.4), and ``spec_schema_version`` reports that current\nversion.\n\
+        \nArgs:\n    tenant_slug: Tenant slug from the path (scoping comes from the\
+        \ token).\n    import_id: Import-spec row id, or repository id when ``path``\
+        \ is given.\n    auth_data: Authenticated principal; supplies the tenant scope.\n\
+        \    path: Repository-relative file path for the ``?path=`` lookup variant.\n\
+        \    branch: Optional branch filter for the ``?path=`` lookup variant.\n\n\
+        Returns:\n    The current-shape import spec for the resolved file.\n\nRaises:\n\
+        \    HTTPException: 404 when no spec exists for the id/path within the tenant."
+      operationId: read_repository_import_spec_v1_tenants__tenant_slug__repository_imports__import_id__spec_get
+      parameters:
+      - name: tenant_slug
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Tenant Slug
+      - name: import_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Import Id
+      - name: path
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Path
+      - name: branch
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Branch
+      - name: authorization
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Authorization
+      - name: X-API-Key
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Api-Key
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RepositoryImportSpecRead'
         '422':
           description: Validation Error
           content:
@@ -8987,7 +9083,7 @@ components:
       properties:
         file:
           type: string
-          contentMediaType: application/octet-stream
+          format: binary
           title: File
           description: Raw specification file bytes.
         metadata:
@@ -10541,6 +10637,55 @@ components:
       type: object
       title: PushWebhookSubscriptionUpdateRequest
       description: Update URL, active flag, and/or rotate signing secret (#2587).
+    RepositoryImportSpecRead:
+      properties:
+        spec_schema_version:
+          type: integer
+          title: Spec Schema Version
+          description: Current envelope version the returned options conform to.
+          default: 1
+        source_kind:
+          type: string
+          title: Source Kind
+          description: Importer discriminator (for example openapi-3, arazzo).
+        format_override:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Format Override
+          description: Explicit format override (the importer --format flag), when
+            the user forced one.
+        content_type:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Content Type
+          description: MIME type used to read the file (for example application/yaml),
+            when known.
+        options:
+          $ref: '#/components/schemas/SpecImportOptions'
+          description: Full SpecImportOptions payload, upgraded to the current shape.
+      additionalProperties: false
+      type: object
+      required:
+      - source_kind
+      title: RepositoryImportSpecRead
+      description: 'Current-shape import spec returned by the read endpoint (RAR-1.5).
+
+
+        The response surface for ``GET …/repository-imports/{id}/spec`` (and its
+
+        ``?path=`` lookup variant). It exposes the captured source descriptor and
+        the
+
+        full ``SpecImportOptions`` payload, upgraded on read to the current envelope
+
+        shape, so the refresh worker, the UI status surface, and the CLI can replay
+
+        the user''s original import request. ``spec_schema_version`` always reports
+        the
+
+        current envelope version because ``options`` has already been migrated forward.'
     RequestBodyContentTypeRequest:
       properties:
         media_type:
@@ -10922,7 +11067,6 @@ components:
         version_record_id:
           type: string
           title: Version Record Id
-      additionalProperties: false
       type: object
       required:
       - job_id
@@ -10979,13 +11123,68 @@ components:
           title: Status Path
           description: Relative URL path for GET …/imports/{job_id} until the job
             reaches a terminal state.
-      additionalProperties: false
       type: object
       required:
       - job_id
       - status_path
       title: SpecImportJobAccepted
       description: Returned when a job is accepted (HTTP 202).
+    SpecImportJobListItem:
+      properties:
+        job_id:
+          type: string
+          title: Job Id
+        state:
+          type: string
+          enum:
+          - queued
+          - running
+          - pending-approval
+          - committing
+          - completed
+          - failed
+          - canceled
+          - rolled-back
+          title: State
+        percent:
+          type: integer
+          maximum: 100.0
+          minimum: 0.0
+          title: Percent
+          default: 0
+        status_path:
+          type: string
+          title: Status Path
+          description: Relative URL for GET …/imports/{job_id}.
+        progress:
+          anyOf:
+          - $ref: '#/components/schemas/SpecImportProgress'
+          - type: 'null'
+        result:
+          anyOf:
+          - $ref: '#/components/schemas/SpecImportJobResult'
+          - type: 'null'
+      additionalProperties: false
+      type: object
+      required:
+      - job_id
+      - state
+      - status_path
+      title: SpecImportJobListItem
+      description: Summary row for GET …/imports (no full event log).
+    SpecImportJobListResponse:
+      properties:
+        jobs:
+          items:
+            $ref: '#/components/schemas/SpecImportJobListItem'
+          type: array
+          title: Jobs
+      additionalProperties: false
+      type: object
+      required:
+      - jobs
+      title: SpecImportJobListResponse
+      description: Tenant-scoped import jobs visible to this API process.
     SpecImportJobResult:
       properties:
         project_id:
@@ -11054,69 +11253,12 @@ components:
           anyOf:
           - $ref: '#/components/schemas/SpecImportJobResult'
           - type: 'null'
-      additionalProperties: false
       type: object
       required:
       - job_id
       - state
       title: SpecImportJobStatus
       description: Poll payload for an import job.
-    SpecImportJobListItem:
-      properties:
-        job_id:
-          type: string
-          title: Job Id
-        state:
-          type: string
-          enum:
-          - queued
-          - running
-          - pending-approval
-          - committing
-          - completed
-          - failed
-          - canceled
-          - rolled-back
-          title: State
-        percent:
-          type: integer
-          maximum: 100.0
-          minimum: 0.0
-          title: Percent
-          default: 0
-        status_path:
-          type: string
-          title: Status Path
-        progress:
-          anyOf:
-          - $ref: '#/components/schemas/SpecImportProgress'
-          - type: 'null'
-        result:
-          anyOf:
-          - $ref: '#/components/schemas/SpecImportJobResult'
-          - type: 'null'
-      additionalProperties: false
-      type: object
-      required:
-      - job_id
-      - state
-      - percent
-      - status_path
-      title: SpecImportJobListItem
-      description: Summary row for GET …/imports (no full event log).
-    SpecImportJobListResponse:
-      properties:
-        jobs:
-          items:
-            $ref: '#/components/schemas/SpecImportJobListItem'
-          type: array
-          title: Jobs
-      additionalProperties: false
-      type: object
-      required:
-      - jobs
-      title: SpecImportJobListResponse
-      description: Wrapper for tenant-scoped import job listing.
     SpecImportOptions:
       properties:
         selected_schemas:
@@ -11169,7 +11311,9 @@ components:
         skip_duplicate_versions:
           type: boolean
           title: Skip Duplicate Versions
-          description: When true, if the target catalog version line already exists in the project, complete successfully without re-importing (idempotent no-op).
+          description: When true, if the target catalog version line already exists
+            in the project, complete successfully without re-importing (idempotent
+            no-op).
           default: false
       additionalProperties: false
       type: object
@@ -11248,7 +11392,6 @@ components:
           - type: string
           - type: 'null'
           title: Version Record Id
-      additionalProperties: false
       type: object
       required:
       - job_id
@@ -11836,11 +11979,6 @@ components:
         type:
           type: string
           title: Error Type
-        input:
-          title: Input
-        ctx:
-          type: object
-          title: Context
       type: object
       required:
       - loc

--- a/objectified-rest/pyproject.toml
+++ b/objectified-rest/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "objectified-rest"
-version = "1.0.62"
+version = "1.0.63"
 description = "REST API for serving OpenAPI specifications from the Objectified database"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/objectified-rest/src/app/database.py
+++ b/objectified-rest/src/app/database.py
@@ -6998,6 +6998,79 @@ class Database:
             return None
         return load_repository_import_options(row).model_dump()
 
+    def get_repository_import_spec_by_id(
+        self, tenant_id: str, spec_id: str
+    ) -> Optional[Dict[str, Any]]:
+        """Return one persisted import spec by its row id, scoped to a tenant (RAR-1.5).
+
+        Backs the ``GET …/repository-imports/{id}/spec`` read endpoint. The
+        ``tenant_id`` predicate enforces tenant isolation: a spec belonging to
+        another tenant resolves to ``None`` (a 404 at the route) rather than
+        leaking across tenants.
+
+        Args:
+            tenant_id: Owning tenant id (scopes the lookup).
+            spec_id: ``odb.repository_import_spec`` row id.
+
+        Returns:
+            The stored row as a dict, or None when no spec matches in the tenant.
+        """
+        query = """
+            SELECT id, tenant_id, repository_id, branch, path, project_id,
+                   source_kind, format_override, content_type,
+                   options_json, spec_schema_version, created_by,
+                   created_at, updated_at
+            FROM odb.repository_import_spec
+            WHERE tenant_id = %s::uuid
+              AND id = %s::uuid
+        """
+        results = self.execute_query(query, (tenant_id, spec_id))
+        return results[0] if results else None
+
+    def get_repository_import_spec_by_path(
+        self,
+        tenant_id: str,
+        repository_id: str,
+        path: str,
+        branch: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """Return the latest persisted import spec for a repository file path (RAR-1.5).
+
+        Backs the ``?path=`` lookup variant of the read endpoint. The table keeps
+        exactly one row per ``(repository_id, branch, path)`` lineage; when
+        ``branch`` is given the lookup is exact, and when it is omitted the most
+        recently updated row across branches for that ``(repository_id, path)`` is
+        returned. The ``tenant_id`` predicate scopes the lookup so a path under
+        another tenant's repository resolves to ``None``.
+
+        Args:
+            tenant_id: Owning tenant id (scopes the lookup).
+            repository_id: Source repository id.
+            path: Repository-relative file path (lineage key).
+            branch: Branch to match exactly; when None, the latest across branches.
+
+        Returns:
+            The stored row as a dict, or None when no spec matches.
+        """
+        select = """
+            SELECT id, tenant_id, repository_id, branch, path, project_id,
+                   source_kind, format_override, content_type,
+                   options_json, spec_schema_version, created_by,
+                   created_at, updated_at
+            FROM odb.repository_import_spec
+            WHERE tenant_id = %s::uuid
+              AND repository_id = %s::uuid
+              AND path = %s
+        """
+        if branch is not None:
+            query = select + "  AND branch = %s\n            ORDER BY updated_at DESC\n            LIMIT 1"
+            params: tuple = (tenant_id, repository_id, path, branch)
+        else:
+            query = select + "            ORDER BY updated_at DESC\n            LIMIT 1"
+            params = (tenant_id, repository_id, path)
+        results = self.execute_query(query, params)
+        return results[0] if results else None
+
     def get_public_browse_directory_stats(self) -> Dict[str, int]:
         """Counts for tenants/projects/versions with published public revisions (browse directory)."""
         query = """

--- a/objectified-rest/src/app/models.py
+++ b/objectified-rest/src/app/models.py
@@ -411,6 +411,67 @@ def load_repository_import_options(
     return SpecImportOptions.model_validate(migrated)
 
 
+class RepositoryImportSpecRead(BaseModel):
+    """Current-shape import spec returned by the read endpoint (RAR-1.5).
+
+    The response surface for ``GET …/repository-imports/{id}/spec`` (and its
+    ``?path=`` lookup variant). It exposes the captured source descriptor and the
+    full ``SpecImportOptions`` payload, upgraded on read to the current envelope
+    shape, so the refresh worker, the UI status surface, and the CLI can replay
+    the user's original import request. ``spec_schema_version`` always reports the
+    current envelope version because ``options`` has already been migrated forward.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    spec_schema_version: int = Field(
+        default=REPOSITORY_IMPORT_SPEC_SCHEMA_VERSION,
+        description="Current envelope version the returned options conform to.",
+    )
+    source_kind: str = Field(
+        description="Importer discriminator (for example openapi-3, arazzo).",
+    )
+    format_override: Optional[str] = Field(
+        default=None,
+        description="Explicit format override (the importer --format flag), when the user forced one.",
+    )
+    content_type: Optional[str] = Field(
+        default=None,
+        description="MIME type used to read the file (for example application/yaml), when known.",
+    )
+    options: SpecImportOptions = Field(
+        default_factory=SpecImportOptions,
+        description="Full SpecImportOptions payload, upgraded to the current shape.",
+    )
+
+
+def repository_import_spec_read_from_row(
+    row: Optional[Dict[str, Any]],
+) -> RepositoryImportSpecRead:
+    """Build a :class:`RepositoryImportSpecRead` from a stored spec row.
+
+    Reuses :func:`load_repository_import_options` to migrate the persisted
+    ``options_json`` blob forward, then surfaces the source descriptor columns
+    verbatim. ``spec_schema_version`` is reported as the current envelope version
+    because the options have been upgraded on read.
+
+    Args:
+        row: A ``odb.repository_import_spec`` row as a dict.
+
+    Returns:
+        The current-shape read model for the endpoint response.
+    """
+    options = load_repository_import_options(row)
+    row = row or {}
+    return RepositoryImportSpecRead(
+        spec_schema_version=REPOSITORY_IMPORT_SPEC_SCHEMA_VERSION,
+        source_kind=str(row.get("source_kind") or ""),
+        format_override=row.get("format_override"),
+        content_type=row.get("content_type"),
+        options=options,
+    )
+
+
 class SpecImportStartMetadata(BaseModel):
     """Shared metadata for JSON-base64 and multipart upload flows."""
 

--- a/objectified-rest/src/app/tenant_repositories_routes.py
+++ b/objectified-rest/src/app/tenant_repositories_routes.py
@@ -19,6 +19,8 @@ from psycopg2 import errors as pg_errors
 from .auth import get_authenticated_user_id, validate_authentication
 from .database import db
 from .models import (
+    RepositoryImportSpecRead,
+    repository_import_spec_read_from_row,
     TenantRepositoryCreate,
     TenantRepositoryCreateResponse,
     TenantRepositoryFileContentResponse,
@@ -406,6 +408,69 @@ async def get_tenant_repository_file_content(
         content=text,
         truncated=truncated,
     )
+
+
+@router.get(
+    "/{tenant_slug}/repository-imports/{import_id}/spec",
+    response_model=RepositoryImportSpecRead,
+)
+async def read_repository_import_spec(
+    tenant_slug: str,
+    import_id: uuid.UUID,
+    auth_data: Dict[str, Any] = Depends(validate_authentication),
+    path: Optional[str] = None,
+    branch: Optional[str] = None,
+) -> RepositoryImportSpecRead:
+    """Read the stored import spec for an imported repository file (RAR-1.5).
+
+    Two lookup modes share this route, mirroring the ticket's
+    ``GET …/repository-imports/{id}/spec`` plus ``?path=`` variant:
+
+    - **By import id (default).** ``import_id`` is the
+      ``odb.repository_import_spec`` row id; the spec for that file lineage is
+      returned. This is the "read the spec for a file/import id" path.
+    - **By path (``?path=`` present).** ``import_id`` is reinterpreted as the
+      *repository* id and the latest spec for that repository / ``branch`` /
+      ``path`` lineage is resolved. ``branch`` is optional: when omitted the most
+      recently updated spec across branches for that path is returned.
+
+    In both modes the lookup is scoped to the caller's tenant (from the auth
+    token), so a spec belonging to another tenant returns 404 rather than
+    leaking. The returned ``options`` blob is upgraded on read to the current
+    envelope shape (RAR-1.4), and ``spec_schema_version`` reports that current
+    version.
+
+    Args:
+        tenant_slug: Tenant slug from the path (scoping comes from the token).
+        import_id: Import-spec row id, or repository id when ``path`` is given.
+        auth_data: Authenticated principal; supplies the tenant scope.
+        path: Repository-relative file path for the ``?path=`` lookup variant.
+        branch: Optional branch filter for the ``?path=`` lookup variant.
+
+    Returns:
+        The current-shape import spec for the resolved file.
+
+    Raises:
+        HTTPException: 404 when no spec exists for the id/path within the tenant.
+    """
+    _ = tenant_slug
+    tenant_id = str(auth_data["tenant_id"])
+
+    if path is not None:
+        path_value = path.strip()
+        if not path_value:
+            raise HTTPException(status_code=400, detail="path must not be empty")
+        branch_value = branch.strip() if branch is not None else None
+        row = db.get_repository_import_spec_by_path(
+            tenant_id, str(import_id), path_value, branch_value or None
+        )
+    else:
+        row = db.get_repository_import_spec_by_id(tenant_id, str(import_id))
+
+    if not row:
+        raise HTTPException(status_code=404, detail="import spec not found")
+
+    return repository_import_spec_read_from_row(row)
 
 
 @router.post("/{tenant_slug}/repositories", response_model=TenantRepositoryCreateResponse)

--- a/objectified-rest/tests/test_repository_import_spec_read_api.py
+++ b/objectified-rest/tests/test_repository_import_spec_read_api.py
@@ -1,0 +1,185 @@
+"""Tests for GET /v1/tenants/{slug}/repository-imports/{id}/spec (RAR-1.5).
+
+Covers the by-id lookup, the ``?path=`` lookup variant, tenant-scoped 404s, and
+the upgrade-on-read of a legacy (unversioned) options blob.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.auth import validate_authentication
+from app.main import app
+from app.models import REPOSITORY_IMPORT_SPEC_SCHEMA_VERSION
+
+client = TestClient(app)
+
+_TENANT_ID = "550e8400-e29b-41d4-a716-446655440000"
+_USER_ID = "660e8400-e29b-41d4-a716-446655440001"
+_SPEC_ID = "990e8400-e29b-41d4-a716-446655440009"
+_REPO_ID = "880e8400-e29b-41d4-a716-446655440003"
+_PROJECT_ID = "770e8400-e29b-41d4-a716-446655440002"
+
+_API_KEY_AUTH = {
+    "tenant_id": _TENANT_ID,
+    "tenant_slug": "acme",
+    "auth_method": "api_key",
+}
+
+
+def _spec_row(**overrides):
+    """A stored ``odb.repository_import_spec`` row with current-shape options."""
+    row = {
+        "id": _SPEC_ID,
+        "tenant_id": _TENANT_ID,
+        "repository_id": _REPO_ID,
+        "branch": "main",
+        "path": "openapi/petstore.yaml",
+        "project_id": _PROJECT_ID,
+        "source_kind": "openapi-3",
+        "format_override": "swagger",
+        "content_type": "application/yaml",
+        "options_json": {
+            "apply_naming_convention": True,
+            "class_naming_convention": "PascalCase",
+            "skip_duplicate_versions": True,
+        },
+        "spec_schema_version": REPOSITORY_IMPORT_SPEC_SCHEMA_VERSION,
+        "created_by": _USER_ID,
+        "created_at": None,
+        "updated_at": None,
+    }
+    row.update(overrides)
+    return row
+
+
+@pytest.fixture(autouse=True)
+def _auth_api_key():
+    app.dependency_overrides[validate_authentication] = lambda: _API_KEY_AUTH
+    yield
+    app.dependency_overrides.pop(validate_authentication, None)
+
+
+def test_read_spec_by_id_ok():
+    with patch("app.tenant_repositories_routes.db") as mdb:
+        mdb.get_repository_import_spec_by_id.return_value = _spec_row()
+        r = client.get(f"/v1/tenants/acme/repository-imports/{_SPEC_ID}/spec")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["spec_schema_version"] == REPOSITORY_IMPORT_SPEC_SCHEMA_VERSION
+    assert body["source_kind"] == "openapi-3"
+    assert body["format_override"] == "swagger"
+    assert body["content_type"] == "application/yaml"
+    assert body["options"]["apply_naming_convention"] is True
+    assert body["options"]["class_naming_convention"] == "PascalCase"
+    assert body["options"]["skip_duplicate_versions"] is True
+    # Tenant scope comes from the auth token, not the path slug.
+    mdb.get_repository_import_spec_by_id.assert_called_once_with(_TENANT_ID, _SPEC_ID)
+    mdb.get_repository_import_spec_by_path.assert_not_called()
+
+
+def test_read_spec_by_id_not_found_returns_404():
+    with patch("app.tenant_repositories_routes.db") as mdb:
+        mdb.get_repository_import_spec_by_id.return_value = None
+        r = client.get(f"/v1/tenants/acme/repository-imports/{_SPEC_ID}/spec")
+    assert r.status_code == 404
+    assert r.json()["detail"] == "import spec not found"
+
+
+def test_read_spec_by_path_with_branch_ok():
+    with patch("app.tenant_repositories_routes.db") as mdb:
+        mdb.get_repository_import_spec_by_path.return_value = _spec_row()
+        r = client.get(
+            f"/v1/tenants/acme/repository-imports/{_REPO_ID}/spec",
+            params={"path": "openapi/petstore.yaml", "branch": "main"},
+        )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["source_kind"] == "openapi-3"
+    # ``import_id`` is reinterpreted as the repository id under ``?path=``.
+    mdb.get_repository_import_spec_by_path.assert_called_once_with(
+        _TENANT_ID, _REPO_ID, "openapi/petstore.yaml", "main"
+    )
+    mdb.get_repository_import_spec_by_id.assert_not_called()
+
+
+def test_read_spec_by_path_without_branch_resolves_latest():
+    with patch("app.tenant_repositories_routes.db") as mdb:
+        mdb.get_repository_import_spec_by_path.return_value = _spec_row()
+        r = client.get(
+            f"/v1/tenants/acme/repository-imports/{_REPO_ID}/spec",
+            params={"path": "openapi/petstore.yaml"},
+        )
+    assert r.status_code == 200
+    mdb.get_repository_import_spec_by_path.assert_called_once_with(
+        _TENANT_ID, _REPO_ID, "openapi/petstore.yaml", None
+    )
+
+
+def test_read_spec_by_path_not_found_returns_404():
+    with patch("app.tenant_repositories_routes.db") as mdb:
+        mdb.get_repository_import_spec_by_path.return_value = None
+        r = client.get(
+            f"/v1/tenants/acme/repository-imports/{_REPO_ID}/spec",
+            params={"path": "missing.yaml"},
+        )
+    assert r.status_code == 404
+
+
+def test_read_spec_empty_path_returns_400():
+    with patch("app.tenant_repositories_routes.db") as mdb:
+        r = client.get(
+            f"/v1/tenants/acme/repository-imports/{_REPO_ID}/spec",
+            params={"path": "   "},
+        )
+    assert r.status_code == 400
+    mdb.get_repository_import_spec_by_path.assert_not_called()
+    mdb.get_repository_import_spec_by_id.assert_not_called()
+
+
+def test_read_spec_blank_branch_treated_as_latest():
+    with patch("app.tenant_repositories_routes.db") as mdb:
+        mdb.get_repository_import_spec_by_path.return_value = _spec_row()
+        r = client.get(
+            f"/v1/tenants/acme/repository-imports/{_REPO_ID}/spec",
+            params={"path": "openapi/petstore.yaml", "branch": "  "},
+        )
+    assert r.status_code == 200
+    mdb.get_repository_import_spec_by_path.assert_called_once_with(
+        _TENANT_ID, _REPO_ID, "openapi/petstore.yaml", None
+    )
+
+
+def test_read_spec_upgrades_legacy_unversioned_options():
+    # A version-0 (unmarked) blob carrying a key the current model no longer
+    # recognizes must upgrade-on-read: the dropped key is gone and the response
+    # reports the current envelope version.
+    legacy = _spec_row(
+        spec_schema_version=None,
+        options_json={
+            "apply_naming_convention": True,
+            "legacy_dropped_flag": "x",
+        },
+    )
+    with patch("app.tenant_repositories_routes.db") as mdb:
+        mdb.get_repository_import_spec_by_id.return_value = legacy
+        r = client.get(f"/v1/tenants/acme/repository-imports/{_SPEC_ID}/spec")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["spec_schema_version"] == REPOSITORY_IMPORT_SPEC_SCHEMA_VERSION
+    assert body["options"]["apply_naming_convention"] is True
+    assert "legacy_dropped_flag" not in body["options"]
+
+
+def test_read_spec_null_descriptor_fields_serialize():
+    row = _spec_row(format_override=None, content_type=None, options_json={})
+    with patch("app.tenant_repositories_routes.db") as mdb:
+        mdb.get_repository_import_spec_by_id.return_value = row
+        r = client.get(f"/v1/tenants/acme/repository-imports/{_SPEC_ID}/spec")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["format_override"] is None
+    assert body["content_type"] is None
+    # Defaulted options round-trip.
+    assert body["options"]["apply_naming_convention"] is False

--- a/objectified-rest/uv.lock
+++ b/objectified-rest/uv.lock
@@ -514,7 +514,7 @@ wheels = [
 
 [[package]]
 name = "objectified-rest"
-version = "1.0.61"
+version = "1.0.63"
 source = { editable = "." }
 dependencies = [
     { name = "bcrypt" },


### PR DESCRIPTION
## What & why
RAR-1.5 exposes the persisted repository import spec over REST so the refresh worker (RAR-3.2/4.1), the Specs tab (RAR-5.1), and the CLI can replay a user's **original** import request instead of importer defaults.

New endpoint:

```
GET /v1/tenants/{tenant_slug}/repository-imports/{id}/spec
  → 200 { spec_schema_version, source_kind, format_override, content_type, options }
```

- **By import id (default):** `{id}` is the `odb.repository_import_spec` row id.
- **`?path=` variant:** `{id}` is reinterpreted as the **repository id** and the latest spec for that repository / `branch` / `path` lineage is resolved. `branch` is optional — when omitted, the most recently updated spec across branches for that path is returned.
- `options` is upgraded on read to the current envelope shape (RAR-1.4), and `spec_schema_version` reports that current version.
- Both modes are **tenant-scoped from the auth token** — a spec under another tenant returns 404, not a leak.

### Changes
- `tenant_repositories_routes.py`: new `read_repository_import_spec` route (both lookup modes, empty-path → 400).
- `database.py`: `get_repository_import_spec_by_id` and `get_repository_import_spec_by_path` DAO methods.
- `models.py`: `RepositoryImportSpecRead` response model + `repository_import_spec_read_from_row` (reuses `load_repository_import_options` for the upgrade-on-read).
- Regenerated `openapi.yaml`/`openapi.json` (also picks up prior un-regenerated drift; **0 endpoints removed**).
- Bumped `objectified-rest` to `1.0.63`; marked RAR-1.5 done in `docs/ROADMAP_REPOSITORY_AUTOREFRESH.md`.

## How to test
```
cd objectified-rest
PYTHONPATH=src uv run pytest tests/test_repository_import_spec_read_api.py -v
```
New tests cover: by-id 200, by-id 404, `?path=` with/without branch, path 404, empty path → 400, blank branch → latest, legacy unversioned options upgrade-on-read, and null descriptor serialization.

Manual: `GET /v1/tenants/<slug>/repository-imports/<spec_id>/spec` returns the captured spec; add `?path=openapi/petstore.yaml&branch=main` against a `<repository_id>` to use the path variant.

## Risk / notes
- Additive only (new route, new DAO methods, new model) — no existing behavior changed.
- The OpenAPI regeneration also brings in drift accumulated by prior tickets that didn't regenerate; verified no paths/operationIds were removed.
- Pre-existing test-suite collection errors (8 files importing `src.app`) and DB-seeded failures are unrelated to this change.

Closes #3516

Work performed by Claude Code via model Opus 4.8 (1M context)