### PR TITLE
Fix #3524 - Enable/disable auto-refresh (per-repo + global kill switch) (RAR-3.3)

### DIFF
--- a/docs/ROADMAP_REPOSITORY_AUTOREFRESH.md
+++ b/docs/ROADMAP_REPOSITORY_AUTOREFRESH.md
@@ -122,7 +122,7 @@ epic. Use this table to resolve any `RAR-*` reference below to its issue number.
 | ~~RAR-1.4~~ ✅ | ~~#3515~~ | ~~RAR-1.5~~ ✅ | ~~#3516~~ | RAR-1.6 | #3517 |
 | ~~RAR-2.1~~ ✅ | ~~#3518~~ | ~~RAR-2.2~~ ✅ | ~~#3519~~ | ~~RAR-2.3~~ ✅ | ~~#3520~~ |
 | ~~RAR-2.4~~ ✅ | ~~#3521~~ | ~~RAR-3.1~~ ✅ | ~~#3522~~ | ~~RAR-3.2~~ ✅ | ~~#3523~~ |
-| RAR-3.3 | #3524 | RAR-3.4 | #3525 | RAR-3.5 | #3526 |
+| ~~RAR-3.3~~ ✅ | ~~#3524~~ | RAR-3.4 | #3525 | RAR-3.5 | #3526 |
 | RAR-4.1 | #3527 | RAR-4.2 | #3528 | RAR-4.3 | #3529 |
 | RAR-4.4 | #3530 | RAR-4.5 | #3531 | RAR-5.1 | #3532 |
 | RAR-5.2 | #3533 | RAR-5.3 | #3534 | RAR-5.4 | #3535 |
