### PR TITLE
Fix #3529 - Change report on refresh (dry-run reuse) (RAR-4.3)

### DIFF
--- a/docs/ROADMAP_REPOSITORY_AUTOREFRESH.md
+++ b/docs/ROADMAP_REPOSITORY_AUTOREFRESH.md
@@ -123,7 +123,7 @@ epic. Use this table to resolve any `RAR-*` reference below to its issue number.
 | ~~RAR-2.1~~ ✅ | ~~#3518~~ | ~~RAR-2.2~~ ✅ | ~~#3519~~ | ~~RAR-2.3~~ ✅ | ~~#3520~~ |
 | ~~RAR-2.4~~ ✅ | ~~#3521~~ | ~~RAR-3.1~~ ✅ | ~~#3522~~ | ~~RAR-3.2~~ ✅ | ~~#3523~~ |
 | ~~RAR-3.3~~ ✅ | ~~#3524~~ | RAR-3.4 | #3525 | RAR-3.5 | #3526 |
-| ~~RAR-4.1~~ ✅ | ~~#3527~~ | ~~RAR-4.2~~ ✅ | ~~#3528~~ | RAR-4.3 | #3529 |
+| ~~RAR-4.1~~ ✅ | ~~#3527~~ | ~~RAR-4.2~~ ✅ | ~~#3528~~ | ~~RAR-4.3~~ ✅ | ~~#3529~~ |
 | RAR-4.4 | #3530 | RAR-4.5 | #3531 | RAR-5.1 | #3532 |
 | RAR-5.2 | #3533 | RAR-5.3 | #3534 | RAR-5.4 | #3535 |
 | RAR-5.5 | #3536 | RAR-5.6 | #3537 | RAR-6.1 | #3538 |
