### PR TITLE
Fix #3450 - Type-registry service skeleton + health/ping

### DIFF
--- a/docs/ROADMAP_TYPE_REGISTRY_GOVERNANCE.md
+++ b/docs/ROADMAP_TYPE_REGISTRY_GOVERNANCE.md
@@ -324,7 +324,7 @@ enforcement, plus the `objectified-ui` proxy + typed client.
 
 | Issue | Title | Summary | Labels | Parallel | MVP | Complexity | Affected Modules |
 |---|---|---|---|:---:|:---:|---|---|
-| 2.1 #3450 | Registry service skeleton + auth/scoping | Registry surface over the extended `odb.primitives`, tenant/scope auth, DB wiring | `type-registry`,`rest`,`mvp`,`roadmap-type-registry` | N | Y | M | objectified-rest |
+| 2.1 #3450 ✅ | Registry service skeleton + auth/scoping | **DONE** — registry health/ping (`GET /v1/primitives/health`) over the `objectified-db` connection; existing tenant/scope auth confirmed, clients unaffected | `type-registry`,`rest`,`mvp`,`roadmap-type-registry` | N | Y | M | objectified-rest |
 | 2.2 #3451 | Namespace CRUD API | Create/list/update namespaces with scope, base URI, version root | `type-registry`,`registry`,`rest`,`mvp`,`roadmap-type-registry` | N | Y | M | objectified-rest |
 | 2.3 #3452 | Type definition CRUD + draft 2020-12 validation | CRUD types; validate `json_schema` against draft 2020-12 | `type-registry`,`rest`,`mvp`,`roadmap-type-registry` | N | Y | L | objectified-rest |
 | 2.4 #3453 | Scope & visibility enforcement | System-core vs tenant access + ref-direction rules | `type-registry`,`governance`,`rest`,`mvp`,`roadmap-type-registry` | Y | Y | M | objectified-rest |

--- a/objectified-rest/CHANGELOG.md
+++ b/objectified-rest/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to the Objectified REST API will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.9] - 2026-06-22
+
+### Added
+- **Type-registry service skeleton + health (#3450)** — added an anonymous
+  registry-layer health/ping endpoint `GET /v1/primitives/health` that reports the
+  `objectified-db` connection status backing the registry's `odb.primitives` storage
+  (overall `status`, `connection`, and whether the storage table is present). The existing
+  tenant-scoped primitive CRUD/import endpoints are unchanged and remain authenticated, so
+  current clients are unaffected. Backed by a new `Database.registry_ping()` probe and a
+  `RegistryHealthResponse` model.
+
 ## [1.0.8] - 2026-06-22
 
 ### Added

--- a/objectified-rest/openapi.json
+++ b/objectified-rest/openapi.json
@@ -863,6 +863,28 @@
         }
       }
     },
