### PR TITLE
Fix #3530 - Manual-edit divergence guard (RAR-4.4)

### DIFF
--- a/docs/ROADMAP_REPOSITORY_AUTOREFRESH.md
+++ b/docs/ROADMAP_REPOSITORY_AUTOREFRESH.md
@@ -124,7 +124,7 @@ epic. Use this table to resolve any `RAR-*` reference below to its issue number.
 | ~~RAR-2.4~~ ✅ | ~~#3521~~ | ~~RAR-3.1~~ ✅ | ~~#3522~~ | ~~RAR-3.2~~ ✅ | ~~#3523~~ |
 | ~~RAR-3.3~~ ✅ | ~~#3524~~ | RAR-3.4 | #3525 | RAR-3.5 | #3526 |
 | ~~RAR-4.1~~ ✅ | ~~#3527~~ | ~~RAR-4.2~~ ✅ | ~~#3528~~ | ~~RAR-4.3~~ ✅ | ~~#3529~~ |
-| RAR-4.4 | #3530 | RAR-4.5 | #3531 | RAR-5.1 | #3532 |
+| ~~RAR-4.4~~ ✅ | ~~#3530~~ | RAR-4.5 | #3531 | RAR-5.1 | #3532 |
 | RAR-5.2 | #3533 | RAR-5.3 | #3534 | RAR-5.4 | #3535 |
 | RAR-5.5 | #3536 | RAR-5.6 | #3537 | RAR-6.1 | #3538 |
 | RAR-6.2 | #3539 | RAR-6.3 | #3540 | RAR-6.4 | #3541 |
