### PR TITLE
Fix #3522 - Configurable refresh cadence (RAR-3.1)

### DIFF
--- a/docs/ROADMAP_REPOSITORY_AUTOREFRESH.md
+++ b/docs/ROADMAP_REPOSITORY_AUTOREFRESH.md
@@ -121,7 +121,7 @@ epic. Use this table to resolve any `RAR-*` reference below to its issue number.
 | ~~RAR-1.1~~ ✅ | ~~#3512~~ | ~~RAR-1.2~~ ✅ | ~~#3513~~ | ~~RAR-1.3~~ ✅ | ~~#3514~~ |
 | ~~RAR-1.4~~ ✅ | ~~#3515~~ | ~~RAR-1.5~~ ✅ | ~~#3516~~ | RAR-1.6 | #3517 |
 | ~~RAR-2.1~~ ✅ | ~~#3518~~ | ~~RAR-2.2~~ ✅ | ~~#3519~~ | ~~RAR-2.3~~ ✅ | ~~#3520~~ |
-| ~~RAR-2.4~~ ✅ | ~~#3521~~ | RAR-3.1 | #3522 | RAR-3.2 | #3523 |
+| ~~RAR-2.4~~ ✅ | ~~#3521~~ | ~~RAR-3.1~~ ✅ | ~~#3522~~ | RAR-3.2 | #3523 |
 | RAR-3.3 | #3524 | RAR-3.4 | #3525 | RAR-3.5 | #3526 |
 | RAR-4.1 | #3527 | RAR-4.2 | #3528 | RAR-4.3 | #3529 |
 | RAR-4.4 | #3530 | RAR-4.5 | #3531 | RAR-5.1 | #3532 |
@@ -362,7 +362,7 @@ Refresh "after a few minutes," configurable, safe under load.
 
 | ID | Title | Summary | Labels | Parallel | MVP | Cmplx | Modules |
 |----|-------|---------|--------|----------|-----|-------|---------|