+    "/v1/primitives/health": {
+      "get": {
+        "tags": [
+          "primitives"
+        ],
+        "summary": "Registry Health",
+        "description": "Health/ping for the Primitives type-registry layer (#3450).\n\nReports whether the registry's storage backend \u2014 the shared\n``objectified-db`` connection backing ``odb.primitives`` \u2014 is reachable.\nLike the global ``/health`` endpoint this is intentionally anonymous so\nmonitors can probe the registry layer without credentials; every data\naccess endpoint below remains authenticated and tenant-scoped.\n\nRegistered before ``GET /{tenant_slug}`` so the literal ``health`` path is\nmatched here rather than being captured as a tenant slug.\n\nReturns:\n    Registry health: overall ``status``, the ``objectified-db``\n    ``connection`` state, and whether the ``odb.primitives`` storage table\n    is present. On failure ``status`` is ``unhealthy`` and ``error`` carries\n    the driver message; the endpoint itself still responds 200 so the probe\n    is always reachable (mirrors the global ``/health`` contract).",
+        "operationId": "registry_health_v1_primitives_health_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RegistryHealthResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/primitives/{tenant_slug}": {
       "get": {
         "tags": [
@@ -1026,6 +1048,183 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/PrimitiveSchema"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/primitives/{tenant_slug}/imports": {
+      "get": {
+        "tags": [
+          "primitives"
+        ],
+        "summary": "List Primitive Imports",
+        "description": "List primitive import provenance records for a tenant, newest first (#3448).\n\nRegistered before GET /{tenant_slug}/{primitive_id} so the literal `imports`\npath is not captured as a primitive id.\n\nArgs:\n    tenant_slug: The tenant slug\n    limit: Maximum number of records to return\n    auth_data: Authentication data (injected by dependency)\n\nReturns:\n    The tenant's import provenance records.",
+        "operationId": "list_primitive_imports_v1_primitives__tenant_slug__imports_get",
+        "parameters": [
+          {
+            "name": "tenant_slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Tenant Slug"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 500,
+              "minimum": 1,
+              "description": "Max number of records to return",
+              "default": 50,
+              "title": "Limit"
+            },
+            "description": "Max number of records to return"
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "name": "X-API-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/PrimitiveImportRecord"
+                  },
+                  "title": "Response List Primitive Imports V1 Primitives  Tenant Slug  Imports Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/primitives/{tenant_slug}/imports/{import_id}": {
+      "get": {
+        "tags": [
+          "primitives"
+        ],
+        "summary": "Get Primitive Import",
+        "description": "Get a single primitive import provenance record, including its report JSON (#3448).\n\nArgs:\n    tenant_slug: The tenant slug\n    import_id: The import provenance record id\n    auth_data: Authentication data (injected by dependency)\n\nReturns:\n    The provenance record with its full options/report payload.",
+        "operationId": "get_primitive_import_v1_primitives__tenant_slug__imports__import_id__get",
+        "parameters": [
+          {
+            "name": "tenant_slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Tenant Slug"
+            }
+          },
+          {
+            "name": "import_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Import Id"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "name": "X-API-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PrimitiveImportRecord"
                 }
               }
             }
@@ -1311,7 +1510,7 @@
           "primitives"
         ],
         "summary": "Import Primitives",
-        "description": "Import primitives from a JSON Schema document.\n\nExtracts type definitions from JSON Schema's $defs or definitions\nand creates primitives from them.\n\nSupports authentication via JWT token or API key.\nWhen using JWT, the created_by field will be set to the authenticated user.\n\nArgs:\n    tenant_slug: The tenant slug\n    request: Import request with JSON Schema document\n    auth_data: Authentication data (injected by dependency)\n\nReturns:\n    Summary of imported primitives",
+        "description": "Import primitives from a JSON Schema document.\n\nExtracts type definitions from JSON Schema's $defs or definitions\nand creates primitives from them.\n\nSupports authentication via JWT token or API key.\nWhen using JWT, the created_by field will be set to the authenticated user.\n\nArgs:\n    tenant_slug: The tenant slug\n    request: Import request with JSON Schema document\n    auth_data: Authentication data (injected by dependency)\n\nReturns:\n    Summary of imported primitives plus the id of the recorded provenance row.",
         "operationId": "import_primitives_v1_primitives__tenant_slug__import_post",
         "parameters": [
           {
@@ -16312,6 +16511,105 @@
         "title": "PrimitiveCreateRequest",
         "description": "Request model for creating a primitive."
       },
+      "PrimitiveImportRecord": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "tenant_id": {
+            "type": "string",
+            "title": "Tenant Id"
+          },
+          "source_kind": {
+            "type": "string",
+            "title": "Source Kind"
+          },
+          "source_label": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Label"
+          },
+          "target_namespace": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Target Namespace"
+          },
+          "options": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Options",
+            "default": {}
+          },
+          "report": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Report",
+            "default": {}
+          },
+          "imported_count": {
+            "type": "integer",
+            "title": "Imported Count",
+            "default": 0
+          },
+          "skipped_count": {
+            "type": "integer",
+            "title": "Skipped Count",
+            "default": 0
+          },
+          "error_count": {
+            "type": "integer",
+            "title": "Error Count",
+            "default": 0
+          },
+          "imported_by": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Imported By"
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "tenant_id",
+          "source_kind"
+        ],
+        "title": "PrimitiveImportRecord",
+        "description": "Provenance record for a single primitive import (#3448)."
+      },
       "PrimitiveImportRequest": {
         "properties": {
           "schema": {
@@ -16337,6 +16635,33 @@
               }
             ],
             "title": "Selected Definitions"
+          },
+          "source_kind": {
+            "type": "string",
+            "title": "Source Kind",
+            "default": "json-schema"
+          },
+          "source_label": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Label"
+          },
+          "target_namespace": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Target Namespace"
           }
         },
         "type": "object",
