### PR TITLE
Fix #3449 - Seed core system primitives (std/v0)

### DIFF
--- a/docs/ROADMAP_TYPE_REGISTRY_GOVERNANCE.md
+++ b/docs/ROADMAP_TYPE_REGISTRY_GOVERNANCE.md
@@ -235,7 +235,7 @@ erDiagram
 | 1.1 #3446 | Consolidate registry into `objectified-db` (remove separate DB) | Rip out the `objectified-types-db` provisioning shipped earlier; registry lives in `odb` | `type-registry`,`types-db`,`mvp`,`roadmap-type-registry` | N | Y | M | objectified-db, objectified-rest |
 | 1.2 #3447 | Extend `odb.primitives` (namespace, `$id`, `$ref`, draft 2020-12) | Migration adding namespace/`base_uri`/`schema_id`/`draft`/`source`/`refs` columns to `odb.primitives` | `type-registry`,`types-db`,`mvp`,`roadmap-type-registry` | N | Y | M | objectified-db |
 | 1.3 #3448 | ~~Import provenance & property binding~~ **DONE** | `odb.primitive_imports` provenance table + `report` JSON; `class_properties.primitive_id`/`primitive_ref` binding read by the Designer | `type-registry`,`types-db`,`import`,`mvp`,`roadmap-type-registry` | Y | Y | M | objectified-db |
-| 1.4 #3449 | Seed core system primitives (`std/v0`) | Seed primitives + std types (date, uuid, money, …) as system-wide `is_system` rows | `type-registry`,`registry`,`mvp`,`roadmap-type-registry` | Y | Y | M | objectified-db, objectified-rest |
+| 1.4 #3449 | ~~Seed core system primitives (`std/v0`)~~ **DONE** | Seed primitives + std types (date, uuid, money, …) as system-wide `is_system` rows | `type-registry`,`registry`,`mvp`,`roadmap-type-registry` | Y | Y | M | objectified-db, objectified-rest |
 
 ### Issue 1.1 — Consolidate registry into `objectified-db` (remove separate DB)
 - **Problem.** An earlier iteration provisioned a **separate** `objectified-types-db` database
@@ -292,7 +292,17 @@ erDiagram
 - **Parallelism/Dependencies.** Depends on 1.2; parallel with 1.4.
 - **Technical Stack.** PostgreSQL, JSONB; ordinary same-database foreign keys.
 
