### PR TITLE
Fix #3533 - Refresh Now one-shot (RAR-5.2)

### DIFF
--- a/docs/ROADMAP_REPOSITORY_AUTOREFRESH.md
+++ b/docs/ROADMAP_REPOSITORY_AUTOREFRESH.md
@@ -125,7 +125,7 @@ epic. Use this table to resolve any `RAR-*` reference below to its issue number.
 | ~~RAR-3.3~~ ✅ | ~~#3524~~ | RAR-3.4 | #3525 | RAR-3.5 | #3526 |
 | ~~RAR-4.1~~ ✅ | ~~#3527~~ | ~~RAR-4.2~~ ✅ | ~~#3528~~ | ~~RAR-4.3~~ ✅ | ~~#3529~~ |
 | ~~RAR-4.4~~ ✅ | ~~#3530~~ | RAR-4.5 | #3531 | ~~RAR-5.1~~ ✅ | ~~#3532~~ |
-| RAR-5.2 | #3533 | RAR-5.3 | #3534 | RAR-5.4 | #3535 |
+| ~~RAR-5.2~~ ✅ | ~~#3533~~ | RAR-5.3 | #3534 | RAR-5.4 | #3535 |
 | RAR-5.5 | #3536 | RAR-5.6 | #3537 | RAR-6.1 | #3538 |
 | RAR-6.2 | #3539 | RAR-6.3 | #3540 | RAR-6.4 | #3541 |
 | RAR-6.5 | #3542 | | | | |
@@ -608,7 +608,7 @@ wiring.
 | ID | Title | Summary | Labels | Parallel | MVP | Cmplx | Modules |
 |----|-------|---------|--------|----------|-----|-------|---------|
 | ~~RAR-5.1~~ ✅ **Done** (#3532) | Per-file refresh status UI | Specs tab shows status, last-refreshed, next-due, divergence | `enhancement`,`mvp`,`import`,`repository`,`ui` | Y | Y | M | objectified-ui |
-| RAR-5.2 | "Refresh Now" one-shot (extend REPO-9.5) | Manual spec-faithful refresh per file/repo | `enhancement`,`mvp`,`import`,`repository`,`ui` | Y | Y | S | objectified-ui, objectified-rest |
+| ~~RAR-5.2~~ ✅ **Done** (#3533) | "Refresh Now" one-shot (extend REPO-9.5) | Manual spec-faithful refresh per file/repo | `enhancement`,`mvp`,`import`,`repository`,`ui` | Y | Y | S | objectified-ui, objectified-rest |
 | RAR-5.3 | Refresh history + change-report linking (extend REPO-12.6) | Audit each refresh cycle with diff link | `enhancement`,`mvp`,`import`,`repository` | Y | Y | M | objectified-rest |
 | RAR-5.4 | Refresh notifications (extend REPO-12.5) | Notify on new version / divergence / failure | `enhancement`,`mvp`,`import`,`repository` | Y | Y | S | objectified-rest |
 | RAR-5.5 | Dashboard widget: stale specs / refresh activity (extend REPO-11) | At-a-glance refresh health | `enhancement`,`import`,`repository`,`dashboard` | Y | N | M | objectified-ui |
@@ -641,6 +641,25 @@ path is fully implemented and unit-tested, ready to light up when the signal lan
 `tests/repository-refresh-specs-dao.test.ts` (SQL contract: tenant/repo scoping, limit clamp, joined
 signals), and `tests/RepositorySpecsTab.test.tsx` (status/last-refreshed/next-due rendering, diverged
 distinctness + review link, error/empty states).
+
+**Status (5.2): ✅ Done (#3533).** The Specs tab gains a per-repo **Refresh now** button (header) and a
+per-file **Refresh** action (one per row); both POST `/api/repositories/{id}/refresh`, which proxies the
+new REST endpoint `POST /v1/tenants/{slug}/repositories/{id}/refresh`. New pure REST module
+`app/repository_manual_refresh.py` (`refresh_repository_now`) reuses the exact enqueue core of the
+RAR-3.2 sweep — refactored out as the shared, path-filterable
+`repository_refresh_sweep.enqueue_stale_files_for_branch` (returning enqueued/skipped counts) — so a
+manual refresh is **spec-faithful** (each job carries the stored `SpecImportOptions` snapshot, RAR-1.2,
+replayed by the RAR-4.1 executor, not defaults), **freshness-gated** (only files newer than the last
+import enqueue, RAR-2.2; an up-to-date file is a reported no-op), and **divergence-safe** (the job runs
+through the same EPIC-4 executor that applies the RAR-4.4 guard). Crucially it **bypasses the cadence and
+the auto-refresh opt-outs**: the manual path never consults due-selection, the per-repo
+`auto_refresh_enabled` flag (RAR-3.3), or the `OBJECTIFIED_REFRESH_ENABLED` kill switch, so it works even
+when scheduled auto-refresh is disabled. Per-file passes `path`+`branch`; per-repo (empty body) sweeps
+every branch with a stored spec. The OpenAPI contract is regenerated. Tests:
+`tests/test_repository_manual_refresh.py` (per-file/per-repo enqueue, stored-spec snapshot, freshness
+no-op, branch scoping, cadence/opt-out bypass, unknown-repo 404, per-branch fault isolation) and
+additions to `tests/RepositorySpecsTab.test.tsx` (button wiring, busy-disable, hidden-when-empty,
+success/no-op notices, POST payload).
 
 ---
 

--- a/objectified-rest/openapi.json
+++ b/objectified-rest/openapi.json
@@ -13778,6 +13778,101 @@
         }
       }
     },
