### PR TITLE
Fix #3448 - Primitives import provenance & property binding

### DIFF
--- a/docs/ROADMAP_TYPE_REGISTRY_GOVERNANCE.md
+++ b/docs/ROADMAP_TYPE_REGISTRY_GOVERNANCE.md
@@ -234,7 +234,7 @@ erDiagram
 |---|---|---|---|:---:|:---:|---|---|
 | 1.1 #3446 | Consolidate registry into `objectified-db` (remove separate DB) | Rip out the `objectified-types-db` provisioning shipped earlier; registry lives in `odb` | `type-registry`,`types-db`,`mvp`,`roadmap-type-registry` | N | Y | M | objectified-db, objectified-rest |
 | 1.2 #3447 | Extend `odb.primitives` (namespace, `$id`, `$ref`, draft 2020-12) | Migration adding namespace/`base_uri`/`schema_id`/`draft`/`source`/`refs` columns to `odb.primitives` | `type-registry`,`types-db`,`mvp`,`roadmap-type-registry` | N | Y | M | objectified-db |
-| 1.3 #3448 | Import provenance & property binding | Import-history reuse + property↔primitive binding column on `class_property` | `type-registry`,`types-db`,`import`,`mvp`,`roadmap-type-registry` | Y | Y | M | objectified-db |
+| 1.3 #3448 | ~~Import provenance & property binding~~ **DONE** | `odb.primitive_imports` provenance table + `report` JSON; `class_properties.primitive_id`/`primitive_ref` binding read by the Designer | `type-registry`,`types-db`,`import`,`mvp`,`roadmap-type-registry` | Y | Y | M | objectified-db |
 | 1.4 #3449 | Seed core system primitives (`std/v0`) | Seed primitives + std types (date, uuid, money, …) as system-wide `is_system` rows | `type-registry`,`registry`,`mvp`,`roadmap-type-registry` | Y | Y | M | objectified-db, objectified-rest |
 
 ### Issue 1.1 — Consolidate registry into `objectified-db` (remove separate DB)
@@ -274,7 +274,12 @@ erDiagram
 - **Parallelism/Dependencies.** Depends on 1.1; blocks Epic 2/3/4.
 - **Technical Stack.** PostgreSQL, JSONB.
 
