### PR TITLE
Fix #3523 - Refresh sweep enqueues stale files (RAR-3.2)

### DIFF
--- a/docs/ROADMAP_REPOSITORY_AUTOREFRESH.md
+++ b/docs/ROADMAP_REPOSITORY_AUTOREFRESH.md
@@ -121,7 +121,7 @@ epic. Use this table to resolve any `RAR-*` reference below to its issue number.
 | ~~RAR-1.1~~ ✅ | ~~#3512~~ | ~~RAR-1.2~~ ✅ | ~~#3513~~ | ~~RAR-1.3~~ ✅ | ~~#3514~~ |
 | ~~RAR-1.4~~ ✅ | ~~#3515~~ | ~~RAR-1.5~~ ✅ | ~~#3516~~ | RAR-1.6 | #3517 |
 | ~~RAR-2.1~~ ✅ | ~~#3518~~ | ~~RAR-2.2~~ ✅ | ~~#3519~~ | ~~RAR-2.3~~ ✅ | ~~#3520~~ |
-| ~~RAR-2.4~~ ✅ | ~~#3521~~ | ~~RAR-3.1~~ ✅ | ~~#3522~~ | RAR-3.2 | #3523 |
+| ~~RAR-2.4~~ ✅ | ~~#3521~~ | ~~RAR-3.1~~ ✅ | ~~#3522~~ | ~~RAR-3.2~~ ✅ | ~~#3523~~ |
 | RAR-3.3 | #3524 | RAR-3.4 | #3525 | RAR-3.5 | #3526 |
 | RAR-4.1 | #3527 | RAR-4.2 | #3528 | RAR-4.3 | #3529 |
 | RAR-4.4 | #3530 | RAR-4.5 | #3531 | RAR-5.1 | #3532 |