+    "/v1/tenants/{tenant_slug}/repositories/{repository_id}/refresh": {
+      "post": {
+        "tags": [
+          "tenant-repositories"
+        ],
+        "summary": "Refresh Tenant Repository Now",
+        "description": "Trigger a one-shot manual \"Refresh Now\" (RAR-5.2, #3533).\n\nRuns the same spec-faithful re-import path as the periodic sweep (RAR-4.1) for\na single file or the whole repository, on demand. It uses the stored import\nspec (not defaults), honors the RAR-2.2 freshness gate (only files newer than\nthe last import enqueue) and the RAR-4.4 divergence guard (applied downstream\nby the executor), and works even when scheduled auto-refresh is disabled \u2014\nthe cadence and the ``auto_refresh_enabled`` / kill-switch gates are\ndeliberately bypassed.\n\nRequest body (all optional): ``path`` for a single file, ``branch`` to scope a\nbranch; omit both to refresh every branch that has a stored spec.\n\nArgs:\n    tenant_slug: Tenant slug from the path (scoping comes from the token).\n    repository_id: The repository to refresh.\n    payload: Optional ``path`` / ``branch`` selectors.\n    auth_data: Authenticated principal; supplies the tenant scope.\n\nReturns:\n    Counts of jobs enqueued / skipped and the branches evaluated.\n\nRaises:\n    HTTPException: 404 when the repository does not belong to the tenant.",
+        "operationId": "refresh_tenant_repository_now_v1_tenants__tenant_slug__repositories__repository_id__refresh_post",
+        "parameters": [
+          {
+            "name": "tenant_slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Tenant Slug"
+            }
+          },
+          {
+            "name": "repository_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Repository Id"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "name": "X-API-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RepositoryRefreshNowRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RepositoryRefreshNowResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/": {
       "get": {
         "summary": "Root",
@@ -17105,6 +17200,67 @@
         ],
         "title": "RepositoryImportSpecRead",
         "description": "Current-shape import spec returned by the read endpoint (RAR-1.5).\n\nThe response surface for ``GET \u2026/repository-imports/{id}/spec`` (and its\n``?path=`` lookup variant). It exposes the captured source descriptor and the\nfull ``SpecImportOptions`` payload, upgraded on read to the current envelope\nshape, so the refresh worker, the UI status surface, and the CLI can replay\nthe user's original import request. ``spec_schema_version`` always reports the\ncurrent envelope version because ``options`` has already been migrated forward."
+      },
+      "RepositoryRefreshNowRequest": {
+        "properties": {
+          "path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Path"
+          },
+          "branch": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Branch"
+          }
+        },
+        "type": "object",
+        "title": "RepositoryRefreshNowRequest",
+        "description": "Dashboard: trigger a one-shot manual \"Refresh Now\" (RAR-5.2, #3533).\n\nBoth fields are optional and accept snake_case or camelCase so the UI can\nsend either:\n\n- omit both \u2192 refresh the whole repository (every branch with a stored spec);\n- ``branch`` only \u2192 refresh that branch;\n- ``path`` (with or without ``branch``) \u2192 refresh that single file."
+      },
+      "RepositoryRefreshNowResponse": {
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "title": "Success",
+            "default": true
+          },
+          "enqueued": {
+            "type": "integer",
+            "title": "Enqueued"
+          },
+          "skipped": {
+            "type": "integer",
+            "title": "Skipped"
+          },
+          "branches": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Branches"
+          }
+        },
+        "type": "object",
+        "required": [
+          "enqueued",
+          "skipped",
+          "branches"
+        ],
+        "title": "RepositoryRefreshNowResponse",
+        "description": "Result of a one-shot manual refresh (RAR-5.2)."
       },
       "RepositoryRefreshProvenance": {
         "properties": {

--- a/objectified-rest/openapi.yaml
+++ b/objectified-rest/openapi.yaml
@@ -8672,6 +8672,76 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /v1/tenants/{tenant_slug}/repositories/{repository_id}/refresh:
+    post:
+      tags:
+      - tenant-repositories
+      summary: Refresh Tenant Repository Now
+      description: "Trigger a one-shot manual \"Refresh Now\" (RAR-5.2, #3533).\n\n\
+        Runs the same spec-faithful re-import path as the periodic sweep (RAR-4.1)\
+        \ for\na single file or the whole repository, on demand. It uses the stored\
+        \ import\nspec (not defaults), honors the RAR-2.2 freshness gate (only files\
+        \ newer than\nthe last import enqueue) and the RAR-4.4 divergence guard (applied\
+        \ downstream\nby the executor), and works even when scheduled auto-refresh\
+        \ is disabled —\nthe cadence and the ``auto_refresh_enabled`` / kill-switch\
+        \ gates are\ndeliberately bypassed.\n\nRequest body (all optional): ``path``\
+        \ for a single file, ``branch`` to scope a\nbranch; omit both to refresh every\
+        \ branch that has a stored spec.\n\nArgs:\n    tenant_slug: Tenant slug from\
+        \ the path (scoping comes from the token).\n    repository_id: The repository\
+        \ to refresh.\n    payload: Optional ``path`` / ``branch`` selectors.\n  \
+        \  auth_data: Authenticated principal; supplies the tenant scope.\n\nReturns:\n\
+        \    Counts of jobs enqueued / skipped and the branches evaluated.\n\nRaises:\n\
+        \    HTTPException: 404 when the repository does not belong to the tenant."
+      operationId: refresh_tenant_repository_now_v1_tenants__tenant_slug__repositories__repository_id__refresh_post
+      parameters:
+      - name: tenant_slug
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Tenant Slug
+      - name: repository_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Repository Id
+      - name: authorization
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Authorization
+      - name: X-API-Key
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Api-Key
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RepositoryRefreshNowRequest'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RepositoryRefreshNowResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /:
     get:
       summary: Root
@@ -10798,6 +10868,57 @@ components:
         the
 
         current envelope version because ``options`` has already been migrated forward.'
+    RepositoryRefreshNowRequest:
+      properties:
+        path:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Path
+        branch:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Branch
+      type: object
+      title: RepositoryRefreshNowRequest
+      description: 'Dashboard: trigger a one-shot manual "Refresh Now" (RAR-5.2, #3533).
+
+
+        Both fields are optional and accept snake_case or camelCase so the UI can
+
+        send either:
+
+
+        - omit both → refresh the whole repository (every branch with a stored spec);
+
+        - ``branch`` only → refresh that branch;
+
+        - ``path`` (with or without ``branch``) → refresh that single file.'
+    RepositoryRefreshNowResponse:
+      properties:
+        success:
+          type: boolean
+          title: Success
+          default: true
+        enqueued:
+          type: integer
+          title: Enqueued
+        skipped:
+          type: integer
+          title: Skipped
+        branches:
+          items:
+            type: string
+          type: array
+          title: Branches
+      type: object
+      required:
+      - enqueued
+      - skipped
+      - branches
+      title: RepositoryRefreshNowResponse
+      description: Result of a one-shot manual refresh (RAR-5.2).
     RepositoryRefreshProvenance:
       properties:
         parent_version_id:

--- a/objectified-rest/pyproject.toml
+++ b/objectified-rest/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "objectified-rest"
-version = "1.0.74"
+version = "1.0.75"
 description = "REST API for serving OpenAPI specifications from the Objectified database"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/objectified-rest/src/app/models.py
+++ b/objectified-rest/src/app/models.py
@@ -2507,6 +2507,34 @@ class TenantRepositoryUpdate(BaseModel):
     )
 
 
+class RepositoryRefreshNowRequest(BaseModel):
+    """Dashboard: trigger a one-shot manual "Refresh Now" (RAR-5.2, #3533).
+
+    Both fields are optional and accept snake_case or camelCase so the UI can
+    send either:
+
+    - omit both → refresh the whole repository (every branch with a stored spec);
+    - ``branch`` only → refresh that branch;
+    - ``path`` (with or without ``branch``) → refresh that single file.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    path: Optional[str] = Field(None)
+    branch: Optional[str] = Field(None)
+
+
+class RepositoryRefreshNowResponse(BaseModel):
+    """Result of a one-shot manual refresh (RAR-5.2)."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    success: bool = True
+    enqueued: int
+    skipped: int
+    branches: List[str]
+
+
 class TenantRepositoriesListResponse(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 

--- a/objectified-rest/src/app/repository_manual_refresh.py
+++ b/objectified-rest/src/app/repository_manual_refresh.py
@@ -1,0 +1,113 @@
+"""Manual one-shot "Refresh Now" (RAR-5.2, #3533).
+
+Extends the REPO-9.5 "Import Now" idea into a *spec-faithful* refresh that a user
+can trigger on demand — for a single imported file or for a whole repository —
+without waiting for the next auto-refresh tick. It reuses the exact enqueue core
+of the periodic sweep (:func:`repository_refresh_sweep.enqueue_stale_files_for_branch`),
+so the same gates apply:
+
+- **Stored spec, not defaults.** Each enqueued job carries the captured
+  ``SpecImportOptions`` snapshot (RAR-1.2) so the EPIC-4 executor replays the
+  user's original request (RAR-4.1).
+- **Freshness gate honored.** Only files genuinely newer than the last import
+  enqueue (RAR-2.2 newer-than comparator); an up-to-date file is a no-op.
+- **Divergence guard honored.** The job runs through the same EPIC-4 executor as
+  an auto-refresh, which applies the RAR-4.4 manual-edit divergence guard before
+  overwriting.
+
+What it deliberately does **not** honor is the *cadence* and the auto-refresh
+opt-outs: unlike the sweep, this path does not consult
+``list_due_repositories`` / ``mark_repository_refreshed``, the per-repo
+``auto_refresh_enabled`` flag (RAR-3.3), or the global ``OBJECTIFIED_REFRESH_ENABLED``
+kill switch. A manual refresh works even when scheduled auto-refresh is disabled —
+that is the whole point of the button.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, NamedTuple, Optional
+
+from .database import Database
+from .repository_refresh_sweep import enqueue_stale_files_for_branch
+
+_logger = logging.getLogger(__name__)
+
+
+class ManualRefreshResult(NamedTuple):
+    """Aggregate outcome of a one-shot manual refresh.
+
+    Attributes:
+        enqueued: Total refresh jobs enqueued across the processed branches.
+        skipped: Candidates considered but not enqueued (already up to date, or
+            already covered by an active job).
+        branches: The branch names that were rescanned and evaluated.
+    """
+
+    enqueued: int
+    skipped: int
+    branches: List[str]
+
+
+def refresh_repository_now(
+    db: Database,
+    *,
+    tenant_id: str,
+    repository_id: str,
+    branch: Optional[str] = None,
+    path: Optional[str] = None,
+) -> Optional[ManualRefreshResult]:
+    """Run a one-shot, spec-faithful refresh for a file or a whole repository.
+
+    Resolves the repository, picks the branches to evaluate, and enqueues a
+    spec-faithful re-import for every stale + newer file (per-file when ``path``
+    is given, otherwise the whole repository). The cadence and auto-refresh
+    opt-outs are intentionally bypassed; the freshness gate (RAR-2.2) and the
+    downstream divergence guard (RAR-4.4) are still honored.
+
+    Branch selection:
+      - ``branch`` given → only that branch is evaluated.
+      - ``branch`` omitted → every branch that has a stored import spec for this
+        repository is evaluated (the same set the sweep walks).
+
+    Args:
+        db: Database handle.
+        tenant_id: Owning tenant id (scopes the repository lookup).
+        repository_id: The repository to refresh.
+        branch: Optional branch to scope the refresh to.
+        path: Optional repository-relative file path for a per-file refresh; when
+            omitted, the whole repository (all selected branches) is refreshed.
+
+    Returns:
+        A :class:`ManualRefreshResult`, or ``None`` when the repository does not
+        belong to the tenant (the caller maps this to a 404).
+    """
+    repo_row = db.get_tenant_repository(tenant_id, repository_id)
+    if not repo_row:
+        return None
+
+    if branch:
+        branches = [branch]
+    else:
+        branches = db.list_repository_import_spec_branches(repository_id)
+
+    enqueued = 0
+    skipped = 0
+    processed: List[str] = []
+    for b in branches:
+        try:
+            result = enqueue_stale_files_for_branch(db, repo_row, b, path_filter=path)
+        except Exception:
+            # A bad branch (GitHub error, etc.) must not abort the others; the
+            # caller still reports what did get enqueued.
+            _logger.exception(
+                "manual refresh rescan failed repository_id=%s branch=%s",
+                repository_id,
+                b,
+            )
+            continue
+        enqueued += result.enqueued
+        skipped += result.skipped
+        processed.append(b)
+
+    return ManualRefreshResult(enqueued=enqueued, skipped=skipped, branches=processed)

--- a/objectified-rest/src/app/repository_refresh_sweep.py
+++ b/objectified-rest/src/app/repository_refresh_sweep.py
@@ -31,7 +31,7 @@ hammer the provider every tick.
 from __future__ import annotations
 
 import logging
-from typing import Any, Dict
+from typing import Any, Dict, NamedTuple, Optional
 
 from .database import Database
 from .repository_file_scan import scan_repository_branch_into_index
@@ -40,18 +40,47 @@ from .repository_refresh_comparator import evaluate_refresh
 _logger = logging.getLogger(__name__)
 
 
-def _enqueue_stale_files_for_branch(
-    db: Database, repo_row: Dict[str, Any], branch: str
-) -> int:
+class BranchEnqueueResult(NamedTuple):
+    """Outcome of a single-branch rescan + enqueue pass.
+
+    Attributes:
+        enqueued: Number of refresh jobs actually inserted.
+        skipped: Candidates considered but not enqueued — either not newer than
+            the last import (RAR-2.2 freshness gate) or already covered by an
+            active (queued/running) job for the same lineage (idempotent no-op).
+    """
+
+    enqueued: int
+    skipped: int
+
+
+def enqueue_stale_files_for_branch(
+    db: Database,
+    repo_row: Dict[str, Any],
+    branch: str,
+    *,
+    path_filter: Optional[str] = None,
+) -> BranchEnqueueResult:
     """Rescan one branch and enqueue a re-import job per stale + newer file.
+
+    This is the shared core used by both the periodic auto-refresh sweep
+    (:func:`process_repository_refresh_sweep`) and the manual one-shot
+    "Refresh Now" path (RAR-5.2, ``repository_manual_refresh``). It always applies
+    the RAR-2.2 newer-than freshness gate, so a file is enqueued only when its
+    remote commit is genuinely newer than the last import; the divergence guard
+    (RAR-4.4) is applied later by the EPIC-4 executor when it processes the job.
 
     Args:
         db: Database handle.
         repo_row: The repository row (from ``get_tenant_repository``).
         branch: The branch to rescan and evaluate.
+        path_filter: When set, only the file at this repository-relative path is
+            considered (the rest of the branch's candidates are ignored). Used by
+            per-file "Refresh Now"; ``None`` evaluates every candidate on the
+            branch.
 
     Returns:
-        The number of refresh jobs enqueued for this branch.
+        A :class:`BranchEnqueueResult` with the enqueued and skipped counts.
     """
     repository_id = str(repo_row["id"])
     tenant_id = str(repo_row["tenant_id"])
@@ -60,7 +89,11 @@ def _enqueue_stale_files_for_branch(
     scan_repository_branch_into_index(db, repo_row, branch)
 
     enqueued = 0
+    skipped = 0
     for cand in db.list_repository_refresh_candidates(repository_id, branch):
+        if path_filter is not None and str(cand.get("path")) != path_filter:
+            continue
+
         decision = evaluate_refresh(
             remote_committed_at=cand.get("remote_committed_at"),
             last_imported_committed_at=cand.get("last_imported_committed_at"),
@@ -68,6 +101,8 @@ def _enqueue_stale_files_for_branch(
             last_imported_checksum=cand.get("last_imported_blob_sha"),
         )
         if not decision.should_refresh:
+            # Up-to-date / stale-guarded: honors the freshness gate (RAR-2.2).
+            skipped += 1
             continue
 
         job = db.enqueue_repository_refresh_job(
@@ -90,7 +125,10 @@ def _enqueue_stale_files_for_branch(
         )
         if job is not None:
             enqueued += 1
-    return enqueued
+        else:
+            # Active job already exists for this lineage (idempotent no-op).
+            skipped += 1
+    return BranchEnqueueResult(enqueued=enqueued, skipped=skipped)
 
 
 def _refresh_one_repository(db: Database, due_row: Dict[str, Any]) -> int:
@@ -121,7 +159,7 @@ def _refresh_one_repository(db: Database, due_row: Dict[str, Any]) -> int:
     enqueued = 0
     for branch in branches:
         try:
-            enqueued += _enqueue_stale_files_for_branch(db, repo_row, branch)
+            enqueued += enqueue_stale_files_for_branch(db, repo_row, branch).enqueued
         except Exception:
             # One bad branch (GitHub error, etc.) must not abort the others.
             _logger.exception(

--- a/objectified-rest/src/app/tenant_repositories_routes.py
+++ b/objectified-rest/src/app/tenant_repositories_routes.py
@@ -21,6 +21,8 @@ from .database import db
 from .models import (
     RepositoryImportSpecRead,
     repository_import_spec_read_from_row,
+    RepositoryRefreshNowRequest,
+    RepositoryRefreshNowResponse,
     TenantRepositoryCreate,
     TenantRepositoryCreateResponse,
     TenantRepositoryFileContentResponse,
@@ -629,6 +631,67 @@ async def update_tenant_repository(
     if not row:
         raise HTTPException(status_code=404, detail="repository not found")
     return TenantRepositoryGetResponse(success=True, repository=_row_to_record(row))
+
+
+@router.post(
+    "/{tenant_slug}/repositories/{repository_id}/refresh",
+    response_model=RepositoryRefreshNowResponse,
+)
+async def refresh_tenant_repository_now(
+    tenant_slug: str,
+    repository_id: uuid.UUID,
+    payload: RepositoryRefreshNowRequest,
+    auth_data: Dict[str, Any] = Depends(validate_authentication),
+) -> RepositoryRefreshNowResponse:
+    """Trigger a one-shot manual "Refresh Now" (RAR-5.2, #3533).
+
+    Runs the same spec-faithful re-import path as the periodic sweep (RAR-4.1) for
+    a single file or the whole repository, on demand. It uses the stored import
+    spec (not defaults), honors the RAR-2.2 freshness gate (only files newer than
+    the last import enqueue) and the RAR-4.4 divergence guard (applied downstream
+    by the executor), and works even when scheduled auto-refresh is disabled —
+    the cadence and the ``auto_refresh_enabled`` / kill-switch gates are
+    deliberately bypassed.
+
+    Request body (all optional): ``path`` for a single file, ``branch`` to scope a
+    branch; omit both to refresh every branch that has a stored spec.
+
+    Args:
+        tenant_slug: Tenant slug from the path (scoping comes from the token).
+        repository_id: The repository to refresh.
+        payload: Optional ``path`` / ``branch`` selectors.
+        auth_data: Authenticated principal; supplies the tenant scope.
+
+    Returns:
+        Counts of jobs enqueued / skipped and the branches evaluated.
+
+    Raises:
+        HTTPException: 404 when the repository does not belong to the tenant.
+    """
+    _ = tenant_slug
+    tenant_id = str(auth_data["tenant_id"])
+
+    path_value = payload.path.strip() if payload.path else None
+    branch_value = payload.branch.strip() if payload.branch else None
+
+    from .repository_manual_refresh import refresh_repository_now
+
+    result = refresh_repository_now(
+        db,
+        tenant_id=tenant_id,
+        repository_id=str(repository_id),
+        branch=branch_value or None,
+        path=path_value or None,
+    )
+    if result is None:
+        raise HTTPException(status_code=404, detail="repository not found")
+
+    return RepositoryRefreshNowResponse(
+        success=True,
+        enqueued=result.enqueued,
+        skipped=result.skipped,
+        branches=result.branches,
+    )
 
 
 @router.delete("/{tenant_slug}/repositories/{repository_id}")

--- a/objectified-rest/tests/test_repository_manual_refresh.py
+++ b/objectified-rest/tests/test_repository_manual_refresh.py
@@ -1,0 +1,300 @@
+"""Manual one-shot "Refresh Now" tests (RAR-5.2, #3533).
+
+Deterministic, DB-free fixtures over ``app.repository_manual_refresh`` using a
+fake ``Database`` that records calls. The GitHub walk
+(``scan_repository_branch_into_index``) is monkeypatched so no network is touched.
+
+Covers the acceptance criteria:
+  - per-file and per-repo refresh both enqueue spec-faithful jobs;
+  - the stored spec snapshot (not defaults) rides each enqueued job;
+  - the RAR-2.2 freshness gate is honored (up-to-date files do not enqueue);
+  - it works regardless of the auto-refresh cadence / opt-out (the manual path
+    never consults due-selection, ``auto_refresh_enabled``, or the kill switch);
+  - branch scoping (explicit branch vs. all spec branches) and the per-file path
+    filter behave as specified;
+  - an unknown repository (wrong tenant) returns ``None`` (caller → 404).
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+import app.repository_refresh_sweep as sweep
+from app.repository_manual_refresh import refresh_repository_now
+
+NOW = datetime(2026, 6, 22, 12, 0, 0, tzinfo=timezone.utc)
+OLDER = (NOW - timedelta(days=2)).isoformat()
+NEWER = (NOW - timedelta(hours=1)).isoformat()
+
+
+def _candidate(path: str, *, remote_committed_at, remote_blob, last_committed_at, last_blob):
+    """Build a refresh-candidate row as ``list_repository_refresh_candidates`` returns."""
+    return {
+        "import_spec_id": f"spec-{path}",
+        "tenant_id": "t1",
+        "repository_id": "r1",
+        "branch": "main",
+        "path": path,
+        "project_id": "p1",
+        "source_kind": "openapi-3",
+        "format_override": None,
+        "content_type": "application/yaml",
+        "options_json": {"naming_convention": "camelCase"},
+        "spec_schema_version": 1,
+        "created_by": "u1",
+        "last_imported_commit_sha": "old-commit",
+        "last_imported_committed_at": last_committed_at,
+        "last_imported_blob_sha": last_blob,
+        "remote_commit_sha": "new-commit",
+        "remote_committed_at": remote_committed_at,
+        "remote_blob_sha": remote_blob,
+    }
+
+
+class FakeDB:
+    """Records manual-refresh interactions; no real database."""
+
+    def __init__(self, *, repo=None, branches=None, candidates=None):
+        self._repo = repo
+        self._branches = branches if branches is not None else {}
+        self._candidates = candidates if candidates is not None else {}
+        self.enqueued = []
+        self.scanned = []
+        # Track active (queued/running) lineages to emulate the idempotent insert.
+        self._active_lineage = set()
+        # Sweep-only methods that must NOT be called by the manual path.
+        self.due_calls = 0
+        self.mark_refreshed_calls = 0
+        self.lock_calls = 0
+
+    def get_tenant_repository(self, tenant_id, repository_id):
+        if self._repo is None:
+            return None
+        return dict(self._repo)
+
+    def list_repository_import_spec_branches(self, repository_id):
+        return list(self._branches.get(repository_id, []))
+
+    def list_repository_refresh_candidates(self, repository_id, branch):
+        return list(self._candidates.get((repository_id, branch), []))
+
+    def enqueue_repository_refresh_job(self, **kwargs):
+        key = (kwargs["repository_id"], kwargs["branch"], kwargs["path"])
+        if key in self._active_lineage:
+            return None  # idempotent no-op (active job already exists)
+        self._active_lineage.add(key)
+        row = dict(kwargs)
+        row["id"] = f"job-{kwargs['path']}"
+        self.enqueued.append(row)
+        return row
+
+    # --- sweep-only surface: presence here lets us assert it is never used ---
+    def list_due_repositories(self):
+        self.due_calls += 1
+        return []
+
+    def mark_repository_refreshed(self, repository_id):
+        self.mark_refreshed_calls += 1
+        return True
+
+    def try_acquire_repository_refresh_lock(self, repository_id):
+        self.lock_calls += 1
+        return True
+
+
+@pytest.fixture(autouse=True)
+def _patch_scan(monkeypatch):
+    """Replace the GitHub walk with a recorder so no network is hit."""
+
+    def _fake_scan(db, repo_row, branch):
+        db.scanned.append((str(repo_row["id"]), branch))
+        return (1, 1)
+
+    monkeypatch.setattr(sweep, "scan_repository_branch_into_index", _fake_scan)
+
+
+def _repo():
+    return {"id": "r1", "tenant_id": "t1", "provider": "github"}
+
+
+def test_per_repo_refresh_enqueues_stale_files_only():
+    """Whole-repo refresh enqueues only stale + newer files across all spec branches."""
+    stale = _candidate(
+        "api/openapi.yaml",
+        remote_committed_at=NEWER, remote_blob="blob-new",
+        last_committed_at=OLDER, last_blob="blob-old",
+    )
+    up_to_date = _candidate(
+        "api/unchanged.yaml",
+        remote_committed_at=OLDER, remote_blob="blob-x",
+        last_committed_at=OLDER, last_blob="blob-x",
+    )
+    db = FakeDB(
+        repo=_repo(),
+        branches={"r1": ["main"]},
+        candidates={("r1", "main"): [stale, up_to_date]},
+    )
+
+    result = refresh_repository_now(db, tenant_id="t1", repository_id="r1")
+
+    assert result is not None
+    assert result.enqueued == 1
+    assert result.skipped == 1
+    assert result.branches == ["main"]
+    assert [j["path"] for j in db.enqueued] == ["api/openapi.yaml"]
+
+
+def test_enqueued_job_carries_stored_spec_not_defaults():
+    """The manual job replays the captured spec snapshot, not importer defaults."""
+    stale = _candidate(
+        "api/openapi.yaml",
+        remote_committed_at=NEWER, remote_blob="blob-new",
+        last_committed_at=OLDER, last_blob="blob-old",
+    )
+    db = FakeDB(
+        repo=_repo(),
+        branches={"r1": ["main"]},
+        candidates={("r1", "main"): [stale]},
+    )
+
+    refresh_repository_now(db, tenant_id="t1", repository_id="r1")
+
+    job = db.enqueued[0]
+    assert job["import_spec_id"] == "spec-api/openapi.yaml"
+    assert job["source_kind"] == "openapi-3"
+    assert job["options_json"] == {"naming_convention": "camelCase"}
+    assert job["remote_blob_sha"] == "blob-new"
+    assert job["refresh_reason"] == "newer-content"
+
+
+def test_per_file_refresh_filters_to_one_path():
+    """A per-file refresh enqueues only the named path even when others are stale."""
+    target = _candidate(
+        "api/openapi.yaml",
+        remote_committed_at=NEWER, remote_blob="blob-new",
+        last_committed_at=OLDER, last_blob="blob-old",
+    )
+    other_stale = _candidate(
+        "api/other.yaml",
+        remote_committed_at=NEWER, remote_blob="blob-new2",
+        last_committed_at=OLDER, last_blob="blob-old2",
+    )
+    db = FakeDB(
+        repo=_repo(),
+        branches={"r1": ["main"]},
+        candidates={("r1", "main"): [target, other_stale]},
+    )
+
+    result = refresh_repository_now(
+        db, tenant_id="t1", repository_id="r1", branch="main", path="api/openapi.yaml"
+    )
+
+    assert result.enqueued == 1
+    assert [j["path"] for j in db.enqueued] == ["api/openapi.yaml"]
+
+
+def test_per_file_up_to_date_is_a_no_op():
+    """Refresh Now on an up-to-date file enqueues nothing (freshness gate)."""
+    up_to_date = _candidate(
+        "api/openapi.yaml",
+        remote_committed_at=OLDER, remote_blob="blob-x",
+        last_committed_at=OLDER, last_blob="blob-x",
+    )
+    db = FakeDB(
+        repo=_repo(),
+        branches={"r1": ["main"]},
+        candidates={("r1", "main"): [up_to_date]},
+    )
+
+    result = refresh_repository_now(
+        db, tenant_id="t1", repository_id="r1", branch="main", path="api/openapi.yaml"
+    )
+
+    assert result.enqueued == 0
+    assert result.skipped == 1
+    assert db.enqueued == []
+
+
+def test_explicit_branch_skips_spec_branch_lookup():
+    """An explicit branch is used directly without walking all spec branches."""
+    stale = _candidate(
+        "api/openapi.yaml",
+        remote_committed_at=NEWER, remote_blob="blob-new",
+        last_committed_at=OLDER, last_blob="blob-old",
+    )
+    db = FakeDB(
+        repo=_repo(),
+        # Only the 'dev' branch is registered, but the caller asks for 'release'.
+        branches={"r1": ["dev"]},
+        candidates={("r1", "release"): [stale]},
+    )
+
+    result = refresh_repository_now(
+        db, tenant_id="t1", repository_id="r1", branch="release"
+    )
+
+    assert result.branches == ["release"]
+    assert result.enqueued == 1
+
+
+def test_bypasses_cadence_and_auto_refresh_gates():
+    """The manual path never consults due-selection, anchors, or advisory locks."""
+    stale = _candidate(
+        "api/openapi.yaml",
+        remote_committed_at=NEWER, remote_blob="blob-new",
+        last_committed_at=OLDER, last_blob="blob-old",
+    )
+    db = FakeDB(
+        repo=_repo(),
+        branches={"r1": ["main"]},
+        candidates={("r1", "main"): [stale]},
+    )
+
+    refresh_repository_now(db, tenant_id="t1", repository_id="r1")
+
+    assert db.due_calls == 0
+    assert db.mark_refreshed_calls == 0
+    assert db.lock_calls == 0
+
+
+def test_unknown_repository_returns_none():
+    """A repository not owned by the tenant yields None (caller maps to 404)."""
+    db = FakeDB(repo=None)
+
+    result = refresh_repository_now(db, tenant_id="t1", repository_id="missing")
+
+    assert result is None
+    assert db.enqueued == []
+
+
+def test_bad_branch_does_not_abort_other_branches():
+    """One branch that raises during rescan does not stop the others."""
+    stale = _candidate(
+        "api/openapi.yaml",
+        remote_committed_at=NEWER, remote_blob="blob-new",
+        last_committed_at=OLDER, last_blob="blob-old",
+    )
+    db = FakeDB(
+        repo=_repo(),
+        branches={"r1": ["bad", "main"]},
+        candidates={("r1", "main"): [stale]},
+    )
+
+    original = sweep.enqueue_stale_files_for_branch
+
+    def _maybe_raise(db_, repo_row, branch, **kwargs):
+        if branch == "bad":
+            raise RuntimeError("github exploded")
+        return original(db_, repo_row, branch, **kwargs)
+
+    # Patch the symbol the manual module imported.
+    import app.repository_manual_refresh as manual
+
+    manual.enqueue_stale_files_for_branch = _maybe_raise
+    try:
+        result = refresh_repository_now(db, tenant_id="t1", repository_id="r1")
+    finally:
+        manual.enqueue_stale_files_for_branch = original
+
+    assert result.enqueued == 1
+    assert result.branches == ["main"]  # only the branch that succeeded

--- a/objectified-rest/uv.lock
+++ b/objectified-rest/uv.lock
@@ -514,7 +514,7 @@ wheels = [
 
 [[package]]
 name = "objectified-rest"
-version = "1.0.74"
+version = "1.0.75"
 source = { editable = "." }
 dependencies = [
     { name = "bcrypt" },

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.124",
+  "version": "0.11.125",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/src/app/api/repositories/[id]/refresh/route.ts
+++ b/objectified-ui/src/app/api/repositories/[id]/refresh/route.ts
@@ -1,0 +1,103 @@
+/**
+ * Manual one-shot "Refresh Now" for a registered repository (RAR-5.2, #3533).
+ *
+ * Proxies to POST /v1/tenants/{slug}/repositories/{id}/refresh, which runs the
+ * spec-faithful re-import path (RAR-4.1) for a single file or the whole
+ * repository, honoring the freshness + divergence gates while bypassing the
+ * auto-refresh cadence. The request body is optional:
+ *   - omit both           → refresh every branch with a stored spec;
+ *   - { branch }          → refresh that branch;
+ *   - { path, branch? }   → refresh that single file.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '../../../auth/[...nextauth]/route';
+import { getTenantById } from '@lib/db/helper';
+import { createRestAuthHeaders, REST_API_BASE_URL } from '@lib/rest-auth';
+
+export const dynamic = 'force-dynamic';
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+interface SessionUser {
+  user_id?: string;
+  email?: string | null;
+  name?: string | null;
+  current_tenant_id?: string;
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await getServerSession(authOptions);
+  const user = session?.user as SessionUser | undefined;
+  if (!user?.user_id) {
+    return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
+  }
+  if (!user.current_tenant_id) {
+    return NextResponse.json({ success: false, error: 'No tenant selected' }, { status: 400 });
+  }
+
+  const { id } = await params;
+  if (!id || !UUID_RE.test(id)) {
+    return NextResponse.json({ success: false, error: 'Invalid repository id' }, { status: 400 });
+  }
+
+  // Body is optional; tolerate an empty body (whole-repo refresh).
+  let body: unknown = {};
+  try {
+    const text = await request.text();
+    if (text && text.trim()) body = JSON.parse(text);
+  } catch {
+    return NextResponse.json({ success: false, error: 'Invalid JSON body' }, { status: 400 });
+  }
+  const payload = body && typeof body === 'object' ? (body as Record<string, unknown>) : {};
+  const forwarded: { path?: string; branch?: string } = {};
+  if (typeof payload.path === 'string' && payload.path.trim()) forwarded.path = payload.path.trim();
+  if (typeof payload.branch === 'string' && payload.branch.trim()) {
+    forwarded.branch = payload.branch.trim();
+  }
+
+  const tenant = await getTenantById(user.current_tenant_id);
+  const tenantSlug =
+    tenant && typeof tenant === 'object' && 'slug' in tenant ? String((tenant as { slug: string }).slug) : '';
+  if (!tenantSlug) {
+    return NextResponse.json({ success: false, error: 'Tenant not found' }, { status: 400 });
+  }
+
+  const url = `${REST_API_BASE_URL}/tenants/${encodeURIComponent(tenantSlug)}/repositories/${encodeURIComponent(id)}/refresh`;
+  try {
+    const rest = await fetch(url, {
+      method: 'POST',
+      headers: { ...createRestAuthHeaders(user), 'Content-Type': 'application/json' },
+      body: JSON.stringify(forwarded),
+      cache: 'no-store',
+    });
+    const text = await rest.text();
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      parsed = { raw: text };
+    }
+    if (rest.ok && parsed && typeof parsed === 'object' && 'enqueued' in parsed) {
+      return NextResponse.json(parsed);
+    }
+    if (rest.status === 404) {
+      return NextResponse.json({ success: false, error: 'Repository not found' }, { status: 404 });
+    }
+    const err =
+      parsed && typeof parsed === 'object' && 'detail' in parsed
+        ? String((parsed as { detail: unknown }).detail)
+        : `Repository API error (${rest.status})`;
+    return NextResponse.json({ success: false, error: err }, { status: rest.status >= 400 ? rest.status : 502 });
+  } catch {
+    return NextResponse.json(
+      { success: false, error: 'Repository API unavailable (objectified-rest not reachable).' },
+      { status: 503 }
+    );
+  }
+}

--- a/objectified-ui/src/app/components/ade/dashboard/repositories/RepositorySpecsTab.tsx
+++ b/objectified-ui/src/app/components/ade/dashboard/repositories/RepositorySpecsTab.tsx
@@ -1,12 +1,20 @@
 'use client';
 
 /**
- * Repository detail "Specs" tab — per-file refresh status (RAR-5.1, #3532).
+ * Repository detail "Specs" tab — per-file refresh status (RAR-5.1, #3532) and
+ * one-shot "Refresh Now" (RAR-5.2, #3533).
  *
  * Lists every imported-file lineage for the repository with its materialized
  * refresh state (RAR-2.3), last-refreshed time, next-due time (RAR-3.1 cadence),
  * and a divergence indicator (RAR-4.4). Diverged files are rendered visually
  * distinct and link to the review action (the file's diff view on the Files tab).
+ *
+ * Each row carries a per-file "Refresh" action and the table header a per-repo
+ * "Refresh now" action. Both POST `/api/repositories/{id}/refresh`, which runs
+ * the spec-faithful re-import path on demand — using the stored import spec, the
+ * freshness gate, and the divergence guard — even when scheduled auto-refresh is
+ * off. The freshness gate means refreshing an up-to-date file is a no-op, which
+ * the success notice reports.
  *
  * Data comes from `GET /api/repositories/{id}/refresh-specs`; the status is
  * derived on the client with `computeRefreshStatus`, the same logic the REST
@@ -19,7 +27,7 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import Link from 'next/link';
-import { AlertTriangle, Loader2 } from 'lucide-react';
+import { AlertTriangle, Loader2, RefreshCw } from 'lucide-react';
 import { cn } from '@lib/utils';
 import {
   getRefreshStatusPresentation,
@@ -103,6 +111,51 @@ export function formatNextDue(nextDue: Date | 'due' | null, now: number = Date.n
   return `in ${Math.floor(sec / 86400)}d`;
 }
 
+/** Busy-key sentinel identifying the per-repo ("Refresh now") action. */
+export const REPO_REFRESH_KEY = '__repo__';
+
+/** A transient feedback notice shown after a refresh action. */
+export type RefreshNotice = { kind: 'success' | 'error'; text: string };
+
+/**
+ * Small "Refresh now"/"Refresh" button used at the repo and file level. Shows a
+ * spinner and disables itself while its own action is in flight, and stays
+ * disabled while any other refresh action runs so a user cannot double-fire.
+ */
+function RefreshNowButton({
+  label,
+  busy,
+  disabled,
+  onClick,
+  testId,
+  ariaLabel,
+}: {
+  label: string;
+  busy: boolean;
+  disabled: boolean;
+  onClick: () => void;
+  testId: string;
+  ariaLabel: string;
+}) {
+  return (
+    <button
+      type="button"
+      data-testid={testId}
+      onClick={onClick}
+      disabled={disabled || busy}
+      aria-label={ariaLabel}
+      className={cn(
+        'inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs font-medium transition-colors',
+        'border-indigo-200 text-indigo-700 hover:bg-indigo-50 dark:border-indigo-800/60 dark:text-indigo-300 dark:hover:bg-indigo-950/40',
+        'disabled:cursor-not-allowed disabled:opacity-50',
+      )}
+    >
+      <RefreshCw className={cn('h-3.5 w-3.5 shrink-0', busy && 'animate-spin')} aria-hidden />
+      {label}
+    </button>
+  );
+}
+
 /** A single refresh-status chip for a spec row. */
 function RefreshStatusChip({ status }: { status: string }) {
   const presentation = getRefreshStatusPresentation(status);
@@ -130,19 +183,60 @@ export function RepositorySpecsTable({
   repositoryId,
   specs,
   now,
+  busyKey = null,
+  notice = null,
+  onRefreshRepo,
+  onRefreshFile,
 }: {
   repositoryId: string;
   specs: RepositoryRefreshSpec[];
   now: number;
+  /** Key of the in-flight refresh: {@link REPO_REFRESH_KEY} or a spec id; null when idle. */
+  busyKey?: string | null;
+  /** Transient feedback from the last refresh action. */
+  notice?: RefreshNotice | null;
+  /** Trigger a whole-repository refresh; omit to hide the per-repo button. */
+  onRefreshRepo?: () => void;
+  /** Trigger a single-file refresh; omit to hide the per-file buttons. */
+  onRefreshFile?: (spec: RepositoryRefreshSpec) => void;
 }) {
+  const anyBusy = busyKey !== null;
+  const showActions = typeof onRefreshFile === 'function';
+  const columnCount = showActions ? 5 : 4;
   return (
     <div className="overflow-hidden rounded-xl border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
       <div className="flex flex-wrap items-center justify-between gap-2 border-b border-gray-200 px-4 py-3 dark:border-gray-700">
-        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Imported specs</h3>
-        <p className="text-xs text-gray-500 dark:text-gray-400">
-          Per-file auto-refresh status, last refresh, and next due.
-        </p>
+        <div>
+          <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Imported specs</h3>
+          <p className="text-xs text-gray-500 dark:text-gray-400">
+            Per-file auto-refresh status, last refresh, and next due.
+          </p>
+        </div>
+        {onRefreshRepo && specs.length > 0 ? (
+          <RefreshNowButton
+            label="Refresh now"
+            testId="repository-refresh-all"
+            ariaLabel="Refresh all imported specs in this repository now"
+            busy={busyKey === REPO_REFRESH_KEY}
+            disabled={anyBusy}
+            onClick={onRefreshRepo}
+          />
+        ) : null}
       </div>
+      {notice ? (
+        <div
+          data-testid="repository-refresh-notice"
+          role="status"
+          className={cn(
+            'border-b px-4 py-2 text-xs',
+            notice.kind === 'success'
+              ? 'border-emerald-200 bg-emerald-50/70 text-emerald-700 dark:border-emerald-900/40 dark:bg-emerald-950/30 dark:text-emerald-300'
+              : 'border-rose-200 bg-rose-50/70 text-rose-700 dark:border-rose-900/40 dark:bg-rose-950/30 dark:text-rose-300',
+          )}
+        >
+          {notice.text}
+        </div>
+      ) : null}
       <table className="w-full text-sm">
         <thead className="border-b border-gray-200 bg-gray-50 text-[11px] uppercase tracking-wider text-gray-500 dark:border-gray-700 dark:bg-gray-900/30 dark:text-gray-400">
           <tr>
@@ -150,13 +244,16 @@ export function RepositorySpecsTable({
             <th className="px-4 py-2 align-middle text-left font-semibold">Status</th>
             <th className="px-4 py-2 align-middle text-left font-semibold">Last refreshed</th>
             <th className="px-4 py-2 align-middle text-left font-semibold">Next due</th>
+            {showActions ? (
+              <th className="px-4 py-2 align-middle text-right font-semibold">Actions</th>
+            ) : null}
           </tr>
         </thead>
         <tbody className="divide-y divide-gray-100 dark:divide-gray-800">
           {specs.length === 0 ? (
             <tr>
               <td
-                colSpan={4}
+                colSpan={columnCount}
                 className="px-4 py-12 align-middle text-center text-sm leading-relaxed text-gray-500 dark:text-gray-400"
               >
                 No imported specs yet. Open the Files tab, import a specification, and its
@@ -231,6 +328,18 @@ export function RepositorySpecsTable({
                   <td className="whitespace-nowrap px-4 py-2 align-middle text-gray-600 dark:text-gray-400">
                     {formatNextDue(nextDue, now)}
                   </td>
+                  {showActions ? (
+                    <td className="whitespace-nowrap px-4 py-2 align-middle text-right">
+                      <RefreshNowButton
+                        label="Refresh"
+                        testId="repository-refresh-file"
+                        ariaLabel={`Refresh ${spec.path} now`}
+                        busy={busyKey === spec.id}
+                        disabled={anyBusy}
+                        onClick={() => onRefreshFile?.(spec)}
+                      />
+                    </td>
+                  ) : null}
                 </tr>
               );
             })
@@ -252,6 +361,10 @@ export function RepositorySpecsTab({ repositoryId }: { repositoryId: string }) {
   const [specs, setSpecs] = useState<RepositoryRefreshSpec[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // Which refresh action is in flight (REPO_REFRESH_KEY or a spec id), and the
+  // last action's feedback notice.
+  const [busyKey, setBusyKey] = useState<string | null>(null);
+  const [notice, setNotice] = useState<RefreshNotice | null>(null);
   // Capture a single render-stable clock for relative-time formatting so the
   // table stays pure (no Date.now() during render).
   const [now] = useState<number>(() => Date.now());
@@ -286,6 +399,61 @@ export function RepositorySpecsTab({ repositoryId }: { repositoryId: string }) {
     void fetchSpecs();
   }, [fetchSpecs]);
 
+  // Trigger a one-shot refresh (whole-repo when body is empty, single file when
+  // path/branch are given), then re-load the rows so statuses update.
+  const runRefresh = useCallback(
+    async (busy: string, body: { path?: string; branch?: string }) => {
+      if (!repositoryId || busyKey !== null) return;
+      setBusyKey(busy);
+      setNotice(null);
+      try {
+        const res = await fetch(`/api/repositories/${encodeURIComponent(repositoryId)}/refresh`, {
+          method: 'POST',
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        });
+        const data = (await res.json().catch(() => ({}))) as {
+          success?: boolean;
+          enqueued?: number;
+          skipped?: number;
+          error?: string;
+        };
+        if (!res.ok || data.success !== true) {
+          throw new Error(typeof data.error === 'string' ? data.error : res.statusText);
+        }
+        const enqueued = Number(data.enqueued ?? 0);
+        setNotice({
+          kind: 'success',
+          text:
+            enqueued > 0
+              ? `Refresh queued for ${enqueued} file${enqueued === 1 ? '' : 's'}.`
+              : 'Already up to date — nothing to refresh.',
+        });
+        await fetchSpecs();
+      } catch (e) {
+        setNotice({
+          kind: 'error',
+          text: e instanceof Error ? e.message : 'Could not start the refresh',
+        });
+      } finally {
+        setBusyKey(null);
+      }
+    },
+    [repositoryId, busyKey, fetchSpecs],
+  );
+
+  const handleRefreshRepo = useCallback(() => {
+    void runRefresh(REPO_REFRESH_KEY, {});
+  }, [runRefresh]);
+
+  const handleRefreshFile = useCallback(
+    (spec: RepositoryRefreshSpec) => {
+      void runRefresh(spec.id, { path: spec.path, branch: spec.branch });
+    },
+    [runRefresh],
+  );
+
   if (error) {
     return (
       <div className="rounded-xl border border-rose-200 bg-rose-50/80 p-6 text-sm text-rose-700 dark:border-rose-800/50 dark:bg-rose-950/30 dark:text-rose-300">
@@ -303,5 +471,15 @@ export function RepositorySpecsTab({ repositoryId }: { repositoryId: string }) {
     );
   }
 
-  return <RepositorySpecsTable repositoryId={repositoryId} specs={specs} now={now} />;
+  return (
+    <RepositorySpecsTable
+      repositoryId={repositoryId}
+      specs={specs}
+      now={now}
+      busyKey={busyKey}
+      notice={notice}
+      onRefreshRepo={handleRefreshRepo}
+      onRefreshFile={handleRefreshFile}
+    />
+  );
 }

--- a/objectified-ui/tests/RepositorySpecsTab.test.tsx
+++ b/objectified-ui/tests/RepositorySpecsTab.test.tsx
@@ -8,10 +8,11 @@
  */
 
 import React from 'react';
-import { render, screen, waitFor, within } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 import {
+  REPO_REFRESH_KEY,
   RepositorySpecsTab,
   RepositorySpecsTable,
   formatNextDue,
@@ -120,6 +121,71 @@ describe('RepositorySpecsTable', () => {
     render(<RepositorySpecsTable repositoryId="repo-1" specs={[]} now={NOW} />);
     expect(screen.getByText(/No imported specs yet/i)).toBeInTheDocument();
   });
+
+  test('per-repo and per-file Refresh actions fire their callbacks (RAR-5.2)', () => {
+    const onRefreshRepo = jest.fn();
+    const onRefreshFile = jest.fn();
+    const spec = makeSpec();
+    render(
+      <RepositorySpecsTable
+        repositoryId="repo-1"
+        specs={[spec]}
+        now={NOW}
+        onRefreshRepo={onRefreshRepo}
+        onRefreshFile={onRefreshFile}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('repository-refresh-all'));
+    expect(onRefreshRepo).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByTestId('repository-refresh-file'));
+    expect(onRefreshFile).toHaveBeenCalledWith(spec);
+  });
+
+  test('a busy refresh disables every refresh button (no double-fire)', () => {
+    render(
+      <RepositorySpecsTable
+        repositoryId="repo-1"
+        specs={[makeSpec()]}
+        now={NOW}
+        busyKey={REPO_REFRESH_KEY}
+        onRefreshRepo={jest.fn()}
+        onRefreshFile={jest.fn()}
+      />,
+    );
+    expect(screen.getByTestId('repository-refresh-all')).toBeDisabled();
+    expect(screen.getByTestId('repository-refresh-file')).toBeDisabled();
+  });
+
+  test('the per-repo button is hidden when there are no specs', () => {
+    render(
+      <RepositorySpecsTable
+        repositoryId="repo-1"
+        specs={[]}
+        now={NOW}
+        onRefreshRepo={jest.fn()}
+        onRefreshFile={jest.fn()}
+      />,
+    );
+    expect(screen.queryByTestId('repository-refresh-all')).not.toBeInTheDocument();
+  });
+
+  test('renders the refresh notice when supplied', () => {
+    render(
+      <RepositorySpecsTable
+        repositoryId="repo-1"
+        specs={[makeSpec()]}
+        now={NOW}
+        notice={{ kind: 'success', text: 'Already up to date — nothing to refresh.' }}
+        onRefreshRepo={jest.fn()}
+        onRefreshFile={jest.fn()}
+      />,
+    );
+    expect(screen.getByTestId('repository-refresh-notice')).toHaveTextContent(
+      /Already up to date/i,
+    );
+  });
 });
 
 describe('RepositorySpecsTab (fetching wrapper)', () => {
@@ -150,5 +216,54 @@ describe('RepositorySpecsTab (fetching wrapper)', () => {
 
     render(<RepositorySpecsTab repositoryId="repo-1" />);
     await waitFor(() => expect(screen.getByText('boom')).toBeInTheDocument());
+  });
+
+  test('Refresh now POSTs to the refresh endpoint and reports the result (RAR-5.2)', async () => {
+    const fetchMock = jest
+      .fn()
+      // initial load
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ success: true, specs: [makeSpec()] }) })
+      // POST /refresh
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ success: true, enqueued: 2, skipped: 0 }) })
+      // reload after refresh
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ success: true, specs: [makeSpec()] }) });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    render(<RepositorySpecsTab repositoryId="repo-1" />);
+    await waitFor(() => expect(screen.getByTestId('repository-refresh-all')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('repository-refresh-all'));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('repository-refresh-notice')).toHaveTextContent(
+        /Refresh queued for 2 files/i,
+      ),
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/repositories/repo-1/refresh',
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+
+  test('an up-to-date single-file refresh reports the no-op (freshness gate)', async () => {
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ success: true, specs: [makeSpec()] }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ success: true, enqueued: 0, skipped: 1 }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ success: true, specs: [makeSpec()] }) });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    render(<RepositorySpecsTab repositoryId="repo-1" />);
+    await waitFor(() => expect(screen.getByTestId('repository-refresh-file')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('repository-refresh-file'));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('repository-refresh-notice')).toHaveTextContent(
+        /Already up to date/i,
+      ),
+    );
+    const body = JSON.parse((fetchMock.mock.calls[1][1] as { body: string }).body);
+    expect(body).toEqual({ path: 'specs/petstore.yaml', branch: 'main' });
   });
 });