-### Issue 1.3 — Import provenance & property binding
+### Issue 1.3 — Import provenance & property binding ✅ DONE (#3448)
+- **Delivered.** `odb.primitive_imports` provenance table (source_kind, options/report JSONB,
+  attribution, tallies) written on every `/v1/primitives/{tenant}/import`, with read endpoints
+  `GET /v1/primitives/{tenant}/imports[/{id}]`; imported primitives marked `source='imported'`.
+  `odb.class_properties` extended with `primitive_id` (FK to `odb.primitives`) + `primitive_ref`,
+  surfaced on the Designer read path and carried through class/version copies.
 - **Problem.** Imports and property bindings need durable records — in the same database.
 - **Solution/Scope.** Reuse the existing import-history/attribution infrastructure (#2299/#2305)
   to record primitive imports (source_kind ∈ {json-schema, type-def-bundle, openapi}, target

--- a/objectified-db/package.json
+++ b/objectified-db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-db",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "Objectified database migrations and the direct-to-database admin CLI (objectified-db).",
   "author": "Objectified",
   "type": "module",

--- a/objectified-db/scripts/20260622-235000.sql
+++ b/objectified-db/scripts/20260622-235000.sql
@@ -1,0 +1,60 @@
+-- Import provenance + property→primitive binding (#3448, ROADMAP_TYPE_REGISTRY_GOVERNANCE.md §6 Issue 1.3).
+--
+-- Two durable records were missing, both in the existing objectified-db / odb schema
+-- (single database, ordinary same-database foreign keys — no cross-DB ids):
+--
+--   1. Primitive imports wrote rows with no audit trail. #3447 added the per-row `source`
+--      column ('human' | 'imported'), but there was no record of WHEN an import ran, WHAT it
+--      pulled from, or its outcome. This mirrors the catalog import-history infrastructure
+--      (odb.tenant_repository_imports, #2299/#2305): one row per import carrying its options
+--      and a JSON report.
+--
+--   2. The Designer merged a selected primitive's JSON inline onto a property with no persisted
+--      link, so a bound property could not reload its `$ref`. We extend odb.class_properties
+--      with the stored `$ref` and a real FK to the resolved odb.primitives row.
+
+SET search_path TO odb, public;
+
+-- 1.3a — Import provenance. One row per primitive import, with its options and report JSON.
+CREATE TABLE IF NOT EXISTS odb.primitive_imports (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  tenant_id UUID NOT NULL REFERENCES odb.tenants(id) ON DELETE CASCADE,
+  source_kind TEXT NOT NULL DEFAULT 'json-schema'
+      CHECK (source_kind IN ('json-schema', 'type-def-bundle', 'openapi')),
+  source_label TEXT,                              -- human label / filename / URL of the source, if known
+  target_namespace TEXT,                          -- registry namespace imported into (NULL for legacy flat imports)
+  options JSONB NOT NULL DEFAULT '{}'::jsonb,      -- import options echoed back for reproducibility
+  report  JSONB NOT NULL DEFAULT '{}'::jsonb,      -- the import report: imported / skipped / errors lists + counts
+  imported_count INTEGER NOT NULL DEFAULT 0,
+  skipped_count  INTEGER NOT NULL DEFAULT 0,
+  error_count    INTEGER NOT NULL DEFAULT 0,
+  imported_by UUID REFERENCES odb.users(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_primitive_imports_tenant_created
+  ON odb.primitive_imports (tenant_id, created_at DESC);
+
+COMMENT ON TABLE odb.primitive_imports IS
+  'One row per primitive import (#3448) — auditable provenance: source, options, and a JSON outcome report.';
+COMMENT ON COLUMN odb.primitive_imports.source_kind IS
+  'Shape of the imported document: json-schema (default), type-def-bundle, or openapi.';
+COMMENT ON COLUMN odb.primitive_imports.options IS
+  'Import options echoed at import time (import_all, selected_definitions, ...) for reproducibility.';
+COMMENT ON COLUMN odb.primitive_imports.report IS
+  'Import outcome report: {"imported": [...], "skipped": [...], "errors": [...]} plus counts.';
+
+-- 1.3b — Property→primitive binding. The stored `$ref` plus a real FK to the resolved primitive.
+ALTER TABLE class_properties
+  ADD COLUMN IF NOT EXISTS primitive_id  UUID REFERENCES primitives(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS primitive_ref TEXT;
+
+COMMENT ON COLUMN class_properties.primitive_id IS
+  'Resolved target: FK to the odb.primitives row this property is bound to (#3448). NULL for inline/library-only properties.';
+COMMENT ON COLUMN class_properties.primitive_ref IS
+  'The registry $ref string the Designer persisted for this binding (e.g. std/v0/primitives/string); pairs with primitive_id.';
+
+-- Reverse lookup: "which class properties bind to this primitive" (impact analysis, cascade checks).
+CREATE INDEX IF NOT EXISTS idx_class_properties_primitive_id
+  ON class_properties (primitive_id)
+  WHERE primitive_id IS NOT NULL;

--- a/objectified-rest/CHANGELOG.md
+++ b/objectified-rest/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to the Objectified REST API will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.8] - 2026-06-22
+
+### Added
+- **Primitive import provenance & property binding (#3448)** — every
+  `POST /v1/primitives/{tenant}/import` now records an auditable provenance row in the new
+  `odb.primitive_imports` table (source kind, options, and a JSON outcome report with
+  imported/skipped/errors) and marks imported primitives `source='imported'`. New read
+  endpoints `GET /v1/primitives/{tenant}/imports` and `GET /v1/primitives/{tenant}/imports/{id}`
+  expose the history and its report. Class properties gained a `primitive_id` foreign key to
+  `odb.primitives` plus a stored `primitive_ref`, surfaced on the Designer read path so a bound
+  property reloads its `$ref`; bindings are carried through class and version copies.
+
 ## [1.0.7] - 2026-06-22
 
 ### Removed

--- a/objectified-rest/package.json
+++ b/objectified-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-rest",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "private": true,
   "description": "Trigger file for Objectified REST Docker publish workflow; app is Python (pyproject.toml).",
   "scripts": {

--- a/objectified-rest/pyproject.toml
+++ b/objectified-rest/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "objectified-rest"
-version = "1.0.77"
+version = "1.0.78"
 description = "REST API for serving OpenAPI specifications from the Objectified database"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/objectified-rest/src/app/classes_routes.py
+++ b/objectified-rest/src/app/classes_routes.py
@@ -319,7 +319,9 @@ async def add_property_to_class(
             name=request['name'],
             description=request.get('description'),
             data=request['data'],
-            parent_id=request.get('parent_id')
+            parent_id=request.get('parent_id'),
+            primitive_id=request.get('primitive_id'),
+            primitive_ref=request.get('primitive_ref')
         )
 
         return property_data
@@ -390,6 +392,11 @@ async def update_class_property(
             updates['description'] = request['description']
         if 'data' in request:
             updates['data'] = request['data']
+        # Property→primitive binding (#3448). Present-but-None clears the binding.
+        if 'primitive_id' in request:
+            updates['primitive_id'] = request['primitive_id']
+        if 'primitive_ref' in request:
+            updates['primitive_ref'] = request['primitive_ref']
 
         property_data = db.update_class_property(
             class_property_id=class_property_id,

--- a/objectified-rest/src/app/database.py
+++ b/objectified-rest/src/app/database.py
@@ -183,6 +183,7 @@ class Database:
         """Get all properties for a specific class."""
         query = """
             SELECT cp.id, cp.class_id, cp.property_id, cp.name, cp.description, cp.data, cp.parent_id,
+                   cp.primitive_id, cp.primitive_ref,
                    p.id as property_source_id, p.name as property_source_name, p.data as property_source_data
             FROM odb.class_properties cp
             LEFT JOIN odb.properties p ON cp.property_id = p.id
@@ -215,6 +216,7 @@ class Database:
         placeholders = ','.join(['%s'] * len(class_ids))
         properties_query = f"""
             SELECT cp.id, cp.class_id, cp.property_id, cp.name, cp.description, cp.data, cp.parent_id,
+                   cp.primitive_id, cp.primitive_ref,
                    p.id as property_source_id, p.name as property_source_name, p.data as property_source_data
             FROM odb.class_properties cp
             LEFT JOIN odb.properties p ON cp.property_id = p.id
@@ -292,6 +294,7 @@ class Database:
         # Query 2: Get all properties for this class
         properties_query = """
             SELECT cp.id, cp.class_id, cp.property_id, cp.name, cp.description, cp.data, cp.parent_id,
+                   cp.primitive_id, cp.primitive_ref,
                    p.id as property_source_id, p.name as property_source_name, p.data as property_source_data
             FROM odb.class_properties cp
             LEFT JOIN odb.properties p ON cp.property_id = p.id
@@ -501,31 +504,42 @@ class Database:
         name: str,
         description: Optional[str],
         data: Dict[str, Any],
-        parent_id: Optional[str] = None
+        parent_id: Optional[str] = None,
+        primitive_id: Optional[str] = None,
+        primitive_ref: Optional[str] = None
     ) -> Dict[str, Any]:
-        """Add a property to a class."""
+        """Add a property to a class.
+
+        Args:
+            primitive_id: Optional FK to the odb.primitives row this property is bound
+                to (the resolved target of a registry $ref). Read by the Designer (#3448).
+            primitive_ref: Optional registry $ref string persisted alongside primitive_id.
+        """
         import json
-        
+
         if not name or not name.strip():
             raise ValueError('Property name is required')
-        
+
         # Validate: either property_id must be set, or data must contain $ref
         has_ref = data and (data.get('$ref') or (data.get('type') == 'array' and data.get('items', {}).get('$ref')))
         if not property_id and not has_ref:
             raise ValueError('Property must have either a library reference (property_id) or a schema $ref')
-        
+
         query = """
-            INSERT INTO odb.class_properties (class_id, property_id, name, description, data, parent_id)
-            VALUES (%s, %s, %s, %s, %s, %s)
-            RETURNING id, class_id, property_id, name, description, data, parent_id
+            INSERT INTO odb.class_properties
+                (class_id, property_id, name, description, data, parent_id, primitive_id, primitive_ref)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+            RETURNING id, class_id, property_id, name, description, data, parent_id,
+                      primitive_id, primitive_ref
         """
-        
+
         conn = self.connect()
         try:
             with conn.cursor() as cursor:
                 cursor.execute(
                     query,
-                    (class_id, property_id, name.strip(), description, json.dumps(data), parent_id)
+                    (class_id, property_id, name.strip(), description, json.dumps(data),
+                     parent_id, primitive_id, primitive_ref)
                 )
                 result = cursor.fetchone()
                 conn.commit()
@@ -578,21 +592,29 @@ class Database:
         if 'data' in updates and updates['data'] is not None:
             update_fields.append("data = %s")
             params.append(json.dumps(updates['data']))
-        
+        # Property→primitive binding (#3448). These accept None so a binding can be cleared.
+        if 'primitive_id' in updates:
+            update_fields.append("primitive_id = %s")
+            params.append(updates['primitive_id'])
+        if 'primitive_ref' in updates:
+            update_fields.append("primitive_ref = %s")
+            params.append(updates['primitive_ref'])
+
         if not update_fields:
             # Nothing to update, return current property
             return self.execute_query(
-                "SELECT id, class_id, property_id, name, description, data, parent_id FROM odb.class_properties WHERE id = %s",
+                "SELECT id, class_id, property_id, name, description, data, parent_id, primitive_id, primitive_ref FROM odb.class_properties WHERE id = %s",
                 (class_property_id,)
             )[0] if self.execute_query("SELECT id FROM odb.class_properties WHERE id = %s", (class_property_id,)) else None
-        
+
         params.append(class_property_id)
-        
+
         query = f"""
             UPDATE odb.class_properties
             SET {', '.join(update_fields)}
             WHERE id = %s
-            RETURNING id, class_id, property_id, name, description, data, parent_id
+            RETURNING id, class_id, property_id, name, description, data, parent_id,
+                      primitive_id, primitive_ref
         """
         
         conn = self.connect()
@@ -1109,7 +1131,7 @@ class Database:
         """Get all primitives for a specific tenant."""
         query = """
             SELECT id, tenant_id, name, description, category, schema, tags,
-                   created_by, is_system, is_public, usage_count,
+                   created_by, is_system, is_public, usage_count, source,
                    created_at, updated_at
             FROM odb.primitives
             WHERE tenant_id = %s
@@ -1127,7 +1149,7 @@ class Database:
         """Get a specific primitive by ID, ensuring it belongs to the tenant."""
         query = """
             SELECT id, tenant_id, name, description, category, schema, tags,
-                   created_by, is_system, is_public, usage_count,
+                   created_by, is_system, is_public, usage_count, source,
                    created_at, updated_at
             FROM odb.primitives
             WHERE id = %s AND tenant_id = %s
@@ -1143,15 +1165,21 @@ class Database:
         schema: Dict[str, Any],
         description: Optional[str] = None,
         tags: Optional[List[str]] = None,
-        created_by: Optional[str] = None
+        created_by: Optional[str] = None,
+        source: str = 'human'
     ) -> Dict[str, Any]:
-        """Create a new primitive."""
+        """Create a new primitive.
+
+        Args:
+            source: Provenance of the primitive — 'human' (authored in-app, default)
+                or 'imported' (created by an import). Stored on odb.primitives.source.
+        """
         query = """
             INSERT INTO odb.primitives
-            (tenant_id, name, description, category, schema, tags, created_by)
-            VALUES (%s, %s, %s, %s, %s, %s, %s)
+            (tenant_id, name, description, category, schema, tags, created_by, source)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
             RETURNING id, tenant_id, name, description, category, schema, tags,
-                      created_by, is_system, is_public, usage_count,
+                      created_by, is_system, is_public, usage_count, source,
                       created_at, updated_at
         """
 
@@ -1163,7 +1191,7 @@ class Database:
             with conn.cursor() as cursor:
                 cursor.execute(
                     query,
-                    (tenant_id, name, description, category, schema_json, tags or [], created_by)
+                    (tenant_id, name, description, category, schema_json, tags or [], created_by, source)
                 )
                 result = cursor.fetchone()
                 conn.commit()
@@ -1211,7 +1239,7 @@ class Database:
             SET {', '.join(update_fields)}
             WHERE id = %s AND tenant_id = %s
             RETURNING id, tenant_id, name, description, category, schema, tags,
-                      created_by, is_system, is_public, usage_count,
+                      created_by, is_system, is_public, usage_count, source,
                       created_at, updated_at
         """
 
@@ -1252,6 +1280,96 @@ class Database:
                 conn.commit()
         except Exception:
             pass  # Don't fail if we can't increment usage
+
+    # ==================== Primitive Import Provenance (#3448) ====================
+
+    def create_primitive_import(
+        self,
+        tenant_id: str,
+        report: Dict[str, Any],
+        source_kind: str = 'json-schema',
+        source_label: Optional[str] = None,
+        target_namespace: Optional[str] = None,
+        options: Optional[Dict[str, Any]] = None,
+        imported_count: int = 0,
+        skipped_count: int = 0,
+        error_count: int = 0,
+        imported_by: Optional[str] = None
+    ) -> Dict[str, Any]:
+        """Record an auditable provenance row for a primitive import.
+
+        Args:
+            tenant_id: The tenant the import ran for.
+            report: The import outcome report (imported/skipped/errors lists + counts).
+            source_kind: Shape of the source document — one of 'json-schema',
+                'type-def-bundle', 'openapi'.
+            source_label: Optional human label (filename / URL) of the source.
+            target_namespace: Optional registry namespace imported into.
+            options: Import options echoed back for reproducibility.
+            imported_count/skipped_count/error_count: Outcome tallies.
+            imported_by: The authenticated user id (None for API-key auth).
+
+        Returns:
+            The persisted provenance row.
+        """
+        import json
+
+        query = """
+            INSERT INTO odb.primitive_imports
+            (tenant_id, source_kind, source_label, target_namespace, options, report,
+             imported_count, skipped_count, error_count, imported_by)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            RETURNING id, tenant_id, source_kind, source_label, target_namespace,
+                      options, report, imported_count, skipped_count, error_count,
+                      imported_by, created_at
+        """
+
+        conn = self.connect()
+        try:
+            with conn.cursor() as cursor:
+                cursor.execute(
+                    query,
+                    (
+                        tenant_id, source_kind, source_label, target_namespace,
+                        json.dumps(options or {}), json.dumps(report),
+                        imported_count, skipped_count, error_count, imported_by
+                    )
+                )
+                result = cursor.fetchone()
+                conn.commit()
+                return result
+        except Exception as e:
+            conn.rollback()
+            raise e
+
+    def get_primitive_imports(
+        self, tenant_id: str, limit: int = 50
+    ) -> List[Dict[str, Any]]:
+        """List primitive import provenance records for a tenant, newest first."""
+        query = """
+            SELECT id, tenant_id, source_kind, source_label, target_namespace,
+                   options, report, imported_count, skipped_count, error_count,
+                   imported_by, created_at
+            FROM odb.primitive_imports
+            WHERE tenant_id = %s
+            ORDER BY created_at DESC
+            LIMIT %s
+        """
+        return self.execute_query(query, (tenant_id, limit))
+
+    def get_primitive_import_by_id(
+        self, import_id: str, tenant_id: str
+    ) -> Optional[Dict[str, Any]]:
+        """Get a single primitive import provenance record scoped to the tenant."""
+        query = """
+            SELECT id, tenant_id, source_kind, source_label, target_namespace,
+                   options, report, imported_count, skipped_count, error_count,
+                   imported_by, created_at
+            FROM odb.primitive_imports
+            WHERE id = %s AND tenant_id = %s
+        """
+        results = self.execute_query(query, (import_id, tenant_id))
+        return results[0] if results else None
 
     # ==================== Project CRUD Operations ====================
     # NOTE: queries below select `change_report_template_version_id`, which requires
@@ -1950,8 +2068,8 @@ class Database:
                     if original:
                         original_class_id = original["id"]
                         cursor.execute("""
-                            INSERT INTO odb.class_properties (class_id, property_id, name, description, data)
-                            SELECT %s, property_id, name, description, data
+                            INSERT INTO odb.class_properties (class_id, property_id, name, description, data, primitive_id, primitive_ref)
+                            SELECT %s, property_id, name, description, data, primitive_id, primitive_ref
                             FROM odb.class_properties
                             WHERE class_id = %s AND parent_id IS NULL
                         """, (new_class_id, original_class_id))
@@ -3119,8 +3237,8 @@ class Database:
 
                         # Copy class properties (simple copy without nested property mapping for now)
                         cursor.execute("""
-                            INSERT INTO odb.class_properties (class_id, property_id, name, description, data)
-                            SELECT %s, property_id, name, description, data
+                            INSERT INTO odb.class_properties (class_id, property_id, name, description, data, primitive_id, primitive_ref)
+                            SELECT %s, property_id, name, description, data, primitive_id, primitive_ref
                             FROM odb.class_properties
                             WHERE class_id = %s AND parent_id IS NULL
                         """, (new_class_id, original_class_id))
@@ -4857,7 +4975,7 @@ class Database:
     ) -> None:
         cursor.execute(
             """
-            SELECT id, property_id, name, description, data, parent_id
+            SELECT id, property_id, name, description, data, parent_id, primitive_id, primitive_ref
             FROM odb.class_properties
             WHERE class_id = %s
             """,
@@ -4886,8 +5004,9 @@ class Database:
                     new_parent = old_to_new.get(str(prop["parent_id"]))
                 cursor.execute(
                     """
-                    INSERT INTO odb.class_properties (class_id, property_id, name, description, data, parent_id)
-                    VALUES (%s, %s, %s, %s, %s, %s)
+                    INSERT INTO odb.class_properties
+                        (class_id, property_id, name, description, data, parent_id, primitive_id, primitive_ref)
+                    VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
                     RETURNING id
                     """,
                     (
@@ -4897,6 +5016,8 @@ class Database:
                         prop["description"],
                         prop["data"],
                         new_parent,
+                        prop.get("primitive_id"),
+                        prop.get("primitive_ref"),
                     ),
                 )
                 new_id = cursor.fetchone()["id"]

--- a/objectified-rest/src/app/models.py
+++ b/objectified-rest/src/app/models.py
@@ -123,6 +123,7 @@ class PrimitiveSchema(BaseModel):
     is_system: bool = False
     is_public: bool = False
     usage_count: int = 0
+    source: str = 'human'  # Provenance: 'human' (authored in-app) or 'imported' (#3448)
     created_at: Optional[Union[datetime, str]] = None
     updated_at: Optional[Union[datetime, str]] = None
     enabled: bool = True
@@ -160,6 +161,29 @@ class PrimitiveImportRequest(BaseModel):
     schema: Dict[str, Any]  # Full JSON Schema document
     import_all: bool = False  # If True, import all definitions; if False, select specific ones
     selected_definitions: Optional[List[str]] = None  # List of definition keys to import
+    # Provenance metadata recorded on the import record (#3448).
+    source_kind: str = 'json-schema'  # 'json-schema' | 'type-def-bundle' | 'openapi'
+    source_label: Optional[str] = None  # Human label / filename / URL of the source
+    target_namespace: Optional[str] = None  # Registry namespace imported into, if any
+
+    class Config:
+        from_attributes = True
+
+
+class PrimitiveImportRecord(BaseModel):
+    """Provenance record for a single primitive import (#3448)."""
+    id: str
+    tenant_id: str
+    source_kind: str
+    source_label: Optional[str] = None
+    target_namespace: Optional[str] = None
+    options: Dict[str, Any] = {}
+    report: Dict[str, Any] = {}
+    imported_count: int = 0
+    skipped_count: int = 0
+    error_count: int = 0
+    imported_by: Optional[str] = None
+    created_at: Optional[Union[datetime, str]] = None
 
     class Config:
         from_attributes = True

--- a/objectified-rest/src/app/primitives_routes.py
+++ b/objectified-rest/src/app/primitives_routes.py
@@ -14,11 +14,15 @@ from .models import (
     PrimitiveSchema,
     PrimitiveCreateRequest,
     PrimitiveUpdateRequest,
-    PrimitiveImportRequest
+    PrimitiveImportRequest,
+    PrimitiveImportRecord
 )
 from .auth import validate_authentication, get_authenticated_user_id
 
 router = APIRouter(prefix="/v1/primitives", tags=["primitives"])
+
+# Allowed import source shapes — must match the odb.primitive_imports CHECK constraint.
+VALID_IMPORT_SOURCE_KINDS = {"json-schema", "type-def-bundle", "openapi"}
 
 
 def determine_category_from_schema(schema: Dict[str, Any]) -> str:
@@ -118,6 +122,56 @@ async def list_primitives(
     primitives = db.get_primitives_for_tenant(auth_data['tenant_id'], category)
 
     return [PrimitiveSchema(**p) for p in primitives]
+
+
+@router.get("/{tenant_slug}/imports")
+async def list_primitive_imports(
+    tenant_slug: str,
+    limit: int = Query(50, ge=1, le=500, description="Max number of records to return"),
+    auth_data: Dict[str, Any] = Depends(validate_authentication)
+) -> List[PrimitiveImportRecord]:
+    """
+    List primitive import provenance records for a tenant, newest first (#3448).
+
+    Registered before GET /{tenant_slug}/{primitive_id} so the literal `imports`
+    path is not captured as a primitive id.
+
+    Args:
+        tenant_slug: The tenant slug
+        limit: Maximum number of records to return
+        auth_data: Authentication data (injected by dependency)
+
+    Returns:
+        The tenant's import provenance records.
+    """
+    records = db.get_primitive_imports(auth_data['tenant_id'], limit)
+    return [PrimitiveImportRecord(**r) for r in records]
+
+
+@router.get("/{tenant_slug}/imports/{import_id}")
+async def get_primitive_import(
+    tenant_slug: str,
+    import_id: str,
+    auth_data: Dict[str, Any] = Depends(validate_authentication)
+) -> PrimitiveImportRecord:
+    """
+    Get a single primitive import provenance record, including its report JSON (#3448).
+
+    Args:
+        tenant_slug: The tenant slug
+        import_id: The import provenance record id
+        auth_data: Authentication data (injected by dependency)
+
+    Returns:
+        The provenance record with its full options/report payload.
+    """
+    record = db.get_primitive_import_by_id(import_id, auth_data['tenant_id'])
+    if not record:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Import record not found: {import_id}"
+        )
+    return PrimitiveImportRecord(**record)
 
 
 @router.get("/{tenant_slug}/{primitive_id}")
@@ -340,8 +394,18 @@ async def import_primitives(
         auth_data: Authentication data (injected by dependency)
 
     Returns:
-        Summary of imported primitives
+        Summary of imported primitives plus the id of the recorded provenance row.
     """
+    # Validate the declared source shape against the persisted CHECK constraint.
+    if request.source_kind not in VALID_IMPORT_SOURCE_KINDS:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Invalid source_kind '{request.source_kind}'. "
+                f"Expected one of: {', '.join(sorted(VALID_IMPORT_SOURCE_KINDS))}"
+            )
+        )
+
     # Extract definitions from schema
     definitions = {}
 
@@ -385,7 +449,8 @@ async def import_primitives(
             # Determine category from schema
             schema_type = determine_category_from_schema(def_schema)
 
-            # Create primitive - the full schema with all metadata is stored
+            # Create primitive - the full schema with all metadata is stored.
+            # source='imported' marks its provenance on odb.primitives (#3448).
             primitive = db.create_primitive(
                 tenant_id=auth_data['tenant_id'],
                 name=def_name,
@@ -393,7 +458,8 @@ async def import_primitives(
                 schema=def_schema,  # Full schema including x-license, x-links, $comment, examples, title, etc.
                 description=def_schema.get('description'),
                 tags=def_schema.get('tags', []),
-                created_by=created_by
+                created_by=created_by,
+                source='imported'
             )
             imported.append(primitive['name'])
         except Exception as e:
@@ -402,12 +468,42 @@ async def import_primitives(
             else:
                 errors.append({"name": def_name, "error": str(e)})
 
-    return {
-        "message": f"Import completed",
+    # Build the auditable report and persist a provenance record (#3448).
+    report = {
         "imported": imported,
         "skipped": skipped,
         "errors": errors,
         "total_imported": len(imported),
         "total_skipped": len(skipped),
-        "total_errors": len(errors)
+        "total_errors": len(errors),
+    }
+    options = {
+        "import_all": request.import_all,
+        "selected_definitions": request.selected_definitions,
+    }
+
+    import_id = None
+    try:
+        import_record = db.create_primitive_import(
+            tenant_id=auth_data['tenant_id'],
+            report=report,
+            source_kind=request.source_kind,
+            source_label=request.source_label,
+            target_namespace=request.target_namespace,
+            options=options,
+            imported_count=len(imported),
+            skipped_count=len(skipped),
+            error_count=len(errors),
+            imported_by=created_by,
+        )
+        import_id = str(import_record['id'])
+    except Exception as e:
+        # Provenance is best-effort: a failure here must not lose a successful import,
+        # but it is surfaced so the audit gap is visible.
+        errors.append({"name": "_provenance", "error": f"Failed to record import provenance: {e}"})
+
+    return {
+        "message": "Import completed",
+        "import_id": import_id,
+        **report,
     }

--- a/objectified-rest/test_primitives_provenance.py
+++ b/objectified-rest/test_primitives_provenance.py
@@ -1,0 +1,134 @@
+"""
+Tests for primitive import provenance and property→primitive binding (#3448).
+
+Covers:
+- Auth gating on the new import-provenance endpoints.
+- Route registration order so the literal `imports` path is not captured as a
+  primitive id by GET /{tenant_slug}/{primitive_id}.
+- Pydantic model contracts for the import request/record and the `source` field.
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.app.main import app
+from src.app.models import (
+    PrimitiveSchema,
+    PrimitiveImportRequest,
+    PrimitiveImportRecord,
+)
+from src.app import primitives_routes
+
+client = TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# Auth gating on the new provenance endpoints
+# ---------------------------------------------------------------------------
+
+def test_list_imports_requires_auth():
+    """Listing import provenance requires authentication."""
+    response = client.get('/v1/primitives/test-tenant/imports')
+    assert response.status_code == 401
+
+
+def test_get_import_requires_auth():
+    """Fetching a single import provenance record requires authentication."""
+    response = client.get('/v1/primitives/test-tenant/imports/some-id')
+    assert response.status_code == 401
+
+
+def test_list_imports_invalid_api_key():
+    """An invalid API key is rejected on the imports list endpoint."""
+    response = client.get(
+        '/v1/primitives/test-tenant/imports',
+        headers={'X-API-Key': 'invalid-key'},
+    )
+    assert response.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Route ordering: `/imports` must win over `/{primitive_id}`
+# ---------------------------------------------------------------------------
+
+def _get_route_index(path: str, method: str = 'GET') -> int:
+    for idx, route in enumerate(app.router.routes):
+        if getattr(route, 'path', None) == path and method in getattr(route, 'methods', set()):
+            return idx
+    raise AssertionError(f"Route not found: {method} {path}")
+
+
+def test_imports_routes_registered_before_primitive_id():
+    """
+    The static `/imports` routes must be registered before the parametric
+    `/{primitive_id}` route, otherwise FastAPI captures `imports` as a primitive id.
+    """
+    imports_idx = _get_route_index('/v1/primitives/{tenant_slug}/imports')
+    detail_idx = _get_route_index('/v1/primitives/{tenant_slug}/imports/{import_id}')
+    primitive_idx = _get_route_index('/v1/primitives/{tenant_slug}/{primitive_id}')
+
+    assert imports_idx < primitive_idx
+    assert detail_idx < primitive_idx
+
+
+# ---------------------------------------------------------------------------
+# Model contracts
+# ---------------------------------------------------------------------------
+
+def test_import_request_defaults():
+    """PrimitiveImportRequest defaults source_kind to json-schema with no label/namespace."""
+    req = PrimitiveImportRequest(schema={'$defs': {}})
+    assert req.source_kind == 'json-schema'
+    assert req.source_label is None
+    assert req.target_namespace is None
+    assert req.import_all is False
+
+
+def test_import_request_accepts_provenance_fields():
+    """Provenance metadata round-trips through the request model."""
+    req = PrimitiveImportRequest(
+        schema={'$defs': {}},
+        source_kind='openapi',
+        source_label='petstore.yaml',
+        target_namespace='tenant/acme/types',
+    )
+    assert req.source_kind == 'openapi'
+    assert req.source_label == 'petstore.yaml'
+    assert req.target_namespace == 'tenant/acme/types'
+
+
+def test_valid_source_kinds_match_constraint():
+    """The route guard set matches the values allowed by the DB CHECK constraint."""
+    assert primitives_routes.VALID_IMPORT_SOURCE_KINDS == {
+        'json-schema', 'type-def-bundle', 'openapi',
+    }
+
+
+def test_import_record_model():
+    """PrimitiveImportRecord exposes the provenance row including the report JSON."""
+    record = PrimitiveImportRecord(
+        id='11111111-1111-1111-1111-111111111111',
+        tenant_id='22222222-2222-2222-2222-222222222222',
+        source_kind='json-schema',
+        report={'imported': ['Money'], 'total_imported': 1},
+        imported_count=1,
+    )
+    assert record.report['total_imported'] == 1
+    assert record.imported_count == 1
+    assert record.skipped_count == 0
+    assert record.options == {}
+
+
+def test_primitive_schema_source_defaults_to_human():
+    """A primitive's provenance defaults to 'human' when unspecified."""
+    primitive = PrimitiveSchema(
+        id='1', tenant_id='t', name='String', category='string',
+        schema={'type': 'string'},
+    )
+    assert primitive.source == 'human'
+
+    imported = PrimitiveSchema(
+        id='1', tenant_id='t', name='String', category='string',
+        schema={'type': 'string'}, source='imported',
+    )
+    assert imported.source == 'imported'


### PR DESCRIPTION
## What & why

Implements **[1.3] Import provenance & property binding** (#3448, MVP; depends on closed #3447). Two durable records were missing, both kept in the existing `objectified-db` / `odb` schema (single database, ordinary same-database foreign keys):

1. **Import provenance.** Primitive import wrote rows with no audit trail. We add `odb.primitive_imports` (mirroring the catalog import-history infra, #2299/#2305): one row per import carrying `source_kind` (`json-schema` | `type-def-bundle` | `openapi`), echoed `options`, a JSON outcome `report` (imported/skipped/errors + counts), attribution, and tallies. Imported primitives are now marked `source='imported'`.
2. **Property→primitive binding.** The Designer merged a primitive's JSON inline with no persisted link. We extend `odb.class_properties` with `primitive_id` (FK to `odb.primitives`, the resolved target) and `primitive_ref` (the stored `$ref`), surfaced on the Designer read path so a bound property reloads its `$ref` (consumed by #3475). Bindings are carried through class duplication and version copy/fork paths.

### Changes
- **objectified-db**: migration `20260622-235000.sql` — new `odb.primitive_imports` table + `class_properties.primitive_id`/`primitive_ref` columns and indexes.
- **objectified-rest**:
  - Import endpoint writes a provenance record + report and returns its `import_id`; imported primitives get `source='imported'`.
  - New `GET /v1/primitives/{tenant}/imports` and `GET /v1/primitives/{tenant}/imports/{id}` (registered before `/{primitive_id}` so `imports` isn't captured as a primitive id).
  - `add_property_to_class` / `update_class_property` accept and return the binding; read SELECTs include it.
  - Models: `source` on `PrimitiveSchema`; provenance fields on `PrimitiveImportRequest`; new `PrimitiveImportRecord`.

## How to test
- **Apply migrations**: `cd objectified-db && yarn build && ./run.sh migrate` (or your usual migrate command). Validated here by applying the script inside a rolled-back transaction against a dev DB.
- **Run tests**: `cd objectified-rest && .venv/bin/python -m pytest test_primitives_provenance.py test_primitives_api.py test_classes_api.py` → all pass.
- **Manually**: authenticate, then **POST** a JSON Schema with `$defs` to `/v1/primitives/{tenant}/import` (optionally with `source_label`/`target_namespace`); the response includes `import_id`. **GET** `/v1/primitives/{tenant}/imports` to see the provenance record and its report JSON. Create/update a class property with `primitive_id` + `primitive_ref` and confirm they round-trip on the class read path.

## Risk / notes
- New columns are nullable / defaulted, so existing rows and copy paths are unaffected; the migration uses `IF NOT EXISTS` guards.
- Provenance write is best-effort: a failure there never loses a successful import, but is surfaced in the report `errors`.
- Local Python lint (ruff) is not installed in the venv; `py_compile` passes and the db `tsc` lint passes via build.

Closes #3448

Work performed by Claude Code via model Opus 4.8 (1M context)