### PR TITLE
Fix #3520 - Per-file refresh state machine (RAR-2.3)

### DIFF
--- a/docs/ROADMAP_REPOSITORY_AUTOREFRESH.md
+++ b/docs/ROADMAP_REPOSITORY_AUTOREFRESH.md
@@ -120,7 +120,7 @@ epic. Use this table to resolve any `RAR-*` reference below to its issue number.
 | RAR-EPIC-4 | #3509 | RAR-EPIC-5 | #3510 | RAR-EPIC-6 | #3511 |
 | ~~RAR-1.1~~ ✅ | ~~#3512~~ | ~~RAR-1.2~~ ✅ | ~~#3513~~ | ~~RAR-1.3~~ ✅ | ~~#3514~~ |
 | ~~RAR-1.4~~ ✅ | ~~#3515~~ | ~~RAR-1.5~~ ✅ | ~~#3516~~ | RAR-1.6 | #3517 |
-| ~~RAR-2.1~~ ✅ | ~~#3518~~ | ~~RAR-2.2~~ ✅ | ~~#3519~~ | RAR-2.3 | #3520 |
+| ~~RAR-2.1~~ ✅ | ~~#3518~~ | ~~RAR-2.2~~ ✅ | ~~#3519~~ | ~~RAR-2.3~~ ✅ | ~~#3520~~ |
 | RAR-2.4 | #3521 | RAR-3.1 | #3522 | RAR-3.2 | #3523 |
 | RAR-3.3 | #3524 | RAR-3.4 | #3525 | RAR-3.5 | #3526 |
 | RAR-4.1 | #3527 | RAR-4.2 | #3528 | RAR-4.3 | #3529 |
