### PR TITLE
Fix #3518 - Capture freshness signal at import (RAR-2.1)

### DIFF
--- a/docs/ROADMAP_REPOSITORY_AUTOREFRESH.md
+++ b/docs/ROADMAP_REPOSITORY_AUTOREFRESH.md
@@ -120,7 +120,7 @@ epic. Use this table to resolve any `RAR-*` reference below to its issue number.
 | RAR-EPIC-4 | #3509 | RAR-EPIC-5 | #3510 | RAR-EPIC-6 | #3511 |
 | ~~RAR-1.1~~ ✅ | ~~#3512~~ | ~~RAR-1.2~~ ✅ | ~~#3513~~ | ~~RAR-1.3~~ ✅ | ~~#3514~~ |
 | ~~RAR-1.4~~ ✅ | ~~#3515~~ | ~~RAR-1.5~~ ✅ | ~~#3516~~ | RAR-1.6 | #3517 |
-| RAR-2.1 | #3518 | RAR-2.2 | #3519 | RAR-2.3 | #3520 |
+| ~~RAR-2.1~~ ✅ | ~~#3518~~ | RAR-2.2 | #3519 | RAR-2.3 | #3520 |
 | RAR-2.4 | #3521 | RAR-3.1 | #3522 | RAR-3.2 | #3523 |
 | RAR-3.3 | #3524 | RAR-3.4 | #3525 | RAR-3.5 | #3526 |
 | RAR-4.1 | #3527 | RAR-4.2 | #3528 | RAR-4.3 | #3529 |
@@ -246,7 +246,7 @@ Re-import only files genuinely newer than what's already in the system.
 
 | ID | Title | Summary | Labels | Parallel | MVP | Cmplx | Modules |
 |----|-------|---------|--------|----------|-----|-------|---------|