@@ -363,7 +363,7 @@ Refresh "after a few minutes," configurable, safe under load.
 | ID | Title | Summary | Labels | Parallel | MVP | Cmplx | Modules |
 |----|-------|---------|--------|----------|-----|-------|---------|
 | ~~RAR-3.1~~ ✅ **Done** (#3522) | Configurable refresh cadence | Replace hardcoded 5s; per-repo interval (default ~5 min, min bound) | `enhancement`,`mvp`,`import`,`repository`,`automation` | N | Y | M | objectified-rest, objectified-db |
-| RAR-3.2 | Refresh sweep → enqueue stale files | Periodic worker enqueues re-import jobs for stale, newer files | `enhancement`,`mvp`,`import`,`repository`,`automation` | N | Y | L | objectified-rest |
+| ~~RAR-3.2~~ ✅ **Done** (#3523) | Refresh sweep → enqueue stale files | Periodic worker enqueues re-import jobs for stale, newer files | `enhancement`,`mvp`,`import`,`repository`,`automation` | N | Y | L | objectified-rest |
 | RAR-3.3 | Enable/disable auto-refresh (per-repo + global kill switch) | Toggle, with global env override | `enhancement`,`mvp`,`import`,`repository` | Y | Y | S | objectified-rest, objectified-ui |
 | RAR-3.4 | Refresh backoff + auto-pause (extend REPO-4.5) | Pause a repo's refresh after N consecutive failures | `enhancement`,`import`,`repository`,`automation` | Y | N | M | objectified-rest |
 | RAR-3.5 | Per-tenant refresh quotas / fairness (extend REPO-4.6) | Bound refresh jobs per tenant per window | `enhancement`,`import`,`repository` | Y | N | M | objectified-rest |
@@ -420,6 +420,31 @@ flowchart TD
 **Acceptance criteria.** Only stale+newer files enqueue; each job carries the stored spec; per-repo
 single-flight; `last_refreshed_at` advanced each tick.
 **Dependencies.** Depends RAR-2.2, RAR-3.1, RAR-1.5; blocks EPIC-4. **Parallel = N.**
+
+**Status: ✅ Done (#3523).** Migration `objectified-db/scripts/20260621-150000.sql` adds the
+Postgres-backed hand-off queue `odb.tenant_repository_refresh_jobs`: each row snapshots the stored
+import spec (project, source descriptor, full `options_json`) plus the remote freshness signals
+(`remote_commit_sha` / `remote_committed_at` / `remote_blob_sha`) and the `refresh_reason`, so the
+EPIC-4 executor can replay the original request even if the spec row later changes. A partial unique
+index `uq_tenant_repo_refresh_jobs_active_lineage` enforces file-level single-flight (one active
+job per `(repository_id, branch, path)`). New module
+`objectified-rest/src/app/repository_refresh_sweep.py` is the sweep:
+`process_repository_refresh_sweep` iterates `list_due_repositories` (RAR-3.1), serializes each repo
+behind a Postgres **session advisory lock**
+(`try_acquire_repository_refresh_lock` / `release_repository_refresh_lock`,
+`pg_try_advisory_lock(hashtext('repo-refresh:'||id))`), rescans only the branches that have a stored
+spec via the reused REPO-2 walker (`repository_file_scan.scan_repository_branch_into_index`, factored
+out of the one-shot scan job for reuse), evaluates each indexed file with the RAR-2.2 newer-than
+comparator, and enqueues a spec-faithful re-import for every **stale + newer** file via
+`enqueue_repository_refresh_job` (idempotent on the lineage index). `last_refreshed_at` advances for
+every locked repo each tick — even on a rescan failure — so a broken repo cannot monopolize the
+sweep. The worker is wired into `main.py` as `_repository_refresh_sweep`, ticking on the
+`OBJECTIFIED_REFRESH_MIN_INTERVAL` floor and deferring the actual per-repo cadence to the DB-side due
+selection. Content-checksum idempotency (RAR-2.4) is deferred to the EPIC-4 executor, which downloads
+the file content the sweep does not. Tests: `tests/test_repository_refresh_sweep.py` (stale-only
+enqueue, spec snapshot carried, lock-held skip, anchor advanced on success/empty/failure, idempotent
+no-double-count, multi-branch) and the static migration guard
+`tests/test_repository_refresh_jobs_migration.py`.
 
 ### RAR-3.3 / 3.4 / 3.5
 - **3.3** per-repo `auto_refresh_enabled` + a global kill switch (ops safety).

--- a/objectified-db/package.json
+++ b/objectified-db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-db",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Objectified database migrations and the direct-to-database admin CLI (objectified-db).",
   "author": "Objectified",
   "type": "module",

--- a/objectified-db/scripts/20260621-150000.sql
+++ b/objectified-db/scripts/20260621-150000.sql
@@ -1,0 +1,71 @@
+-- Repository auto-refresh job queue (RAR-3.2, #3523).
+--
+-- RAR-3.1 made the refresh cadence configurable and gave the sweep its
+-- due-selection anchor (`last_refreshed_at`). RAR-3.2 is the sweep itself: per
+-- due repo it rescans the branch (REPO-2 walker), computes stale + newer files
+-- (RAR-2.2/2.3), loads each file's stored import spec (RAR-1.5), and **enqueues a
+-- spec-faithful re-import** for the spec-faithful execution epic (RAR-4.1) to
+-- consume. This table is that hand-off queue.
+--
+-- Each job carries a self-contained snapshot of the stored spec — project,
+-- source descriptor, and the full `SpecImportOptions` blob — plus the remote
+-- freshness signals that triggered it, so the EPIC-4 worker can replay the user's
+-- original import without re-reading the spec table (the spec row may change
+-- between enqueue and execution). `import_spec_id` is kept as a back-reference but
+-- the snapshot is authoritative.
+--
+-- The partial unique index enforces file-level single-flight: at most one active
+-- (queued/running) job per `(repository_id, branch, path)` lineage, so a repeated
+-- sweep tick cannot pile up duplicate jobs for the same file before the previous
+-- one finishes. Per-repo single-flight across the sweep itself is enforced by a
+-- session advisory lock in the worker (RAR-3.2), not in the schema.
+SET search_path TO odb, public;
+
+CREATE TABLE IF NOT EXISTS odb.tenant_repository_refresh_jobs (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  tenant_id UUID NOT NULL REFERENCES odb.tenants(id) ON DELETE CASCADE,
+  repository_id UUID NOT NULL REFERENCES odb.tenant_repositories(id) ON DELETE CASCADE,
+  import_spec_id UUID REFERENCES odb.repository_import_spec(id) ON DELETE SET NULL,
+  branch TEXT NOT NULL,
+  path TEXT NOT NULL,
+  project_id UUID,
+  source_kind VARCHAR(128),
+  format_override VARCHAR(64),
+  content_type VARCHAR(128),
+  options_json JSONB NOT NULL DEFAULT '{}'::jsonb,
+  spec_schema_version SMALLINT NOT NULL DEFAULT 1,
+  created_by UUID,
+  remote_commit_sha VARCHAR(64),
+  remote_committed_at TIMESTAMPTZ,
+  remote_blob_sha VARCHAR(64),
+  refresh_reason VARCHAR(64),
+  status VARCHAR(32) NOT NULL DEFAULT 'queued'
+    CHECK (status IN ('queued', 'running', 'succeeded', 'failed')),
+  error_message TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  started_at TIMESTAMPTZ,
+  finished_at TIMESTAMPTZ
+);
+
+-- Queue claim path: oldest queued job first (mirrors the file-scan queue).
+CREATE INDEX IF NOT EXISTS idx_tenant_repo_refresh_jobs_queued
+  ON odb.tenant_repository_refresh_jobs (created_at)
+  WHERE status = 'queued';
+
+CREATE INDEX IF NOT EXISTS idx_tenant_repo_refresh_jobs_repository
+  ON odb.tenant_repository_refresh_jobs (repository_id);
+
+-- File-level single-flight: only one active job per imported-file lineage so a
+-- re-run of the sweep before EPIC-4 drains the queue does not duplicate work.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_tenant_repo_refresh_jobs_active_lineage
+  ON odb.tenant_repository_refresh_jobs (repository_id, branch, path)
+  WHERE status IN ('queued', 'running');
+
+COMMENT ON TABLE odb.tenant_repository_refresh_jobs IS
+  'Postgres-backed queue of spec-faithful re-import jobs produced by the auto-refresh sweep (RAR-3.2) and consumed by spec-faithful execution (RAR-4.1). Each row snapshots the stored import spec plus the remote freshness signals that triggered it.';
+
+COMMENT ON COLUMN odb.tenant_repository_refresh_jobs.options_json IS
+  'Snapshot of the full SpecImportOptions blob from the stored import spec at enqueue time; authoritative for replay even if the source spec row later changes.';
+
+COMMENT ON COLUMN odb.tenant_repository_refresh_jobs.refresh_reason IS
+  'Stable RAR-2.2 RefreshReason code (for example newer-content) explaining why the sweep enqueued this file.';

--- a/objectified-rest/pyproject.toml
+++ b/objectified-rest/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "objectified-rest"
-version = "1.0.68"
+version = "1.0.69"
 description = "REST API for serving OpenAPI specifications from the Objectified database"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/objectified-rest/src/app/database.py
+++ b/objectified-rest/src/app/database.py
@@ -6607,6 +6607,218 @@ class Database:
             conn.rollback()
             raise e
 
+    def try_acquire_repository_refresh_lock(self, repository_id: str) -> bool:
+        """Try to take the per-repo auto-refresh advisory lock (RAR-3.2).
+
+        Per-repo single-flight for the refresh sweep is enforced with a Postgres
+        **session** advisory lock keyed on the repository id, so two workers (or
+        two overlapping sweep ticks) never rescan and enqueue for the same repo at
+        once. The lock is held on this :class:`Database`'s connection until
+        :meth:`release_repository_refresh_lock` is called (or the connection
+        closes); ``pg_try_advisory_lock`` is non-blocking, returning False
+        immediately when another session holds it so the sweep can move on.
+
+        Because the lock is session-scoped (not transaction-scoped), the
+        ``execute_query`` commit here does not release it — acquire and release
+        must run on the same connection, which the single-``Database``-per-tick
+        sweep guarantees.
+
+        Args:
+            repository_id: The repository to serialize refreshes for.
+
+        Returns:
+            True when the lock was acquired, False when another session holds it.
+        """
+        rows = self.execute_query(
+            "SELECT pg_try_advisory_lock(hashtext(%s)) AS locked",
+            (f"repo-refresh:{repository_id}",),
+        )
+        return bool(rows and rows[0].get("locked"))
+
+    def release_repository_refresh_lock(self, repository_id: str) -> None:
+        """Release the per-repo auto-refresh advisory lock (RAR-3.2).
+
+        Counterpart to :meth:`try_acquire_repository_refresh_lock`; must run on the
+        same connection that acquired the lock. Safe to call even if the lock was
+        not held (Postgres returns False and logs a warning, which is harmless).
+
+        Args:
+            repository_id: The repository whose lock to release.
+        """
+        self.execute_query(
+            "SELECT pg_advisory_unlock(hashtext(%s)) AS unlocked",
+            (f"repo-refresh:{repository_id}",),
+        )
+
+    def list_repository_import_spec_branches(self, repository_id: str) -> List[str]:
+        """Distinct branches that have a stored import spec for this repository (RAR-3.2).
+
+        The refresh sweep only needs to rescan branches that actually have
+        imported files to refresh; a repository with no captured spec yields an
+        empty list and the sweep skips the (rate-limited) GitHub walk entirely.
+
+        Args:
+            repository_id: The repository to inspect.
+
+        Returns:
+            Distinct branch names with at least one stored import spec, sorted.
+        """
+        q = """
+            SELECT DISTINCT branch
+            FROM odb.repository_import_spec
+            WHERE repository_id = %s::uuid
+            ORDER BY branch ASC
+        """
+        rows = self.execute_query(q, (repository_id,))
+        return [str(r["branch"]) for r in rows if r.get("branch")]
+
+    def list_repository_refresh_candidates(
+        self, repository_id: str, branch: str
+    ) -> List[Dict[str, Any]]:
+        """Stored specs joined to their current indexed file, for one branch (RAR-3.2).
+
+        Returns one row per imported-file lineage that still exists in the latest
+        scan index, pairing the stored import spec (project, source descriptor,
+        options, and the ``last_imported_*`` recency anchors from RAR-2.1) with the
+        file's current remote freshness signals (``remote_committed_at`` /
+        ``remote_blob_sha`` / ``remote_commit_sha``) from the just-completed
+        rescan. The sweep feeds each row to the RAR-2.2 newer-than comparator to
+        decide whether to enqueue a re-import.
+
+        The join is an INNER join on ``tenant_repository_files`` so a spec whose
+        file no longer exists upstream (deleted file) is *not* a refresh candidate
+        — handling deletions is out of scope here.
+
+        Args:
+            repository_id: The repository to scan candidates for.
+            branch: The branch whose files were just re-indexed.
+
+        Returns:
+            Candidate rows with the spec fields and the current remote signals.
+        """
+        q = """
+            SELECT s.id AS import_spec_id, s.tenant_id, s.repository_id, s.branch, s.path,
+                   s.project_id, s.source_kind, s.format_override, s.content_type,
+                   s.options_json, s.spec_schema_version, s.created_by,
+                   s.last_imported_commit_sha, s.last_imported_committed_at,
+                   s.last_imported_blob_sha,
+                   trf.commit_sha AS remote_commit_sha,
+                   trf.committed_at AS remote_committed_at,
+                   trf.blob_sha AS remote_blob_sha
+            FROM odb.repository_import_spec s
+            INNER JOIN odb.tenant_repository_files trf
+              ON trf.repository_id = s.repository_id
+             AND trf.branch = s.branch
+             AND trf.path = s.path
+            WHERE s.repository_id = %s::uuid AND s.branch = %s
+            ORDER BY s.path ASC
+        """
+        return self.execute_query(q, (repository_id, branch))
+
+    def enqueue_repository_refresh_job(
+        self,
+        *,
+        tenant_id: str,
+        repository_id: str,
+        branch: str,
+        path: str,
+        import_spec_id: Optional[str] = None,
+        project_id: Optional[str] = None,
+        source_kind: Optional[str] = None,
+        format_override: Optional[str] = None,
+        content_type: Optional[str] = None,
+        options_json: Optional[Any] = None,
+        spec_schema_version: int = 1,
+        created_by: Optional[str] = None,
+        remote_commit_sha: Optional[str] = None,
+        remote_committed_at: Optional[Any] = None,
+        remote_blob_sha: Optional[str] = None,
+        refresh_reason: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """Enqueue one spec-faithful re-import job for the EPIC-4 worker (RAR-3.2).
+
+        Inserts a row into ``odb.tenant_repository_refresh_jobs`` carrying a
+        self-contained snapshot of the stored import spec (so the executor replays
+        the user's original request even if the spec row later changes) plus the
+        remote freshness signals that triggered it. The insert is idempotent at the
+        file-lineage level via the partial unique index
+        (``uq_tenant_repo_refresh_jobs_active_lineage``): if an active
+        (queued/running) job already exists for ``(repository_id, branch, path)``
+        the insert is a no-op and ``None`` is returned, so a repeated sweep tick
+        never duplicates work.
+
+        Args:
+            tenant_id: Owning tenant id.
+            repository_id: Source repository id.
+            branch: Branch the file lives on.
+            path: Repository-relative file path (lineage key).
+            import_spec_id: Back-reference to the source spec row, if known.
+            project_id: Catalog project the original import targeted.
+            source_kind: Importer discriminator (for example ``openapi-3``).
+            format_override: Explicit importer ``--format`` override, if any.
+            content_type: MIME type used to read the file, if known.
+            options_json: Snapshot of the full ``SpecImportOptions`` payload.
+            spec_schema_version: Envelope version of the captured spec.
+            created_by: User id that initiated the original import, if known.
+            remote_commit_sha: Branch-tip commit SHA observed at sweep time.
+            remote_committed_at: Committed-at of the observed commit.
+            remote_blob_sha: Blob SHA of the file at sweep time.
+            refresh_reason: Stable RAR-2.2 ``RefreshReason`` code for the enqueue.
+
+        Returns:
+            The inserted job row as a dict, or ``None`` when an active job already
+            existed for the lineage (idempotent no-op).
+        """
+        import json
+
+        if isinstance(options_json, str):
+            options_text = options_json if options_json.strip() else "{}"
+        else:
+            options_text = json.dumps(options_json or {})
+
+        q = """
+            INSERT INTO odb.tenant_repository_refresh_jobs (
+                tenant_id, repository_id, import_spec_id, branch, path,
+                project_id, source_kind, format_override, content_type,
+                options_json, spec_schema_version, created_by,
+                remote_commit_sha, remote_committed_at, remote_blob_sha, refresh_reason
+            )
+            VALUES (
+                %s::uuid, %s::uuid, %s::uuid, %s, %s,
+                %s::uuid, %s, %s, %s,
+                %s::jsonb, %s, %s::uuid,
+                %s, %s::timestamptz, %s, %s
+            )
+            ON CONFLICT (repository_id, branch, path)
+                WHERE status IN ('queued', 'running')
+            DO NOTHING
+            RETURNING id, tenant_id, repository_id, import_spec_id, branch, path,
+                      project_id, source_kind, format_override, content_type,
+                      options_json, spec_schema_version, created_by,
+                      remote_commit_sha, remote_committed_at, remote_blob_sha,
+                      refresh_reason, status, created_at
+        """
+        params = (
+            tenant_id, repository_id,
+            (str(import_spec_id) if import_spec_id else None),
+            branch, path,
+            (str(project_id) if project_id else None),
+            source_kind, format_override, content_type,
+            options_text, spec_schema_version,
+            (str(created_by) if created_by else None),
+            remote_commit_sha, remote_committed_at, remote_blob_sha, refresh_reason,
+        )
+        conn = self.connect()
+        try:
+            with conn.cursor() as cursor:
+                cursor.execute(q, params)
+                row = cursor.fetchone()
+                conn.commit()
+                return dict(row) if row else None
+        except Exception as e:
+            conn.rollback()
+            raise e
+
     def list_tenant_repository_file_branches(self, tenant_id: str, repository_id: str) -> List[str]:
         """Distinct branch names that have indexed file rows for this repository."""
         q = """

--- a/objectified-rest/src/app/main.py
+++ b/objectified-rest/src/app/main.py
@@ -117,6 +117,7 @@ app.include_router(tenant_repositories_router)
 
 _webhook_delivery_task: asyncio.Task | None = None
 _repository_file_scan_task: asyncio.Task | None = None
+_repository_refresh_task: asyncio.Task | None = None
 
 
 @app.on_event("startup")
@@ -190,10 +191,46 @@ async def startup_event():
             except Exception:
                 log.exception("repository file scan sweep")
 
+    async def _repository_refresh_sweep() -> None:
+        """Periodically enqueue spec-faithful re-imports for stale files (RAR-3.2).
+
+        Ticks on the configured refresh floor (``OBJECTIFIED_REFRESH_MIN_INTERVAL``,
+        default 60s) and lets the per-repo cadence + due-selection in
+        ``list_due_repositories`` decide which repositories are actually processed
+        each tick, so the cheap floor cadence here never refreshes a repo more
+        often than its own ``refresh_interval_seconds`` allows.
+        """
+        from .config import settings
+
+        log = logging.getLogger(__name__)
+        tick_seconds = max(1, int(settings.refresh_min_interval_seconds))
+        while True:
+            await asyncio.sleep(tick_seconds)
+            try:
+
+                def _run_refresh() -> int:
+                    thread_db = Database()
+                    try:
+                        from .repository_refresh_sweep import (
+                            process_repository_refresh_sweep,
+                        )
+
+                        return process_repository_refresh_sweep(thread_db)
+                    finally:
+                        thread_db.close()
+
+                await asyncio.to_thread(_run_refresh)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                log.exception("repository refresh sweep")
+
     global _webhook_delivery_task
     _webhook_delivery_task = asyncio.create_task(_webhook_delivery_sweep())
     global _repository_file_scan_task
     _repository_file_scan_task = asyncio.create_task(_repository_file_scan_sweep())
+    global _repository_refresh_task
+    _repository_refresh_task = asyncio.create_task(_repository_refresh_sweep())
 
 
 @app.on_event("shutdown")
@@ -215,6 +252,14 @@ async def shutdown_event():
         except asyncio.CancelledError:
             pass
         _repository_file_scan_task = None
+    global _repository_refresh_task
+    if _repository_refresh_task is not None:
+        _repository_refresh_task.cancel()
+        try:
+            await _repository_refresh_task
+        except asyncio.CancelledError:
+            pass
+        _repository_refresh_task = None
     db.close()
 
 

--- a/objectified-rest/src/app/repository_file_scan.py
+++ b/objectified-rest/src/app/repository_file_scan.py
@@ -248,6 +248,71 @@ def fetch_github_repository_file_text(
     return text, truncated
 
 
+def scan_repository_branch_into_index(
+    db: Database, repo_row: Dict[str, Any], branch: str
+) -> Tuple[int, int]:
+    """Rescan one branch's Git tree and replace its indexed file rows (REPO-2 walker).
+
+    The shared core of the repository walk: resolve the GitHub owner/repo and a
+    linked-account token, fetch the branch tree (with the branch-tip recency
+    signals, RAR-2.1), persist every blob to ``odb.tenant_repository_files``, and
+    update the repository's file counts / status. Used both by the one-shot scan
+    job (``process_next_repository_file_scan_job``) and the periodic auto-refresh
+    sweep (RAR-3.2), so the two paths walk the tree identically.
+
+    Unlike the job path this raises on any error rather than recording job/repo
+    failure state; the caller owns failure bookkeeping.
+
+    Args:
+        db: Database handle.
+        repo_row: A ``tenant_repositories`` row (must include ``id``,
+            ``tenant_id``, ``provider``, ``visibility`` and the GitHub locators;
+            ``linked_account_id`` / ``created_by`` are used for private repos).
+        branch: The branch to rescan.
+
+    Returns:
+        ``(total_files, importable_count)`` for the rescanned branch.
+
+    Raises:
+        ValueError: For an unsupported provider, an unresolvable owner/repo, a
+            private repository with no token, or a GitHub API error.
+    """
+    tenant_id = str(repo_row["tenant_id"])
+    repository_id = str(repo_row["id"])
+
+    provider = str(repo_row.get("provider") or "").lower()
+    if provider != "github":
+        raise ValueError(f"file scan not implemented for provider: {provider}")
+
+    owner, repo = _github_owner_repo(repo_row)
+
+    token: Optional[str] = None
+    linked = repo_row.get("linked_account_id")
+    created_by = repo_row.get("created_by")
+    if linked and created_by:
+        oauth = db.get_external_auth_provider_for_user(str(linked), str(created_by))
+        if oauth and oauth.get("access_token"):
+            token = str(oauth["access_token"])
+
+    vis = str(repo_row.get("visibility") or "").lower()
+    if vis == "private" and not token:
+        raise ValueError("private repository requires a linked account token")
+
+    blobs = fetch_github_tree_blobs(owner, repo, branch, token)
+    importable = sum(1 for b in blobs if _importable_hint(b.get("detected_kind")))
+
+    db.replace_tenant_repository_files(repository_id, branch, blobs)
+    db.update_tenant_repository_after_file_scan(
+        tenant_id=tenant_id,
+        repository_id=repository_id,
+        total_files=len(blobs),
+        importable_count=importable,
+        status="ready",
+        touch_last_scanned_at=True,
+    )
+    return len(blobs), importable
+
+
 def _fail_job_and_repo(db: Database, tenant_id: str, repository_id: str, job_id: str, message: str) -> None:
     db.mark_repository_file_scan_job_failed(job_id, message)
     db.update_tenant_repository_after_file_scan(
@@ -279,44 +344,15 @@ def process_next_repository_file_scan_job(db: Database) -> int:
             db.mark_repository_file_scan_job_failed(job_id, "repository row missing")
             return 1
 
-        provider = str(repo_row.get("provider") or "").lower()
-        if provider != "github":
-            _fail_job_and_repo(db, tenant_id, repository_id, job_id, f"file scan not implemented for provider: {provider}")
-            return 1
-
-        owner, repo = _github_owner_repo(repo_row)
-
-        token: Optional[str] = None
-        linked = repo_row.get("linked_account_id")
-        created_by = repo_row.get("created_by")
-        if linked and created_by:
-            oauth = db.get_external_auth_provider_for_user(str(linked), str(created_by))
-            if oauth and oauth.get("access_token"):
-                token = str(oauth["access_token"])
-
-        vis = str(repo_row.get("visibility") or "").lower()
-        if vis == "private" and not token:
-            _fail_job_and_repo(db, tenant_id, repository_id, job_id, "private repository requires a linked account token")
-            return 1
-
-        blobs = fetch_github_tree_blobs(owner, repo, branch, token)
-        importable = sum(1 for b in blobs if _importable_hint(b.get("detected_kind")))
-
-        db.replace_tenant_repository_files(repository_id, branch, blobs)
-        db.update_tenant_repository_after_file_scan(
-            tenant_id=tenant_id,
-            repository_id=repository_id,
-            total_files=len(blobs),
-            importable_count=importable,
-            status="ready",
-            touch_last_scanned_at=True,
-        )
+        # Unsupported provider / private-without-token / GitHub errors all raise
+        # ValueError from the shared walker and are recorded by the except below.
+        total, importable = scan_repository_branch_into_index(db, repo_row, branch)
         db.mark_repository_file_scan_job_succeeded(job_id)
         _logger.info(
             "repository file scan succeeded repository_id=%s branch=%s files=%s importable_hints=%s",
             repository_id,
             branch,
-            len(blobs),
+            total,
             importable,
         )
     except Exception as exc:

--- a/objectified-rest/src/app/repository_refresh_sweep.py
+++ b/objectified-rest/src/app/repository_refresh_sweep.py
@@ -1,0 +1,182 @@
+"""Repository auto-refresh sweep — enqueue stale files (RAR-3.2, #3523).
+
+RAR-3.1 made the refresh cadence configurable and gave the sweep its due-selection
+primitives (``list_due_repositories`` / ``mark_repository_refreshed``). This module
+is the sweep itself: the worker that ties freshness gating and the stored import
+spec into a periodic enqueue. Per the roadmap
+(``docs/ROADMAP_REPOSITORY_AUTOREFRESH.md``), for each *due* repository it:
+
+1. takes a per-repo advisory lock so two ticks / workers never overlap on one repo
+   (single-flight);
+2. rescans the branches that have a stored import spec, reusing the REPO-2 walker
+   (:func:`repository_file_scan.scan_repository_branch_into_index`);
+3. computes the stale + newer files via the RAR-2.2 newer-than comparator
+   (:func:`repository_refresh_comparator.evaluate_refresh`) — a file is a candidate
+   exactly when it is ``stale`` (RAR-2.3);
+4. loads each stale file's stored spec (RAR-1.5) and enqueues a self-contained,
+   spec-faithful re-import job for the EPIC-4 executor (RAR-4.1); and
+5. advances ``last_refreshed_at`` for the repo each tick.
+
+The freshness gate here runs on the branch-tip ``committed_at`` and the file
+``blob_sha`` — the signals the rescan captures. The finer REPO-8.3 content-checksum
+idempotency (RAR-2.4) needs the file *content*, which only the EPIC-4 executor
+downloads, so it is applied there; this sweep deliberately enqueues on the
+blob-level newer-than verdict and lets the executor suppress no-op churn.
+
+``last_refreshed_at`` is advanced for every processed repo, success or failure, so
+a repository that errors on the GitHub walk does not stay perpetually "due" and
+hammer the provider every tick.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict
+
+from .database import Database
+from .repository_file_scan import scan_repository_branch_into_index
+from .repository_refresh_comparator import evaluate_refresh
+
+_logger = logging.getLogger(__name__)
+
+
+def _enqueue_stale_files_for_branch(
+    db: Database, repo_row: Dict[str, Any], branch: str
+) -> int:
+    """Rescan one branch and enqueue a re-import job per stale + newer file.
+
+    Args:
+        db: Database handle.
+        repo_row: The repository row (from ``get_tenant_repository``).
+        branch: The branch to rescan and evaluate.
+
+    Returns:
+        The number of refresh jobs enqueued for this branch.
+    """
+    repository_id = str(repo_row["id"])
+    tenant_id = str(repo_row["tenant_id"])
+
+    # Reindex the branch so the candidate query sees current remote signals.
+    scan_repository_branch_into_index(db, repo_row, branch)
+
+    enqueued = 0
+    for cand in db.list_repository_refresh_candidates(repository_id, branch):
+        decision = evaluate_refresh(
+            remote_committed_at=cand.get("remote_committed_at"),
+            last_imported_committed_at=cand.get("last_imported_committed_at"),
+            remote_checksum=cand.get("remote_blob_sha"),
+            last_imported_checksum=cand.get("last_imported_blob_sha"),
+        )
+        if not decision.should_refresh:
+            continue
+
+        job = db.enqueue_repository_refresh_job(
+            tenant_id=tenant_id,
+            repository_id=repository_id,
+            branch=branch,
+            path=str(cand["path"]),
+            import_spec_id=cand.get("import_spec_id"),
+            project_id=cand.get("project_id"),
+            source_kind=cand.get("source_kind"),
+            format_override=cand.get("format_override"),
+            content_type=cand.get("content_type"),
+            options_json=cand.get("options_json"),
+            spec_schema_version=int(cand.get("spec_schema_version") or 1),
+            created_by=cand.get("created_by"),
+            remote_commit_sha=cand.get("remote_commit_sha"),
+            remote_committed_at=cand.get("remote_committed_at"),
+            remote_blob_sha=cand.get("remote_blob_sha"),
+            refresh_reason=decision.reason.value,
+        )
+        if job is not None:
+            enqueued += 1
+    return enqueued
+
+
+def _refresh_one_repository(db: Database, due_row: Dict[str, Any]) -> int:
+    """Rescan + enqueue for a single due repository (already holding its lock).
+
+    Args:
+        db: Database handle.
+        due_row: A row from ``list_due_repositories``.
+
+    Returns:
+        The number of refresh jobs enqueued across the repo's spec branches.
+    """
+    repository_id = str(due_row["id"])
+    tenant_id = str(due_row["tenant_id"])
+
+    branches = db.list_repository_import_spec_branches(repository_id)
+    if not branches:
+        # No captured spec for any branch -> nothing to refresh; skip the GitHub
+        # walk entirely. The anchor still advances (caller's finally block).
+        return 0
+
+    # The due row lacks created_by (needed for private-repo token resolution);
+    # fetch the full row.
+    repo_row = db.get_tenant_repository(tenant_id, repository_id)
+    if not repo_row:
+        return 0
+
+    enqueued = 0
+    for branch in branches:
+        try:
+            enqueued += _enqueue_stale_files_for_branch(db, repo_row, branch)
+        except Exception:
+            # One bad branch (GitHub error, etc.) must not abort the others.
+            _logger.exception(
+                "repository refresh rescan failed repository_id=%s branch=%s",
+                repository_id,
+                branch,
+            )
+    return enqueued
+
+
+def process_repository_refresh_sweep(db: Database) -> int:
+    """Run one auto-refresh sweep tick over all due repositories (RAR-3.2).
+
+    Iterates the repositories due for a refresh (RAR-3.1 cadence), serializing each
+    behind a per-repo advisory lock, rescanning its spec branches, and enqueuing a
+    spec-faithful re-import for every stale + newer file. ``last_refreshed_at`` is
+    advanced for each repository whose lock was acquired — even when its rescan
+    fails — so the cadence keeps moving and a broken repo cannot monopolize the
+    sweep.
+
+    Args:
+        db: Database handle for this tick (one connection holds the advisory
+            locks; the caller uses a dedicated ``Database`` per tick).
+
+    Returns:
+        The total number of refresh jobs enqueued this tick.
+    """
+    enqueued_total = 0
+    for due_row in db.list_due_repositories():
+        repository_id = str(due_row["id"])
+
+        if not db.try_acquire_repository_refresh_lock(repository_id):
+            # Another worker / overlapping tick owns this repo right now.
+            _logger.debug(
+                "repository refresh skipped (lock held) repository_id=%s",
+                repository_id,
+            )
+            continue
+
+        try:
+            enqueued_total += _refresh_one_repository(db, due_row)
+        except Exception:
+            _logger.exception(
+                "repository refresh sweep failed repository_id=%s", repository_id
+            )
+        finally:
+            # Advance the cadence anchor each tick (success or failure) so the repo
+            # is not immediately due again, then release the lock.
+            try:
+                db.mark_repository_refreshed(repository_id)
+            except Exception:
+                _logger.exception(
+                    "repository refresh anchor advance failed repository_id=%s",
+                    repository_id,
+                )
+            db.release_repository_refresh_lock(repository_id)
+
+    return enqueued_total

--- a/objectified-rest/tests/test_repository_refresh_jobs_migration.py
+++ b/objectified-rest/tests/test_repository_refresh_jobs_migration.py
@@ -1,0 +1,33 @@
+"""Guardrails for the refresh-jobs queue migration (RAR-3.2, #3523)."""
+
+from pathlib import Path
+
+_MIGRATION = "objectified-db/scripts/20260621-150000.sql"
+
+# Fragments the migration must contain so the queue + its single-flight guard
+# survive accidental edits. Acceptance criteria for #3523:
+#   - a queue table for spec-faithful re-import jobs;
+#   - each job carries the stored spec snapshot (options_json + descriptor);
+#   - file-level single-flight via a partial unique index on the lineage.
+_REQUIRED_FRAGMENTS = (
+    "CREATE TABLE IF NOT EXISTS odb.tenant_repository_refresh_jobs",
+    "import_spec_id UUID REFERENCES odb.repository_import_spec(id)",
+    "options_json JSONB NOT NULL DEFAULT '{}'::jsonb",
+    "refresh_reason VARCHAR(64)",
+    "CHECK (status IN ('queued', 'running', 'succeeded', 'failed'))",
+    "uq_tenant_repo_refresh_jobs_active_lineage",
+    "ON odb.tenant_repository_refresh_jobs (repository_id, branch, path)",
+    "WHERE status IN ('queued', 'running')",
+)
+
+
+def test_migration_creates_refresh_jobs_queue(repo_root: Path) -> None:
+    text = (repo_root / _MIGRATION).read_text()
+    missing = [frag for frag in _REQUIRED_FRAGMENTS if frag not in text]
+    assert not missing, f"Migration missing expected fragments: {missing}"
+
+
+def test_migration_single_flight_is_partial_unique(repo_root: Path) -> None:
+    """The lineage single-flight guard must be a partial UNIQUE index."""
+    text = (repo_root / _MIGRATION).read_text()
+    assert "CREATE UNIQUE INDEX IF NOT EXISTS uq_tenant_repo_refresh_jobs_active_lineage" in text

--- a/objectified-rest/tests/test_repository_refresh_sweep.py
+++ b/objectified-rest/tests/test_repository_refresh_sweep.py
@@ -1,0 +1,266 @@
+"""Refresh sweep orchestration tests (RAR-3.2, #3523).
+
+Deterministic, DB-free fixtures over ``app.repository_refresh_sweep`` using a fake
+``Database`` that records calls. The GitHub walk
+(``scan_repository_branch_into_index``) is monkeypatched so no network is touched.
+
+Covers the acceptance criteria:
+  - only stale + newer files enqueue (up-to-date / stale-guarded files do not);
+  - each enqueued job carries the stored spec snapshot;
+  - per-repo single-flight via the advisory lock (a held lock skips the repo);
+  - ``last_refreshed_at`` is advanced each tick, including on rescan failure.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+import app.repository_refresh_sweep as sweep
+from app.repository_refresh_sweep import process_repository_refresh_sweep
+
+NOW = datetime(2026, 6, 21, 12, 0, 0, tzinfo=timezone.utc)
+OLDER = (NOW - timedelta(days=2)).isoformat()
+NEWER = (NOW - timedelta(hours=1)).isoformat()
+
+
+def _candidate(path: str, *, remote_committed_at, remote_blob, last_committed_at, last_blob):
+    """Build a refresh-candidate row as ``list_repository_refresh_candidates`` returns."""
+    return {
+        "import_spec_id": f"spec-{path}",
+        "tenant_id": "t1",
+        "repository_id": "r1",
+        "branch": "main",
+        "path": path,
+        "project_id": "p1",
+        "source_kind": "openapi-3",
+        "format_override": None,
+        "content_type": "application/yaml",
+        "options_json": {"naming_convention": "camelCase"},
+        "spec_schema_version": 1,
+        "created_by": "u1",
+        "last_imported_commit_sha": "old-commit",
+        "last_imported_committed_at": last_committed_at,
+        "last_imported_blob_sha": last_blob,
+        "remote_commit_sha": "new-commit",
+        "remote_committed_at": remote_committed_at,
+        "remote_blob_sha": remote_blob,
+    }
+
+
+class FakeDB:
+    """Records sweep interactions; no real database."""
+
+    def __init__(self, *, due=None, branches=None, candidates=None, lock_result=True):
+        self._due = due if due is not None else []
+        self._branches = branches if branches is not None else {}
+        self._candidates = candidates if candidates is not None else {}
+        self._lock_result = lock_result
+        self.acquired = []
+        self.released = []
+        self.scanned = []
+        self.enqueued = []
+        self.refreshed = []
+        # Track active (queued/running) lineages to emulate the idempotent insert.
+        self._active_lineage = set()
+
+    # --- due selection / lock ---
+    def list_due_repositories(self):
+        return list(self._due)
+
+    def try_acquire_repository_refresh_lock(self, repository_id):
+        self.acquired.append(repository_id)
+        return self._lock_result
+
+    def release_repository_refresh_lock(self, repository_id):
+        self.released.append(repository_id)
+
+    # --- per-repo work ---
+    def list_repository_import_spec_branches(self, repository_id):
+        return list(self._branches.get(repository_id, []))
+
+    def get_tenant_repository(self, tenant_id, repository_id):
+        return {"id": repository_id, "tenant_id": tenant_id, "provider": "github"}
+
+    def list_repository_refresh_candidates(self, repository_id, branch):
+        return list(self._candidates.get((repository_id, branch), []))
+
+    def enqueue_repository_refresh_job(self, **kwargs):
+        key = (kwargs["repository_id"], kwargs["branch"], kwargs["path"])
+        if key in self._active_lineage:
+            return None  # idempotent no-op (active job already exists)
+        self._active_lineage.add(key)
+        row = dict(kwargs)
+        row["id"] = f"job-{kwargs['path']}"
+        self.enqueued.append(row)
+        return row
+
+    def mark_repository_refreshed(self, repository_id):
+        self.refreshed.append(repository_id)
+        return True
+
+
+@pytest.fixture(autouse=True)
+def _patch_scan(monkeypatch):
+    """Replace the GitHub walk with a recorder so no network is hit."""
+    calls = []
+
+    def _fake_scan(db, repo_row, branch):
+        calls.append((str(repo_row["id"]), branch))
+        db.scanned.append((str(repo_row["id"]), branch))
+        return (1, 1)
+
+    monkeypatch.setattr(sweep, "scan_repository_branch_into_index", _fake_scan)
+    return calls
+
+
+def test_only_stale_files_enqueue():
+    """A stale file enqueues; an up-to-date and a stale-guarded file do not."""
+    stale = _candidate(
+        "api/openapi.yaml",
+        remote_committed_at=NEWER, remote_blob="blob-new",
+        last_committed_at=OLDER, last_blob="blob-old",
+    )
+    up_to_date = _candidate(
+        "api/unchanged.yaml",
+        remote_committed_at=OLDER, remote_blob="blob-x",
+        last_committed_at=OLDER, last_blob="blob-x",
+    )
+    reverted = _candidate(  # remote commit OLDER than last import -> stale guard
+        "api/reverted.yaml",
+        remote_committed_at=OLDER, remote_blob="blob-different",
+        last_committed_at=NEWER, last_blob="blob-old",
+    )
+    db = FakeDB(
+        due=[{"id": "r1", "tenant_id": "t1"}],
+        branches={"r1": ["main"]},
+        candidates={("r1", "main"): [stale, up_to_date, reverted]},
+    )
+
+    enqueued = process_repository_refresh_sweep(db)
+
+    assert enqueued == 1
+    assert [j["path"] for j in db.enqueued] == ["api/openapi.yaml"]
+
+
+def test_enqueued_job_carries_stored_spec():
+    """The job snapshot carries the stored spec + the remote signals that fired it."""
+    stale = _candidate(
+        "api/openapi.yaml",
+        remote_committed_at=NEWER, remote_blob="blob-new",
+        last_committed_at=OLDER, last_blob="blob-old",
+    )
+    db = FakeDB(
+        due=[{"id": "r1", "tenant_id": "t1"}],
+        branches={"r1": ["main"]},
+        candidates={("r1", "main"): [stale]},
+    )
+
+    process_repository_refresh_sweep(db)
+
+    job = db.enqueued[0]
+    assert job["import_spec_id"] == "spec-api/openapi.yaml"
+    assert job["project_id"] == "p1"
+    assert job["source_kind"] == "openapi-3"
+    assert job["content_type"] == "application/yaml"
+    assert job["options_json"] == {"naming_convention": "camelCase"}
+    assert job["remote_blob_sha"] == "blob-new"
+    assert job["remote_commit_sha"] == "new-commit"
+    assert job["refresh_reason"] == "newer-content"
+
+
+def test_lock_held_skips_repo():
+    """A repo whose advisory lock is held is skipped: no scan, no enqueue, no anchor."""
+    db = FakeDB(
+        due=[{"id": "r1", "tenant_id": "t1"}],
+        branches={"r1": ["main"]},
+        candidates={("r1", "main"): []},
+        lock_result=False,
+    )
+
+    enqueued = process_repository_refresh_sweep(db)
+
+    assert enqueued == 0
+    assert db.acquired == ["r1"]
+    assert db.released == []          # never acquired -> never released
+    assert db.scanned == []
+    assert db.refreshed == []         # anchor NOT advanced when we never held the lock
+
+
+def test_anchor_advanced_and_lock_released_each_tick():
+    """Even with nothing to enqueue, the anchor advances and the lock releases."""
+    db = FakeDB(
+        due=[{"id": "r1", "tenant_id": "t1"}],
+        branches={"r1": []},          # no specs -> no GitHub walk
+    )
+
+    enqueued = process_repository_refresh_sweep(db)
+
+    assert enqueued == 0
+    assert db.scanned == []           # branch list empty -> walker untouched
+    assert db.refreshed == ["r1"]
+    assert db.released == ["r1"]
+
+
+def test_anchor_advanced_on_rescan_failure(monkeypatch):
+    """A GitHub walk failure still advances the anchor and releases the lock."""
+
+    def _boom(db, repo_row, branch):
+        raise ValueError("GitHub branches API error: HTTP 503")
+
+    monkeypatch.setattr(sweep, "scan_repository_branch_into_index", _boom)
+
+    db = FakeDB(
+        due=[{"id": "r1", "tenant_id": "t1"}],
+        branches={"r1": ["main"]},
+        candidates={("r1", "main"): []},
+    )
+
+    enqueued = process_repository_refresh_sweep(db)
+
+    assert enqueued == 0
+    assert db.refreshed == ["r1"]     # advanced despite the failure
+    assert db.released == ["r1"]
+
+
+def test_idempotent_enqueue_not_double_counted():
+    """A second tick over an already-queued lineage enqueues nothing new."""
+    stale = _candidate(
+        "api/openapi.yaml",
+        remote_committed_at=NEWER, remote_blob="blob-new",
+        last_committed_at=OLDER, last_blob="blob-old",
+    )
+    db = FakeDB(
+        due=[{"id": "r1", "tenant_id": "t1"}],
+        branches={"r1": ["main"]},
+        candidates={("r1", "main"): [stale]},
+    )
+
+    first = process_repository_refresh_sweep(db)
+    second = process_repository_refresh_sweep(db)
+
+    assert first == 1
+    assert second == 0                # active job already exists -> no-op
+    assert len(db.enqueued) == 1
+
+
+def test_multiple_branches_each_rescanned():
+    """Every branch with a stored spec is rescanned and evaluated."""
+    stale_main = _candidate(
+        "main.yaml",
+        remote_committed_at=NEWER, remote_blob="b1",
+        last_committed_at=OLDER, last_blob="b0",
+    )
+    stale_dev = dict(stale_main, path="dev.yaml", branch="dev")
+    db = FakeDB(
+        due=[{"id": "r1", "tenant_id": "t1"}],
+        branches={"r1": ["main", "dev"]},
+        candidates={
+            ("r1", "main"): [stale_main],
+            ("r1", "dev"): [stale_dev],
+        },
+    )
+
+    enqueued = process_repository_refresh_sweep(db)
+
+    assert enqueued == 2
+    assert db.scanned == [("r1", "main"), ("r1", "dev")]


### PR DESCRIPTION
## What & why

Implements **RAR-3.2** (#3523), the auto-refresh **sweep worker**. RAR-3.1 made the refresh cadence configurable and exposed the due-selection primitives; this ticket adds the worker that actually ties freshness gating + the stored import spec into a periodic enqueue, producing spec-faithful re-import jobs for the EPIC-4 executor (RAR-4.1) to consume.

For each **due** repository the sweep:
1. takes a per-repo **session advisory lock** (`pg_try_advisory_lock`) so two ticks/workers never overlap on one repo — single-flight;
2. rescans only the branches that have a stored import spec, reusing the REPO-2 walker (`scan_repository_branch_into_index`, factored out of the one-shot scan job);
3. evaluates each indexed file with the RAR-2.2 newer-than comparator — a file is a candidate exactly when it is `stale`;
4. enqueues a self-contained, spec-faithful re-import job (carrying the stored spec snapshot + the remote freshness signals) for every stale + newer file; and
5. advances `last_refreshed_at` for the repo **each tick** (even on rescan failure, so a broken repo can't monopolize the sweep).

### Acceptance criteria
- ✅ Only stale + newer files enqueue; each job carries the stored spec snapshot (`project_id`, source descriptor, full `options_json`).
- ✅ Per-repo single-flight via the advisory lock; plus file-level single-flight via a partial unique index on `(repository_id, branch, path)` for `queued`/`running`.
- ✅ `last_refreshed_at` advanced each tick.

## Changes
- **Migration** `objectified-db/scripts/20260621-150000.sql` — `odb.tenant_repository_refresh_jobs` hand-off queue + `uq_tenant_repo_refresh_jobs_active_lineage` partial unique index.
- **`repository_refresh_sweep.py`** (new) — `process_repository_refresh_sweep`, wired into `main.py` as `_repository_refresh_sweep` (ticks on `OBJECTIFIED_REFRESH_MIN_INTERVAL`, defers cadence to DB-side due selection).
- **`repository_file_scan.py`** — extracted reusable `scan_repository_branch_into_index` (shared by the scan job and the sweep).
- **`database.py`** — advisory-lock helpers, `list_repository_import_spec_branches`, `list_repository_refresh_candidates`, `enqueue_repository_refresh_job`.

## How to test
- `cd objectified-rest && python -m pytest tests/test_repository_refresh_sweep.py tests/test_repository_refresh_jobs_migration.py -q` — 9 pass.
- DB-free sweep tests cover: stale-only enqueue, spec snapshot carried, lock-held skip, anchor advanced on success/empty/failure, idempotent no-double-count, multi-branch rescan.

## Risk / notes
- Content-checksum idempotency (RAR-2.4) is intentionally deferred to the EPIC-4 executor, which downloads the file content the sweep does not; the sweep gates on the branch-tip `committed_at` + file `blob_sha`.
- Pre-existing, unrelated test failures in the suite (merge/publish/change-report integration tests requiring a live DB) are present on `main` and untouched by this change.
- Versions bumped: objectified-rest `1.0.69`, objectified-db `0.1.4`.

Closes #3523

Work performed by Claude Code via model claude-opus-4-8[1m].