@@ -489,7 +489,7 @@ Replay the original spec; version + protect.
 |----|-------|---------|--------|----------|-----|-------|---------|
 | ~~RAR-4.1~~ ✅ **Done** (#3527) | Re-import worker applies stored spec | Worker re-runs import with stored options, not defaults | `enhancement`,`mvp`,`import`,`repository`,`rest` | N | Y | L | objectified-ui (worker), objectified-rest |
 | ~~RAR-4.2~~ ✅ **Done** (#3528) | Version creation on refresh with provenance | New version links prior version + source commit | `enhancement`,`mvp`,`import`,`repository`,`versions` | N | Y | M | objectified-rest, objectified-db |
-| RAR-4.3 | Change report on refresh (dry-run reuse) | Produce diff/change report for each refresh | `enhancement`,`mvp`,`import` | Y | Y | M | objectified-ui, objectified-rest |
+| ~~RAR-4.3~~ ✅ **Done** (#3529) | Change report on refresh (dry-run reuse) | Produce diff/change report for each refresh | `enhancement`,`mvp`,`import` | Y | Y | M | objectified-ui, objectified-rest |
 | RAR-4.4 | Manual-edit divergence guard | Hold (don't clobber) if version edited since import | `enhancement`,`mvp`,`import`,`repository` | N | Y | L | objectified-rest |
 | RAR-4.5 | Per-repo/file conflict policy | overwrite / hold-for-review / new-branch on divergence | `enhancement`,`import`,`repository` | Y | N | M | objectified-rest, objectified-ui |
 
@@ -563,6 +563,28 @@ camelCase wire shape + create-request parsing + migration guard) and new provena
 normalization, metadata carriage). The OpenAPI contract is regenerated. Consuming the refresh queue and
 invoking the worker (which then carries this provenance onto the new version) is the EPIC-4 dispatcher's
 job, mirroring how RAR-2.2/2.4 deferred their wiring.
+
+**Status of 4.3: ✅ Done (#3529).** New objectified-rest module
+`app/repository_refresh_change_report.py` exposes the best-effort
+`generate_change_report_on_refresh(...)`, which reuses the publication change-report pipeline
+(`build_publication_change_report_render`) to diff the RAR-4.2 prior (parent) version against the new
+refresh version, persist the report against the new version via `insert_change_report_if_absent` (so the
+version always links to a report), and append a refresh-scoped `workflow_audit` row
+(`schema.refresh.change_report.generated`) carrying the baseline, per-section change counts, and the
+`noChanges` flag (RAR-5.3 reads this action). Unlike publish it diffs against the RAR-4.2 parent rather
+than the latest published ancestor and tolerates an unpublished candidate; a missing parent yields an
+initial-style empty-baseline report. **Zero-change refreshes are reported as no-ops** — the report row is
+still written and both the stored change model and the audit entry are flagged `noChanges: true`. A new
+`openapi_change_report` helper trio (`change_report_change_counts` / `change_report_total_changes` /
+`change_report_is_noop`) counts only *substantive* sections (schemas/properties/references/relationships/
+documentation), so a warning-only diff (e.g. an unfollowed external `$ref`) is still a no-op. On the UI,
+`lib/change-report-mustache-context.ts` gains `changeModelTotalChanges` / `isNoOpChangeModel` (mirroring the
+Python helpers, honoring the stamped `noChanges` flag) and a `noChangesSection` context field so the existing
+change-report rendering shows a "no changes" state on a no-op refresh. Tests:
+`tests/test_repository_refresh_change_report.py`, the no-op cases in `tests/test_openapi_change_report.py`, and
+the UI cases in `tests/change-report-mustache-context.test.ts`. Invoking this from the refresh dispatcher
+(after RAR-4.2 creates the version) is the EPIC-4 dispatcher's job, mirroring how RAR-4.1/4.2 deferred their
+wiring.
 
 ---
 

--- a/objectified-rest/pyproject.toml
+++ b/objectified-rest/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "objectified-rest"
-version = "1.0.72"
+version = "1.0.73"
 description = "REST API for serving OpenAPI specifications from the Objectified database"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/objectified-rest/src/app/openapi_change_report.py
+++ b/objectified-rest/src/app/openapi_change_report.py
@@ -551,3 +551,59 @@ def compute_openapi_change_report(
 ) -> Dict[str, Any]:
     """Alias for :func:`build_change_report` (explicit name for callers)."""
     return build_change_report(baseline_openapi, candidate_openapi)
+
+
+# Sections of a ChangeReportModel that represent a *substantive* change. ``warnings``
+# and ``skipped`` are diagnostic notes (e.g. an external $ref that could not be
+# followed) and are intentionally excluded: a refresh whose only output is a warning
+# carries no schema/property/reference/relationship/documentation delta and is still a
+# no-op for change-report purposes (RAR-4.3).
+_SUBSTANTIVE_LIST_SECTIONS = (
+    "properties",
+    "references",
+    "relationships",
+    "documentation",
+)
+
+
+def change_report_change_counts(change_model: Dict[str, Any]) -> Dict[str, int]:
+    """Count substantive changes in a ChangeReportModel, by section.
+
+    Args:
+        change_model: A ChangeReportModel dict as produced by :func:`build_change_report`.
+
+    Returns:
+        A dict with one entry per substantive section: ``schemasAdded``,
+        ``schemasRemoved``, ``schemasModified``, ``properties``, ``references``,
+        ``relationships`` and ``documentation``. Diagnostic ``warnings`` / ``skipped``
+        are not counted (see :data:`_SUBSTANTIVE_LIST_SECTIONS`).
+    """
+    schemas = change_model.get("schemas")
+    schemas = schemas if isinstance(schemas, dict) else {}
+
+    def _len(value: Any) -> int:
+        return len(value) if isinstance(value, list) else 0
+
+    counts = {
+        "schemasAdded": _len(schemas.get("added")),
+        "schemasRemoved": _len(schemas.get("removed")),
+        "schemasModified": _len(schemas.get("modified")),
+    }
+    for section in _SUBSTANTIVE_LIST_SECTIONS:
+        counts[section] = _len(change_model.get(section))
+    return counts
+
+
+def change_report_total_changes(change_model: Dict[str, Any]) -> int:
+    """Return the total number of substantive changes in a ChangeReportModel."""
+    return sum(change_report_change_counts(change_model).values())
+
+
+def change_report_is_noop(change_model: Dict[str, Any]) -> bool:
+    """Return ``True`` when a ChangeReportModel carries no substantive change.
+
+    A no-op report is one where the candidate and baseline are semantically identical
+    across every diffed section (schemas, properties, references, relationships,
+    documentation). Diagnostic warnings/skipped notes do not make a report non-no-op.
+    """
+    return change_report_total_changes(change_model) == 0

--- a/objectified-rest/src/app/repository_refresh_change_report.py
+++ b/objectified-rest/src/app/repository_refresh_change_report.py
@@ -1,0 +1,201 @@
+"""Per-refresh change report via the publication change-report pipeline (RAR-4.3, #3529).
+
+A spec-faithful auto-refresh (RAR-4.1) creates a new, provenance-linked version
+(RAR-4.2). Silently mutating a version gives the user no insight into *what* changed,
+so this module reuses the publication change-report pipeline
+(:mod:`publication_change_report`) to diff the prior (parent) version against the new
+refresh version, persist the report against the new version, and record a refresh
+audit entry — exactly the machinery that already runs on publish, pointed at the
+refresh lineage instead.
+
+Unlike publish, a refresh version is *not* published, so this path:
+
+* uses the RAR-4.2 ``parent_version_id`` provenance as the diff baseline (rather than
+  the latest published ancestor), and
+* tolerates an unpublished candidate (the publish path early-returns on those).
+
+Zero-change refreshes are still reported: the report row is written (so the version
+always links to a report) and both the stored change model and the audit entry are
+flagged ``noChanges`` so the UI can render the refresh as a no-op.
+
+Like :func:`publication_change_report.generate_change_report_on_publish`, the public
+entrypoint is best-effort: failures are logged and recorded in ``workflow_audit`` with
+outcome ``failure`` rather than raised, so a report problem never fails the refresh.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Optional
+
+from .database import db
+from .openapi_change_report import (
+    change_report_change_counts,
+    change_report_is_noop,
+)
+from .publication_change_report import (
+    _resolve_template_row,
+    build_publication_change_report_render,
+)
+
+logger = logging.getLogger(__name__)
+
+# Workflow-audit action for a refresh change report, distinct from the publish action
+# ``schema.change_report.generated`` so refresh history (RAR-5.3) can filter on it.
+REFRESH_CHANGE_REPORT_ACTION = "schema.refresh.change_report.generated"
+
+
+def generate_change_report_on_refresh(
+    *,
+    tenant_slug: str,
+    tenant_id: str,
+    project_id: str,
+    refresh_version_id: str,
+    parent_version_id: Optional[str],
+    actor_id: Optional[str],
+) -> Optional[Dict[str, Any]]:
+    """Produce, persist, and audit a change report for one auto-refresh (RAR-4.3).
+
+    Best-effort: never raises. On failure the error is logged and a ``failure`` row is
+    appended to ``workflow_audit`` so the refresh itself is unaffected.
+
+    Args:
+        tenant_slug: The tenant slug used to resolve OpenAPI for each revision.
+        tenant_id: The owning tenant id.
+        project_id: The catalog project the refresh version belongs to.
+        refresh_version_id: The new version created by the refresh (RAR-4.2); the
+            change report is keyed to (and thus linked from) this version.
+        parent_version_id: The prior version the refresh supersedes (RAR-4.2
+            provenance), used as the diff baseline. ``None`` for the first revision on
+            the lineage, in which case an initial-style report against the empty
+            baseline is produced.
+        actor_id: The actor to attribute the audit entry to (the refresh trigger), or
+            ``None`` for system-initiated refreshes.
+
+    Returns:
+        The persisted ``change_reports`` row (existing row if one was already present
+        for this version), or ``None`` if generation was skipped or failed.
+    """
+    try:
+        return _generate_change_report_on_refresh_impl(
+            tenant_slug=tenant_slug,
+            tenant_id=tenant_id,
+            project_id=project_id,
+            refresh_version_id=refresh_version_id,
+            parent_version_id=parent_version_id,
+            actor_id=actor_id,
+        )
+    except Exception as e:
+        logger.warning(
+            "change report generation failed after refresh (version=%s): %s",
+            refresh_version_id,
+            e,
+            exc_info=True,
+        )
+        db.insert_workflow_audit(
+            tenant_id,
+            project_id,
+            refresh_version_id,
+            REFRESH_CHANGE_REPORT_ACTION,
+            "failure",
+            actor_id,
+            {"error": str(e), "phase": "unexpected"},
+        )
+        return None
+
+
+def _normalize_baseline_revision_id(parent_version_id: Optional[str]) -> Optional[str]:
+    """Return a stripped non-empty baseline id, or ``None`` for blank/missing values."""
+    if parent_version_id is None:
+        return None
+    text = str(parent_version_id).strip()
+    return text or None
+
+
+def _generate_change_report_on_refresh_impl(
+    *,
+    tenant_slug: str,
+    tenant_id: str,
+    project_id: str,
+    refresh_version_id: str,
+    parent_version_id: Optional[str],
+    actor_id: Optional[str],
+) -> Optional[Dict[str, Any]]:
+    version = db.get_version_by_id(refresh_version_id, tenant_id)
+    if not version:
+        logger.warning(
+            "refresh version %s not found; skipping change report", refresh_version_id
+        )
+        return None
+    if str(version.get("project_id")) != str(project_id):
+        logger.warning(
+            "refresh version %s is not in project %s; skipping change report",
+            refresh_version_id,
+            project_id,
+        )
+        return None
+
+    baseline_revision_id = _normalize_baseline_revision_id(parent_version_id)
+
+    (
+        change_model,
+        header,
+        body,
+        footnote,
+        stored_baseline_id,
+        _requested_ghost,
+        baseline_row_missing,
+        _from_label,
+    ) = build_publication_change_report_render(
+        tenant_slug=tenant_slug,
+        tenant_id=tenant_id,
+        project_id=project_id,
+        candidate_version=version,
+        baseline_revision_id=baseline_revision_id,
+    )
+
+    counts = change_report_change_counts(change_model)
+    is_noop = change_report_is_noop(change_model)
+    # Flag the stored model so change-report rendering can show "no changes" without
+    # recomputing the diff (mirrors how the publish path flags ``initialPublication``).
+    change_model["noChanges"] = is_noop
+
+    template_row = _resolve_template_row(tenant_id, project_id)
+    tpl_id = str(template_row["id"]) if template_row.get("id") else None
+
+    stored = db.insert_change_report_if_absent(
+        tenant_id,
+        project_id,
+        refresh_version_id,
+        baseline_revision_id=stored_baseline_id,
+        change_model_json=change_model,
+        rendered_body=body,
+        header_snapshot=header,
+        footnote_snapshot=footnote,
+        template_version_id=tpl_id,
+    )
+
+    audit_detail: Dict[str, Any] = {
+        "refreshVersionId": refresh_version_id,
+        "baselineRevisionId": stored_baseline_id,
+        "parentVersionId": baseline_revision_id,
+        "templateVersionId": tpl_id,
+        "noChanges": is_noop,
+        "changeCounts": counts,
+        "totalChanges": sum(counts.values()),
+        "initialRefresh": baseline_revision_id is None,
+    }
+    if baseline_row_missing and baseline_revision_id is not None:
+        audit_detail["baselineLookupMissing"] = True
+
+    db.insert_workflow_audit(
+        tenant_id,
+        project_id,
+        refresh_version_id,
+        REFRESH_CHANGE_REPORT_ACTION,
+        "success",
+        actor_id,
+        audit_detail,
+    )
+
+    return stored

--- a/objectified-rest/tests/test_openapi_change_report.py
+++ b/objectified-rest/tests/test_openapi_change_report.py
@@ -7,7 +7,12 @@ from fastapi.testclient import TestClient
 
 from app.auth import validate_authentication
 from app.main import app
-from app.openapi_change_report import build_change_report
+from app.openapi_change_report import (
+    build_change_report,
+    change_report_change_counts,
+    change_report_is_noop,
+    change_report_total_changes,
+)
 
 client = TestClient(app)
 
@@ -137,6 +142,45 @@ def test_deterministic_output():
     r1 = build_change_report(base, cand)
     r2 = build_change_report(base, cand)
     assert r1 == r2
+
+
+def test_change_report_is_noop_for_identical_documents():
+    base = _min_openapi()
+    base["components"]["schemas"]["S"] = {"type": "object"}
+    cand = copy.deepcopy(base)
+    report = build_change_report(base, cand)
+    assert change_report_is_noop(report) is True
+    assert change_report_total_changes(report) == 0
+    assert change_report_change_counts(report) == {
+        "schemasAdded": 0,
+        "schemasRemoved": 0,
+        "schemasModified": 0,
+        "properties": 0,
+        "references": 0,
+        "relationships": 0,
+        "documentation": 0,
+    }
+
+
+def test_change_report_warning_only_is_still_noop():
+    # An external $ref emits a warning but no substantive delta: still a no-op.
+    base = _min_openapi()
+    base["components"]["schemas"]["X"] = {"$ref": "http://example.com/other.json#/Foo"}
+    cand = copy.deepcopy(base)
+    report = build_change_report(base, cand)
+    assert report["warnings"]
+    assert change_report_is_noop(report) is True
+
+
+def test_change_report_counts_added_schema():
+    base = _min_openapi()
+    cand = copy.deepcopy(base)
+    cand["components"]["schemas"]["New"] = {"type": "boolean"}
+    report = build_change_report(base, cand)
+    assert change_report_is_noop(report) is False
+    counts = change_report_change_counts(report)
+    assert counts["schemasAdded"] == 1
+    assert change_report_total_changes(report) == 1
 
 
 def test_post_change_report_route():

--- a/objectified-rest/tests/test_repository_refresh_change_report.py
+++ b/objectified-rest/tests/test_repository_refresh_change_report.py
@@ -1,0 +1,179 @@
+"""Per-refresh change report via the publication pipeline (RAR-4.3, #3529)."""
+
+from unittest.mock import patch
+
+from app.repository_refresh_change_report import (
+    REFRESH_CHANGE_REPORT_ACTION,
+    generate_change_report_on_refresh,
+)
+
+_EMPTY_CM = {
+    "schemaVersion": "1.0",
+    "schemas": {"added": [], "removed": [], "modified": []},
+    "properties": [],
+    "references": [],
+    "relationships": [],
+    "documentation": [],
+    "warnings": [],
+    "skipped": [],
+}
+
+
+def _render(change_model, *, baseline_id, baseline_missing=False, from_label="1.0.0"):
+    """Shape the 8-tuple build_publication_change_report_render returns."""
+    return (
+        change_model,
+        "header",
+        "body",
+        "footnote",
+        baseline_id,
+        None,
+        baseline_missing,
+        from_label,
+    )
+
+
+def _patches(change_model, *, baseline_id="parent-v", baseline_missing=False):
+    return (
+        patch("app.repository_refresh_change_report.db"),
+        patch(
+            "app.repository_refresh_change_report.build_publication_change_report_render",
+            return_value=_render(
+                change_model, baseline_id=baseline_id, baseline_missing=baseline_missing
+            ),
+        ),
+        patch(
+            "app.repository_refresh_change_report._resolve_template_row",
+            return_value={"id": "00000000-0000-4000-a000-000000000001"},
+        ),
+    )
+
+
+def test_skips_when_version_missing():
+    with patch("app.repository_refresh_change_report.db") as mdb:
+        mdb.get_version_by_id.return_value = None
+        out = generate_change_report_on_refresh(
+            tenant_slug="t",
+            tenant_id="tid",
+            project_id="pid",
+            refresh_version_id="vid",
+            parent_version_id="parent-v",
+            actor_id="uid",
+        )
+    assert out is None
+    mdb.insert_change_report_if_absent.assert_not_called()
+
+
+def test_skips_when_version_in_other_project():
+    with patch("app.repository_refresh_change_report.db") as mdb:
+        mdb.get_version_by_id.return_value = {"project_id": "other"}
+        out = generate_change_report_on_refresh(
+            tenant_slug="t",
+            tenant_id="tid",
+            project_id="pid",
+            refresh_version_id="vid",
+            parent_version_id="parent-v",
+            actor_id="uid",
+        )
+    assert out is None
+    mdb.insert_change_report_if_absent.assert_not_called()
+
+
+def test_changed_refresh_persists_report_and_audits_not_noop():
+    cm = dict(_EMPTY_CM)
+    cm["schemas"] = {"added": [{"name": "New"}], "removed": [], "modified": []}
+    p_db, p_render, p_tpl = _patches(cm)
+    with p_db as mdb, p_render, p_tpl:
+        mdb.get_version_by_id.return_value = {"project_id": "pid", "version_id": "2.0.0"}
+        mdb.insert_change_report_if_absent.return_value = {"id": "cr-1"}
+        out = generate_change_report_on_refresh(
+            tenant_slug="t",
+            tenant_id="tid",
+            project_id="pid",
+            refresh_version_id="vid",
+            parent_version_id="parent-v",
+            actor_id="uid",
+        )
+
+    assert out == {"id": "cr-1"}
+    # report keyed to the refresh version, baseline = the parent version
+    insert_kwargs = mdb.insert_change_report_if_absent.call_args
+    assert insert_kwargs.args[2] == "vid"
+    assert insert_kwargs.kwargs["baseline_revision_id"] == "parent-v"
+    assert insert_kwargs.kwargs["change_model_json"]["noChanges"] is False
+
+    audit = mdb.insert_workflow_audit.call_args.args
+    assert audit[3] == REFRESH_CHANGE_REPORT_ACTION
+    assert audit[4] == "success"
+    detail = audit[6]
+    assert detail["noChanges"] is False
+    assert detail["totalChanges"] == 1
+    assert detail["changeCounts"]["schemasAdded"] == 1
+    assert detail["initialRefresh"] is False
+
+
+def test_zero_change_refresh_reported_as_noop():
+    p_db, p_render, p_tpl = _patches(dict(_EMPTY_CM))
+    with p_db as mdb, p_render, p_tpl:
+        mdb.get_version_by_id.return_value = {"project_id": "pid", "version_id": "2.0.0"}
+        mdb.insert_change_report_if_absent.return_value = {"id": "cr-2"}
+        generate_change_report_on_refresh(
+            tenant_slug="t",
+            tenant_id="tid",
+            project_id="pid",
+            refresh_version_id="vid",
+            parent_version_id="parent-v",
+            actor_id="uid",
+        )
+
+    # Report still written so the version always links to a report...
+    mdb.insert_change_report_if_absent.assert_called_once()
+    stored_model = mdb.insert_change_report_if_absent.call_args.kwargs["change_model_json"]
+    assert stored_model["noChanges"] is True
+    # ...and the audit flags the no-op.
+    detail = mdb.insert_workflow_audit.call_args.args[6]
+    assert detail["noChanges"] is True
+    assert detail["totalChanges"] == 0
+
+
+def test_initial_refresh_without_parent_uses_empty_baseline():
+    p_db, p_render, p_tpl = _patches(dict(_EMPTY_CM), baseline_id=None)
+    with p_db as mdb, p_render, p_tpl:
+        mdb.get_version_by_id.return_value = {"project_id": "pid", "version_id": "1.0.0"}
+        mdb.insert_change_report_if_absent.return_value = {"id": "cr-3"}
+        generate_change_report_on_refresh(
+            tenant_slug="t",
+            tenant_id="tid",
+            project_id="pid",
+            refresh_version_id="vid",
+            parent_version_id="   ",  # blank normalizes to None
+            actor_id=None,
+        )
+
+    detail = mdb.insert_workflow_audit.call_args.args[6]
+    assert detail["initialRefresh"] is True
+    assert detail["parentVersionId"] is None
+    assert mdb.insert_change_report_if_absent.call_args.kwargs["baseline_revision_id"] is None
+
+
+def test_failure_is_swallowed_and_audited():
+    with patch("app.repository_refresh_change_report.db") as mdb, patch(
+        "app.repository_refresh_change_report.build_publication_change_report_render",
+        side_effect=RuntimeError("boom"),
+    ):
+        mdb.get_version_by_id.return_value = {"project_id": "pid", "version_id": "2.0.0"}
+        out = generate_change_report_on_refresh(
+            tenant_slug="t",
+            tenant_id="tid",
+            project_id="pid",
+            refresh_version_id="vid",
+            parent_version_id="parent-v",
+            actor_id="uid",
+        )
+
+    assert out is None
+    mdb.insert_change_report_if_absent.assert_not_called()
+    audit = mdb.insert_workflow_audit.call_args.args
+    assert audit[3] == REFRESH_CHANGE_REPORT_ACTION
+    assert audit[4] == "failure"
+    assert audit[6]["phase"] == "unexpected"

--- a/objectified-ui/lib/change-report-mustache-context.ts
+++ b/objectified-ui/lib/change-report-mustache-context.ts
@@ -34,6 +34,39 @@ function counts(cm: ChangeModelJson) {
 }
 
 /**
+ * Total number of *substantive* changes in a change model (schemas added/removed/
+ * modified plus property, reference, relationship, and documentation deltas).
+ *
+ * Diagnostic `warnings` / `skipped` notes are excluded, mirroring the objectified-rest
+ * `change_report_change_counts` helper, so a refresh whose only output is a warning is
+ * still treated as a no-op (RAR-4.3).
+ */
+export function changeModelTotalChanges(cm: ChangeModelJson): number {
+  const c = counts(cm);
+  return (
+    c.schemaCounts.added +
+    c.schemaCounts.removed +
+    c.schemaCounts.modified +
+    c.propertyCount +
+    c.referenceCount +
+    c.relationshipCount +
+    c.documentationCount
+  );
+}
+
+/**
+ * True when a change model carries no substantive change — a zero-change refresh that
+ * should render as a no-op. Honors an explicit `noChanges` flag stamped by the
+ * objectified-rest refresh pipeline, falling back to recomputing from the model.
+ */
+export function isNoOpChangeModel(cm: ChangeModelJson): boolean {
+  if (typeof cm.noChanges === 'boolean') {
+    return cm.noChanges;
+  }
+  return changeModelTotalChanges(cm) === 0;
+}
+
+/**
  * Build the merged Mustache context used by header, body, and footnote templates.
  */
 export function buildMustacheContext(
@@ -90,5 +123,6 @@ export function buildMustacheContext(
     documentationSection: documentation.length > 0,
     warningsSection: warnings.length > 0,
     skippedSection: skipped.length > 0,
+    noChangesSection: isNoOpChangeModel(cm),
   };
 }

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.122",
+  "version": "0.11.123",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/tests/change-report-mustache-context.test.ts
+++ b/objectified-ui/tests/change-report-mustache-context.test.ts
@@ -1,7 +1,22 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { describe, it, expect } from '@jest/globals';
-import { buildMustacheContext } from '../lib/change-report-mustache-context';
+import {
+  buildMustacheContext,
+  changeModelTotalChanges,
+  isNoOpChangeModel,
+} from '../lib/change-report-mustache-context';
+
+const EMPTY_MODEL: Record<string, unknown> = {
+  schemaVersion: '1.0',
+  schemas: { added: [], removed: [], modified: [] },
+  properties: [],
+  references: [],
+  relationships: [],
+  documentation: [],
+  warnings: [],
+  skipped: [],
+};
 
 const sampleFixture = JSON.parse(
   fs.readFileSync(
@@ -21,5 +36,44 @@ describe('buildMustacheContext', () => {
     expect(ctx.propertyCount).toBe(1);
     expect(ctx.generatorVersion).toBe('objectified-ui/preview');
     expect(ctx.schemaSection).toBe(true);
+    expect(ctx.noChangesSection).toBe(false);
+  });
+});
+
+describe('isNoOpChangeModel / changeModelTotalChanges (RAR-4.3)', () => {
+  it('treats an empty diff as a no-op', () => {
+    expect(changeModelTotalChanges(EMPTY_MODEL)).toBe(0);
+    expect(isNoOpChangeModel(EMPTY_MODEL)).toBe(true);
+    expect(buildMustacheContext(EMPTY_MODEL).noChangesSection).toBe(true);
+  });
+
+  it('ignores warning-only diffs when deciding no-op', () => {
+    const warnOnly = {
+      ...EMPTY_MODEL,
+      warnings: [{ code: 'external_ref_not_followed', message: 'x', path: '/' }],
+    };
+    expect(isNoOpChangeModel(warnOnly)).toBe(true);
+    expect(buildMustacheContext(warnOnly).noChangesSection).toBe(true);
+  });
+
+  it('counts substantive schema and property changes', () => {
+    const changed = {
+      ...EMPTY_MODEL,
+      schemas: { added: [{ name: 'New' }], removed: [], modified: [] },
+      properties: [{ schemaName: 'S', path: '/x', changeKind: 'added' }],
+    };
+    expect(changeModelTotalChanges(changed)).toBe(2);
+    expect(isNoOpChangeModel(changed)).toBe(false);
+    expect(buildMustacheContext(changed).noChangesSection).toBe(false);
+  });
+
+  it('honors an explicit noChanges flag stamped by the refresh pipeline', () => {
+    const flagged = {
+      ...EMPTY_MODEL,
+      schemas: { added: [{ name: 'New' }], removed: [], modified: [] },
+      noChanges: true,
+    };
+    // Flag wins over recomputation.
+    expect(isNoOpChangeModel(flagged)).toBe(true);
   });
 });


### PR DESCRIPTION
## What & why

Closes #3529 (RAR-4.3). A spec-faithful auto-refresh (RAR-4.1) creates a new, provenance-linked version (RAR-4.2) but silently mutates it, giving the user no insight into *what* changed. This wires the existing **publication change-report pipeline** to the refresh path so every refresh produces a human-readable diff attached to the new version and the refresh audit.

## Changes

**objectified-rest (Python)**
- New `app/repository_refresh_change_report.py` with best-effort `generate_change_report_on_refresh(...)`:
  - Reuses `publication_change_report.build_publication_change_report_render` to diff the RAR-4.2 **parent** version (baseline) against the new refresh version (candidate).
  - Persists the report against the new version via `insert_change_report_if_absent` (so the version always links to a report).
  - Appends a refresh-scoped `workflow_audit` row `schema.refresh.change_report.generated` carrying baseline, per-section change counts, and a `noChanges` flag (RAR-5.3 reads this action).
  - Unlike publish, it diffs against the RAR-4.2 parent rather than the latest published ancestor and tolerates an **unpublished** candidate; a missing parent yields an initial empty-baseline report. Never raises — failures are logged + audited as `failure`.
- `openapi_change_report.py`: new `change_report_change_counts` / `change_report_total_changes` / `change_report_is_noop` count only *substantive* sections (schemas / properties / references / relationships / documentation), so a warning-only diff (e.g. an unfollowed external `$ref`) is still a no-op.

**objectified-ui (rendering)**
- `lib/change-report-mustache-context.ts`: new `changeModelTotalChanges` / `isNoOpChangeModel` (mirror the Python helpers, honor the stamped `noChanges` flag) and a `noChangesSection` context field so the existing change-report rendering can show a "no changes" state on a no-op refresh.

## Acceptance criteria
- [x] Every refresh produces a change report (added/removed/modified schemas, properties, warnings).
- [x] Report linked from the version (keyed `change_reports.published_revision_id`) and from the refresh audit (`schema.refresh.change_report.generated`, consumed by RAR-5.3).
- [x] Zero-change refreshes are reported as no-ops (report still written; model + audit flagged `noChanges: true`).

## How to test
- **Run** `cd objectified-rest && uv run pytest tests/test_repository_refresh_change_report.py tests/test_openapi_change_report.py -q` — covers changed/no-op/initial/failure paths and the no-op helpers.
- **Run** `cd objectified-ui && yarn jest change-report-mustache-context --no-coverage` — covers no-op detection, warning-only no-op, substantive counts, and the stamped-flag override.
- **Build** `cd objectified-ui && yarn build` — passes.

## Risk / notes
- Pure/reusable function plus tests; the dispatcher invocation (after RAR-4.2 creates the version) is the EPIC-4 dispatcher's job, mirroring how RAR-4.1/4.2 deferred their wiring. No runtime call site is added in this PR, so existing behavior is unchanged.
- Semver bumps: objectified-rest 1.0.72→1.0.73, objectified-ui 0.11.122→0.11.123.

Work performed by Claude Code via model claude-opus-4-8[1m].

🤖 Generated with [Claude Code](https://claude.com/claude-code)