### PR TITLE
Fix #3521 - Checksum idempotency guard (RAR-2.4)

### DIFF
--- a/docs/ROADMAP_REPOSITORY_AUTOREFRESH.md
+++ b/docs/ROADMAP_REPOSITORY_AUTOREFRESH.md
@@ -121,7 +121,7 @@ epic. Use this table to resolve any `RAR-*` reference below to its issue number.
 | ~~RAR-1.1~~ ✅ | ~~#3512~~ | ~~RAR-1.2~~ ✅ | ~~#3513~~ | ~~RAR-1.3~~ ✅ | ~~#3514~~ |
 | ~~RAR-1.4~~ ✅ | ~~#3515~~ | ~~RAR-1.5~~ ✅ | ~~#3516~~ | RAR-1.6 | #3517 |
 | ~~RAR-2.1~~ ✅ | ~~#3518~~ | ~~RAR-2.2~~ ✅ | ~~#3519~~ | ~~RAR-2.3~~ ✅ | ~~#3520~~ |
-| RAR-2.4 | #3521 | RAR-3.1 | #3522 | RAR-3.2 | #3523 |
+| ~~RAR-2.4~~ ✅ | ~~#3521~~ | RAR-3.1 | #3522 | RAR-3.2 | #3523 |
 | RAR-3.3 | #3524 | RAR-3.4 | #3525 | RAR-3.5 | #3526 |
 | RAR-4.1 | #3527 | RAR-4.2 | #3528 | RAR-4.3 | #3529 |
 | RAR-4.4 | #3530 | RAR-4.5 | #3531 | RAR-5.1 | #3532 |