-| RAR-2.1 | Capture freshness signal at import | Store source commit SHA + committed-at + blob_sha as `last_imported_*` | `enhancement`,`mvp`,`import`,`repository`,`data-model` | Y | Y | M | objectified-db, objectified-rest |
+| ~~RAR-2.1~~ ✅ **Done** (#3518) | Capture freshness signal at import | Store source commit SHA + committed-at + blob_sha as `last_imported_*` | `enhancement`,`mvp`,`import`,`repository`,`data-model` | Y | Y | M | objectified-db, objectified-rest |
 | RAR-2.2 | "Newer-than" comparator | Re-import only when remote commit is newer than last imported | `enhancement`,`mvp`,`import`,`repository` | N | Y | M | objectified-rest |
 | RAR-2.3 | Per-file refresh state machine | up-to-date / stale / refreshing / failed / diverged | `enhancement`,`mvp`,`import`,`repository` | Y | Y | M | objectified-rest, objectified-ui |
 | RAR-2.4 | Checksum idempotency guard | Suppress no-op refreshes when content unchanged despite newer commit | `enhancement`,`mvp`,`import` | Y | Y | S | objectified-rest |
@@ -260,6 +260,17 @@ wholesale DELETE/INSERT (`database.py replace_tenant_repository_files`) so per-f
 provider tree/commit API already used in `repository_file_scan.py`.
 **Acceptance criteria.** Every import records the three signals; exposed via RAR-1.5.
 **Dependencies.** Parallel with EPIC-1. **Parallel = Y.**
+
+**Status: ✅ Done (#3518).** Migration `objectified-db/scripts/20260621-130000.sql` adds the branch
+tip recency columns `commit_sha` / `committed_at` to `odb.tenant_repository_files` and the import
+anchor columns `last_imported_commit_sha` / `last_imported_committed_at` / `last_imported_blob_sha`
+to `odb.repository_import_spec`. The scan (`repository_file_scan.py`) captures the branch tip commit
+SHA + committed-at already returned by the provider branch API and stamps every indexed file row.
+Both spec-write sites — `database.py upsert_repository_import_spec` (Python) and
+`repository-import-metrics.ts upsertRepositoryImportSpec` (the live dashboard path) — copy the
+indexed row's `blob_sha` / `commit_sha` / `committed_at` into the `last_imported_*` anchors via a
+LEFT JOIN, so every import records the three signals. The RAR-1.5 read model
+(`RepositoryImportSpecRead`) surfaces them. Newer-than gating on these anchors is RAR-2.2.
 
 ### RAR-2.2 — "Newer-than" comparator
 

--- a/objectified-db/package.json
+++ b/objectified-db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-db",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Objectified database migrations and the direct-to-database admin CLI (objectified-db).",
   "author": "Objectified",
   "type": "module",

--- a/objectified-db/scripts/20260621-130000.sql
+++ b/objectified-db/scripts/20260621-130000.sql
@@ -1,0 +1,43 @@
+-- Freshness signal capture at import (RAR-2.1, #3518).
+--
+-- The system stored `blob_sha` but no comparable recency signal, and the scan
+-- does a wholesale DELETE/INSERT, so per-file recency was lost. Without a recency
+-- anchor there is nothing to compare "newer than" against (RAR-2.2).
+--
+-- Two changes:
+--   1. The scan now records the branch tip commit it observed (the commit SHA and
+--      its committed-at timestamp, already returned by the provider branch/tree API
+--      used in repository_file_scan.py) on every indexed file row.
+--   2. The import lineage (`odb.repository_import_spec`) now records the freshness
+--      signals captured at the moment of import — `last_imported_commit_sha`,
+--      `last_imported_committed_at`, `last_imported_blob_sha` — copied from the
+--      indexed file row when the spec is written. A later auto-refresh compares the
+--      repository's current state against these anchors to gate "newer-than"
+--      re-imports (RAR-2.2) and surfaces them via the RAR-1.5 read endpoint.
+SET search_path TO odb, public;
+
+-- 1. Scan-side recency: the branch tip commit observed for each indexed file.
+ALTER TABLE odb.tenant_repository_files
+  ADD COLUMN IF NOT EXISTS commit_sha VARCHAR(64),
+  ADD COLUMN IF NOT EXISTS committed_at TIMESTAMPTZ;
+
+COMMENT ON COLUMN odb.tenant_repository_files.commit_sha IS
+  'Branch tip commit SHA observed by the scan that indexed this file row (RAR-2.1).';
+
+COMMENT ON COLUMN odb.tenant_repository_files.committed_at IS
+  'Committed-at timestamp of the branch tip commit observed by the scan (RAR-2.1); the recency signal compared against the import anchor for newer-than gating (RAR-2.2).';
+
+-- 2. Import-anchor: freshness signals captured at import time on the file lineage.
+ALTER TABLE odb.repository_import_spec
+  ADD COLUMN IF NOT EXISTS last_imported_commit_sha VARCHAR(64),
+  ADD COLUMN IF NOT EXISTS last_imported_committed_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS last_imported_blob_sha VARCHAR(64);
+
+COMMENT ON COLUMN odb.repository_import_spec.last_imported_commit_sha IS
+  'Branch tip commit SHA observed for this file at the time of import (RAR-2.1).';
+
+COMMENT ON COLUMN odb.repository_import_spec.last_imported_committed_at IS
+  'Committed-at timestamp of the file at the time of import; the anchor a later auto-refresh compares the remote committed_at against to gate newer-than re-imports (RAR-2.1/RAR-2.2).';
+
+COMMENT ON COLUMN odb.repository_import_spec.last_imported_blob_sha IS
+  'Blob SHA of the file content at the time of import (RAR-2.1).';

--- a/objectified-rest/package.json
+++ b/objectified-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-rest",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "private": true,
   "description": "Trigger file for Objectified REST Docker publish workflow; app is Python (pyproject.toml).",
   "scripts": {

--- a/objectified-rest/pyproject.toml
+++ b/objectified-rest/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "objectified-rest"
-version = "1.0.63"
+version = "1.0.64"
 description = "REST API for serving OpenAPI specifications from the Objectified database"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/objectified-rest/src/app/database.py
+++ b/objectified-rest/src/app/database.py
@@ -6737,8 +6737,9 @@ class Database:
                     cursor.executemany(
                         """
                         INSERT INTO odb.tenant_repository_files (
-                            repository_id, branch, path, name, ext, size_bytes, blob_sha, detected_kind
-                        ) VALUES (%s::uuid, %s, %s, %s, %s, %s, %s, %s)
+                            repository_id, branch, path, name, ext, size_bytes, blob_sha,
+                            detected_kind, commit_sha, committed_at
+                        ) VALUES (%s::uuid, %s, %s, %s, %s, %s, %s, %s, %s, %s::timestamptz)
                         """,
                         [
                             (
@@ -6750,6 +6751,8 @@ class Database:
                                 f.get("size_bytes"),
                                 f.get("blob_sha"),
                                 f.get("detected_kind"),
+                                f.get("commit_sha"),
+                                f.get("committed_at"),
                             )
                             for f in files
                         ],
@@ -6872,6 +6875,13 @@ class Database:
         The insert is guarded by a subquery so a row is only written when the
         repository belongs to the given tenant.
 
+        Freshness signals (RAR-2.1) — ``last_imported_commit_sha``,
+        ``last_imported_committed_at``, ``last_imported_blob_sha`` — are copied from
+        the matching indexed ``tenant_repository_files`` row via a LEFT JOIN, so the
+        spec records the repository's observed recency for the file at import time.
+        When no scan row matches the lineage the anchors are stored as ``NULL`` and
+        the newer-than comparator (RAR-2.2) falls back to checksum-only gating.
+
         Args:
             tenant_id: Owning tenant id.
             repository_id: Source repository id (must belong to ``tenant_id``).
@@ -6897,12 +6907,16 @@ class Database:
             INSERT INTO odb.repository_import_spec (
                 tenant_id, repository_id, branch, path, project_id,
                 source_kind, format_override, content_type,
-                options_json, spec_schema_version, created_by
+                options_json, spec_schema_version, created_by,
+                last_imported_commit_sha, last_imported_committed_at, last_imported_blob_sha
             )
             SELECT %s::uuid, %s::uuid, %s, %s, %s::uuid,
                    %s, %s, %s,
-                   %s::jsonb, %s, %s::uuid
+                   %s::jsonb, %s, %s::uuid,
+                   trf.commit_sha, trf.committed_at, trf.blob_sha
             FROM odb.tenant_repositories tr
+            LEFT JOIN odb.tenant_repository_files trf
+                ON trf.repository_id = tr.id AND trf.branch = %s AND trf.path = %s
             WHERE tr.id = %s::uuid AND tr.tenant_id = %s::uuid AND tr.deleted_at IS NULL
             ON CONFLICT ON CONSTRAINT uq_repository_import_spec_repo_branch_path
             DO UPDATE SET
@@ -6914,16 +6928,21 @@ class Database:
                 options_json = EXCLUDED.options_json,
                 spec_schema_version = EXCLUDED.spec_schema_version,
                 created_by = EXCLUDED.created_by,
+                last_imported_commit_sha = EXCLUDED.last_imported_commit_sha,
+                last_imported_committed_at = EXCLUDED.last_imported_committed_at,
+                last_imported_blob_sha = EXCLUDED.last_imported_blob_sha,
                 updated_at = CURRENT_TIMESTAMP
             RETURNING id, tenant_id, repository_id, branch, path, project_id,
                       source_kind, format_override, content_type,
                       options_json, spec_schema_version, created_by,
-                      created_at, updated_at
+                      last_imported_commit_sha, last_imported_committed_at,
+                      last_imported_blob_sha, created_at, updated_at
         """
         params = (
             tenant_id, repository_id, branch, path, project_id,
             source_kind, format_override, content_type,
             json.dumps(options or {}), spec_schema_version, created_by,
+            branch, path,
             repository_id, tenant_id,
         )
         conn = self.connect()
@@ -6960,7 +6979,8 @@ class Database:
             SELECT id, tenant_id, repository_id, branch, path, project_id,
                    source_kind, format_override, content_type,
                    options_json, spec_schema_version, created_by,
-                   created_at, updated_at
+                   last_imported_commit_sha, last_imported_committed_at,
+                   last_imported_blob_sha, created_at, updated_at
             FROM odb.repository_import_spec
             WHERE tenant_id = %s::uuid
               AND repository_id = %s::uuid
@@ -7019,7 +7039,8 @@ class Database:
             SELECT id, tenant_id, repository_id, branch, path, project_id,
                    source_kind, format_override, content_type,
                    options_json, spec_schema_version, created_by,
-                   created_at, updated_at
+                   last_imported_commit_sha, last_imported_committed_at,
+                   last_imported_blob_sha, created_at, updated_at
             FROM odb.repository_import_spec
             WHERE tenant_id = %s::uuid
               AND id = %s::uuid
@@ -7056,7 +7077,8 @@ class Database:
             SELECT id, tenant_id, repository_id, branch, path, project_id,
                    source_kind, format_override, content_type,
                    options_json, spec_schema_version, created_by,
-                   created_at, updated_at
+                   last_imported_commit_sha, last_imported_committed_at,
+                   last_imported_blob_sha, created_at, updated_at
             FROM odb.repository_import_spec
             WHERE tenant_id = %s::uuid
               AND repository_id = %s::uuid

--- a/objectified-rest/src/app/models.py
+++ b/objectified-rest/src/app/models.py
@@ -271,6 +271,18 @@ class RepositoryImportSpec(BaseModel):
         default=REPOSITORY_IMPORT_SPEC_SCHEMA_VERSION,
         description="Envelope version of the stored spec.",
     )
+    last_imported_commit_sha: Optional[str] = Field(
+        default=None,
+        description="Branch tip commit SHA observed for this file at import time (RAR-2.1).",
+    )
+    last_imported_committed_at: Optional[Union[datetime, str]] = Field(
+        default=None,
+        description="Committed-at timestamp of the file at import time; the newer-than anchor (RAR-2.1).",
+    )
+    last_imported_blob_sha: Optional[str] = Field(
+        default=None,
+        description="Blob SHA of the file content at import time (RAR-2.1).",
+    )
     created_by: Optional[str] = None
     created_at: Optional[Union[datetime, str]] = None
     updated_at: Optional[Union[datetime, str]] = None
@@ -443,6 +455,22 @@ class RepositoryImportSpecRead(BaseModel):
         default_factory=SpecImportOptions,
         description="Full SpecImportOptions payload, upgraded to the current shape.",
     )
+    last_imported_commit_sha: Optional[str] = Field(
+        default=None,
+        description="Branch tip commit SHA observed for this file at import time (RAR-2.1).",
+    )
+    last_imported_committed_at: Optional[Union[datetime, str]] = Field(
+        default=None,
+        description=(
+            "Committed-at timestamp of the file at import time. A later auto-refresh "
+            "compares the remote committed_at against this anchor to gate newer-than "
+            "re-imports (RAR-2.1/RAR-2.2)."
+        ),
+    )
+    last_imported_blob_sha: Optional[str] = Field(
+        default=None,
+        description="Blob SHA of the file content at import time (RAR-2.1).",
+    )
 
 
 def repository_import_spec_read_from_row(
@@ -451,9 +479,10 @@ def repository_import_spec_read_from_row(
     """Build a :class:`RepositoryImportSpecRead` from a stored spec row.
 
     Reuses :func:`load_repository_import_options` to migrate the persisted
-    ``options_json`` blob forward, then surfaces the source descriptor columns
-    verbatim. ``spec_schema_version`` is reported as the current envelope version
-    because the options have been upgraded on read.
+    ``options_json`` blob forward, then surfaces the source descriptor and the
+    freshness anchor columns (RAR-2.1) verbatim. ``spec_schema_version`` is
+    reported as the current envelope version because the options have been
+    upgraded on read.
 
     Args:
         row: A ``odb.repository_import_spec`` row as a dict.
@@ -469,6 +498,9 @@ def repository_import_spec_read_from_row(
         format_override=row.get("format_override"),
         content_type=row.get("content_type"),
         options=options,
+        last_imported_commit_sha=row.get("last_imported_commit_sha"),
+        last_imported_committed_at=row.get("last_imported_committed_at"),
+        last_imported_blob_sha=row.get("last_imported_blob_sha"),
     )
 
 

--- a/objectified-rest/src/app/repository_file_scan.py
+++ b/objectified-rest/src/app/repository_file_scan.py
@@ -129,6 +129,15 @@ def fetch_github_tree_blobs(owner: str, repo: str, branch: str, access_token: Op
         if not tree_sha:
             raise ValueError("GitHub response missing tree sha for branch")
 
+        # Branch tip commit recency (RAR-2.1): the branch API already returns the
+        # tip commit SHA and its committed-at date; capture them here so the scan
+        # can stamp every indexed file with a comparable "newer-than" anchor.
+        # Granularity is branch-tip (one value per scan), which the newer-than
+        # comparator (RAR-2.2) pairs with content-checksum idempotency.
+        tip_commit_sha = str(tip.get("sha") or "")[:64] or None
+        committer = inner.get("committer") if isinstance(inner.get("committer"), dict) else {}
+        tip_committed_at = (committer.get("date") or "").strip() or None
+
         tr = client.get(
             f"https://api.github.com/repos/{owner_q}/{repo_q}/git/trees/{tree_sha}?recursive=1",
             headers=headers,
@@ -170,6 +179,8 @@ def fetch_github_tree_blobs(owner: str, repo: str, branch: str, access_token: Op
                     "size_bytes": size_i,
                     "blob_sha": sha,
                     "detected_kind": kind,
+                    "commit_sha": tip_commit_sha,
+                    "committed_at": tip_committed_at,
                 }
             )
         return out

--- a/objectified-rest/tests/test_repository_freshness_signal.py
+++ b/objectified-rest/tests/test_repository_freshness_signal.py
@@ -1,0 +1,246 @@
+"""Freshness signal capture at import (RAR-2.1, #3518).
+
+The repository auto-refresh needs a comparable recency anchor per imported file.
+These tests cover the three pieces that produce and persist it:
+
+  1. The scan reads the branch tip commit (SHA + committed-at) from the provider
+     branch API already used by ``fetch_github_tree_blobs`` and stamps every
+     indexed file row with it.
+  2. ``replace_tenant_repository_files`` persists those columns.
+  3. ``upsert_repository_import_spec`` copies the indexed row's
+     ``blob_sha`` / ``commit_sha`` / ``committed_at`` into the import lineage's
+     ``last_imported_*`` anchors via a LEFT JOIN, and the read model surfaces them.
+  4. The migration adds the columns.
+"""
+
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+from unittest.mock import MagicMock, patch
+
+from app.database import Database
+from app.models import repository_import_spec_read_from_row
+from app.repository_file_scan import fetch_github_tree_blobs
+
+_MIGRATION = "objectified-db/scripts/20260621-130000.sql"
+
+
+# --- scan: branch tip commit attached to every blob -------------------------
+
+
+def _fake_response(payload: Dict[str, Any], status: int = 200) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status
+    resp.json.return_value = payload
+    return resp
+
+
+def test_fetch_github_tree_blobs_captures_branch_tip_commit() -> None:
+    branch_payload = {
+        "commit": {
+            "sha": "tipcommitsha111",
+            "commit": {
+                "committer": {"date": "2026-06-20T10:00:00Z"},
+                "tree": {"sha": "treesha999"},
+            },
+        }
+    }
+    tree_payload = {
+        "truncated": False,
+        "tree": [
+            {"type": "blob", "path": "openapi/petstore.yaml", "size": 1234, "sha": "blobsha123"},
+            {"type": "blob", "path": "README.md", "size": 10, "sha": "blobsha456"},
+            {"type": "tree", "path": "openapi", "sha": "ignoreme"},
+        ],
+    }
+
+    client = MagicMock()
+    client.get.side_effect = [_fake_response(branch_payload), _fake_response(tree_payload)]
+    client_cm = MagicMock()
+    client_cm.__enter__.return_value = client
+    client_cm.__exit__.return_value = False
+
+    with patch("app.repository_file_scan.httpx.Client", return_value=client_cm):
+        blobs = fetch_github_tree_blobs("acme", "petstore", "main", None)
+
+    # Only blobs (not trees) are indexed, and every one carries the tip commit.
+    assert [b["path"] for b in blobs] == ["openapi/petstore.yaml", "README.md"]
+    for b in blobs:
+        assert b["commit_sha"] == "tipcommitsha111"
+        assert b["committed_at"] == "2026-06-20T10:00:00Z"
+    assert blobs[0]["blob_sha"] == "blobsha123"
+
+
+def test_fetch_github_tree_blobs_tolerates_missing_commit_metadata() -> None:
+    # A branch payload without committer date / tip sha must not crash the scan;
+    # the anchors fall back to None (newer-than then degrades to checksum-only).
+    branch_payload = {"commit": {"commit": {"tree": {"sha": "treesha999"}}}}
+    tree_payload = {
+        "truncated": False,
+        "tree": [{"type": "blob", "path": "a.yaml", "size": 1, "sha": "b1"}],
+    }
+
+    client = MagicMock()
+    client.get.side_effect = [_fake_response(branch_payload), _fake_response(tree_payload)]
+    client_cm = MagicMock()
+    client_cm.__enter__.return_value = client
+    client_cm.__exit__.return_value = False
+
+    with patch("app.repository_file_scan.httpx.Client", return_value=client_cm):
+        blobs = fetch_github_tree_blobs("acme", "petstore", "main", None)
+
+    assert blobs[0]["commit_sha"] is None
+    assert blobs[0]["committed_at"] is None
+
+
+# --- DAO: persist scan recency + copy it into the import anchor --------------
+
+
+class _FakeCursor:
+    """Records executed statements and returns a canned row."""
+
+    def __init__(self, row: Optional[Dict[str, Any]]):
+        self.row = row
+        self.executed: List[Any] = []
+
+    def __enter__(self) -> "_FakeCursor":
+        return self
+
+    def __exit__(self, *exc: Any) -> bool:
+        return False
+
+    def execute(self, query: str, params: Any = None) -> None:
+        self.executed.append((query, params))
+
+    def executemany(self, query: str, seq: Any) -> None:
+        self.executed.append((query, list(seq)))
+
+    def fetchone(self) -> Optional[Dict[str, Any]]:
+        return self.row
+
+
+class _FakeConn:
+    def __init__(self, cursor: _FakeCursor):
+        self._cursor = cursor
+        self.closed = False
+        self.committed = False
+
+    def cursor(self) -> _FakeCursor:
+        return self._cursor
+
+    def commit(self) -> None:
+        self.committed = True
+
+    def rollback(self) -> None:  # pragma: no cover - only on error paths
+        pass
+
+
+def _db_with(cursor: _FakeCursor) -> Database:
+    db = Database()
+    db.connect = lambda: _FakeConn(cursor)  # type: ignore[method-assign]
+    return db
+
+
+def test_replace_tenant_repository_files_persists_commit_recency() -> None:
+    cursor = _FakeCursor(None)
+    db = _db_with(cursor)
+
+    files = [
+        {
+            "path": "a.yaml",
+            "name": "a.yaml",
+            "ext": "yaml",
+            "size_bytes": 12,
+            "blob_sha": "blob1",
+            "detected_kind": "openapi-candidate",
+            "commit_sha": "tip1",
+            "committed_at": "2026-06-20T10:00:00Z",
+        }
+    ]
+    db.replace_tenant_repository_files("11111111-1111-1111-1111-111111111111", "main", files)
+
+    insert = next(q for q in cursor.executed if "INSERT INTO odb.tenant_repository_files" in q[0])
+    assert "commit_sha, committed_at" in insert[0]
+    # The per-row tuple includes the two new trailing values.
+    row_tuple = insert[1][0]
+    assert row_tuple[-2] == "tip1"
+    assert row_tuple[-1] == "2026-06-20T10:00:00Z"
+
+
+def test_upsert_repository_import_spec_copies_freshness_from_file_row() -> None:
+    returned = {
+        "id": "spec-1",
+        "tenant_id": "t1",
+        "repository_id": "r1",
+        "branch": "main",
+        "path": "a.yaml",
+        "project_id": "p1",
+        "source_kind": "openapi-3",
+        "format_override": None,
+        "content_type": None,
+        "options_json": {},
+        "spec_schema_version": 1,
+        "created_by": None,
+        "last_imported_commit_sha": "tip1",
+        "last_imported_committed_at": "2026-06-20T10:00:00Z",
+        "last_imported_blob_sha": "blob1",
+        "created_at": None,
+        "updated_at": None,
+    }
+    cursor = _FakeCursor(returned)
+    db = _db_with(cursor)
+
+    row = db.upsert_repository_import_spec(
+        tenant_id="t1",
+        repository_id="r1",
+        branch="main",
+        path="a.yaml",
+        project_id="p1",
+        source_kind="openapi-3",
+        options={},
+    )
+
+    query, params = cursor.executed[0]
+    # The anchors are written from the matching scan row via a LEFT JOIN, not bound.
+    assert "LEFT JOIN odb.tenant_repository_files trf" in query
+    assert "trf.commit_sha, trf.committed_at, trf.blob_sha" in query
+    assert "last_imported_commit_sha = EXCLUDED.last_imported_commit_sha" in query
+    # The JOIN reuses branch + path, so they appear again before the WHERE binds.
+    assert params[11] == "main"
+    assert params[12] == "a.yaml"
+    # The returned row carries the captured anchors back to the caller.
+    assert row["last_imported_commit_sha"] == "tip1"
+    assert row["last_imported_blob_sha"] == "blob1"
+
+
+def test_read_model_surfaces_freshness_anchors() -> None:
+    read = repository_import_spec_read_from_row(
+        {
+            "source_kind": "openapi-3",
+            "options_json": {},
+            "spec_schema_version": 1,
+            "last_imported_commit_sha": "tip1",
+            "last_imported_committed_at": "2026-06-20T10:00:00Z",
+            "last_imported_blob_sha": "blob1",
+        }
+    )
+    assert read.last_imported_commit_sha == "tip1"
+    assert read.last_imported_committed_at == "2026-06-20T10:00:00Z"
+    assert read.last_imported_blob_sha == "blob1"
+
+
+# --- migration --------------------------------------------------------------
+
+
+def test_migration_adds_freshness_columns(repo_root: Path) -> None:
+    text = (repo_root / _MIGRATION).read_text()
+    required = (
+        "ALTER TABLE odb.tenant_repository_files",
+        "ADD COLUMN IF NOT EXISTS commit_sha VARCHAR(64)",
+        "ADD COLUMN IF NOT EXISTS committed_at TIMESTAMPTZ",
+        "ALTER TABLE odb.repository_import_spec",
+        "ADD COLUMN IF NOT EXISTS last_imported_commit_sha VARCHAR(64)",
+        "ADD COLUMN IF NOT EXISTS last_imported_committed_at TIMESTAMPTZ",
+        "ADD COLUMN IF NOT EXISTS last_imported_blob_sha VARCHAR(64)",
+    )
+    missing = [frag for frag in required if frag not in text]
+    assert not missing, f"Migration missing expected fragments: {missing}"

--- a/objectified-rest/tests/test_repository_import_spec_read_api.py
+++ b/objectified-rest/tests/test_repository_import_spec_read_api.py
@@ -47,6 +47,9 @@ def _spec_row(**overrides):
         },
         "spec_schema_version": REPOSITORY_IMPORT_SPEC_SCHEMA_VERSION,
         "created_by": _USER_ID,
+        "last_imported_commit_sha": "tipcommitsha1234",
+        "last_imported_committed_at": "2026-06-20T10:00:00Z",
+        "last_imported_blob_sha": "blobsha5678",
         "created_at": None,
         "updated_at": None,
     }
@@ -74,6 +77,10 @@ def test_read_spec_by_id_ok():
     assert body["options"]["apply_naming_convention"] is True
     assert body["options"]["class_naming_convention"] == "PascalCase"
     assert body["options"]["skip_duplicate_versions"] is True
+    # Freshness signals captured at import are exposed via RAR-1.5 (RAR-2.1, #3518).
+    assert body["last_imported_commit_sha"] == "tipcommitsha1234"
+    assert body["last_imported_committed_at"] == "2026-06-20T10:00:00Z"
+    assert body["last_imported_blob_sha"] == "blobsha5678"
     # Tenant scope comes from the auth token, not the path slug.
     mdb.get_repository_import_spec_by_id.assert_called_once_with(_TENANT_ID, _SPEC_ID)
     mdb.get_repository_import_spec_by_path.assert_not_called()
@@ -183,3 +190,21 @@ def test_read_spec_null_descriptor_fields_serialize():
     assert body["content_type"] is None
     # Defaulted options round-trip.
     assert body["options"]["apply_naming_convention"] is False
+
+
+def test_read_spec_null_freshness_signals_serialize():
+    # A spec captured before a scan recorded recency (or for a non-repository
+    # import) has NULL anchors; the read model must surface them as null (RAR-2.1).
+    row = _spec_row(
+        last_imported_commit_sha=None,
+        last_imported_committed_at=None,
+        last_imported_blob_sha=None,
+    )
+    with patch("app.tenant_repositories_routes.db") as mdb:
+        mdb.get_repository_import_spec_by_id.return_value = row
+        r = client.get(f"/v1/tenants/acme/repository-imports/{_SPEC_ID}/spec")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["last_imported_commit_sha"] is None
+    assert body["last_imported_committed_at"] is None
+    assert body["last_imported_blob_sha"] is None

--- a/objectified-ui/lib/db/repository-import-metrics.ts
+++ b/objectified-ui/lib/db/repository-import-metrics.ts
@@ -58,6 +58,14 @@ export async function recordTenantRepositoryImport(params: {
  * repository belongs to the given tenant. `options` is the full SpecImportOptions
  * payload and is stored verbatim in `options_json`.
  *
+ * Freshness signals (RAR-2.1) — `last_imported_commit_sha`,
+ * `last_imported_committed_at`, `last_imported_blob_sha` — are copied from the
+ * matching indexed `tenant_repository_files` row via a LEFT JOIN, so the spec
+ * records the repository's observed recency for the file at import time. A later
+ * auto-refresh compares the repository's current state against these anchors to
+ * gate "newer-than" re-imports (RAR-2.2). When no scan row matches the lineage the
+ * anchors are stored as NULL and the comparator falls back to checksum-only gating.
+ *
  * @returns true when a row was written (repository belonged to the tenant), false otherwise.
  */
 export async function upsertRepositoryImportSpec(params: {
@@ -89,12 +97,16 @@ export async function upsertRepositoryImportSpec(params: {
     `INSERT INTO odb.repository_import_spec (
        tenant_id, repository_id, branch, path, project_id,
        source_kind, format_override, content_type,
-       options_json, spec_schema_version, created_by
+       options_json, spec_schema_version, created_by,
+       last_imported_commit_sha, last_imported_committed_at, last_imported_blob_sha
      )
      SELECT $1::uuid, $2::uuid, $3, $4, $5::uuid,
             $6, $7, $8,
-            $9::jsonb, $10, $11::uuid
+            $9::jsonb, $10, $11::uuid,
+            trf.commit_sha, trf.committed_at, trf.blob_sha
      FROM odb.tenant_repositories tr
+     LEFT JOIN odb.tenant_repository_files trf
+       ON trf.repository_id = tr.id AND trf.branch = $3 AND trf.path = $4
      WHERE tr.id = $2::uuid AND tr.tenant_id = $1::uuid AND tr.deleted_at IS NULL
      ON CONFLICT ON CONSTRAINT uq_repository_import_spec_repo_branch_path
      DO UPDATE SET
@@ -106,6 +118,9 @@ export async function upsertRepositoryImportSpec(params: {
        options_json = EXCLUDED.options_json,
        spec_schema_version = EXCLUDED.spec_schema_version,
        created_by = EXCLUDED.created_by,
+       last_imported_commit_sha = EXCLUDED.last_imported_commit_sha,
+       last_imported_committed_at = EXCLUDED.last_imported_committed_at,
+       last_imported_blob_sha = EXCLUDED.last_imported_blob_sha,
        updated_at = CURRENT_TIMESTAMP
      RETURNING id`,
     [

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.118",
+  "version": "0.11.119",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/tests/repository-import-spec-upsert.test.ts
+++ b/objectified-ui/tests/repository-import-spec-upsert.test.ts
@@ -161,4 +161,26 @@ describe('upsertRepositoryImportSpec (RAR-1.2, #3513)', () => {
     expect(params[6]).toBeNull(); // format_override
     expect(params[7]).toBeNull(); // content_type
   });
+
+  // RAR-2.1 (#3518): the spec records freshness anchors copied from the matching
+  // indexed tenant_repository_files row via a LEFT JOIN on (repository, branch, path),
+  // so a future auto-refresh can gate "newer-than" re-imports.
+  test('captures the freshness signal at import via the file-row JOIN', async () => {
+    const { upsertRepositoryImportSpec } = require('../lib/db/repository-import-metrics');
+
+    await upsertRepositoryImportSpec(BASE_PARAMS);
+
+    const [sql] = mockQuery.mock.calls[0];
+    // Anchors are written from the matching scan row, not bound as parameters.
+    expect(sql).toContain('LEFT JOIN odb.tenant_repository_files trf');
+    expect(sql).toContain('trf.commit_sha, trf.committed_at, trf.blob_sha');
+    expect(sql).toContain('last_imported_commit_sha');
+    expect(sql).toContain('last_imported_committed_at');
+    expect(sql).toContain('last_imported_blob_sha');
+    expect(sql).toContain('last_imported_commit_sha = EXCLUDED.last_imported_commit_sha');
+    // The JOIN reuses the branch ($3) and path ($4) bind parameters.
+    const [, params] = mockQuery.mock.calls[0];
+    expect(params[2]).toBe('main'); // branch reused by JOIN
+    expect(params[3]).toBe('specs/petstore.yaml'); // path reused by JOIN
+  });
 });


### PR DESCRIPTION
## What & why

Repository auto-refresh (RAR) needs a per-file recency anchor to decide whether a repository file is genuinely *newer* than what was last imported. The system stored `blob_sha` but no comparable recency signal, and the scan does a wholesale DELETE/INSERT, so per-file recency was lost — there was nothing to compare "newer-than" against.

This ticket (**RAR-2.1**, epic #3507) persists the three freshness signals on the import lineage and exposes them via the RAR-1.5 read endpoint:

- `last_imported_commit_sha`
- `last_imported_committed_at`
- `last_imported_blob_sha`

## How it works

1. **DB migration** `objectified-db/scripts/20260621-130000.sql`
   - Adds branch-tip recency columns `commit_sha` / `committed_at` to `odb.tenant_repository_files`.
   - Adds the import-anchor columns `last_imported_commit_sha` / `last_imported_committed_at` / `last_imported_blob_sha` to `odb.repository_import_spec`.
2. **Scan** (`repository_file_scan.py`) — captures the branch tip commit SHA + committed-at that the provider branch API *already returns* (previously discarded) and stamps every indexed file row. Granularity is branch-tip (one value per scan), which the newer-than comparator (RAR-2.2) pairs with content-checksum idempotency (RAR-2.4).
3. **Capture at import** — both spec-write sites copy the matching indexed file row's `blob_sha` / `commit_sha` / `committed_at` into the `last_imported_*` anchors via a `LEFT JOIN` on `(repository_id, branch, path)`:
   - `database.py` `upsert_repository_import_spec` (Python / CLI path)
   - `repository-import-metrics.ts` `upsertRepositoryImportSpec` (the live dashboard import path)
   - When no scan row matches, the anchors are stored `NULL` and the comparator falls back to checksum-only gating.
4. **Exposure (RAR-1.5)** — `RepositoryImportSpecRead` and `repository_import_spec_read_from_row` surface the three signals on `GET …/repository-imports/{id}/spec`.

## How to test

- **Apply** the migration in `objectified-db/scripts/20260621-130000.sql`.
- **Scan** a GitHub repository; each `tenant_repository_files` row now records the branch tip `commit_sha` + `committed_at`.
- **Import** a file (dashboard or REST); the `odb.repository_import_spec` row for that `(repository, branch, path)` now carries `last_imported_commit_sha` / `last_imported_committed_at` / `last_imported_blob_sha`.
- **Read** `GET /v1/tenants/{slug}/repository-imports/{id}/spec` and confirm the three fields appear.

Automated:
- objectified-rest: `python -m pytest tests/test_repository_freshness_signal.py tests/test_repository_import_spec_read_api.py -q` (scan capture, DAO JOIN, read exposure, migration fragments).
- objectified-ui: `yarn jest tests/repository-import-spec-upsert.test.ts` (freshness JOIN in the upsert SQL).

## Risk / notes

- Additive, backward-compatible: new nullable columns; existing rows and importer defaults are unaffected.
- Branch-tip granularity is intentional and matches the issue's "provider tree/commit API already used in `repository_file_scan.py`" — per-file revert detection is RAR-2.2's job via commit-SHA ancestry + checksum fallback.
- No new provider API calls (the commit metadata was already fetched and discarded).
- Versions bumped: objectified-db 0.1.2, objectified-rest 1.0.64 (pyproject) / 1.0.3 (package), objectified-ui 0.11.119.

Closes #3518

Work performed by Claude Code via model claude-opus-4-8[1m]