### PR TITLE
Fix #3535 - Refresh notifications (extend REPO-12.5) (RAR-5.4)

### DIFF
--- a/docs/ROADMAP_REPOSITORY_AUTOREFRESH.md
+++ b/docs/ROADMAP_REPOSITORY_AUTOREFRESH.md
@@ -125,7 +125,7 @@ epic. Use this table to resolve any `RAR-*` reference below to its issue number.
 | ~~RAR-3.3~~ ✅ | ~~#3524~~ | RAR-3.4 | #3525 | RAR-3.5 | #3526 |
 | ~~RAR-4.1~~ ✅ | ~~#3527~~ | ~~RAR-4.2~~ ✅ | ~~#3528~~ | ~~RAR-4.3~~ ✅ | ~~#3529~~ |
 | ~~RAR-4.4~~ ✅ | ~~#3530~~ | RAR-4.5 | #3531 | ~~RAR-5.1~~ ✅ | ~~#3532~~ |
-| ~~RAR-5.2~~ ✅ | ~~#3533~~ | ~~RAR-5.3~~ ✅ | ~~#3534~~ | RAR-5.4 | #3535 |
+| ~~RAR-5.2~~ ✅ | ~~#3533~~ | ~~RAR-5.3~~ ✅ | ~~#3534~~ | ~~RAR-5.4~~ ✅ | ~~#3535~~ |
 | RAR-5.5 | #3536 | RAR-5.6 | #3537 | RAR-6.1 | #3538 |
 | RAR-6.2 | #3539 | RAR-6.3 | #3540 | RAR-6.4 | #3541 |
 | RAR-6.5 | #3542 | | | | |
