### PR TITLE
Fix #3446 - Provision separate registry database & connection

### DIFF
--- a/docker-compose.env.example
+++ b/docker-compose.env.example
@@ -1,9 +1,13 @@
 # Copy to `.env` in the repo root (same directory as docker-compose.yml) to override defaults.
 
-# Postgres (must match across postgres / migrate / mcp)
+# Postgres (must match across postgres / migrate / types-migrate / mcp)
 # POSTGRES_USER=postgres
 # POSTGRES_PASSWORD=objectified_local_dev
 # POSTGRES_DB=objectified
+
+# Separate type-registry database (objectified-types-db), provisioned and migrated by the
+# types-migrate service on the same Postgres instance. Override the database name here.
+# OBJECTIFIED_TYPES_DB=objectified-types-db
 
 # Host port mapping (optional)
 # POSTGRES_PUBLISH_PORT=5432

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,29 @@ services:
     networks:
       - objectified-mcp
 
+  # Provisions the separate type-registry database (objectified-types-db) on the same
+  # Postgres instance and applies its registry-scripts/ migrations. `registry migrate`
+  # self-provisions: it creates the database from the `postgres` maintenance database
+  # if absent, then migrates it. Independent of the core `migrate` service above.
+  types-migrate:
+    build:
+      context: ./objectified-db
+      dockerfile: Dockerfile
+    command: ["registry", "migrate"]
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-objectified_local_dev}
+      POSTGRES_HOST: postgres
+      POSTGRES_PORT: "5432"
+      POSTGRES_DB: ${POSTGRES_DB:-objectified}
+      OBJECTIFIED_TYPES_DB: ${OBJECTIFIED_TYPES_DB:-objectified-types-db}
+    depends_on:
+      postgres:
+        condition: service_healthy
+    restart: "no"
+    networks:
+      - objectified-mcp
+
   mcp:
     build:
       context: .

--- a/docs/ROADMAP_TYPE_REGISTRY_GOVERNANCE.md
+++ b/docs/ROADMAP_TYPE_REGISTRY_GOVERNANCE.md
@@ -220,12 +220,19 @@ erDiagram
 
 | Issue | Title | Summary | Labels | Parallel | MVP | Complexity | Affected Modules |
 |---|---|---|---|:---:|:---:|---|---|
-| 1.1 #3446 | Provision separate registry database & connection | Stand up `objectified-types-db` + connection/pool config | `type-registry`,`types-db`,`mvp`,`roadmap-type-registry` | N | Y | M | objectified-db, objectified-rest |
+| 1.1 #3446 | ~~Provision separate registry database & connection~~ ✅ **Done** | Stand up `objectified-types-db` + connection/pool config | `type-registry`,`types-db`,`mvp`,`roadmap-type-registry` | N | Y | M | objectified-db, objectified-rest |
 | 1.2 #3447 | Core registry schema (namespaces, types, refs) | Migrations for `type_namespace`, `type_definition`, `type_ref` | `type-registry`,`types-db`,`mvp`,`roadmap-type-registry` | N | Y | M | objectified-db |
 | 1.3 #3448 | Import & binding tables | `type_import` records + property↔type binding link model | `type-registry`,`types-db`,`import`,`mvp`,`roadmap-type-registry` | Y | Y | M | objectified-db |
 | 1.4 #3449 | Seed core system types (`std/v0`) | Seed 8 primitives + std types (date, uuid, money, …) as system-core | `type-registry`,`registry`,`mvp`,`roadmap-type-registry` | Y | Y | M | objectified-db, objectified-rest |
 
-### Issue 1.1 — Provision separate registry database & connection
+### Issue 1.1 — Provision separate registry database & connection ✅ Done (#3446)
+- **Delivered.** Separate logical database `objectified-types-db` (its own `otr` schema)
+  provisioned on the core Postgres instance. `objectified-db` gained a `registry` command
+  group (`provision` / `migrate` / `migrate status` / `ping`) with an independent
+  `registry-scripts/` migration directory; docker-compose adds a `types-migrate` service that
+  self-provisions and migrates it. `objectified-rest` connects to it independently
+  (`registry_database.py`, `OBJECTIFIED_TYPES_DB` / `OBJECTIFIED_TYPES_DB_URL`) and `GET /health`
+  reports its status. Existing `/v1/primitives` (`odb.primitives`) is untouched.
 - **Problem.** The registry must live in its own database (`objectified-types-db`), separate
   from `objectified-db`, per the Settings mockup and conversation.
 - **Solution/Scope.** Add the new database (docker-compose service + env), a dedicated

--- a/objectified-db/Dockerfile
+++ b/objectified-db/Dockerfile
@@ -23,6 +23,7 @@ COPY package.json ./
 COPY --from=build /app/dist ./dist
 COPY --from=build /app/node_modules ./node_modules
 COPY scripts ./scripts/
+COPY registry-scripts ./registry-scripts/
 
 # Default: apply pending migrations (override with users, tenants, ping, etc.)
 ENTRYPOINT ["node", "dist/cli.js"]

--- a/objectified-db/README.md
+++ b/objectified-db/README.md
@@ -64,6 +64,14 @@ objectified-db ping                         Verify the database connection
 migrate [--dry-run] [--scripts-dir <path>]  Apply pending SQL migrations
 migrate status [--scripts-dir <path>]       List applied / pending migrations
 
+registry provision [--registry-database <name>]
+                                            Create the registry database if absent
+registry migrate [--dry-run] [--registry-database <name>] [--scripts-dir <path>]
+                                            Provision (if needed) + apply registry migrations
+registry migrate status [--registry-database <name>] [--scripts-dir <path>]
+                                            List applied / pending registry migrations
+registry ping [--registry-database <name>]  Verify the registry database connection
+
 users create   --name --email (--password | --password-stdin | --random-password)
                                             [--unverified] [--disabled]
 users list     [--all]
@@ -110,6 +118,13 @@ objectified-db migrate
 objectified-db migrate status
 objectified-db migrate --dry-run
 
+# Stand up the separate type-registry database (objectified-types-db) and migrate it.
+# Reuses the same connection flags/env; only the database name differs
+# (override with --registry-database or OBJECTIFIED_TYPES_DB).
+objectified-db registry migrate          # provisions the DB (if absent) then applies registry-scripts/
+objectified-db registry migrate status
+objectified-db registry ping
+
 # Create a user with a generated password (printed once)
 objectified-db users create --name "Ada Lovelace" --email ada@example.com --random-password
 
