### PR TITLE
Fix #3452 - Type definition CRUD + draft 2020-12 validation

### DIFF
--- a/docs/ROADMAP_TYPE_REGISTRY_GOVERNANCE.md
+++ b/docs/ROADMAP_TYPE_REGISTRY_GOVERNANCE.md
@@ -45,7 +45,7 @@ Before implementing net-new registry mechanics, account for what is **already li
 | UI proxy | `/api/primitives/*` | ✅ **Done** — closed as duplicate (#3455) |
 | Management UI | `/ade/dashboard/primitives` — stats, table, CRUD, import dialog | ✅ Nav done (#3466 closed); overview/import are **partial** — extend, don't rebuild |
 | Designer | `PrimitiveSelector` — merges primitive schema onto property | No persisted `$ref` binding (#3475); picker lacks namespace tabs (#3474) |
-| Validation | AJV in `PrimitiveEditorDialog` (client) | REST persist not strictly validated (#3452) |
+| Validation | AJV in `PrimitiveEditorDialog` (client) | ✅ **Done** — REST persist strictly validated against draft 2020-12 with field-level errors (#3452) |
 | Scope | `is_system` immutability, tenant rows | No namespace visibility or core→tenant `$ref` rules (#3453) |
 
 **Tickets closed as duplicates:** #3455 (UI proxy), #3466 (Governance nav). All other #3446–#3481
@@ -326,7 +326,7 @@ enforcement, plus the `objectified-ui` proxy + typed client.
 |---|---|---|---|:---:|:---:|---|---|
 | 2.1 #3450 ✅ | Registry service skeleton + auth/scoping | **DONE** — registry health/ping (`GET /v1/primitives/health`) over the `objectified-db` connection; existing tenant/scope auth confirmed, clients unaffected | `type-registry`,`rest`,`mvp`,`roadmap-type-registry` | N | Y | M | objectified-rest |
 | 2.2 #3451 ✅ | Namespace CRUD API | **DONE** — `GET/POST/PUT /v1/types/{tenant_slug}/namespaces` over `odb.type_namespaces`; tenant-admin writes, system-core read-only, type counts joined from `odb.primitives` | `type-registry`,`registry`,`rest`,`mvp`,`roadmap-type-registry` | N | Y | M | objectified-rest |
-| 2.3 #3452 | Type definition CRUD + draft 2020-12 validation | CRUD types; validate `json_schema` against draft 2020-12 | `type-registry`,`rest`,`mvp`,`roadmap-type-registry` | N | Y | L | objectified-rest |
+| 2.3 #3452 ✅ | Type definition CRUD + draft 2020-12 validation | **DONE** — strict JSON Schema draft 2020-12 meta-validation on primitive create/update/import (`app/schema_validation.py`), field-level 422 errors, stable derived `$id` (`schema_id`) + stamped `draft` persisted to `odb.primitives` | `type-registry`,`rest`,`mvp`,`roadmap-type-registry` | N | Y | L | objectified-rest |
 | 2.4 #3453 | Scope & visibility enforcement | System-core vs tenant access + ref-direction rules | `type-registry`,`governance`,`rest`,`mvp`,`roadmap-type-registry` | Y | Y | M | objectified-rest |
 | 2.5 #3454 | Registry coverage/stats endpoint | Counts by scope, imported, unresolved (for dashboard KPIs) | `type-registry`,`rest`,`mvp`,`roadmap-type-registry` | Y | Y | S | objectified-rest |
 | 2.6 #3455 | ~~UI proxy routes + typed client~~ | **CLOSED — duplicate** (`/api/primitives/*` shipped) | `type-registry`,`ui`,`mvp`,`roadmap-type-registry` | N | Y | S | objectified-ui |

--- a/objectified-rest/CHANGELOG.md
+++ b/objectified-rest/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to the Objectified REST API will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.11] - 2026-06-22
+
+### Added
+- **Type definition draft 2020-12 validation (#3452)** — the Primitives create, update, and
+  import endpoints now strictly validate the supplied `schema` against the JSON Schema
+  **draft 2020-12 meta-schema** server-side (new `app/schema_validation.py`, backed by the
+  `jsonschema` library). An invalid schema is rejected at the REST boundary with HTTP 422 and a
+  structured, field-level `errors` list (`path` / `message` / `keyword`) instead of being
+  persisted. Valid types persist with a stable, derived JSON Schema `$id` (the
+  `odb.primitives.schema_id` column) — an author-declared `$id` is honored, otherwise it is
+  computed from the namespace base URI (or a stable tenant-default base) plus a url-safe slug of
+  the name — and a stamped `draft` (default `2020-12`, read from `$schema`). The stored schema
+  document is stamped with its `$id`/`$schema` so it is self-describing. `PrimitiveCreateRequest`/
+  `PrimitiveUpdateRequest` gained optional `namespace`/`base_uri` placement fields (and `enabled`
+  on update); `PrimitiveSchema` now exposes `schema_id`/`draft`/`namespace`/`base_uri`. The import
+  path runs the same validator per `$defs` definition, recording invalid definitions in the import
+  report (`error: "invalid_schema"` with `details`) without blocking the valid ones.
+
 ## [1.0.10] - 2026-06-22
 
 ### Added

--- a/objectified-rest/openapi.json
+++ b/objectified-rest/openapi.json
@@ -16756,6 +16756,28 @@
               }
             ],
             "title": "Tags"
+          },
+          "namespace": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Namespace"
+          },
+          "base_uri": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Base Uri"
           }
         },
         "type": "object",
@@ -17006,6 +17028,44 @@
             "title": "Source",
             "default": "human"
           },
+          "schema_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Schema Id"
+          },
+          "draft": {
+            "type": "string",
+            "title": "Draft",
+            "default": "2020-12"
+          },
+          "namespace": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Namespace"
+          },
+          "base_uri": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Base Uri"
+          },
           "created_at": {
             "anyOf": [
               {
@@ -17113,6 +17173,39 @@
               }
             ],
             "title": "Tags"
+          },
+          "enabled": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Enabled"
+          },
+          "namespace": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Namespace"
+          },
+          "base_uri": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Base Uri"
           }
         },
         "type": "object",

--- a/objectified-rest/openapi.yaml
+++ b/objectified-rest/openapi.yaml
@@ -10634,6 +10634,16 @@ components:
             type: array
           - type: 'null'
           title: Tags
+        namespace:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Namespace
+        base_uri:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Base Uri
       type: object
       required:
       - name
@@ -10790,6 +10800,25 @@ components:
           type: string
           title: Source
           default: human
+        schema_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Schema Id
+        draft:
+          type: string
+          title: Draft
+          default: 2020-12
+        namespace:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Namespace
+        base_uri:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Base Uri
         created_at:
           anyOf:
           - type: string
@@ -10847,6 +10876,21 @@ components:
             type: array
           - type: 'null'
           title: Tags
+        enabled:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Enabled
+        namespace:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Namespace
+        base_uri:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Base Uri
       type: object
       title: PrimitiveUpdateRequest
       description: Request model for updating a primitive.

--- a/objectified-rest/package.json
+++ b/objectified-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-rest",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "private": true,
   "description": "Trigger file for Objectified REST Docker publish workflow; app is Python (pyproject.toml).",
   "scripts": {

--- a/objectified-rest/pyproject.toml
+++ b/objectified-rest/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "objectified-rest"
-version = "1.0.80"
+version = "1.0.81"
 description = "REST API for serving OpenAPI specifications from the Objectified database"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -35,6 +35,7 @@ dependencies = [
     "numpy>=2.4.2",
     "pgvector>=0.4.2",
     "chevron>=0.14.0",
+    "jsonschema>=4.21.0",
 ]
 
 [project.optional-dependencies]

--- a/objectified-rest/requirements.txt
+++ b/objectified-rest/requirements.txt
@@ -16,3 +16,4 @@ httpx>=0.27.0
 pgvector>=0.4.2
 chevron>=0.14.0
 email-validator==2.2.0
+jsonschema>=4.21.0

--- a/objectified-rest/src/app/database.py
+++ b/objectified-rest/src/app/database.py
@@ -1158,6 +1158,7 @@ class Database:
         query = """
             SELECT id, tenant_id, name, description, category, schema, tags,
                    created_by, is_system, is_public, usage_count, source,
+                   schema_id, draft, namespace, base_uri,
                    created_at, updated_at
             FROM odb.primitives
             WHERE tenant_id = %s
@@ -1176,6 +1177,7 @@ class Database:
         query = """
             SELECT id, tenant_id, name, description, category, schema, tags,
                    created_by, is_system, is_public, usage_count, source,
+                   schema_id, draft, namespace, base_uri,
                    created_at, updated_at
             FROM odb.primitives
             WHERE id = %s AND tenant_id = %s
@@ -1192,20 +1194,30 @@ class Database:
         description: Optional[str] = None,
         tags: Optional[List[str]] = None,
         created_by: Optional[str] = None,
-        source: str = 'human'
+        source: str = 'human',
+        schema_id: Optional[str] = None,
+        draft: str = '2020-12',
+        namespace: Optional[str] = None,
+        base_uri: Optional[str] = None
     ) -> Dict[str, Any]:
         """Create a new primitive.
 
         Args:
             source: Provenance of the primitive — 'human' (authored in-app, default)
                 or 'imported' (created by an import). Stored on odb.primitives.source.
+            schema_id: The computed JSON Schema ``$id`` for the primitive (#3452).
+            draft: The JSON Schema dialect/draft, default '2020-12' (#3452).
+            namespace: Optional registry namespace path locating the primitive (#3452).
+            base_uri: Optional namespace base URI the ``$id`` was computed against (#3452).
         """
         query = """
             INSERT INTO odb.primitives
-            (tenant_id, name, description, category, schema, tags, created_by, source)
-            VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+            (tenant_id, name, description, category, schema, tags, created_by, source,
+             schema_id, draft, namespace, base_uri)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
             RETURNING id, tenant_id, name, description, category, schema, tags,
                       created_by, is_system, is_public, usage_count, source,
+                      schema_id, draft, namespace, base_uri,
                       created_at, updated_at
         """
 
@@ -1217,7 +1229,8 @@ class Database:
             with conn.cursor() as cursor:
                 cursor.execute(
                     query,
-                    (tenant_id, name, description, category, schema_json, tags or [], created_by, source)
+                    (tenant_id, name, description, category, schema_json, tags or [],
+                     created_by, source, schema_id, draft, namespace, base_uri)
                 )
                 result = cursor.fetchone()
                 conn.commit()
@@ -1254,6 +1267,23 @@ class Database:
         if 'tags' in updates and updates['tags'] is not None:
             update_fields.append("tags = %s")
             params.append(updates['tags'])
+        if 'enabled' in updates and updates['enabled'] is not None:
+            update_fields.append("enabled = %s")
+            params.append(updates['enabled'])
+        # JSON Schema 2020-12 registry identity columns (#3452). Re-derived by the
+        # route whenever the schema or registry placement changes.
+        if 'schema_id' in updates and updates['schema_id'] is not None:
+            update_fields.append("schema_id = %s")
+            params.append(updates['schema_id'])
+        if 'draft' in updates and updates['draft'] is not None:
+            update_fields.append("draft = %s")
+            params.append(updates['draft'])
+        if 'namespace' in updates and updates['namespace'] is not None:
+            update_fields.append("namespace = %s")
+            params.append(updates['namespace'])
+        if 'base_uri' in updates and updates['base_uri'] is not None:
+            update_fields.append("base_uri = %s")
+            params.append(updates['base_uri'])
 
         if not update_fields:
             # Nothing to update, return current primitive
@@ -1266,6 +1296,7 @@ class Database:
             WHERE id = %s AND tenant_id = %s
             RETURNING id, tenant_id, name, description, category, schema, tags,
                       created_by, is_system, is_public, usage_count, source,
