### PR TITLE
Fix #3519 - Newer-than comparator (RAR-2.2)

### DIFF
--- a/docs/ROADMAP_REPOSITORY_AUTOREFRESH.md
+++ b/docs/ROADMAP_REPOSITORY_AUTOREFRESH.md
@@ -120,7 +120,7 @@ epic. Use this table to resolve any `RAR-*` reference below to its issue number.
 | RAR-EPIC-4 | #3509 | RAR-EPIC-5 | #3510 | RAR-EPIC-6 | #3511 |
 | ~~RAR-1.1~~ ✅ | ~~#3512~~ | ~~RAR-1.2~~ ✅ | ~~#3513~~ | ~~RAR-1.3~~ ✅ | ~~#3514~~ |
 | ~~RAR-1.4~~ ✅ | ~~#3515~~ | ~~RAR-1.5~~ ✅ | ~~#3516~~ | RAR-1.6 | #3517 |
-| ~~RAR-2.1~~ ✅ | ~~#3518~~ | RAR-2.2 | #3519 | RAR-2.3 | #3520 |
+| ~~RAR-2.1~~ ✅ | ~~#3518~~ | ~~RAR-2.2~~ ✅ | ~~#3519~~ | RAR-2.3 | #3520 |
 | RAR-2.4 | #3521 | RAR-3.1 | #3522 | RAR-3.2 | #3523 |
 | RAR-3.3 | #3524 | RAR-3.4 | #3525 | RAR-3.5 | #3526 |
 | RAR-4.1 | #3527 | RAR-4.2 | #3528 | RAR-4.3 | #3529 |