-### Issue 1.4 — Seed core system primitives (`std/v0`)
+### Issue 1.4 — Seed core system primitives (`std/v0`) ✅ DONE (#3449)
+- **Delivered.** Migration `objectified-db/scripts/20260622-240000.sql` seeds the `std/v0/primitives`
+  (string, number, integer, boolean, null, array, object) and `std/v0/types` (date, date-time,
+  time, uuid, email, uri, decimal, currency-code, money) namespaces as system-wide
+  `is_system`/`is_public` rows in `odb.primitives`, with the #3447 registry columns populated
+  (`namespace`, `base_uri`, `schema_id` = `$id`, `draft` = 2020-12, `source` = human) and relative
+  `$ref` chains recorded in `refs` (`date` → `../primitives/string` + `format: date`; `money` →
+  `./decimal`, `./currency-code`). Verified end-to-end against Postgres: 0 unresolved refs, `money`/
+  `date` match the canonical schemas, and re-running the seed is idempotent
+  (`ON CONFLICT (tenant_id, category, name) DO NOTHING`). DB-free structural tests in
+  `objectified-db/test/primitives-std-seed.test.ts`.
 - **Problem.** Tenants need a baseline of core types available to all.
 - **Solution/Scope.** Seed `std/v0/primitives` (string, number, integer, boolean, null, array,
   object) and `std/v0/types` (date, date-time, uuid, email, uri, decimal, currency-code, money,

--- a/objectified-db/package.json
+++ b/objectified-db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-db",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "Objectified database migrations and the direct-to-database admin CLI (objectified-db).",
   "author": "Objectified",
   "type": "module",

--- a/objectified-db/scripts/20260622-240000.sql
+++ b/objectified-db/scripts/20260622-240000.sql
@@ -1,0 +1,125 @@
+-- Seed core system primitives & types (std/v0) — #3449, ROADMAP_TYPE_REGISTRY_GOVERNANCE.md §6 Issue 1.4.
+--
+-- The earlier 20260124-140000.sql seeded 36 ISO-aligned system primitives as FLAT JSON Schemas
+-- with no namespace and no $ref graph. This migration seeds the registry-shaped baseline the
+-- type registry actually addresses: the `std/v0` namespaces, with the JSON Schema 2020-12
+-- registry columns (namespace / base_uri / schema_id / draft / source / refs) the #3447 migration
+-- added populated, and composite types carrying RELATIVE $ref chains recorded in `refs`.
+--
+-- Two system namespaces are seeded as is_system / is_public rows, visible to every tenant:
+--
+--   std/v0/primitives  — the seven JSON Schema base types (string, number, integer, boolean,
+--                        null, array, object). No $ref edges (refs = []).
+--   std/v0/types       — derived & composite types that reference the primitives by relative
+--                        $ref: date / date-time / time / uuid / email / uri (string + format),
+--                        decimal (number), currency-code (string + ISO-4217 pattern), and money
+--                        (object { amount: ./decimal, currency: ./currency-code }).
+--
+-- Relative $ref resolution model (verified against docs/planning/mockups/.../type-resolver.html):
+--   resolution base = each type's base_uri (its namespace rooted at https://api.objectified.dev/types/)
+--   $ref            = ../primitives/string   (source: std/v0/types/date, base .../std/v0/types/)
+--   resolved        = https://api.objectified.dev/types/std/v0/primitives/string         ✓
+-- Each edge is stored in `refs` as {relative_ref, resolved_target, status}, where resolved_target
+-- is the namespace-path form (e.g. std/v0/primitives/string) the resolver surfaces.
+--
+-- Seeding is idempotent: rows are inserted per tenant (matching the 20260124 system-primitive
+-- convention) and guarded by ON CONFLICT (tenant_id, category, name) DO NOTHING, so re-running the
+-- migration — or applying it to a database that already has the rows — is a no-op. The leaf names
+-- (string, date, money, …) do not collide with the existing flat ISO primitives, whose names are
+-- display-cased (e.g. 'Email Address', 'UUID', 'Date (ISO 8601)').
+--
+-- NOTE: std/v0/primitives/string already serves plain strings, so no redundant std/v0/types/string
+-- alias is seeded — it would collide with the primitive on the legacy (tenant_id, category, name)
+-- uniqueness key, and no seeded type references it (the seed graph resolves with 0 unresolved refs).
+
+SET search_path TO odb, public;
+
+-- All std/v0 rows for one tenant, cross-joined onto every live tenant below.
+-- Columns: leaf name, description, JSON Schema base category, namespace, schema document, $ref edges.
+WITH seed (name, description, category, namespace, schema, refs) AS (
+    VALUES
+        -- ── std/v0/primitives — the seven JSON Schema base types (no $ref edges) ──────────────
+        ('string', 'JSON Schema base string type.', 'string', 'std/v0/primitives',
+         '{"$schema":"https://json-schema.org/draft/2020-12/schema","$id":"https://api.objectified.dev/types/std/v0/primitives/string","title":"String","type":"string"}',
+         '[]'),
+        ('number', 'JSON Schema base number type (integer or floating-point).', 'number', 'std/v0/primitives',
+         '{"$schema":"https://json-schema.org/draft/2020-12/schema","$id":"https://api.objectified.dev/types/std/v0/primitives/number","title":"Number","type":"number"}',
+         '[]'),
+        ('integer', 'JSON Schema base integer type.', 'integer', 'std/v0/primitives',
+         '{"$schema":"https://json-schema.org/draft/2020-12/schema","$id":"https://api.objectified.dev/types/std/v0/primitives/integer","title":"Integer","type":"integer"}',
+         '[]'),
+        ('boolean', 'JSON Schema base boolean type.', 'boolean', 'std/v0/primitives',
+         '{"$schema":"https://json-schema.org/draft/2020-12/schema","$id":"https://api.objectified.dev/types/std/v0/primitives/boolean","title":"Boolean","type":"boolean"}',
+         '[]'),
+        ('null', 'JSON Schema base null type.', 'null', 'std/v0/primitives',
+         '{"$schema":"https://json-schema.org/draft/2020-12/schema","$id":"https://api.objectified.dev/types/std/v0/primitives/null","title":"Null","type":"null"}',
+         '[]'),
+        ('array', 'JSON Schema base array type.', 'array', 'std/v0/primitives',
+         '{"$schema":"https://json-schema.org/draft/2020-12/schema","$id":"https://api.objectified.dev/types/std/v0/primitives/array","title":"Array","type":"array"}',
+         '[]'),
+        ('object', 'JSON Schema base object type.', 'object', 'std/v0/primitives',
+         '{"$schema":"https://json-schema.org/draft/2020-12/schema","$id":"https://api.objectified.dev/types/std/v0/primitives/object","title":"Object","type":"object"}',
+         '[]'),
+
+        -- ── std/v0/types — derived & composite types (relative $ref chains) ───────────────────
+        ('date', 'Calendar date (ISO 8601, YYYY-MM-DD): the string primitive with format date.', 'string', 'std/v0/types',
+         '{"$schema":"https://json-schema.org/draft/2020-12/schema","$id":"https://api.objectified.dev/types/std/v0/types/date","title":"Date","$ref":"../primitives/string","format":"date"}',
+         '[{"relative_ref":"../primitives/string","resolved_target":"std/v0/primitives/string","status":"resolved"}]'),
+        ('date-time', 'Timestamp (ISO 8601 with timezone): the string primitive with format date-time.', 'string', 'std/v0/types',
+         '{"$schema":"https://json-schema.org/draft/2020-12/schema","$id":"https://api.objectified.dev/types/std/v0/types/date-time","title":"Date-Time","$ref":"../primitives/string","format":"date-time"}',
+         '[{"relative_ref":"../primitives/string","resolved_target":"std/v0/primitives/string","status":"resolved"}]'),
+        ('time', 'Time of day (ISO 8601, HH:mm:ss): the string primitive with format time.', 'string', 'std/v0/types',
+         '{"$schema":"https://json-schema.org/draft/2020-12/schema","$id":"https://api.objectified.dev/types/std/v0/types/time","title":"Time","$ref":"../primitives/string","format":"time"}',
+         '[{"relative_ref":"../primitives/string","resolved_target":"std/v0/primitives/string","status":"resolved"}]'),
+        ('uuid', 'UUID (RFC 4122): the string primitive with format uuid.', 'string', 'std/v0/types',
+         '{"$schema":"https://json-schema.org/draft/2020-12/schema","$id":"https://api.objectified.dev/types/std/v0/types/uuid","title":"UUID","$ref":"../primitives/string","format":"uuid"}',
+         '[{"relative_ref":"../primitives/string","resolved_target":"std/v0/primitives/string","status":"resolved"}]'),
+        ('email', 'Email address (RFC 5322): the string primitive with format email.', 'string', 'std/v0/types',
+         '{"$schema":"https://json-schema.org/draft/2020-12/schema","$id":"https://api.objectified.dev/types/std/v0/types/email","title":"Email","$ref":"../primitives/string","format":"email"}',
+         '[{"relative_ref":"../primitives/string","resolved_target":"std/v0/primitives/string","status":"resolved"}]'),
+        ('uri', 'URI (RFC 3986): the string primitive with format uri.', 'string', 'std/v0/types',
+         '{"$schema":"https://json-schema.org/draft/2020-12/schema","$id":"https://api.objectified.dev/types/std/v0/types/uri","title":"URI","$ref":"../primitives/string","format":"uri"}',
+         '[{"relative_ref":"../primitives/string","resolved_target":"std/v0/primitives/string","status":"resolved"}]'),
+        ('decimal', 'Arbitrary-precision decimal: the number primitive.', 'number', 'std/v0/types',
+         '{"$schema":"https://json-schema.org/draft/2020-12/schema","$id":"https://api.objectified.dev/types/std/v0/types/decimal","title":"Decimal","$ref":"../primitives/number"}',
+         '[{"relative_ref":"../primitives/number","resolved_target":"std/v0/primitives/number","status":"resolved"}]'),
+        ('currency-code', 'ISO 4217 three-letter currency code: the string primitive with an uppercase pattern.', 'string', 'std/v0/types',
+         '{"$schema":"https://json-schema.org/draft/2020-12/schema","$id":"https://api.objectified.dev/types/std/v0/types/currency-code","title":"Currency Code","$ref":"../primitives/string","pattern":"^[A-Z]{3}$"}',
+         '[{"relative_ref":"../primitives/string","resolved_target":"std/v0/primitives/string","status":"resolved"}]'),
+        ('money', 'Monetary amount: an object pairing a decimal amount with an ISO 4217 currency code.', 'object', 'std/v0/types',
+         '{"$schema":"https://json-schema.org/draft/2020-12/schema","$id":"https://api.objectified.dev/types/std/v0/types/money","title":"Money","type":"object","properties":{"amount":{"$ref":"./decimal"},"currency":{"$ref":"./currency-code"}},"required":["amount","currency"],"additionalProperties":false}',
+         '[{"relative_ref":"./decimal","resolved_target":"std/v0/types/decimal","status":"resolved"},{"relative_ref":"./currency-code","resolved_target":"std/v0/types/currency-code","status":"resolved"}]')
+)
+INSERT INTO primitives (
+    tenant_id, name, description, category, schema, tags,
+    namespace, base_uri, schema_id, draft, source, refs,
+    is_system, is_public
+)
+SELECT
+    t.id,
+    s.name,
+    s.description,
+    s.category,
+    s.schema::jsonb,
+    -- Discoverability tags: the std layer + the namespace leaf (primitives | types).
+    ARRAY['std', 'std/v0', split_part(s.namespace, '/', 3)]::text[],
+    s.namespace,
+    -- base_uri: the namespace rooted at the registry's resolution base, trailing slash.
+    'https://api.objectified.dev/types/' || s.namespace || '/',
+    -- schema_id ($id): base_uri + leaf name.
+    'https://api.objectified.dev/types/' || s.namespace || '/' || s.name,
+    '2020-12',
+    'human',
+    s.refs::jsonb,
+    true,
+    true
+FROM tenants t
+CROSS JOIN seed s
+WHERE t.deleted_at IS NULL
+ON CONFLICT (tenant_id, category, name) DO NOTHING;
+
+-- Log completion.
+DO $$
+BEGIN
+    RAISE NOTICE 'std/v0 core system primitives & types seeded (7 primitives + 9 types per tenant).';
+END $$;

--- a/objectified-db/test/primitives-std-seed.test.ts
+++ b/objectified-db/test/primitives-std-seed.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Structural assertions over the std/v0 core-system-types seed migration (#3449).
+ *
+ * Issue 1.4 seeds the `std/v0/primitives` and `std/v0/types` namespaces as system-wide
+ * (is_system) rows in the existing `odb.primitives` table, with the #3447 registry columns
+ * populated and composite types carrying relative $ref chains in `refs`. These tests verify the
+ * seed's contract — namespaces, the canonical money/date schemas, $ref edges, and idempotency —
+ * without a live database (the package's test suite is DB-free).
+ */
+
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import { describe, expect, it, beforeAll } from "vitest";
+
+import { listMigrationFiles } from "../src/migrate.js";
+
+const SCRIPTS_DIR = new URL("../scripts", import.meta.url).pathname;
+const MIGRATION = "20260622-240000.sql";
+
+let sql = "";
+let lower = "";
+
+/** Pull every single-quoted JSON document/array literal out of the migration and JSON.parse it. */
+function jsonLiterals(): unknown[] {
+  // Match '{...}' or '[...]' single-quoted literals (no escaped quotes appear in this seed).
+  const matches = sql.match(/'(\{[^']*\}|\[[^']*\])'/g) ?? [];
+  return matches.map((m) => JSON.parse(m.slice(1, -1)));
+}
+
+/** Find the parsed JSON Schema document whose $id ends with the given registry path. */
+function schemaFor(pathSuffix: string): Record<string, unknown> {
+  const doc = jsonLiterals().find(
+    (d): d is Record<string, unknown> =>
+      typeof d === "object" &&
+      d !== null &&
+      typeof (d as Record<string, unknown>).$id === "string" &&
+      ((d as Record<string, unknown>).$id as string).endsWith(pathSuffix),
+  );
+  expect(doc, `schema for ${pathSuffix} present`).toBeDefined();
+  return doc as Record<string, unknown>;
+}
+
+beforeAll(async () => {
+  sql = await fs.readFile(path.join(SCRIPTS_DIR, MIGRATION), "utf8");
+  lower = sql.toLowerCase();
+});
+
+describe("std/v0 core system types seed migration", () => {
+  it("is present in scripts/ and ordered after the #3447/#3448 migrations", async () => {
+    const files = await listMigrationFiles(SCRIPTS_DIR);
+    expect(files).toContain(MIGRATION);
+    expect(files.indexOf(MIGRATION)).toBeGreaterThan(files.indexOf("20260622-235000.sql"));
+  });
+
+  it("seeds into the existing odb.primitives table — no new table or schema", () => {
+    expect(lower).toMatch(/insert into primitives/);
+    expect(lower).not.toMatch(/create table/);
+    expect(lower).not.toMatch(/create schema/);
+  });
+
+  it("seeds both std/v0 namespaces", () => {
+    expect(sql).toContain("std/v0/primitives");
+    expect(sql).toContain("std/v0/types");
+  });
+
+  it("seeds the seven JSON Schema base primitives", () => {
+    for (const base of ["string", "number", "integer", "boolean", "null", "array", "object"]) {
+      const schema = schemaFor(`/std/v0/primitives/${base}`);
+      expect(schema.type).toBe(base);
+      expect(schema.$schema).toBe("https://json-schema.org/draft/2020-12/schema");
+    }
+  });
+
+  it("marks every seeded row system-wide and authored, on draft 2020-12", () => {
+    // The single INSERT projects literal flags for all seeded rows.
+    expect(lower).toMatch(/'2020-12'/);
+    expect(lower).toMatch(/'human'/);
+    // is_system, is_public projected as `true` (last two SELECT columns).
+    expect(lower).toMatch(/true,\s+true\s+from tenants/);
+  });
+
+  it("derives base_uri and schema_id from the resolution base", () => {
+    expect(sql).toContain("'https://api.objectified.dev/types/' || s.namespace || '/'");
+    expect(sql).toContain("'https://api.objectified.dev/types/' || s.namespace || '/' || s.name");
+  });
+
+  it("date is the string primitive with format date and a resolved $ref edge", () => {
+    const date = schemaFor("/std/v0/types/date");
+    expect(date.$ref).toBe("../primitives/string");
+    expect(date.format).toBe("date");
+    // Its refs edge resolves to the primitive.
+    expect(sql).toContain(
+      '{"relative_ref":"../primitives/string","resolved_target":"std/v0/primitives/string","status":"resolved"}',
+    );
+  });
+
+  it("money matches the canonical composite schema (amount/currency $refs)", () => {
+    const money = schemaFor("/std/v0/types/money");
+    expect(money.type).toBe("object");
+    expect(money.additionalProperties).toBe(false);
+    expect(money.required).toEqual(["amount", "currency"]);
+    const props = money.properties as Record<string, { $ref: string }>;
+    expect(props.amount.$ref).toBe("./decimal");
+    expect(props.currency.$ref).toBe("./currency-code");
+  });
+
+  it("records money's $ref edges resolving to sibling std/v0/types", () => {
+    expect(sql).toContain('"relative_ref":"./decimal","resolved_target":"std/v0/types/decimal"');
+    expect(sql).toContain(
+      '"relative_ref":"./currency-code","resolved_target":"std/v0/types/currency-code"',
+    );
+  });
+
+  it("every recorded $ref edge is resolved (0 unresolved in the seed graph)", () => {
+    expect(lower).not.toContain('"status":"unresolved"');
+    expect(lower).not.toContain('"status":"circular"');
+    expect(lower).toContain('"status":"resolved"');
+  });
+
+  it("every seeded JSON literal is valid JSON", () => {
+    expect(() => jsonLiterals()).not.toThrow();
+    // 7 primitives + 9 types = 16 schema docs, plus 9 non-empty refs arrays + 7 empty arrays.
+    const docs = jsonLiterals().filter(
+      (d) => typeof d === "object" && d !== null && "$schema" in (d as object),
+    );
+    expect(docs).toHaveLength(16);
+  });
+
+  it("is idempotent on the legacy uniqueness key", () => {
+    expect(lower).toMatch(/on conflict \(tenant_id, category, name\) do nothing/);
+  });
+});


### PR DESCRIPTION
## What & why

Issue 1.4 (#3449) of the Type Registry roadmap. The earlier `20260124-140000.sql` seeded 36 ISO-aligned system primitives as **flat** JSON Schemas — no namespace and no `$ref` graph. This seeds the registry-shaped baseline the type registry actually addresses: the `std/v0` namespaces, populating the `#3447` registry columns and recording relative `$ref` chains.

New migration `objectified-db/scripts/20260622-240000.sql` seeds two system namespaces as `is_system`/`is_public` rows (one set per live tenant, matching the existing system-primitive convention), visible to every tenant:

- **`std/v0/primitives`** — the seven JSON Schema base types: `string`, `number`, `integer`, `boolean`, `null`, `array`, `object` (no `$ref` edges).
- **`std/v0/types`** — derived & composite types with relative `$ref` chains: `date` / `date-time` / `time` / `uuid` / `email` / `uri` (string + `format`), `decimal` (number), `currency-code` (string + ISO‑4217 pattern), and `money` (object `{ amount: ./decimal, currency: ./currency-code }`).

Each row populates the `#3447` columns: `namespace`, `base_uri` (rooted at `https://api.objectified.dev/types/`), `schema_id` (`$id`), `draft` = `2020-12`, `source` = `human`, and `refs` (the `{relative_ref, resolved_target, status}` edge list). The `money`/`date` schemas match the canonical mockups (`docs/planning/mockups/.../type-detail.html`, `type-resolver.html`).

> A redundant `std/v0/types/string` alias is intentionally **not** seeded — it would collide with `std/v0/primitives/string` on the legacy `(tenant_id, category, name)` uniqueness key, and no seeded type references it (the graph still resolves with 0 unresolved refs).

## How to test

- **Run the package tests:** `cd objectified-db && yarn test` — 12 new DB-free structural tests in `test/primitives-std-seed.test.ts` (plus the existing suite) pass.
- **Apply against Postgres:** apply migrations through `20260622-240000.sql` to a database with `odb.primitives` extended by `20260622-230000.sql`, then:
  - `SELECT namespace, count(*) FROM odb.primitives WHERE namespace LIKE 'std/v0%' GROUP BY 1;` → 7 (`std/v0/primitives`) + 9 (`std/v0/types`) **per tenant**.
  - Unresolved/circular edges are **0**: `SELECT count(*) FROM odb.primitives p, jsonb_array_elements(p.refs) e WHERE e->>'status' <> 'resolved';` → `0`.
  - **Re-run** the migration → row count is unchanged (idempotent via `ON CONFLICT (tenant_id, category, name) DO NOTHING`).

All of the above was verified end-to-end against a throwaway Postgres database during development.

## Acceptance criteria

- [x] Core primitives resolve fully (0 unresolved refs).
- [x] `money` and `date` match the canonical schemas.
- [x] Re-running the seed is idempotent.

## Risk / notes

Additive, idempotent seed migration only — no schema changes, no changes to existing rows (leaf names like `string`/`date`/`money` don't collide with the display-cased flat ISO primitives). The REST read path is unaffected (it already selects `source`; the other new columns are consumed by later Epic 2/3 tickets). Like the existing system-primitive seeds, rows are created for tenants present at apply time. `objectified-db` bumped `0.1.10` → `0.1.11`.

Closes #3449

Work performed by Claude Code via model claude-opus-4-8[1m]