@@ -16419,6 +16744,11 @@
             "type": "integer",
             "title": "Usage Count",
             "default": 0
+          },
+          "source": {
+            "type": "string",
+            "title": "Source",
+            "default": "human"
           },
           "created_at": {
             "anyOf": [
@@ -17556,6 +17886,51 @@
         ],
         "title": "RefreshStatus",
         "description": "The materialized refresh state of a single imported repository file.\n\nValues are the stable wire/display codes (kebab-case) surfaced to the UI and\nthe sweep; they match the states in the roadmap state diagram."
+      },
+      "RegistryHealthResponse": {
+        "properties": {
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
+          "service": {
+            "type": "string",
+            "title": "Service",
+            "default": "primitives-registry"
+          },
+          "database": {
+            "type": "string",
+            "title": "Database",
+            "default": "objectified-db"
+          },
+          "connection": {
+            "type": "string",
+            "title": "Connection"
+          },
+          "storage_present": {
+            "type": "boolean",
+            "title": "Storage Present",
+            "default": false
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          }
+        },
+        "type": "object",
+        "required": [
+          "status",
+          "connection"
+        ],
+        "title": "RegistryHealthResponse",
+        "description": "Health/ping response for the Primitives type-registry layer (#3450).\n\nReports whether the registry's storage backend \u2014 the shared\n``objectified-db`` connection backing ``odb.primitives`` \u2014 is reachable."
       },
       "RepositoryImportSpecRead": {
         "properties": {

--- a/objectified-rest/openapi.yaml
+++ b/objectified-rest/openapi.yaml
@@ -536,6 +536,31 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /v1/primitives/health:
+    get:
+      tags:
+      - primitives
+      summary: Registry Health
+      description: "Health/ping for the Primitives type-registry layer (#3450).\n\n\
+        Reports whether the registry's storage backend — the shared\n``objectified-db``\
+        \ connection backing ``odb.primitives`` — is reachable.\nLike the global ``/health``\
+        \ endpoint this is intentionally anonymous so\nmonitors can probe the registry\
+        \ layer without credentials; every data\naccess endpoint below remains authenticated\
+        \ and tenant-scoped.\n\nRegistered before ``GET /{tenant_slug}`` so the literal\
+        \ ``health`` path is\nmatched here rather than being captured as a tenant\
+        \ slug.\n\nReturns:\n    Registry health: overall ``status``, the ``objectified-db``\n\
+        \    ``connection`` state, and whether the ``odb.primitives`` storage table\n\
+        \    is present. On failure ``status`` is ``unhealthy`` and ``error`` carries\n\
+        \    the driver message; the endpoint itself still responds 200 so the probe\n\
+        \    is always reachable (mirrors the global ``/health`` contract)."
+      operationId: registry_health_v1_primitives_health_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RegistryHealthResponse'
   /v1/primitives/{tenant_slug}:
     get:
       tags:
@@ -642,6 +667,122 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PrimitiveSchema'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /v1/primitives/{tenant_slug}/imports:
+    get:
+      tags:
+      - primitives
+      summary: List Primitive Imports
+      description: "List primitive import provenance records for a tenant, newest\
+        \ first (#3448).\n\nRegistered before GET /{tenant_slug}/{primitive_id} so\
+        \ the literal `imports`\npath is not captured as a primitive id.\n\nArgs:\n\
+        \    tenant_slug: The tenant slug\n    limit: Maximum number of records to\
+        \ return\n    auth_data: Authentication data (injected by dependency)\n\n\
+        Returns:\n    The tenant's import provenance records."
+      operationId: list_primitive_imports_v1_primitives__tenant_slug__imports_get
+      parameters:
+      - name: tenant_slug
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Tenant Slug
+      - name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          maximum: 500
+          minimum: 1
+          description: Max number of records to return
+          default: 50
+          title: Limit
+        description: Max number of records to return
+      - name: authorization
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Authorization
+      - name: X-API-Key
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Api-Key
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PrimitiveImportRecord'
+                title: Response List Primitive Imports V1 Primitives  Tenant Slug  Imports
+                  Get
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /v1/primitives/{tenant_slug}/imports/{import_id}:
+    get:
+      tags:
+      - primitives
+      summary: Get Primitive Import
+      description: "Get a single primitive import provenance record, including its\
+        \ report JSON (#3448).\n\nArgs:\n    tenant_slug: The tenant slug\n    import_id:\
+        \ The import provenance record id\n    auth_data: Authentication data (injected\
+        \ by dependency)\n\nReturns:\n    The provenance record with its full options/report\
+        \ payload."
+      operationId: get_primitive_import_v1_primitives__tenant_slug__imports__import_id__get
+      parameters:
+      - name: tenant_slug
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Tenant Slug
+      - name: import_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Import Id
+      - name: authorization
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Authorization
+      - name: X-API-Key
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Api-Key
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PrimitiveImportRecord'
         '422':
           description: Validation Error
           content:
@@ -823,7 +964,8 @@ paths:
         \ JWT, the created_by field will be set to the authenticated user.\n\nArgs:\n\
         \    tenant_slug: The tenant slug\n    request: Import request with JSON Schema\
         \ document\n    auth_data: Authentication data (injected by dependency)\n\n\
-        Returns:\n    Summary of imported primitives"
+        Returns:\n    Summary of imported primitives plus the id of the recorded provenance\
+        \ row."
       operationId: import_primitives_v1_primitives__tenant_slug__import_post
       parameters:
       - name: tenant_slug
@@ -10334,6 +10476,68 @@ components:
       - schema
       title: PrimitiveCreateRequest
       description: Request model for creating a primitive.
+    PrimitiveImportRecord:
+      properties:
+        id:
+          type: string
+          title: Id
+        tenant_id:
+          type: string
+          title: Tenant Id
+        source_kind:
+          type: string
+          title: Source Kind
+        source_label:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Source Label
+        target_namespace:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Target Namespace
+        options:
+          additionalProperties: true
+          type: object
+          title: Options
+          default: {}
+        report:
+          additionalProperties: true
+          type: object
+          title: Report
+          default: {}
+        imported_count:
+          type: integer
+          title: Imported Count
+          default: 0
+        skipped_count:
+          type: integer
+          title: Skipped Count
+          default: 0
+        error_count:
+          type: integer
+          title: Error Count
+          default: 0
+        imported_by:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Imported By
+        created_at:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: string
+          - type: 'null'
+          title: Created At
+      type: object
+      required:
+      - id
+      - tenant_id
+      - source_kind
+      title: PrimitiveImportRecord
+      description: Provenance record for a single primitive import (#3448).
     PrimitiveImportRequest:
       properties:
         schema:
@@ -10351,6 +10555,20 @@ components:
             type: array
           - type: 'null'
           title: Selected Definitions
+        source_kind:
+          type: string
+          title: Source Kind
+          default: json-schema
+        source_label:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Source Label
+        target_namespace:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Target Namespace
       type: object
       required:
       - schema
@@ -10403,6 +10621,10 @@ components:
           type: integer
           title: Usage Count
           default: 0
+        source:
+          type: string
+          title: Source
+          default: human
         created_at:
           anyOf:
           - type: string
@@ -11074,6 +11296,42 @@ components:
         Values are the stable wire/display codes (kebab-case) surfaced to the UI and
 
         the sweep; they match the states in the roadmap state diagram.'
+    RegistryHealthResponse:
+      properties:
+        status:
+          type: string
+          title: Status
+        service:
+          type: string
+          title: Service
+          default: primitives-registry
+        database:
+          type: string
+          title: Database
+          default: objectified-db
+        connection:
+          type: string
+          title: Connection
+        storage_present:
+          type: boolean
+          title: Storage Present
+          default: false
+        error:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Error
+      type: object
+      required:
+      - status
+      - connection
+      title: RegistryHealthResponse
+      description: 'Health/ping response for the Primitives type-registry layer (#3450).
+
+
+        Reports whether the registry''s storage backend — the shared
+
+        ``objectified-db`` connection backing ``odb.primitives`` — is reachable.'
     RepositoryImportSpecRead:
       properties:
         spec_schema_version:

--- a/objectified-rest/package.json
+++ b/objectified-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-rest",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "private": true,
   "description": "Trigger file for Objectified REST Docker publish workflow; app is Python (pyproject.toml).",
   "scripts": {

--- a/objectified-rest/pyproject.toml
+++ b/objectified-rest/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "objectified-rest"
-version = "1.0.78"
+version = "1.0.79"
 description = "REST API for serving OpenAPI specifications from the Objectified database"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/objectified-rest/src/app/database.py
+++ b/objectified-rest/src/app/database.py
@@ -1127,6 +1127,32 @@ class Database:
         """
         return self.execute_query(query, (path_operation_id,))
 
+    def registry_ping(self) -> Dict[str, Any]:
+        """Probe the Primitives type-registry storage backend (#3450).
+
+        The registry lives in the existing ``objectified-db`` database, backed
+        by the ``odb.primitives`` table (see ROADMAP_TYPE_REGISTRY_GOVERNANCE.md
+        §1a — single database, no separate registry DB). This runs a single
+        lightweight query that both confirms the shared connection is actually
+        live (not merely an object that claims to be open) and reports whether
+        the registry's storage table is present.
+
+        Returns:
+            A dict with:
+              - ``connection``: ``"connected"`` when the query succeeds.
+              - ``storage_present``: ``True`` when ``odb.primitives`` exists.
+
+        Raises:
+            Exception: Propagated from the driver when the objectified-db
+            connection cannot be established or the probe query fails, so the
+            caller can report an unhealthy registry layer.
+        """
+        rows = self.execute_query(
+            "SELECT to_regclass('odb.primitives') IS NOT NULL AS storage_present"
+        )
+        storage_present = bool(rows and rows[0].get("storage_present"))
+        return {"connection": "connected", "storage_present": storage_present}
+
     def get_primitives_for_tenant(self, tenant_id: str, category: Optional[str] = None) -> List[Dict[str, Any]]:
         """Get all primitives for a specific tenant."""
         query = """

--- a/objectified-rest/src/app/main.py
+++ b/objectified-rest/src/app/main.py
@@ -321,6 +321,7 @@ async def root():
             "jsonschema_spec": "/v1/json/{tenant-slug}/{project-slug}/{version-slug}",
             "class_jsonschema_spec": "/v1/json/{tenant-slug}/{project-slug}/{version-slug}/{class-name}",
             "primitives": {
+                "health": "/v1/primitives/health",
                 "list": "/v1/primitives/{tenant-slug}",
                 "get": "/v1/primitives/{tenant-slug}/{primitive-id}",
                 "create": "POST /v1/primitives/{tenant-slug}",

--- a/objectified-rest/src/app/models.py
+++ b/objectified-rest/src/app/models.py
@@ -170,6 +170,23 @@ class PrimitiveImportRequest(BaseModel):
         from_attributes = True
 
 
+class RegistryHealthResponse(BaseModel):
+    """Health/ping response for the Primitives type-registry layer (#3450).
+
+    Reports whether the registry's storage backend — the shared
+    ``objectified-db`` connection backing ``odb.primitives`` — is reachable.
+    """
+    status: str  # 'healthy' | 'unhealthy'
+    service: str = 'primitives-registry'
+    database: str = 'objectified-db'
+    connection: str  # 'connected' | 'disconnected'
+    storage_present: bool = False  # whether the odb.primitives registry table is reachable
+    error: Optional[str] = None  # populated only when status == 'unhealthy'
+
+    class Config:
+        from_attributes = True
+
+
 class PrimitiveImportRecord(BaseModel):
     """Provenance record for a single primitive import (#3448)."""
     id: str

--- a/objectified-rest/src/app/primitives_routes.py
+++ b/objectified-rest/src/app/primitives_routes.py
@@ -15,7 +15,8 @@ from .models import (
     PrimitiveCreateRequest,
     PrimitiveUpdateRequest,
     PrimitiveImportRequest,
-    PrimitiveImportRecord
+    PrimitiveImportRecord,
+    RegistryHealthResponse
 )
 from .auth import validate_authentication, get_authenticated_user_id
 
@@ -23,6 +24,43 @@ router = APIRouter(prefix="/v1/primitives", tags=["primitives"])
 
 # Allowed import source shapes — must match the odb.primitive_imports CHECK constraint.
 VALID_IMPORT_SOURCE_KINDS = {"json-schema", "type-def-bundle", "openapi"}
+
+
+@router.get("/health", response_model=RegistryHealthResponse)
+async def registry_health() -> RegistryHealthResponse:
+    """
+    Health/ping for the Primitives type-registry layer (#3450).
+
+    Reports whether the registry's storage backend — the shared
+    ``objectified-db`` connection backing ``odb.primitives`` — is reachable.
+    Like the global ``/health`` endpoint this is intentionally anonymous so
+    monitors can probe the registry layer without credentials; every data
+    access endpoint below remains authenticated and tenant-scoped.
+
+    Registered before ``GET /{tenant_slug}`` so the literal ``health`` path is
+    matched here rather than being captured as a tenant slug.
+
+    Returns:
+        Registry health: overall ``status``, the ``objectified-db``
+        ``connection`` state, and whether the ``odb.primitives`` storage table
+        is present. On failure ``status`` is ``unhealthy`` and ``error`` carries
+        the driver message; the endpoint itself still responds 200 so the probe
+        is always reachable (mirrors the global ``/health`` contract).
+    """
+    try:
+        probe = db.registry_ping()
+        return RegistryHealthResponse(
+            status="healthy",
+            connection=probe["connection"],
+            storage_present=probe["storage_present"],
+        )
+    except Exception as e:
+        return RegistryHealthResponse(
+            status="unhealthy",
+            connection="disconnected",
+            storage_present=False,
+            error=str(e),
+        )
 
 
 def determine_category_from_schema(schema: Dict[str, Any]) -> str:

--- a/objectified-rest/tests/test_primitives_registry_health.py
+++ b/objectified-rest/tests/test_primitives_registry_health.py
@@ -1,0 +1,85 @@
+"""Primitives type-registry skeleton: health/ping + auth scoping (#3450).
+
+Covers the registry-layer health endpoint (anonymous, reports the
+``objectified-db`` connection status backing ``odb.primitives``) and confirms
+the existing primitive data endpoints remain authenticated and tenant-scoped.
+"""
+
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_registry_health_healthy():
+    """A live objectified-db connection yields a healthy registry report."""
+    with patch("app.primitives_routes.db") as mdb:
+        mdb.registry_ping.return_value = {
+            "connection": "connected",
+            "storage_present": True,
+        }
+        r = client.get("/v1/primitives/health")
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body["status"] == "healthy"
+    assert body["service"] == "primitives-registry"
+    assert body["database"] == "objectified-db"
+    assert body["connection"] == "connected"
+    assert body["storage_present"] is True
+    assert body["error"] is None
+
+
+def test_registry_health_reports_missing_storage_table():
+    """A live connection but absent odb.primitives is still healthy/connected."""
+    with patch("app.primitives_routes.db") as mdb:
+        mdb.registry_ping.return_value = {
+            "connection": "connected",
+            "storage_present": False,
+        }
+        r = client.get("/v1/primitives/health")
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body["status"] == "healthy"
+    assert body["connection"] == "connected"
+    assert body["storage_present"] is False
+
+
+def test_registry_health_unhealthy_on_connection_failure():
+    """When the objectified-db probe raises, the registry reports unhealthy."""
+    with patch("app.primitives_routes.db") as mdb:
+        mdb.registry_ping.side_effect = RuntimeError("could not connect to server")
+        r = client.get("/v1/primitives/health")
+
+    assert r.status_code == 200  # probe must always be reachable (mirrors /health)
+    body = r.json()
+    assert body["status"] == "unhealthy"
+    assert body["connection"] == "disconnected"
+    assert body["storage_present"] is False
+    assert "could not connect to server" in body["error"]
+
+
+def test_registry_health_is_anonymous():
+    """The health route requires no credentials and is not shadowed by the
+    tenant-slug list route (``health`` must not be read as a tenant slug)."""
+    with patch("app.primitives_routes.db") as mdb:
+        mdb.registry_ping.return_value = {
+            "connection": "connected",
+            "storage_present": True,
+        }
+        r = client.get("/v1/primitives/health")  # no Authorization / X-API-Key
+
+    assert r.status_code == 200
+    # Proves we hit the health handler, not list_primitives(tenant_slug="health").
+    assert r.json()["service"] == "primitives-registry"
+    mdb.get_primitives_for_tenant.assert_not_called()
+
+
+def test_primitive_list_requires_authentication():
+    """Existing tenant-scoped data access stays authenticated (unaffected)."""
+    r = client.get("/v1/primitives/acme")  # no credentials supplied
+    assert r.status_code == 401


### PR DESCRIPTION
## What & why

Sub-issue of **Epic 2 — Registry Service & API (#3440)**. This is the registry **skeleton + auth/scoping** ticket (2.1). Its acceptance criteria are narrow: an authenticated, tenant-scoped registry surface (already shipped via `/v1/primitives`), a **health endpoint reporting the `objectified-db` connection status**, and **no impact on existing primitive clients**. The richer namespace/type-ref endpoints are tracked by the tickets this one *blocks* (#3451–#3455) and by the `odb.primitives` column extension (#3446), so they are intentionally out of scope here.

Per `ROADMAP_TYPE_REGISTRY_GOVERNANCE.md §1a`, the registry is **not** a separate database — it lives in `objectified-db` (`odb.primitives`). The health probe reflects that single-database design.

### Changes
- **`database.py`** — new `Database.registry_ping()`: a single lightweight query (`SELECT to_regclass('odb.primitives') IS NOT NULL`) that both confirms the shared `objectified-db` connection is genuinely live and reports whether the registry storage table is present. Raises on connection failure.
- **`models.py`** — new `RegistryHealthResponse` DTO (`status`, `service`, `database`, `connection`, `storage_present`, `error`).
- **`primitives_routes.py`** — new `GET /v1/primitives/health`. Anonymous (mirrors the global `/health`) so monitors can probe without credentials; **registered before `GET /{tenant_slug}`** so the literal `health` path is not captured as a tenant slug. Always responds `200` with a `status` field (matches the existing `/health` contract).
- **`main.py`** — advertise the endpoint on the root API listing.
- Regenerated `openapi.json` / `openapi.yaml`; bumped `package.json` (1.0.8→1.0.9) and `pyproject.toml` (1.0.78→1.0.79); updated `CHANGELOG.md` and marked 2.1 done in the ROADMAP.

## How to test
1. `cd objectified-rest`
2. `PYTHONPATH=src .venv/bin/python -m pytest tests/test_primitives_registry_health.py -v` — 5 passing tests cover healthy, missing-storage-table, unhealthy-on-failure, anonymous/not-shadowed, and "data routes still require auth".
3. Against a running server with a live DB: `curl http://localhost:8000/v1/primitives/health` → `{"status":"healthy","service":"primitives-registry","database":"objectified-db","connection":"connected","storage_present":true,...}`.

## Risk / notes
- Backward compatible — only adds one new anonymous route; all existing tenant-scoped CRUD/import endpoints are untouched and still authenticated.
- Full suite: **547 passed, 5 new, 2 skipped**. The 18 remaining failures are **pre-existing** DB/asyncpg integration-suite blockers (verified failing identically on a clean tree before this change) and are unrelated.

Closes #3450

Work performed by Claude Code via model claude-opus-4-8[1m].