+                      schema_id, draft, namespace, base_uri,
                       created_at, updated_at
         """
 

--- a/objectified-rest/src/app/models.py
+++ b/objectified-rest/src/app/models.py
@@ -124,6 +124,13 @@ class PrimitiveSchema(BaseModel):
     is_public: bool = False
     usage_count: int = 0
     source: str = 'human'  # Provenance: 'human' (authored in-app) or 'imported' (#3448)
+    # JSON Schema 2020-12 registry identity (#3452). schema_id is the computed/stored
+    # `$id`; draft is the dialect (default '2020-12'); namespace/base_uri locate it in
+    # the registry. Optional so legacy flat primitives (no `$id`) still round-trip.
+    schema_id: Optional[str] = None
+    draft: str = '2020-12'
+    namespace: Optional[str] = None
+    base_uri: Optional[str] = None
     created_at: Optional[Union[datetime, str]] = None
     updated_at: Optional[Union[datetime, str]] = None
     enabled: bool = True
@@ -139,6 +146,11 @@ class PrimitiveCreateRequest(BaseModel):
     category: str
     schema: Dict[str, Any]
     tags: Optional[List[str]] = None
+    # Optional registry placement (#3452). When omitted, the `$id` is derived from a
+    # stable tenant-default base URI; when provided, the primitive's `$id` is computed
+    # against this namespace / base URI.
+    namespace: Optional[str] = None
+    base_uri: Optional[str] = None
 
     class Config:
         from_attributes = True
@@ -151,6 +163,10 @@ class PrimitiveUpdateRequest(BaseModel):
     category: Optional[str] = None
     schema: Optional[Dict[str, Any]] = None
     tags: Optional[List[str]] = None
+    enabled: Optional[bool] = None
+    # Registry placement may be re-pinned on update (#3452); see PrimitiveCreateRequest.
+    namespace: Optional[str] = None
+    base_uri: Optional[str] = None
 
     class Config:
         from_attributes = True

--- a/objectified-rest/src/app/primitives_routes.py
+++ b/objectified-rest/src/app/primitives_routes.py
@@ -19,11 +19,88 @@ from .models import (
     RegistryHealthResponse
 )
 from .auth import validate_authentication, get_authenticated_user_id
+from .schema_validation import (
+    SchemaValidationError,
+    validate_schema_document,
+    derive_base_uri,
+    derive_draft,
+    derive_schema_id,
+    stamp_identity,
+)
 
 router = APIRouter(prefix="/v1/primitives", tags=["primitives"])
 
 # Allowed import source shapes — must match the odb.primitive_imports CHECK constraint.
 VALID_IMPORT_SOURCE_KINDS = {"json-schema", "type-def-bundle", "openapi"}
+
+
+def _schema_validation_http_error(errors: List[Dict[str, str]]) -> HTTPException:
+    """Build the 422 response for a JSON Schema that fails draft 2020-12 validation (#3452).
+
+    Args:
+        errors: Field-level errors from ``schema_validation.validate_schema_document``.
+
+    Returns:
+        An ``HTTPException`` whose detail carries a human message plus the structured,
+        field-level ``errors`` list so clients can highlight the offending keywords.
+    """
+    return HTTPException(
+        status_code=422,
+        detail={
+            "message": "Schema is not a valid JSON Schema draft 2020-12 document",
+            "errors": errors,
+        },
+    )
+
+
+def resolve_primitive_identity(
+    schema: Dict[str, Any],
+    *,
+    name: str,
+    namespace: Optional[str],
+    base_uri: Optional[str],
+    tenant_slug: str,
+) -> Dict[str, Any]:
+    """Validate a schema and derive its persisted JSON Schema 2020-12 identity (#3452).
+
+    Shared by the create, update, and import paths so all three reject invalid schemas
+    identically and compute a stable ``$id`` the same way.
+
+    Args:
+        schema: The candidate JSON Schema document.
+        name: The primitive name (drives the derived ``$id`` leaf).
+        namespace: Optional registry namespace path.
+        base_uri: Optional explicit base URI (wins over ``namespace``).
+        tenant_slug: The tenant slug (used for the default base URI).
+
+    Returns:
+        A dict with ``schema`` (identity-stamped copy), ``schema_id``, ``draft``,
+        and ``base_uri``.
+
+    Raises:
+        SchemaValidationError: If ``schema`` is not a valid draft 2020-12 document,
+            or is a boolean schema (valid per spec, but a primitive needs an object
+            schema to carry a derived ``$id``).
+    """
+    if not isinstance(schema, dict):
+        raise SchemaValidationError(
+            [{"path": "(root)", "message": "Schema must be a JSON object", "keyword": "type"}]
+        )
+
+    errors = validate_schema_document(schema)
+    if errors:
+        raise SchemaValidationError(errors)
+
+    resolved_base = derive_base_uri(namespace, base_uri, tenant_slug)
+    schema_id = derive_schema_id(schema, name=name, base_uri=resolved_base)
+    draft = derive_draft(schema)
+    stamped = stamp_identity(schema, schema_id=schema_id, draft=draft)
+    return {
+        "schema": stamped,
+        "schema_id": schema_id,
+        "draft": draft,
+        "base_uri": resolved_base,
+    }
 
 
 @router.get("/health", response_model=RegistryHealthResponse)
@@ -263,6 +340,18 @@ async def create_primitive(
     Returns:
         The created primitive
     """
+    # Strict server-side draft 2020-12 validation + stable $id derivation (#3452).
+    try:
+        identity = resolve_primitive_identity(
+            request.schema,
+            name=request.name,
+            namespace=request.namespace,
+            base_uri=request.base_uri,
+            tenant_slug=tenant_slug,
+        )
+    except SchemaValidationError as e:
+        raise _schema_validation_http_error(e.errors)
+
     try:
         # Get user_id from auth data (will be None for API key auth)
         created_by = get_authenticated_user_id(auth_data)
@@ -272,13 +361,19 @@ async def create_primitive(
             tenant_id=auth_data['tenant_id'],
             name=request.name,
             category=request.category,
-            schema=request.schema,
+            schema=identity['schema'],
             description=request.description,
             tags=request.tags,
-            created_by=created_by
+            created_by=created_by,
+            schema_id=identity['schema_id'],
+            draft=identity['draft'],
+            namespace=request.namespace,
+            base_uri=identity['base_uri'],
         )
 
         return PrimitiveSchema(**primitive)
+    except HTTPException:
+        raise
     except Exception as e:
         # Check for unique constraint violation
         if "unique constraint" in str(e).lower():
@@ -325,22 +420,55 @@ async def update_primitive(
             detail="Cannot update system primitives"
         )
 
-    try:
-        # Build updates dict from request
-        updates = {}
-        if request.name is not None:
-            updates['name'] = request.name
-        if request.description is not None:
-            updates['description'] = request.description
-        if request.category is not None:
-            updates['category'] = request.category
-        if request.schema is not None:
-            updates['schema'] = request.schema
-        if request.tags is not None:
-            updates['tags'] = request.tags
-        if request.enabled is not None:
-            updates['enabled'] = request.enabled
+    # Build updates dict from request
+    updates = {}
+    if request.name is not None:
+        updates['name'] = request.name
+    if request.description is not None:
+        updates['description'] = request.description
+    if request.category is not None:
+        updates['category'] = request.category
+    if request.tags is not None:
+        updates['tags'] = request.tags
+    if request.enabled is not None:
+        updates['enabled'] = request.enabled
+    if request.namespace is not None:
+        updates['namespace'] = request.namespace
 
+    # Re-validate and re-derive the JSON Schema 2020-12 identity whenever the schema or
+    # its registry placement changes (#3452). Identity is computed against the effective
+    # (post-update) name and namespace/base_uri, falling back to the stored values.
+    identity_touched = (
+        request.schema is not None
+        or request.namespace is not None
+        or request.base_uri is not None
+        or request.name is not None
+    )
+    if identity_touched:
+        schema_doc = request.schema if request.schema is not None else existing['schema']
+        effective_name = request.name if request.name is not None else existing['name']
+        effective_namespace = (
+            request.namespace if request.namespace is not None else existing.get('namespace')
+        )
+        effective_base_uri = (
+            request.base_uri if request.base_uri is not None else existing.get('base_uri')
+        )
+        try:
+            identity = resolve_primitive_identity(
+                schema_doc,
+                name=effective_name,
+                namespace=effective_namespace,
+                base_uri=effective_base_uri,
+                tenant_slug=tenant_slug,
+            )
+        except SchemaValidationError as e:
+            raise _schema_validation_http_error(e.errors)
+        updates['schema'] = identity['schema']
+        updates['schema_id'] = identity['schema_id']
+        updates['draft'] = identity['draft']
+        updates['base_uri'] = identity['base_uri']
+
+    try:
         # Update primitive
         primitive = db.update_primitive(
             primitive_id,
@@ -355,6 +483,8 @@ async def update_primitive(
             )
 
         return PrimitiveSchema(**primitive)
+    except HTTPException:
+        raise
     except Exception as e:
         # Check for unique constraint violation
         if "unique constraint" in str(e).lower():
@@ -483,21 +613,40 @@ async def import_primitives(
     errors = []
 
     for def_name, def_schema in definitions.items():
+        # Each imported definition goes through the SAME draft 2020-12 validator and
+        # $id derivation as create/update (#3452). An invalid definition is rejected
+        # with its field-level errors and skipped; valid ones are not blocked by it.
+        try:
+            identity = resolve_primitive_identity(
+                def_schema,
+                name=def_name,
+                namespace=request.target_namespace,
+                base_uri=None,
+                tenant_slug=tenant_slug,
+            )
+        except SchemaValidationError as e:
+            errors.append({"name": def_name, "error": "invalid_schema", "details": e.errors})
+            continue
+
         try:
             # Determine category from schema
             schema_type = determine_category_from_schema(def_schema)
 
-            # Create primitive - the full schema with all metadata is stored.
-            # source='imported' marks its provenance on odb.primitives (#3448).
+            # Create primitive - the full (identity-stamped) schema with all metadata is
+            # stored. source='imported' marks its provenance on odb.primitives (#3448).
             primitive = db.create_primitive(
                 tenant_id=auth_data['tenant_id'],
                 name=def_name,
                 category=schema_type,
-                schema=def_schema,  # Full schema including x-license, x-links, $comment, examples, title, etc.
+                schema=identity['schema'],  # Full schema (x-license, $comment, examples, …) + stamped $id.
                 description=def_schema.get('description'),
                 tags=def_schema.get('tags', []),
                 created_by=created_by,
-                source='imported'
+                source='imported',
+                schema_id=identity['schema_id'],
+                draft=identity['draft'],
+                namespace=request.target_namespace,
+                base_uri=identity['base_uri'],
             )
             imported.append(primitive['name'])
         except Exception as e:

--- a/objectified-rest/src/app/schema_validation.py
+++ b/objectified-rest/src/app/schema_validation.py
@@ -1,0 +1,221 @@
+"""
+JSON Schema draft 2020-12 validation and identity derivation for primitives (#3452).
+
+The Primitives CRUD layer stores arbitrary JSON Schema documents in
+``odb.primitives.schema``. Before this module those documents were only validated
+client-side (AJV in the UI editor); the REST service persisted whatever it was
+given. This module makes the REST service the authority:
+
+* :func:`validate_schema_document` checks that a document is itself a *valid*
+  JSON Schema under the draft 2020-12 dialect (it validates the document against
+  the 2020-12 **meta-schema**), returning structured, field-level errors.
+* :func:`derive_schema_id` computes the stable JSON Schema ``$id`` for a
+  primitive (the ``schema_id`` column on ``odb.primitives``) from a namespace
+  base URI and the primitive name, honoring an author-declared ``$id``.
+* :func:`derive_draft` reads the dialect (``draft``) from the document's
+  ``$schema`` URI, defaulting to ``2020-12``.
+* :func:`stamp_identity` returns a copy of the document with its ``$id`` /
+  ``$schema`` filled in so the persisted JSON Schema is self-describing.
+
+Everything here is pure and side-effect free so the create, update, and import
+paths can share exactly one validator (an acceptance criterion of #3452).
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, List
+
+from jsonschema.validators import Draft202012Validator
+
+# The dialect this service validates against, in both its short and URI forms.
+DRAFT_2020_12 = "2020-12"
+DRAFT_2020_12_META_URI = "https://json-schema.org/draft/2020-12/schema"
+
+# Registry root every derived ``$id`` / namespace base URI hangs off. Matches the
+# seeded ``std/v0`` primitives (#3449) and ``type_namespaces_routes.REGISTRY_BASE_URL``.
+REGISTRY_BASE_URL = "https://api.objectified.dev/types/"
+
+# Extracts the draft token from a ``$schema`` URI, e.g.
+# ``.../draft/2020-12/schema`` -> ``2020-12`` and ``.../draft-07/schema`` -> ``07``.
+_DRAFT_URI_RE = re.compile(r"draft[/-](?P<draft>\d{4}-\d{2}|\d+)")
+
+# Collapses any run of non-url-safe characters into a single hyphen for the
+# ``$id`` leaf segment (e.g. "Email Address" -> "email-address").
+_SLUG_NONWORD_RE = re.compile(r"[^a-z0-9]+")
+
+# One shared meta-schema validator. Constructing the draft 2020-12 validator with
+# its own ``META_SCHEMA`` as the schema makes ``iter_errors(document)`` report every
+# way ``document`` fails to be a valid 2020-12 schema. Reused across all calls so the
+# meta-schema and its vocabulary registry are resolved exactly once.
+_META_VALIDATOR = Draft202012Validator(Draft202012Validator.META_SCHEMA)
+
+
+class SchemaValidationError(Exception):
+    """Raised when a JSON Schema document fails draft 2020-12 meta-validation.
+
+    Attributes:
+        errors: Structured, field-level errors as returned by
+            :func:`validate_schema_document` (never empty for this exception).
+    """
+
+    def __init__(self, errors: List[Dict[str, str]]):
+        self.errors = errors
+        super().__init__(
+            f"Schema failed JSON Schema draft 2020-12 validation "
+            f"({len(errors)} error(s))"
+        )
+
+
+def validate_schema_document(schema: Any) -> List[Dict[str, str]]:
+    """Validate a JSON Schema document against the draft 2020-12 meta-schema.
+
+    This answers "is ``schema`` a valid JSON Schema?" — not "does some instance
+    satisfy ``schema``?". A malformed schema (an unknown ``type``, a negative
+    ``maxLength``, a non-array ``required``, …) is reported here.
+
+    Args:
+        schema: The candidate JSON Schema document (typically a ``dict``).
+
+    Returns:
+        A list of structured errors, deduplicated and ordered by location. Each
+        entry has:
+            * ``path``: a slash-joined location within the document of the
+              offending keyword (``"(root)"`` for the top level);
+            * ``message``: the human-readable validator message;
+            * ``keyword``: the JSON Schema keyword that failed (e.g. ``type``).
+        The list is empty when the document is a valid 2020-12 schema.
+    """
+    errors: List[Dict[str, str]] = []
+    seen: set = set()
+    for error in sorted(
+        _META_VALIDATOR.iter_errors(schema),
+        key=lambda e: list(map(str, e.absolute_path)),
+    ):
+        path = "/".join(str(part) for part in error.absolute_path)
+        # The 2020-12 meta-schema is a union of vocabulary subschemas, so a single
+        # structural fault can surface from several branches with the same message;
+        # collapse those to one field-level error per (location, message).
+        dedupe_key = (path, error.message)
+        if dedupe_key in seen:
+            continue
+        seen.add(dedupe_key)
+        errors.append(
+            {
+                "path": path or "(root)",
+                "message": error.message,
+                "keyword": str(error.validator),
+            }
+        )
+    return errors
+
+
+def assert_valid_schema_document(schema: Any) -> None:
+    """Validate ``schema`` and raise :class:`SchemaValidationError` if it is invalid.
+
+    Args:
+        schema: The candidate JSON Schema document.
+
+    Raises:
+        SchemaValidationError: If the document is not a valid draft 2020-12 schema;
+            the exception carries the field-level error list.
+    """
+    errors = validate_schema_document(schema)
+    if errors:
+        raise SchemaValidationError(errors)
+
+
+def derive_draft(schema: Dict[str, Any]) -> str:
+    """Derive the JSON Schema dialect (``draft``) for a document.
+
+    Args:
+        schema: The JSON Schema document; its ``$schema`` URI, when present and
+            recognizable, names the dialect.
+
+    Returns:
+        The draft token (e.g. ``"2020-12"``), defaulting to :data:`DRAFT_2020_12`
+        when ``$schema`` is absent or unrecognized.
+    """
+    declared = schema.get("$schema") if isinstance(schema, dict) else None
+    if isinstance(declared, str):
+        match = _DRAFT_URI_RE.search(declared)
+        if match:
+            return match.group("draft")
+    return DRAFT_2020_12
+
+
+def _slug(name: str) -> str:
+    """Return a lowercase, hyphen-separated, url-safe leaf for an ``$id``."""
+    slug = _SLUG_NONWORD_RE.sub("-", (name or "").strip().lower()).strip("-")
+    return slug or "type"
+
+
+def derive_schema_id(schema: Dict[str, Any], *, name: str, base_uri: str) -> str:
+    """Derive the stable JSON Schema ``$id`` (the ``schema_id`` column) for a primitive.
+
+    An author-declared, non-empty ``$id`` on the document wins — identity is the
+    author's to assert and the seeded ``std/v0`` types rely on it. Otherwise the id
+    is the namespace ``base_uri`` joined with a url-safe slug of ``name``, which is
+    deterministic: the same name in the same namespace always yields the same id.
+
+    Args:
+        schema: The JSON Schema document (may carry an explicit ``$id``).
+        name: The primitive's name, used for the derived leaf segment.
+        base_uri: The namespace base URI the id hangs off (trailing slash optional).
+
+    Returns:
+        The resolved ``$id`` string.
+    """
+    declared = schema.get("$id") if isinstance(schema, dict) else None
+    if isinstance(declared, str) and declared.strip():
+        return declared.strip()
+    base = (base_uri or "").strip().rstrip("/")
+    return f"{base}/{_slug(name)}"
+
+
+def derive_base_uri(namespace: str | None, base_uri: str | None, tenant_slug: str) -> str:
+    """Resolve the namespace base URI a primitive's ``$id`` is computed against.
+
+    Precedence: an explicit ``base_uri`` wins; else a ``namespace`` path is rooted
+    under :data:`REGISTRY_BASE_URL`; else a stable tenant-default base is used so a
+    primitive created without registry placement still gets a deterministic id.
+
+    Args:
+        namespace: Optional registry namespace path (e.g. ``tenant/acme/v1/types``).
+        base_uri: Optional explicit base URI (wins when provided).
+        tenant_slug: The tenant slug, used for the default base.
+
+    Returns:
+        A base URI ending in a single trailing slash.
+    """
+    if base_uri and base_uri.strip():
+        resolved = base_uri.strip()
+    elif namespace and namespace.strip():
+        resolved = f"{REGISTRY_BASE_URL}{namespace.strip().strip('/')}/"
+    else:
+        resolved = f"{REGISTRY_BASE_URL}tenant/{tenant_slug.strip().strip('/')}/"
+    return resolved if resolved.endswith("/") else resolved + "/"
+
+
+def stamp_identity(schema: Dict[str, Any], *, schema_id: str, draft: str) -> Dict[str, Any]:
+    """Return a copy of ``schema`` with its ``$id`` / ``$schema`` filled in.
+
+    Persisting the derived identity into the stored document keeps the JSON Schema
+    self-describing (matching the seeded ``std/v0`` rows). The canonical ``$id`` is
+    always written; ``$schema`` is only added when missing so an author who pinned a
+    specific dialect URI keeps it.
+
+    Args:
+        schema: The validated JSON Schema document.
+        schema_id: The resolved ``$id`` to stamp.
+        draft: The dialect token (used only to pick the meta URI when ``$schema``
+            is absent and the draft is :data:`DRAFT_2020_12`).
+
+    Returns:
+        A new dict; the input is not mutated.
+    """
+    stamped = dict(schema)
+    stamped["$id"] = schema_id
+    if "$schema" not in stamped and draft == DRAFT_2020_12:
+        stamped["$schema"] = DRAFT_2020_12_META_URI
+    return stamped

--- a/objectified-rest/tests/test_primitives_validation_routes.py
+++ b/objectified-rest/tests/test_primitives_validation_routes.py
@@ -1,0 +1,235 @@
+"""API tests for server-side draft 2020-12 validation on the Primitives CRUD (#3452).
+
+Covers create / update / import: invalid schemas are rejected at the REST boundary with
+field-level errors, valid types persist with a stable derived ``$id`` (``schema_id``) and a
+stamped ``draft``, an author-declared ``$id`` is honored, and the import path runs the same
+validator per definition.
+"""
+
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.auth import validate_authentication
+from app.main import app
+
+client = TestClient(app)
+
+_JWT = {"tenant_id": "t1", "user_id": "u1", "auth_method": "jwt"}
+_NOW = datetime(2026, 6, 22, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _row(**overrides):
+    """A representative odb.primitives row as returned by the DB layer."""
+    row = {
+        "id": "p1",
+        "tenant_id": "t1",
+        "name": "My Type",
+        "description": None,
+        "category": "string",
+        "schema": {"type": "string"},
+        "tags": [],
+        "created_by": "u1",
+        "is_system": False,
+        "is_public": False,
+        "usage_count": 0,
+        "source": "human",
+        "schema_id": None,
+        "draft": "2020-12",
+        "namespace": None,
+        "base_uri": None,
+        "created_at": _NOW,
+        "updated_at": _NOW,
+        "enabled": True,
+    }
+    row.update(overrides)
+    return row
+
+
+@pytest.fixture(autouse=True)
+def _auth():
+    app.dependency_overrides[validate_authentication] = lambda: _JWT
+    yield
+    app.dependency_overrides.pop(validate_authentication, None)
+
+
+# ===========================================================================
+# CREATE — validation
+# ===========================================================================
+
+
+def test_create_rejects_invalid_schema_with_field_errors():
+    with patch("app.primitives_routes.db") as mdb:
+        r = client.post(
+            "/v1/primitives/acme",
+            json={"name": "Bad", "category": "string", "schema": {"type": "stringg"}},
+        )
+    assert r.status_code == 422
+    detail = r.json()["detail"]
+    assert "draft 2020-12" in detail["message"]
+    assert detail["errors"][0]["path"] == "type"
+    # An invalid schema never reaches the database.
+    mdb.create_primitive.assert_not_called()
+
+
+def test_create_persists_derived_schema_id_and_draft():
+    with patch("app.primitives_routes.db") as mdb:
+        mdb.create_primitive.return_value = _row(
+            schema_id="https://api.objectified.dev/types/tenant/acme/my-type",
+            base_uri="https://api.objectified.dev/types/tenant/acme/",
+        )
+        r = client.post(
+            "/v1/primitives/acme",
+            json={"name": "My Type", "category": "string", "schema": {"type": "string"}},
+        )
+    assert r.status_code == 200
+    kwargs = mdb.create_primitive.call_args.kwargs
+    # Derived against the tenant-default base URI from the URL slug.
+    assert kwargs["schema_id"] == "https://api.objectified.dev/types/tenant/acme/my-type"
+    assert kwargs["draft"] == "2020-12"
+    assert kwargs["base_uri"] == "https://api.objectified.dev/types/tenant/acme/"
+    # The persisted schema is stamped with its $id.
+    assert kwargs["schema"]["$id"] == "https://api.objectified.dev/types/tenant/acme/my-type"
+    assert kwargs["schema"]["$schema"].endswith("/draft/2020-12/schema")
+
+
+def test_create_honors_author_declared_id():
+    declared = "https://api.objectified.dev/types/std/v0/primitives/string"
+    with patch("app.primitives_routes.db") as mdb:
+        mdb.create_primitive.return_value = _row(schema_id=declared)
+        r = client.post(
+            "/v1/primitives/acme",
+            json={
+                "name": "My Type",
+                "category": "string",
+                "schema": {"$id": declared, "type": "string"},
+            },
+        )
+    assert r.status_code == 200
+    assert mdb.create_primitive.call_args.kwargs["schema_id"] == declared
+
+
+def test_create_uses_namespace_for_base_uri():
+    with patch("app.primitives_routes.db") as mdb:
+        mdb.create_primitive.return_value = _row()
+        r = client.post(
+            "/v1/primitives/acme",
+            json={
+                "name": "Money",
+                "category": "object",
+                "schema": {"type": "object"},
+                "namespace": "tenant/acme/v1/types",
+            },
+        )
+    assert r.status_code == 200
+    kwargs = mdb.create_primitive.call_args.kwargs
+    assert kwargs["base_uri"] == "https://api.objectified.dev/types/tenant/acme/v1/types/"
+    assert kwargs["schema_id"] == "https://api.objectified.dev/types/tenant/acme/v1/types/money"
+    assert kwargs["namespace"] == "tenant/acme/v1/types"
+
+
+# ===========================================================================
+# UPDATE — validation
+# ===========================================================================
+
+
+def test_update_rejects_invalid_schema():
+    with patch("app.primitives_routes.db") as mdb:
+        mdb.get_primitive_by_id.return_value = _row()
+        r = client.put(
+            "/v1/primitives/acme/p1",
+            json={"schema": {"type": "nope"}},
+        )
+    assert r.status_code == 422
+    assert r.json()["detail"]["errors"][0]["path"] == "type"
+    mdb.update_primitive.assert_not_called()
+
+
+def test_update_rederives_identity_on_schema_change():
+    with patch("app.primitives_routes.db") as mdb:
+        mdb.get_primitive_by_id.return_value = _row(name="My Type")
+        mdb.update_primitive.return_value = _row(schema={"type": "integer"})
+        r = client.put(
+            "/v1/primitives/acme/p1",
+            json={"schema": {"type": "integer"}},
+        )
+    assert r.status_code == 200
+    updates = mdb.update_primitive.call_args.args[2]
+    assert updates["schema_id"] == "https://api.objectified.dev/types/tenant/acme/my-type"
+    assert updates["draft"] == "2020-12"
+    assert updates["schema"]["$id"].endswith("/my-type")
+
+
+def test_update_system_primitive_forbidden_before_validation():
+    with patch("app.primitives_routes.db") as mdb:
+        mdb.get_primitive_by_id.return_value = _row(is_system=True)
+        r = client.put("/v1/primitives/acme/p1", json={"schema": {"type": "nope"}})
+    assert r.status_code == 403
+    mdb.update_primitive.assert_not_called()
+
+
+def test_update_metadata_only_does_not_touch_identity():
+    with patch("app.primitives_routes.db") as mdb:
+        mdb.get_primitive_by_id.return_value = _row()
+        mdb.update_primitive.return_value = _row(description="updated")
+        r = client.put("/v1/primitives/acme/p1", json={"description": "updated"})
+    assert r.status_code == 200
+    updates = mdb.update_primitive.call_args.args[2]
+    assert "schema_id" not in updates and "schema" not in updates
+
+
+# ===========================================================================
+# IMPORT — same validator per definition
+# ===========================================================================
+
+
+def test_import_rejects_invalid_definition_but_imports_valid():
+    def _create(**kwargs):
+        return {"name": kwargs["name"]}
+
+    with patch("app.primitives_routes.db") as mdb:
+        mdb.create_primitive.side_effect = _create
+        mdb.create_primitive_import.return_value = {"id": "imp1"}
+        r = client.post(
+            "/v1/primitives/acme/import",
+            json={
+                "schema": {
+                    "$defs": {
+                        "Good": {"type": "string"},
+                        "Bad": {"type": "stringg"},
+                    }
+                },
+                "import_all": True,
+            },
+        )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["imported"] == ["Good"]
+    assert body["total_errors"] == 1
+    err = next(e for e in body["errors"] if e["name"] == "Bad")
+    assert err["error"] == "invalid_schema"
+    assert err["details"][0]["path"] == "type"
+    # Only the valid definition is created.
+    assert mdb.create_primitive.call_count == 1
+
+
+def test_import_stamps_identity_using_target_namespace():
+    with patch("app.primitives_routes.db") as mdb:
+        mdb.create_primitive.return_value = {"name": "Good"}
+        mdb.create_primitive_import.return_value = {"id": "imp1"}
+        r = client.post(
+            "/v1/primitives/acme/import",
+            json={
+                "schema": {"$defs": {"Good": {"type": "string"}}},
+                "import_all": True,
+                "target_namespace": "tenant/acme/v1/types",
+            },
+        )
+    assert r.status_code == 200
+    kwargs = mdb.create_primitive.call_args.kwargs
+    assert kwargs["base_uri"] == "https://api.objectified.dev/types/tenant/acme/v1/types/"
+    assert kwargs["schema_id"] == "https://api.objectified.dev/types/tenant/acme/v1/types/good"
+    assert kwargs["namespace"] == "tenant/acme/v1/types"
+    assert kwargs["source"] == "imported"

--- a/objectified-rest/tests/test_schema_validation.py
+++ b/objectified-rest/tests/test_schema_validation.py
@@ -1,0 +1,184 @@
+"""Unit tests for the JSON Schema draft 2020-12 validator/identity helpers (#3452).
+
+Covers the pure functions in ``app.schema_validation`` that the Primitives create,
+update, and import paths all share: meta-schema validation with structured field-level
+errors, draft/dialect derivation, stable ``$id`` derivation, base-URI resolution, and
+identity stamping.
+"""
+
+import pytest
+
+from app import schema_validation as sv
+
+
+# ===========================================================================
+# validate_schema_document
+# ===========================================================================
+
+
+def test_valid_string_schema_has_no_errors():
+    assert sv.validate_schema_document({"type": "string"}) == []
+
+
+def test_valid_full_schema_has_no_errors():
+    schema = {
+        "$schema": sv.DRAFT_2020_12_META_URI,
+        "$id": "https://api.objectified.dev/types/std/v0/primitives/string",
+        "type": "string",
+        "maxLength": 5,
+    }
+    assert sv.validate_schema_document(schema) == []
+
+
+def test_invalid_type_is_reported_field_level():
+    errors = sv.validate_schema_document({"type": "stringg"})
+    assert len(errors) == 1
+    assert errors[0]["path"] == "type"
+    assert errors[0]["keyword"] == "anyOf"
+    assert "message" in errors[0]
+
+
+def test_invalid_maxlength_is_reported():
+    errors = sv.validate_schema_document({"type": "string", "maxLength": -1})
+    assert any(e["path"] == "maxLength" for e in errors)
+
+
+def test_multiple_faults_each_reported_once():
+    errors = sv.validate_schema_document(
+        {"type": "objectt", "required": "notalist", "properties": "nope"}
+    )
+    paths = sorted(e["path"] for e in errors)
+    assert paths == ["properties", "required", "type"]
+    # Deduplicated: the union-of-vocabularies meta-schema must not double-report a path.
+    assert len(paths) == len(set(paths))
+
+
+def test_boolean_schema_is_valid_per_spec():
+    # ``true`` / ``false`` are valid JSON Schemas under the meta-schema.
+    assert sv.validate_schema_document(True) == []
+    assert sv.validate_schema_document(False) == []
+
+
+# ===========================================================================
+# assert_valid_schema_document
+# ===========================================================================
+
+
+def test_assert_valid_passes_silently():
+    sv.assert_valid_schema_document({"type": "integer"})
+
+
+def test_assert_valid_raises_with_errors():
+    with pytest.raises(sv.SchemaValidationError) as exc:
+        sv.assert_valid_schema_document({"type": "nope"})
+    assert exc.value.errors
+    assert exc.value.errors[0]["path"] == "type"
+
+
+# ===========================================================================
+# derive_draft
+# ===========================================================================
+
+
+def test_derive_draft_defaults_to_2020_12():
+    assert sv.derive_draft({"type": "string"}) == "2020-12"
+
+
+def test_derive_draft_reads_2020_12_uri():
+    assert sv.derive_draft({"$schema": sv.DRAFT_2020_12_META_URI}) == "2020-12"
+
+
+def test_derive_draft_reads_legacy_dash_form():
+    assert sv.derive_draft({"$schema": "http://json-schema.org/draft-07/schema#"}) == "07"
+
+
+def test_derive_draft_unrecognized_uri_defaults():
+    assert sv.derive_draft({"$schema": "https://example.com/custom"}) == "2020-12"
+
+
+# ===========================================================================
+# derive_base_uri
+# ===========================================================================
+
+
+def test_base_uri_explicit_wins():
+    assert (
+        sv.derive_base_uri("tenant/acme/v1/types", "https://x.example/base/", "acme")
+        == "https://x.example/base/"
+    )
+
+
+def test_base_uri_explicit_gets_trailing_slash():
+    assert sv.derive_base_uri(None, "https://x.example/base", "acme") == "https://x.example/base/"
+
+
+def test_base_uri_from_namespace():
+    assert (
+        sv.derive_base_uri("tenant/acme/v1/types", None, "acme")
+        == "https://api.objectified.dev/types/tenant/acme/v1/types/"
+    )
+
+
+def test_base_uri_tenant_default_when_unplaced():
+    assert (
+        sv.derive_base_uri(None, None, "acme")
+        == "https://api.objectified.dev/types/tenant/acme/"
+    )
+
+
+# ===========================================================================
+# derive_schema_id
+# ===========================================================================
+
+
+def test_schema_id_honors_explicit_id():
+    schema = {"$id": "https://api.objectified.dev/types/std/v0/primitives/string", "type": "string"}
+    assert (
+        sv.derive_schema_id(schema, name="Anything", base_uri="https://x/")
+        == "https://api.objectified.dev/types/std/v0/primitives/string"
+    )
+
+
+def test_schema_id_derived_from_base_and_slugged_name():
+    schema = {"type": "string"}
+    assert (
+        sv.derive_schema_id(schema, name="Email Address", base_uri="https://x.example/ns/")
+        == "https://x.example/ns/email-address"
+    )
+
+
+def test_schema_id_is_stable_for_same_name_and_base():
+    a = sv.derive_schema_id({"type": "string"}, name="UUID", base_uri="https://x/ns")
+    b = sv.derive_schema_id({"type": "string"}, name="UUID", base_uri="https://x/ns/")
+    assert a == b == "https://x/ns/uuid"
+
+
+def test_schema_id_blank_explicit_id_falls_back_to_derived():
+    schema = {"$id": "   ", "type": "string"}
+    assert sv.derive_schema_id(schema, name="X", base_uri="https://x/ns/") == "https://x/ns/x"
+
+
+# ===========================================================================
+# stamp_identity
+# ===========================================================================
+
+
+def test_stamp_identity_writes_id_and_schema():
+    out = sv.stamp_identity({"type": "string"}, schema_id="https://x/ns/s", draft="2020-12")
+    assert out["$id"] == "https://x/ns/s"
+    assert out["$schema"] == sv.DRAFT_2020_12_META_URI
+
+
+def test_stamp_identity_does_not_mutate_input():
+    src = {"type": "string"}
+    sv.stamp_identity(src, schema_id="https://x/ns/s", draft="2020-12")
+    assert "$id" not in src and "$schema" not in src
+
+
+def test_stamp_identity_preserves_existing_schema_uri():
+    out = sv.stamp_identity(
+        {"type": "string", "$schema": "https://example.com/custom"},
+        schema_id="https://x/ns/s",
+        draft="2020-12",
+    )
+    assert out["$schema"] == "https://example.com/custom"

--- a/objectified-rest/uv.lock
+++ b/objectified-rest/uv.lock
@@ -35,6 +35,15 @@ wheels = [
 ]
 
 [[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
 name = "bcrypt"
 version = "4.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -434,6 +443,33 @@ wheels = [
 ]
 
 [[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
 name = "numpy"
 version = "2.4.2"
 source = { registry = "https://pypi.org/simple" }
@@ -514,7 +550,7 @@ wheels = [
 
 [[package]]
 name = "objectified-rest"
-version = "1.0.77"
+version = "1.0.81"
 source = { editable = "." }
 dependencies = [
     { name = "bcrypt" },
@@ -523,6 +559,7 @@ dependencies = [
     { name = "email-validator" },
     { name = "fastapi" },
     { name = "httpx" },
+    { name = "jsonschema" },
     { name = "numpy" },
     { name = "pgvector" },
     { name = "psycopg2-binary" },
@@ -560,6 +597,7 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27.0" },
+    { name = "jsonschema", specifier = ">=4.21.0" },
     { name = "numpy", specifier = ">=2.4.2" },
     { name = "pgvector", specifier = ">=0.4.2" },
     { name = "psycopg2-binary", specifier = ">=2.9.9" },
@@ -922,6 +960,20 @@ wheels = [
 ]
 
 [[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
 name = "requests"
 version = "2.32.5"
 source = { registry = "https://pypi.org/simple" }
@@ -934,6 +986,143 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+]
+
+[[package]]
+name = "rpds-py"
+version = "2026.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/43/25a8dcd3feedd735039a8f0b5b7e3b118232b5eae288c4fd9ab200d41094/rpds_py-2026.5.1.tar.gz", hash = "sha256:07b24fea40541e28570e5b795a4a38fbdcd12550c06bd0748005ecc8116ca256", size = 64459, upload-time = "2026-05-28T12:02:13.232Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4f/a0/acf8b6fc20bfdcd3a45bd3f57680fb198e157b7e997b9123b10763798bd2/rpds_py-2026.5.1-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:3397a5ed7174dc2786bb214030232fc36fe8e5584fec43a9952cc542b1a12036", size = 355609, upload-time = "2026-05-28T11:58:50.78Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/95/f8203fd997484b1690a6869cd0e503b6c3c6be55b0ecc36d1a491fe742f0/rpds_py-2026.5.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:99ab6ba7bfa2cb0f96a04e3652355bf04e3f51aceb1e943b8541dab7ba4828cc", size = 348460, upload-time = "2026-05-28T11:58:52.374Z" },
+    { url = "https://files.pythonhosted.org/packages/33/8c/b47326ad2f0be545a5e5c1a55937a12afaea7d392ba2837bb9680f57e6c9/rpds_py-2026.5.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d0efbe45632665e53e3db8fe1e5692db58fc5cb9bab4459d570b83efefe11164", size = 381031, upload-time = "2026-05-28T11:58:53.775Z" },
+    { url = "https://files.pythonhosted.org/packages/22/0b/e83bbd97ffac6f6389b605cd4e1c8ac5761dc7e977769c9255d8c5adb7bd/rpds_py-2026.5.1-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:01d17b29c0c23d82b1f4751147ec49cf451f1fc2554eb9ef5f957e55d2656ead", size = 387121, upload-time = "2026-05-28T11:58:55.243Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/0e/d285d1bc8864245919c61e1ca82263e4a66d337759c3a4cef72766ff9afc/rpds_py-2026.5.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7559f72b94ae52659086c595dfa017cde03155f7832071d30959049052cb3ece", size = 501026, upload-time = "2026-05-28T11:58:56.788Z" },
+    { url = "https://files.pythonhosted.org/packages/86/06/ccb2109a1e543437b5e43816f2b43b9554cc6783145528a4e3711e05c011/rpds_py-2026.5.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9e25b7088f9ccbfc0dfcaa52bf969300ca229e10ecf758974ebcbb080a4b37bb", size = 391865, upload-time = "2026-05-28T11:58:58.298Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/33/237173db1cfef10105b3839a24de00eb8d2a523711add4632447cdf0aedd/rpds_py-2026.5.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:613fc4ee9eaef26dc5840666214dd6fbcebcf32f46e76f4abc473059f4e13dda", size = 378012, upload-time = "2026-05-28T11:58:59.589Z" },
+    { url = "https://files.pythonhosted.org/packages/97/64/1eae54e34d5161f9969295e80bd6b62a55f2b6ac5f2a5b60d02c2140e758/rpds_py-2026.5.1-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:85264a90ff4c05c1568dd65f5921c837614b67c60358fb4c17df3b7f2e90690a", size = 391111, upload-time = "2026-05-28T11:59:01.104Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/34/5bb334a5a0f65d77869217c4654f34c78a7d11b93938a3c076a2edeafc52/rpds_py-2026.5.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fe71bca7d547acb17027c7fd1624ff8aae623499c498d3e7011182c4de5c25e0", size = 409225, upload-time = "2026-05-28T11:59:02.433Z" },
+    { url = "https://files.pythonhosted.org/packages/16/0f/007ec21283b5b040b4ec3bd95e0402591e22bfa7d5c93dfe01c465c2d2d7/rpds_py-2026.5.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a05fa4f41f37ec97c9c260441a940450a192f78d774d2b097eee1379f1e1246a", size = 556487, upload-time = "2026-05-28T11:59:04.012Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/10/5437c94508169b6b22d8418fef7a66e9ffb5f3b9e9c94460f2eedafe06ff/rpds_py-2026.5.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:df1d2a1996755b24b9ecee92cb4d36c28f86f464a6a173349c26bab41e94b8c2", size = 620798, upload-time = "2026-05-28T11:59:05.485Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/d5/9937dce4d6bda74157b954e7d1460db05a22f5929dccfeeba1ed27a93df0/rpds_py-2026.5.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:8895840ac4809e5f60c88fd07617cd71326e73d6e5a8aa783c5c0f7c24985de2", size = 584053, upload-time = "2026-05-28T11:59:06.837Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/31/750617dd0ae1752471bf43f9e41d263398fae7cde7849d23b8574a70e617/rpds_py-2026.5.1-cp311-cp311-win32.whl", hash = "sha256:3684a59b158a7683aaeb8e25352e9a9dd2122cec78f2d8530266e4f91b4c7b3f", size = 214390, upload-time = "2026-05-28T11:59:08.402Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/bb/3dcab0e1d9516303f2eb672a5d6f62eca5a69e2886301e9c8c54b520c39b/rpds_py-2026.5.1-cp311-cp311-win_amd64.whl", hash = "sha256:7bd530e6a530bb3ea892f194fafa455f3516ac25ecf7143fd33c09be62b0470a", size = 231097, upload-time = "2026-05-28T11:59:09.786Z" },
+    { url = "https://files.pythonhosted.org/packages/49/d6/c6bbf5cb1cf12b9732df8074b57f6ef8341ba884c95d40632ae8bddb44e4/rpds_py-2026.5.1-cp311-cp311-win_arm64.whl", hash = "sha256:0a5ae4dbe43c1076983b72616496919872ae7bbe7a1e21cc48336bc3154d130b", size = 226361, upload-time = "2026-05-28T11:59:11.079Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/e7/a78582dc57caa592dcc7d4fb69b61390561e908eb3d2f5df5928a8e354c0/rpds_py-2026.5.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:3abe24a66e57adcfa645d718063a5fa5103ecc71ddbf26d78af8f9368018ff1d", size = 353040, upload-time = "2026-05-28T11:59:12.531Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/43/35e3f136343aef451e545ce8c38d36c2f93c0ed88703db8b64ba2b205c68/rpds_py-2026.5.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:58b1d94308ddf0b1982f61f2eb54bf92997c9ece8a8093ef014250f4a517906c", size = 345775, upload-time = "2026-05-28T11:59:13.827Z" },
+    { url = "https://files.pythonhosted.org/packages/20/e1/0f2160c5982d3157734d5cb3ed63d8b2d583a73c9864f77b666449f32cf8/rpds_py-2026.5.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0fa92420128dadce7f54bd73ba1825a273e9268fe9e35dbf7e6362890efa4e08", size = 376329, upload-time = "2026-05-28T11:59:15.271Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/11/ee0ba42aff83bf4effdbc576673c6be64c5e173978c3f6d537e94482f77d/rpds_py-2026.5.1-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ca653c6546386227cd9800d1bef6a348099acf8db4250341da6d90f663d6dfcb", size = 383539, upload-time = "2026-05-28T11:59:16.665Z" },
+    { url = "https://files.pythonhosted.org/packages/11/df/d94aa6a499d4ac40afe2d7620f2c597fd3c0f182e854ad7cf3f596a81cb6/rpds_py-2026.5.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:66c93681c4729e4e3ecba31b8179fae083ff3118841672835140338b4b9867c1", size = 494674, upload-time = "2026-05-28T11:59:17.991Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/75/33d30f43bb2f458de11979486a591b1bf6e5651765ed1704c6197c2dc773/rpds_py-2026.5.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:40ff257542e04796880e011e15cd4dc21c2599975df2aaa8f2c8495ca574e1a5", size = 389268, upload-time = "2026-05-28T11:59:19.434Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/1e/2c9096fc19d5fd084b0184ca2b651e659aa0a37e6fdbecf6ece47f147fe1/rpds_py-2026.5.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b6825cc329b290e93c5f6a9be2393118a763f6ccf6abd83704e0c102ca583644", size = 376280, upload-time = "2026-05-28T11:59:21Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/e5/61ec9f8be8211ea7f48448195549e4aaf02004083475493b0e137702ecb2/rpds_py-2026.5.1-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:de42116e69cb53b911cc34aee5ab98f36c597b822545045d49e938818b99e5e4", size = 387233, upload-time = "2026-05-28T11:59:22.454Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/ca/bcec1005c4f4a234f92a29078631fee49206c7265ccae966f18fd332e80e/rpds_py-2026.5.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c0f920015df2a504bebaba6d4c31ccf3fcf942f92655c086da30b671aad19aa6", size = 405009, upload-time = "2026-05-28T11:59:23.845Z" },
+    { url = "https://files.pythonhosted.org/packages/72/e6/4d5718c5cf26c522dc7c9999e238da1e77380b81d0c5d1df11e271ddfeb1/rpds_py-2026.5.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0408a24e44feb919423dc6d9da677cb5cddb894d2ca9e763967d156d9c60fab4", size = 553113, upload-time = "2026-05-28T11:59:25.184Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/25/2ee807bdb3e1f0b7eddf7782acd5665a8b5205a331a7d7244a52c4812fd9/rpds_py-2026.5.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:cea68bcd53467561ae2f96a6bdad1544299ba97b5b0ddcd5ac3d376e5c781c24", size = 618838, upload-time = "2026-05-28T11:59:26.749Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/c1/7d4c26f167f8c41501cc073d30ee22082b16ce358cf5b00ec97cbc7804ea/rpds_py-2026.5.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:4be8b1d2a705cc37d08256004e1d07de143fa0075c8e85a3df020b776f62b732", size = 582436, upload-time = "2026-05-28T11:59:28.11Z" },
+    { url = "https://files.pythonhosted.org/packages/04/1d/9d12b0a337bab46f4769f8857f4007e3b2d639e14f9a44a0efe157696e64/rpds_py-2026.5.1-cp312-cp312-win32.whl", hash = "sha256:6736718bd4fc49cbcb538ba30516fdbef161522acefb739657d48b97bd864fed", size = 212734, upload-time = "2026-05-28T11:59:29.689Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/93/e4116f2de7f56bc7406a76033dc501811ddeb22b7f056b92d632871ebb0c/rpds_py-2026.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:0a7d1eec967df0e9b22614a5e177622e0c89611d03727fa0cb48e45028907870", size = 229045, upload-time = "2026-05-28T11:59:31.033Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/53/6c3419d85eb2ec5938a37627c585b42d76a63bb731d6e42ed4b079ebf486/rpds_py-2026.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:1841d067089e117142d79b98aa0df2f08b52f2ecc1819dd2700636c0db74a473", size = 223967, upload-time = "2026-05-28T11:59:32.318Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/32/14c961ad295f490eb0849ada8b79683e93a59b9de3afdd983eaf55fa6867/rpds_py-2026.5.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:efef4ac29c6ff495531eb17ee705b62841ecaa291b7c7077e848ea03e237164d", size = 352787, upload-time = "2026-05-28T11:59:33.655Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/bb/d1b85117967c11191441a7274ae616c65d93901d082c588f89a50a8da5ae/rpds_py-2026.5.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c39f5b67a8a2e67179ada2a954227d670fe65fa9098457f698f56ddf248709b3", size = 345179, upload-time = "2026-05-28T11:59:35Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/46/d84105f062e626a1b233f863907288a4708c2d833b8b4c6fb2764bc080c0/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b5c30f3f04eef4fbd362226a6f31d7c8895ca4fbb6e0b790f6890a98d8da8559", size = 376173, upload-time = "2026-05-28T11:59:36.43Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/ae/469d7959ce5b1201e1de135dc735b86db3b35dd0d1734f6a44246d5f061c/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:277f6c82f0580848796c7ecc8a7173aa3bfb928e4ff831261c2f60a81dc270db", size = 383162, upload-time = "2026-05-28T11:59:37.995Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/a2/57853d31a1116a561aa072794602ad3f6341e18d70a8523f1bd5b9fc1e5a/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:63c2c4c213f1a4e3f3de28ecab029dbdee976324e729c0d7a55211be72576b02", size = 495093, upload-time = "2026-05-28T11:59:39.453Z" },
+    { url = "https://files.pythonhosted.org/packages/99/63/3a8eabcad9314b7daf5c65f451d2c33d989235cd8a5762186cf2c3f5a4f8/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3350ec808fb538fe71a1f94dfaa0e29c598dfad805ce49f0caec5ae3183c652b", size = 389829, upload-time = "2026-05-28T11:59:40.896Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/25/05678d97fc25e2622df14dc530fb82023174ecfff6733991ed0d78f167bd/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b1b964e3ab599e718dc46c018d104b1ebc007cbc6567d827c94a687fca56d77e", size = 374786, upload-time = "2026-05-28T11:59:42.626Z" },
+    { url = "https://files.pythonhosted.org/packages/88/d1/8c90b6431e80a3b91b284a5c7c8c0c4f9c006444d90477a740d6e0f9c694/rpds_py-2026.5.1-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:19cb09fab7b7fc96b2a6e28f2e34b72a3705ff27b37edb77455316e5d3f3dc9b", size = 386920, upload-time = "2026-05-28T11:59:44.124Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/99/4638f672ab356682d633ee0da9255f5b67ce6efd0b85eb94ad3e255e65a5/rpds_py-2026.5.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:abe76bcdba31e576cb83eeb8797aa0d882b738fef6dc65d0601fc753806a5b46", size = 405059, upload-time = "2026-05-28T11:59:47.177Z" },
+    { url = "https://files.pythonhosted.org/packages/66/3f/3546524b6eb4cc2e1f363a3d638fa52f6c24faae3500c25fb488b02f1740/rpds_py-2026.5.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:8bff7073db3899158fff55ebf57b113a67030af26f80a18978f9f0aa60250ddf", size = 553030, upload-time = "2026-05-28T11:59:48.603Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/c3/7b3388c796fcf471bd17194242d4dc1a7608567c0fa422bcc1c5e79f9c1e/rpds_py-2026.5.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:8ba264fa49be666cd9cc56bf34ec7002fb3d27a4aee5bcb4d43d0d18feb1bb6f", size = 618975, upload-time = "2026-05-28T11:59:50.314Z" },
+    { url = "https://files.pythonhosted.org/packages/61/1e/a3cb07f2795075d1d88efddae2f541359fde5f08c81ee114c29c2949c90a/rpds_py-2026.5.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4860b603ddda0475a8885499b3729e90229d480105b42651962a5397d995fa89", size = 581178, upload-time = "2026-05-28T11:59:51.673Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/74/e758c03a5ef46f04c37f2651a2893db846d569ba8a7bca469d4b58939bcd/rpds_py-2026.5.1-cp313-cp313-win32.whl", hash = "sha256:7944270ae71383f6e2657dd7d5ce4eeb4ac2d0059a6738f0510583d462ab4842", size = 212481, upload-time = "2026-05-28T11:59:53.148Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ec/a2aca432db9c7359b40fa393eeeaa0d166c2f70175be956e75fa24197c44/rpds_py-2026.5.1-cp313-cp313-win_amd64.whl", hash = "sha256:88647f43a73c4e01be19b04ceef0c8d3a1958153604d13c773becd8016f2a0cf", size = 228519, upload-time = "2026-05-28T11:59:54.505Z" },
+    { url = "https://files.pythonhosted.org/packages/29/60/a73bfdd45b096574556acf303bbd9fa9eed36ca8a818b514e2a5d5fe2b9d/rpds_py-2026.5.1-cp313-cp313-win_arm64.whl", hash = "sha256:453895624ecf7db7063b1004e44037522bbaef9ff6a945e59bc71662d7a03abd", size = 223446, upload-time = "2026-05-28T11:59:56.081Z" },
+    { url = "https://files.pythonhosted.org/packages/18/e2/408105fd611823f00882aea810f3989a30d26b1bab8b6beb20f98c724e0e/rpds_py-2026.5.1-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:b4e4bc98639ec915f512fde3aa7a95e0041d95d9c3cc86eea841fa63cb1e8600", size = 355287, upload-time = "2026-05-28T11:59:57.448Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/58/5c4a43436843c90d0f6d19f82c200c80e3843ca9fa07b237623327f6d384/rpds_py-2026.5.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:cacedb7a6e167680acba45ad5716e89067d225dc80da0d7040cae8c81d4572fa", size = 347033, upload-time = "2026-05-28T11:59:58.881Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/c2/1a71acdacaf4e259b10278fb87b039ded3cf80041bcd89dd8a3ea702ded6/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:68700371c5d7ae1412862ddfa719090925c93ecf351c566d66f09d04b136ea00", size = 376891, upload-time = "2026-05-28T12:00:00.516Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c8/535f3d9b65addd8e28aa87b83c6e526799c3717a88273db8ea795beeef7a/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:296c799becfa849c779c8725494fe9ed94959ed886787df4364b058465bad7f0", size = 385646, upload-time = "2026-05-28T12:00:02.394Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/91/dc033f313345c354ade914dbe73cdb90b615a4409ea02430d5356794f3d8/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d3858b908218ee108d0bbfb2095ccc237648053c9bf98affad7cb079acaf1d97", size = 498830, upload-time = "2026-05-28T12:00:04.189Z" },
+    { url = "https://files.pythonhosted.org/packages/27/fc/90fcbea459dbb8ddc18a2e0fd1de9412b48bc84ffff2db771cf714bacfd6/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4fb8d2e7cb2f850b169806d61d1b991738acec96500a75c30f49caf064ce7cef", size = 392830, upload-time = "2026-05-28T12:00:05.797Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/1d/46cd11a228c9750684a798d98f878be6f614aa762438da7378f035e79e35/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:27b74c10ed6a8f190f4287f53bcfea348b92a84a9c9f70d30183d1e6172d580d", size = 379613, upload-time = "2026-05-28T12:00:07.433Z" },
+    { url = "https://files.pythonhosted.org/packages/24/4a/d9b0c6af3a1de03eb93741bbe8be2bdce84d8fda8224f3005451d86df389/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:b9a6528956191c48c52294a592dbd4a8386d7048bdb25c0efcb6b966466c6d83", size = 388183, upload-time = "2026-05-28T12:00:09.227Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/b4/db7aaabdda6d020afc87d981bcc2f57a434c7dec60ecfc2ab3dd50b20351/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:af03e34e860047bc7a352b842856fcf78798fbb81132cc98bd2f907ab4eb9cd2", size = 408578, upload-time = "2026-05-28T12:00:10.779Z" },
+    { url = "https://files.pythonhosted.org/packages/08/d6/070f6a41cbb343e2ac4171859bf3f3623e0ab002f72619d6d505313ec2de/rpds_py-2026.5.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:fea6e836d10abbe191d557d33bd58bd5987725fe63aa1eefe557d230209855bd", size = 553573, upload-time = "2026-05-28T12:00:12.443Z" },
+    { url = "https://files.pythonhosted.org/packages/75/ab/1a71ea3589c4345dac0a0518f0e6a031cb42689277851b683c46d27463a5/rpds_py-2026.5.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:fc0c0f878ea770a0a8a462456c5ad36fc9fe6358e6b76fdadc7f17575e0b8bf1", size = 620861, upload-time = "2026-05-28T12:00:14.09Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/22/9bf80a56069c0c443fcfefac639a86a744550a2898817a6dfd3e26654924/rpds_py-2026.5.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:e0b360f316d966b048b085857630b3cc51f3db2f07b06f440eac8f695374d1e3", size = 585633, upload-time = "2026-05-28T12:00:15.66Z" },
+    { url = "https://files.pythonhosted.org/packages/da/68/3b2c0a75c9e04125696f84ebdbbf304acf5a40b58ba4481cdb98a922c3ba/rpds_py-2026.5.1-cp313-cp313t-win32.whl", hash = "sha256:a2999883eedf72fdfb7520b92c7d4ec2572a71ff40239377aa604cc529eecafc", size = 210074, upload-time = "2026-05-28T12:00:17.291Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/8b/609157d5a25d37d4f29f92840ba531f416907c34ae5c5739dd21fc2bef98/rpds_py-2026.5.1-cp313-cp313t-win_amd64.whl", hash = "sha256:e07be2a9d7122bd6e82dea89814ef8dc893feb1aae97fec1630f3263bbb30e55", size = 228635, upload-time = "2026-05-28T12:00:18.73Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/6f/19c1918a4b590d8de87e712e4abe4b3875771eff60216fb6153cf6665c68/rpds_py-2026.5.1-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:1f2c391c3059798093b65df23aca2cac150460ae9c630d99dec83d703d9485b9", size = 349756, upload-time = "2026-05-28T12:00:20.217Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/60/a06fe7da34eca79dacbf958a2ba0c6eea85bc2b29de20080bf40f72f66fa/rpds_py-2026.5.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:413b424f7c4ee65ab5e5be91f5731be0f8b41a1ee2b12dfe810d716312e95a78", size = 343831, upload-time = "2026-05-28T12:00:21.711Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/ec/b2333b97b90e2a6ef6ca8ad386ee284968e74bcfe113b3f1a8d9036429a9/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2c595a1d9255dce0599e13130d1440ab2506654f2b50294226ee06402f8fef63", size = 375127, upload-time = "2026-05-28T12:00:23.326Z" },
+    { url = "https://files.pythonhosted.org/packages/14/7f/e00aae54067f2b488c4637961d5f58204d470795fc791085fa3f15060d2e/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:1c27c5f6102eac8c03e7595a00827a53b271ba40a53b59ff8709170e0855ea4a", size = 379034, upload-time = "2026-05-28T12:00:24.89Z" },
+    { url = "https://files.pythonhosted.org/packages/be/cc/423999bbb8ae8dc93c77fc1d5e984ade5eb89d237d3bb884ccfa72ae2890/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6c7fcf61d44cacecaf3aea542b0e053db77972a4573e7ceda16fb2b399161195", size = 490823, upload-time = "2026-05-28T12:00:26.676Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/aa/c671bf660f12e68d3c52ff86c7066ed1372df5a0f4f2ff584e419b8207e7/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2c817a189d4ee14290420e5ff051e4dd6baa13f3edf84685071dee07a6d538ee", size = 388144, upload-time = "2026-05-28T12:00:28.577Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c8/d63bb75b68afe77b229e3021c6031bcaf01da5db5b0e69d0d10f9ba679a7/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:21846aac0ed2e0589f38c12dc44e77bb64e494b771eadbcf169cba00566ba7ba", size = 371959, upload-time = "2026-05-28T12:00:30.304Z" },
+    { url = "https://files.pythonhosted.org/packages/82/35/c51122014d8274ff37dc606d60049c3db7d83da02b5b282511e5a906a9a6/rpds_py-2026.5.1-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:b317c87a13f769a4e787819bd508aaa5d69aa09b0880de9af6d3a8a54571cdec", size = 383558, upload-time = "2026-05-28T12:00:31.764Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f9/2790cb99c136a5363acdeacf5c27c56f3de0d4118a1f48fca83404c99c89/rpds_py-2026.5.1-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ce87129d9f2c14fa6c4a8601fb80eb4488c80d38a20cd13758ef11123e14995d", size = 402789, upload-time = "2026-05-28T12:00:33.247Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/1b/e4fb584f8c75d35c38150ff6a332cda949e6f97acba1f4fd123b14ab56fe/rpds_py-2026.5.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9cdddb6c1207d284d94fd1530adf57fbd797fe7c4b8704ba85f49414f2557e7d", size = 551405, upload-time = "2026-05-28T12:00:34.819Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/f7/a6731b4216cb3793ea1af5391da240f5683dacc0d13e034fe5fc3503f240/rpds_py-2026.5.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:4e237e139f94d3c036fd28eb9f564c99055476ff4ff05cd42be55ce349b5aa02", size = 616975, upload-time = "2026-05-28T12:00:36.268Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/2e051a81d95d8e63f4b35a1c463a87e8766bc3d083c067c5dfb6bf220747/rpds_py-2026.5.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ed0954b524873214369184a9c82b0eaa45a3fbb9a798cd95b17e0d98499e7ea0", size = 578701, upload-time = "2026-05-28T12:00:37.82Z" },
+    { url = "https://files.pythonhosted.org/packages/65/56/b5f6fdb2083e32bca8a8993d89e70db114b4756c9e2c38421328126689d2/rpds_py-2026.5.1-cp314-cp314-win32.whl", hash = "sha256:2d88621d6a7d4dfa633d21abe90f280bb205274e16b1d1e61c6ad4640b2453b7", size = 209806, upload-time = "2026-05-28T12:00:39.492Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/80/65a5aa96c155e611d1ed844e4e1f57f3e36b021f396d9f8585d756e6b90d/rpds_py-2026.5.1-cp314-cp314-win_amd64.whl", hash = "sha256:cef8ac28d26f4dda3533060c20fbf80a325458fa9fd23ea72a73cdfa8e978838", size = 225985, upload-time = "2026-05-28T12:00:40.94Z" },
+    { url = "https://files.pythonhosted.org/packages/27/7c/ad185212e87b05f196daef92bc5f3caf07298eb47c295b5585c3dd3093ac/rpds_py-2026.5.1-cp314-cp314-win_arm64.whl", hash = "sha256:eaaea962c68cdc68d4a533ba985ab8e9484277910bbfaa2ab3ef7732667bfed8", size = 221219, upload-time = "2026-05-28T12:00:43.15Z" },
+    { url = "https://files.pythonhosted.org/packages/23/58/e14ae18759020334646b031e708ab4158d653a938822bfb7b95ef2e93aa3/rpds_py-2026.5.1-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:21942f52dbbd5f8758bf021213d28bd45c39e873e65e2407faf5f1846f5761ad", size = 352148, upload-time = "2026-05-28T12:00:44.638Z" },
+    { url = "https://files.pythonhosted.org/packages/31/9b/5f4a1e2f960bca3ac5d052b139dd31eed97b259f9d909173821760d542e8/rpds_py-2026.5.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:f414556f6e3958300ff941e40c9f97e3dc9774ddd1b3434c475d73dd354bbed3", size = 345196, upload-time = "2026-05-28T12:00:46.14Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/71/1d9574d6a2fa20ab60eaa55c7467f5aa20cbc770f341a05f09c0876f59e2/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ef1013a8625c74043210190b246f5b1551e09757c1f356c6e4160ef96c5bc081", size = 374981, upload-time = "2026-05-28T12:00:47.531Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/9a/37e99f4915a80aa71670263c1267f7ae0af95f53a3f61e6c3bdc016d4515/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:cc68e231a77a5f0d774ae278a1f8e55c0456501820847c1e4efb3829f3441df6", size = 379961, upload-time = "2026-05-28T12:00:49.216Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/ff/6e73f74b89d2e0715e0fc86b7dde893f9a61ae2f9b256ff3bdfe41ac4e94/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9baffb505aff33acc69b422a19f77806680f3c8632227d79f48de8a810d1c2c5", size = 495965, upload-time = "2026-05-28T12:00:51.111Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/e0/425faba25f59d74d4638b267f7c7a80e8649d2ef4db10a19b0c4a71e6e6f/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b8d2f912928d426e8cfa396f7f3f8d29a59e6689c86dcca3c420730c1096322b", size = 389526, upload-time = "2026-05-28T12:00:52.77Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/76/7a41960e3fddae47fab43a28684d5da981401dffd88253de0944148654cb/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:90f628283be835db980c941767d41c9a27b5239e54ba0a9c1335247e82406964", size = 376190, upload-time = "2026-05-28T12:00:54.215Z" },
+    { url = "https://files.pythonhosted.org/packages/27/60/5f38dc70824fc6951b51d35377e577a3a3a4c81a6769cc5a2de25ebe0ad1/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:1ebb2f0ab7e16132995a72de805170e0203df0c3dd22e1ef1cd1fdd90bd7a131", size = 383921, upload-time = "2026-05-28T12:00:55.673Z" },
+    { url = "https://files.pythonhosted.org/packages/60/1a/d60a38caa1505f4b9483c3fbbde12c94e1079154f4f401a6da96f7e77621/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f3df3d16ded76f1f8c9cdebd0e1ea55fdf4c23b812de189814da7cf229c22a81", size = 404766, upload-time = "2026-05-28T12:00:57.518Z" },
+    { url = "https://files.pythonhosted.org/packages/87/ff/602fd3f174d6425f0bce05ad0dfbec0e96b38d0f7d08a79af5aa20083885/rpds_py-2026.5.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:9af8905b8f854990e40d5206aa5ac58d9b0fe0b7f351ff2bb086c20f6c8c6a47", size = 551343, upload-time = "2026-05-28T12:00:58.978Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/c1/1be13327acdbead3eca1fde03b6a34dbb011f1e864e217f0d32cc1779a7f/rpds_py-2026.5.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:036a36a87fb1cd3b214d11c4b3c4f7d2ddad933625dca1c900b56a057c07740a", size = 618502, upload-time = "2026-05-28T12:01:00.656Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d7/afb49b49d7f2be8b7ba1a9f0977fa5168003437b93086726f066544e8351/rpds_py-2026.5.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:62ae3853454fe9ef283a03c96c2d835d39e84b14643a9d62c82ef0fb87d702ca", size = 581916, upload-time = "2026-05-28T12:01:02.22Z" },
+    { url = "https://files.pythonhosted.org/packages/25/d1/dbef8c1f8a10f07beb62b5f054e20099fd9924b3ec001b8f0b6ac7813a85/rpds_py-2026.5.1-cp314-cp314t-win32.whl", hash = "sha256:6c3d771a46ec18b12af06ce36243a9a80b07a5d0515236332d90863ca8bb326a", size = 207855, upload-time = "2026-05-28T12:01:03.821Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/72/bfa4e61ab8e7dc1c8adf397e05e6cbdd4239357bd72b248d3de662f23915/rpds_py-2026.5.1-cp314-cp314t-win_amd64.whl", hash = "sha256:c93c629be4636cf54337bd5f06c104d55e42ced54d681f6fe21ae510a65116f6", size = 225422, upload-time = "2026-05-28T12:01:05.194Z" },
+    { url = "https://files.pythonhosted.org/packages/27/3a/7b5da92b640f67b6717ccafc83cdd06bfa7ff2395c3685c68922bb54d703/rpds_py-2026.5.1-cp315-cp315-macosx_10_12_x86_64.whl", hash = "sha256:3574b55c604b8f75dacb007136508bbc0db406e626301778096a133327e7f2fb", size = 349576, upload-time = "2026-05-28T12:01:06.722Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/8a/2aafd7ad355a1bd48ca76e2262b74b15e6432b5a1efe150efd4d779cd55d/rpds_py-2026.5.1-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:94068eb3ae6d43f5a786b7db96a406a34e6d5c24489feef32fd6e8946ea7b291", size = 343640, upload-time = "2026-05-28T12:01:08.441Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/7d/6c9523c1abbe840a1b7fba3c516d48e1d3487cc80fea4366c4071cf56784/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f3a5b10e8ce894825f380a8f1b6444cf73c294dfea62afbb2d13e3a9e630cec1", size = 375322, upload-time = "2026-05-28T12:01:09.934Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/5d/0b7b03fb1dc509321f01de3149784ab773e34c8573022029af8076afcb9c/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fc09f82e63d4bcd58149572f857a431bae851dc747e313c3b5bdf7abb907fda8", size = 379066, upload-time = "2026-05-28T12:01:11.48Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/e2/8ef6012999ebf1cb1c22f876d9ce5e63d960fd4631d2af3202d3f480aa25/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e10464d17df3b582745c25cec695cb9558bca2cb6ddb631aee1787fc72c767b2", size = 494586, upload-time = "2026-05-28T12:01:13.051Z" },
+    { url = "https://files.pythonhosted.org/packages/80/af/1eeb029bec67582c226b7809172207cd005073af4ebd906e65ff494f4983/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ba05adbf15d994c38ec0b7ab32e858e5110c21e9009a00a86545fd220f84e038", size = 388415, upload-time = "2026-05-28T12:01:14.631Z" },
+    { url = "https://files.pythonhosted.org/packages/18/23/ffbe10711c4d766c1cab0557d6906c074f795814863c67b351355d29354a/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:77c004fdc7b891967106f78ddfd7b076bfe6813c6139c6fff6aed3bcaa960b26", size = 372427, upload-time = "2026-05-28T12:01:16.153Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/3a/30ba4a6ad457e5b070c18d742a33fb77d8d922b565cc881f8a5313d63bfe/rpds_py-2026.5.1-cp315-cp315-manylinux_2_31_riscv64.whl", hash = "sha256:83bcf894486c9d78dd290d3c0124ff6dd8875d3025e2090a8ec49fcc37c55fdd", size = 383615, upload-time = "2026-05-28T12:01:17.809Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/69/62e242b53ce39c0814bd24e1a6e6eba6c92be716277745f317f9540a2e7b/rpds_py-2026.5.1-cp315-cp315-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c3df104083952a0e0c6f10de33e440eabe98fb6317d23e1a58c68f6df08d01b9", size = 402786, upload-time = "2026-05-28T12:01:19.419Z" },
+    { url = "https://files.pythonhosted.org/packages/38/c1/a770b9c186928a1ed0f7e6d7ae50e7f3950ed23e3f9e366dbc8e38cb55de/rpds_py-2026.5.1-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:980450826cf22e133c57e0835070bdd0dd3f73b9b708c3ce223def2cb9469e14", size = 551583, upload-time = "2026-05-28T12:01:21.013Z" },
+    { url = "https://files.pythonhosted.org/packages/21/7c/68e8579b95375b70d2a963103c42e705856cdb98569258bd807f4423891c/rpds_py-2026.5.1-cp315-cp315-musllinux_1_2_i686.whl", hash = "sha256:205dde846f24332ab0c1188699a043b8d165b79bb84529ce272c45048ff6be01", size = 616941, upload-time = "2026-05-28T12:01:22.548Z" },
+    { url = "https://files.pythonhosted.org/packages/70/a1/a6135aed5730ff03ab957182259987ac11e55fb392a28dc6f0592048a280/rpds_py-2026.5.1-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:3966b82dd563176396df030f3dd52a6e54cb69b718e95e78bd555ed3d1e0185d", size = 578349, upload-time = "2026-05-28T12:01:24.118Z" },
+    { url = "https://files.pythonhosted.org/packages/09/6e/f24201a76a84e6c49d0bdfdfcb735210e21701e9b21c5bfc0ba497dd62f6/rpds_py-2026.5.1-cp315-cp315-win32.whl", hash = "sha256:7818f8d0a415be74d2be3590b0a1c1f463a642f4d0217e7d10602dceef5b79aa", size = 209922, upload-time = "2026-05-28T12:01:25.522Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/e4/966bc240bb0485fc265278f6de44d05834bf0b3618886e0b22e33d54c49a/rpds_py-2026.5.1-cp315-cp315-win_amd64.whl", hash = "sha256:b3cc20c0d800af78fd0fac68086e28c1856cec51ea528bb81ea851aa40d39325", size = 226003, upload-time = "2026-05-28T12:01:27.062Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/5c/a15a59269cd5e74472734516c73795c15eccfc841b3d4b0228c3f53f19d0/rpds_py-2026.5.1-cp315-cp315-win_arm64.whl", hash = "sha256:3609e9939a8a76cd904cf98a3f1f13b5dc7e150adeaee89e0ea09652ea213e16", size = 221245, upload-time = "2026-05-28T12:01:28.51Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/22/135ce03804e179a71ceb13be095deda4a279bc88f7a6b8fa161c5ad44e12/rpds_py-2026.5.1-cp315-cp315t-macosx_10_12_x86_64.whl", hash = "sha256:5d333a7127d4b307601ac37792bee01bb95c867cbfacf21b6375b804d6bbd723", size = 352015, upload-time = "2026-05-28T12:01:30.214Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/5f/f1f6d2652eb9d848f6eb369d8db83a2da6249bb49ad2c2a48f45d54538d3/rpds_py-2026.5.1-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:b5f077b44a4f7808520f66dae234988d867deb9aed9be5da057ce9ba831b2a41", size = 345016, upload-time = "2026-05-28T12:01:31.656Z" },
+    { url = "https://files.pythonhosted.org/packages/88/66/b74182775691ea2290c99e52ac8d5db844e56fbec90ce421f107658c8314/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:55d8f9b7b78c9538fc9e04e82ec0e888ff0c3cffcfad152c77e57cd09351a98a", size = 374775, upload-time = "2026-05-28T12:01:33.136Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/8f/15e5a61d9f0a43902d36561d4f07cae6ae9f4716be825159fd72717f33af/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e3a8ae58895ac107ed934a6bf51e5846f95c53b9b940c2c6d310838fd5846358", size = 380270, upload-time = "2026-05-28T12:01:34.574Z" },
+    { url = "https://files.pythonhosted.org/packages/02/c3/f859b12763a80540cdf2af0f15b19904cf756a71d7bdd3f82ff3e5b1bbf9/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0957cf3c2b8632ec7aaebffebea8005b353cc2a237b6e2ae3c2cac0820704cfb", size = 495285, upload-time = "2026-05-28T12:01:36.127Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/c7/ff27c2ac8411d30b03b1829fd88cae8dad1a4d0da48dd25e57c4038042e6/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c396c1304de421050b3681ea70f371874b54d41b0151e96109758144c231e30b", size = 389581, upload-time = "2026-05-28T12:01:37.635Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/67/fe92ee32a6cc05c77228a2f8b1762e7124f386ec20ff83d0757b762d58d0/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aad1bff7f666b9598e573815affd666aac6a13a585dde336f843e33350c7fadc", size = 376041, upload-time = "2026-05-28T12:01:39.307Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/91/b4d6685c27aba55bd82f25b278be8237038117d05f9659a6213ad3408130/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_31_riscv64.whl", hash = "sha256:656a042550878f12d45752452d47094b7cfe5ad1e9d7b87b5a22ad3ae5ff8015", size = 383946, upload-time = "2026-05-28T12:01:41.043Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/79/2c1d832a53c8e0f8e98fc970ec257b950fecd4f62be2ab7182b500a0cbc8/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:73c4bd4f70294737b5206a3e8e30ccadbf8a60301831c8ea23eec5dbeea1ecfa", size = 405526, upload-time = "2026-05-28T12:01:43.032Z" },
+    { url = "https://files.pythonhosted.org/packages/78/c4/c98117b03c6a8581ab2c2dfccfe9a5ad82bd8128a3c28b46a6ad2d97c393/rpds_py-2026.5.1-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:43bca78665423cabae77146f2fe7ce55272b6c8d55d82cca83effd42c7e13972", size = 551165, upload-time = "2026-05-28T12:01:44.648Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/c1/bc479ca069200af730881b1bd525e3114b2b391a351509fcb1b772f28086/rpds_py-2026.5.1-cp315-cp315t-musllinux_1_2_i686.whl", hash = "sha256:42d0f20e85e549c870749d0e247f0c10d318a45b7e9676d575d2dcb04a1b2e66", size = 618778, upload-time = "2026-05-28T12:01:46.337Z" },
+    { url = "https://files.pythonhosted.org/packages/77/65/38ab2f90df44c2febfb63cc10ced40763d9b4bc94d173e734528663fe7f5/rpds_py-2026.5.1-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:b1be5c35683684d5331b93600c210e8367c254683d8a6df6bd21bd2da3a334fb", size = 581839, upload-time = "2026-05-28T12:01:48.109Z" },
+    { url = "https://files.pythonhosted.org/packages/15/2d/ce1f605fe036aadd460e5822e578c6c7ec3a860936cca37d6e0f299daa77/rpds_py-2026.5.1-cp315-cp315t-win32.whl", hash = "sha256:75808f6c38ce7749bb68cc2770161aae5045e6c6f6781a9782e74b93304399df", size = 207866, upload-time = "2026-05-28T12:01:49.648Z" },
+    { url = "https://files.pythonhosted.org/packages/79/cb/966040123eb102371559746908ef2c9471f4d43e17ec9a645a2258dab64b/rpds_py-2026.5.1-cp315-cp315t-win_amd64.whl", hash = "sha256:90bd6630002a1c7f09e7843dd79f0d24f3d2897cc25a753480917865d14f15b3", size = 225441, upload-time = "2026-05-28T12:01:51.408Z" },
+    { url = "https://files.pythonhosted.org/packages/42/56/3fe0fb34820ff667be791b3a3c22b85e8bcba54e9c832f47438c191fa7be/rpds_py-2026.5.1-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:edf2765d84e42447f112ad877af8fe1db0089aaec5b28e88d6eab45e7fe99cea", size = 357151, upload-time = "2026-05-28T12:01:53.43Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/f2/3eb9ccdb9f143b8c9b003978898cb497f942a324c077401e6b8834238e63/rpds_py-2026.5.1-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:ad3773236e95f7f33991eb125224b7da66f206504d032a253a02da7e134519fb", size = 350195, upload-time = "2026-05-28T12:01:54.901Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/24/dbda232bc4f3ed732120692ab0d2c8402cb020516556d8bee622dcef2413/rpds_py-2026.5.1-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a04df86b3f0fade39ec8fd0e0aab089b1da9fbd2b48df778a57ef96f5e7d38df", size = 381850, upload-time = "2026-05-28T12:01:56.601Z" },
+    { url = "https://files.pythonhosted.org/packages/40/30/32e769839a358f78810c234f160f2cc21d1e4e47e1c0e0e0d535be5a0219/rpds_py-2026.5.1-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6142dbd80c4df62a5d899f0d616d417f84e0bc8d32526c8e5589019d75d028a7", size = 387899, upload-time = "2026-05-28T12:01:58.212Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/86/ec84d243aadb3b34b71dd26a010d0930b2d284ff5fc9a69fec53810ee6fd/rpds_py-2026.5.1-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0b35217adefe87f2fe4db7e9766cabe84744bfe9616d9667be18988928c7f2dc", size = 501618, upload-time = "2026-05-28T12:01:59.888Z" },
+    { url = "https://files.pythonhosted.org/packages/74/25/b60e52686bbff777a64f9e4f4d3dd57980dc846913777177a2c92e4937aa/rpds_py-2026.5.1-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b95d5e11fc712b752081183a55a244c03cd00570489edd7014d8899f8ceb8162", size = 394003, upload-time = "2026-05-28T12:02:01.482Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/c7/b3a6a588cc2219510ef3f42e207483a93950bedd1e3a0fd4015c95cff9e5/rpds_py-2026.5.1-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:141c9498daf2ace9eda35d2b0e376f9ea8b058d84f2aef4f96fccfd449a2f251", size = 379778, upload-time = "2026-05-28T12:02:03.197Z" },
+    { url = "https://files.pythonhosted.org/packages/31/00/c7dba3fc8a3da8cb3f6db1eb3386be4d79c2e97c6890d20eb9ac66ae8c43/rpds_py-2026.5.1-pp311-pypy311_pp73-manylinux_2_31_riscv64.whl", hash = "sha256:6f249f8b860a200ad35193af961183ebe9132710484e6f6ce0cf89fd83c63a9a", size = 392359, upload-time = "2026-05-28T12:02:04.817Z" },
+    { url = "https://files.pythonhosted.org/packages/93/dd/472ba494c70753f93745992c99855bee0636daf74e6984e5e003f150316f/rpds_py-2026.5.1-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e4abbf391a70be864920858bf360f4fb380577c9a0f732438a1996726e2c195b", size = 412820, upload-time = "2026-05-28T12:02:06.401Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/6f/93831a3bfe789542ed0c1d0d74b78b440f055d6dc3ea4640eba2d95e6e23/rpds_py-2026.5.1-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:c74005a7bb87752acf351c93897ec63ad77a07a0da7ecad9c050e32e7286ba34", size = 557243, upload-time = "2026-05-28T12:02:08.013Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/ff/0b3d604614ffc77522c6b288fdbce68957eb583da1002aa65ba38ac0ee40/rpds_py-2026.5.1-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:8213afbe8a3a906fb9acb2014423fe3359ee783d0bf90995f70623a3217bfa6c", size = 623541, upload-time = "2026-05-28T12:02:09.661Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/ea/e7b0251441da9adfeaebcf29601d10f2a1455fcf0772fae9e7e19032bd96/rpds_py-2026.5.1-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:8c43a8a973270fd173bf48cdf80bbe66312421cba68d40845034f174f2389049", size = 586326, upload-time = "2026-05-28T12:02:11.47Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What & why

Closes #3452. The Primitives layer already stored JSON Schema JSONB and validated client-side (AJV), but the REST service persisted whatever it was given — no server-side **draft 2020-12** validation, no computed `$id`, no rejection of invalid schemas. This PR closes that gap (the DB columns `schema_id`/`draft`/`namespace`/`base_uri` already exist from the #3447 migration; this is the REST-layer work).

### Changes
- **`app/schema_validation.py` (new)** — shared, pure helpers backed by the `jsonschema` library:
  - `validate_schema_document` validates a document against the **draft 2020-12 meta-schema** and returns deduplicated, field-level errors (`path` / `message` / `keyword`).
  - `derive_schema_id` computes a stable `$id` (honors an author-declared `$id`, else `base_uri` + url-safe slug of the name); `derive_base_uri` resolves namespace/explicit/tenant-default base; `derive_draft` reads the dialect from `$schema` (default `2020-12`); `stamp_identity` writes `$id`/`$schema` into the stored document.
- **`primitives_routes.py`** — create, update, and import share one `resolve_primitive_identity` helper. Invalid schemas are rejected with **HTTP 422 + structured field-level errors** and never reach the DB; valid types persist with a derived `$id` and stamped `draft`. Import runs the same validator per `$defs` definition — invalid definitions are recorded in the import report (`error: "invalid_schema"` with `details`) without blocking valid ones. Also fixes a latent bug where the update path's inner 404 was swallowed into a 500.
- **`database.py`** — `create_primitive`/`update_primitive` persist and return `schema_id`/`draft`/`namespace`/`base_uri` (and `enabled` on update); SELECTs round-trip the columns.
- **`models.py`** — `PrimitiveSchema` exposes the new fields; create/update requests gain optional `namespace`/`base_uri` (and `enabled` on update, which the route already referenced).
- **Deps/artifacts** — add `jsonschema>=4.21` (pyproject/requirements/uv.lock); regenerate `openapi.json`/`openapi.yaml`; CHANGELOG + version bump (`1.0.10`/`1.0.80` → `1.0.11`/`1.0.81`); mark #3452 done in `ROADMAP_TYPE_REGISTRY_GOVERNANCE.md`.

### Acceptance criteria
- ✅ Invalid 2020-12 rejected at API with field-level errors
- ✅ Valid types persist with stable `$id` (`schema_id`)
- ✅ Import path uses the same validator

## How to test
- `cd objectified-rest && PYTHONPATH=src .venv/bin/python -m pytest tests/test_schema_validation.py tests/test_primitives_validation_routes.py -q` — 33 new tests pass; full primitives set (71 tests) green.
- Manual: `POST /v1/primitives/{tenant}` with `{"name":"Bad","category":"string","schema":{"type":"stringg"}}` → **422** with `detail.errors[0].path == "type"`. With `{"type":"string"}` → **200**, response carries a derived `schema_id` and `draft: "2020-12"`.

## Risk/notes
- New runtime dependency `jsonschema` (+ `referencing`, `jsonschema-specifications`, `attrs`, `rpds-py`).
- 18 unrelated pre-existing test failures (merge/publish/change-report/draft-lock) are environmental (DB connection) and reproduce on `main`; not touched here.

Work performed by Claude Code via model Opus 4.8 (1M context).