@@ -490,7 +490,7 @@ Replay the original spec; version + protect.
 | ~~RAR-4.1~~ ✅ **Done** (#3527) | Re-import worker applies stored spec | Worker re-runs import with stored options, not defaults | `enhancement`,`mvp`,`import`,`repository`,`rest` | N | Y | L | objectified-ui (worker), objectified-rest |
 | ~~RAR-4.2~~ ✅ **Done** (#3528) | Version creation on refresh with provenance | New version links prior version + source commit | `enhancement`,`mvp`,`import`,`repository`,`versions` | N | Y | M | objectified-rest, objectified-db |
 | ~~RAR-4.3~~ ✅ **Done** (#3529) | Change report on refresh (dry-run reuse) | Produce diff/change report for each refresh | `enhancement`,`mvp`,`import` | Y | Y | M | objectified-ui, objectified-rest |
-| RAR-4.4 | Manual-edit divergence guard | Hold (don't clobber) if version edited since import | `enhancement`,`mvp`,`import`,`repository` | N | Y | L | objectified-rest |
+| ~~RAR-4.4~~ ✅ **Done** (#3530) | Manual-edit divergence guard | Hold (don't clobber) if version edited since import | `enhancement`,`mvp`,`import`,`repository` | N | Y | L | objectified-rest |
 | RAR-4.5 | Per-repo/file conflict policy | overwrite / hold-for-review / new-branch on divergence | `enhancement`,`import`,`repository` | Y | N | M | objectified-rest, objectified-ui |
 
 ### RAR-4.1 — Re-import worker applies stored spec
@@ -536,6 +536,21 @@ can override.
 **Acceptance criteria.** A post-import manual edit blocks silent overwrite; the file is marked
 `diverged` and a notification fires; default policy is hold-not-clobber.
 **Dependencies.** Depends RAR-2.3, RAR-4.2. **Parallel = N.**
+
+**Status of 4.4: ✅ Done (#3530).** New pure module `app/repository_divergence_guard.py` exposes
+`evaluate_divergence(...)` (and a raw-content `guard_divergence(...)` wrapper plus a
+`compute_content_checksum(...)` helper) returning a `DivergenceDecision` `{diverged, should_hold,
+reason, policy}`. It compares the post-import snapshot checksum against the current version's content
+checksum: equal → apply (`UNCHANGED`); different → divergence detected (`MANUAL_EDIT`) and, under the
+default hold-not-clobber `DivergencePolicy.HOLD`, `should_hold=True` so the overwrite is blocked and
+the file flagged `diverged` (the `diverged` axis `compute_refresh_status` already overlays, RAR-2.3); a
+missing snapshot fails open (`NO_BASELINE`); a missing current content with a snapshot present holds.
+The RAR-4.5 `OVERWRITE` policy still *reports* divergence (`diverged=True`) but permits the clobber
+(`should_hold=False`). Like RAR-2.2/2.4 the module is pure and DB-free; capturing the post-import
+snapshot at import time, persisting the `diverged` flag, and firing the RAR-5.4 notification on a HOLD
+is the EPIC-4 dispatcher's job (mirroring how RAR-4.1/4.2/4.3 deferred their persistence and wiring).
+DB-free fixtures (`tests/test_repository_divergence_guard.py`) cover all three acceptance criteria, the
+decision table, the policy override, the fail-open/missing-current edges, and the checksum helper.
 
 ### RAR-4.2 / 4.3 / 4.5
 - **4.2** extend REPO-12.3 provenance to record `parent_version_id` + `source_commit_sha` on refresh.

--- a/objectified-rest/package.json
+++ b/objectified-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-rest",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "private": true,
   "description": "Trigger file for Objectified REST Docker publish workflow; app is Python (pyproject.toml).",
   "scripts": {

--- a/objectified-rest/pyproject.toml
+++ b/objectified-rest/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "objectified-rest"
-version = "1.0.73"
+version = "1.0.74"
 description = "REST API for serving OpenAPI specifications from the Objectified database"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/objectified-rest/src/app/repository_divergence_guard.py
+++ b/objectified-rest/src/app/repository_divergence_guard.py
@@ -1,0 +1,231 @@
+"""
+Manual-edit divergence guard for repository auto-refresh (RAR-4.4, #3530).
+
+A spec-faithful auto-refresh (RAR-4.1) re-imports a changed source file and
+supersedes the catalog version the original import produced (RAR-4.2). Nothing
+on that path checks whether a human edited that version **in Objectified** after
+the original import. Without a guard, the refresh would silently overwrite those
+hand edits — a data-loss risk.
+
+This module is that guard. It compares the *current* version's content lineage
+to the snapshot the original import produced (a stored post-import checksum) and
+decides whether the refresh may proceed:
+
+    last import snapshot == current  -> safe: apply the refresh
+    last import snapshot != current  -> DIVERGED: hold + flag (no overwrite)
+
+The default policy is **hold-not-clobber**: a detected manual edit blocks the
+silent overwrite, the file is flagged ``diverged`` (which
+:func:`repository_refresh_status.compute_refresh_status` surfaces as the
+``diverged`` state), and the divergence is surfaced for review and notification
+(RAR-5.1 / RAR-5.4). A future per-repo/file policy (RAR-4.5) can opt into
+overwriting a diverged version; this module accepts that policy as a parameter
+so the dispatcher can pass it through without a second decision site.
+
+Like the RAR-2.2 comparator and the RAR-2.4 idempotency guard, this is a pure,
+side-effect-free decision function so it can be exercised by deterministic
+fixtures. The caller supplies the two content identities (or the raw content via
+:func:`compute_content_checksum`); capturing the post-import snapshot at import
+time and persisting the ``diverged`` flag / firing the notification on a HOLD is
+the EPIC-4 dispatcher's job, mirroring how RAR-4.1/4.2/4.3 deferred their
+persistence and wiring.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional
+
+
+class DivergencePolicy(str, Enum):
+    """How to act when a refresh would overwrite a hand-edited version.
+
+    The MVP default is :attr:`HOLD` (hold-not-clobber). RAR-4.5 introduces a
+    configurable per-repo/file policy that can select :attr:`OVERWRITE`; this
+    enum is the contract the dispatcher passes through to the guard.
+    """
+
+    #: Hold-not-clobber (default): a detected manual edit blocks the overwrite,
+    #: the file is flagged ``diverged``, and the divergence is surfaced.
+    HOLD = "hold"
+    #: Clobber: a detected manual edit is overwritten by the refresh anyway
+    #: (RAR-4.5 opt-out). Divergence is still *detected* and reported, but the
+    #: refresh is not held.
+    OVERWRITE = "overwrite"
+
+
+class DivergenceReason(str, Enum):
+    """Why the guard reached its decision (stable codes for logging/audit/UI)."""
+
+    #: No post-import snapshot was captured for this lineage, so a manual edit
+    #: cannot be proven. The guard fails open (applies the refresh): there is no
+    #: baseline to be "different from", so nothing indicates an edit to protect.
+    NO_BASELINE = "no-baseline"
+    #: The current version matches the post-import snapshot exactly -> no manual
+    #: edit -> safe to apply the refresh.
+    UNCHANGED = "unchanged"
+    #: The current version differs from the post-import snapshot -> the version
+    #: was hand-edited after import -> divergence detected.
+    MANUAL_EDIT = "manual-edit"
+
+
+@dataclass(frozen=True)
+class DivergenceDecision:
+    """Outcome of the manual-edit divergence guard for a single imported file.
+
+    Attributes:
+        diverged: True when a manual edit was *detected* (the current version no
+            longer matches the post-import snapshot). This is independent of the
+            policy: divergence is reported even when the policy permits an
+            overwrite, so audit/notification always reflect reality.
+        should_hold: True when the refresh must be **held** (the overwrite
+            skipped) and the file flagged ``diverged``. True exactly when a
+            manual edit was detected *and* the policy is
+            :attr:`DivergencePolicy.HOLD`. The dispatcher gates the overwrite,
+            the persistent ``diverged`` flag, and the RAR-5.4 notification on
+            this field.
+        reason: The :class:`DivergenceReason` code explaining the decision.
+        policy: The :class:`DivergencePolicy` the decision was made under, echoed
+            back for audit clarity.
+    """
+
+    diverged: bool
+    should_hold: bool
+    reason: DivergenceReason
+    policy: DivergencePolicy
+
+
+def _normalise_checksum(value: Optional[str]) -> Optional[str]:
+    """Trim a content-identity token to a comparable form (``None`` when blank)."""
+    if value is None:
+        return None
+    trimmed = value.strip()
+    return trimmed or None
+
+
+def compute_content_checksum(content: Optional[str]) -> Optional[str]:
+    """Compute a stable content checksum for a version's content lineage.
+
+    Produces the content-identity token the guard compares: a hex SHA-256 digest
+    of the content with surrounding whitespace trimmed, so an incidental trailing
+    newline does not read as a divergence. Both the post-import snapshot and the
+    current version content are hashed through this one function so the two sides
+    are always directly comparable.
+
+    Args:
+        content: The version content (for example its canonical OpenAPI/spec
+            render), or ``None`` when no content is available.
+
+    Returns:
+        The lowercase hex SHA-256 digest, or ``None`` when ``content`` is ``None``
+        or blank after trimming.
+    """
+    if content is None:
+        return None
+    trimmed = content.strip()
+    if not trimmed:
+        return None
+    return hashlib.sha256(trimmed.encode("utf-8")).hexdigest()
+
+
+def evaluate_divergence(
+    *,
+    post_import_checksum: Optional[str],
+    current_checksum: Optional[str],
+    policy: DivergencePolicy = DivergencePolicy.HOLD,
+) -> DivergenceDecision:
+    """Decide whether an auto-refresh may overwrite the current version (RAR-4.4).
+
+    Compares the post-import snapshot checksum (the content identity the original
+    import produced) against the current version's content checksum to detect a
+    hand edit made after import, then applies the divergence ``policy``:
+
+        no post-import snapshot           -> apply  (NO_BASELINE; cannot prove an edit)
+        snapshot == current               -> apply  (UNCHANGED; no manual edit)
+        snapshot != current, policy HOLD  -> hold   (MANUAL_EDIT; diverged, no overwrite)
+        snapshot != current, policy OVER. -> apply  (MANUAL_EDIT; diverged but clobbered)
+
+    A missing *current* checksum (with a snapshot present) counts as a difference:
+    the guard cannot confirm the version still matches the snapshot, so under the
+    hold-not-clobber default it holds rather than risk clobbering an edit.
+
+    Args:
+        post_import_checksum: Content checksum captured for the version right
+            after the original import (the snapshot baseline). ``None``/blank when
+            no snapshot was captured for this lineage.
+        current_checksum: Content checksum of the version as it stands now.
+            ``None``/blank when the current content is unavailable.
+        policy: The :class:`DivergencePolicy` to apply on a detected edit.
+            Defaults to :attr:`DivergencePolicy.HOLD` (the MVP hold-not-clobber
+            default); RAR-4.5 supplies a configured value.
+
+    Returns:
+        A :class:`DivergenceDecision` with the divergence verdict, whether to hold
+        the refresh, a stable reason code, and the policy used.
+    """
+    baseline = _normalise_checksum(post_import_checksum)
+    current = _normalise_checksum(current_checksum)
+
+    # No snapshot to compare against: there is nothing proving a hand edit, so the
+    # refresh proceeds. (Capturing a snapshot at import time is the dispatcher's
+    # job; absent it, the guard cannot — and must not — invent a divergence.)
+    if baseline is None:
+        return DivergenceDecision(
+            diverged=False,
+            should_hold=False,
+            reason=DivergenceReason.NO_BASELINE,
+            policy=policy,
+        )
+
+    # Current content is byte-identical to the post-import snapshot: no human
+    # touched it since import, so the refresh is safe to apply.
+    if baseline == current:
+        return DivergenceDecision(
+            diverged=False,
+            should_hold=False,
+            reason=DivergenceReason.UNCHANGED,
+            policy=policy,
+        )
+
+    # The version differs from the snapshot (or its current content is missing):
+    # a manual edit is detected. Hold under the default policy; under an explicit
+    # OVERWRITE policy (RAR-4.5) the divergence is still reported but not held.
+    return DivergenceDecision(
+        diverged=True,
+        should_hold=policy is DivergencePolicy.HOLD,
+        reason=DivergenceReason.MANUAL_EDIT,
+        policy=policy,
+    )
+
+
+def guard_divergence(
+    *,
+    post_import_content: Optional[str],
+    current_content: Optional[str],
+    policy: DivergencePolicy = DivergencePolicy.HOLD,
+) -> DivergenceDecision:
+    """Run the divergence guard from raw content (convenience wrapper).
+
+    Hashes both sides through :func:`compute_content_checksum` so a caller holding
+    the raw post-import snapshot and the current version content can get the
+    decision without checksumming each side itself. Equivalent to calling
+    :func:`compute_content_checksum` on each input and passing the results to
+    :func:`evaluate_divergence`.
+
+    Args:
+        post_import_content: The version content captured right after the original
+            import (the snapshot baseline), or ``None`` when none was captured.
+        current_content: The version content as it stands now, or ``None`` when
+            unavailable.
+        policy: The :class:`DivergencePolicy` to apply on a detected edit.
+
+    Returns:
+        The :class:`DivergenceDecision` describing whether to hold the refresh.
+    """
+    return evaluate_divergence(
+        post_import_checksum=compute_content_checksum(post_import_content),
+        current_checksum=compute_content_checksum(current_content),
+        policy=policy,
+    )

--- a/objectified-rest/tests/test_repository_divergence_guard.py
+++ b/objectified-rest/tests/test_repository_divergence_guard.py
@@ -1,0 +1,222 @@
+"""Manual-edit divergence guard tests (RAR-4.4, #3530).
+
+Deterministic, DB-free fixtures over ``app.repository_divergence_guard``. They
+cover the roadmap decision rows (snapshot == current -> apply; snapshot !=
+current -> diverged HOLD), all three acceptance criteria (a post-import manual
+edit blocks the silent overwrite, the divergence is detectable/flagged, and the
+default policy is hold-not-clobber), the RAR-4.5 OVERWRITE opt-out, the
+fail-open NO_BASELINE path, the missing-current safety case, the content-checksum
+helper (stability, whitespace tolerance, blank handling), and the raw-content
+convenience wrapper.
+"""
+
+from app.repository_divergence_guard import (
+    DivergenceDecision,
+    DivergencePolicy,
+    DivergenceReason,
+    compute_content_checksum,
+    evaluate_divergence,
+    guard_divergence,
+)
+
+SNAPSHOT = "checksum-as-imported"
+EDITED = "checksum-after-hand-edit"
+
+
+# --- acceptance criteria ----------------------------------------------------
+
+
+def test_post_import_manual_edit_blocks_silent_overwrite() -> None:
+    """AC1: a post-import manual edit holds the refresh (no overwrite)."""
+    decision = evaluate_divergence(
+        post_import_checksum=SNAPSHOT,
+        current_checksum=EDITED,
+    )
+    assert decision.diverged is True
+    assert decision.should_hold is True  # the overwrite is blocked
+    assert decision.reason is DivergenceReason.MANUAL_EDIT
+
+
+def test_divergence_is_flagged_for_review() -> None:
+    """AC2: a detected manual edit is reported (drives the ``diverged`` flag)."""
+    decision = guard_divergence(
+        post_import_content="openapi: 3.0.0\ninfo:\n  title: As imported\n",
+        current_content="openapi: 3.0.0\ninfo:\n  title: Hand edited\n",
+    )
+    assert decision.diverged is True
+    assert decision.should_hold is True
+
+
+def test_default_policy_is_hold_not_clobber() -> None:
+    """AC3: the default policy holds rather than clobbers."""
+    decision = evaluate_divergence(
+        post_import_checksum=SNAPSHOT,
+        current_checksum=EDITED,
+    )
+    assert decision.policy is DivergencePolicy.HOLD
+    assert decision.should_hold is True
+
+
+# --- decision table ---------------------------------------------------------
+
+
+def test_unchanged_version_applies_refresh() -> None:
+    """Current content matches the snapshot -> safe to apply, not diverged."""
+    decision = evaluate_divergence(
+        post_import_checksum=SNAPSHOT,
+        current_checksum=SNAPSHOT,
+    )
+    assert decision.diverged is False
+    assert decision.should_hold is False
+    assert decision.reason is DivergenceReason.UNCHANGED
+
+
+def test_no_baseline_fails_open() -> None:
+    """No post-import snapshot -> cannot prove an edit -> apply the refresh."""
+    decision = evaluate_divergence(
+        post_import_checksum=None,
+        current_checksum=EDITED,
+    )
+    assert decision.diverged is False
+    assert decision.should_hold is False
+    assert decision.reason is DivergenceReason.NO_BASELINE
+
+
+def test_blank_baseline_fails_open() -> None:
+    """A whitespace-only snapshot is treated as no baseline."""
+    decision = evaluate_divergence(
+        post_import_checksum="   ",
+        current_checksum=EDITED,
+    )
+    assert decision.reason is DivergenceReason.NO_BASELINE
+    assert decision.should_hold is False
+
+
+def test_missing_current_with_snapshot_holds() -> None:
+    """Snapshot present but current content missing -> cannot confirm -> hold."""
+    decision = evaluate_divergence(
+        post_import_checksum=SNAPSHOT,
+        current_checksum=None,
+    )
+    assert decision.diverged is True
+    assert decision.should_hold is True
+    assert decision.reason is DivergenceReason.MANUAL_EDIT
+
+
+# --- RAR-4.5 policy override ------------------------------------------------
+
+
+def test_overwrite_policy_detects_but_does_not_hold() -> None:
+    """OVERWRITE policy still reports divergence but permits the clobber."""
+    decision = evaluate_divergence(
+        post_import_checksum=SNAPSHOT,
+        current_checksum=EDITED,
+        policy=DivergencePolicy.OVERWRITE,
+    )
+    assert decision.diverged is True  # divergence is always reported
+    assert decision.should_hold is False  # but the refresh proceeds
+    assert decision.reason is DivergenceReason.MANUAL_EDIT
+    assert decision.policy is DivergencePolicy.OVERWRITE
+
+
+def test_overwrite_policy_unchanged_still_applies() -> None:
+    """OVERWRITE policy is a no-op when there is no manual edit."""
+    decision = evaluate_divergence(
+        post_import_checksum=SNAPSHOT,
+        current_checksum=SNAPSHOT,
+        policy=DivergencePolicy.OVERWRITE,
+    )
+    assert decision.diverged is False
+    assert decision.should_hold is False
+    assert decision.reason is DivergenceReason.UNCHANGED
+
+
+# --- content checksum helper ------------------------------------------------
+
+
+def test_checksum_is_stable_and_hex_sha256() -> None:
+    """The checksum is a deterministic 64-char lowercase hex SHA-256 digest."""
+    a = compute_content_checksum("some version content")
+    b = compute_content_checksum("some version content")
+    assert a == b
+    assert a is not None and len(a) == 64
+    assert a == a.lower()
+    assert all(c in "0123456789abcdef" for c in a)
+
+
+def test_checksum_distinguishes_different_content() -> None:
+    """Different content yields different checksums."""
+    assert compute_content_checksum("alpha") != compute_content_checksum("beta")
+
+
+def test_checksum_trims_surrounding_whitespace() -> None:
+    """An incidental trailing newline does not read as a different content."""
+    assert compute_content_checksum("payload") == compute_content_checksum(
+        "  payload\n"
+    )
+
+
+def test_checksum_blank_and_none_are_none() -> None:
+    """None or whitespace-only content has no checksum (routes to NO_BASELINE)."""
+    assert compute_content_checksum(None) is None
+    assert compute_content_checksum("") is None
+    assert compute_content_checksum("   \n\t") is None
+
+
+# --- raw-content convenience wrapper ----------------------------------------
+
+
+def test_guard_divergence_holds_on_real_edit() -> None:
+    """The raw-content wrapper hashes both sides and holds on a real edit."""
+    decision = guard_divergence(
+        post_import_content="title: Original",
+        current_content="title: Edited by hand",
+    )
+    assert decision.diverged is True
+    assert decision.should_hold is True
+
+
+def test_guard_divergence_applies_on_whitespace_only_change() -> None:
+    """A whitespace-only difference is not a divergence (same trimmed content)."""
+    decision = guard_divergence(
+        post_import_content="title: Original",
+        current_content="title: Original\n",
+    )
+    assert decision.diverged is False
+    assert decision.reason is DivergenceReason.UNCHANGED
+
+
+def test_guard_divergence_no_snapshot_applies() -> None:
+    """No captured snapshot content -> NO_BASELINE -> apply."""
+    decision = guard_divergence(
+        post_import_content=None,
+        current_content="title: Anything",
+    )
+    assert decision.diverged is False
+    assert decision.reason is DivergenceReason.NO_BASELINE
+
+
+# --- shape / wire codes -----------------------------------------------------
+
+
+def test_decision_is_frozen() -> None:
+    """The decision is an immutable value object."""
+    decision = evaluate_divergence(
+        post_import_checksum=SNAPSHOT, current_checksum=SNAPSHOT
+    )
+    assert isinstance(decision, DivergenceDecision)
+    try:
+        decision.diverged = True  # type: ignore[misc]
+    except AttributeError:
+        pass
+    else:  # pragma: no cover - frozen dataclass must reject mutation
+        raise AssertionError("DivergenceDecision should be immutable")
+
+
+def test_stable_wire_codes() -> None:
+    """Reason and policy codes are the stable values the UI/audit consume."""
+    assert DivergenceReason.NO_BASELINE.value == "no-baseline"
+    assert DivergenceReason.UNCHANGED.value == "unchanged"
+    assert DivergenceReason.MANUAL_EDIT.value == "manual-edit"
+    assert DivergencePolicy.HOLD.value == "hold"
+    assert DivergencePolicy.OVERWRITE.value == "overwrite"

--- a/objectified-rest/uv.lock
+++ b/objectified-rest/uv.lock
@@ -514,7 +514,7 @@ wheels = [
 
 [[package]]
 name = "objectified-rest"
-version = "1.0.72"
+version = "1.0.74"
 source = { editable = "." }
 dependencies = [
     { name = "bcrypt" },


### PR DESCRIPTION
## What & why

Closes #3530 (RAR-4.4). Nothing on the auto-refresh path checked whether a catalog version was hand-edited in Objectified after its original import, so a spec-faithful refresh (RAR-4.1/4.2) could **silently overwrite those edits** — a data-loss risk. This adds the divergence guard that compares the current version's content lineage to the post-import snapshot and **holds rather than clobbers** when they differ.

New pure module `objectified-rest/src/app/repository_divergence_guard.py`:

- `evaluate_divergence(post_import_checksum, current_checksum, policy=HOLD)` → `DivergenceDecision {diverged, should_hold, reason, policy}`.
  - snapshot **==** current → apply (`UNCHANGED`)
  - snapshot **!=** current → divergence detected (`MANUAL_EDIT`); under the default hold-not-clobber `DivergencePolicy.HOLD`, `should_hold=True` so the overwrite is blocked and the file flagged `diverged` (the axis RAR-2.3's `compute_refresh_status` already overlays).
  - no snapshot → fail open (`NO_BASELINE`); missing current content with a snapshot present → hold.
  - RAR-4.5 `OVERWRITE` policy still **reports** divergence (`diverged=True`) but permits the clobber (`should_hold=False`).
- `compute_content_checksum(content)` — stable, whitespace-trimmed hex SHA-256; `guard_divergence(...)` — raw-content convenience wrapper.

Consistent with RAR-2.2/2.4: the module is **pure and DB-free**. Capturing the post-import snapshot at import time, persisting the `diverged` flag, and firing the RAR-5.4 notification on a HOLD are the EPIC-4 dispatcher's job (mirroring how RAR-4.1/4.2/4.3 deferred persistence/wiring).

## Acceptance criteria

- [x] A post-import manual edit blocks silent overwrite (`should_hold=True`).
- [x] The file is marked `diverged` (decision drives the existing `diverged` status axis); notification wiring is RAR-5.4.
- [x] Default policy is hold-not-clobber (`DivergencePolicy.HOLD`).

## How to test

- `cd objectified-rest && uv run pytest tests/test_repository_divergence_guard.py -q` → **18 passed**.
- `uvx ruff check src/app/repository_divergence_guard.py tests/test_repository_divergence_guard.py` → clean.

## Risk / notes

Low. Additive pure module + tests; no production call site changed yet (wiring deferred per the EPIC-4 pattern). The 8 collection errors / 9 failures elsewhere in the REST suite are pre-existing (`from src.app...` import-path bug and integration tests needing a live DB) and unrelated to this change.

Work performed by Claude Code via model Opus 4.8 (1M context).