### PR TITLE
Fix #3527 - Re-import worker applies stored spec (RAR-4.1)

### DIFF
--- a/docs/ROADMAP_REPOSITORY_AUTOREFRESH.md
+++ b/docs/ROADMAP_REPOSITORY_AUTOREFRESH.md
@@ -123,7 +123,7 @@ epic. Use this table to resolve any `RAR-*` reference below to its issue number.
 | ~~RAR-2.1~~ ✅ | ~~#3518~~ | ~~RAR-2.2~~ ✅ | ~~#3519~~ | ~~RAR-2.3~~ ✅ | ~~#3520~~ |
 | ~~RAR-2.4~~ ✅ | ~~#3521~~ | ~~RAR-3.1~~ ✅ | ~~#3522~~ | ~~RAR-3.2~~ ✅ | ~~#3523~~ |
 | ~~RAR-3.3~~ ✅ | ~~#3524~~ | RAR-3.4 | #3525 | RAR-3.5 | #3526 |
-| RAR-4.1 | #3527 | RAR-4.2 | #3528 | RAR-4.3 | #3529 |
+| ~~RAR-4.1~~ ✅ | ~~#3527~~ | RAR-4.2 | #3528 | RAR-4.3 | #3529 |
 | RAR-4.4 | #3530 | RAR-4.5 | #3531 | RAR-5.1 | #3532 |
 | RAR-5.2 | #3533 | RAR-5.3 | #3534 | RAR-5.4 | #3535 |
 | RAR-5.5 | #3536 | RAR-5.6 | #3537 | RAR-6.1 | #3538 |
@@ -504,6 +504,18 @@ source descriptor (RAR-1.3).
 mapping) re-imports with the **same** options on refresh; golden-fixture test asserts byte-identical
 option application vs the original run.
 **Dependencies.** Depends RAR-1.2, RAR-3.2. **Parallel = N.**
+
+**Status: ✅ Done (#3527).** The spec-import worker now resolves its importer input through the pure,
+reusable `objectified-ui/lib/repository-auto-refresh-import.ts`. When `source_kind ==
+'repository_auto_import'` it hydrates the importer kind, options, and document parsing from the stored
+import spec carried in the metadata instead of importer defaults: options come from the verbatim
+captured blob (RAR-1.2), and the source descriptor (RAR-1.3) drives routing (`format_override` →
+importer kind) and parsing (`content_type` → JSON/YAML). On the REST side `SpecImportStartMetadata`
+gained an optional `repository_import_spec` (`SpecImportStoredSpec`), and
+`app/repository_refresh_executor.py` maps an enqueued RAR-3.2 refresh job row into that worker
+metadata. A golden-fixture test (`tests/repository-auto-refresh-worker.test.ts`) asserts byte-identical
+option application vs the original run; Python unit tests pin the row→metadata hydration. The OpenAPI
+contract is regenerated.
 
 ### RAR-4.4 — Manual-edit divergence guard
 

--- a/objectified-rest/openapi.json
+++ b/objectified-rest/openapi.json
@@ -13172,6 +13172,99 @@
           }
         }
       },
+      "patch": {
+        "tags": [
+          "tenant-repositories"
+        ],
+        "summary": "Update Tenant Repository",
+        "description": "Patch mutable repository settings (RAR-3.3 auto-refresh toggle, #3524).\n\nApplies only the fields present in the request body. Currently the per-repo\n``auto_refresh_enabled`` opt-out: when set to False the auto-refresh sweep skips\nthis repository (manual \"Refresh Now\" is unaffected). Returns the updated\nrepository record. 404 when the repository does not belong to the tenant.",
+        "operationId": "update_tenant_repository_v1_tenants__tenant_slug__repositories__repository_id__patch",
+        "parameters": [
+          {
+            "name": "tenant_slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Tenant Slug"
+            }
+          },
+          {
+            "name": "repository_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Repository Id"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "name": "X-API-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TenantRepositoryUpdate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TenantRepositoryGetResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
       "delete": {
         "tags": [
           "tenant-repositories"
@@ -16906,6 +16999,18 @@
         "title": "PushWebhookSubscriptionUpdateRequest",
         "description": "Update URL, active flag, and/or rotate signing secret (#2587)."
       },
+      "RefreshStatus": {
+        "type": "string",
+        "enum": [
+          "up-to-date",
+          "stale",
+          "refreshing",
+          "failed",
+          "diverged"
+        ],
+        "title": "RefreshStatus",
+        "description": "The materialized refresh state of a single imported repository file.\n\nValues are the stable wire/display codes (kebab-case) surfaced to the UI and\nthe sweep; they match the states in the roadmap state diagram."
+      },
       "RepositoryImportSpecRead": {
         "properties": {
           "spec_schema_version": {
@@ -16946,6 +17051,51 @@
           "options": {
             "$ref": "#/components/schemas/SpecImportOptions",
             "description": "Full SpecImportOptions payload, upgraded to the current shape."
+          },
+          "last_imported_commit_sha": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Imported Commit Sha",
+            "description": "Branch tip commit SHA observed for this file at import time (RAR-2.1)."
+          },
+          "last_imported_committed_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Imported Committed At",
+            "description": "Committed-at timestamp of the file at import time. A later auto-refresh compares the remote committed_at against this anchor to gate newer-than re-imports (RAR-2.1/RAR-2.2)."
+          },
+          "last_imported_blob_sha": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Imported Blob Sha",
+            "description": "Blob SHA of the file content at import time (RAR-2.1)."
+          },
+          "refresh_status": {
+            "$ref": "#/components/schemas/RefreshStatus",
+            "description": "Materialized per-file refresh state (RAR-2.3): one of up-to-date / stale / refreshing / failed / diverged. Derived from the current scan recency vs the last_imported_* anchors, overlaid with any in-flight refresh, last-attempt failure, or divergence hold.",
+            "default": "up-to-date"
           }
         },
         "additionalProperties": false,
@@ -18146,7 +18296,7 @@
           "source_kind": {
             "type": "string",
             "title": "Source Kind",
-            "description": "Importer discriminator (for example openapi-3, asyncapi-2, protobuf). Supported values match product import kinds."
+            "description": "Importer discriminator (for example openapi-3, asyncapi-2, protobuf). Supported values match product import kinds. The synthetic value 'repository_auto_import' marks a repository auto-refresh, in which case the importer kind/options/parsing come from 'repository_import_spec' rather than this metadata (RAR-4.1)."
           },
           "project": {
             "$ref": "#/components/schemas/SpecImportProjectTarget"
@@ -18168,6 +18318,17 @@
           },
           "options": {
             "$ref": "#/components/schemas/SpecImportOptions"
+          },
+          "repository_import_spec": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SpecImportStoredSpec"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Stored import spec for a repository auto-refresh; required and consulted only when source_kind is 'repository_auto_import' (RAR-4.1)."
           }
         },
         "additionalProperties": false,
@@ -18179,6 +18340,58 @@
         ],
         "title": "SpecImportStartMetadata",
         "description": "Shared metadata for JSON-base64 and multipart upload flows."