@@ -248,7 +248,7 @@ Re-import only files genuinely newer than what's already in the system.
 |----|-------|---------|--------|----------|-----|-------|---------|
 | ~~RAR-2.1~~ ✅ **Done** (#3518) | Capture freshness signal at import | Store source commit SHA + committed-at + blob_sha as `last_imported_*` | `enhancement`,`mvp`,`import`,`repository`,`data-model` | Y | Y | M | objectified-db, objectified-rest |
 | ~~RAR-2.2~~ ✅ **Done** (#3519) | "Newer-than" comparator | Re-import only when remote commit is newer than last imported | `enhancement`,`mvp`,`import`,`repository` | N | Y | M | objectified-rest |
-| RAR-2.3 | Per-file refresh state machine | up-to-date / stale / refreshing / failed / diverged | `enhancement`,`mvp`,`import`,`repository` | Y | Y | M | objectified-rest, objectified-ui |
+| ~~RAR-2.3~~ ✅ **Done** (#3520) | Per-file refresh state machine | up-to-date / stale / refreshing / failed / diverged | `enhancement`,`mvp`,`import`,`repository` | Y | Y | M | objectified-rest, objectified-ui |
 | RAR-2.4 | Checksum idempotency guard | Suppress no-op refreshes when content unchanged despite newer commit | `enhancement`,`mvp`,`import` | Y | Y | S | objectified-rest |
 
 ### RAR-2.1 — Capture freshness signal at import
@@ -312,6 +312,28 @@ worker is RAR-4.1.
   UI and the sweep.
 - **2.4** even when timestamp is newer, skip when `content_checksum` is unchanged (reuse REPO-8.3) to
   avoid empty version churn.
+
+**Status (2.3): ✅ Done (#3520).** New pure module
+`objectified-rest/src/app/repository_refresh_status.py` exposes the `RefreshStatus` enum
+(`up-to-date` / `stale` / `refreshing` / `failed` / `diverged`) and `compute_refresh_status(...)`,
+which materializes a file's state from two axes: the **recency** axis (delegated to the RAR-2.2
+`evaluate_refresh` comparator so the two modules cannot disagree about "newer" — `stale` exactly when
+the comparator would re-import, else `up-to-date`) and the **operational** axis supplied by sweep /
+divergence bookkeeping (`is_refreshing` → `refreshing`, `diverged` → `diverged` safety hold,
+`last_refresh_failed` → `failed`), with operational signals taking documented precedence over recency.
+The status is **derived on read** — the RAR-1.5 read DAOs (`get_repository_import_spec_by_id` /
+`_by_path`) now LEFT JOIN the current `odb.tenant_repository_files` row for `remote_committed_at` /
+`remote_blob_sha`, and `RepositoryImportSpecRead.refresh_status` computes from those vs the
+`last_imported_*` anchors — so it is recomputed automatically whenever a scan updates the remote
+recency columns or a finished refresh updates the anchors (no separate stored column to drift).
+objectified-ui adds the presentational chip helper
+`repository-refresh-status-chip-copy.ts` (label + tooltip + tone classes per state, mirroring the
+branch-divergence chip) for the status surface. Tests:
+`tests/test_repository_refresh_status.py` (recency axis, operational axis, precedence, reachability of
+all five states, stable wire codes), read-API coverage in `test_repository_import_spec_read_api.py`,
+and the UI unit test `tests/unit/repository-refresh-status-chip-copy.test.ts`. The `refreshing` /
+`failed` flags are populated when the sweep (RAR-3/RAR-4) lands and `diverged` by the manual-edit
+check (RAR-4.4).
 
 ---
 

--- a/objectified-rest/pyproject.toml
+++ b/objectified-rest/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "objectified-rest"
-version = "1.0.65"
+version = "1.0.66"
 description = "REST API for serving OpenAPI specifications from the Objectified database"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/objectified-rest/src/app/database.py
+++ b/objectified-rest/src/app/database.py
@@ -7036,14 +7036,20 @@ class Database:
             The stored row as a dict, or None when no spec matches in the tenant.
         """
         query = """
-            SELECT id, tenant_id, repository_id, branch, path, project_id,
-                   source_kind, format_override, content_type,
-                   options_json, spec_schema_version, created_by,
-                   last_imported_commit_sha, last_imported_committed_at,
-                   last_imported_blob_sha, created_at, updated_at
-            FROM odb.repository_import_spec
-            WHERE tenant_id = %s::uuid
-              AND id = %s::uuid
+            SELECT s.id, s.tenant_id, s.repository_id, s.branch, s.path, s.project_id,
+                   s.source_kind, s.format_override, s.content_type,
+                   s.options_json, s.spec_schema_version, s.created_by,
+                   s.last_imported_commit_sha, s.last_imported_committed_at,
+                   s.last_imported_blob_sha, s.created_at, s.updated_at,
+                   trf.committed_at AS remote_committed_at,
+                   trf.blob_sha AS remote_blob_sha
+            FROM odb.repository_import_spec s
+            LEFT JOIN odb.tenant_repository_files trf
+              ON trf.repository_id = s.repository_id
+             AND trf.branch = s.branch
+             AND trf.path = s.path
+            WHERE s.tenant_id = %s::uuid
+              AND s.id = %s::uuid
         """
         results = self.execute_query(query, (tenant_id, spec_id))
         return results[0] if results else None
@@ -7074,21 +7080,27 @@ class Database:
             The stored row as a dict, or None when no spec matches.
         """
         select = """
-            SELECT id, tenant_id, repository_id, branch, path, project_id,
-                   source_kind, format_override, content_type,
-                   options_json, spec_schema_version, created_by,
-                   last_imported_commit_sha, last_imported_committed_at,
-                   last_imported_blob_sha, created_at, updated_at
-            FROM odb.repository_import_spec
-            WHERE tenant_id = %s::uuid
-              AND repository_id = %s::uuid
-              AND path = %s
+            SELECT s.id, s.tenant_id, s.repository_id, s.branch, s.path, s.project_id,
+                   s.source_kind, s.format_override, s.content_type,
+                   s.options_json, s.spec_schema_version, s.created_by,
+                   s.last_imported_commit_sha, s.last_imported_committed_at,
+                   s.last_imported_blob_sha, s.created_at, s.updated_at,
+                   trf.committed_at AS remote_committed_at,
+                   trf.blob_sha AS remote_blob_sha
+            FROM odb.repository_import_spec s
+            LEFT JOIN odb.tenant_repository_files trf
+              ON trf.repository_id = s.repository_id
+             AND trf.branch = s.branch
+             AND trf.path = s.path
+            WHERE s.tenant_id = %s::uuid
+              AND s.repository_id = %s::uuid
+              AND s.path = %s
         """
         if branch is not None:
-            query = select + "  AND branch = %s\n            ORDER BY updated_at DESC\n            LIMIT 1"
+            query = select + "  AND s.branch = %s\n            ORDER BY s.updated_at DESC\n            LIMIT 1"
             params: tuple = (tenant_id, repository_id, path, branch)
         else:
-            query = select + "            ORDER BY updated_at DESC\n            LIMIT 1"
+            query = select + "            ORDER BY s.updated_at DESC\n            LIMIT 1"
             params = (tenant_id, repository_id, path)
         results = self.execute_query(query, params)
         return results[0] if results else None

--- a/objectified-rest/src/app/models.py
+++ b/objectified-rest/src/app/models.py
@@ -2,6 +2,8 @@ from datetime import datetime
 from pydantic import BaseModel, Field, AliasChoices, ConfigDict, model_validator
 from typing import Callable, Optional, Dict, Any, List, Union, Literal
 
+from .repository_refresh_status import RefreshStatus, compute_refresh_status
+
 
 class TagSchema(BaseModel):
     """Pydantic model for a tag."""
@@ -471,6 +473,15 @@ class RepositoryImportSpecRead(BaseModel):
         default=None,
         description="Blob SHA of the file content at import time (RAR-2.1).",
     )
+    refresh_status: RefreshStatus = Field(
+        default=RefreshStatus.UP_TO_DATE,
+        description=(
+            "Materialized per-file refresh state (RAR-2.3): one of up-to-date / "
+            "stale / refreshing / failed / diverged. Derived from the current scan "
+            "recency vs the last_imported_* anchors, overlaid with any in-flight "
+            "refresh, last-attempt failure, or divergence hold."
+        ),
+    )
 
 
 def repository_import_spec_read_from_row(
@@ -484,14 +495,35 @@ def repository_import_spec_read_from_row(
     reported as the current envelope version because the options have been
     upgraded on read.
 
+    ``refresh_status`` (RAR-2.3) is materialized on read by comparing the current
+    scan recency for the file — the ``remote_committed_at`` / ``remote_blob_sha``
+    columns the read DAO joins from ``odb.tenant_repository_files`` — against the
+    ``last_imported_*`` anchors, overlaid with the operational flags
+    (``is_refreshing`` / ``last_refresh_failed`` / ``diverged``) carried on the
+    row when the sweep (RAR-3/RAR-4) and divergence check (RAR-4.4) populate them.
+    Deriving on read means the status is recomputed whenever its inputs change —
+    the scan refreshes the remote recency columns and a finished refresh updates
+    the anchors — so it is always current without a separate stored column.
+
     Args:
-        row: A ``odb.repository_import_spec`` row as a dict.
+        row: A ``odb.repository_import_spec`` row as a dict, optionally joined to
+            the current indexed file row (``remote_committed_at`` /
+            ``remote_blob_sha``) and any operational refresh flags.
 
     Returns:
         The current-shape read model for the endpoint response.
     """
     options = load_repository_import_options(row)
     row = row or {}
+    refresh_status = compute_refresh_status(
+        remote_committed_at=row.get("remote_committed_at"),
+        last_imported_committed_at=row.get("last_imported_committed_at"),
+        remote_checksum=row.get("remote_blob_sha"),
+        last_imported_checksum=row.get("last_imported_blob_sha"),
+        is_refreshing=bool(row.get("is_refreshing")),
+        last_refresh_failed=bool(row.get("last_refresh_failed")),
+        diverged=bool(row.get("diverged")),
+    )
     return RepositoryImportSpecRead(
         spec_schema_version=REPOSITORY_IMPORT_SPEC_SCHEMA_VERSION,
         source_kind=str(row.get("source_kind") or ""),
@@ -501,6 +533,7 @@ def repository_import_spec_read_from_row(
         last_imported_commit_sha=row.get("last_imported_commit_sha"),
         last_imported_committed_at=row.get("last_imported_committed_at"),
         last_imported_blob_sha=row.get("last_imported_blob_sha"),
+        refresh_status=refresh_status,
     )
 
 

--- a/objectified-rest/src/app/repository_refresh_status.py
+++ b/objectified-rest/src/app/repository_refresh_status.py
@@ -1,0 +1,129 @@
+"""
+Per-file refresh state machine for repository auto-refresh (RAR-2.3, #3520).
+
+There was no materialized per-file refresh status to drive the sweep, the UI, or
+divergence handling — status was implicit and uncomputable at a glance. This
+module materializes it: a single ``RefreshStatus`` value derived from scan
+recency vs the ``last_imported_*`` anchors (RAR-2.1), overlaid with the
+operational signals an in-flight or just-finished refresh produces.
+
+State machine (matches the roadmap, ``docs/ROADMAP_REPOSITORY_AUTOREFRESH.md``)::
+
+    [*] --> up_to_date
+    up_to_date --> stale:      newer commit detected
+    stale --> refreshing:      sweep enqueues
+    refreshing --> up_to_date:  success
+    refreshing --> failed:      error
+    refreshing --> diverged:    manual edit detected (RAR-4.4)
+    failed --> refreshing:      retry
+    diverged --> up_to_date:    resolved
+
+The recency axis (``up-to-date`` vs ``stale``) is decided by the RAR-2.2
+comparator (:func:`repository_refresh_comparator.evaluate_refresh`) so the two
+modules cannot disagree about what "newer" means: a file is ``stale`` exactly
+when the comparator would re-import it. The operational axis (``refreshing`` /
+``failed`` / ``diverged``) is supplied by the caller from sweep bookkeeping and
+the RAR-4.4 divergence check.
+
+The function is deliberately pure and side-effect free so it can be evaluated
+on demand — "recomputed on scan and on refresh completion" is satisfied simply
+by calling it whenever the underlying inputs change (the scan refreshes the
+remote recency columns; a finished refresh updates the ``last_imported_*``
+anchors and clears/sets the operational flags).
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Optional
+
+from .repository_refresh_comparator import TimestampInput, evaluate_refresh
+
+
+class RefreshStatus(str, Enum):
+    """The materialized refresh state of a single imported repository file.
+
+    Values are the stable wire/display codes (kebab-case) surfaced to the UI and
+    the sweep; they match the states in the roadmap state diagram.
+    """
+
+    #: The imported version reflects the latest source commit; nothing to do.
+    UP_TO_DATE = "up-to-date"
+    #: A newer source commit with changed content exists; awaiting refresh.
+    STALE = "stale"
+    #: A refresh is currently in flight for this file (sweep enqueued it).
+    REFRESHING = "refreshing"
+    #: The most recent refresh attempt errored; awaiting retry.
+    FAILED = "failed"
+    #: The imported version was hand-edited since import (RAR-4.4); held, not
+    #: auto-overwritten, until a human resolves it.
+    DIVERGED = "diverged"
+
+
+def compute_refresh_status(
+    *,
+    remote_committed_at: TimestampInput = None,
+    last_imported_committed_at: TimestampInput = None,
+    remote_checksum: Optional[str] = None,
+    last_imported_checksum: Optional[str] = None,
+    is_refreshing: bool = False,
+    last_refresh_failed: bool = False,
+    diverged: bool = False,
+) -> RefreshStatus:
+    """Materialize the per-file refresh status (RAR-2.3).
+
+    Combines two axes:
+
+    * **Operational** — supplied by the caller from sweep/refresh bookkeeping:
+      whether a refresh is in flight, whether the last attempt errored, and
+      whether the imported version has diverged (RAR-4.4). These describe an
+      explicit position in the refresh lifecycle and therefore take precedence
+      over the derived recency axis.
+    * **Recency** — derived from scan recency vs the ``last_imported_*`` anchors
+      via the RAR-2.2 comparator. When no refresh is in flight and the file is
+      neither diverged nor in a failed state, the status is ``stale`` exactly
+      when the comparator would re-import the file, otherwise ``up-to-date``.
+
+    Precedence (highest first), mirroring the state diagram's transitions:
+
+    1. ``is_refreshing``      -> :attr:`RefreshStatus.REFRESHING` (in flight)
+    2. ``diverged``           -> :attr:`RefreshStatus.DIVERGED` (safety hold)
+    3. ``last_refresh_failed``-> :attr:`RefreshStatus.FAILED` (awaiting retry)
+    4. comparator says refresh-> :attr:`RefreshStatus.STALE`
+    5. otherwise              -> :attr:`RefreshStatus.UP_TO_DATE`
+
+    ``diverged`` outranks ``failed`` because divergence is a content-safety hold
+    that must not be masked by a transient error; both outrank the recency axis
+    because they describe the outcome of an actual refresh attempt rather than a
+    mere comparison.
+
+    Args:
+        remote_committed_at: Committed-at of the current remote file
+            (datetime/ISO-8601/None) — the scan recency signal.
+        last_imported_committed_at: Stored ``last_imported_committed_at`` anchor.
+        remote_checksum: Current remote content identity (blob SHA / checksum).
+        last_imported_checksum: Stored ``last_imported_blob_sha`` / checksum
+            anchor captured at import time.
+        is_refreshing: True when a refresh is currently enqueued/running.
+        last_refresh_failed: True when the most recent refresh attempt errored
+            and has not since succeeded.
+        diverged: True when the imported version was hand-edited after import
+            (RAR-4.4) and is held for review.
+
+    Returns:
+        The single :class:`RefreshStatus` for the file.
+    """
+    if is_refreshing:
+        return RefreshStatus.REFRESHING
+    if diverged:
+        return RefreshStatus.DIVERGED
+    if last_refresh_failed:
+        return RefreshStatus.FAILED
+
+    decision = evaluate_refresh(
+        remote_committed_at=remote_committed_at,
+        last_imported_committed_at=last_imported_committed_at,
+        remote_checksum=remote_checksum,
+        last_imported_checksum=last_imported_checksum,
+    )
+    return RefreshStatus.STALE if decision.should_refresh else RefreshStatus.UP_TO_DATE

--- a/objectified-rest/tests/test_repository_import_spec_read_api.py
+++ b/objectified-rest/tests/test_repository_import_spec_read_api.py
@@ -208,3 +208,49 @@ def test_read_spec_null_freshness_signals_serialize():
     assert body["last_imported_commit_sha"] is None
     assert body["last_imported_committed_at"] is None
     assert body["last_imported_blob_sha"] is None
+
+
+def test_read_spec_refresh_status_stale_when_remote_newer():
+    # A newer remote commit with changed content materializes as stale (RAR-2.3).
+    row = _spec_row(
+        last_imported_committed_at="2026-06-20T10:00:00Z",
+        last_imported_blob_sha="blob-old",
+        remote_committed_at="2026-06-21T10:00:00Z",
+        remote_blob_sha="blob-new",
+    )
+    with patch("app.tenant_repositories_routes.db") as mdb:
+        mdb.get_repository_import_spec_by_id.return_value = row
+        r = client.get(f"/v1/tenants/acme/repository-imports/{_SPEC_ID}/spec")
+    assert r.status_code == 200
+    assert r.json()["refresh_status"] == "stale"
+
+
+def test_read_spec_refresh_status_up_to_date_when_remote_matches():
+    # Same recency and content is the steady state -> up-to-date (RAR-2.3).
+    row = _spec_row(
+        last_imported_committed_at="2026-06-21T10:00:00Z",
+        last_imported_blob_sha="blob-x",
+        remote_committed_at="2026-06-21T10:00:00Z",
+        remote_blob_sha="blob-x",
+    )
+    with patch("app.tenant_repositories_routes.db") as mdb:
+        mdb.get_repository_import_spec_by_id.return_value = row
+        r = client.get(f"/v1/tenants/acme/repository-imports/{_SPEC_ID}/spec")
+    assert r.status_code == 200
+    assert r.json()["refresh_status"] == "up-to-date"
+
+
+def test_read_spec_refresh_status_diverged_overlay():
+    # A divergence hold (RAR-4.4) overlays the recency axis even when stale.
+    row = _spec_row(
+        last_imported_committed_at="2026-06-20T10:00:00Z",
+        last_imported_blob_sha="blob-old",
+        remote_committed_at="2026-06-21T10:00:00Z",
+        remote_blob_sha="blob-new",
+        diverged=True,
+    )
+    with patch("app.tenant_repositories_routes.db") as mdb:
+        mdb.get_repository_import_spec_by_id.return_value = row
+        r = client.get(f"/v1/tenants/acme/repository-imports/{_SPEC_ID}/spec")
+    assert r.status_code == 200
+    assert r.json()["refresh_status"] == "diverged"

--- a/objectified-rest/tests/test_repository_refresh_status.py
+++ b/objectified-rest/tests/test_repository_refresh_status.py
@@ -1,0 +1,219 @@
+"""Per-file refresh state machine tests (RAR-2.3, #3520).
+
+Deterministic, DB-free fixtures over
+``app.repository_refresh_status.compute_refresh_status``. They cover:
+
+  * The recency axis (up-to-date vs stale), delegated to the RAR-2.2 comparator.
+  * The operational axis (refreshing / failed / diverged).
+  * The documented precedence between the two axes.
+  * That every roadmap state is reachable.
+"""
+
+from datetime import datetime, timezone
+
+from app.repository_refresh_status import RefreshStatus, compute_refresh_status
+
+OLD = "2026-06-20T10:00:00Z"
+NEW = "2026-06-21T10:00:00Z"
+
+
+# --- recency axis: up-to-date vs stale -------------------------------------
+
+
+def test_newer_changed_content_is_stale() -> None:
+    """A newer remote commit with changed content materializes as stale."""
+    assert (
+        compute_refresh_status(
+            remote_committed_at=NEW,
+            last_imported_committed_at=OLD,
+            remote_checksum="blob-new",
+            last_imported_checksum="blob-old",
+        )
+        is RefreshStatus.STALE
+    )
+
+
+def test_newer_same_content_is_up_to_date() -> None:
+    """Newer commit but identical content is idempotent -> up-to-date."""
+    assert (
+        compute_refresh_status(
+            remote_committed_at=NEW,
+            last_imported_committed_at=OLD,
+            remote_checksum="blob-same",
+            last_imported_checksum="blob-same",
+        )
+        is RefreshStatus.UP_TO_DATE
+    )
+
+
+def test_older_remote_is_up_to_date() -> None:
+    """An older/equal remote commit never makes a file stale (stale guard)."""
+    assert (
+        compute_refresh_status(
+            remote_committed_at=OLD,
+            last_imported_committed_at=NEW,
+            remote_checksum="blob-old",
+            last_imported_checksum="blob-new",
+        )
+        is RefreshStatus.UP_TO_DATE
+    )
+
+
+def test_equal_recency_same_content_is_up_to_date() -> None:
+    """Same commit and content is the steady state -> up-to-date."""
+    assert (
+        compute_refresh_status(
+            remote_committed_at=NEW,
+            last_imported_committed_at=NEW,
+            remote_checksum="blob-x",
+            last_imported_checksum="blob-x",
+        )
+        is RefreshStatus.UP_TO_DATE
+    )
+
+
+def test_checksum_fallback_changed_is_stale() -> None:
+    """No comparable timestamp + changed content -> stale (checksum fallback)."""
+    assert (
+        compute_refresh_status(
+            remote_committed_at=None,
+            last_imported_committed_at=None,
+            remote_checksum="blob-new",
+            last_imported_checksum="blob-old",
+        )
+        is RefreshStatus.STALE
+    )
+
+
+def test_checksum_fallback_unchanged_is_up_to_date() -> None:
+    """No comparable timestamp + identical content -> up-to-date."""
+    assert (
+        compute_refresh_status(
+            remote_committed_at=None,
+            last_imported_committed_at=None,
+            remote_checksum="blob-same",
+            last_imported_checksum="blob-same",
+        )
+        is RefreshStatus.UP_TO_DATE
+    )
+
+
+def test_accepts_datetime_inputs() -> None:
+    """The recency axis accepts datetime objects, not only ISO strings."""
+    older = datetime(2026, 6, 20, 10, 0, tzinfo=timezone.utc)
+    newer = datetime(2026, 6, 21, 10, 0, tzinfo=timezone.utc)
+    assert (
+        compute_refresh_status(
+            remote_committed_at=newer,
+            last_imported_committed_at=older,
+            remote_checksum="b2",
+            last_imported_checksum="b1",
+        )
+        is RefreshStatus.STALE
+    )
+
+
+# --- operational axis -------------------------------------------------------
+
+
+def test_in_flight_refresh_is_refreshing() -> None:
+    """An enqueued/running refresh reports refreshing."""
+    assert (
+        compute_refresh_status(is_refreshing=True)
+        is RefreshStatus.REFRESHING
+    )
+
+
+def test_last_attempt_error_is_failed() -> None:
+    """A file whose last refresh attempt errored reports failed."""
+    assert (
+        compute_refresh_status(last_refresh_failed=True)
+        is RefreshStatus.FAILED
+    )
+
+
+def test_diverged_flag_is_diverged() -> None:
+    """A hand-edited (diverged) file is held in the diverged state (RAR-4.4)."""
+    assert compute_refresh_status(diverged=True) is RefreshStatus.DIVERGED
+
+
+# --- precedence between the axes -------------------------------------------
+
+
+def test_refreshing_outranks_diverged_failed_and_recency() -> None:
+    """In-flight refresh wins over every other signal."""
+    assert (
+        compute_refresh_status(
+            remote_committed_at=NEW,
+            last_imported_committed_at=OLD,
+            remote_checksum="blob-new",
+            last_imported_checksum="blob-old",
+            is_refreshing=True,
+            last_refresh_failed=True,
+            diverged=True,
+        )
+        is RefreshStatus.REFRESHING
+    )
+
+
+def test_diverged_outranks_failed_and_recency() -> None:
+    """Divergence is a safety hold that outranks a failed attempt and staleness."""
+    assert (
+        compute_refresh_status(
+            remote_committed_at=NEW,
+            last_imported_committed_at=OLD,
+            remote_checksum="blob-new",
+            last_imported_checksum="blob-old",
+            last_refresh_failed=True,
+            diverged=True,
+        )
+        is RefreshStatus.DIVERGED
+    )
+
+
+def test_failed_outranks_recency() -> None:
+    """A failed attempt is surfaced over a derived stale/up-to-date verdict."""
+    assert (
+        compute_refresh_status(
+            remote_committed_at=NEW,
+            last_imported_committed_at=OLD,
+            remote_checksum="blob-new",
+            last_imported_checksum="blob-old",
+            last_refresh_failed=True,
+        )
+        is RefreshStatus.FAILED
+    )
+
+
+# --- reachability + wire values --------------------------------------------
+
+
+def test_all_states_reachable() -> None:
+    """Every roadmap state is producible from some input combination."""
+    produced = {
+        compute_refresh_status(is_refreshing=True),
+        compute_refresh_status(diverged=True),
+        compute_refresh_status(last_refresh_failed=True),
+        compute_refresh_status(
+            remote_committed_at=NEW,
+            last_imported_committed_at=OLD,
+            remote_checksum="b2",
+            last_imported_checksum="b1",
+        ),
+        compute_refresh_status(
+            remote_committed_at=OLD,
+            last_imported_committed_at=NEW,
+            remote_checksum="b1",
+            last_imported_checksum="b2",
+        ),
+    }
+    assert produced == set(RefreshStatus)
+
+
+def test_status_wire_values_are_stable_kebab_case() -> None:
+    """The display/wire codes are the kebab-case strings the UI keys on."""
+    assert RefreshStatus.UP_TO_DATE.value == "up-to-date"
+    assert RefreshStatus.STALE.value == "stale"
+    assert RefreshStatus.REFRESHING.value == "refreshing"
+    assert RefreshStatus.FAILED.value == "failed"
+    assert RefreshStatus.DIVERGED.value == "diverged"

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.119",
+  "version": "0.11.120",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/src/app/components/ade/dashboard/repositories/repository-refresh-status-chip-copy.ts
+++ b/objectified-ui/src/app/components/ade/dashboard/repositories/repository-refresh-status-chip-copy.ts
@@ -1,0 +1,97 @@
+/**
+ * Presentational copy + tone classes for the per-file refresh status chip
+ * (RAR-2.3, #3520).
+ *
+ * The REST read model surfaces `refresh_status` as one of the kebab-case codes
+ * below (see objectified-rest `RefreshStatus`). This module is the single place
+ * that maps a code to user-facing label + tooltip + tone classes, so the
+ * repository file browser and any other surface render the state machine
+ * identically. Kept pure (no React) so it is unit-testable in isolation, mirroring
+ * `branch-divergence-chip-copy.ts`.
+ */
+
+/** Wire codes for the per-file refresh state (must match REST `RefreshStatus`). */
+export type RefreshStatusCode =
+  | 'up-to-date'
+  | 'stale'
+  | 'refreshing'
+  | 'failed'
+  | 'diverged';
+
+export type RefreshStatusTone = RefreshStatusCode;
+
+export interface RefreshStatusPresentation {
+  /** Short chip label. */
+  label: string;
+  /** Longer hover/aria explanation of the state. */
+  description: string;
+  /** Tone key for class selection. */
+  tone: RefreshStatusTone;
+}
+
+const PRESENTATION: Record<RefreshStatusCode, Omit<RefreshStatusPresentation, 'tone'>> = {
+  'up-to-date': {
+    label: 'Up to date',
+    description: 'The imported version reflects the latest source commit.',
+  },
+  stale: {
+    label: 'Stale',
+    description: 'A newer source commit with changed content is available to import.',
+  },
+  refreshing: {
+    label: 'Refreshing',
+    description: 'A refresh is in progress for this file.',
+  },
+  failed: {
+    label: 'Failed',
+    description: 'The most recent refresh attempt failed; it will be retried.',
+  },
+  diverged: {
+    label: 'Diverged',
+    description:
+      'The imported version was edited after import; auto-refresh is held until resolved.',
+  },
+};
+
+/**
+ * Resolve the chip label, description, and tone for a refresh status code.
+ * Unknown/missing codes fall back to the neutral up-to-date presentation so the
+ * UI never renders a blank chip.
+ *
+ * @param status The `refresh_status` code from the REST read model.
+ * @returns Label, description, and tone for the chip.
+ */
+export function getRefreshStatusPresentation(
+  status: string | null | undefined,
+): RefreshStatusPresentation {
+  const code = (status ?? '') as RefreshStatusCode;
+  const copy = PRESENTATION[code] ?? PRESENTATION['up-to-date'];
+  const tone: RefreshStatusTone = (code in PRESENTATION ? code : 'up-to-date');
+  return { ...copy, tone };
+}
+
+/**
+ * Tailwind utility classes for a refresh-status chip, keyed by tone. Mirrors the
+ * glass/border styling used by the branch divergence chip so the two read as a
+ * family.
+ *
+ * @param tone The tone returned by {@link getRefreshStatusPresentation}.
+ * @returns A class string for the chip element.
+ */
+export function refreshStatusChipToneClasses(tone: RefreshStatusTone): string {
+  const base =
+    'inline-flex items-center gap-1 rounded-lg border px-2.5 py-1 text-xs font-medium shadow-sm backdrop-blur-md transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500/30';
+  switch (tone) {
+    case 'up-to-date':
+      return `${base} border-emerald-300/60 bg-emerald-50/50 text-emerald-900 dark:border-emerald-700/45 dark:bg-emerald-950/35 dark:text-emerald-100`;
+    case 'stale':
+      return `${base} border-amber-300/60 bg-amber-50/50 text-amber-950 dark:border-amber-700/45 dark:bg-amber-950/40 dark:text-amber-100`;
+    case 'refreshing':
+      return `${base} border-indigo-300/60 bg-indigo-50/50 text-indigo-950 dark:border-indigo-700/45 dark:bg-indigo-950/40 dark:text-indigo-100`;
+    case 'failed':
+      return `${base} border-rose-300/60 bg-rose-50/50 text-rose-950 dark:border-rose-700/45 dark:bg-rose-950/40 dark:text-rose-100`;
+    case 'diverged':
+    default:
+      return `${base} border-purple-300/60 bg-purple-50/50 text-purple-950 dark:border-purple-700/45 dark:bg-purple-950/40 dark:text-purple-100`;
+  }
+}

--- a/objectified-ui/tests/unit/repository-refresh-status-chip-copy.test.ts
+++ b/objectified-ui/tests/unit/repository-refresh-status-chip-copy.test.ts
@@ -1,0 +1,47 @@
+import {
+  getRefreshStatusPresentation,
+  refreshStatusChipToneClasses,
+  type RefreshStatusCode,
+} from '@/app/components/ade/dashboard/repositories/repository-refresh-status-chip-copy';
+
+describe('getRefreshStatusPresentation', () => {
+  const cases: Array<[RefreshStatusCode, string]> = [
+    ['up-to-date', 'Up to date'],
+    ['stale', 'Stale'],
+    ['refreshing', 'Refreshing'],
+    ['failed', 'Failed'],
+    ['diverged', 'Diverged'],
+  ];
+
+  test.each(cases)('maps %s to its label and tone', (code, label) => {
+    const p = getRefreshStatusPresentation(code);
+    expect(p.label).toBe(label);
+    expect(p.tone).toBe(code);
+    expect(p.description.length).toBeGreaterThan(0);
+  });
+
+  test('falls back to up-to-date for unknown codes', () => {
+    expect(getRefreshStatusPresentation('bogus').tone).toBe('up-to-date');
+    expect(getRefreshStatusPresentation('bogus').label).toBe('Up to date');
+  });
+
+  test('falls back to up-to-date for null/undefined', () => {
+    expect(getRefreshStatusPresentation(null).tone).toBe('up-to-date');
+    expect(getRefreshStatusPresentation(undefined).tone).toBe('up-to-date');
+  });
+});
+
+describe('refreshStatusChipToneClasses', () => {
+  test('every tone yields a distinct, non-empty class string', () => {
+    const tones: RefreshStatusCode[] = [
+      'up-to-date',
+      'stale',
+      'refreshing',
+      'failed',
+      'diverged',
+    ];
+    const classStrings = tones.map(refreshStatusChipToneClasses);
+    classStrings.forEach((c) => expect(c).toContain('inline-flex'));
+    expect(new Set(classStrings).size).toBe(tones.length);
+  });
+});


### PR DESCRIPTION
## What & why

Closes #3520 (RAR-2.3). There was no materialized per-file refresh status to drive the sweep, the UI, or divergence handling — status was implicit and uncomputable at a glance. This materializes a single per-file refresh state derived from scan recency vs the `last_imported_*` anchors (RAR-2.1), surfaced to the UI and consumable by the sweep.

The state machine matches the roadmap diagram: `up-to-date` / `stale` / `refreshing` / `failed` / `diverged`.

## Changes

**objectified-rest**
- New pure module `repository_refresh_status.py`: the `RefreshStatus` enum + `compute_refresh_status(...)`. Two axes:
  - **Recency** (`up-to-date` vs `stale`) is delegated to the RAR-2.2 `evaluate_refresh` comparator, so the two modules cannot disagree about what "newer" means — a file is `stale` exactly when the comparator would re-import it.
  - **Operational** (`refreshing` / `failed` / `diverged`) is supplied by sweep/divergence bookkeeping, taking documented precedence over recency (`refreshing` > `diverged` > `failed` > recency).
- `RepositoryImportSpecRead.refresh_status` is **derived on read**: the RAR-1.5 read DAOs (`get_repository_import_spec_by_id` / `_by_path`) now LEFT JOIN the current `odb.tenant_repository_files` row for `remote_committed_at` / `remote_blob_sha`. No new stored column — the status is recomputed automatically whenever a scan updates the remote recency columns or a finished refresh updates the anchors. This satisfies "recomputed on scan and on refresh completion".

**objectified-ui**
- Reusable presentational chip helper `repository-refresh-status-chip-copy.ts` (label + tooltip + tone classes per state), mirroring `branch-divergence-chip-copy.ts`. The full Specs-tab rendering is RAR-5.1 (#3532).

The `refreshing` / `failed` flags are populated when the sweep (RAR-3/RAR-4) lands; `diverged` by the manual-edit check (RAR-4.4). The enum and precedence are already in place for them.

## How to test

- **REST unit:** from `objectified-rest`, run `./.venv/bin/python -m pytest tests/test_repository_refresh_status.py tests/test_repository_import_spec_read_api.py -q` — covers the recency axis, operational axis, precedence, reachability of all five states, stable wire codes, and the read endpoint surfacing `refresh_status` (stale / up-to-date / diverged overlay).
- **UI unit:** from `objectified-ui`, run `yarn jest tests/unit/repository-refresh-status-chip-copy.test.ts` — covers label/tone mapping for all five states, unknown/null fallback, and distinct tone classes.
- **Manual (read endpoint):** call `GET /v1/tenants/{slug}/repository-imports/{id}/spec`; with a newer indexed commit + changed blob the response `refresh_status` is `"stale"`, with matching recency/content it is `"up-to-date"`.

## Risk / notes

- No schema migration — only read-path SQL gained a LEFT JOIN; the write paths are unchanged.
- Derive-on-read means there is no status column to drift; cost is one extra LEFT JOIN on the per-file spec read.
- Scope boundary: full UI integration into the Specs tab is RAR-5.1; this ships the state machine, the read-model surface, and the reusable chip primitive.
- No new lint errors introduced (new module is ruff-clean; pre-existing models.py/database.py debt unchanged).

Work performed by Claude Code via model Claude Opus 4.8 (1M context).