@@ -129,7 +144,23 @@ objectified-db --yes api-keys revoke sk_265e18808...
 
 ### Notes
 
-- All tables are addressed in the `odb` schema (`odb.users`, `odb.tenants`, `odb.api_keys`, …),
-  matching `objectified-rest`.
+- All core tables are addressed in the `odb` schema (`odb.users`, `odb.tenants`, `odb.api_keys`,
+  …), matching `objectified-rest`.
 - `api-keys create` writes `created_by_user_id` when the column exists and transparently falls
   back for older databases (same behavior as the REST service).
+
+### Type registry database (`objectified-types-db`)
+
+The JSON Schema type registry lives in a **separate database** so its namespaces, type
+definitions, and `$ref` edges never share tables with the core ADE schema (`odb`). Registry
+tables are created in the `otr` schema by migrations under
+[`registry-scripts/`](./registry-scripts), tracked independently from the core
+[`scripts/`](./scripts) (each database keeps its own `schema_evolution_manager.scripts`).
+
+- `registry migrate` connects to the **same** Postgres server using the global connection
+  flags/env, then provisions the registry database (issuing `CREATE DATABASE` from the
+  `postgres` maintenance database if absent) and applies pending registry migrations.
+- The registry database name resolves from `--registry-database` → `OBJECTIFIED_TYPES_DB`
+  env → `objectified-types-db` (default). To place the registry on a *different* server, set
+  `OBJECTIFIED_TYPES_DB_URL` to a full connection string.
+- This is ticket #3446 (foundation); the registry entity tables arrive in #3447.

--- a/objectified-db/package.json
+++ b/objectified-db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-db",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Objectified database migrations and the direct-to-database admin CLI (objectified-db).",
   "author": "Objectified",
   "type": "module",
@@ -9,7 +9,8 @@
   "files": [
     "/bin",
     "/dist",
-    "/scripts"
+    "/scripts",
+    "/registry-scripts"
   ],
   "scripts": {
     "build": "tsc -p tsconfig.json",

--- a/objectified-db/registry-scripts/20260622-200000.sql
+++ b/objectified-db/registry-scripts/20260622-200000.sql
@@ -1,0 +1,12 @@
+-- Type-registry baseline (#3446, ROADMAP_TYPE_REGISTRY_GOVERNANCE.md §1.1).
+--
+-- Provisions the schema namespace for the separate registry database
+-- (objectified-types-db). Registry entity tables — type_namespace,
+-- type_definition, type_ref — arrive in ticket #3447 (1.2) and are created
+-- inside this `otr` schema. The core ADE schema (`odb`) lives in a different
+-- database and is never referenced here (no cross-database foreign keys).
+
+CREATE SCHEMA IF NOT EXISTS otr;
+
+COMMENT ON SCHEMA otr IS
+  'Objectified Type Registry: namespaces, type definitions, and $ref edges (objectified-types-db).';

--- a/objectified-db/src/cli.ts
+++ b/objectified-db/src/cli.ts
@@ -15,6 +15,7 @@ import { Command, CommanderError } from "commander";
 import { runInteractiveRepl } from "./lib/interactive/repl.js";
 import * as apikeys from "./commands/apikeys.js";
 import * as migrate from "./commands/migrate.js";
+import * as registry from "./commands/registry.js";
 import * as tenants from "./commands/tenants.js";
 import * as users from "./commands/users.js";
 import { type ConnectionOptions, describeConnection, withClient } from "./db.js";
@@ -140,6 +141,69 @@ migrateCmd
         { scriptsDir: opts.scriptsDir },
         modeOf(g),
       ),
+    );
+  });
+
+// ──────────────────────────── registry ───────────────────────────
+// Separate type-registry database (objectified-types-db). Reuses the global
+// connection flags/env for host/port/user/password; only the database name
+// changes (override with --registry-database / OBJECTIFIED_TYPES_DB).
+const registryCmd = program
+  .command("registry")
+  .description("Provision and migrate the separate type-registry database (objectified-types-db)");
+
+registryCmd
+  .command("provision")
+  .description("Create the registry database if it does not exist")
+  .option("--registry-database <name>", "Registry database name (env: OBJECTIFIED_TYPES_DB; default objectified-types-db)")
+  .action(async (opts, cmd: Command) => {
+    const g = cmd.optsWithGlobals() as GlobalOpts;
+    await registry.runRegistryProvision(
+      connectionOf(g),
+      { registryDatabase: opts.registryDatabase },
+      modeOf(g),
+    );
+  });
+
+const registryMigrateCmd = registryCmd
+  .command("migrate")
+  .description("Provision (if needed) and apply pending registry migrations from registry-scripts/")
+  .option("--registry-database <name>", "Registry database name (env: OBJECTIFIED_TYPES_DB; default objectified-types-db)")
+  .option("--scripts-dir <path>", "Directory containing *.sql migrations (default: package registry-scripts/)")
+  .option("--dry-run", "Print pending scripts without applying them", false)
+  .action(async (opts, cmd: Command) => {
+    const g = cmd.optsWithGlobals() as GlobalOpts;
+    await registry.runRegistryMigrate(
+      connectionOf(g),
+      { registryDatabase: opts.registryDatabase, scriptsDir: opts.scriptsDir, dryRun: Boolean(opts.dryRun) },
+      modeOf(g),
+    );
+  });
+
+registryMigrateCmd
+  .command("status")
+  .description("List applied and pending registry migration scripts")
+  .option("--registry-database <name>", "Registry database name (env: OBJECTIFIED_TYPES_DB; default objectified-types-db)")
+  .option("--scripts-dir <path>", "Directory containing *.sql migrations (default: package registry-scripts/)")
+  .action(async (opts, cmd: Command) => {
+    const g = cmd.optsWithGlobals() as GlobalOpts;
+    await registry.runRegistryMigrateStatus(
+      connectionOf(g),
+      { registryDatabase: opts.registryDatabase, scriptsDir: opts.scriptsDir },
+      modeOf(g),
+    );
+  });
+
+registryCmd
+  .command("ping")
+  .description("Verify the registry database connection")
+  .option("--registry-database <name>", "Registry database name (env: OBJECTIFIED_TYPES_DB; default objectified-types-db)")
+  .action(async (opts, cmd: Command) => {
+    const g = cmd.optsWithGlobals() as GlobalOpts;
+    await registry.runRegistryPing(
+      connectionOf(g),
+      { registryDatabase: opts.registryDatabase },
+      modeOf(g),
     );
   });
 