### PR DESCRIPTION
## What & why

Implements **RAR-5.2** (#3533): a manual, on-demand **"Refresh Now"** that extends REPO-9.5 "Import Now". Users can trigger a spec-faithful refresh without waiting for the next auto-refresh tick — for a single imported file or the whole repository.

It reuses the exact enqueue core of the RAR-3.2 periodic sweep, so the same gates apply:

- **Stored spec, not defaults** — each enqueued job carries the captured `SpecImportOptions` snapshot (RAR-1.2), replayed by the RAR-4.1 executor.
- **Freshness-gated** — only files genuinely newer than the last import enqueue (RAR-2.2); an up-to-date file is a reported no-op.
- **Divergence-safe** — the job runs through the same EPIC-4 executor that applies the RAR-4.4 manual-edit guard.
- **Cadence bypassed** — the manual path never consults due-selection, the per-repo `auto_refresh_enabled` flag (RAR-3.3), or the `OBJECTIFIED_REFRESH_ENABLED` kill switch, so **it works even when scheduled auto-refresh is disabled**.

### Changes
- **REST**: new pure module `app/repository_manual_refresh.py` (`refresh_repository_now`); the sweep's per-branch enqueue is refactored into the shared, path-filterable `repository_refresh_sweep.enqueue_stale_files_for_branch` (now returns enqueued/skipped counts). New `POST /v1/tenants/{slug}/repositories/{id}/refresh` endpoint + `RepositoryRefreshNow` request/response models. OpenAPI regenerated.
- **UI**: `POST /api/repositories/[id]/refresh` proxy; Specs tab gains a per-repo **Refresh now** header button and a per-file **Refresh** row action, with busy-state disabling, success/no-op notices, and auto-reload of the rows.

## How to test
1. **Open** a repository's detail page → **Specs** tab.
2. **Click "Refresh now"** (header) to refresh the whole repo, or **"Refresh"** on a row for one file.
3. With an unchanged file, the notice reads **"Already up to date — nothing to refresh."** (freshness gate).
4. Push a newer commit to an imported spec, then **click Refresh** — the notice reads **"Refresh queued for N file(s)."** and the row status moves to refreshing.
5. **Toggle auto-refresh off** for the repo (RAR-3.3) and confirm Refresh Now still enqueues.

Backend unit tests: `cd objectified-rest && uv run python -m pytest tests/test_repository_manual_refresh.py tests/test_repository_refresh_sweep.py`. UI tests: `cd objectified-ui && yarn jest tests/RepositorySpecsTab.test.tsx`.

## Risk / notes
- Per-file refresh rescans the whole branch (reuses the sweep's index path) then filters to the path — heavier than a single-file fetch but keeps gating identical to the sweep.
- Divergence-guard enforcement is the EPIC-4 executor's responsibility (its dispatcher wiring is tracked separately, as noted in the roadmap); this change routes manual jobs through that same pipeline.
- New endpoint is tenant-scoped from the auth token (404 cross-tenant). No DB migration.
- Pre-existing, DB-dependent REST test failures (merge/publish/change-report suites) are unrelated and fail on a clean tree too.

Closes #3533

Work performed by Claude Code via model Opus 4.8 (1M context).

🤖 Generated with [Claude Code](https://claude.com/claude-code)