@@ -247,7 +247,7 @@ Re-import only files genuinely newer than what's already in the system.
 | ID | Title | Summary | Labels | Parallel | MVP | Cmplx | Modules |
 |----|-------|---------|--------|----------|-----|-------|---------|
 | ~~RAR-2.1~~ ✅ **Done** (#3518) | Capture freshness signal at import | Store source commit SHA + committed-at + blob_sha as `last_imported_*` | `enhancement`,`mvp`,`import`,`repository`,`data-model` | Y | Y | M | objectified-db, objectified-rest |
-| RAR-2.2 | "Newer-than" comparator | Re-import only when remote commit is newer than last imported | `enhancement`,`mvp`,`import`,`repository` | N | Y | M | objectified-rest |
+| ~~RAR-2.2~~ ✅ **Done** (#3519) | "Newer-than" comparator | Re-import only when remote commit is newer than last imported | `enhancement`,`mvp`,`import`,`repository` | N | Y | M | objectified-rest |
 | RAR-2.3 | Per-file refresh state machine | up-to-date / stale / refreshing / failed / diverged | `enhancement`,`mvp`,`import`,`repository` | Y | Y | M | objectified-rest, objectified-ui |
 | RAR-2.4 | Checksum idempotency guard | Suppress no-op refreshes when content unchanged despite newer commit | `enhancement`,`mvp`,`import` | Y | Y | S | objectified-rest |
 
@@ -291,6 +291,21 @@ equal-timestamp when timestamps are unavailable.
 **Acceptance criteria.** Reverting a file to older content does **not** trigger re-import; forward
 edits do; deterministic fixtures cover all four rows.
 **Dependencies.** Depends RAR-2.1. Blocks RAR-3.2, RAR-4.1. **Parallel = N.**
+
+**Status: ✅ Done (#3519).** New pure module
+`objectified-rest/src/app/repository_refresh_comparator.py` exposes `evaluate_refresh(...)`, a
+side-effect-free decision function that gates dispatch on commit recency rather than raw checksum
+drift. It takes the remote file's `committed_at` + content identity and the stored RAR-2.1
+`last_imported_committed_at` / `last_imported_blob_sha` anchors and returns a `RefreshDecision`
+(`should_refresh`, a stable `RefreshReason` code, and whether the timestamp comparison or the
+checksum fallback was used). When both timestamps parse the comparison is authoritative — newer +
+changed → REFRESH, newer + same → SKIP (idempotent), older/equal → SKIP (stale guard); when either
+timestamp is missing/unparseable it falls back to legacy checksum-changed gating. Timestamps accept
+ISO-8601 (incl. trailing `Z`) or `datetime`; naive datetimes are assumed UTC.
+`tests/test_repository_refresh_comparator.py` covers all four decision rows, both acceptance
+criteria, input-shape handling (datetime/naive/mixed-offset/blank/unparseable), and the
+no-prior-import case (19 deterministic DB-free fixtures). The dispatch wiring into the auto-refresh
+worker is RAR-4.1.
 
 ### RAR-2.3 / 2.4
 - **2.3** materialize a per-file refresh status (joins scan recency vs `last_imported_*`) surfaced to

--- a/objectified-rest/pyproject.toml
+++ b/objectified-rest/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "objectified-rest"
-version = "1.0.64"
+version = "1.0.65"
 description = "REST API for serving OpenAPI specifications from the Objectified database"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/objectified-rest/src/app/repository_refresh_comparator.py
+++ b/objectified-rest/src/app/repository_refresh_comparator.py
@@ -1,0 +1,183 @@
+"""
+Newer-than comparator for repository auto-refresh (RAR-2.2, #3519).
+
+Re-import used to fire whenever ``content_checksum != last_imported_checksum``.
+A checksum difference is **not** the same as "newer": reverting a file to older
+content yields a different checksum and would re-import a *stale* version. The
+request is to re-import only files genuinely **newer** than what the system last
+imported.
+
+This module is the pure decision function the auto-refresh dispatch (RAR-4.1)
+calls per file. It is deliberately side-effect free and provider-agnostic so it
+can be exercised by deterministic fixtures: callers pass the remote file's
+freshness signals and the stored ``last_imported_*`` anchors (RAR-2.1), and it
+returns a :class:`RefreshDecision`.
+
+Decision table (matches the roadmap, ``docs/ROADMAP_REPOSITORY_AUTOREFRESH.md``)::
+
+    committed_at newer + checksum diff  -> REFRESH  (newer content)
+    committed_at newer + checksum same  -> SKIP     (idempotent, RAR-2.4)
+    committed_at older / equal          -> SKIP     (stale guard)
+    no timestamp available              -> fall back to checksum-changed
+
+When timestamps are present the comparison is authoritative. When either side
+lacks a parseable timestamp the comparator cannot prove recency, so it falls
+back to the legacy checksum-changed behaviour (refresh iff the content identity
+differs) rather than risk either clobbering with a stale file or missing a real
+update.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Optional, Union
+
+TimestampInput = Optional[Union[datetime, str]]
+
+
+class RefreshReason(str, Enum):
+    """Why the comparator reached its decision (stable codes for logging/audit)."""
+
+    #: Remote commit is newer and the content differs -> re-import.
+    NEWER_CONTENT = "newer-content"
+    #: Remote commit is newer but the content is identical -> idempotent skip (RAR-2.4).
+    IDEMPOTENT = "idempotent"
+    #: Remote commit is older than or equal to the last import -> stale guard.
+    STALE = "stale"
+    #: No comparable timestamp; content differs -> refresh via checksum fallback.
+    CHECKSUM_FALLBACK_CHANGED = "checksum-fallback-changed"
+    #: No comparable timestamp; content identical -> skip via checksum fallback.
+    CHECKSUM_FALLBACK_UNCHANGED = "checksum-fallback-unchanged"
+    #: Nothing was ever imported for this lineage -> treat as a fresh import.
+    NO_PRIOR_IMPORT = "no-prior-import"
+
+
+@dataclass(frozen=True)
+class RefreshDecision:
+    """Outcome of the newer-than comparator for a single repository file.
+
+    Attributes:
+        should_refresh: True when the file should be re-imported.
+        reason: The :class:`RefreshReason` code explaining the outcome.
+        used_timestamp: True when the decision used the committed-at comparison;
+            False when it fell back to checksum-only gating (or no prior import).
+    """
+
+    should_refresh: bool
+    reason: RefreshReason
+    used_timestamp: bool
+
+
+def _parse_timestamp(value: TimestampInput) -> Optional[datetime]:
+    """Coerce a committed-at value to a timezone-aware ``datetime`` or ``None``.
+
+    Accepts an aware/naive :class:`datetime` or an ISO-8601 string (including the
+    trailing ``Z`` UTC designator returned by the GitHub branch API). Naive
+    datetimes are assumed to be UTC so comparisons are always well defined.
+    Anything unparseable yields ``None``, which routes the caller to the
+    checksum-only fallback.
+
+    Args:
+        value: A datetime, ISO-8601 string, or None.
+
+    Returns:
+        A timezone-aware datetime, or None when the value is missing/unparseable.
+    """
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        dt = value
+    elif isinstance(value, str):
+        raw = value.strip()
+        if not raw:
+            return None
+        # ``datetime.fromisoformat`` only learned to accept a trailing ``Z`` in
+        # 3.11+, but normalising here keeps behaviour explicit and stable.
+        if raw.endswith(("Z", "z")):
+            raw = raw[:-1] + "+00:00"
+        try:
+            dt = datetime.fromisoformat(raw)
+        except ValueError:
+            return None
+    else:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def _normalise_checksum(value: Optional[str]) -> Optional[str]:
+    """Trim a content-identity token (blob SHA or checksum) to a comparable form."""
+    if value is None:
+        return None
+    trimmed = value.strip()
+    return trimmed or None
+
+
+def evaluate_refresh(
+    *,
+    remote_committed_at: TimestampInput,
+    last_imported_committed_at: TimestampInput,
+    remote_checksum: Optional[str],
+    last_imported_checksum: Optional[str],
+) -> RefreshDecision:
+    """Decide whether a repository file should be re-imported (RAR-2.2).
+
+    The comparator gates dispatch on commit recency, not raw checksum drift, so a
+    revert to older content does not pull a stale spec. ``remote_checksum`` and
+    ``last_imported_checksum`` are opaque content-identity tokens — in practice
+    the file's ``blob_sha`` (or a content checksum); they only need to be equal
+    when the content is unchanged and differ otherwise.
+
+    Logic:
+
+    * No prior import anchor at all (both stored timestamp and checksum absent)
+      -> :attr:`RefreshReason.NO_PRIOR_IMPORT`, refresh.
+    * Both committed-at timestamps parse -> authoritative comparison:
+        * remote strictly newer + content differs -> refresh (NEWER_CONTENT)
+        * remote strictly newer + content identical -> skip (IDEMPOTENT)
+        * remote older or equal -> skip (STALE)
+    * Either timestamp missing/unparseable -> checksum fallback: refresh iff the
+      content identity differs.
+
+    Args:
+        remote_committed_at: Committed-at of the remote file (datetime/ISO/None).
+        last_imported_committed_at: Stored ``last_imported_committed_at`` anchor.
+        remote_checksum: Remote content identity (blob SHA / checksum), if known.
+        last_imported_checksum: Stored content identity at last import, if known.
+
+    Returns:
+        A :class:`RefreshDecision` with the boolean verdict, a stable reason code,
+        and whether the timestamp comparison (vs the fallback) was used.
+    """
+    remote_ts = _parse_timestamp(remote_committed_at)
+    last_ts = _parse_timestamp(last_imported_committed_at)
+    remote_sum = _normalise_checksum(remote_checksum)
+    last_sum = _normalise_checksum(last_imported_checksum)
+
+    # Nothing recorded for this lineage: there is no anchor to be "newer than",
+    # so this is effectively a first import and should proceed.
+    if last_ts is None and last_sum is None:
+        return RefreshDecision(
+            should_refresh=True,
+            reason=RefreshReason.NO_PRIOR_IMPORT,
+            used_timestamp=False,
+        )
+
+    content_differs = remote_sum != last_sum
+
+    # Authoritative path: both timestamps comparable.
+    if remote_ts is not None and last_ts is not None:
+        if remote_ts > last_ts:
+            if content_differs:
+                return RefreshDecision(True, RefreshReason.NEWER_CONTENT, True)
+            return RefreshDecision(False, RefreshReason.IDEMPOTENT, True)
+        # Older or equal commit timestamp: never pull it (stale guard).
+        return RefreshDecision(False, RefreshReason.STALE, True)
+
+    # Fallback: no comparable timestamp -> legacy checksum-changed gating.
+    if content_differs:
+        return RefreshDecision(True, RefreshReason.CHECKSUM_FALLBACK_CHANGED, False)
+    return RefreshDecision(False, RefreshReason.CHECKSUM_FALLBACK_UNCHANGED, False)

--- a/objectified-rest/tests/test_repository_refresh_comparator.py
+++ b/objectified-rest/tests/test_repository_refresh_comparator.py
@@ -1,0 +1,251 @@
+"""Newer-than comparator decision tests (RAR-2.2, #3519).
+
+These are deterministic, DB-free fixtures over
+``app.repository_refresh_comparator.evaluate_refresh``. They cover every row of
+the roadmap decision table plus the two acceptance criteria that motivate the
+ticket:
+
+  * Reverting a file to older content does NOT trigger re-import.
+  * Forward edits DO trigger re-import.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from app.repository_refresh_comparator import (
+    RefreshReason,
+    evaluate_refresh,
+)
+
+OLD = "2026-06-20T10:00:00Z"
+NEW = "2026-06-21T10:00:00Z"
+
+
+# --- decision table: the four roadmap rows ---------------------------------
+
+
+def test_newer_commit_changed_content_refreshes() -> None:
+    """Row 1: committed_at newer + checksum diff -> REFRESH."""
+    decision = evaluate_refresh(
+        remote_committed_at=NEW,
+        last_imported_committed_at=OLD,
+        remote_checksum="blob-new",
+        last_imported_checksum="blob-old",
+    )
+    assert decision.should_refresh is True
+    assert decision.reason is RefreshReason.NEWER_CONTENT
+    assert decision.used_timestamp is True
+
+
+def test_newer_commit_same_content_skips_idempotent() -> None:
+    """Row 2: committed_at newer + checksum same -> SKIP (idempotency)."""
+    decision = evaluate_refresh(
+        remote_committed_at=NEW,
+        last_imported_committed_at=OLD,
+        remote_checksum="blob-same",
+        last_imported_checksum="blob-same",
+    )
+    assert decision.should_refresh is False
+    assert decision.reason is RefreshReason.IDEMPOTENT
+    assert decision.used_timestamp is True
+
+
+def test_older_commit_skips_stale_even_with_different_checksum() -> None:
+    """Row 3a: committed_at older -> SKIP (stale guard), regardless of checksum.
+
+    This is the core bug the ticket fixes: a revert changes the checksum but the
+    commit is older, so it must not be pulled.
+    """
+    decision = evaluate_refresh(
+        remote_committed_at=OLD,
+        last_imported_committed_at=NEW,
+        remote_checksum="blob-reverted",
+        last_imported_checksum="blob-current",
+    )
+    assert decision.should_refresh is False
+    assert decision.reason is RefreshReason.STALE
+    assert decision.used_timestamp is True
+
+
+def test_equal_commit_skips_stale() -> None:
+    """Row 3b: committed_at equal -> SKIP (stale guard)."""
+    decision = evaluate_refresh(
+        remote_committed_at=NEW,
+        last_imported_committed_at=NEW,
+        remote_checksum="blob-x",
+        last_imported_checksum="blob-y",
+    )
+    assert decision.should_refresh is False
+    assert decision.reason is RefreshReason.STALE
+
+
+def test_no_timestamp_falls_back_to_checksum_changed() -> None:
+    """Row 4a: no timestamp + checksum diff -> REFRESH via fallback."""
+    decision = evaluate_refresh(
+        remote_committed_at=None,
+        last_imported_committed_at=None,
+        remote_checksum="blob-new",
+        last_imported_checksum="blob-old",
+    )
+    assert decision.should_refresh is True
+    assert decision.reason is RefreshReason.CHECKSUM_FALLBACK_CHANGED
+    assert decision.used_timestamp is False
+
+
+def test_no_timestamp_falls_back_to_checksum_unchanged() -> None:
+    """Row 4b: no timestamp + checksum same -> SKIP via fallback.
+
+    A prior checksum exists (so this is not a first import) but no comparable
+    timestamp does, so the legacy checksum-only gating applies.
+    """
+    decision = evaluate_refresh(
+        remote_committed_at=None,
+        last_imported_committed_at=None,
+        remote_checksum="blob-same",
+        last_imported_checksum="blob-same",
+    )
+    assert decision.should_refresh is False
+    assert decision.reason is RefreshReason.CHECKSUM_FALLBACK_UNCHANGED
+    assert decision.used_timestamp is False
+
+
+# --- acceptance criteria ----------------------------------------------------
+
+
+def test_acceptance_revert_to_older_content_does_not_reimport() -> None:
+    """AC: reverting a file to older content does NOT trigger re-import."""
+    # The system last imported the NEW commit; the remote now points back at the
+    # OLD commit's content (a revert), which carries the OLD committed-at.
+    decision = evaluate_refresh(
+        remote_committed_at=OLD,
+        last_imported_committed_at=NEW,
+        remote_checksum="content-v1",
+        last_imported_checksum="content-v2",
+    )
+    assert decision.should_refresh is False
+
+
+def test_acceptance_forward_edit_triggers_reimport() -> None:
+    """AC: forward edits DO trigger re-import."""
+    decision = evaluate_refresh(
+        remote_committed_at=NEW,
+        last_imported_committed_at=OLD,
+        remote_checksum="content-v2",
+        last_imported_checksum="content-v1",
+    )
+    assert decision.should_refresh is True
+
+
+# --- input shape handling ---------------------------------------------------
+
+
+def test_accepts_datetime_objects() -> None:
+    """Datetime anchors (as returned from the DB) compare like ISO strings."""
+    decision = evaluate_refresh(
+        remote_committed_at=datetime(2026, 6, 21, 10, 0, tzinfo=timezone.utc),
+        last_imported_committed_at=datetime(2026, 6, 20, 10, 0, tzinfo=timezone.utc),
+        remote_checksum="b",
+        last_imported_checksum="a",
+    )
+    assert decision.should_refresh is True
+    assert decision.reason is RefreshReason.NEWER_CONTENT
+
+
+def test_naive_datetime_treated_as_utc() -> None:
+    """A naive datetime anchor is assumed UTC and still compares cleanly."""
+    decision = evaluate_refresh(
+        remote_committed_at=datetime(2026, 6, 19, 10, 0),  # naive, older
+        last_imported_committed_at="2026-06-20T10:00:00Z",
+        remote_checksum="b",
+        last_imported_checksum="a",
+    )
+    assert decision.should_refresh is False
+    assert decision.reason is RefreshReason.STALE
+
+
+def test_mixed_timezone_offsets_compare_correctly() -> None:
+    """Equal instants expressed in different offsets are treated as equal."""
+    decision = evaluate_refresh(
+        # 10:00Z == 06:00-04:00 -> same instant -> not newer -> stale guard.
+        remote_committed_at="2026-06-20T06:00:00-04:00",
+        last_imported_committed_at="2026-06-20T10:00:00Z",
+        remote_checksum="b",
+        last_imported_checksum="a",
+    )
+    assert decision.should_refresh is False
+    assert decision.reason is RefreshReason.STALE
+
+
+def test_unparseable_timestamp_uses_fallback() -> None:
+    """A garbage timestamp string routes to the checksum fallback, not a crash."""
+    decision = evaluate_refresh(
+        remote_committed_at="not-a-date",
+        last_imported_committed_at=OLD,
+        remote_checksum="b",
+        last_imported_checksum="a",
+    )
+    assert decision.should_refresh is True
+    assert decision.reason is RefreshReason.CHECKSUM_FALLBACK_CHANGED
+    assert decision.used_timestamp is False
+
+
+def test_blank_strings_are_treated_as_missing() -> None:
+    """Empty/whitespace timestamp and checksum tokens normalise to None."""
+    # Blank timestamps -> no comparable timestamp; blank checksums both -> equal.
+    decision = evaluate_refresh(
+        remote_committed_at="   ",
+        last_imported_committed_at=OLD,
+        remote_checksum="   ",
+        last_imported_checksum="blob-old",
+    )
+    # remote checksum normalises to None, last is "blob-old" -> differ -> refresh.
+    assert decision.should_refresh is True
+    assert decision.reason is RefreshReason.CHECKSUM_FALLBACK_CHANGED
+
+
+# --- first-import / missing-anchor handling ---------------------------------
+
+
+def test_no_prior_import_anchor_refreshes() -> None:
+    """With no stored timestamp AND no stored checksum, treat as a fresh import."""
+    decision = evaluate_refresh(
+        remote_committed_at=NEW,
+        last_imported_committed_at=None,
+        remote_checksum="blob-new",
+        last_imported_checksum=None,
+    )
+    assert decision.should_refresh is True
+    assert decision.reason is RefreshReason.NO_PRIOR_IMPORT
+    assert decision.used_timestamp is False
+
+
+def test_prior_checksum_without_timestamp_is_not_first_import() -> None:
+    """A stored checksum but no stored timestamp is a real prior import (fallback)."""
+    decision = evaluate_refresh(
+        remote_committed_at=None,
+        last_imported_committed_at=None,
+        remote_checksum="blob-same",
+        last_imported_checksum="blob-same",
+    )
+    assert decision.reason is RefreshReason.CHECKSUM_FALLBACK_UNCHANGED
+
+
+@pytest.mark.parametrize(
+    "remote_ts,last_ts,remote_sum,last_sum,expected",
+    [
+        (NEW, OLD, "b", "a", True),   # newer + changed
+        (NEW, OLD, "a", "a", False),  # newer + same
+        (OLD, NEW, "b", "a", False),  # older + changed (revert)
+        (NEW, NEW, "b", "a", False),  # equal
+    ],
+)
+def test_decision_table_matrix(remote_ts, last_ts, remote_sum, last_sum, expected) -> None:
+    """Compact matrix asserting the verdict for every roadmap decision row."""
+    decision = evaluate_refresh(
+        remote_committed_at=remote_ts,
+        last_imported_committed_at=last_ts,
+        remote_checksum=remote_sum,
+        last_imported_checksum=last_sum,
+    )
+    assert decision.should_refresh is expected


### PR DESCRIPTION
## What & why

Re-import previously fired whenever `content_checksum != last_imported_checksum`. A checksum **difference** is not the same as **newer**: reverting a file to older content yields a different checksum and would re-import a *stale* version. RAR-2.2 (#3519) gates dispatch on commit **recency** instead.

This adds a pure, side-effect-free decision function — `objectified-rest/src/app/repository_refresh_comparator.py::evaluate_refresh(...)` — that the auto-refresh dispatch (RAR-4.1) will call per file. It takes the remote file's `committed_at` + content identity and the stored RAR-2.1 `last_imported_committed_at` / `last_imported_blob_sha` anchors, and returns a `RefreshDecision` (`should_refresh`, a stable `RefreshReason` code, and whether the timestamp comparison or the checksum fallback was used).

Decision table (from `docs/ROADMAP_REPOSITORY_AUTOREFRESH.md`):

```
committed_at newer + checksum diff  -> REFRESH  (newer content)
committed_at newer + checksum same  -> SKIP     (idempotent, RAR-2.4)
committed_at older / equal          -> SKIP     (stale guard)
no timestamp available              -> fall back to checksum-changed
```

When both timestamps parse the comparison is authoritative; when either is missing/unparseable it falls back to legacy checksum-changed gating. Timestamps accept ISO-8601 (incl. trailing `Z`) or `datetime`; naive datetimes are assumed UTC; mixed offsets compare by instant.

## How to test

```
cd objectified-rest
./.venv/bin/pytest tests/test_repository_refresh_comparator.py -q
```

19 deterministic, DB-free fixtures cover all four decision rows, both acceptance criteria (revert-does-not-reimport / forward-edit-does), input-shape handling (datetime / naive / mixed-offset / blank / unparseable), and the no-prior-import case. `ruff check` is clean.

## Risk / notes

- Pure new module + new test file; no existing code paths changed. Wiring it into the auto-refresh worker is RAR-4.1 (#3527), which this unblocks.
- Pre-existing, unrelated suite failures remain (DB-dependent tests with no live DB / `from src.app` import modules) — not introduced here.
- Bumps `objectified-rest` 1.0.64 -> 1.0.65; marks RAR-2.2 done in the roadmap.

Closes #3519

Work performed by Claude Code via model Opus 4.8 (1M context)