--- a/objectified-db/src/commands/registry.ts
+++ b/objectified-db/src/commands/registry.ts
@@ -1,0 +1,149 @@
+/**
+ * `registry` command group — manage the separate type-registry database
+ * (`objectified-types-db`): provision it, apply its migrations, and verify connectivity.
+ *
+ * The migration machinery is shared with the core database (see migrate.ts); only the
+ * target connection and scripts directory differ. See registry.ts and #3446.
+ */
+
+import {
+  applyPendingMigrations,
+  getMigrationStatus,
+} from "../migrate.js";
+import {
+  type ConnectionOptions,
+  describeConnection,
+  withClient,
+} from "../db.js";
+import {
+  defaultRegistryScriptsDir,
+  ensureRegistryDatabase,
+  maintenanceConnection,
+  registryConnection,
+  resolveRegistryDatabaseName,
+} from "../registry.js";
+import type { OutputMode } from "../output.js";
+import { note, printRecord, printRows } from "../output.js";
+
+export type RegistryOptions = {
+  registryDatabase?: string;
+  scriptsDir?: string;
+  dryRun?: boolean;
+};
+
+/**
+ * Create the registry database if it does not already exist.
+ *
+ * @param base Base connection (host/port/user/password) — the database is overridden to
+ *             the maintenance database to run `CREATE DATABASE`.
+ */
+export async function runRegistryProvision(
+  base: ConnectionOptions,
+  opts: RegistryOptions,
+  mode: OutputMode,
+): Promise<void> {
+  const database = resolveRegistryDatabaseName(opts.registryDatabase);
+  const result = await withClient(maintenanceConnection(base), (client) =>
+    ensureRegistryDatabase(client, database),
+  );
+
+  if (mode.json) {
+    printRecord(mode, result);
+    return;
+  }
+  note(
+    result.created
+      ? `Created registry database "${result.database}".`
+      : `Registry database "${result.database}" already exists.`,
+  );
+}
+
+/**
+ * Apply pending registry migrations, provisioning the database first if needed so a single
+ * command takes a fresh server all the way to a migrated registry database.
+ */
+export async function runRegistryMigrate(
+  base: ConnectionOptions,
+  opts: RegistryOptions,
+  mode: OutputMode,
+): Promise<void> {
+  const database = resolveRegistryDatabaseName(opts.registryDatabase);
+  const scriptsDir = opts.scriptsDir ?? defaultRegistryScriptsDir();
+
+  // Ensure the database exists before connecting to it (skipped on --dry-run, which is read-only).
+  if (!opts.dryRun) {
+    await withClient(maintenanceConnection(base), (client) =>
+      ensureRegistryDatabase(client, database),
+    );
+  }
+
+  const result = await withClient(registryConnection(base, opts.registryDatabase), (client) =>
+    applyPendingMigrations(client, { scriptsDir, dryRun: opts.dryRun }),
+  );
+
+  if (mode.json) {
+    printRecord(mode, { database, scriptsDir, ...result });
+    return;
+  }
+
+  if (result.dryRun) {
+    if (result.applied.length === 0) {
+      note("Dry run: no pending registry migrations.");
+    } else {
+      note("Dry run: would apply:");
+      for (const f of result.applied) note(`  ${f}`);
+    }
+    return;
+  }
+
+  if (result.applied.length === 0) {
+    note("All registry scripts have been previously applied.");
+    return;
+  }
+
+  note(`Applied ${result.applied.length} registry migration(s) to "${database}":`);
+  for (const f of result.applied) note(`  ${f}`);
+}
+
+/** List applied and pending registry migration scripts (read-only; does not provision). */
+export async function runRegistryMigrateStatus(
+  base: ConnectionOptions,
+  opts: RegistryOptions,
+  mode: OutputMode,
+): Promise<void> {
+  const scriptsDir = opts.scriptsDir ?? defaultRegistryScriptsDir();
+  const status = await withClient(registryConnection(base, opts.registryDatabase), (client) =>
+    getMigrationStatus(client, scriptsDir),
+  );
+
+  if (mode.json) {
+    printRecord(mode, status);
+    return;
+  }
+
+  note(`Registry migrations directory: ${status.scriptsDir}`);
+  note(`Applied: ${status.applied.length} · Pending: ${status.pending.length}`);
+  if (status.pending.length > 0) {
+    printRows(
+      mode,
+      status.pending.map((filename) => ({ filename })),
+      [{ key: "filename", label: "filename" }],
+    );
+  }
+  if (status.applied.length > 0 && status.pending.length === 0) {
+    note("All registry scripts have been previously applied.");
+  }
+}
+
+/** Verify connectivity to the registry database. */
+export async function runRegistryPing(
+  base: ConnectionOptions,
+  opts: RegistryOptions,
+  mode: OutputMode,
+): Promise<void> {
+  const conn = registryConnection(base, opts.registryDatabase);
+  await withClient(conn, async (client) => {
+    await client.query("SELECT 1");
+    printRecord(mode, { status: "ok", target: describeConnection(conn) });
+  });
+}

--- a/objectified-db/src/db.ts
+++ b/objectified-db/src/db.ts
@@ -33,6 +33,45 @@ function buildPgConfig(opts: ConnectionOptions): pg.ClientConfig {
   };
 }
 