+      },
+      "SpecImportStoredSpec": {
+        "properties": {
+          "source_kind": {
+            "type": "string",
+            "title": "Source Kind",
+            "description": "Importer discriminator used at first import (for example openapi-3, arazzo)."
+          },
+          "format_override": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Format Override",
+            "description": "Resolved spec format the importer routed on (RAR-1.3); drives format detection on refresh."
+          },
+          "content_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Content Type",
+            "description": "MIME type the document was read as at first import (RAR-1.3); drives parsing on refresh."
+          },
+          "options": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Options",
+            "description": "Verbatim options blob persisted at first import, replayed as-is."
+          },
+          "spec_schema_version": {
+            "type": "integer",
+            "title": "Spec Schema Version",
+            "description": "Envelope version of the stored spec (RAR-1.4).",
+            "default": 1
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "source_kind"
+        ],
+        "title": "SpecImportStoredSpec",
+        "description": "Stored import spec carried into the worker for a repository auto-refresh (RAR-4.1).\n\nA repository auto-refresh re-imports a file the user already imported, and must\nreplay that original request rather than fall back to importer defaults. This\nmodel carries the captured spec (RAR-1.1/1.2) and its source descriptor\n(RAR-1.3) to the spec-import worker so it routes, parses, and applies options\nidentically to the first run.\n\n``options`` is the verbatim options blob persisted at first import (the worker's\ncamelCase option shape), passed through untouched \u2014 not re-validated into the\nlossy :class:`SpecImportOptions` subset \u2014 so advanced options (class prefixes,\ntype mappings, \u2026) survive the round-trip to the worker."
       },
       "SpecImportVersionTarget": {
         "properties": {
@@ -18926,6 +19139,11 @@
             ],
             "title": "Branch Count"
           },