@@ -364,7 +364,7 @@ Refresh "after a few minutes," configurable, safe under load.
 |----|-------|---------|--------|----------|-----|-------|---------|
 | ~~RAR-3.1~~ ✅ **Done** (#3522) | Configurable refresh cadence | Replace hardcoded 5s; per-repo interval (default ~5 min, min bound) | `enhancement`,`mvp`,`import`,`repository`,`automation` | N | Y | M | objectified-rest, objectified-db |
 | ~~RAR-3.2~~ ✅ **Done** (#3523) | Refresh sweep → enqueue stale files | Periodic worker enqueues re-import jobs for stale, newer files | `enhancement`,`mvp`,`import`,`repository`,`automation` | N | Y | L | objectified-rest |
-| RAR-3.3 | Enable/disable auto-refresh (per-repo + global kill switch) | Toggle, with global env override | `enhancement`,`mvp`,`import`,`repository` | Y | Y | S | objectified-rest, objectified-ui |
+| ~~RAR-3.3~~ ✅ **Done** (#3524) | Enable/disable auto-refresh (per-repo + global kill switch) | Toggle, with global env override | `enhancement`,`mvp`,`import`,`repository` | Y | Y | S | objectified-rest, objectified-ui |
 | RAR-3.4 | Refresh backoff + auto-pause (extend REPO-4.5) | Pause a repo's refresh after N consecutive failures | `enhancement`,`import`,`repository`,`automation` | Y | N | M | objectified-rest |
 | RAR-3.5 | Per-tenant refresh quotas / fairness (extend REPO-4.6) | Bound refresh jobs per tenant per window | `enhancement`,`import`,`repository` | Y | N | M | objectified-rest |
 
@@ -446,8 +446,36 @@ enqueue, spec snapshot carried, lock-held skip, anchor advanced on success/empty
 no-double-count, multi-branch) and the static migration guard
 `tests/test_repository_refresh_jobs_migration.py`.
 
-### RAR-3.3 / 3.4 / 3.5
-- **3.3** per-repo `auto_refresh_enabled` + a global kill switch (ops safety).
+### RAR-3.3 — Enable/disable auto-refresh (per-repo + global kill switch)
+
+**Problem.** Auto-refresh must be controllable: a repo owner may want it off, and operators need a
+global kill switch for incident response.
+**Solution / scope.** Add `auto_refresh_enabled` per repo (default on) and a global
+`OBJECTIFIED_REFRESH_ENABLED` env override. The sweep skips repos where either is disabled.
+**Acceptance criteria.** Per-repo toggle persisted and surfaced in the UI; global kill switch halts all
+refresh sweeps; disabling does not affect manual "Refresh Now" (RAR-5.2).
+**Dependencies.** Parallel with RAR-3.1/3.2. **Parallel = Y.**
+
+**Status: ✅ Done (#3524).** Migration `objectified-db/scripts/20260622-120000.sql` adds
+`auto_refresh_enabled` (`BOOLEAN NOT NULL DEFAULT TRUE`) to `odb.tenant_repositories`, so existing
+repositories keep auto-refreshing. `config.py` adds the global kill switch `OBJECTIFIED_REFRESH_ENABLED`
+(`refresh_enabled`, default True). The **per-repo opt-out** is enforced in `database.py`
+`list_due_repositories`, which now filters `auto_refresh_enabled = TRUE` (so a disabled repo is never
+selected as due) and surfaces the column on the repo read queries; a new setter
+`set_repository_auto_refresh_enabled` persists the flag (tenant-scoped). The **global kill switch** is
+enforced in `repository_refresh_sweep.process_repository_refresh_sweep`, which short-circuits the whole
+tick (no lock, scan, enqueue, or anchor advance) when `settings.refresh_enabled` is False. Both gates
+are independent of manual "Refresh Now" (RAR-5.2), which does not run through the sweep. REST surfaces
+the flag on `TenantRepositoryRecord` and a new `PATCH /v1/tenants/{slug}/repositories/{id}` endpoint
+(`TenantRepositoryUpdate`) toggles it. The UI exposes an **Auto-refresh** Switch in the repository
+Settings tab (`RepositoryDetailClient`), which optimistically PATCHes via the Next route handler
+(`/api/repositories/[id]` PATCH) and reconciles to the server's returned value, rolling back on error.
+Tests: `tests/test_repository_refresh_sweep.py` adds the kill-switch halt/enabled cases,
+`tests/test_repository_auto_refresh_toggle_migration.py` guards the migration, and
+`tests/unit/repository-auto-refresh-toggle.test.ts` pins the UI flag parsing (explicit true/false,
+camelCase, default-on for older rows / null).
+
+### RAR-3.4 / 3.5
 - **3.4** (v2) extend REPO-4.5 backoff specifically to the refresh loop.
 - **3.5** (v2) per-tenant fairness so one busy tenant can't starve the sweep.
 

--- a/objectified-db/package.json
+++ b/objectified-db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-db",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Objectified database migrations and the direct-to-database admin CLI (objectified-db).",
   "author": "Objectified",
   "type": "module",

--- a/objectified-db/scripts/20260622-120000.sql
+++ b/objectified-db/scripts/20260622-120000.sql
@@ -1,0 +1,19 @@
+-- Enable/disable auto-refresh per repository (RAR-3.3, #3524).
+--
+-- The auto-refresh sweep (RAR-3.2) refreshes every scannable repository on its
+-- configured cadence (RAR-3.1). Acceptance criteria for #3524 require a per-repo
+-- opt-out so a repo owner can turn auto-refresh off for a single repository,
+-- independent of the global `OBJECTIFIED_REFRESH_ENABLED` kill switch (applied in
+-- the application, not the schema).
+--
+--   `auto_refresh_enabled` — BOOLEAN NOT NULL DEFAULT TRUE. When FALSE the sweep's
+--      due-selection (`list_due_repositories`) skips the repository, so it is never
+--      auto-refreshed. Defaults to TRUE so existing repositories keep refreshing.
+--      Manual "Refresh Now" (RAR-5.2) does not consult this flag.
+SET search_path TO odb, public;
+
+ALTER TABLE odb.tenant_repositories
+  ADD COLUMN IF NOT EXISTS auto_refresh_enabled BOOLEAN NOT NULL DEFAULT TRUE;
+
+COMMENT ON COLUMN odb.tenant_repositories.auto_refresh_enabled IS
+  'Per-repo auto-refresh opt-out (RAR-3.3). TRUE (default) lets the refresh sweep pick this repo on its cadence; FALSE makes list_due_repositories skip it. Independent of the global OBJECTIFIED_REFRESH_ENABLED kill switch and of manual Refresh Now (RAR-5.2).';

--- a/objectified-rest/pyproject.toml
+++ b/objectified-rest/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "objectified-rest"
-version = "1.0.69"
+version = "1.0.70"
 description = "REST API for serving OpenAPI specifications from the Objectified database"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/objectified-rest/src/app/config.py
+++ b/objectified-rest/src/app/config.py
@@ -59,6 +59,18 @@ class Settings(BaseSettings):
         ),
     )
 
+    # Global auto-refresh kill switch (RAR-3.3, #3524). When False, the refresh
+    # sweep halts entirely (no repository is auto-refreshed) regardless of per-repo
+    # auto_refresh_enabled. Intended for incident response. Manual "Refresh Now"
+    # (RAR-5.2) is unaffected. Per-repo opt-out is the auto_refresh_enabled column.
+    refresh_enabled: bool = Field(
+        default=True,
+        validation_alias=AliasChoices(
+            "OBJECTIFIED_REFRESH_ENABLED",
+            "refresh_enabled",
+        ),
+    )
+
     @property
     def effective_database_url(self) -> str:
         """Get the database URL, preferring DATABASE_URL over building from components."""

--- a/objectified-rest/src/app/database.py
+++ b/objectified-rest/src/app/database.py
@@ -6454,7 +6454,7 @@ class Database:
             SELECT id, tenant_id, source, provider, clone_url, repository_full_name,
                    description, default_branch, visibility, status, created_at, updated_at,
                    linked_account_id, last_scanned_at, total_files, importable_count, branch_count,
-                   refresh_interval_seconds, last_refreshed_at
+                   refresh_interval_seconds, last_refreshed_at, auto_refresh_enabled
             FROM odb.tenant_repositories
             WHERE tenant_id = %s::uuid AND deleted_at IS NULL
             ORDER BY created_at DESC
@@ -6466,7 +6466,7 @@ class Database:
             SELECT id, tenant_id, source, provider, clone_url, repository_full_name,
                    description, default_branch, visibility, status, created_at, updated_at,
                    linked_account_id, last_scanned_at, total_files, importable_count, branch_count, created_by,
-                   refresh_interval_seconds, last_refreshed_at
+                   refresh_interval_seconds, last_refreshed_at, auto_refresh_enabled
             FROM odb.tenant_repositories
             WHERE id = %s::uuid AND tenant_id = %s::uuid AND deleted_at IS NULL
             LIMIT 1
@@ -6486,7 +6486,8 @@ class Database:
         has elapsed since the last tick. The effective interval is the per-repo
         ``refresh_interval_seconds`` clamped up to the global floor, so a
         too-aggressive per-repo cadence cannot defeat the floor. Soft-deleted
-        repositories and those not in a scannable ``ready``/``error`` state are
+        repositories, those not in a scannable ``ready``/``error`` state, and those
+        with ``auto_refresh_enabled = FALSE`` (the per-repo RAR-3.3 opt-out) are
         excluded. The recency comparison is done in the database against
         ``now()`` so it does not depend on application clock skew.
 
@@ -6513,10 +6514,11 @@ class Database:
             SELECT id, tenant_id, source, provider, clone_url, repository_full_name,
                    description, default_branch, visibility, status, created_at, updated_at,
                    linked_account_id, last_scanned_at, total_files, importable_count, branch_count,
-                   refresh_interval_seconds, last_refreshed_at
+                   refresh_interval_seconds, last_refreshed_at, auto_refresh_enabled
             FROM odb.tenant_repositories
             WHERE deleted_at IS NULL
               AND status IN ('ready', 'error')
+              AND auto_refresh_enabled = TRUE
               AND (
                 last_refreshed_at IS NULL
                 OR last_refreshed_at <= now() - make_interval(
@@ -6603,6 +6605,46 @@ class Database:
                 row = cursor.fetchone()
                 conn.commit()
                 return effective if row else None
+        except Exception as e:
+            conn.rollback()
+            raise e
+
+    def set_repository_auto_refresh_enabled(
+        self,
+        tenant_id: str,
+        repository_id: str,
+        enabled: bool,
+    ) -> Optional[bool]:
+        """Set a repository's per-repo auto-refresh opt-out flag (RAR-3.3).
+
+        When ``enabled`` is False the refresh sweep's due-selection
+        (:meth:`list_due_repositories`) skips this repository, so it is never
+        auto-refreshed. The global ``OBJECTIFIED_REFRESH_ENABLED`` kill switch and
+        manual "Refresh Now" (RAR-5.2) are independent of this flag.
+
+        Args:
+            tenant_id: Owning tenant id (scopes the update for isolation).
+            repository_id: The repository to update.
+            enabled: True to allow auto-refresh, False to opt this repo out.
+
+        Returns:
+            The stored value (``enabled``) when a live repository matched the
+            tenant + id, or None when no row was updated.
+        """
+        q = """
+            UPDATE odb.tenant_repositories
+            SET auto_refresh_enabled = %s,
+                updated_at = CURRENT_TIMESTAMP
+            WHERE id = %s::uuid AND tenant_id = %s::uuid AND deleted_at IS NULL
+            RETURNING id
+        """
+        conn = self.connect()
+        try:
+            with conn.cursor() as cursor:
+                cursor.execute(q, (bool(enabled), repository_id, tenant_id))
+                row = cursor.fetchone()
+                conn.commit()
+                return bool(enabled) if row else None
         except Exception as e:
             conn.rollback()
             raise e

--- a/objectified-rest/src/app/models.py
+++ b/objectified-rest/src/app/models.py
@@ -2363,8 +2363,28 @@ class TenantRepositoryRecord(BaseModel):
     total_files: Optional[int] = None
     importable_count: Optional[int] = None
     branch_count: Optional[int] = None
+    # Per-repo auto-refresh opt-out (RAR-3.3, #3524). True = sweep may refresh this
+    # repo on its cadence; False = the sweep skips it. Defaults to True for repos
+    # whose row predates the column.
+    auto_refresh_enabled: bool = True
     created_at: Optional[str] = None
     updated_at: Optional[str] = None
+
+
+class TenantRepositoryUpdate(BaseModel):
+    """Dashboard: patch mutable settings on a registered repository (RAR-3.3).
+
+    Only fields present in the request body are applied. Currently the per-repo
+    auto-refresh toggle (``auto_refresh_enabled``); accepts both the snake_case and
+    camelCase spellings so the UI can send either.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    auto_refresh_enabled: Optional[bool] = Field(
+        None,
+        validation_alias=AliasChoices("autoRefreshEnabled", "auto_refresh_enabled"),
+    )
 
 
 class TenantRepositoriesListResponse(BaseModel):

--- a/objectified-rest/src/app/repository_refresh_sweep.py
+++ b/objectified-rest/src/app/repository_refresh_sweep.py
@@ -142,13 +142,30 @@ def process_repository_refresh_sweep(db: Database) -> int:
     fails — so the cadence keeps moving and a broken repo cannot monopolize the
     sweep.
 
+    The global ``OBJECTIFIED_REFRESH_ENABLED`` kill switch (RAR-3.3) short-circuits
+    the whole tick: when it is disabled the sweep halts immediately without touching
+    any repository (no rescan, no enqueue, no anchor advance), so operators can stop
+    all auto-refresh for incident response. The per-repo ``auto_refresh_enabled``
+    opt-out is enforced earlier, in ``list_due_repositories``. Neither gate affects
+    manual "Refresh Now" (RAR-5.2), which does not run through this sweep.
+
     Args:
         db: Database handle for this tick (one connection holds the advisory
             locks; the caller uses a dedicated ``Database`` per tick).
 
     Returns:
-        The total number of refresh jobs enqueued this tick.
+        The total number of refresh jobs enqueued this tick (0 when the global
+        kill switch is disabled).
     """
+    from .config import settings
+
+    if not settings.refresh_enabled:
+        # Global kill switch (RAR-3.3): halt all auto-refresh for this tick.
+        _logger.info(
+            "repository refresh sweep halted: OBJECTIFIED_REFRESH_ENABLED is disabled"
+        )
+        return 0
+
     enqueued_total = 0
     for due_row in db.list_due_repositories():
         repository_id = str(due_row["id"])

--- a/objectified-rest/src/app/tenant_repositories_routes.py
+++ b/objectified-rest/src/app/tenant_repositories_routes.py
@@ -28,6 +28,7 @@ from .models import (
     TenantRepositoryFilesListResponse,
     TenantRepositoryGetResponse,
     TenantRepositoryRecord,
+    TenantRepositoryUpdate,
     TenantRepositoriesListResponse,
 )
 from .repository_file_scan import _github_owner_repo, fetch_github_repository_file_text
@@ -149,6 +150,8 @@ def _row_to_record(row: Dict[str, Any]) -> TenantRepositoryRecord:
         total_files=row.get("total_files") if isinstance(row.get("total_files"), int) else None,
         importable_count=row.get("importable_count") if isinstance(row.get("importable_count"), int) else None,
         branch_count=row.get("branch_count") if isinstance(row.get("branch_count"), int) else None,
+        # Default-on so a repo whose row predates the RAR-3.3 column reads as enabled.
+        auto_refresh_enabled=bool(row.get("auto_refresh_enabled", True)),
         created_at=_ts(row.get("created_at")),
         updated_at=_ts(row.get("updated_at")),
     )
@@ -592,6 +595,40 @@ async def create_tenant_repository(
 
     record = _row_to_record(inserted)
     return TenantRepositoryCreateResponse(success=True, repository=record)
+
+
+@router.patch(
+    "/{tenant_slug}/repositories/{repository_id}",
+    response_model=TenantRepositoryGetResponse,
+)
+async def update_tenant_repository(
+    tenant_slug: str,
+    repository_id: uuid.UUID,
+    payload: TenantRepositoryUpdate,
+    auth_data: Dict[str, Any] = Depends(validate_authentication),
+) -> TenantRepositoryGetResponse:
+    """Patch mutable repository settings (RAR-3.3 auto-refresh toggle, #3524).
+
+    Applies only the fields present in the request body. Currently the per-repo
+    ``auto_refresh_enabled`` opt-out: when set to False the auto-refresh sweep skips
+    this repository (manual "Refresh Now" is unaffected). Returns the updated
+    repository record. 404 when the repository does not belong to the tenant.
+    """
+    _ = tenant_slug
+    tenant_id = str(auth_data["tenant_id"])
+    rid = str(repository_id)
+
+    if payload.auto_refresh_enabled is not None:
+        updated = db.set_repository_auto_refresh_enabled(
+            tenant_id, rid, payload.auto_refresh_enabled
+        )
+        if updated is None:
+            raise HTTPException(status_code=404, detail="repository not found")
+
+    row = db.get_tenant_repository(tenant_id, rid)
+    if not row:
+        raise HTTPException(status_code=404, detail="repository not found")
+    return TenantRepositoryGetResponse(success=True, repository=_row_to_record(row))
 
 
 @router.delete("/{tenant_slug}/repositories/{repository_id}")

--- a/objectified-rest/tests/test_repository_auto_refresh_toggle_migration.py
+++ b/objectified-rest/tests/test_repository_auto_refresh_toggle_migration.py
@@ -1,0 +1,25 @@
+"""Guardrails for the auto-refresh enable/disable migration (RAR-3.3, #3524)."""
+
+from pathlib import Path
+
+_MIGRATION = "objectified-db/scripts/20260622-120000.sql"
+
+# Fragments the migration must keep so the per-repo toggle survives accidental
+# edits. Acceptance criteria for #3524: a per-repo `auto_refresh_enabled` flag,
+# default TRUE so existing repositories keep auto-refreshing.
+_REQUIRED_FRAGMENTS = (
+    "ALTER TABLE odb.tenant_repositories",
+    "ADD COLUMN IF NOT EXISTS auto_refresh_enabled BOOLEAN NOT NULL DEFAULT TRUE",
+)
+
+
+def test_migration_adds_auto_refresh_column(repo_root: Path) -> None:
+    text = (repo_root / _MIGRATION).read_text()
+    missing = [frag for frag in _REQUIRED_FRAGMENTS if frag not in text]
+    assert not missing, f"Migration missing expected fragments: {missing}"
+
+
+def test_migration_default_is_enabled(repo_root: Path) -> None:
+    """The default must remain TRUE so existing repos keep auto-refreshing."""
+    text = (repo_root / _MIGRATION).read_text()
+    assert "DEFAULT TRUE" in text

--- a/objectified-rest/tests/test_repository_refresh_sweep.py
+++ b/objectified-rest/tests/test_repository_refresh_sweep.py
@@ -243,6 +243,56 @@ def test_idempotent_enqueue_not_double_counted():
     assert len(db.enqueued) == 1
 
 
+def test_global_kill_switch_halts_sweep(monkeypatch):
+    """OBJECTIFIED_REFRESH_ENABLED=False halts the tick before any repo work (RAR-3.3)."""
+    import app.config as config
+
+    monkeypatch.setattr(config.settings, "refresh_enabled", False)
+
+    stale = _candidate(
+        "api/openapi.yaml",
+        remote_committed_at=NEWER, remote_blob="blob-new",
+        last_committed_at=OLDER, last_blob="blob-old",
+    )
+    db = FakeDB(
+        due=[{"id": "r1", "tenant_id": "t1"}],
+        branches={"r1": ["main"]},
+        candidates={("r1", "main"): [stale]},
+    )
+
+    enqueued = process_repository_refresh_sweep(db)
+
+    assert enqueued == 0
+    # Halt is total: no lock taken, no scan, no enqueue, no anchor advance.
+    assert db.acquired == []
+    assert db.scanned == []
+    assert db.enqueued == []
+    assert db.refreshed == []
+
+
+def test_global_kill_switch_enabled_runs_sweep(monkeypatch):
+    """With the kill switch explicitly enabled the sweep behaves normally (RAR-3.3)."""
+    import app.config as config
+
+    monkeypatch.setattr(config.settings, "refresh_enabled", True)
+
+    stale = _candidate(
+        "api/openapi.yaml",
+        remote_committed_at=NEWER, remote_blob="blob-new",
+        last_committed_at=OLDER, last_blob="blob-old",
+    )
+    db = FakeDB(
+        due=[{"id": "r1", "tenant_id": "t1"}],
+        branches={"r1": ["main"]},
+        candidates={("r1", "main"): [stale]},
+    )
+
+    enqueued = process_repository_refresh_sweep(db)
+
+    assert enqueued == 1
+    assert db.refreshed == ["r1"]
+
+
 def test_multiple_branches_each_rescanned():
     """Every branch with a stored spec is rescanned and evaluated."""
     stale_main = _candidate(

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.120",
+  "version": "0.11.121",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/src/app/ade/dashboard/repositories/[id]/RepositoryDetailClient.tsx
+++ b/objectified-ui/src/app/ade/dashboard/repositories/[id]/RepositoryDetailClient.tsx
@@ -24,6 +24,7 @@ import {
 import { Button, buttonVariants } from '@/app/components/ui/Button';
 import { Input } from '@/app/components/ui/Input';
 import { LoadingState } from '@/app/components/ui/LoadingState';
+import { Switch } from '@/app/components/ui/Switch';
 import {
   Select,
   SelectContent,
@@ -208,6 +209,7 @@ export function RepositoryDetailClient() {
   const [tab, setTab] = useState<RepoTab>('preview');
   const [removing, setRemoving] = useState(false);
   const [removeDialogOpen, setRemoveDialogOpen] = useState(false);
+  const [savingAutoRefresh, setSavingAutoRefresh] = useState(false);
   const [repoImports, setRepoImports] = useState<RepositoryImportMetricApiRow[]>([]);
   const [importsLoading, setImportsLoading] = useState(false);
   const [importsError, setImportsError] = useState<string | null>(null);
@@ -354,6 +356,40 @@ export function RepositoryDetailClient() {
       toast.error(e instanceof Error ? e.message : 'Could not remove repository.');
     } finally {
       setRemoving(false);
+    }
+  };
+
+  /**
+   * Toggle this repository's auto-refresh opt-out (RAR-3.3). Optimistically flips
+   * the local switch, PATCHes the repo, and reconciles to the server's returned
+   * value — rolling back on error so the UI never lies about persisted state.
+   */
+  const performToggleAutoRefresh = async (next: boolean) => {
+    if (!id || !repo || savingAutoRefresh) return;
+    const previous = repo.auto_refresh_enabled ?? true;
+    setSavingAutoRefresh(true);
+    setRepo({ ...repo, auto_refresh_enabled: next });
+    try {
+      const res = await fetch(`/api/repositories/${encodeURIComponent(id)}`, {
+        method: 'PATCH',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ auto_refresh_enabled: next }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        throw new Error(typeof data.error === 'string' ? data.error : res.statusText);
+      }
+      const parsed = dashboardRepositoryFromApi(
+        data && typeof data === 'object' ? (data as { repository?: unknown }).repository : null,
+      );
+      if (parsed) setRepo(parsed);
+      toast.success(next ? 'Auto-refresh enabled.' : 'Auto-refresh disabled.');
+    } catch (e) {
+      setRepo({ ...repo, auto_refresh_enabled: previous });
+      toast.error(e instanceof Error ? e.message : 'Could not update auto-refresh.');
+    } finally {
+      setSavingAutoRefresh(false);
     }
   };
 
@@ -899,6 +935,32 @@ export function RepositoryDetailClient() {
 
           <div className="space-y-4 rounded-xl border border-gray-200 bg-white p-5 dark:border-gray-700 dark:bg-gray-800">
             <h3 className="border-b border-gray-100 pb-2 text-sm font-semibold dark:border-gray-700 dark:text-gray-100">Scan cadence</h3>
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+              <div className="space-y-1">
+                <label
+                  htmlFor="auto-refresh-toggle"
+                  className="text-[10px] font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400"
+                >
+                  Auto-refresh
+                </label>
+                <p className="max-w-md text-xs text-gray-500 dark:text-gray-400">
+                  When on, this repository is rescanned on its cadence and changed files are re-imported automatically.
+                  Turn it off to pause auto-refresh for this repo. Manual “Refresh now” is unaffected.
+                </p>
+              </div>
+              <div className="flex shrink-0 items-center gap-2">
+                <Switch
+                  id="auto-refresh-toggle"
+                  checked={repo.auto_refresh_enabled ?? true}
+                  disabled={savingAutoRefresh}
+                  onCheckedChange={(next) => void performToggleAutoRefresh(next)}
+                  aria-label="Toggle auto-refresh for this repository"
+                />
+                <span className="text-xs font-medium text-gray-600 dark:text-gray-300">
+                  {(repo.auto_refresh_enabled ?? true) ? 'Enabled' : 'Disabled'}
+                </span>
+              </div>
+            </div>
             <p className="text-xs text-gray-500 dark:text-gray-400">
               Scheduling + webhook secrets are product decisions: poll interval vs GitHub/GitLab push hooks. Persist on a
               repo settings extension once requirements settle.

--- a/objectified-ui/src/app/api/repositories/[id]/route.ts
+++ b/objectified-ui/src/app/api/repositories/[id]/route.ts
@@ -78,6 +78,72 @@ export async function GET(
   }
 }
 
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await getServerSession(authOptions);
+  const user = session?.user as SessionUser | undefined;
+  if (!user?.user_id) {
+    return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
+  }
+  if (!user.current_tenant_id) {
+    return NextResponse.json({ success: false, error: 'No tenant selected' }, { status: 400 });
+  }
+
+  const { id } = await params;
+  if (!id || !UUID_RE.test(id)) {
+    return NextResponse.json({ success: false, error: 'Invalid repository id' }, { status: 400 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ success: false, error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const tenant = await getTenantById(user.current_tenant_id);
+  const tenantSlug =
+    tenant && typeof tenant === 'object' && 'slug' in tenant ? String((tenant as { slug: string }).slug) : '';
+  if (!tenantSlug) {
+    return NextResponse.json({ success: false, error: 'Tenant not found' }, { status: 400 });
+  }
+
+  const url = `${REST_API_BASE_URL}/tenants/${encodeURIComponent(tenantSlug)}/repositories/${encodeURIComponent(id)}`;
+  try {
+    const rest = await fetch(url, {
+      method: 'PATCH',
+      headers: { ...createRestAuthHeaders(user), 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+      cache: 'no-store',
+    });
+    const text = await rest.text();
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      parsed = { raw: text };
+    }
+    if (rest.ok && parsed && typeof parsed === 'object' && 'repository' in parsed) {
+      return NextResponse.json(parsed);
+    }
+    if (rest.status === 404) {
+      return NextResponse.json({ success: false, error: 'Repository not found' }, { status: 404 });
+    }
+    const err =
+      parsed && typeof parsed === 'object' && 'detail' in parsed
+        ? String((parsed as { detail: unknown }).detail)
+        : `Repository API error (${rest.status})`;
+    return NextResponse.json({ success: false, error: err }, { status: rest.status >= 400 ? rest.status : 502 });
+  } catch {
+    return NextResponse.json(
+      { success: false, error: 'Repository API unavailable (objectified-rest not reachable).' },
+      { status: 503 }
+    );
+  }
+}
+
 export async function DELETE(
   _request: NextRequest,
   { params }: { params: Promise<{ id: string }> }

--- a/objectified-ui/src/app/components/ade/dashboard/repositories/repositoryStoreUi.tsx
+++ b/objectified-ui/src/app/components/ade/dashboard/repositories/repositoryStoreUi.tsx
@@ -42,6 +42,8 @@ export interface DashboardRepository {
   importable_count?: number | null;
   /** Git remote branches (GitHub list-branches at registration); null if unknown. */
   branch_count?: number | null;
+  /** Per-repo auto-refresh opt-out (RAR-3.3). True (default) = sweep may refresh this repo. */
+  auto_refresh_enabled?: boolean;
   clone_url?: string | null;
   source?: string | null;
   created_at?: string | null;
@@ -111,6 +113,11 @@ export function dashboardRepositoryFromApi(x: unknown): DashboardRepository | nu
     total_files: typeof o.total_files === 'number' ? o.total_files : null,
     importable_count: typeof o.importable_count === 'number' ? o.importable_count : null,
     branch_count: typeof o.branch_count === 'number' ? o.branch_count : null,
+    // Default-on: a repo whose API payload omits the flag (older row) reads as enabled.
+    auto_refresh_enabled: (() => {
+      const v = o.auto_refresh_enabled ?? (o as { autoRefreshEnabled?: unknown }).autoRefreshEnabled;
+      return v == null ? true : Boolean(v);
+    })(),
     clone_url: o.clone_url != null ? String(o.clone_url) : null,
     source: o.source != null ? String(o.source) : null,
     created_at: o.created_at != null ? String(o.created_at) : null,

--- a/objectified-ui/tests/unit/repository-auto-refresh-toggle.test.ts
+++ b/objectified-ui/tests/unit/repository-auto-refresh-toggle.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Auto-refresh enable/disable parsing (RAR-3.3, #3524).
+ *
+ * The repository detail Settings tab drives a Switch from
+ * `DashboardRepository.auto_refresh_enabled`. These tests pin how
+ * `dashboardRepositoryFromApi` derives that flag from the REST payload, including
+ * the default-on fallback for older rows whose payload omits the field.
+ */
+
+import { dashboardRepositoryFromApi } from '@/app/components/ade/dashboard/repositories/repositoryStoreUi';
+
+function basePayload(extra: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: 'r1',
+    name: 'repo',
+    full_name: 'org/repo',
+    provider: 'github',
+    default_branch: 'main',
+    status: 'ready',
+    ...extra,
+  };
+}
+
+describe('dashboardRepositoryFromApi auto_refresh_enabled', () => {
+  it('parses an explicit true', () => {
+    const repo = dashboardRepositoryFromApi(basePayload({ auto_refresh_enabled: true }));
+    expect(repo?.auto_refresh_enabled).toBe(true);
+  });
+
+  it('parses an explicit false', () => {
+    const repo = dashboardRepositoryFromApi(basePayload({ auto_refresh_enabled: false }));
+    expect(repo?.auto_refresh_enabled).toBe(false);
+  });
+
+  it('accepts the camelCase spelling', () => {
+    const repo = dashboardRepositoryFromApi(basePayload({ autoRefreshEnabled: false }));
+    expect(repo?.auto_refresh_enabled).toBe(false);
+  });
+
+  it('defaults to enabled when the field is absent (older row)', () => {
+    const repo = dashboardRepositoryFromApi(basePayload());
+    expect(repo?.auto_refresh_enabled).toBe(true);
+  });
+
+  it('defaults to enabled when the field is null', () => {
+    const repo = dashboardRepositoryFromApi(basePayload({ auto_refresh_enabled: null }));
+    expect(repo?.auto_refresh_enabled).toBe(true);
+  });
+});


### PR DESCRIPTION
## What & why

Auto-refresh must be controllable: a repo owner may want it off for one repository, and operators need a global kill switch for incident response (RAR-3.3, `RAR-3.3` · epic #3508).

This adds:
- **Per-repo opt-out** — `auto_refresh_enabled` (default ON) on `odb.tenant_repositories`. The refresh sweep's due-selection (`list_due_repositories`) filters `auto_refresh_enabled = TRUE`, so a disabled repo is never picked.
- **Global kill switch** — `OBJECTIFIED_REFRESH_ENABLED` (default True). `process_repository_refresh_sweep` short-circuits the entire tick (no lock, scan, enqueue, or anchor advance) when it is disabled.
- Both gates are independent of manual "Refresh Now" (RAR-5.2), which does not run through the sweep.

### Changes
- **objectified-db**: migration `20260622-120000.sql` adds `auto_refresh_enabled BOOLEAN NOT NULL DEFAULT TRUE` (existing repos keep refreshing).
- **objectified-rest**: `OBJECTIFIED_REFRESH_ENABLED` config; `list_due_repositories` filter + column surfaced; new `set_repository_auto_refresh_enabled` setter (tenant-scoped); sweep kill-switch short-circuit; `auto_refresh_enabled` on `TenantRepositoryRecord`; new `PATCH /v1/tenants/{slug}/repositories/{id}` (`TenantRepositoryUpdate`).
- **objectified-ui**: Auto-refresh `Switch` in the repository **Settings** tab with optimistic PATCH + rollback on error, via a new `PATCH /api/repositories/[id]` route handler; flag parsing in `repositoryStoreUi`.

## How to test
1. **Browse to** a repository → **Settings** tab. The **Auto-refresh** toggle reflects the current state (default **Enabled**).
2. **Toggle it off** — a "Auto-refresh disabled." toast appears and the state persists across reload. The repo is now skipped by the auto-refresh sweep (no new refresh jobs enqueued).
3. **Toggle it on** again — re-enabled and eligible for the sweep on its cadence.
4. **Global kill switch**: set `OBJECTIFIED_REFRESH_ENABLED=false` in the objectified-rest environment and restart. The sweep halts entirely (log: `repository refresh sweep halted: OBJECTIFIED_REFRESH_ENABLED is disabled`) regardless of per-repo flags. Manual "Refresh Now" is unaffected.

### Automated tests
- objectified-rest: `uv run pytest tests/test_repository_refresh_sweep.py tests/test_repository_auto_refresh_toggle_migration.py` (kill-switch halt/enabled, per-repo behavior, migration guard).
- objectified-ui: `yarn jest repository-auto-refresh-toggle` (flag parsing: true/false, camelCase, default-on for older/null rows).

## Risk / notes
- New column defaults to TRUE, so existing repositories keep auto-refreshing — no behavioral change until a user opts out or an operator flips the global switch.
- The per-repo gate is in SQL (due-selection); the global gate is in the sweep entry point — both verified by unit tests with a DB-free fake.
- Pre-existing, unrelated test failures (DB-dependent suites using a `src.app` import convention) were confirmed present on a clean tree and are untouched.

Closes #3524

Work performed by Claude Code via model Opus 4.8 (1M context).