+/**
+ * Return a copy of `opts` pointed at a different database on the *same* server.
+ *
+ * This is the basis for talking to the separate registry database
+ * (`objectified-types-db`) and to the `postgres` maintenance database (needed to
+ * `CREATE DATABASE`) while reusing the operator's host/port/user/password.
+ *
+ * It deliberately mirrors the connection resolution in {@link buildPgConfig}: a
+ * connection string (flag or `OBJECTIFIED_DB_URL`/`DATABASE_URL` env) wins, so
+ * when one is present we rewrite its path segment; otherwise we override the
+ * discrete `database` field and let env/defaults fill the rest.
+ *
+ * @param opts     Base connection options.
+ * @param database Target database name (used verbatim as the connection database).
+ * @returns        New `ConnectionOptions` selecting `database`.
+ */
+export function withDatabaseOverride(
+  opts: ConnectionOptions,
+  database: string,
+): ConnectionOptions {
+  const url = opts.databaseUrl ?? process.env.OBJECTIFIED_DB_URL ?? process.env.DATABASE_URL;
+  if (url && url.trim() !== "") {
+    try {
+      const u = new URL(url.trim());
+      u.pathname = `/${database}`;
+      return { databaseUrl: u.toString() };
+    } catch {
+      // Not a parseable URL — fall through to discrete-field override below.
+    }
+  }
+  return {
+    host: opts.host,
+    port: opts.port,
+    user: opts.user,
+    password: opts.password,
+    database,
+  };
+}
+
 /** Human-readable target (no secrets) for status output / errors. */
 export function describeConnection(opts: ConnectionOptions): string {
   const url = opts.databaseUrl ?? process.env.OBJECTIFIED_DB_URL ?? process.env.DATABASE_URL;

--- a/objectified-db/src/registry.ts
+++ b/objectified-db/src/registry.ts
@@ -1,0 +1,110 @@
+/**
+ * Connection resolution and provisioning for the **separate type-registry database**
+ * (`objectified-types-db`), kept apart from the core `objectified` database so the
+ * registry's namespaces / type definitions / `$ref` edges never share tables with the
+ * core ADE schema (`odb`). See docs/ROADMAP_TYPE_REGISTRY_GOVERNANCE.md §1.1 (#3446).
+ *
+ * The registry reuses the operator's host/port/user/password and only swaps the target
+ * database name. Migration files live in their own `registry-scripts/` directory and are
+ * tracked independently (each database keeps its own `schema_evolution_manager.scripts`).
+ */
+
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import type pg from "pg";
+
+import { type ConnectionOptions, withDatabaseOverride } from "./db.js";
+
+/** Default registry database name (overridable via `--registry-database` / `OBJECTIFIED_TYPES_DB`). */
+export const DEFAULT_REGISTRY_DATABASE = "objectified-types-db";
+
+/** The Postgres maintenance database used to issue `CREATE DATABASE`. */
+export const MAINTENANCE_DATABASE = "postgres";
+
+/** Package root (parent of dist/ at runtime), where `registry-scripts/` is shipped. */
+export function defaultRegistryScriptsDir(): string {
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  return path.join(here, "..", "registry-scripts");
+}
+
+/**
+ * Resolve the registry database name from (highest precedence first):
+ * an explicit option → `OBJECTIFIED_TYPES_DB` env → {@link DEFAULT_REGISTRY_DATABASE}.
+ */
+export function resolveRegistryDatabaseName(registryDatabase?: string): string {
+  const explicit = registryDatabase?.trim();
+  if (explicit) return explicit;
+  const fromEnv = process.env.OBJECTIFIED_TYPES_DB?.trim();
+  if (fromEnv) return fromEnv;
+  return DEFAULT_REGISTRY_DATABASE;
+}
+
+/**
+ * Build the connection options that target the registry database.
+ *
+ * A dedicated `OBJECTIFIED_TYPES_DB_URL` connection string, when set, takes precedence
+ * (allowing the registry to live on a different server entirely); otherwise the base
+ * connection is reused with only the database name overridden.
+ */
+export function registryConnection(
+  base: ConnectionOptions,
+  registryDatabase?: string,
+): ConnectionOptions {
+  const dedicatedUrl = process.env.OBJECTIFIED_TYPES_DB_URL?.trim();
+  if (dedicatedUrl) {
+    return { databaseUrl: dedicatedUrl };
+  }
+  return withDatabaseOverride(base, resolveRegistryDatabaseName(registryDatabase));
+}
+
+/**
+ * Build the connection options that target the maintenance database (`postgres`) on the
+ * same server as the registry, so `CREATE DATABASE` can run (you cannot create a database
+ * while connected to it).
+ */
+export function maintenanceConnection(base: ConnectionOptions): ConnectionOptions {
+  const dedicatedUrl = process.env.OBJECTIFIED_TYPES_DB_URL?.trim();
+  if (dedicatedUrl) {
+    return withDatabaseOverride({ databaseUrl: dedicatedUrl }, MAINTENANCE_DATABASE);
+  }
+  return withDatabaseOverride(base, MAINTENANCE_DATABASE);
+}
+
+/**
+ * Quote a SQL identifier (double-quote, doubling embedded quotes) so a database name with
+ * hyphens — e.g. `objectified-types-db` — is a legal `CREATE DATABASE` target.
+ */
+export function quoteIdentifier(name: string): string {
+  return `"${name.replace(/"/g, '""')}"`;
+}
+
+export type ProvisionResult = {
+  database: string;
+  created: boolean;
+};
+
+/**
+ * Ensure the registry database exists, creating it if absent. Must be called on a client
+ * connected to the maintenance database. Idempotent: returns `created: false` when the
+ * database was already present.
+ *
+ * `CREATE DATABASE` cannot run inside a transaction block, so this issues it directly.
+ *
+ * @param maintenanceClient Client connected to the `postgres` maintenance database.
+ * @param database          Registry database name to ensure.
+ * @returns                 Whether the database was newly created.
+ */
+export async function ensureRegistryDatabase(
+  maintenanceClient: pg.Client,
+  database: string,
+): Promise<ProvisionResult> {
+  const existing = await maintenanceClient.query("SELECT 1 FROM pg_database WHERE datname = $1", [
+    database,
+  ]);
+  if ((existing.rowCount ?? 0) > 0) {
+    return { database, created: false };
+  }
+  await maintenanceClient.query(`CREATE DATABASE ${quoteIdentifier(database)}`);
+  return { database, created: true };
+}

--- a/objectified-db/test/migrate.test.ts
+++ b/objectified-db/test/migrate.test.ts
@@ -37,4 +37,10 @@ describe("listMigrationFiles", () => {
     const sorted = [...files].sort();
     expect(files).toEqual(sorted);
   });
+
+  it("returns valid timestamped filenames from registry-scripts/", async () => {
+    const files = await listMigrationFiles(new URL("../registry-scripts", import.meta.url).pathname);
+    expect(files.length).toBeGreaterThan(0);
+    for (const f of files) expect(f).toMatch(/^\d{8}-\d{6}\.sql$/);
+  });
 });