@@ -249,7 +249,7 @@ Re-import only files genuinely newer than what's already in the system.
 | ~~RAR-2.1~~ ✅ **Done** (#3518) | Capture freshness signal at import | Store source commit SHA + committed-at + blob_sha as `last_imported_*` | `enhancement`,`mvp`,`import`,`repository`,`data-model` | Y | Y | M | objectified-db, objectified-rest |
 | ~~RAR-2.2~~ ✅ **Done** (#3519) | "Newer-than" comparator | Re-import only when remote commit is newer than last imported | `enhancement`,`mvp`,`import`,`repository` | N | Y | M | objectified-rest |
 | ~~RAR-2.3~~ ✅ **Done** (#3520) | Per-file refresh state machine | up-to-date / stale / refreshing / failed / diverged | `enhancement`,`mvp`,`import`,`repository` | Y | Y | M | objectified-rest, objectified-ui |
-| RAR-2.4 | Checksum idempotency guard | Suppress no-op refreshes when content unchanged despite newer commit | `enhancement`,`mvp`,`import` | Y | Y | S | objectified-rest |
+| ~~RAR-2.4~~ ✅ **Done** (#3521) | Checksum idempotency guard | Suppress no-op refreshes when content unchanged despite newer commit | `enhancement`,`mvp`,`import` | Y | Y | S | objectified-rest |
 
 ### RAR-2.1 — Capture freshness signal at import
 
@@ -334,6 +334,25 @@ all five states, stable wire codes), read-API coverage in `test_repository_impor
 and the UI unit test `tests/unit/repository-refresh-status-chip-copy.test.ts`. The `refreshing` /
 `failed` flags are populated when the sweep (RAR-3/RAR-4) lands and `diverged` by the manual-edit
 check (RAR-4.4).
+
+**Status (2.4): ✅ Done (#3521).** New pure module
+`objectified-rest/src/app/repository_checksum_idempotency.py` adds the second, finer gate that runs
+after the RAR-2.2 recency comparator. The comparator gates on `blob_sha`, but a newer commit can
+change the blob without changing the **spec content** (reformat, comment, header bump, no-op
+re-commit), which would churn empty versions. `evaluate_checksum_idempotency(...)` takes the RAR-2.2
+`RefreshDecision` plus the REPO-8.3 (#2933) **content checksum** and returns an `IdempotencyOutcome`
+(`RefreshAction` of `reimport` / `advance-anchor-only` / `skip`, an `IdempotencyReason`, and an
+`advance_committed_anchor` flag): newer commit + content changed → `reimport`; newer commit + content
+**unchanged** → `advance-anchor-only` marked `unchanged-checksum` (no version, but advance
+`last_imported_commit_sha` / `last_imported_committed_at` so the same commit is not re-seen as newer);
+older/equal → `skip` (stale guard); first import → `reimport`. When a content checksum is missing on
+either side it defers to the comparator's verdict verbatim. `guard_refresh(...)` is a convenience
+wrapper that runs the full RAR-2.2 + RAR-2.4 gate from the raw freshness signals.
+`tests/test_repository_checksum_idempotency.py` covers both acceptance criteria, the roadmap decision
+row, the cosmetic-blob-change churn case, the defer-on-missing-checksum behaviour, the no-timestamp
+fallback path, and stable wire codes (14 deterministic DB-free fixtures). Persisting the advanced
+anchor and the `unchanged-checksum` marker is the dispatcher's job (RAR-4.1), mirroring how RAR-2.2's
+wiring was deferred.
 
 ---
 

--- a/objectified-rest/pyproject.toml
+++ b/objectified-rest/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "objectified-rest"
-version = "1.0.66"
+version = "1.0.67"
 description = "REST API for serving OpenAPI specifications from the Objectified database"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/objectified-rest/src/app/repository_checksum_idempotency.py
+++ b/objectified-rest/src/app/repository_checksum_idempotency.py
@@ -1,0 +1,238 @@
+"""
+Checksum idempotency guard for repository auto-refresh (RAR-2.4, #3521).
+
+The RAR-2.2 newer-than comparator (:mod:`repository_refresh_comparator`) gates a
+re-import on commit recency, using the file ``blob_sha`` as its content-identity
+token. But a newer commit can change the ``blob_sha`` without changing the
+**spec content** — a reformat, a comment, a license-header bump, or even a
+no-op re-commit of identical bytes. Re-importing on those would create empty /
+no-op versions: churn.
+
+This module is the second, finer gate. It takes the RAR-2.2 decision plus the
+REPO-8.3 (#2933) **content checksum** — a normalized digest of the parsed spec
+content that is stable across cosmetic changes — and decides the final action:
+
+    newer commit + content checksum changed   -> REIMPORT
+    newer commit + content checksum unchanged -> ADVANCE_ANCHOR_ONLY (no churn)
+    older / equal commit                       -> SKIP (stale guard, RAR-2.2)
+    no prior import                            -> REIMPORT (first import)
+
+``ADVANCE_ANCHOR_ONLY`` is the heart of the ticket: it tells the dispatch
+(RAR-4.1) to create **no new version** yet still advance the recency anchor
+(``last_imported_commit_sha`` / ``last_imported_committed_at``) to the observed
+commit and record the file as ``unchanged-checksum``, so the same newer commit
+is not re-evaluated as "newer" on every subsequent sweep.
+
+Like the comparator, this is a pure, side-effect-free decision function so it
+can be exercised by deterministic fixtures. Persisting the advanced anchor and
+the ``unchanged-checksum`` marker is the dispatcher's job (RAR-4.1).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional
+
+from .repository_refresh_comparator import (
+    RefreshDecision,
+    RefreshReason,
+    TimestampInput,
+    evaluate_refresh,
+)
+
+
+class RefreshAction(str, Enum):
+    """The final action the auto-refresh dispatch should take for one file."""
+
+    #: Re-import the file: create a new version and advance every anchor.
+    REIMPORT = "reimport"
+    #: Newer commit but identical content: create NO version, but advance the
+    #: recency anchor and record the file as ``unchanged-checksum`` (RAR-2.4).
+    ADVANCE_ANCHOR_ONLY = "advance-anchor-only"
+    #: Nothing to do — the remote is not newer (or has no meaningful change).
+    SKIP = "skip"
+
+
+class IdempotencyReason(str, Enum):
+    """Why the guard reached its action (stable codes for logging/audit/UI)."""
+
+    #: Nothing was ever imported for this lineage -> treat as a fresh import.
+    FIRST_IMPORT = "first-import"
+    #: Newer commit and the content checksum differs -> real change, re-import.
+    CONTENT_CHANGED = "content-changed"
+    #: Newer commit but the content checksum is unchanged -> skip the version,
+    #: advance the anchor. This is the acceptance-criteria marker for the file.
+    UNCHANGED_CHECKSUM = "unchanged-checksum"
+    #: The remote commit is older than / equal to the last import -> stale guard.
+    STALE = "stale"
+    #: No newer commit and content identical -> nothing to do.
+    UNCHANGED = "unchanged"
+
+
+@dataclass(frozen=True)
+class IdempotencyOutcome:
+    """Outcome of the checksum idempotency guard for a single file.
+
+    Attributes:
+        action: The :class:`RefreshAction` the dispatch should take.
+        reason: The :class:`IdempotencyReason` code explaining the action.
+        advance_committed_anchor: True when the dispatch should advance the
+            ``last_imported_commit_sha`` / ``last_imported_committed_at`` recency
+            anchor to the observed commit even though it may create no version.
+            True for ``REIMPORT`` (newer commit) and ``ADVANCE_ANCHOR_ONLY``;
+            False for ``SKIP`` and the first import (where the dispatch sets the
+            anchor as part of the import itself).
+    """
+
+    action: RefreshAction
+    reason: IdempotencyReason
+    advance_committed_anchor: bool
+
+
+def _normalise_checksum(value: Optional[str]) -> Optional[str]:
+    """Trim a content checksum to a comparable form (``None`` when blank)."""
+    if value is None:
+        return None
+    trimmed = value.strip()
+    return trimmed or None
+
+
+def evaluate_checksum_idempotency(
+    *,
+    decision: RefreshDecision,
+    remote_content_checksum: Optional[str],
+    last_imported_content_checksum: Optional[str],
+) -> IdempotencyOutcome:
+    """Refine a RAR-2.2 refresh decision with the REPO-8.3 content checksum.
+
+    Given the recency verdict from :func:`evaluate_refresh` and the normalized
+    content checksums, decide whether a newer commit actually warrants a new
+    version (content genuinely changed) or should only advance the anchor
+    (content identical despite a newer commit), suppressing version churn.
+
+    When a content checksum is missing on either side the guard cannot prove
+    content equality, so it defers to the comparator's verdict verbatim rather
+    than risk suppressing a real change or churning on a cosmetic one.
+
+    Args:
+        decision: The :class:`RefreshDecision` from the RAR-2.2 comparator.
+        remote_content_checksum: REPO-8.3 content checksum of the remote file
+            (the normalized spec-content digest), or None when unavailable.
+        last_imported_content_checksum: The content checksum recorded at the last
+            import, or None when unavailable.
+
+    Returns:
+        An :class:`IdempotencyOutcome` with the action, reason, and whether the
+        recency anchor should be advanced.
+    """
+    reason = decision.reason
+
+    # First import for this lineage: there is no anchor to compare against.
+    if reason is RefreshReason.NO_PRIOR_IMPORT:
+        return IdempotencyOutcome(
+            action=RefreshAction.REIMPORT,
+            reason=IdempotencyReason.FIRST_IMPORT,
+            advance_committed_anchor=False,
+        )
+
+    # Stale guard: the remote commit is older than / equal to the last import.
+    if reason is RefreshReason.STALE:
+        return IdempotencyOutcome(
+            action=RefreshAction.SKIP,
+            reason=IdempotencyReason.STALE,
+            advance_committed_anchor=False,
+        )
+
+    # Whether this branch of the comparator observed a strictly newer commit.
+    # NEWER_CONTENT (newer + blob differs) and IDEMPOTENT (newer + blob same)
+    # both mean "newer commit"; the checksum-fallback reasons mean "no
+    # comparable timestamp", so there is no newer-commit anchor to advance.
+    newer_commit = reason in (
+        RefreshReason.NEWER_CONTENT,
+        RefreshReason.IDEMPOTENT,
+    )
+
+    remote_sum = _normalise_checksum(remote_content_checksum)
+    last_sum = _normalise_checksum(last_imported_content_checksum)
+
+    # No comparable content checksum: defer to the comparator's verdict. The
+    # blob-level decision already gated content identity as best it could.
+    if remote_sum is None or last_sum is None:
+        if decision.should_refresh:
+            return IdempotencyOutcome(
+                action=RefreshAction.REIMPORT,
+                reason=IdempotencyReason.CONTENT_CHANGED,
+                advance_committed_anchor=newer_commit,
+            )
+        return IdempotencyOutcome(
+            action=RefreshAction.SKIP,
+            reason=IdempotencyReason.UNCHANGED,
+            advance_committed_anchor=False,
+        )
+
+    content_unchanged = remote_sum == last_sum
+
+    if content_unchanged:
+        # The defining RAR-2.4 case. A newer commit with identical content
+        # advances the anchor without churning a version; without a newer
+        # commit (checksum fallback) there is simply nothing to do.
+        if newer_commit:
+            return IdempotencyOutcome(
+                action=RefreshAction.ADVANCE_ANCHOR_ONLY,
+                reason=IdempotencyReason.UNCHANGED_CHECKSUM,
+                advance_committed_anchor=True,
+            )
+        return IdempotencyOutcome(
+            action=RefreshAction.SKIP,
+            reason=IdempotencyReason.UNCHANGED,
+            advance_committed_anchor=False,
+        )
+
+    # Content genuinely changed -> re-import. Advance the anchor when a newer
+    # commit was observed (the fallback path has no timestamp to advance).
+    return IdempotencyOutcome(
+        action=RefreshAction.REIMPORT,
+        reason=IdempotencyReason.CONTENT_CHANGED,
+        advance_committed_anchor=newer_commit,
+    )
+
+
+def guard_refresh(
+    *,
+    remote_committed_at: TimestampInput,
+    last_imported_committed_at: TimestampInput,
+    remote_blob_sha: Optional[str],
+    last_imported_blob_sha: Optional[str],
+    remote_content_checksum: Optional[str],
+    last_imported_content_checksum: Optional[str],
+) -> IdempotencyOutcome:
+    """Run the full RAR-2.2 + RAR-2.4 gate in one call (convenience wrapper).
+
+    Composes :func:`evaluate_refresh` (commit-recency gating on ``blob_sha``)
+    with :func:`evaluate_checksum_idempotency` (content-churn suppression on the
+    REPO-8.3 content checksum) so a caller can get the final dispatch action from
+    the raw freshness signals without threading the intermediate decision.
+
+    Args:
+        remote_committed_at: Committed-at of the remote file (datetime/ISO/None).
+        last_imported_committed_at: Stored ``last_imported_committed_at`` anchor.
+        remote_blob_sha: Remote blob SHA (the RAR-2.2 content-identity token).
+        last_imported_blob_sha: Stored ``last_imported_blob_sha`` anchor.
+        remote_content_checksum: REPO-8.3 content checksum of the remote file.
+        last_imported_content_checksum: Content checksum at the last import.
+
+    Returns:
+        The :class:`IdempotencyOutcome` describing the action to take.
+    """
+    decision = evaluate_refresh(
+        remote_committed_at=remote_committed_at,
+        last_imported_committed_at=last_imported_committed_at,
+        remote_checksum=remote_blob_sha,
+        last_imported_checksum=last_imported_blob_sha,
+    )
+    return evaluate_checksum_idempotency(
+        decision=decision,
+        remote_content_checksum=remote_content_checksum,
+        last_imported_content_checksum=last_imported_content_checksum,
+    )

--- a/objectified-rest/tests/test_repository_checksum_idempotency.py
+++ b/objectified-rest/tests/test_repository_checksum_idempotency.py
@@ -1,0 +1,255 @@
+"""Checksum idempotency guard tests (RAR-2.4, #3521).
+
+Deterministic, DB-free fixtures over
+``app.repository_checksum_idempotency``. They cover the roadmap decision row
+(``newer commit + checksum unchanged -> SKIP``), both acceptance criteria, the
+churn-suppression case the ticket exists for (cosmetic blob change with an
+unchanged content checksum), and the defer-to-comparator behaviour when a content
+checksum is unavailable.
+"""
+
+from app.repository_checksum_idempotency import (
+    IdempotencyReason,
+    RefreshAction,
+    evaluate_checksum_idempotency,
+    guard_refresh,
+)
+from app.repository_refresh_comparator import (
+    RefreshDecision,
+    RefreshReason,
+    evaluate_refresh,
+)
+
+OLD = "2026-06-20T10:00:00Z"
+NEW = "2026-06-21T10:00:00Z"
+
+
+# --- acceptance criteria ----------------------------------------------------
+
+
+def test_newer_commit_identical_content_creates_no_version() -> None:
+    """AC1: a newer commit with identical content produces no new version."""
+    outcome = guard_refresh(
+        remote_committed_at=NEW,
+        last_imported_committed_at=OLD,
+        remote_blob_sha="blob-new",  # blob changed (cosmetic commit)
+        last_imported_blob_sha="blob-old",
+        remote_content_checksum="content-same",
+        last_imported_content_checksum="content-same",
+    )
+    assert outcome.action is RefreshAction.ADVANCE_ANCHOR_ONLY
+    assert outcome.action is not RefreshAction.REIMPORT
+
+
+def test_newer_commit_identical_content_marks_unchanged_and_advances() -> None:
+    """AC2: the file is marked unchanged_checksum and the anchor is advanced."""
+    outcome = guard_refresh(
+        remote_committed_at=NEW,
+        last_imported_committed_at=OLD,
+        remote_blob_sha="blob-new",
+        last_imported_blob_sha="blob-old",
+        remote_content_checksum="content-same",
+        last_imported_content_checksum="content-same",
+    )
+    assert outcome.reason is IdempotencyReason.UNCHANGED_CHECKSUM
+    assert outcome.advance_committed_anchor is True
+
+
+# --- the roadmap decision row + its complement ------------------------------
+
+
+def test_newer_commit_changed_content_reimports() -> None:
+    """Newer commit + content checksum differs -> REIMPORT."""
+    outcome = guard_refresh(
+        remote_committed_at=NEW,
+        last_imported_committed_at=OLD,
+        remote_blob_sha="blob-new",
+        last_imported_blob_sha="blob-old",
+        remote_content_checksum="content-new",
+        last_imported_content_checksum="content-old",
+    )
+    assert outcome.action is RefreshAction.REIMPORT
+    assert outcome.reason is IdempotencyReason.CONTENT_CHANGED
+    assert outcome.advance_committed_anchor is True
+
+
+def test_newer_commit_same_blob_same_content_advances_only() -> None:
+    """RAR-2.2 IDEMPOTENT (newer + same blob) is still an anchor advance."""
+    outcome = guard_refresh(
+        remote_committed_at=NEW,
+        last_imported_committed_at=OLD,
+        remote_blob_sha="blob-same",
+        last_imported_blob_sha="blob-same",
+        remote_content_checksum="content-same",
+        last_imported_content_checksum="content-same",
+    )
+    assert outcome.action is RefreshAction.ADVANCE_ANCHOR_ONLY
+    assert outcome.reason is IdempotencyReason.UNCHANGED_CHECKSUM
+    assert outcome.advance_committed_anchor is True
+
+
+def test_older_commit_skips_stale() -> None:
+    """Older / equal commit -> SKIP (stale guard), no anchor advance."""
+    outcome = guard_refresh(
+        remote_committed_at=OLD,
+        last_imported_committed_at=NEW,
+        remote_blob_sha="blob-x",
+        last_imported_blob_sha="blob-y",
+        remote_content_checksum="content-x",
+        last_imported_content_checksum="content-y",
+    )
+    assert outcome.action is RefreshAction.SKIP
+    assert outcome.reason is IdempotencyReason.STALE
+    assert outcome.advance_committed_anchor is False
+
+
+def test_first_import_reimports() -> None:
+    """No prior import anchor -> REIMPORT (first import)."""
+    outcome = guard_refresh(
+        remote_committed_at=NEW,
+        last_imported_committed_at=None,
+        remote_blob_sha="blob-new",
+        last_imported_blob_sha=None,
+        remote_content_checksum="content-new",
+        last_imported_content_checksum=None,
+    )
+    assert outcome.action is RefreshAction.REIMPORT
+    assert outcome.reason is IdempotencyReason.FIRST_IMPORT
+    assert outcome.advance_committed_anchor is False
+
+
+# --- guard operating directly on a RefreshDecision -------------------------
+
+
+def test_guard_on_newer_content_decision_unchanged_checksum() -> None:
+    """A NEWER_CONTENT decision with an unchanged checksum downgrades to advance."""
+    decision = RefreshDecision(True, RefreshReason.NEWER_CONTENT, True)
+    outcome = evaluate_checksum_idempotency(
+        decision=decision,
+        remote_content_checksum="same",
+        last_imported_content_checksum="same",
+    )
+    assert outcome.action is RefreshAction.ADVANCE_ANCHOR_ONLY
+    assert outcome.reason is IdempotencyReason.UNCHANGED_CHECKSUM
+
+
+def test_guard_on_newer_content_decision_changed_checksum() -> None:
+    """A NEWER_CONTENT decision with a changed checksum re-imports."""
+    decision = RefreshDecision(True, RefreshReason.NEWER_CONTENT, True)
+    outcome = evaluate_checksum_idempotency(
+        decision=decision,
+        remote_content_checksum="a",
+        last_imported_content_checksum="b",
+    )
+    assert outcome.action is RefreshAction.REIMPORT
+    assert outcome.reason is IdempotencyReason.CONTENT_CHANGED
+
+
+# --- defer-to-comparator when content checksum is unavailable --------------
+
+
+def test_missing_remote_checksum_defers_to_comparator_refresh() -> None:
+    """No remote content checksum + comparator says refresh -> REIMPORT."""
+    outcome = guard_refresh(
+        remote_committed_at=NEW,
+        last_imported_committed_at=OLD,
+        remote_blob_sha="blob-new",
+        last_imported_blob_sha="blob-old",
+        remote_content_checksum=None,
+        last_imported_content_checksum="content-old",
+    )
+    assert outcome.action is RefreshAction.REIMPORT
+    assert outcome.reason is IdempotencyReason.CONTENT_CHANGED
+    # The commit was still newer, so the anchor advances.
+    assert outcome.advance_committed_anchor is True
+
+
+def test_missing_checksum_defers_to_comparator_skip() -> None:
+    """No content checksum + comparator says skip (idempotent) -> SKIP/advance.
+
+    The comparator returns IDEMPOTENT (newer commit, same blob) and there is no
+    content checksum to refine with, so the guard defers: nothing to re-import,
+    but the newer commit still advances the anchor.
+    """
+    decision = evaluate_refresh(
+        remote_committed_at=NEW,
+        last_imported_committed_at=OLD,
+        remote_checksum="blob-same",
+        last_imported_checksum="blob-same",
+    )
+    assert decision.reason is RefreshReason.IDEMPOTENT
+    outcome = evaluate_checksum_idempotency(
+        decision=decision,
+        remote_content_checksum=None,
+        last_imported_content_checksum=None,
+    )
+    assert outcome.action is RefreshAction.SKIP
+    assert outcome.reason is IdempotencyReason.UNCHANGED
+    assert outcome.advance_committed_anchor is False
+
+
+def test_blank_checksum_treated_as_missing() -> None:
+    """Whitespace-only checksums are normalised to missing and defer."""
+    outcome = guard_refresh(
+        remote_committed_at=NEW,
+        last_imported_committed_at=OLD,
+        remote_blob_sha="blob-new",
+        last_imported_blob_sha="blob-old",
+        remote_content_checksum="   ",
+        last_imported_content_checksum="content-old",
+    )
+    # Defers to the comparator (blob differs + newer) -> REIMPORT.
+    assert outcome.action is RefreshAction.REIMPORT
+
+
+# --- checksum-fallback path (no comparable timestamp) ----------------------
+
+
+def test_fallback_changed_blob_but_unchanged_content_advances_nothing() -> None:
+    """No timestamp + blob differs but content checksum same -> SKIP unchanged.
+
+    Without a comparable commit timestamp there is no newer-commit anchor to
+    advance, so an unchanged content checksum is simply a no-op skip rather than
+    an anchor advance.
+    """
+    outcome = guard_refresh(
+        remote_committed_at=None,
+        last_imported_committed_at=None,
+        remote_blob_sha="blob-new",
+        last_imported_blob_sha="blob-old",
+        remote_content_checksum="content-same",
+        last_imported_content_checksum="content-same",
+    )
+    assert outcome.action is RefreshAction.SKIP
+    assert outcome.reason is IdempotencyReason.UNCHANGED
+    assert outcome.advance_committed_anchor is False
+
+
+def test_fallback_changed_content_reimports_without_advancing() -> None:
+    """No timestamp + content checksum differs -> REIMPORT, no anchor advance."""
+    outcome = guard_refresh(
+        remote_committed_at=None,
+        last_imported_committed_at=None,
+        remote_blob_sha="blob-new",
+        last_imported_blob_sha="blob-old",
+        remote_content_checksum="content-new",
+        last_imported_content_checksum="content-old",
+    )
+    assert outcome.action is RefreshAction.REIMPORT
+    assert outcome.reason is IdempotencyReason.CONTENT_CHANGED
+    assert outcome.advance_committed_anchor is False
+
+
+# --- stable wire values -----------------------------------------------------
+
+
+def test_action_and_reason_wire_values_are_stable() -> None:
+    """Stable kebab-case codes for logging/audit/UI."""
+    assert RefreshAction.REIMPORT.value == "reimport"
+    assert RefreshAction.ADVANCE_ANCHOR_ONLY.value == "advance-anchor-only"
+    assert RefreshAction.SKIP.value == "skip"
+    assert IdempotencyReason.UNCHANGED_CHECKSUM.value == "unchanged-checksum"
+    assert IdempotencyReason.CONTENT_CHANGED.value == "content-changed"
+    assert IdempotencyReason.FIRST_IMPORT.value == "first-import"
+    assert IdempotencyReason.STALE.value == "stale"
+    assert IdempotencyReason.UNCHANGED.value == "unchanged"


### PR DESCRIPTION
## What & why

Closes #3521 (RAR-2.4). A newer commit can touch a file's metadata or re-commit identical content without changing the spec content; re-importing then would create empty/no-op versions — churn. This adds a second, finer gate that runs after the RAR-2.2 recency comparator: when a commit is newer but the **content** is unchanged, skip version creation and advance the recency anchor instead.

The RAR-2.2 comparator gates on `blob_sha`, but `blob_sha` changes on any byte difference (reformat, comment, header bump). This guard re-checks the REPO-8.3 (#2933) **content checksum** — a normalized digest of the parsed spec content that is stable across cosmetic changes — so only genuine content changes produce a new version.

## Changes

**objectified-rest** — new pure, DB-free module `repository_checksum_idempotency.py`:
- `evaluate_checksum_idempotency(decision, remote_content_checksum, last_imported_content_checksum)` refines a RAR-2.2 `RefreshDecision` and returns an `IdempotencyOutcome`:
  - `action`: `RefreshAction` — `reimport` / `advance-anchor-only` / `skip`
  - `reason`: `IdempotencyReason` — `first-import` / `content-changed` / `unchanged-checksum` / `stale` / `unchanged`
  - `advance_committed_anchor`: whether the dispatch should advance `last_imported_commit_sha` / `last_imported_committed_at`
- Decision table: newer commit + content changed → `reimport`; **newer commit + content unchanged → `advance-anchor-only`, marked `unchanged-checksum` (no version, anchor advanced)**; older/equal → `skip` (stale guard); first import → `reimport`; missing content checksum on either side → defer to the comparator's verdict verbatim.
- `guard_refresh(...)` — convenience wrapper running the full RAR-2.2 + RAR-2.4 gate from the raw freshness signals.

Both acceptance criteria are met: (1) a newer commit with identical content produces no new version (`advance-anchor-only`, not `reimport`); (2) the file is marked `unchanged-checksum` and the recency anchor is advanced (`advance_committed_anchor=True`).

## How to test

From `objectified-rest`, run:

```
./.venv/bin/python -m pytest tests/test_repository_checksum_idempotency.py -q
```

14 deterministic fixtures cover both acceptance criteria, the roadmap decision row, the cosmetic-blob-change churn case (blob differs but content checksum same → `advance-anchor-only`), the defer-on-missing-checksum behaviour, the no-timestamp fallback path, and the stable wire codes.

## Risk / notes

- No schema migration and no runtime wiring — this is a pure decision function, mirroring how RAR-2.2's dispatch wiring was deferred to RAR-4.1.
- Persisting the advanced anchor and the `unchanged-checksum` marker is the dispatcher's job (RAR-4.1); this ticket delivers the decision the dispatcher consumes.
- New module is ruff-clean; the repository REST test group (87 tests) passes.

Work performed by Claude Code via model Claude Opus 4.8 (1M context).