-| RAR-3.1 | Configurable refresh cadence | Replace hardcoded 5s; per-repo interval (default ~5 min, min bound) | `enhancement`,`mvp`,`import`,`repository`,`automation` | N | Y | M | objectified-rest, objectified-db |
+| ~~RAR-3.1~~ ✅ **Done** (#3522) | Configurable refresh cadence | Replace hardcoded 5s; per-repo interval (default ~5 min, min bound) | `enhancement`,`mvp`,`import`,`repository`,`automation` | N | Y | M | objectified-rest, objectified-db |
 | RAR-3.2 | Refresh sweep → enqueue stale files | Periodic worker enqueues re-import jobs for stale, newer files | `enhancement`,`mvp`,`import`,`repository`,`automation` | N | Y | L | objectified-rest |
 | RAR-3.3 | Enable/disable auto-refresh (per-repo + global kill switch) | Toggle, with global env override | `enhancement`,`mvp`,`import`,`repository` | Y | Y | S | objectified-rest, objectified-ui |
 | RAR-3.4 | Refresh backoff + auto-pause (extend REPO-4.5) | Pause a repo's refresh after N consecutive failures | `enhancement`,`import`,`repository`,`automation` | Y | N | M | objectified-rest |
@@ -378,6 +378,25 @@ plus a global `OBJECTIFIED_REFRESH_MIN_INTERVAL` env floor. The sweep reads due 
 **Acceptance criteria.** Interval configurable per repo and globally; values below the floor are
 clamped with a warning; default behaves as ~5-minute refresh.
 **Dependencies.** Blocks RAR-3.2. **Parallel = N.**
+
+**Status: ✅ Done (#3522).** Migration `objectified-db/scripts/20260621-140000.sql` adds
+`refresh_interval_seconds` (`INTEGER NOT NULL DEFAULT 300`, with a named
+`ck_tenant_repositories_refresh_interval_positive` CHECK > 0) and the `last_refreshed_at` anchor to
+`odb.tenant_repositories`. `config.py` adds the global knobs `OBJECTIFIED_REFRESH_DEFAULT_INTERVAL`
+(300) and `OBJECTIFIED_REFRESH_MIN_INTERVAL` (60s floor). New pure module
+`objectified-rest/src/app/repository_refresh_cadence.py` holds the policy: `resolve_refresh_interval`
+applies the default and clamps sub-floor values up to the floor (logging a WARNING when it clamps;
+the floor itself can never drop below 1s), and `is_repository_due` decides whether a repo is due from
+its `last_refreshed_at` + effective interval (`now - last_refreshed_at >= interval`; never-refreshed →
+due; accepts datetime/ISO/naive-as-UTC). `database.py` exposes the sweep primitives the RAR-3.2 worker
+will iterate: `list_due_repositories` (DB-side `now()` due selection with the floor applied via
+`GREATEST(refresh_interval_seconds, floor)`, NULLS-first fair ordering, scannable-status filter),
+`mark_repository_refreshed` (advance the anchor each tick), and `set_repository_refresh_interval`
+(per-repo setter that persists the clamped value); the two repo read queries now surface the cadence
+columns. Tests: `tests/test_repository_refresh_cadence.py` (default/clamp/warning/floor + due-boundary
++ input-shape + config knobs) and the static migration guard
+`tests/test_repository_refresh_cadence_migration.py`. The periodic worker that calls these primitives
+(and advances `last_refreshed_at` each tick) is RAR-3.2; the per-repo UI toggle is RAR-3.3.
 
 ### RAR-3.2 — Refresh sweep → enqueue stale files
 

--- a/objectified-db/package.json
+++ b/objectified-db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-db",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Objectified database migrations and the direct-to-database admin CLI (objectified-db).",
   "author": "Objectified",
   "type": "module",

--- a/objectified-db/scripts/20260621-140000.sql
+++ b/objectified-db/scripts/20260621-140000.sql
@@ -1,0 +1,34 @@
+-- Configurable refresh cadence (RAR-3.1, #3522).
+--
+-- The repository auto-refresh sweep was a hardcoded, global `await asyncio.sleep(5)`
+-- (`objectified-rest/src/app/main.py:179`); "refresh after a few minutes" could not
+-- be expressed per repository. Two columns make the cadence configurable and give
+-- the sweep (RAR-3.2) a due-selection anchor:
+--
+--   1. `refresh_interval_seconds` — per-repo refresh cadence in seconds. Defaults to
+--      300 (~5 minutes), the v1 default behaviour. A global floor
+--      (`OBJECTIFIED_REFRESH_MIN_INTERVAL`, default 60s) clamps sub-floor values at
+--      read time in the application; the CHECK below only enforces a positive value.
+--   2. `last_refreshed_at` — the timestamp of the last refresh sweep tick for this
+--      repository. The sweep selects due repos via
+--      `last_refreshed_at IS NULL OR now() - last_refreshed_at >= interval` and
+--      advances it each tick (RAR-3.2).
+SET search_path TO odb, public;
+
+ALTER TABLE odb.tenant_repositories
+  ADD COLUMN IF NOT EXISTS refresh_interval_seconds INTEGER NOT NULL DEFAULT 300,
+  ADD COLUMN IF NOT EXISTS last_refreshed_at TIMESTAMPTZ;
+
+-- Reject non-positive cadences outright; the configurable floor (default 60s) is
+-- applied in the application so it can be tuned per environment without a migration.
+ALTER TABLE odb.tenant_repositories
+  DROP CONSTRAINT IF EXISTS ck_tenant_repositories_refresh_interval_positive;
+ALTER TABLE odb.tenant_repositories
+  ADD CONSTRAINT ck_tenant_repositories_refresh_interval_positive
+  CHECK (refresh_interval_seconds > 0);
+
+COMMENT ON COLUMN odb.tenant_repositories.refresh_interval_seconds IS
+  'Per-repo auto-refresh cadence in seconds (RAR-3.1). Default 300 (~5 min); the global OBJECTIFIED_REFRESH_MIN_INTERVAL floor (default 60s) clamps sub-floor values at read time.';
+
+COMMENT ON COLUMN odb.tenant_repositories.last_refreshed_at IS
+  'Timestamp of the last auto-refresh sweep tick for this repository (RAR-3.1); the sweep picks repos where now() - last_refreshed_at >= refresh_interval_seconds and advances it each tick (RAR-3.2).';

--- a/objectified-rest/pyproject.toml
+++ b/objectified-rest/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "objectified-rest"
-version = "1.0.67"
+version = "1.0.68"
 description = "REST API for serving OpenAPI specifications from the Objectified database"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/objectified-rest/src/app/config.py
+++ b/objectified-rest/src/app/config.py
@@ -40,6 +40,25 @@ class Settings(BaseSettings):
         ),
     )
 
+    # Repository auto-refresh cadence (RAR-3.1, #3522). Per-repo cadence is stored
+    # in odb.tenant_repositories.refresh_interval_seconds; these set the default
+    # applied when a repo has no explicit value and the global minimum floor that
+    # clamps sub-floor per-repo values at read time.
+    refresh_default_interval_seconds: int = Field(
+        default=300,
+        validation_alias=AliasChoices(
+            "OBJECTIFIED_REFRESH_DEFAULT_INTERVAL",
+            "refresh_default_interval_seconds",
+        ),
+    )
+    refresh_min_interval_seconds: int = Field(
+        default=60,
+        validation_alias=AliasChoices(
+            "OBJECTIFIED_REFRESH_MIN_INTERVAL",
+            "refresh_min_interval_seconds",
+        ),
+    )
+
     @property
     def effective_database_url(self) -> str:
         """Get the database URL, preferring DATABASE_URL over building from components."""

--- a/objectified-rest/src/app/database.py
+++ b/objectified-rest/src/app/database.py
@@ -6453,7 +6453,8 @@ class Database:
         q = """
             SELECT id, tenant_id, source, provider, clone_url, repository_full_name,
                    description, default_branch, visibility, status, created_at, updated_at,
-                   linked_account_id, last_scanned_at, total_files, importable_count, branch_count
+                   linked_account_id, last_scanned_at, total_files, importable_count, branch_count,
+                   refresh_interval_seconds, last_refreshed_at
             FROM odb.tenant_repositories
             WHERE tenant_id = %s::uuid AND deleted_at IS NULL
             ORDER BY created_at DESC
@@ -6464,13 +6465,147 @@ class Database:
         q = """
             SELECT id, tenant_id, source, provider, clone_url, repository_full_name,
                    description, default_branch, visibility, status, created_at, updated_at,
-                   linked_account_id, last_scanned_at, total_files, importable_count, branch_count, created_by
+                   linked_account_id, last_scanned_at, total_files, importable_count, branch_count, created_by,
+                   refresh_interval_seconds, last_refreshed_at
             FROM odb.tenant_repositories
             WHERE id = %s::uuid AND tenant_id = %s::uuid AND deleted_at IS NULL
             LIMIT 1
         """
         rows = self.execute_query(q, (repository_id, tenant_id))
         return dict(rows[0]) if rows else None
+
+    def list_due_repositories(
+        self,
+        *,
+        floor_seconds: Optional[int] = None,
+    ) -> List[Dict[str, Any]]:
+        """Return repositories due for an auto-refresh sweep tick (RAR-3.1).
+
+        A repository is due when it has never been refreshed
+        (``last_refreshed_at IS NULL``) or when at least its effective interval
+        has elapsed since the last tick. The effective interval is the per-repo
+        ``refresh_interval_seconds`` clamped up to the global floor, so a
+        too-aggressive per-repo cadence cannot defeat the floor. Soft-deleted
+        repositories and those not in a scannable ``ready``/``error`` state are
+        excluded. The recency comparison is done in the database against
+        ``now()`` so it does not depend on application clock skew.
+
+        The actual rescan + enqueue is the RAR-3.2 sweep; this is the
+        due-selection primitive it iterates.
+
+        Args:
+            floor_seconds: The global minimum interval; per-repo values below it
+                are treated as the floor. Defaults to
+                ``settings.refresh_min_interval_seconds`` when omitted.
+
+        Returns:
+            Repository rows due for refresh, oldest ``last_refreshed_at`` first
+            (NULLs — never refreshed — first) for fair scheduling.
+        """
+        from .config import settings
+        from .repository_refresh_cadence import DEFAULT_MIN_REFRESH_INTERVAL_SECONDS
+
+        floor = floor_seconds if floor_seconds is not None else settings.refresh_min_interval_seconds
+        if floor < 1:
+            floor = DEFAULT_MIN_REFRESH_INTERVAL_SECONDS
+
+        q = """
+            SELECT id, tenant_id, source, provider, clone_url, repository_full_name,
+                   description, default_branch, visibility, status, created_at, updated_at,
+                   linked_account_id, last_scanned_at, total_files, importable_count, branch_count,
+                   refresh_interval_seconds, last_refreshed_at
+            FROM odb.tenant_repositories
+            WHERE deleted_at IS NULL
+              AND status IN ('ready', 'error')
+              AND (
+                last_refreshed_at IS NULL
+                OR last_refreshed_at <= now() - make_interval(
+                     secs => GREATEST(refresh_interval_seconds, %s)
+                   )
+              )
+            ORDER BY last_refreshed_at ASC NULLS FIRST, created_at ASC
+        """
+        return self.execute_query(q, (floor,))
+
+    def mark_repository_refreshed(self, repository_id: str) -> bool:
+        """Advance a repository's ``last_refreshed_at`` to now (RAR-3.1).
+
+        Called by the sweep at the end of each tick for a repository so the next
+        due check is measured from this moment. Returns True when a live row was
+        updated (False when the id is unknown or soft-deleted).
+
+        Args:
+            repository_id: The repository whose refresh anchor to advance.
+
+        Returns:
+            True when a row was updated.
+        """
+        q = """
+            UPDATE odb.tenant_repositories
+            SET last_refreshed_at = CURRENT_TIMESTAMP
+            WHERE id = %s::uuid AND deleted_at IS NULL
+            RETURNING id
+        """
+        conn = self.connect()
+        try:
+            with conn.cursor() as cursor:
+                cursor.execute(q, (repository_id,))
+                row = cursor.fetchone()
+                conn.commit()
+                return bool(row)
+        except Exception as e:
+            conn.rollback()
+            raise e
+
+    def set_repository_refresh_interval(
+        self,
+        tenant_id: str,
+        repository_id: str,
+        interval_seconds: Optional[int],
+    ) -> Optional[int]:
+        """Set a repository's per-repo refresh cadence, clamped to the floor (RAR-3.1).
+
+        The value is resolved through
+        :func:`repository_refresh_cadence.resolve_refresh_interval` first, so a
+        ``None``/non-positive value falls back to the configured default and a
+        sub-floor value is clamped up (with a warning). The clamped value is what
+        is persisted, so a later read needs no re-clamping.
+
+        Args:
+            tenant_id: Owning tenant id (scopes the update for isolation).
+            repository_id: The repository to update.
+            interval_seconds: The requested cadence in seconds, or None to reset
+                to the configured default.
+
+        Returns:
+            The effective (clamped) interval that was stored, or None when no
+            live repository matched the tenant + id.
+        """
+        from .config import settings
+        from .repository_refresh_cadence import resolve_refresh_interval
+
+        effective = resolve_refresh_interval(
+            interval_seconds,
+            floor_seconds=settings.refresh_min_interval_seconds,
+            default_seconds=settings.refresh_default_interval_seconds,
+        )
+        q = """
+            UPDATE odb.tenant_repositories
+            SET refresh_interval_seconds = %s,
+                updated_at = CURRENT_TIMESTAMP
+            WHERE id = %s::uuid AND tenant_id = %s::uuid AND deleted_at IS NULL
+            RETURNING id
+        """
+        conn = self.connect()
+        try:
+            with conn.cursor() as cursor:
+                cursor.execute(q, (effective, repository_id, tenant_id))
+                row = cursor.fetchone()
+                conn.commit()
+                return effective if row else None
+        except Exception as e:
+            conn.rollback()
+            raise e
 
     def list_tenant_repository_file_branches(self, tenant_id: str, repository_id: str) -> List[str]:
         """Distinct branch names that have indexed file rows for this repository."""

--- a/objectified-rest/src/app/repository_refresh_cadence.py
+++ b/objectified-rest/src/app/repository_refresh_cadence.py
@@ -1,0 +1,137 @@
+"""
+Configurable refresh cadence for repository auto-refresh (RAR-3.1, #3522).
+
+The auto-refresh sweep used a hardcoded, global ``await asyncio.sleep(5)``
+(``main.py:179``); "refresh after a few minutes" could not be expressed per
+repository. RAR-3.1 stores a per-repo ``refresh_interval_seconds`` (default 300)
+on ``odb.tenant_repositories`` and adds a ``last_refreshed_at`` anchor, gated by a
+global floor (``OBJECTIFIED_REFRESH_MIN_INTERVAL``, default 60s).
+
+This module is the pure, side-effect-free policy layer the DAO and the sweep
+(RAR-3.2) build on:
+
+* :func:`resolve_refresh_interval` applies the default and clamps sub-floor
+  values to the floor, logging a warning when it clamps.
+* :func:`is_repository_due` decides whether a repo is due for a refresh from its
+  ``last_refreshed_at`` and effective interval.
+
+Keeping the policy here (rather than inline in SQL or the sweep loop) means the
+clamping and due rules are deterministic and unit-testable, and the floor can be
+tuned per environment without a migration.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Optional
+
+#: Default per-repo cadence when a repository has no explicit interval (~5 min).
+DEFAULT_REFRESH_INTERVAL_SECONDS = 300
+#: Default global floor below which a configured interval is clamped.
+DEFAULT_MIN_REFRESH_INTERVAL_SECONDS = 60
+
+_log = logging.getLogger(__name__)
+
+
+def resolve_refresh_interval(
+    configured_seconds: Optional[int],
+    *,
+    floor_seconds: int = DEFAULT_MIN_REFRESH_INTERVAL_SECONDS,
+    default_seconds: int = DEFAULT_REFRESH_INTERVAL_SECONDS,
+) -> int:
+    """Resolve a repository's effective refresh interval in seconds (RAR-3.1).
+
+    Applies the default when no per-repo value is configured, then clamps the
+    result up to the floor so a too-aggressive cadence cannot hammer providers.
+    A clamp (or a non-positive configured value, which is treated as "unset")
+    is logged at WARNING so operators can see it took effect.
+
+    The floor itself is clamped to at least 1 second so a misconfigured
+    ``floor_seconds`` of 0 or negative can never disable the guard entirely.
+
+    Args:
+        configured_seconds: The per-repo ``refresh_interval_seconds`` value, or
+            None when the repository has no explicit cadence. Non-positive values
+            are treated as unset and fall back to ``default_seconds``.
+        floor_seconds: The global minimum interval; results below it are clamped.
+        default_seconds: The interval used when ``configured_seconds`` is unset.
+
+    Returns:
+        The effective interval in seconds (always >= max(floor, 1)).
+    """
+    floor = floor_seconds if floor_seconds >= 1 else 1
+
+    if configured_seconds is None or configured_seconds <= 0:
+        interval = default_seconds
+    else:
+        interval = configured_seconds
+
+    if interval < floor:
+        _log.warning(
+            "refresh interval %ss is below the floor %ss; clamping to %ss",
+            interval,
+            floor,
+            floor,
+        )
+        return floor
+    return interval
+
+
+def _as_utc(value: Optional[object]) -> Optional[datetime]:
+    """Coerce a timestamp to a timezone-aware UTC ``datetime`` or ``None``.
+
+    Accepts an aware/naive :class:`datetime` or an ISO-8601 string (including a
+    trailing ``Z``). Naive datetimes are assumed UTC. Anything unparseable yields
+    ``None``.
+    """
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        dt = value
+    elif isinstance(value, str):
+        raw = value.strip()
+        if not raw:
+            return None
+        if raw.endswith(("Z", "z")):
+            raw = raw[:-1] + "+00:00"
+        try:
+            dt = datetime.fromisoformat(raw)
+        except ValueError:
+            return None
+    else:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def is_repository_due(
+    *,
+    last_refreshed_at: Optional[object],
+    interval_seconds: int,
+    now: Optional[object] = None,
+) -> bool:
+    """Return True when a repository is due for an auto-refresh (RAR-3.1).
+
+    A repository is due when it has never been refreshed
+    (``last_refreshed_at is None``) or when at least ``interval_seconds`` have
+    elapsed since its last refresh, i.e. ``now - last_refreshed_at >= interval``.
+
+    Args:
+        last_refreshed_at: The repository's ``last_refreshed_at`` (datetime / ISO
+            string / None). None means never refreshed -> due.
+        interval_seconds: The effective interval from
+            :func:`resolve_refresh_interval`.
+        now: The reference "current" time (datetime / ISO string); defaults to the
+            current UTC time when omitted.
+
+    Returns:
+        True when the repository should be refreshed now.
+    """
+    last = _as_utc(last_refreshed_at)
+    if last is None:
+        return True
+    current = _as_utc(now) or datetime.now(timezone.utc)
+    elapsed = (current - last).total_seconds()
+    return elapsed >= interval_seconds

--- a/objectified-rest/tests/test_repository_refresh_cadence.py
+++ b/objectified-rest/tests/test_repository_refresh_cadence.py
@@ -1,0 +1,113 @@
+"""Refresh cadence policy tests (RAR-3.1, #3522).
+
+Deterministic, DB-free fixtures over ``app.repository_refresh_cadence`` plus a
+check that the config exposes the global floor / default knobs. They cover the
+acceptance criteria: interval configurable per repo and globally, sub-floor
+values clamped with a warning, and the default behaving as a ~5-minute refresh.
+"""
+
+import logging
+from datetime import datetime, timedelta, timezone
+
+from app.config import settings
+from app.repository_refresh_cadence import (
+    DEFAULT_MIN_REFRESH_INTERVAL_SECONDS,
+    DEFAULT_REFRESH_INTERVAL_SECONDS,
+    is_repository_due,
+    resolve_refresh_interval,
+)
+
+NOW = datetime(2026, 6, 21, 12, 0, 0, tzinfo=timezone.utc)
+
+
+# --- resolve_refresh_interval ----------------------------------------------
+
+
+def test_default_interval_is_five_minutes() -> None:
+    """Unset cadence -> the ~5-minute default."""
+    assert resolve_refresh_interval(None) == 300
+    assert DEFAULT_REFRESH_INTERVAL_SECONDS == 300
+
+
+def test_configured_interval_above_floor_is_preserved() -> None:
+    """A sane per-repo value is used verbatim."""
+    assert resolve_refresh_interval(600) == 600
+
+
+def test_sub_floor_value_is_clamped_with_warning(caplog) -> None:
+    """A value below the floor is clamped up and a warning is emitted."""
+    with caplog.at_level(logging.WARNING):
+        result = resolve_refresh_interval(10, floor_seconds=60)
+    assert result == 60
+    assert any("clamp" in r.message.lower() for r in caplog.records)
+
+
+def test_non_positive_configured_value_falls_back_to_default() -> None:
+    """Zero / negative per-repo values are treated as unset."""
+    assert resolve_refresh_interval(0) == DEFAULT_REFRESH_INTERVAL_SECONDS
+    assert resolve_refresh_interval(-5) == DEFAULT_REFRESH_INTERVAL_SECONDS
+
+
+def test_custom_floor_and_default_are_honoured() -> None:
+    """The floor and default are parameters (configurable globally)."""
+    assert resolve_refresh_interval(30, floor_seconds=120) == 120
+    assert resolve_refresh_interval(None, default_seconds=900) == 900
+
+
+def test_floor_itself_cannot_drop_below_one_second() -> None:
+    """A misconfigured floor of 0 / negative is itself clamped to 1s."""
+    assert resolve_refresh_interval(0, floor_seconds=0, default_seconds=0) == 1
+    assert resolve_refresh_interval(None, floor_seconds=-10, default_seconds=0) == 1
+
+
+# --- is_repository_due ------------------------------------------------------
+
+
+def test_never_refreshed_is_due() -> None:
+    """A repo with no last_refreshed_at is always due."""
+    assert is_repository_due(last_refreshed_at=None, interval_seconds=300, now=NOW) is True
+
+
+def test_not_yet_elapsed_is_not_due() -> None:
+    """Less than one interval since the last refresh -> not due."""
+    last = NOW - timedelta(seconds=120)
+    assert is_repository_due(last_refreshed_at=last, interval_seconds=300, now=NOW) is False
+
+
+def test_elapsed_past_interval_is_due() -> None:
+    """At least one interval elapsed -> due."""
+    last = NOW - timedelta(seconds=301)
+    assert is_repository_due(last_refreshed_at=last, interval_seconds=300, now=NOW) is True
+
+
+def test_exactly_at_interval_is_due() -> None:
+    """Boundary: elapsed == interval is due (>=)."""
+    last = NOW - timedelta(seconds=300)
+    assert is_repository_due(last_refreshed_at=last, interval_seconds=300, now=NOW) is True
+
+
+def test_accepts_iso_string_timestamps() -> None:
+    """ISO-8601 strings (with trailing Z) are accepted for both anchors."""
+    assert (
+        is_repository_due(
+            last_refreshed_at="2026-06-21T11:50:00Z",
+            interval_seconds=300,
+            now="2026-06-21T12:00:00Z",
+        )
+        is True
+    )
+
+
+def test_naive_last_refreshed_assumed_utc() -> None:
+    """A naive datetime is treated as UTC so the comparison is well defined."""
+    last = datetime(2026, 6, 21, 11, 0, 0)  # naive
+    assert is_repository_due(last_refreshed_at=last, interval_seconds=300, now=NOW) is True
+
+
+# --- config knobs -----------------------------------------------------------
+
+
+def test_config_exposes_cadence_floor_and_default() -> None:
+    """The global floor / default are configurable via env (RAR-3.1)."""
+    assert settings.refresh_default_interval_seconds == 300
+    assert settings.refresh_min_interval_seconds == DEFAULT_MIN_REFRESH_INTERVAL_SECONDS

--- a/objectified-rest/tests/test_repository_refresh_cadence_migration.py
+++ b/objectified-rest/tests/test_repository_refresh_cadence_migration.py
@@ -1,0 +1,30 @@
+"""Guardrails for the refresh cadence migration (RAR-3.1, #3522)."""
+
+from pathlib import Path
+
+_MIGRATION = "objectified-db/scripts/20260621-140000.sql"
+
+# Fragments the migration must contain so the cadence columns + constraint survive
+# accidental edits. Acceptance criteria for #3522:
+#   - per-repo `refresh_interval_seconds` (default 300 -> ~5-minute refresh)
+#   - `last_refreshed_at` column for the sweep's due-selection anchor
+#   - a positive-value CHECK (the configurable floor is applied in the app)
+_REQUIRED_FRAGMENTS = (
+    "ALTER TABLE odb.tenant_repositories",
+    "ADD COLUMN IF NOT EXISTS refresh_interval_seconds INTEGER NOT NULL DEFAULT 300",
+    "ADD COLUMN IF NOT EXISTS last_refreshed_at TIMESTAMPTZ",
+    "ck_tenant_repositories_refresh_interval_positive",
+    "CHECK (refresh_interval_seconds > 0)",
+)
+
+
+def test_migration_adds_cadence_columns(repo_root: Path) -> None:
+    text = (repo_root / _MIGRATION).read_text()
+    missing = [frag for frag in _REQUIRED_FRAGMENTS if frag not in text]
+    assert not missing, f"Migration missing expected fragments: {missing}"
+
+
+def test_migration_default_is_five_minutes(repo_root: Path) -> None:
+    """The default cadence must remain 300s so v1 behaves as a ~5-minute refresh."""
+    text = (repo_root / _MIGRATION).read_text()
+    assert "DEFAULT 300" in text


### PR DESCRIPTION
## What & why

Closes #3522 (RAR-3.1). The repository auto-refresh sweep was a hardcoded, global `await asyncio.sleep(5)` (`main.py:179`); "refresh after a few minutes" could not be expressed per repository. This adds a per-repo, configurable cadence with a global floor, and the due-selection primitives the RAR-3.2 sweep will iterate.

## Changes

**objectified-db** — migration `20260621-140000.sql`:
- `refresh_interval_seconds INTEGER NOT NULL DEFAULT 300` (~5-minute default), with a named CHECK `> 0`.
- `last_refreshed_at TIMESTAMPTZ` — the sweep's due-selection anchor.

**objectified-rest**
- `config.py`: `OBJECTIFIED_REFRESH_DEFAULT_INTERVAL` (300) and `OBJECTIFIED_REFRESH_MIN_INTERVAL` (60s floor).
- New pure module `repository_refresh_cadence.py`:
  - `resolve_refresh_interval(...)` — applies the default when unset, clamps sub-floor values up to the floor and logs a WARNING when it clamps; the floor itself can never drop below 1s.
  - `is_repository_due(...)` — `now - last_refreshed_at >= interval`; never-refreshed → due; accepts datetime / ISO-8601 / naive-as-UTC.
- `database.py` sweep primitives (for RAR-3.2):
  - `list_due_repositories(...)` — DB-side `now()` due selection with the floor applied via `GREATEST(refresh_interval_seconds, floor)`, NULLS-first fair ordering, scannable-status filter.
  - `mark_repository_refreshed(...)` — advance the anchor each tick.
  - `set_repository_refresh_interval(...)` — per-repo setter that persists the clamped value.
  - The two repo read queries now surface the cadence columns.

## Acceptance criteria

- ✅ Interval configurable per repo (`refresh_interval_seconds` column + `set_repository_refresh_interval`) and globally (env floor/default).
- ✅ Sub-floor values clamped with a warning (`resolve_refresh_interval`; DB-side `GREATEST` in the due query).
- ✅ Default behaves as ~5-minute refresh (300s default).
- ✅ `last_refreshed_at` column added.

## How to test

From `objectified-rest`, run:

```
./.venv/bin/python -m pytest tests/test_repository_refresh_cadence.py tests/test_repository_refresh_cadence_migration.py -q
```

15 deterministic fixtures cover the default (~5 min), sub-floor clamping + warning, non-positive → default, custom floor/default, the due boundaries (never-refreshed, not-yet-elapsed, exactly-at-interval, elapsed), ISO/naive timestamp handling, the migration fragments, and the config knobs.

## Risk / notes

- Additive migration (two columns + a positive-value CHECK); the configurable floor (default 60s) is applied in the app so it can be tuned per environment without a migration.
- The periodic worker that calls these primitives and advances `last_refreshed_at` each tick is RAR-3.2; the per-repo UI toggle is RAR-3.3. This ticket delivers the cadence config, policy, and due-selection primitives.
- New modules are ruff-clean; no new lint errors in `database.py`; the repository REST test group (98 tests) passes.

Work performed by Claude Code via model Claude Opus 4.8 (1M context).