--- a/objectified-db/test/registry.test.ts
+++ b/objectified-db/test/registry.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { withDatabaseOverride } from "../src/db.js";
+import {
+  DEFAULT_REGISTRY_DATABASE,
+  MAINTENANCE_DATABASE,
+  defaultRegistryScriptsDir,
+  ensureRegistryDatabase,
+  maintenanceConnection,
+  quoteIdentifier,
+  registryConnection,
+  resolveRegistryDatabaseName,
+} from "../src/registry.js";
+
+const ENV_KEYS = ["OBJECTIFIED_DB_URL", "DATABASE_URL", "OBJECTIFIED_TYPES_DB", "OBJECTIFIED_TYPES_DB_URL"];
+
+describe("registry connection resolution", () => {
+  let saved: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    saved = {};
+    for (const k of ENV_KEYS) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+  });
+
+  afterEach(() => {
+    for (const k of ENV_KEYS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  });
+
+  describe("resolveRegistryDatabaseName", () => {
+    it("defaults to objectified-types-db", () => {
+      expect(resolveRegistryDatabaseName()).toBe(DEFAULT_REGISTRY_DATABASE);
+      expect(DEFAULT_REGISTRY_DATABASE).toBe("objectified-types-db");
+    });
+
+    it("prefers an explicit name over the env var", () => {
+      process.env.OBJECTIFIED_TYPES_DB = "from-env";
+      expect(resolveRegistryDatabaseName("explicit")).toBe("explicit");
+    });
+
+    it("falls back to OBJECTIFIED_TYPES_DB env when no explicit name", () => {
+      process.env.OBJECTIFIED_TYPES_DB = "from-env";
+      expect(resolveRegistryDatabaseName()).toBe("from-env");
+    });
+  });
+
+  describe("withDatabaseOverride", () => {
+    it("overrides the discrete database field when no URL is configured", () => {
+      const out = withDatabaseOverride({ host: "h", port: "6", user: "u", password: "p" }, "registry");
+      expect(out.database).toBe("registry");
+      expect(out.host).toBe("h");
+      expect(out.databaseUrl).toBeUndefined();
+    });
+
+    it("rewrites the path segment of an explicit connection URL", () => {
+      const out = withDatabaseOverride(
+        { databaseUrl: "postgresql://u:p@host:5432/objectified" },
+        "objectified-types-db",
+      );
+      expect(out.databaseUrl).toBe("postgresql://u:p@host:5432/objectified-types-db");
+    });
+
+    it("rewrites an OBJECTIFIED_DB_URL env URL rather than leaking the core database", () => {
+      process.env.OBJECTIFIED_DB_URL = "postgresql://u:p@host:5432/objectified";
+      const out = withDatabaseOverride({}, "objectified-types-db");
+      expect(out.databaseUrl).toBe("postgresql://u:p@host:5432/objectified-types-db");
+    });
+  });
+
+  describe("registryConnection", () => {
+    it("reuses the base connection with only the database swapped", () => {
+      const out = registryConnection({ host: "db", port: "5432", user: "postgres", password: "pw" });
+      expect(out.database).toBe("objectified-types-db");
+      expect(out.host).toBe("db");
+      expect(out.password).toBe("pw");
+    });
+
+    it("honors a dedicated OBJECTIFIED_TYPES_DB_URL", () => {
+      process.env.OBJECTIFIED_TYPES_DB_URL = "postgresql://u:p@other:5433/registry";
+      const out = registryConnection({ host: "db" });
+      expect(out.databaseUrl).toBe("postgresql://u:p@other:5433/registry");
+    });
+  });
+
+  describe("maintenanceConnection", () => {
+    it("targets the postgres maintenance database for CREATE DATABASE", () => {
+      const out = maintenanceConnection({ host: "db", port: "5432", user: "postgres", password: "pw" });
+      expect(out.database).toBe(MAINTENANCE_DATABASE);
+      expect(out.database).toBe("postgres");
+    });
+
+    it("rewrites a dedicated registry URL to the maintenance database", () => {
+      process.env.OBJECTIFIED_TYPES_DB_URL = "postgresql://u:p@other:5433/registry";
+      const out = maintenanceConnection({ host: "db" });
+      expect(out.databaseUrl).toBe("postgresql://u:p@other:5433/postgres");
+    });
+  });
+});
+
+describe("quoteIdentifier", () => {
+  it("double-quotes identifiers so hyphenated names are valid CREATE DATABASE targets", () => {
+    expect(quoteIdentifier("objectified-types-db")).toBe('"objectified-types-db"');
+  });
+
+  it("escapes embedded double quotes", () => {
+    expect(quoteIdentifier('a"b')).toBe('"a""b"');
+  });
+});
+
+describe("defaultRegistryScriptsDir", () => {
+  it("points at a registry-scripts directory", () => {
+    expect(defaultRegistryScriptsDir().endsWith("registry-scripts")).toBe(true);
+  });
+});
+
+describe("ensureRegistryDatabase", () => {
+  it("creates the database when it does not exist", async () => {
+    const query = vi
+      .fn()
+      .mockResolvedValueOnce({ rowCount: 0, rows: [] }) // pg_database lookup
+      .mockResolvedValueOnce({ rowCount: 0, rows: [] }); // CREATE DATABASE
+    const client = { query } as unknown as import("pg").Client;
+
+    const result = await ensureRegistryDatabase(client, "objectified-types-db");
+
+    expect(result).toEqual({ database: "objectified-types-db", created: true });
+    expect(query).toHaveBeenNthCalledWith(1, "SELECT 1 FROM pg_database WHERE datname = $1", [
+      "objectified-types-db",
+    ]);
+    expect(query).toHaveBeenNthCalledWith(2, 'CREATE DATABASE "objectified-types-db"');
+  });
+
+  it("is idempotent when the database already exists", async () => {
+    const query = vi.fn().mockResolvedValueOnce({ rowCount: 1, rows: [{ "?column?": 1 }] });
+    const client = { query } as unknown as import("pg").Client;
+
+    const result = await ensureRegistryDatabase(client, "objectified-types-db");
+
+    expect(result).toEqual({ database: "objectified-types-db", created: false });
+    expect(query).toHaveBeenCalledTimes(1);
+  });
+});