@@ -610,7 +610,7 @@ wiring.
 | ~~RAR-5.1~~ ✅ **Done** (#3532) | Per-file refresh status UI | Specs tab shows status, last-refreshed, next-due, divergence | `enhancement`,`mvp`,`import`,`repository`,`ui` | Y | Y | M | objectified-ui |
 | ~~RAR-5.2~~ ✅ **Done** (#3533) | "Refresh Now" one-shot (extend REPO-9.5) | Manual spec-faithful refresh per file/repo | `enhancement`,`mvp`,`import`,`repository`,`ui` | Y | Y | S | objectified-ui, objectified-rest |
 | ~~RAR-5.3~~ ✅ **Done** (#3534) | Refresh history + change-report linking (extend REPO-12.6) | Audit each refresh cycle with diff link | `enhancement`,`mvp`,`import`,`repository` | Y | Y | M | objectified-rest |
-| RAR-5.4 | Refresh notifications (extend REPO-12.5) | Notify on new version / divergence / failure | `enhancement`,`mvp`,`import`,`repository` | Y | Y | S | objectified-rest |
+| ~~RAR-5.4~~ ✅ **Done** (#3535) | Refresh notifications (extend REPO-12.5) | Notify on new version / divergence / failure | `enhancement`,`mvp`,`import`,`repository` | Y | Y | S | objectified-rest |
 | RAR-5.5 | Dashboard widget: stale specs / refresh activity (extend REPO-11) | At-a-glance refresh health | `enhancement`,`import`,`repository`,`dashboard` | Y | N | M | objectified-ui |
 | RAR-5.6 | CLI `objectified repository refresh` + status | Trigger / inspect refresh from CLI | `enhancement`,`import`,`cli` | Y | N | M | objectified-cli |
 
@@ -684,6 +684,31 @@ the dispatcher's job, mirroring how RAR-4.1/4.2/4.3/4.4 deferred their wiring. T
 lineage capture, enum guarding, and the DAO SQL contract for per-repo/per-file query) and
 `tests/test_repository_refresh_history_api.py` (per-repo + per-file query, filter forwarding, 404,
 detail→field projection, pagination).
+
+**Status (5.4): ✅ Done (#3535).** New objectified-rest module
+`app/repository_refresh_notifications.py` turns the three *interesting* refresh outcomes into
+notifications delivered over the **existing** push-webhook channels (`odb.push_webhook_subscriptions` /
+`push_webhook_delivery_events`, #2587/#2588) — extending REPO-12.5 (#2954) failure notifications to the
+auto-refresh loop. Only `new-version` (RAR-4.2), `diverged` (RAR-4.4 hold), and `failed` outcomes fire,
+each under a namespaced event type (`repository.refresh.new_version` / `.diverged` / `.failed`); an
+`unchanged` no-op (RAR-2.4) is intentionally **silent** so the channels stay quiet in the common case.
+The module reuses the `RefreshOutcome` / `RefreshTrigger` vocabulary and the lineage/link facets from the
+RAR-5.3 audit module, so a notification a stakeholder receives and a history row a reviewer reads describe
+the same cycle in the same terms. **Preferences are honored**: `RefreshNotificationPreferences` gives each
+notifiable outcome an independent toggle (all on by default, mirroring REPO-12.5's `auto_import_failed` /
+`auto_import_breaking` defaults), parsed tolerantly from a stored blob (`from_mapping` accepts the
+`user_settings.notifications.repository` aliases and **fails open** on partial/malformed data); a muted
+outcome enqueues nothing. **Links** are carried in every payload: a deep-link to the review action
+(`reviewHref`, mirroring the RAR-5.1 `repositorySpecReviewHref` convention) plus the `versionId` /
+`changeReportId` (RAR-4.2/4.3) that resolve the change report. Fan-out enqueues one delivery per active
+tenant subscription (new DAO `list_active_push_webhook_subscription_ids`) and is **best-effort** — a
+per-subscription enqueue failure is logged and skipped and the function never raises, so a notification
+problem cannot break the refresh it describes (**no migration; objectified-rest only**). Invoking
+`notify_refresh_outcome(...)` from the EPIC-4 refresh dispatcher (after the version + change report land)
+is the dispatcher's job, mirroring how RAR-4.x and RAR-5.3 deferred their wiring. Tests:
+`tests/test_repository_refresh_notifications.py` (notifiability rule, per-outcome + per-toggle gating,
+preference parsing incl. aliases / partial / null, payload assembly + review-href encoding, fan-out across
+subscriptions, silent/muted/no-subscription short-circuits, best-effort skip-on-error, and enum guarding).
 
 ---
 

--- a/objectified-rest/pyproject.toml
+++ b/objectified-rest/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "objectified-rest"
-version = "1.0.76"
+version = "1.0.77"
 description = "REST API for serving OpenAPI specifications from the Objectified database"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/objectified-rest/src/app/database.py
+++ b/objectified-rest/src/app/database.py
@@ -6003,6 +6003,27 @@ class Database:
         """
         return self.execute_query(q, (tenant_id,))
 
+    def list_active_push_webhook_subscription_ids(self, tenant_id: str) -> List[str]:
+        """Return the ids of every active (non-deleted) push-webhook subscription for a tenant.
+
+        Used by the refresh-notification fan-out (RAR-5.4) to enqueue one delivery
+        per subscribed channel. Inactive and soft-deleted subscriptions are excluded
+        so a notification is never queued for a channel that cannot receive it.
+
+        Args:
+            tenant_id: Owning tenant id.
+
+        Returns:
+            A list of subscription id strings (possibly empty), newest first.
+        """
+        q = """
+            SELECT id
+            FROM odb.push_webhook_subscriptions
+            WHERE tenant_id = %s::uuid AND active = true AND deleted_at IS NULL
+            ORDER BY created_at DESC
+        """
+        return [str(row["id"]) for row in self.execute_query(q, (tenant_id,))]
+
     def get_push_webhook_subscription(
         self, tenant_id: str, subscription_id: str
     ) -> Optional[Dict[str, Any]]:

--- a/objectified-rest/src/app/repository_refresh_notifications.py
+++ b/objectified-rest/src/app/repository_refresh_notifications.py
@@ -1,0 +1,397 @@
+"""Refresh-cycle notifications (RAR-5.4, #3535).
+
+Stakeholders need to know when an auto-refresh cycle *changes* something —
+without watching a dashboard. This module extends the REPO-12.5 (#2954) failure
+notifications to cover the auto-refresh loop: it turns the three *interesting*
+refresh outcomes into notifications delivered over the **existing** push-webhook
+channels (``odb.push_webhook_subscriptions`` / ``push_webhook_delivery_events``,
+#2587/#2588)::
+
+    refresh outcome ──► notify { new_version | diverged | failed } via existing channels
+
+Only outcomes a stakeholder must act on or be aware of fire a notification:
+
+* ``new-version`` — the re-import created a new, provenance-linked version (RAR-4.2).
+* ``diverged``    — a manual edit since import was detected and the refresh was
+  *held*, not applied (RAR-4.4 divergence guard); someone must review.
+* ``failed``      — the refresh cycle errored before producing a version.
+
+An ``unchanged`` cycle (a freshness/idempotency no-op, RAR-2.4) is intentionally
+*silent* — there is nothing to act on — which also keeps the channels quiet under
+the common case.
+
+This module reuses the :class:`RefreshOutcome` / :class:`RefreshTrigger` vocabulary
+and the lineage/link facets from the sibling RAR-5.3 audit module
+(:mod:`app.repository_refresh_audit`) so the notification a stakeholder receives
+and the history row a reviewer reads describe the same cycle in the same terms.
+
+**Preferences are honored.** Each notifiable outcome has an independent toggle in
+:class:`RefreshNotificationPreferences` (all on by default, mirroring REPO-12.5's
+``auto_import_failed`` / ``auto_import_breaking`` defaults). The caller loads the
+tenant/user preference blob (e.g. ``user_settings.notifications.repository``) and
+passes it in; :func:`notify_refresh_outcome` short-circuits when the matching
+toggle is off, so a muted outcome never enqueues a delivery.
+
+**Links to the review action / change report.** Every payload carries a deep-link
+to the review action (the file's diff view, RAR-5.1) plus the ``versionId`` /
+``changeReportId`` (RAR-4.2/4.3) that resolve the change report, so the recipient
+can jump straight to the diff.
+
+Like the sibling RAR-4.x / RAR-5.3 building blocks, delivery here is
+**best-effort**: fan-out swallows per-subscription errors and the function never
+raises, so a notification problem can never fail the refresh it describes.
+Invoking :func:`notify_refresh_outcome` from the EPIC-4 refresh dispatcher — after
+the version is created (RAR-4.2) and the change report is generated (RAR-4.3) — is
+the dispatcher's job, mirroring how RAR-4.1/4.2/4.3/4.4 and RAR-5.3 deferred their
+wiring.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Dict, List, Mapping, Optional
+from urllib.parse import quote, urlencode
+
+from .repository_refresh_audit import RefreshOutcome, RefreshTrigger
+
+logger = logging.getLogger(__name__)
+
+# Push-webhook event types stamped on each refresh notification. Namespaced under
+# ``repository.refresh.*`` so a subscriber can route/filter refresh events distinctly
+# from other repository webhooks; the suffix is the outcome.
+EVENT_TYPE_BY_OUTCOME: Dict[RefreshOutcome, str] = {
+    RefreshOutcome.NEW_VERSION: "repository.refresh.new_version",
+    RefreshOutcome.DIVERGED: "repository.refresh.diverged",
+    RefreshOutcome.FAILED: "repository.refresh.failed",
+}
+
+# The outcomes that produce a notification at all. ``UNCHANGED`` is intentionally
+# absent: a no-op refresh has nothing to act on, so it stays silent.
+NOTIFIABLE_OUTCOMES = frozenset(EVENT_TYPE_BY_OUTCOME.keys())
+
+
+@dataclass(frozen=True)
+class RefreshNotificationPreferences:
+    """Per-recipient toggles for refresh notifications (one per notifiable outcome).
+
+    Mirrors the REPO-12.5 ``user_settings.notifications.repository`` preference shape:
+    each notifiable refresh outcome can be muted independently, and all default *on*
+    (a stakeholder is told about new versions, divergence holds, and failures unless
+    they opt out). An ``unchanged`` cycle never notifies regardless of preferences.
+    """
+
+    #: Notify when a refresh creates a new version (RAR-4.2). Default on.
+    notify_new_version: bool = True
+    #: Notify when a refresh is held for review due to divergence (RAR-4.4). Default on.
+    notify_diverged: bool = True
+    #: Notify when a refresh cycle fails. Default on.
+    notify_failed: bool = True
+
+    def allows(self, outcome: RefreshOutcome) -> bool:
+        """Return whether ``outcome`` is permitted to notify under these preferences.
+
+        A non-notifiable outcome (e.g. ``unchanged``) is always ``False``.
+
+        Args:
+            outcome: The refresh outcome being considered.
+
+        Returns:
+            ``True`` if a notification for ``outcome`` should be delivered.
+        """
+        if outcome is RefreshOutcome.NEW_VERSION:
+            return self.notify_new_version
+        if outcome is RefreshOutcome.DIVERGED:
+            return self.notify_diverged
+        if outcome is RefreshOutcome.FAILED:
+            return self.notify_failed
+        return False
+
+    @classmethod
+    def from_mapping(
+        cls, prefs: Optional[Mapping[str, Any]]
+    ) -> "RefreshNotificationPreferences":
+        """Build preferences from a stored blob, tolerating missing/partial keys.
+
+        Recognizes both the local snake_case keys (``notify_new_version`` …) and the
+        REPO-12.5 ``user_settings.notifications.repository`` aliases
+        (``refresh_new_version`` / ``refresh_diverged`` / ``refresh_failed``). Any key
+        that is absent keeps its default (on); only an explicit ``False`` mutes an
+        outcome, so a malformed/partial blob fails *open* (the user keeps getting the
+        notifications they did not explicitly disable).
+
+        Args:
+            prefs: A mapping of preference toggles, or ``None`` for all-default.
+
+        Returns:
+            A populated :class:`RefreshNotificationPreferences`.
+        """
+        if not prefs:
+            return cls()
+
+        def _flag(*keys: str, default: bool = True) -> bool:
+            for key in keys:
+                if key in prefs and prefs[key] is not None:
+                    return bool(prefs[key])
+            return default
+
+        return cls(
+            notify_new_version=_flag("notify_new_version", "refresh_new_version"),
+            notify_diverged=_flag("notify_diverged", "refresh_diverged"),
+            notify_failed=_flag("notify_failed", "refresh_failed"),
+        )
+
+
+def should_notify(
+    outcome: RefreshOutcome,
+    preferences: Optional[RefreshNotificationPreferences] = None,
+) -> bool:
+    """Return whether a refresh ``outcome`` should produce a notification.
+
+    Combines the static notifiability rule (only ``new-version`` / ``diverged`` /
+    ``failed`` ever notify) with the recipient's preferences.
+
+    Args:
+        outcome: The refresh outcome.
+        preferences: The recipient's toggles; defaults (all on) when ``None``.
+
+    Returns:
+        ``True`` if a notification should be delivered for ``outcome``.
+    """
+    if outcome not in NOTIFIABLE_OUTCOMES:
+        return False
+    prefs = preferences or RefreshNotificationPreferences()
+    return prefs.allows(outcome)
+
+
+def _clean_str(raw: Any) -> Optional[str]:
+    """Return a stripped non-empty string, or ``None`` for blank/missing values."""
+    if raw is None:
+        return None
+    text = str(raw).strip()
+    return text or None
+
+
+def build_review_href(repository_id: str, branch: str, path: str) -> Optional[str]:
+    """Build the deep-link to the file's review (diff) action (RAR-5.1).
+
+    Mirrors the UI's ``repositorySpecReviewHref`` so the link a notification carries
+    matches the one the Specs tab renders: it opens the repository's Files tab on the
+    affected file/branch. Returns ``None`` when the repository id is missing (the
+    minimum needed to form a stable link).
+
+    Args:
+        repository_id: The repository whose file was refreshed.
+        branch: The branch the file was refreshed on.
+        path: The repository-relative file path.
+
+    Returns:
+        A relative deep-link path, or ``None`` if no usable link can be formed.
+    """
+    repo = _clean_str(repository_id)
+    if repo is None:
+        return None
+    params = [("tab", "files")]
+    path_v = _clean_str(path)
+    if path_v is not None:
+        params.append(("path", path_v))
+    branch_v = _clean_str(branch)
+    if branch_v is not None:
+        params.append(("branch", branch_v))
+    return f"/ade/dashboard/repositories/{quote(repo, safe='')}/preview?{urlencode(params)}"
+
+
+def build_refresh_notification(
+    *,
+    trigger: RefreshTrigger,
+    outcome: RefreshOutcome,
+    repository_id: str,
+    branch: str,
+    path: str,
+    project_id: Optional[str] = None,
+    version_id: Optional[str] = None,
+    parent_version_id: Optional[str] = None,
+    change_report_id: Optional[str] = None,
+    source_commit_sha: Optional[str] = None,
+    error: Optional[str] = None,
+    extra: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Assemble the JSON-serializable notification payload for one refresh outcome.
+
+    The ``event``, ``outcome``, ``trigger`` and lineage keys
+    (``repositoryId`` / ``branch`` / ``path``) plus the ``reviewHref`` are always
+    present so a recipient can route the event and jump to the review action; the
+    version / change-report links and context fields are included only when supplied,
+    so a failed or held cycle does not carry empty links.
+
+    Args:
+        trigger: What initiated the cycle (:class:`RefreshTrigger`).
+        outcome: What the cycle produced (must be a notifiable outcome).
+        repository_id: The repository whose file was refreshed (lineage key).
+        branch: The branch the file was refreshed on (lineage key).
+        path: The repository-relative file path (lineage key).
+        project_id: The catalog project the refresh targets, when known.
+        version_id: The new version created by the refresh (RAR-4.2), when any.
+        parent_version_id: The prior version the refresh supersedes, when any.
+        change_report_id: The change report documenting the diff (RAR-4.3), when any.
+        source_commit_sha: The remote commit SHA that triggered the refresh, when known.
+        error: A short error message, for a failed cycle.
+        extra: Optional additional structured context merged into the payload (callers
+            must not override the reserved keys above).
+
+    Returns:
+        A JSON-serializable notification dict with camelCase keys.
+
+    Raises:
+        TypeError: If ``trigger`` or ``outcome`` is not the matching enum type.
+        ValueError: If ``outcome`` is not a notifiable outcome (the caller must gate
+            on :func:`should_notify` first).
+    """
+    if not isinstance(trigger, RefreshTrigger):
+        raise TypeError(f"trigger must be a RefreshTrigger, got {type(trigger).__name__}")
+    if not isinstance(outcome, RefreshOutcome):
+        raise TypeError(f"outcome must be a RefreshOutcome, got {type(outcome).__name__}")
+    if outcome not in NOTIFIABLE_OUTCOMES:
+        raise ValueError(f"outcome {outcome.value!r} is not notifiable")
+
+    payload: Dict[str, Any] = {
+        "event": EVENT_TYPE_BY_OUTCOME[outcome],
+        "trigger": trigger.value,
+        "outcome": outcome.value,
+        "repositoryId": _clean_str(repository_id),
+        "branch": _clean_str(branch),
+        "path": _clean_str(path),
+    }
+    review_href = build_review_href(repository_id, branch, path)
+    if review_href is not None:
+        payload["reviewHref"] = review_href
+
+    for key, value in (
+        ("projectId", project_id),
+        ("versionId", version_id),
+        ("parentVersionId", parent_version_id),
+        ("changeReportId", change_report_id),
+        ("sourceCommitSha", source_commit_sha),
+        ("error", error),
+    ):
+        cleaned = _clean_str(value)
+        if cleaned is not None:
+            payload[key] = cleaned
+
+    if extra:
+        for k, v in extra.items():
+            payload.setdefault(k, v)
+    return payload
+
+
+def notify_refresh_outcome(
+    db: Any,
+    *,
+    tenant_id: str,
+    repository_id: str,
+    branch: str,
+    path: str,
+    trigger: RefreshTrigger,
+    outcome: RefreshOutcome,
+    preferences: Optional[RefreshNotificationPreferences] = None,
+    project_id: Optional[str] = None,
+    version_id: Optional[str] = None,
+    parent_version_id: Optional[str] = None,
+    change_report_id: Optional[str] = None,
+    source_commit_sha: Optional[str] = None,
+    error: Optional[str] = None,
+    extra: Optional[Dict[str, Any]] = None,
+) -> List[str]:
+    """Notify a refresh outcome by fanning out one delivery per active channel.
+
+    Gates on :func:`should_notify` (static notifiability + the recipient's
+    preferences): a silent outcome (``unchanged``) or a muted toggle enqueues
+    nothing and returns an empty list. Otherwise it enqueues one push-webhook
+    delivery per active tenant subscription
+    (:meth:`Database.list_active_push_webhook_subscription_ids`), each carrying the
+    payload from :func:`build_refresh_notification`.
+
+    Best-effort: a per-subscription enqueue failure (e.g. a subscription deactivated
+    between the listing and the enqueue) is logged and skipped, and the function never
+    raises, so a notification problem cannot break the refresh it describes.
+
+    Args:
+        db: The database handle exposing ``list_active_push_webhook_subscription_ids``
+            and ``enqueue_push_webhook_delivery``.
+        tenant_id: Owning tenant id (notification + subscription scope).
+        repository_id: The repository whose file was refreshed.
+        branch: The branch the file was refreshed on.
+        path: The repository-relative file path.
+        trigger: What initiated the cycle (:class:`RefreshTrigger`).
+        outcome: What the cycle produced (:class:`RefreshOutcome`).
+        preferences: The recipient's toggles; defaults (all on) when ``None``.
+        project_id: The catalog project the refresh targets, when known.
+        version_id: The new version created by the refresh (RAR-4.2), when any.
+        parent_version_id: The prior version the refresh supersedes, when any.
+        change_report_id: The change report documenting the diff (RAR-4.3), when any.
+        source_commit_sha: The remote commit SHA that triggered the refresh.
+        error: A short error message, for a failed cycle.
+        extra: Optional additional structured context for the payload.
+
+    Returns:
+        The list of enqueued delivery-event ids (empty when the outcome did not notify
+        or no active subscription exists).
+
+    Raises:
+        TypeError: If ``trigger`` or ``outcome`` is not the matching enum type
+            (a programming error, surfaced at call time).
+    """
+    if not isinstance(trigger, RefreshTrigger):
+        raise TypeError(f"trigger must be a RefreshTrigger, got {type(trigger).__name__}")
+    if not isinstance(outcome, RefreshOutcome):
+        raise TypeError(f"outcome must be a RefreshOutcome, got {type(outcome).__name__}")
+
+    if not should_notify(outcome, preferences):
+        return []
+
+    payload = build_refresh_notification(
+        trigger=trigger,
+        outcome=outcome,
+        repository_id=repository_id,
+        branch=branch,
+        path=path,
+        project_id=project_id,
+        version_id=version_id,
+        parent_version_id=parent_version_id,
+        change_report_id=change_report_id,
+        source_commit_sha=source_commit_sha,
+        error=error,
+        extra=extra,
+    )
+    event_type = payload["event"]
+
+    try:
+        subscription_ids = db.list_active_push_webhook_subscription_ids(tenant_id)
+    except Exception:
+        logger.exception(
+            "refresh-notification fan-out: failed to list subscriptions for tenant %s",
+            tenant_id,
+        )
+        return []
+
+    enqueued: List[str] = []
+    for subscription_id in subscription_ids:
+        try:
+            row = db.enqueue_push_webhook_delivery(
+                tenant_id,
+                subscription_id,
+                event_type,
+                payload,
+            )
+            event_id = _clean_str(row.get("id")) if isinstance(row, Mapping) else None
+            if event_id is not None:
+                enqueued.append(event_id)
+        except Exception:
+            # A subscription may have been deactivated/deleted between the listing and
+            # the enqueue; skip it rather than fail the whole fan-out.
+            logger.exception(
+                "refresh-notification fan-out: failed to enqueue %s for subscription %s",
+                event_type,
+                subscription_id,
+            )
+    return enqueued

--- a/objectified-rest/tests/test_repository_refresh_notifications.py
+++ b/objectified-rest/tests/test_repository_refresh_notifications.py
@@ -1,0 +1,349 @@
+"""Refresh-cycle notification tests (RAR-5.4, #3535).
+
+Deterministic, DB-free fixtures over ``app.repository_refresh_notifications`` using a
+fake ``Database`` that captures the active-subscription listing and the
+``enqueue_push_webhook_delivery`` fan-out. Covers both acceptance criteria —
+*notifications fire on new-version / divergence / failure refresh outcomes* and
+*notification preferences honored; links to the change report / review action* —
+plus the notifiability rule (``unchanged`` is silent), payload assembly, the
+preference parser, best-effort fan-out, and enum guarding.
+"""
+
+import pytest
+
+from app.repository_refresh_audit import RefreshOutcome, RefreshTrigger
+from app.repository_refresh_notifications import (
+    EVENT_TYPE_BY_OUTCOME,
+    NOTIFIABLE_OUTCOMES,
+    RefreshNotificationPreferences,
+    build_refresh_notification,
+    build_review_href,
+    notify_refresh_outcome,
+    should_notify,
+)
+
+
+class FakeDB:
+    """Captures the subscription listing and each ``enqueue_push_webhook_delivery`` call."""
+
+    def __init__(self, subscription_ids=None, *, list_raises=False, enqueue_fail_ids=()):
+        self._subscription_ids = list(subscription_ids or [])
+        self._list_raises = list_raises
+        self._enqueue_fail_ids = set(enqueue_fail_ids)
+        self.list_calls = []
+        self.enqueue_calls = []
+
+    def list_active_push_webhook_subscription_ids(self, tenant_id):
+        self.list_calls.append(tenant_id)
+        if self._list_raises:
+            raise RuntimeError("boom listing subscriptions")
+        return list(self._subscription_ids)
+
+    def enqueue_push_webhook_delivery(self, tenant_id, subscription_id, event_type, payload):
+        self.enqueue_calls.append(
+            {
+                "tenant_id": tenant_id,
+                "subscription_id": subscription_id,
+                "event_type": event_type,
+                "payload": payload,
+            }
+        )
+        if subscription_id in self._enqueue_fail_ids:
+            raise ValueError("subscription_inactive")
+        return {"id": f"evt-{subscription_id}"}
+
+
+# --------------------------------------------------------------- should_notify
+
+
+def test_notifiable_outcomes_are_the_three_interesting_ones():
+    assert NOTIFIABLE_OUTCOMES == frozenset(
+        {RefreshOutcome.NEW_VERSION, RefreshOutcome.DIVERGED, RefreshOutcome.FAILED}
+    )
+    # Every notifiable outcome has an event type, and unchanged has none.
+    assert set(EVENT_TYPE_BY_OUTCOME) == NOTIFIABLE_OUTCOMES
+    assert RefreshOutcome.UNCHANGED not in EVENT_TYPE_BY_OUTCOME
+
+
+@pytest.mark.parametrize(
+    "outcome",
+    [RefreshOutcome.NEW_VERSION, RefreshOutcome.DIVERGED, RefreshOutcome.FAILED],
+)
+def test_should_notify_true_for_notifiable_outcomes_by_default(outcome):
+    assert should_notify(outcome) is True
+
+
+def test_should_notify_false_for_unchanged():
+    assert should_notify(RefreshOutcome.UNCHANGED) is False
+    # Even with all toggles on, unchanged never notifies.
+    assert should_notify(RefreshOutcome.UNCHANGED, RefreshNotificationPreferences()) is False
+
+
+def test_should_notify_respects_each_muted_toggle():
+    prefs = RefreshNotificationPreferences(
+        notify_new_version=False, notify_diverged=False, notify_failed=False
+    )
+    assert should_notify(RefreshOutcome.NEW_VERSION, prefs) is False
+    assert should_notify(RefreshOutcome.DIVERGED, prefs) is False
+    assert should_notify(RefreshOutcome.FAILED, prefs) is False
+
+
+def test_should_notify_independent_toggles():
+    # Mute only divergence; the other two still fire.
+    prefs = RefreshNotificationPreferences(notify_diverged=False)
+    assert should_notify(RefreshOutcome.NEW_VERSION, prefs) is True
+    assert should_notify(RefreshOutcome.DIVERGED, prefs) is False
+    assert should_notify(RefreshOutcome.FAILED, prefs) is True
+
+
+# --------------------------------------------------- preference parsing
+
+
+def test_preferences_from_none_is_all_on():
+    prefs = RefreshNotificationPreferences.from_mapping(None)
+    assert prefs == RefreshNotificationPreferences(True, True, True)
+
+
+def test_preferences_from_empty_is_all_on():
+    assert RefreshNotificationPreferences.from_mapping({}) == RefreshNotificationPreferences()
+
+
+def test_preferences_partial_blob_fails_open():
+    # Only the failed toggle is set; the rest keep their default (on).
+    prefs = RefreshNotificationPreferences.from_mapping({"notify_failed": False})
+    assert prefs.notify_new_version is True
+    assert prefs.notify_diverged is True
+    assert prefs.notify_failed is False
+
+
+def test_preferences_accepts_repo12_5_aliases():
+    prefs = RefreshNotificationPreferences.from_mapping(
+        {
+            "refresh_new_version": False,
+            "refresh_diverged": True,
+            "refresh_failed": False,
+        }
+    )
+    assert prefs.notify_new_version is False
+    assert prefs.notify_diverged is True
+    assert prefs.notify_failed is False
+
+
+def test_preferences_none_value_keeps_default():
+    # An explicit null in the blob is treated as "unset" → default on.
+    prefs = RefreshNotificationPreferences.from_mapping({"notify_failed": None})
+    assert prefs.notify_failed is True
+
+
+# ------------------------------------------------------ build_review_href
+
+
+def test_build_review_href_matches_ui_convention():
+    href = build_review_href("repo-1", "main", "specs/api.yaml")
+    assert href == (
+        "/ade/dashboard/repositories/repo-1/preview?tab=files&path=specs%2Fapi.yaml&branch=main"
+    )
+
+
+def test_build_review_href_url_encodes_repository_id():
+    href = build_review_href("a/b id", "main", "x.yaml")
+    assert href.startswith("/ade/dashboard/repositories/a%2Fb%20id/preview?")
+
+
+def test_build_review_href_none_without_repository():
+    assert build_review_href("", "main", "x.yaml") is None
+    assert build_review_href(None, "main", "x.yaml") is None
+
+
+def test_build_review_href_omits_blank_path_and_branch():
+    href = build_review_href("repo-1", "", "")
+    assert href == "/ade/dashboard/repositories/repo-1/preview?tab=files"
+
+
+# -------------------------------------------------- build_refresh_notification
+
+
+def test_build_notification_new_version_full_payload():
+    payload = build_refresh_notification(
+        trigger=RefreshTrigger.SCHEDULED,
+        outcome=RefreshOutcome.NEW_VERSION,
+        repository_id="repo-1",
+        branch="main",
+        path="specs/api.yaml",
+        project_id="proj-1",
+        version_id="ver-2",
+        parent_version_id="ver-1",
+        change_report_id="cr-9",
+        source_commit_sha="abc123",
+    )
+    assert payload["event"] == "repository.refresh.new_version"
+    assert payload["trigger"] == "scheduled"
+    assert payload["outcome"] == "new-version"
+    assert payload["repositoryId"] == "repo-1"
+    assert payload["branch"] == "main"
+    assert payload["path"] == "specs/api.yaml"
+    assert payload["projectId"] == "proj-1"
+    assert payload["versionId"] == "ver-2"
+    assert payload["parentVersionId"] == "ver-1"
+    # Links to the change report (id) and the review action (href).
+    assert payload["changeReportId"] == "cr-9"
+    assert payload["sourceCommitSha"] == "abc123"
+    assert payload["reviewHref"] == (
+        "/ade/dashboard/repositories/repo-1/preview?tab=files&path=specs%2Fapi.yaml&branch=main"
+    )
+
+
+def test_build_notification_failed_carries_error_and_no_empty_links():
+    payload = build_refresh_notification(
+        trigger=RefreshTrigger.MANUAL,
+        outcome=RefreshOutcome.FAILED,
+        repository_id="repo-1",
+        branch="main",
+        path="specs/api.yaml",
+        error="parse error at line 3",
+    )
+    assert payload["event"] == "repository.refresh.failed"
+    assert payload["outcome"] == "failed"
+    assert payload["error"] == "parse error at line 3"
+    # A failed cycle has no version / change report — those keys are omitted, not null.
+    for absent in ("versionId", "parentVersionId", "changeReportId", "projectId", "sourceCommitSha"):
+        assert absent not in payload
+    # The review action link is still present so the recipient can investigate.
+    assert "reviewHref" in payload
+
+
+def test_build_notification_diverged_event_type():
+    payload = build_refresh_notification(
+        trigger=RefreshTrigger.WEBHOOK,
+        outcome=RefreshOutcome.DIVERGED,
+        repository_id="repo-1",
+        branch="main",
+        path="x.yaml",
+    )
+    assert payload["event"] == "repository.refresh.diverged"
+    assert payload["outcome"] == "diverged"
+
+
+def test_build_notification_extra_does_not_override_reserved_keys():
+    payload = build_refresh_notification(
+        trigger=RefreshTrigger.SCHEDULED,
+        outcome=RefreshOutcome.NEW_VERSION,
+        repository_id="repo-1",
+        branch="main",
+        path="x.yaml",
+        extra={"outcome": "hacked", "custom": "kept"},
+    )
+    assert payload["outcome"] == "new-version"  # reserved key wins
+    assert payload["custom"] == "kept"
+
+
+def test_build_notification_rejects_non_notifiable_outcome():
+    with pytest.raises(ValueError):
+        build_refresh_notification(
+            trigger=RefreshTrigger.SCHEDULED,
+            outcome=RefreshOutcome.UNCHANGED,
+            repository_id="repo-1",
+            branch="main",
+            path="x.yaml",
+        )
+
+
+def test_build_notification_enum_guarding():
+    with pytest.raises(TypeError):
+        build_refresh_notification(
+            trigger="scheduled",
+            outcome=RefreshOutcome.NEW_VERSION,
+            repository_id="repo-1",
+            branch="main",
+            path="x.yaml",
+        )
+    with pytest.raises(TypeError):
+        build_refresh_notification(
+            trigger=RefreshTrigger.SCHEDULED,
+            outcome="new-version",
+            repository_id="repo-1",
+            branch="main",
+            path="x.yaml",
+        )
+
+
+# ----------------------------------------------------- notify_refresh_outcome
+
+
+def _notify(db, outcome, **kwargs):
+    return notify_refresh_outcome(
+        db,
+        tenant_id="tenant-1",
+        repository_id="repo-1",
+        branch="main",
+        path="specs/api.yaml",
+        trigger=RefreshTrigger.SCHEDULED,
+        outcome=outcome,
+        **kwargs,
+    )
+
+
+def test_notify_fans_out_one_delivery_per_active_subscription():
+    db = FakeDB(["sub-a", "sub-b"])
+    event_ids = _notify(db, RefreshOutcome.NEW_VERSION)
+
+    assert event_ids == ["evt-sub-a", "evt-sub-b"]
+    assert db.list_calls == ["tenant-1"]
+    assert [c["subscription_id"] for c in db.enqueue_calls] == ["sub-a", "sub-b"]
+    # Every enqueue carries the same tenant, event type, and payload.
+    for call in db.enqueue_calls:
+        assert call["tenant_id"] == "tenant-1"
+        assert call["event_type"] == "repository.refresh.new_version"
+        assert call["payload"]["outcome"] == "new-version"
+        assert call["payload"]["reviewHref"].startswith("/ade/dashboard/repositories/repo-1/")
+
+
+def test_notify_unchanged_is_silent():
+    db = FakeDB(["sub-a"])
+    assert _notify(db, RefreshOutcome.UNCHANGED) == []
+    # No subscriptions are even listed for a silent outcome.
+    assert db.list_calls == []
+    assert db.enqueue_calls == []
+
+
+def test_notify_muted_preference_enqueues_nothing():
+    db = FakeDB(["sub-a"])
+    prefs = RefreshNotificationPreferences(notify_failed=False)
+    assert _notify(db, RefreshOutcome.FAILED, preferences=prefs) == []
+    assert db.enqueue_calls == []
+
+
+def test_notify_no_active_subscriptions_returns_empty():
+    db = FakeDB([])
+    assert _notify(db, RefreshOutcome.FAILED) == []
+    assert db.list_calls == ["tenant-1"]
+    assert db.enqueue_calls == []
+
+
+def test_notify_best_effort_when_listing_raises():
+    db = FakeDB(["sub-a"], list_raises=True)
+    # Listing blows up but the call must not raise.
+    assert _notify(db, RefreshOutcome.NEW_VERSION) == []
+    assert db.enqueue_calls == []
+
+
+def test_notify_skips_failed_enqueue_but_continues():
+    db = FakeDB(["sub-a", "sub-b", "sub-c"], enqueue_fail_ids={"sub-b"})
+    event_ids = _notify(db, RefreshOutcome.DIVERGED)
+    # sub-b failed; sub-a and sub-c still delivered.
+    assert event_ids == ["evt-sub-a", "evt-sub-c"]
+    assert [c["subscription_id"] for c in db.enqueue_calls] == ["sub-a", "sub-b", "sub-c"]
+
+
+def test_notify_enum_guarding():
+    db = FakeDB(["sub-a"])
+    with pytest.raises(TypeError):
+        notify_refresh_outcome(
+            db,
+            tenant_id="tenant-1",
+            repository_id="repo-1",
+            branch="main",
+            path="x.yaml",
+            trigger="scheduled",
+            outcome=RefreshOutcome.NEW_VERSION,
+        )


### PR DESCRIPTION
## What & why

RAR-5.4 (#3535, epic #3510). Stakeholders need to know when an auto-refresh cycle **changes** something — without watching a dashboard. This extends the REPO-12.5 (#2954) failure notifications to the auto-refresh loop:

```
refresh outcome ──► notify { new_version | diverged | failed } via existing channels
```

New objectified-rest module `app/repository_refresh_notifications.py`:

- **Fires on the three interesting outcomes only** — `new-version` (RAR-4.2), `diverged` (RAR-4.4 hold), `failed` — each under a namespaced push-webhook event type (`repository.refresh.new_version` / `.diverged` / `.failed`). An `unchanged` no-op (RAR-2.4) is intentionally **silent**, keeping the channels quiet in the common case.
- **Honors preferences** — `RefreshNotificationPreferences` gives each notifiable outcome an independent toggle (all on by default, mirroring REPO-12.5's `auto_import_failed` / `auto_import_breaking`). `from_mapping` parses a stored blob tolerantly (accepts the `user_settings.notifications.repository` aliases and **fails open** on partial/malformed data); a muted outcome enqueues nothing.
- **Links to the change report / review action** — every payload carries a `reviewHref` deep-link (mirroring the RAR-5.1 `repositorySpecReviewHref` convention) plus the `versionId` / `changeReportId` (RAR-4.2/4.3) that resolve the change report.
- **Delivers over the existing channels** — fans out one delivery per active tenant push-webhook subscription (`odb.push_webhook_subscriptions` / `push_webhook_delivery_events`, #2587/#2588) via the new DAO `list_active_push_webhook_subscription_ids`. Fan-out is **best-effort**: a per-subscription enqueue failure is logged and skipped and the function never raises, so a notification problem cannot break the refresh it describes.

Reuses the `RefreshOutcome` / `RefreshTrigger` vocabulary from the RAR-5.3 audit module so a received notification and a history row describe the same cycle in the same terms. **No migration; objectified-rest only.** Invoking `notify_refresh_outcome(...)` from the EPIC-4 dispatcher is deferred to dispatcher wiring, mirroring how RAR-4.x and RAR-5.3 deferred theirs.

## How to test

```
cd objectified-rest && source .venv/bin/activate
python -m pytest tests/test_repository_refresh_notifications.py -q
```

29 new tests cover: the notifiability rule, per-outcome and per-toggle gating, preference parsing (aliases / partial / null), payload assembly + review-href URL-encoding, fan-out across subscriptions, silent/muted/no-subscription short-circuits, best-effort skip-on-error, and enum guarding.

## Risk / notes

- Additive: a new pure module, one new read-only DAO, no schema or route change, no OpenAPI change.
- The 18 pre-existing failures in the broader suite (merge / publish / change-report-template / draft-lock — DB/JWT-dependent) reproduce on `main` and are unrelated to this change.
- Producer wiring into the refresh dispatcher is intentionally deferred (consistent with the RAR-4.x / RAR-5.3 pattern).

Closes #3535

Work performed by Claude Code via model Opus 4.8 (1M context)

🤖 Generated with [Claude Code](https://claude.com/claude-code)