+          "auto_refresh_enabled": {
+            "type": "boolean",
+            "title": "Auto Refresh Enabled",
+            "default": true
+          },
           "created_at": {
             "anyOf": [
               {
@@ -18960,6 +19178,24 @@
         ],
         "title": "TenantRepositoryRecord",
         "description": "Single repository row returned to the UI (snake_case keys for the dashboard)."
+      },
+      "TenantRepositoryUpdate": {
+        "properties": {
+          "autoRefreshEnabled": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Autorefreshenabled"
+          }
+        },
+        "type": "object",
+        "title": "TenantRepositoryUpdate",
+        "description": "Dashboard: patch mutable settings on a registered repository (RAR-3.3).\n\nOnly fields present in the request body are applied. Currently the per-repo\nauto-refresh toggle (``auto_refresh_enabled``); accepts both the snake_case and\ncamelCase spellings so the UI can send either."
       },
       "TenantsMeResponse": {
         "properties": {

--- a/objectified-rest/openapi.yaml
+++ b/objectified-rest/openapi.yaml
@@ -8287,6 +8287,72 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+    patch:
+      tags:
+      - tenant-repositories
+      summary: Update Tenant Repository
+      description: 'Patch mutable repository settings (RAR-3.3 auto-refresh toggle,
+        #3524).
+
+
+        Applies only the fields present in the request body. Currently the per-repo
+
+        ``auto_refresh_enabled`` opt-out: when set to False the auto-refresh sweep
+        skips
+
+        this repository (manual "Refresh Now" is unaffected). Returns the updated
+
+        repository record. 404 when the repository does not belong to the tenant.'
+      operationId: update_tenant_repository_v1_tenants__tenant_slug__repositories__repository_id__patch
+      parameters:
+      - name: tenant_slug
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Tenant Slug
+      - name: repository_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Repository Id
+      - name: authorization
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Authorization
+      - name: X-API-Key
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Api-Key
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TenantRepositoryUpdate'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TenantRepositoryGetResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
     delete:
       tags:
       - tenant-repositories
@@ -10637,6 +10703,22 @@ components:
       type: object
       title: PushWebhookSubscriptionUpdateRequest
       description: Update URL, active flag, and/or rotate signing secret (#2587).
+    RefreshStatus:
+      type: string
+      enum:
+      - up-to-date
+      - stale
+      - refreshing
+      - failed
+      - diverged
+      title: RefreshStatus
+      description: 'The materialized refresh state of a single imported repository
+        file.
+
+
+        Values are the stable wire/display codes (kebab-case) surfaced to the UI and
+
+        the sweep; they match the states in the roadmap state diagram.'
     RepositoryImportSpecRead:
       properties:
         spec_schema_version:
@@ -10665,6 +10747,36 @@ components:
         options:
           $ref: '#/components/schemas/SpecImportOptions'
           description: Full SpecImportOptions payload, upgraded to the current shape.
+        last_imported_commit_sha:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Last Imported Commit Sha
+          description: Branch tip commit SHA observed for this file at import time
+            (RAR-2.1).
+        last_imported_committed_at:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: string
+          - type: 'null'
+          title: Last Imported Committed At
+          description: Committed-at timestamp of the file at import time. A later
+            auto-refresh compares the remote committed_at against this anchor to gate
+            newer-than re-imports (RAR-2.1/RAR-2.2).
+        last_imported_blob_sha:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Last Imported Blob Sha
+          description: Blob SHA of the file content at import time (RAR-2.1).
+        refresh_status:
+          $ref: '#/components/schemas/RefreshStatus'
+          description: 'Materialized per-file refresh state (RAR-2.3): one of up-to-date
+            / stale / refreshing / failed / diverged. Derived from the current scan
+            recency vs the last_imported_* anchors, overlaid with any in-flight refresh,
+            last-attempt failure, or divergence hold.'
+          default: up-to-date
       additionalProperties: false
       type: object
       required:
@@ -11432,7 +11544,10 @@ components:
           type: string
           title: Source Kind
           description: Importer discriminator (for example openapi-3, asyncapi-2,
-            protobuf). Supported values match product import kinds.
+            protobuf). Supported values match product import kinds. The synthetic
+            value 'repository_auto_import' marks a repository auto-refresh, in which
+            case the importer kind/options/parsing come from 'repository_import_spec'
+            rather than this metadata (RAR-4.1).
         project:
           $ref: '#/components/schemas/SpecImportProjectTarget'
         version:
@@ -11446,6 +11561,12 @@ components:
             catalog project id.
         options:
           $ref: '#/components/schemas/SpecImportOptions'
+        repository_import_spec:
+          anyOf:
+          - $ref: '#/components/schemas/SpecImportStoredSpec'
+          - type: 'null'
+          description: Stored import spec for a repository auto-refresh; required
+            and consulted only when source_kind is 'repository_auto_import' (RAR-4.1).
       additionalProperties: false
       type: object
       required:
@@ -11454,6 +11575,66 @@ components:
       - version
       title: SpecImportStartMetadata
       description: Shared metadata for JSON-base64 and multipart upload flows.
+    SpecImportStoredSpec:
+      properties:
+        source_kind:
+          type: string
+          title: Source Kind
+          description: Importer discriminator used at first import (for example openapi-3,
+            arazzo).
+        format_override:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Format Override
+          description: Resolved spec format the importer routed on (RAR-1.3); drives
+            format detection on refresh.
+        content_type:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Content Type
+          description: MIME type the document was read as at first import (RAR-1.3);
+            drives parsing on refresh.
+        options:
+          additionalProperties: true
+          type: object
+          title: Options
+          description: Verbatim options blob persisted at first import, replayed as-is.
+        spec_schema_version:
+          type: integer
+          title: Spec Schema Version
+          description: Envelope version of the stored spec (RAR-1.4).
+          default: 1
+      additionalProperties: false
+      type: object
+      required:
+      - source_kind
+      title: SpecImportStoredSpec
+      description: 'Stored import spec carried into the worker for a repository auto-refresh
+        (RAR-4.1).
+
+
+        A repository auto-refresh re-imports a file the user already imported, and
+        must
+
+        replay that original request rather than fall back to importer defaults. This
+
+        model carries the captured spec (RAR-1.1/1.2) and its source descriptor
+
+        (RAR-1.3) to the spec-import worker so it routes, parses, and applies options
+
+        identically to the first run.
+
+
+        ``options`` is the verbatim options blob persisted at first import (the worker''s
+
+        camelCase option shape), passed through untouched — not re-validated into
+        the
+
+        lossy :class:`SpecImportOptions` subset — so advanced options (class prefixes,
+
+        type mappings, …) survive the round-trip to the worker.'
     SpecImportVersionTarget:
       properties:
         version_id:
@@ -11918,6 +12099,10 @@ components:
           - type: integer
           - type: 'null'
           title: Branch Count
+        auto_refresh_enabled:
+          type: boolean
+          title: Auto Refresh Enabled
+          default: true
         created_at:
           anyOf:
           - type: string
@@ -11939,6 +12124,24 @@ components:
       title: TenantRepositoryRecord
       description: Single repository row returned to the UI (snake_case keys for the
         dashboard).
+    TenantRepositoryUpdate:
+      properties:
+        autoRefreshEnabled:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Autorefreshenabled
+      type: object
+      title: TenantRepositoryUpdate
+      description: 'Dashboard: patch mutable settings on a registered repository (RAR-3.3).
+
+
+        Only fields present in the request body are applied. Currently the per-repo
+
+        auto-refresh toggle (``auto_refresh_enabled``); accepts both the snake_case
+        and
+
+        camelCase spellings so the UI can send either.'
     TenantsMeResponse:
       properties:
         items:

--- a/objectified-rest/pyproject.toml
+++ b/objectified-rest/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "objectified-rest"
-version = "1.0.70"
+version = "1.0.71"
 description = "REST API for serving OpenAPI specifications from the Objectified database"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/objectified-rest/src/app/models.py
+++ b/objectified-rest/src/app/models.py
@@ -537,6 +537,52 @@ def repository_import_spec_read_from_row(
     )
 
 
+# Synthetic ``source_kind`` the REST layer stamps on a repository auto-refresh
+# import (REPO-12.1). It is not a real importer kind: when the spec-import worker
+# sees it, the actual importer kind, options, and parsing come from the stored
+# import spec carried in ``SpecImportStartMetadata.repository_import_spec`` rather
+# than the request metadata (RAR-4.1).
+REPOSITORY_AUTO_IMPORT_SOURCE_KIND = "repository_auto_import"
+
+
+class SpecImportStoredSpec(BaseModel):
+    """Stored import spec carried into the worker for a repository auto-refresh (RAR-4.1).
+
+    A repository auto-refresh re-imports a file the user already imported, and must
+    replay that original request rather than fall back to importer defaults. This
+    model carries the captured spec (RAR-1.1/1.2) and its source descriptor
+    (RAR-1.3) to the spec-import worker so it routes, parses, and applies options
+    identically to the first run.
+
+    ``options`` is the verbatim options blob persisted at first import (the worker's
+    camelCase option shape), passed through untouched — not re-validated into the
+    lossy :class:`SpecImportOptions` subset — so advanced options (class prefixes,
+    type mappings, …) survive the round-trip to the worker.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    source_kind: str = Field(
+        description="Importer discriminator used at first import (for example openapi-3, arazzo).",
+    )
+    format_override: Optional[str] = Field(
+        default=None,
+        description="Resolved spec format the importer routed on (RAR-1.3); drives format detection on refresh.",
+    )
+    content_type: Optional[str] = Field(
+        default=None,
+        description="MIME type the document was read as at first import (RAR-1.3); drives parsing on refresh.",
+    )
+    options: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="Verbatim options blob persisted at first import, replayed as-is.",
+    )
+    spec_schema_version: int = Field(
+        default=REPOSITORY_IMPORT_SPEC_SCHEMA_VERSION,
+        description="Envelope version of the stored spec (RAR-1.4).",
+    )
+
+
 class SpecImportStartMetadata(BaseModel):
     """Shared metadata for JSON-base64 and multipart upload flows."""
 
@@ -545,7 +591,10 @@ class SpecImportStartMetadata(BaseModel):
     source_kind: str = Field(
         description=(
             "Importer discriminator (for example openapi-3, asyncapi-2, protobuf). "
-            "Supported values match product import kinds."
+            "Supported values match product import kinds. The synthetic value "
+            f"'{REPOSITORY_AUTO_IMPORT_SOURCE_KIND}' marks a repository auto-refresh, "
+            "in which case the importer kind/options/parsing come from "
+            "'repository_import_spec' rather than this metadata (RAR-4.1)."
         )
     )
     project: SpecImportProjectTarget
@@ -555,6 +604,13 @@ class SpecImportStartMetadata(BaseModel):
         description="When set, skip project creation and attach the job to this catalog project id.",
     )
     options: SpecImportOptions = Field(default_factory=SpecImportOptions)
+    repository_import_spec: Optional[SpecImportStoredSpec] = Field(
+        default=None,
+        description=(
+            "Stored import spec for a repository auto-refresh; required and consulted "
+            f"only when source_kind is '{REPOSITORY_AUTO_IMPORT_SOURCE_KIND}' (RAR-4.1)."
+        ),
+    )
 
 
 class SpecImportStartJsonRequest(BaseModel):

--- a/objectified-rest/src/app/repository_refresh_executor.py
+++ b/objectified-rest/src/app/repository_refresh_executor.py
@@ -1,0 +1,136 @@
+"""Spec-faithful re-import hydration for repository auto-refresh (RAR-4.1, #3527).
+
+The RAR-3.2 sweep (:mod:`repository_refresh_sweep`) enqueues a self-contained
+``odb.tenant_repository_refresh_jobs`` row per stale file, snapshotting the stored
+import spec (source kind, source descriptor, and the verbatim options blob) that
+was captured at first import (RAR-1.1/1.2/1.3). This module turns one such row into
+the metadata the spec-import worker consumes, stamped with the synthetic
+``repository_auto_import`` source kind so the worker hydrates the importer kind,
+options, and parsing from the stored spec instead of falling back to importer
+defaults.
+
+It is a pure mapping (no DB, no I/O): the EPIC-4 executor (RAR-4.2) and the worker
+agree on the envelope here, and a golden-fixture test can assert byte-identical
+option application versus the original import.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, Mapping, Optional
+
+from .models import (
+    REPOSITORY_AUTO_IMPORT_SOURCE_KIND,
+    REPOSITORY_IMPORT_SPEC_SCHEMA_VERSION,
+    SpecImportProjectTarget,
+    SpecImportStartMetadata,
+    SpecImportStoredSpec,
+    SpecImportVersionTarget,
+)
+
+
+def _coerce_options_blob(raw: Any) -> Dict[str, Any]:
+    """Normalize a stored ``options_json`` value into a plain dict.
+
+    The column is JSONB, but a cursor may surface it either as a dict (the common
+    case) or as a JSON-encoded string. An empty/``None`` value yields an empty dict
+    so a spec with no options replays as importer defaults rather than failing.
+
+    Args:
+        raw: The stored options value (dict, JSON string, or ``None``).
+
+    Returns:
+        The options as a plain dict.
+
+    Raises:
+        ValueError: If ``raw`` is a non-empty string that is not valid JSON, or a
+            type that is neither a mapping nor a string.
+    """
+    if raw is None:
+        return {}
+    if isinstance(raw, Mapping):
+        return dict(raw)
+    if isinstance(raw, str):
+        text = raw.strip()
+        if not text:
+            return {}
+        decoded = json.loads(text)
+        if not isinstance(decoded, Mapping):
+            raise ValueError("Stored options_json must decode to a JSON object.")
+        return dict(decoded)
+    raise ValueError(
+        f"Unsupported stored options_json type {type(raw).__name__}; expected object or JSON string."
+    )
+
+
+def build_stored_spec_from_refresh_job(job_row: Mapping[str, Any]) -> SpecImportStoredSpec:
+    """Build the worker's stored-spec payload from a refresh job row.
+
+    Mirrors the snapshot the RAR-3.2 sweep persisted on the
+    ``odb.tenant_repository_refresh_jobs`` row so the worker replays the original
+    import faithfully (RAR-4.1).
+
+    Args:
+        job_row: An enqueued refresh job row (or any mapping carrying the same
+            ``source_kind`` / ``format_override`` / ``content_type`` /
+            ``options_json`` / ``spec_schema_version`` keys).
+
+    Returns:
+        The :class:`SpecImportStoredSpec` to carry into the worker metadata.
+
+    Raises:
+        ValueError: If the row lacks a ``source_kind`` (nothing to route on), or the
+            stored options blob cannot be decoded.
+    """
+    source_kind = (job_row.get("source_kind") or "").strip()
+    if not source_kind:
+        raise ValueError(
+            "Refresh job row is missing source_kind; cannot replay the original import (RAR-4.1)."
+        )
+
+    schema_version = job_row.get("spec_schema_version")
+    return SpecImportStoredSpec(
+        source_kind=source_kind,
+        format_override=job_row.get("format_override"),
+        content_type=job_row.get("content_type"),
+        options=_coerce_options_blob(job_row.get("options_json")),
+        spec_schema_version=(
+            int(schema_version)
+            if schema_version is not None
+            else REPOSITORY_IMPORT_SPEC_SCHEMA_VERSION
+        ),
+    )
+
+
+def build_auto_refresh_import_metadata(
+    job_row: Mapping[str, Any],
+    *,
+    project: SpecImportProjectTarget,
+    version: SpecImportVersionTarget,
+    existing_project_id: Optional[str] = None,
+) -> SpecImportStartMetadata:
+    """Build worker metadata for a repository auto-refresh re-import (RAR-4.1).
+
+    Stamps the synthetic ``repository_auto_import`` source kind and attaches the
+    stored spec snapshot so the worker hydrates kind/options/parsing from it. The
+    catalog target (project/version) is supplied by the caller because version
+    creation and provenance for a refresh are owned by RAR-4.2; this function only
+    makes the import spec-faithful.
+
+    Args:
+        job_row: The enqueued refresh job row carrying the stored spec snapshot.
+        project: The catalog project target the refresh imports into.
+        version: The target catalog revision for the refresh.
+        existing_project_id: When set, attach to this existing catalog project id
+            instead of creating one (the usual case for a refresh).
+
+    Returns:
+        The :class:`SpecImportStartMetadata` for :func:`schedule_spec_import`.
+    """
+    return SpecImportStartMetadata(
+        source_kind=REPOSITORY_AUTO_IMPORT_SOURCE_KIND,
+        project=project,
+        version=version,
+        existing_project_id=existing_project_id,
+        repository_import_spec=build_stored_spec_from_refresh_job(job_row),
+    )

--- a/objectified-rest/tests/test_repository_refresh_executor.py
+++ b/objectified-rest/tests/test_repository_refresh_executor.py
@@ -1,0 +1,128 @@
+"""Spec-faithful auto-refresh hydration tests (RAR-4.1, #3527).
+
+Deterministic, DB-free unit tests over ``app.repository_refresh_executor``. They
+pin the RAR-4.1 contract on the REST side: a refresh job row enqueued by the
+RAR-3.2 sweep is hydrated into worker metadata stamped with the synthetic
+``repository_auto_import`` source kind, carrying the stored spec snapshot
+(source descriptor + verbatim options blob) so the worker replays the original
+import instead of importer defaults.
+
+The headline test is the golden fixture: the options blob captured at first import
+round-trips byte-identically into the worker metadata.
+"""
+
+import pytest
+
+from app.models import (
+    REPOSITORY_AUTO_IMPORT_SOURCE_KIND,
+    SpecImportProjectTarget,
+    SpecImportVersionTarget,
+)
+from app.repository_refresh_executor import (
+    build_auto_refresh_import_metadata,
+    build_stored_spec_from_refresh_job,
+)
+
+# Non-default options the user submitted at first import, in the verbatim camelCase
+# shape persisted to ``repository_import_spec.options_json`` — naming convention +
+# class prefix + type mapping, the advanced options the acceptance criteria call out.
+ORIGINAL_OPTIONS = {
+    "selectedSchemas": ["Pet"],
+    "applyNamingConvention": True,
+    "classNamingConvention": "camelCase",
+    "classPrefix": "Api",
+    "typeMapping": {"string": {"type": "string", "format": "text"}},
+    "generateExamples": True,
+}
+
+
+def _refresh_job_row(**overrides):
+    """A refresh job row as ``enqueue_repository_refresh_job`` returns it."""
+    row = {
+        "id": "refresh-1",
+        "tenant_id": "t1",
+        "repository_id": "repo-1",
+        "import_spec_id": "spec-1",
+        "branch": "main",
+        "path": "specs/petstore.json",
+        "project_id": "proj-1",
+        "source_kind": "openapi-3",
+        "format_override": "swagger",
+        "content_type": "application/json",
+        "options_json": dict(ORIGINAL_OPTIONS),
+        "spec_schema_version": 1,
+    }
+    row.update(overrides)
+    return row
+
+
+def _project():
+    return SpecImportProjectTarget(name="Petstore", slug="petstore")
+
+
+def _version():
+    return SpecImportVersionTarget(version_id="1.0.1")
+
+
+def test_golden_fixture_options_round_trip_into_worker_metadata():
+    """The stored options blob is replayed verbatim — the acceptance criterion."""
+    meta = build_auto_refresh_import_metadata(
+        _refresh_job_row(),
+        project=_project(),
+        version=_version(),
+        existing_project_id="proj-1",
+    )
+
+    assert meta.source_kind == REPOSITORY_AUTO_IMPORT_SOURCE_KIND
+    assert meta.existing_project_id == "proj-1"
+    assert meta.repository_import_spec is not None
+    spec = meta.repository_import_spec
+    # Verbatim, byte-identical option application vs the original import.
+    assert spec.options == ORIGINAL_OPTIONS
+    # The source descriptor is carried so the worker routes/parses identically.
+    assert spec.source_kind == "openapi-3"
+    assert spec.format_override == "swagger"
+    assert spec.content_type == "application/json"
+
+
+def test_stored_spec_from_job_row_maps_descriptor_and_options():
+    spec = build_stored_spec_from_refresh_job(_refresh_job_row())
+    assert spec.source_kind == "openapi-3"
+    assert spec.format_override == "swagger"
+    assert spec.content_type == "application/json"
+    assert spec.options["classPrefix"] == "Api"
+    assert spec.spec_schema_version == 1
+
+
+def test_options_json_accepts_a_json_encoded_string():
+    """A cursor that surfaces JSONB as text is decoded transparently."""
+    import json
+
+    row = _refresh_job_row(options_json=json.dumps(ORIGINAL_OPTIONS))
+    spec = build_stored_spec_from_refresh_job(row)
+    assert spec.options == ORIGINAL_OPTIONS
+
+
+def test_missing_options_blob_replays_as_empty_defaults():
+    for empty in (None, "", "   ", {}):
+        spec = build_stored_spec_from_refresh_job(_refresh_job_row(options_json=empty))
+        assert spec.options == {}
+
+
+def test_absent_spec_schema_version_falls_back_to_current():
+    spec = build_stored_spec_from_refresh_job(_refresh_job_row(spec_schema_version=None))
+    assert spec.spec_schema_version == 1
+
+
+def test_missing_source_kind_is_a_clear_error():
+    with pytest.raises(ValueError, match="missing source_kind"):
+        build_stored_spec_from_refresh_job(_refresh_job_row(source_kind=None))
+    with pytest.raises(ValueError, match="missing source_kind"):
+        build_stored_spec_from_refresh_job(_refresh_job_row(source_kind="  "))
+
+
+def test_invalid_options_json_string_is_rejected():
+    with pytest.raises(ValueError):
+        build_stored_spec_from_refresh_job(_refresh_job_row(options_json="not-json"))
+    with pytest.raises(ValueError, match="JSON object"):
+        build_stored_spec_from_refresh_job(_refresh_job_row(options_json="[1, 2, 3]"))

--- a/objectified-ui/lib/repository-auto-refresh-import.ts
+++ b/objectified-ui/lib/repository-auto-refresh-import.ts
@@ -1,0 +1,265 @@
+/**
+ * Spec-faithful re-import resolution for repository auto-refresh (RAR-4.1, #3527).
+ *
+ * The REST spec-import worker (`scripts/rest-spec-import-worker.ts`) builds its
+ * importer input from the *request* metadata. A repository auto-refresh job
+ * (`source_kind === 'repository_auto_import'`, REPO-12.1) supplies no per-request
+ * options, so without this module the worker would fall back to importer defaults
+ * and silently drop the user's original import specification.
+ *
+ * This module hydrates the importer input from the stored import spec captured at
+ * first import (RAR-1.1/1.2) and its source descriptor (RAR-1.3) so a refresh
+ * routes, parses, and applies options identically to the original run:
+ *
+ *   auto-refresh job ──► stored spec (options + source descriptor) ──► importer input
+ *
+ * It is a pure, side-effect-free module (no DB, no I/O) so the worker can reuse it
+ * and a golden-fixture test can assert byte-identical option application.
+ */
+
+import { parse as parseYaml } from 'yaml';
+
+import type { ImportJobInput } from './db/import-helper';
+
+/**
+ * Synthetic `source_kind` the REST layer stamps on a repository auto-refresh job
+ * (REPO-12.1). It is not a real importer kind: when the worker sees it the actual
+ * importer kind, options, and parsing come from the stored import spec instead of
+ * the request metadata.
+ */
+export const AUTO_REFRESH_SOURCE_KIND = 'repository_auto_import';
+
+/** Resolved importer discriminator the worker can hand to the importer. */
+export type ResolvedImportSourceKind = 'openapi' | 'arazzo';
+
+/**
+ * The stored import spec (RAR-1.1/1.2/1.3), carried into the worker so a refresh
+ * replays the original import. `options` is the verbatim options blob persisted at
+ * first import (the camelCase `ImportJobInput['options']` shape) — read as-is, not
+ * the lossy REST `SpecImportOptions` subset — so prefixes, type mappings, and other
+ * advanced options survive the round-trip.
+ */
+export interface StoredImportSpec {
+  /** Importer discriminator used at first import (for example `openapi-3`, `arazzo`). */
+  source_kind: string;
+  /** Resolved spec format the importer routed on (for example `swagger`); drives format detection on refresh. */
+  format_override?: string | null;
+  /** MIME type the document was read as at first import (for example `application/yaml`); drives parsing on refresh. */
+  content_type?: string | null;
+  /** Verbatim options blob persisted at first import. */
+  options?: Record<string, unknown> | null;
+  /** Envelope version of the stored spec (RAR-1.4). */
+  spec_schema_version?: number;
+}
+
+/** Worker metadata: the importer target plus, for a refresh, the stored spec. */
+export interface WorkerImportMetadata {
+  source_kind: string;
+  project: { name: string; slug: string; description?: string | null };
+  version: { version_id: string; description?: string | null };
+  existing_project_id?: string | null;
+  options?: Record<string, unknown>;
+  /**
+   * The stored import spec for a repository auto-refresh. Required (and consulted)
+   * only when `source_kind === 'repository_auto_import'`; ignored otherwise.
+   */
+  repository_import_spec?: StoredImportSpec | null;
+}
+
+/** The worker stdin payload from the REST layer. */
+export interface WorkerImportPayload {
+  tenant_id: string;
+  user_id: string;
+  rest_job_id: string;
+  metadata: WorkerImportMetadata;
+  document_base64: string;
+  filename?: string | null;
+  content_type?: string | null;
+}
+
+/**
+ * Map an importer kind or resolved format to the importer discriminator the
+ * importer registry understands.
+ *
+ * @param kind the importer kind (`openapi-3`, `arazzo`, …) or resolved format (`swagger`, …).
+ * @returns the resolved `openapi` or `arazzo` discriminator.
+ * @throws when the kind is not a REST-supported spec import kind.
+ */
+export function mapSourceKind(kind: string): ResolvedImportSourceKind {
+  const k = kind.trim().toLowerCase();
+  if (k === 'openapi-3' || k === 'openapi3' || k === 'swagger' || k === 'openapi') {
+    return 'openapi';
+  }
+  if (k === 'arazzo') {
+    return 'arazzo';
+  }
+  throw new Error(
+    `Unsupported source_kind "${kind}" for REST import (supported: openapi-3, arazzo).`,
+  );
+}
+
+/**
+ * Build the importer options from a stored/raw options blob, accepting both the
+ * snake_case REST shape and the camelCase `ImportJobInput` shape so the same logic
+ * serves request metadata and the verbatim stored spec. `incrementalMode` is forced
+ * on: the REST worker always imports incrementally so the transaction is not held
+ * across HTTP requests, independent of how the option was stored.
+ *
+ * @param o a raw options record (snake_case or camelCase keys).
+ * @returns the normalized `ImportJobInput['options']`.
+ */
+export function optionsFromRecord(o: Record<string, unknown>): ImportJobInput['options'] {
+  const sel = (o.selected_schemas ?? o.selectedSchemas) as unknown;
+  const selectedSchemas = Array.isArray(sel) ? (sel as string[]) : [];
+  return {
+    selectedSchemas,
+    dryRun: Boolean(o.dry_run ?? o.dryRun),
+    incrementalMode: true,
+    autoLayout: Boolean(o.auto_layout ?? o.autoLayout),
+    createRelationships: Boolean(o.create_relationships ?? o.createRelationships),
+    applyNamingConvention: Boolean(o.apply_naming_convention ?? o.applyNamingConvention),
+    classNamingConvention: (o.class_naming_convention ?? o.classNamingConvention) as
+      | ImportJobInput['options']['classNamingConvention']
+      | undefined,
+    propertyNamingConvention: (o.property_naming_convention ?? o.propertyNamingConvention) as
+      | ImportJobInput['options']['propertyNamingConvention']
+      | undefined,
+    classNameMap: (o.class_name_map ?? o.classNameMap) as Record<string, string> | undefined,
+    classPrefix: (o.class_prefix ?? o.classPrefix) as string | undefined,
+    classSuffix: (o.class_suffix ?? o.classSuffix) as string | undefined,
+    typeMapping: (o.type_mapping ?? o.typeMapping) as Record<string, unknown> | undefined,
+    defaultValues: (o.default_values ?? o.defaultValues) as Record<string, unknown> | undefined,
+    requiredOverrides: (o.required_overrides ?? o.requiredOverrides) as
+      | Record<string, Record<string, boolean>>
+      | undefined,
+    descriptionOverrides: (o.description_overrides ?? o.descriptionOverrides) as
+      | Record<string, Record<string, string>>
+      | undefined,
+    generateExamples: Boolean(o.generate_examples ?? o.generateExamples),
+    skipDuplicateVersions: Boolean(o.skip_duplicate_versions ?? o.skipDuplicateVersions),
+  };
+}
+
+/**
+ * Parse a specification document. When `contentType` resolves to JSON or YAML the
+ * matching parser is used so a refresh reads the bytes exactly as the first import
+ * did (the stored source descriptor driving detection); otherwise the syntax is
+ * sniffed from the leading character.
+ *
+ * @param text the decoded document text.
+ * @param contentType the stored/declared content type, or null to sniff.
+ * @returns the parsed document.
+ * @throws when the document cannot be parsed.
+ */
+export function parseSpecDocument(text: string, contentType?: string | null): unknown {
+  const ct = (contentType ?? '').trim().toLowerCase();
+  const t = text.trim();
+  if (ct.includes('json')) {
+    return JSON.parse(text) as unknown;
+  }
+  if (ct.includes('yaml') || ct.includes('yml')) {
+    return parseYaml(text) as unknown;
+  }
+  // No usable content-type hint: sniff JSON vs YAML from the first token.
+  if (t.startsWith('{') || t.startsWith('[')) {
+    return JSON.parse(text) as unknown;
+  }
+  return parseYaml(text) as unknown;
+}
+
+/** The importer kind, options, and parse hint resolved for one import job. */
+export interface ResolvedImport {
+  sourceKind: ResolvedImportSourceKind;
+  options: ImportJobInput['options'];
+  /** Content type to parse with (stored descriptor on refresh; else null to sniff). */
+  contentType: string | null;
+  /** Resolved spec format override carried from the stored descriptor, when any. */
+  formatOverride: string | null;
+}
+
+/**
+ * Resolve the importer kind, options, and parse hint for an import job.
+ *
+ * For a repository auto-refresh (`source_kind === 'repository_auto_import'`) these
+ * come from the stored import spec so the refresh replays the original request:
+ * the importer kind is routed from the stored source descriptor
+ * (`format_override` preferred, else the stored `source_kind`), options are
+ * hydrated from the stored options blob, and parsing follows the stored
+ * `content_type`. For every other kind they come from the request metadata, with
+ * format sniffed from the document as before.
+ *
+ * @param meta the worker import metadata.
+ * @returns the resolved importer kind, options, and parse hints.
+ * @throws when an auto-refresh job is missing its stored spec, or the kind is unsupported.
+ */
+export function resolveImport(meta: WorkerImportMetadata): ResolvedImport {
+  if (meta.source_kind.trim().toLowerCase() === AUTO_REFRESH_SOURCE_KIND) {
+    const spec = meta.repository_import_spec;
+    if (!spec || !spec.source_kind || !spec.source_kind.trim()) {
+      throw new Error(
+        'Repository auto-refresh job is missing its stored import spec; cannot replay the ' +
+          'original import options (RAR-4.1). Expected metadata.repository_import_spec.source_kind.',
+      );
+    }
+    // The source descriptor drives format detection on refresh: prefer the resolved
+    // format the importer recorded the first time, falling back to the importer kind.
+    const routingKind = spec.format_override?.trim() || spec.source_kind;
+    return {
+      sourceKind: mapSourceKind(routingKind),
+      options: optionsFromRecord(spec.options ?? {}),
+      contentType: spec.content_type ?? null,
+      formatOverride: spec.format_override?.trim() || null,
+    };
+  }
+  return {
+    sourceKind: mapSourceKind(meta.source_kind),
+    options: optionsFromRecord(meta.options ?? {}),
+    contentType: null,
+    formatOverride: null,
+  };
+}
+
+/**
+ * Build the full importer input for the worker from its stdin payload, decoding and
+ * parsing the document and resolving kind/options/descriptor. For a repository
+ * auto-refresh this yields the same importer input the original import produced
+ * (modulo the always-incremental REST execution mode).
+ *
+ * @param payload the worker stdin payload.
+ * @returns the importer input to hand to `startImport`.
+ * @throws when the document cannot be decoded/parsed or the kind is unsupported.
+ */
+export function buildImportJobInput(payload: WorkerImportPayload): ImportJobInput {
+  const meta = payload.metadata;
+  const resolved = resolveImport(meta);
+
+  let document: unknown;
+  try {
+    const bytes = Buffer.from(payload.document_base64, 'base64');
+    const text = bytes.toString('utf8');
+    // The stored descriptor's content type wins on refresh; otherwise honor the
+    // request content type when present, else sniff.
+    document = parseSpecDocument(text, resolved.contentType ?? payload.content_type ?? null);
+  } catch (e: unknown) {
+    throw new Error(`Could not parse specification document: ${(e as Error)?.message ?? e}`);
+  }
+
+  const existing = meta.existing_project_id?.trim();
+  return {
+    tenantId: payload.tenant_id,
+    userId: payload.user_id,
+    sourceKind: resolved.sourceKind,
+    document,
+    project: {
+      name: meta.project.name,
+      slug: meta.project.slug,
+      description: meta.project.description ?? undefined,
+    },
+    version: {
+      versionId: meta.version.version_id,
+      description: meta.version.description ?? null,
+    },
+    options: resolved.options,
+    existingProjectId: existing !== undefined && existing !== '' ? existing : undefined,
+  };
+}

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.121",
+  "version": "0.11.122",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/scripts/rest-spec-import-worker.ts
+++ b/objectified-ui/scripts/rest-spec-import-worker.ts
@@ -6,26 +6,13 @@
 
 import { stdin as input } from "node:process";
 
-import { parse as parseYaml } from "yaml";
-
-import type { ImportJobInput } from "../lib/db/import-helper";
 import { getImportStatus, startImport } from "../lib/db/import-helper";
+import {
+  buildImportJobInput,
+  type WorkerImportPayload,
+} from "../lib/repository-auto-refresh-import";
 
-type Payload = {
-  tenant_id: string;
-  user_id: string;
-  rest_job_id: string;
-  metadata: {
-    source_kind: string;
-    project: { name: string; slug: string; description?: string | null };
-    version: { version_id: string; description?: string | null };
-    existing_project_id?: string | null;
-    options?: Record<string, unknown>;
-  };
-  document_base64: string;
-  filename?: string | null;
-  content_type?: string | null;
-};
+type Payload = WorkerImportPayload;
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -37,60 +24,6 @@ async function readStdin(): Promise<string> {
     chunks.push(chunk as Buffer);
   }
   return Buffer.concat(chunks).toString("utf8");
-}
-
-function mapSourceKind(kind: string): "openapi" | "arazzo" {
-  const k = kind.trim().toLowerCase();
-  if (k === "openapi-3" || k === "openapi3" || k === "swagger" || k === "openapi") {
-    return "openapi";
-  }
-  if (k === "arazzo") {
-    return "arazzo";
-  }
-  throw new Error(
-    `Unsupported source_kind "${kind}" for REST import (supported: openapi-3, arazzo).`,
-  );
-}
-
-function parseDocument(text: string): unknown {
-  const t = text.trim();
-  if (t.startsWith("{") || t.startsWith("[")) {
-    return JSON.parse(text) as unknown;
-  }
-  return parseYaml(text) as unknown;
-}
-
-function optionsFromMeta(meta: Payload["metadata"]): ImportJobInput["options"] {
-  const o = meta.options ?? {};
-  const sel = (o.selected_schemas ?? o.selectedSchemas) as unknown;
-  const selectedSchemas = Array.isArray(sel) ? (sel as string[]) : [];
-  return {
-    selectedSchemas,
-    dryRun: Boolean(o.dry_run ?? o.dryRun),
-    incrementalMode: true,
-    autoLayout: Boolean(o.auto_layout ?? o.autoLayout),
-    createRelationships: Boolean(o.create_relationships ?? o.createRelationships),
-    applyNamingConvention: Boolean(o.apply_naming_convention ?? o.applyNamingConvention),
-    classNamingConvention: (o.class_naming_convention ?? o.classNamingConvention) as
-      | ImportJobInput["options"]["classNamingConvention"]
-      | undefined,
-    propertyNamingConvention: (o.property_naming_convention ?? o.propertyNamingConvention) as
-      | ImportJobInput["options"]["propertyNamingConvention"]
-      | undefined,
-    classNameMap: (o.class_name_map ?? o.classNameMap) as Record<string, string> | undefined,
-    classPrefix: (o.class_prefix ?? o.classPrefix) as string | undefined,
-    classSuffix: (o.class_suffix ?? o.classSuffix) as string | undefined,
-    typeMapping: (o.type_mapping ?? o.typeMapping) as Record<string, unknown> | undefined,
-    defaultValues: (o.default_values ?? o.defaultValues) as Record<string, unknown> | undefined,
-    requiredOverrides: (o.required_overrides ?? o.requiredOverrides) as
-      | Record<string, Record<string, boolean>>
-      | undefined,
-    descriptionOverrides: (o.description_overrides ?? o.descriptionOverrides) as
-      | Record<string, Record<string, string>>
-      | undefined,
-    generateExamples: Boolean(o.generate_examples ?? o.generateExamples),
-    skipDuplicateVersions: Boolean(o.skip_duplicate_versions ?? o.skipDuplicateVersions),
-  };
 }
 
 function progressToRest(st: Awaited<ReturnType<typeof getImportStatus>>): Record<string, unknown> | undefined {
@@ -151,34 +84,11 @@ function writeWorkerStdoutLine(obj: unknown): void {
 }
 
 async function runFromPayload(payload: Payload): Promise<void> {
-  const sourceKind = mapSourceKind(payload.metadata.source_kind);
-  let document: unknown;
-  try {
-    const bytes = Buffer.from(payload.document_base64, "base64");
-    const text = bytes.toString("utf8");
-    document = parseDocument(text);
-  } catch (e: unknown) {
-    throw new Error(`Could not parse specification document: ${(e as Error)?.message ?? e}`);
-  }
-
-  const existing = payload.metadata.existing_project_id?.trim();
-  const inputPayload: ImportJobInput = {
-    tenantId: payload.tenant_id,
-    userId: payload.user_id,
-    sourceKind,
-    document,
-    project: {
-      name: payload.metadata.project.name,
-      slug: payload.metadata.project.slug,
-      description: payload.metadata.project.description ?? undefined,
-    },
-    version: {
-      versionId: payload.metadata.version.version_id,
-      description: payload.metadata.version.description ?? null,
-    },
-    options: optionsFromMeta(payload.metadata),
-    existingProjectId: existing !== undefined && existing !== "" ? existing : undefined,
-  };
+  // Resolve the importer kind, options, and document. For a repository
+  // auto-refresh (source_kind === 'repository_auto_import') this hydrates options
+  // and source descriptor from the stored import spec so the refresh replays the
+  // user's original request instead of importer defaults (RAR-4.1).
+  const inputPayload = buildImportJobInput(payload);
 
   const { jobId } = await startImport(inputPayload);
 

--- a/objectified-ui/tests/repository-auto-refresh-worker.test.ts
+++ b/objectified-ui/tests/repository-auto-refresh-worker.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Spec-faithful auto-refresh re-import tests (RAR-4.1, #3527).
+ *
+ * The REST spec-import worker builds its importer input from
+ * `lib/repository-auto-refresh-import.ts`. These tests pin the RAR-4.1 contract:
+ * a repository auto-refresh (`source_kind === 'repository_auto_import'`) replays
+ * the user's ORIGINAL import — options, importer kind, and document parsing all
+ * come from the stored import spec, not importer defaults.
+ *
+ * The headline test is the golden fixture: a file first imported with non-default
+ * options (camelCase naming + class prefix + a type mapping) must re-import with
+ * byte-identical option application versus the original run.
+ */
+
+import { describe, test, expect } from '@jest/globals';
+
+import {
+  AUTO_REFRESH_SOURCE_KIND,
+  buildImportJobInput,
+  resolveImport,
+  type StoredImportSpec,
+  type WorkerImportPayload,
+} from '../lib/repository-auto-refresh-import';
+
+/** A Swagger 2.0 document the original import resolved as `swagger` + JSON. */
+const SWAGGER_DOC = {
+  swagger: '2.0',
+  info: { title: 'Petstore', version: '1.0.0' },
+  definitions: { Pet: { type: 'object', properties: { id: { type: 'string' } } } },
+};
+
+const SWAGGER_DOC_B64 = Buffer.from(JSON.stringify(SWAGGER_DOC), 'utf8').toString('base64');
+
+/**
+ * Non-default options the user submitted at first import, in the verbatim
+ * camelCase shape persisted to `repository_import_spec.options_json`. Includes a
+ * naming convention, a class prefix, and a type mapping — exactly the advanced
+ * options the acceptance criteria call out.
+ */
+const ORIGINAL_OPTIONS = {
+  selectedSchemas: ['Pet'],
+  dryRun: false,
+  incrementalMode: false,
+  applyNamingConvention: true,
+  classNamingConvention: 'camelCase',
+  propertyNamingConvention: 'snake_case',
+  autoLayout: true,
+  createRelationships: true,
+  classPrefix: 'Api',
+  typeMapping: { string: { type: 'string', format: 'text' } },
+  generateExamples: true,
+  skipDuplicateVersions: false,
+};
+
+/** The worker payload the ORIGINAL (manual) import would have run. */
+function originalImportPayload(): WorkerImportPayload {
+  return {
+    tenant_id: 'tenant-1',
+    user_id: 'user-1',
+    rest_job_id: 'job-original',
+    metadata: {
+      source_kind: 'openapi-3',
+      project: { name: 'Petstore', slug: 'petstore', description: null },
+      version: { version_id: '1.0.0', description: null },
+      options: ORIGINAL_OPTIONS,
+    },
+    document_base64: SWAGGER_DOC_B64,
+    filename: 'petstore.json',
+    content_type: 'application/json',
+  };
+}
+
+/** The stored spec captured for that import (options + source descriptor). */
+function storedSpec(): StoredImportSpec {
+  return {
+    source_kind: 'openapi-3',
+    format_override: 'swagger',
+    content_type: 'application/json',
+    options: ORIGINAL_OPTIONS,
+    spec_schema_version: 1,
+  };
+}
+
+/** The auto-refresh payload the REST layer enqueues, carrying the stored spec. */
+function autoRefreshPayload(overrides: Partial<StoredImportSpec> = {}): WorkerImportPayload {
+  return {
+    tenant_id: 'tenant-1',
+    user_id: 'user-1',
+    rest_job_id: 'job-refresh',
+    metadata: {
+      source_kind: AUTO_REFRESH_SOURCE_KIND,
+      project: { name: 'Petstore', slug: 'petstore', description: null },
+      version: { version_id: '1.0.1', description: null },
+      existing_project_id: 'proj-1',
+      // Auto path supplies no per-request options — the stored spec drives everything.
+      repository_import_spec: { ...storedSpec(), ...overrides },
+    },
+    document_base64: SWAGGER_DOC_B64,
+    filename: null,
+    content_type: null,
+  };
+}
+
+describe('Repository auto-refresh spec-faithful re-import (RAR-4.1, #3527)', () => {
+  test('golden fixture: refresh applies the SAME options as the original import', () => {
+    const original = buildImportJobInput(originalImportPayload());
+    const refreshed = buildImportJobInput(autoRefreshPayload());
+
+    // Identical option application — the acceptance criterion.
+    expect(refreshed.options).toEqual(original.options);
+    // Same importer kind and parsed document, too.
+    expect(refreshed.sourceKind).toBe(original.sourceKind);
+    expect(refreshed.document).toEqual(original.document);
+    // Advanced options specifically survived (not defaults).
+    expect(refreshed.options.classPrefix).toBe('Api');
+    expect(refreshed.options.classNamingConvention).toBe('camelCase');
+    expect(refreshed.options.typeMapping).toEqual({ string: { type: 'string', format: 'text' } });
+  });
+
+  test('without the stored spec a refresh would fall back to defaults (regression guard)', () => {
+    // Build the importer input from an EMPTY options blob — what the worker did
+    // before RAR-4.1 (the auto path supplied no options).
+    const defaulted = buildImportJobInput({
+      ...autoRefreshPayload(),
+      metadata: {
+        ...autoRefreshPayload().metadata,
+        repository_import_spec: { source_kind: 'openapi-3', options: {} },
+      },
+    });
+    expect(defaulted.options.classPrefix).toBeUndefined();
+    expect(defaulted.options.applyNamingConvention).toBe(false);
+    // Proving the golden fixture is meaningful: defaults differ from the original.
+    expect(defaulted.options).not.toEqual(buildImportJobInput(originalImportPayload()).options);
+  });
+
+  test('the stored source descriptor drives importer routing (swagger -> openapi)', () => {
+    const resolved = resolveImport(autoRefreshPayload({ format_override: 'swagger' }).metadata);
+    expect(resolved.sourceKind).toBe('openapi');
+    expect(resolved.formatOverride).toBe('swagger');
+    expect(resolved.contentType).toBe('application/json');
+  });
+
+  test('routing falls back to the stored source_kind when no format override', () => {
+    const resolved = resolveImport(
+      autoRefreshPayload({ format_override: null, source_kind: 'arazzo' }).metadata,
+    );
+    expect(resolved.sourceKind).toBe('arazzo');
+  });
+
+  test('the stored content type drives document parsing (YAML on refresh)', () => {
+    const yamlDoc = 'swagger: "2.0"\ninfo:\n  title: Petstore\n  version: 1.0.0\n';
+    const payload = autoRefreshPayload({ content_type: 'application/yaml' });
+    payload.document_base64 = Buffer.from(yamlDoc, 'utf8').toString('base64');
+    const built = buildImportJobInput(payload);
+    expect((built.document as { info: { title: string } }).info.title).toBe('Petstore');
+  });
+
+  test('a refresh job missing its stored spec is a clear error, not a silent default', () => {
+    const payload = autoRefreshPayload();
+    payload.metadata.repository_import_spec = null;
+    expect(() => buildImportJobInput(payload)).toThrow(/missing its stored import spec/i);
+  });
+
+  test('a non-refresh import is unaffected: options come from request metadata', () => {
+    const built = buildImportJobInput(originalImportPayload());
+    expect(built.sourceKind).toBe('openapi');
+    expect(built.options.classPrefix).toBe('Api');
+    expect(built.existingProjectId).toBeUndefined();
+  });
+
+  test('existing_project_id is carried through for a refresh', () => {
+    const built = buildImportJobInput(autoRefreshPayload());
+    expect(built.existingProjectId).toBe('proj-1');
+    expect(built.version.versionId).toBe('1.0.1');
+  });
+});


### PR DESCRIPTION
## What & why

Repository auto-refresh re-imports a file the user already imported. Until now the spec-import worker (`rest-spec-import-worker.ts`) read options from the *request* metadata, and the auto path supplied none — so a refresh fell back to importer defaults and silently dropped the user's original import specification (naming conventions, prefixes, type mappings, …).

This makes the worker **spec-faithful** (RAR-4.1): when `source_kind == 'repository_auto_import'` it hydrates the importer kind, options, and document parsing from the stored import spec instead of defaults.

```
auto-refresh job ──► stored spec (options + source descriptor) ──► importer (same as first run)
```

### Changes
- **objectified-ui** — new pure, side-effect-free `lib/repository-auto-refresh-import.ts`:
  - `buildImportJobInput(payload)` resolves the importer input.
  - For an auto-refresh: options come from the **verbatim captured options blob** (RAR-1.2); the **source descriptor** (RAR-1.3) drives routing (`format_override` → importer kind) and parsing (`content_type` → JSON/YAML).
  - Non-refresh imports are unchanged (options from request metadata, format sniffed).
  - `scripts/rest-spec-import-worker.ts` now delegates to the lib (no behavior change for normal imports).
- **objectified-rest**:
  - `SpecImportStartMetadata` gains optional `repository_import_spec` (`SpecImportStoredSpec`) — the stored options blob is passed through as a raw dict, not the lossy `SpecImportOptions` subset, so advanced options survive.
  - new `app/repository_refresh_executor.py` maps an enqueued RAR-3.2 refresh job row into that worker metadata, stamped with the `repository_auto_import` source kind.
  - **OpenAPI regenerated** (`openapi.json`/`openapi.yaml`). Note: the regen also picks up a pre-existing drift — the RAR-3.3 (#3524) `PATCH /repositories/{id}` endpoint that had not been regenerated — bringing the contract back in sync.

## How to test
- UI: `cd objectified-ui && yarn jest repository-auto-refresh-worker` — 8 tests, incl. the **golden fixture** asserting byte-identical option application (camelCase + class prefix + type mapping) on refresh vs the original run.
- REST: `cd objectified-rest && PYTHONPATH=src python -m pytest tests/test_repository_refresh_executor.py` — 7 tests pinning row→metadata hydration (verbatim options round-trip, JSONB-as-string decode, missing/invalid guards).
- Regression: related suites green (`repository-import-spec`, `import-helper`, `repository-import-source-descriptor`; `test_repository_refresh_sweep`, `test_repository_import_spec_read_api`, `test_spec_import_contract`). `yarn build` and `tsc --noEmit` clean.

## Risk / notes
- Pure additive change: a new optional metadata field + a new pure module; normal import path is untouched. The RAR-4.2 executor will consume `build_auto_refresh_import_metadata` to dispatch jobs (out of scope here).

Closes #3527

Work performed by Claude Code via model claude-opus-4-8[1m]