--- a/objectified-rest/.env.example
+++ b/objectified-rest/.env.example
@@ -5,6 +5,12 @@
 #   psql -U postgres -h localhost -p 5432 -c 'CREATE DATABASE objectified;'
 # Then run migrations in order from objectified-db/scripts (see objectified-db/docs/README.md).
 
+# Separate type-registry database (objectified-types-db, #3446). Defaults to the core
+# connection with the database name swapped; provision + migrate it with
+# `objectified-db registry migrate`. Override the name or point at another server:
+# OBJECTIFIED_TYPES_DB=objectified-types-db
+# OBJECTIFIED_TYPES_DB_URL=postgresql://postgres:password@localhost:5432/objectified-types-db
+
 # Server configuration
 HOST=0.0.0.0
 PORT=8000

--- a/objectified-rest/CHANGELOG.md
+++ b/objectified-rest/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to the Objectified REST API will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.6] - 2026-06-22
+
+### Added
+- **Type-registry database connection (#3446)** — dedicated, independent connection to the
+  separate `objectified-types-db` database (`registry_database.py`, `RegistryDatabase`),
+  configured via `OBJECTIFIED_TYPES_DB` / `OBJECTIFIED_TYPES_DB_URL` (defaults to the core
+  connection with the database name swapped). `GET /health` now reports the registry status
+  (`registry_database`: `connected`/`disconnected`) independently of the core database.
+
 ## [1.2.0] - 2024-12-07
 
 ### Added

--- a/objectified-rest/README.md
+++ b/objectified-rest/README.md
@@ -63,6 +63,12 @@ Create a `.env` file based on `.env.example`:
 DATABASE_URL=postgresql://user:password@localhost:5432/objectified
 API_HOST=0.0.0.0
 API_PORT=8000
+
+# Separate type-registry database (objectified-types-db, #3446). By default it reuses the
+# core connection above and only swaps the database name; set OBJECTIFIED_TYPES_DB_URL to
+# point at a different server. Provision it with `objectified-db registry migrate`.
+# OBJECTIFIED_TYPES_DB=objectified-types-db
+# OBJECTIFIED_TYPES_DB_URL=postgresql://user:password@localhost:5432/objectified-types-db
 ```
 
 ### Running the Server
@@ -153,7 +159,14 @@ Returns API information and available endpoints.
 ```
 GET /health
 ```
-Returns API health status and database connection status.
+Returns API health status and database connection status. The response reports the core
+database (`database`) and the separate type-registry database (`registry_database`)
+independently; overall `status` is `healthy` when the core database is reachable (the
+registry is reported but does not, on its own, mark the service unhealthy). Example:
+
+```json
+{ "database": "connected", "registry_database": "connected", "status": "healthy" }
+```
 
 ## Content Negotiation
 

--- a/objectified-rest/package.json
+++ b/objectified-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-rest",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "private": true,
   "description": "Trigger file for Objectified REST Docker publish workflow; app is Python (pyproject.toml).",
   "scripts": {

--- a/objectified-rest/src/app/config.py
+++ b/objectified-rest/src/app/config.py
@@ -15,6 +15,19 @@ class Settings(BaseSettings):
     postgres_port: int = 5432
     postgres_db: str = "objectified"
 
+    # Separate type-registry database (objectified-types-db, #3446). The registry's
+    # namespaces / type definitions / $ref edges live here, isolated from the core
+    # ADE schema. By default it reuses the core host/port/user/password and only the
+    # database name differs; set OBJECTIFIED_TYPES_DB_URL to point at another server.
+    types_database_url: Optional[str] = Field(
+        default=None,
+        validation_alias=AliasChoices("OBJECTIFIED_TYPES_DB_URL", "types_database_url"),
+    )
+    types_postgres_db: str = Field(
+        default="objectified-types-db",
+        validation_alias=AliasChoices("OBJECTIFIED_TYPES_DB", "types_postgres_db"),
+    )
+
     host: str = "0.0.0.0"
     port: int = 8000
     reload: bool = True
@@ -77,6 +90,19 @@ class Settings(BaseSettings):
         if self.database_url:
             return self.database_url
         return f"postgresql://{self.postgres_user}:{self.postgres_password}@{self.postgres_host}:{self.postgres_port}/{self.postgres_db}"
+
+    @property
+    def effective_types_database_url(self) -> str:
+        """Get the type-registry database URL (#3446).
+
+        Prefers an explicit OBJECTIFIED_TYPES_DB_URL. Otherwise it reuses the core
+        connection's host/port/user/password and only swaps the database name to
+        ``types_postgres_db`` (default ``objectified-types-db``), so the registry can
+        share the core Postgres instance while remaining an independent database.
+        """
+        if self.types_database_url:
+            return self.types_database_url
+        return f"postgresql://{self.postgres_user}:{self.postgres_password}@{self.postgres_host}:{self.postgres_port}/{self.types_postgres_db}"
 
     @property
     def effective_jwt_secret(self) -> str:

--- a/objectified-rest/src/app/main.py
+++ b/objectified-rest/src/app/main.py
@@ -9,6 +9,7 @@ import logging
 import yaml
 
 from .database import db, Database
+from .registry_database import registry_db
 from .openapi_generator import generate_openapi_spec, generate_class_openapi_spec
 from .arazzo_generator import generate_arazzo_spec, generate_class_arazzo_spec
 from .jsonschema_generator import generate_jsonschema_spec, generate_class_jsonschema_spec
@@ -146,6 +147,21 @@ async def startup_event():
                 "change report system template seed failed with unexpected error: %s", e
             )
     validate_webhook_signing_key()
+
+    # Connect to the separate type-registry database (objectified-types-db, #3446).
+    # Non-fatal: the registry DB is provisioned independently (objectified-db registry
+    # migrate / types-migrate), so a missing/unreachable registry must not block startup
+    # of the core service. The /health endpoint reports its live status.
+    try:
+        registry_db.connect()
+        _startup_log.info("type-registry database connected")
+    except Exception as e:
+        _startup_log.warning(
+            "type-registry database not connected (provision with `objectified-db registry "
+            "migrate`): %s",
+            e,
+        )
+
     # Log data API routes so we can confirm POST /v1/data/{tenant_slug}/records is registered
     for route in app.routes:
         if hasattr(route, "path") and "data" in route.path and hasattr(route, "methods"):
@@ -261,6 +277,7 @@ async def shutdown_event():
             pass
         _repository_refresh_task = None
     db.close()
+    registry_db.close()
 
 
 def validate_private_access(version: Dict[str, Any], tenant_slug: str, api_key: Optional[str]) -> None:
@@ -925,11 +942,32 @@ async def get_class_jsonschema_spec(
 
 @app.get("/health")
 async def health_check():
-    """Health check endpoint."""
+    """Health check endpoint.
+
+    Reports the core database and the separate type-registry database
+    (objectified-types-db, #3446) independently. Overall status is ``healthy`` only when
+    the core database is reachable; the registry is reported but does not, on its own,
+    make the service unhealthy (it is provisioned separately).
+    """
+    result: dict = {}
+
     try:
-        # Try to connect to database
         db.connect()
-        return {"status": "healthy", "database": "connected"}
+        result["database"] = "connected"
+        core_ok = True
     except Exception as e:
-        return {"status": "unhealthy", "database": "disconnected", "error": str(e)}
+        result["database"] = "disconnected"
+        result["error"] = str(e)
+        core_ok = False
+
+    # Independent connection — a registry failure never masks core health and vice versa.
+    try:
+        registry_db.ping()
+        result["registry_database"] = "connected"
+    except Exception as e:
+        result["registry_database"] = "disconnected"
+        result["registry_error"] = str(e)
+
+    result["status"] = "healthy" if core_ok else "unhealthy"
+    return result
 

--- a/objectified-rest/src/app/registry_database.py
+++ b/objectified-rest/src/app/registry_database.py
@@ -1,0 +1,88 @@
+"""Dedicated connection to the separate type-registry database (objectified-types-db).
+
+The registry lives in its own database, isolated from the core ADE schema, so the REST
+service connects to it independently of the primary :class:`~app.database.Database`. This
+module provides a minimal connection manager used by the health check and (later tickets)
+the registry service layer; it deliberately does not import or share state with the core
+``db`` singleton so a failure in one database cannot mask the health of the other.
+
+See docs/ROADMAP_TYPE_REGISTRY_GOVERNANCE.md §1.1 (#3446).
+"""
+
+import logging
+
+import psycopg2
+from psycopg2.extras import RealDictCursor
+
+from .config import settings
+
+_logger = logging.getLogger(__name__)
+
+
+class RegistryDatabase:
+    """Lazy, single-connection manager for the type-registry database.
+
+    Mirrors the connection style of :class:`~app.database.Database` (a shared psycopg2
+    connection, reconnected on demand) but targets ``settings.effective_types_database_url``.
+    Credentials are never logged: connection errors surface the driver message only, which
+    does not include the password.
+    """
+
+    def __init__(self) -> None:
+        self.connection = None
+
+    def connect(self):
+        """Establish (or reuse) the registry database connection.
+
+        Returns the live psycopg2 connection. Raises ``psycopg2.OperationalError`` (with a
+        provisioning hint when the database is absent) on failure — callers decide whether
+        that is fatal.
+        """
+        if not self.connection or self.connection.closed:
+            try:
+                self.connection = psycopg2.connect(
+                    settings.effective_types_database_url,
+                    cursor_factory=RealDictCursor,
+                )
+            except psycopg2.OperationalError as e:
+                err_s = str(e).lower()
+                if "does not exist" in err_s and "database" in err_s:
+                    raise psycopg2.OperationalError(
+                        f"{e}\n\n"
+                        "The type-registry database does not exist yet. Provision it with:\n"
+                        "  objectified-db registry migrate\n"
+                        "(or `docker compose up types-migrate`). Override the name with "
+                        "OBJECTIFIED_TYPES_DB / OBJECTIFIED_TYPES_DB_URL."
+                    ) from e
+                raise
+        return self.connection
+
+    def close(self) -> None:
+        """Close the registry database connection if open."""
+        if self.connection and not self.connection.closed:
+            self.connection.close()
+
+    def ping(self) -> bool:
+        """Return ``True`` if a trivial query succeeds against the registry database.
+
+        Reconnects if needed and commits so the shared connection returns to IDLE.
+        Raises the underlying error on connection/query failure (the caller maps it to a
+        health status).
+        """
+        conn = self.connect()
+        try:
+            with conn.cursor() as cursor:
+                cursor.execute("SELECT 1")
+                cursor.fetchone()
+            conn.commit()
+            return True
+        except Exception:
+            try:
+                conn.rollback()
+            except Exception:
+                pass
+            raise
+
+
+# Global registry database instance (independent of the core ``db`` singleton).
+registry_db = RegistryDatabase()

--- a/objectified-rest/tests/test_registry_config.py
+++ b/objectified-rest/tests/test_registry_config.py
@@ -1,0 +1,46 @@
+"""Type-registry database connection settings (#3446).
+
+Deterministic, DB-free checks that ``Settings`` exposes an independent registry
+database URL: by default it reuses the core host/port/user/password and only swaps
+the database name, and an explicit ``OBJECTIFIED_TYPES_DB_URL`` overrides it.
+"""
+
+from app.config import Settings
+
+
+def test_registry_db_defaults_to_objectified_types_db() -> None:
+    """The registry database name defaults to ``objectified-types-db``."""
+    s = Settings(_env_file=None)
+    assert s.types_postgres_db == "objectified-types-db"
+
+
+def test_effective_types_url_reuses_core_connection_with_swapped_database() -> None:
+    """Without a dedicated URL, only the database name differs from the core URL."""
+    s = Settings(
+        _env_file=None,
+        postgres_user="u",
+        postgres_password="pw",
+        postgres_host="dbhost",
+        postgres_port=5432,
+        postgres_db="objectified",
+        types_postgres_db="objectified-types-db",
+        types_database_url=None,
+    )
+    assert s.effective_database_url == "postgresql://u:pw@dbhost:5432/objectified"
+    assert s.effective_types_database_url == "postgresql://u:pw@dbhost:5432/objectified-types-db"
+
+
+def test_effective_types_url_prefers_dedicated_url() -> None:
+    """An explicit registry URL points the service at a separate server entirely."""
+    s = Settings(
+        _env_file=None,
+        postgres_host="dbhost",
+        types_database_url="postgresql://r:rp@other:5433/registry",
+    )
+    assert s.effective_types_database_url == "postgresql://r:rp@other:5433/registry"
+
+
+def test_registry_database_name_is_configurable() -> None:
+    """The registry database name is overridable (no hardcoded value in the URL)."""
+    s = Settings(_env_file=None, types_postgres_db="custom-registry", types_database_url=None)
+    assert s.effective_types_database_url.endswith("/custom-registry")

--- a/objectified-rest/tests/test_registry_health.py
+++ b/objectified-rest/tests/test_registry_health.py
@@ -1,0 +1,53 @@
+"""/health reporting for the separate type-registry database (#3446).
+
+Verifies the acceptance criterion "health reports Connected" for the registry, and
+that the registry connection is independent of the core database: a registry failure
+does not make the service unhealthy, and a core failure does not hide registry status.
+"""
+
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_health_reports_both_databases_connected():
+    with patch("app.main.db") as core, patch("app.main.registry_db") as reg:
+        core.connect.return_value = object()
+        reg.ping.return_value = True
+        r = client.get("/health")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["status"] == "healthy"
+    assert body["database"] == "connected"
+    assert body["registry_database"] == "connected"
+
+
+def test_registry_failure_does_not_make_service_unhealthy():
+    with patch("app.main.db") as core, patch("app.main.registry_db") as reg:
+        core.connect.return_value = object()
+        reg.ping.side_effect = Exception("registry db does not exist")
+        r = client.get("/health")
+    assert r.status_code == 200
+    body = r.json()
+    # Core is healthy, so overall stays healthy even though the registry is down.
+    assert body["status"] == "healthy"
+    assert body["database"] == "connected"
+    assert body["registry_database"] == "disconnected"
+    assert "registry_error" in body
+
+
+def test_core_failure_is_unhealthy_but_registry_still_reported():
+    with patch("app.main.db") as core, patch("app.main.registry_db") as reg:
+        core.connect.side_effect = Exception("core down")
+        reg.ping.return_value = True
+        r = client.get("/health")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["status"] == "unhealthy"
+    assert body["database"] == "disconnected"
+    # Registry health is independent of the core failure.
+    assert body["registry_database"] == "connected"


### PR DESCRIPTION
## What & why

Foundation ticket for the Type Registry Database epic (#3439). Stands up the **separate type-registry database** `objectified-types-db` so the registry's namespaces / type definitions / `$ref` edges never share tables with the core ADE schema (`odb`). Per the roadmap (§1.1, authoritative over the issue body's "decide"), this is provisioned as a **separate logical database** on the existing Postgres 16 instance, isolated in its own `otr` schema — lighter than a second container while still connecting independently. Existing `/v1/primitives` (backed by `odb.primitives`) is untouched.

This ticket is infrastructure only: the registry **entity tables** arrive in #3447 (1.2). The baseline migration here just creates the `otr` schema so the tooling is demonstrably functional and 1.2 has a home.

### objectified-db (migration tooling)
- New `registry` command group: `provision`, `migrate`, `migrate status`, `ping`.
- `registry migrate` self-provisions (issues `CREATE DATABASE` from the `postgres` maintenance DB if absent) then applies migrations from a dedicated `registry-scripts/` directory, tracked independently (each DB keeps its own `schema_evolution_manager.scripts`).
- Reuses the operator's host/port/user/password; only the database name differs (`--registry-database` → `OBJECTIFIED_TYPES_DB` → default `objectified-types-db`). `OBJECTIFIED_TYPES_DB_URL` targets a different server entirely.
- Hyphenated DB name handled via identifier quoting. Ships `registry-scripts/` in package `files` + Dockerfile.

### docker-compose
- New `types-migrate` service runs `registry migrate` (self-provisioning) against the same Postgres instance.

### objectified-rest (connection + health)
- `config.py`: `effective_types_database_url` (reuses core connection, swaps DB name; or `OBJECTIFIED_TYPES_DB_URL`).
- `registry_database.py`: independent `RegistryDatabase` (connect/ping), connected **non-fatally** on startup (a missing registry must not block core startup).
- `GET /health` now reports `registry_database` (`connected`/`disconnected`) independently — overall `status` is `healthy` when the core DB is reachable.

## How to test
1. **Build the CLI:** `yarn workspace objectified-db build`
2. **Provision + migrate the registry DB** (against a running Postgres): `objectified-db registry migrate` — creates `objectified-types-db`, applies the `otr` baseline.
3. **Verify connectivity:** `objectified-db registry ping` → `status: ok`.
4. **Check status:** `objectified-db registry migrate status` → baseline listed as applied.
5. **Compose path:** `docker compose up --build types-migrate` provisions + migrates it automatically.
6. **REST health:** start the REST service and `GET /health` → `{ "database": "connected", "registry_database": "connected", "status": "healthy" }`.
7. **Automated:** `yarn workspace objectified-db test` (registry connection resolution + provisioning, 31 pass) and `cd objectified-rest && uv run pytest tests/test_registry_config.py tests/test_registry_health.py` (config + health, 7 pass).

## Risk / notes
- Separate **logical** DB on the same instance (not a second container); `OBJECTIFIED_TYPES_DB_URL` allows a fully separate server.
- Startup registry connect is non-fatal by design; credentials are never logged (errors surface driver messages only, no password).
- Pre-existing in `objectified-rest/tests` and unrelated to this change: 8 modules import `from src.app.main` (wrong path) and ~9 tests require a live Postgres — both reproduce on a clean tree.

Versions bumped: objectified-db 0.1.6 → 0.1.7, objectified-rest 1.0.5 → 1.0.6. Roadmap 1.1 marked done.

Closes #3446

Work performed by Claude Code via model Opus 4.8 (1M context).

🤖 Generated with [Claude Code](https://claude.com/claude-code)