### PR TITLE
Fix #3453 - Primitives scope & visibility enforcement

### DIFF
--- a/docs/ROADMAP_TYPE_REGISTRY_GOVERNANCE.md
+++ b/docs/ROADMAP_TYPE_REGISTRY_GOVERNANCE.md
@@ -46,7 +46,7 @@ Before implementing net-new registry mechanics, account for what is **already li
 | Management UI | `/ade/dashboard/primitives` — stats, table, CRUD, import dialog | ✅ Nav done (#3466 closed); overview/import are **partial** — extend, don't rebuild |
 | Designer | `PrimitiveSelector` — merges primitive schema onto property | No persisted `$ref` binding (#3475); picker lacks namespace tabs (#3474) |
 | Validation | AJV in `PrimitiveEditorDialog` (client) | ✅ **Done** — REST persist strictly validated against draft 2020-12 with field-level errors (#3452) |
-| Scope | `is_system` immutability, tenant rows | No namespace visibility or core→tenant `$ref` rules (#3453) |
+| Scope | `is_system` immutability, tenant rows | ✅ **Done** — reads resolve `is_system ∪ tenant` (cross-tenant isolation; all tenants see `std/*`); core→tenant and tenant→other-tenant `$ref` rejected on save/import (#3453) |
 
 **Tickets closed as duplicates:** #3455 (UI proxy), #3466 (Governance nav). All other #3446–#3481
 issues remain open with scopes adjusted to **extend** Primitives toward full JSON Schema 2020-12 support.
@@ -327,7 +327,7 @@ enforcement, plus the `objectified-ui` proxy + typed client.
 | 2.1 #3450 ✅ | Registry service skeleton + auth/scoping | **DONE** — registry health/ping (`GET /v1/primitives/health`) over the `objectified-db` connection; existing tenant/scope auth confirmed, clients unaffected | `type-registry`,`rest`,`mvp`,`roadmap-type-registry` | N | Y | M | objectified-rest |
 | 2.2 #3451 ✅ | Namespace CRUD API | **DONE** — `GET/POST/PUT /v1/types/{tenant_slug}/namespaces` over `odb.type_namespaces`; tenant-admin writes, system-core read-only, type counts joined from `odb.primitives` | `type-registry`,`registry`,`rest`,`mvp`,`roadmap-type-registry` | N | Y | M | objectified-rest |
 | 2.3 #3452 ✅ | Type definition CRUD + draft 2020-12 validation | **DONE** — strict JSON Schema draft 2020-12 meta-validation on primitive create/update/import (`app/schema_validation.py`), field-level 422 errors, stable derived `$id` (`schema_id`) + stamped `draft` persisted to `odb.primitives` | `type-registry`,`rest`,`mvp`,`roadmap-type-registry` | N | Y | L | objectified-rest |
-| 2.4 #3453 | Scope & visibility enforcement | System-core vs tenant access + ref-direction rules | `type-registry`,`governance`,`rest`,`mvp`,`roadmap-type-registry` | Y | Y | M | objectified-rest |
+| 2.4 #3453 ✅ | Scope & visibility enforcement | **DONE** — read scope `is_system ∪ tenant` on `odb.primitives` reads (cross-tenant isolation, all tenants see `std/*`); centralized `$ref`-direction rules (`app/primitives_scope.py`) reject core→tenant and tenant→other-tenant refs on create/update/import with structured 422 violations | `type-registry`,`governance`,`rest`,`mvp`,`roadmap-type-registry` | Y | Y | M | objectified-rest |
 | 2.5 #3454 | Registry coverage/stats endpoint | Counts by scope, imported, unresolved (for dashboard KPIs) | `type-registry`,`rest`,`mvp`,`roadmap-type-registry` | Y | Y | S | objectified-rest |
 | 2.6 #3455 | ~~UI proxy routes + typed client~~ | **CLOSED — duplicate** (`/api/primitives/*` shipped) | `type-registry`,`ui`,`mvp`,`roadmap-type-registry` | N | Y | S | objectified-ui |
 

--- a/objectified-rest/package.json
+++ b/objectified-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-rest",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "private": true,
   "description": "Trigger file for Objectified REST Docker publish workflow; app is Python (pyproject.toml).",
   "scripts": {

--- a/objectified-rest/pyproject.toml
+++ b/objectified-rest/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "objectified-rest"
-version = "1.0.81"
+version = "1.0.82"
 description = "REST API for serving OpenAPI specifications from the Objectified database"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/objectified-rest/src/app/database.py
+++ b/objectified-rest/src/app/database.py
@@ -1154,14 +1154,30 @@ class Database:
         return {"connection": "connected", "storage_present": storage_present}
 
     def get_primitives_for_tenant(self, tenant_id: str, category: Optional[str] = None) -> List[Dict[str, Any]]:
-        """Get all primitives for a specific tenant."""
+        """List the primitives a tenant may read: system-core ∪ the tenant's own (#3453).
+
+        Read scope is ``is_system = true`` (shared system-core types, visible to every
+        tenant) unioned with ``tenant_id = <caller>`` (the tenant's private types). A
+        different tenant's private types are never returned, so Tenant A cannot read
+        Tenant B's custom types. System-core types are seeded per tenant, so a tenant
+        that already owns a core row would otherwise see it twice; ``DISTINCT ON
+        (category, name)`` collapses those, preferring the caller's own row.
+
+        Args:
+            tenant_id: The caller's tenant id (scopes visibility).
+            category: Optional category filter.
+
+        Returns:
+            The visible primitives, ordered by category then name.
+        """
         query = """
-            SELECT id, tenant_id, name, description, category, schema, tags,
+            SELECT DISTINCT ON (category, name)
+                   id, tenant_id, name, description, category, schema, tags,
                    created_by, is_system, is_public, usage_count, source,
                    schema_id, draft, namespace, base_uri,
                    created_at, updated_at
             FROM odb.primitives
-            WHERE tenant_id = %s
+            WHERE (tenant_id = %s OR is_system = true)
         """
         params = [tenant_id]
 
@@ -1169,18 +1185,34 @@ class Database:
             query += " AND category = %s"
             params.append(category)
 
-        query += " ORDER BY category, name"
+        # Within each (category, name) group prefer the caller's own row over a
+        # foreign system-core copy; the leading keys satisfy DISTINCT ON.
+        query += " ORDER BY category, name, (tenant_id = %s) DESC"
+        params.append(tenant_id)
         return self.execute_query(query, tuple(params))
 
     def get_primitive_by_id(self, primitive_id: str, tenant_id: str) -> Optional[Dict[str, Any]]:
-        """Get a specific primitive by ID, ensuring it belongs to the tenant."""
+        """Get a primitive by ID within the tenant's read scope: system-core ∪ own (#3453).
+
+        Returns the row when it is the tenant's own or a shared system-core type; a
+        different tenant's private type resolves to ``None`` (cross-tenant isolation).
+        System-core rows are read-only — the route layer rejects writes to them — so
+        returning one here for a read does not grant write access.
+
+        Args:
+            primitive_id: The primitive id.
+            tenant_id: The caller's tenant id (scopes visibility).
+
+        Returns:
+            The primitive row, or None when missing or not visible to the tenant.
+        """
         query = """
             SELECT id, tenant_id, name, description, category, schema, tags,
                    created_by, is_system, is_public, usage_count, source,
                    schema_id, draft, namespace, base_uri,
                    created_at, updated_at
             FROM odb.primitives
-            WHERE id = %s AND tenant_id = %s
+            WHERE id = %s AND (tenant_id = %s OR is_system = true)
         """
         results = self.execute_query(query, (primitive_id, tenant_id))
         return results[0] if results else None

--- a/objectified-rest/src/app/primitives_routes.py
+++ b/objectified-rest/src/app/primitives_routes.py
@@ -26,6 +26,13 @@ from .schema_validation import (
     derive_draft,
     derive_schema_id,
     stamp_identity,
+    REGISTRY_BASE_URL,
+)
+from .primitives_scope import (
+    ScopeViolationError,
+    enforce_ref_scope,
+    is_core_namespace,
+    tenant_segment_of,
 )
 
 router = APIRouter(prefix="/v1/primitives", tags=["primitives"])
@@ -53,6 +60,25 @@ def _schema_validation_http_error(errors: List[Dict[str, str]]) -> HTTPException
     )
 
 
+def _scope_violation_http_error(error: ScopeViolationError) -> HTTPException:
+    """Build the 422 response for a ``$ref`` that crosses a forbidden scope boundary (#3453).
+
+    Args:
+        error: The raised scope violation, carrying its per-ref ``violations`` list.
+
+    Returns:
+        An ``HTTPException`` whose detail carries a human message plus the
+        structured ``violations`` so clients can highlight the offending ``$ref``.
+    """
+    return HTTPException(
+        status_code=422,
+        detail={
+            "message": error.message,
+            "violations": error.violations,
+        },
+    )
+
+
 def resolve_primitive_identity(
     schema: Dict[str, Any],
     *,
@@ -60,6 +86,7 @@ def resolve_primitive_identity(
     namespace: Optional[str],
     base_uri: Optional[str],
     tenant_slug: str,
+    is_system: bool = False,
 ) -> Dict[str, Any]:
     """Validate a schema and derive its persisted JSON Schema 2020-12 identity (#3452).
 
@@ -72,6 +99,9 @@ def resolve_primitive_identity(
         namespace: Optional registry namespace path.
         base_uri: Optional explicit base URI (wins over ``namespace``).
         tenant_slug: The tenant slug (used for the default base URI).
+        is_system: Whether the primitive is system-core. Core types are held to the
+            stricter reference-direction rule (they may not ``$ref`` a tenant
+            namespace). A namespace under ``std/`` is also treated as core (#3453).
 
     Returns:
         A dict with ``schema`` (identity-stamped copy), ``schema_id``, ``draft``,
@@ -81,6 +111,8 @@ def resolve_primitive_identity(
         SchemaValidationError: If ``schema`` is not a valid draft 2020-12 document,
             or is a boolean schema (valid per spec, but a primitive needs an object
             schema to carry a derived ``$id``).
+        ScopeViolationError: If a ``$ref`` crosses a forbidden scope boundary
+            (core→tenant, or tenant→other-tenant) (#3453).
     """
     if not isinstance(schema, dict):
         raise SchemaValidationError(
@@ -94,6 +126,25 @@ def resolve_primitive_identity(
     resolved_base = derive_base_uri(namespace, base_uri, tenant_slug)
     schema_id = derive_schema_id(schema, name=name, base_uri=resolved_base)
     draft = derive_draft(schema)
+
+    # Centralized scope/visibility enforcement (#3453): a core type may not reference a
+    # tenant namespace, and a tenant type may not reference another tenant's namespace.
+    # Core-ness comes from the explicit flag or a std/* placement; the owning tenant is
+    # derived from the resolved base URI (e.g. .../types/tenant/acme/... -> tenant/acme).
+    base_path = (
+        resolved_base[len(REGISTRY_BASE_URL):]
+        if resolved_base.startswith(REGISTRY_BASE_URL)
+        else None
+    )
+    is_core = is_system or is_core_namespace(namespace) or is_core_namespace(base_path)
+    own_tenant_segment = None if is_core else tenant_segment_of(base_path)
+    enforce_ref_scope(
+        schema,
+        is_core=is_core,
+        base_uri=resolved_base,
+        own_tenant_segment=own_tenant_segment,
+    )
+
     stamped = stamp_identity(schema, schema_id=schema_id, draft=draft)
     return {
         "schema": stamped,
@@ -351,6 +402,8 @@ async def create_primitive(
         )
     except SchemaValidationError as e:
         raise _schema_validation_http_error(e.errors)
+    except ScopeViolationError as e:
+        raise _scope_violation_http_error(e)
 
     try:
         # Get user_id from auth data (will be None for API key auth)
@@ -463,6 +516,8 @@ async def update_primitive(
             )
         except SchemaValidationError as e:
             raise _schema_validation_http_error(e.errors)
+        except ScopeViolationError as e:
+            raise _scope_violation_http_error(e)
         updates['schema'] = identity['schema']
         updates['schema_id'] = identity['schema_id']
         updates['draft'] = identity['draft']
@@ -613,9 +668,10 @@ async def import_primitives(
     errors = []
 
     for def_name, def_schema in definitions.items():
-        # Each imported definition goes through the SAME draft 2020-12 validator and
-        # $id derivation as create/update (#3452). An invalid definition is rejected
-        # with its field-level errors and skipped; valid ones are not blocked by it.
+        # Each imported definition goes through the SAME draft 2020-12 validator,
+        # $id derivation, and scope enforcement as create/update (#3452, #3453). An
+        # invalid or scope-violating definition is rejected with its details and
+        # skipped; valid ones are not blocked by it.
         try:
             identity = resolve_primitive_identity(
                 def_schema,
@@ -626,6 +682,9 @@ async def import_primitives(
             )
         except SchemaValidationError as e:
             errors.append({"name": def_name, "error": "invalid_schema", "details": e.errors})
+            continue
+        except ScopeViolationError as e:
+            errors.append({"name": def_name, "error": "scope_violation", "details": e.violations})
             continue
 
         try:

--- a/objectified-rest/src/app/primitives_scope.py
+++ b/objectified-rest/src/app/primitives_scope.py
@@ -1,0 +1,221 @@
+"""Scope & visibility enforcement for the Primitives type registry (#3453).
+
+The Primitives layer stores types from two scopes in one ``odb.primitives`` table:
+
+* **system-core** rows (``is_system = true``, namespaces under ``std/*``) are shared
+  with every tenant and are read-only to tenants;
+* **tenant** rows (``tenant_id``-owned, private) are visible only to their owner.
+
+Two rules follow from that split, and both are enforced here so create / update /
+import share exactly one implementation (mirroring how :mod:`app.schema_validation`
+centralizes draft 2020-12 validation):
+
+1. **Reference direction.** A system-core type must never ``$ref`` a tenant
+   namespace (a shared type may not depend on a private one); the reverse —
+   tenant→core — is allowed. See :func:`find_forbidden_refs`.
+2. **Cross-tenant isolation.** A tenant type must never ``$ref`` a *different*
+   tenant's namespace. (Read isolation is enforced in the DB layer; this closes
+   the same gap at the reference layer.)
+
+Everything here is pure and side-effect free. The read-scope half of #3453
+(``reads = is_system ∪ current tenant``) lives in the DB layer
+(:meth:`app.database.Database.get_primitives_for_tenant` /
+:meth:`app.database.Database.get_primitive_by_id`).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterator, List, Optional
+from urllib.parse import urljoin
+
+from .schema_validation import REGISTRY_BASE_URL
+
+__all__ = [
+    "ScopeViolationError",
+    "iter_refs",
+    "registry_namespace_of_ref",
+    "tenant_segment_of",
+    "is_core_namespace",
+    "find_forbidden_refs",
+    "enforce_ref_scope",
+]
+
+
+class ScopeViolationError(Exception):
+    """Raised when a type's ``$ref`` set violates a registry scope rule (#3453).
+
+    Attributes:
+        message: A human-readable summary of the violation.
+        violations: One entry per offending ``$ref``; each has ``$ref`` (the value
+            as written), ``target`` (the resolved registry namespace path), and
+            ``reason`` (``"core-to-tenant"`` or ``"cross-tenant"``). Never empty.
+    """
+
+    def __init__(self, message: str, violations: List[Dict[str, str]]):
+        self.message = message
+        self.violations = violations
+        super().__init__(message)
+
+
+def iter_refs(node: Any) -> Iterator[str]:
+    """Yield every ``$ref`` *string* value anywhere within a JSON Schema document.
+
+    Walks objects and arrays recursively. A ``$ref`` whose value is not a string
+    (malformed) is ignored — meta-validation is the place that rejects those.
+
+    Args:
+        node: Any node of a parsed JSON Schema document (object, array, or scalar).
+
+    Yields:
+        Each ``$ref`` value found, in document order.
+    """
+    if isinstance(node, dict):
+        for key, value in node.items():
+            if key == "$ref" and isinstance(value, str):
+                yield value
+            else:
+                yield from iter_refs(value)
+    elif isinstance(node, list):
+        for item in node:
+            yield from iter_refs(item)
+
+
+def registry_namespace_of_ref(ref: str, base_uri: Optional[str]) -> Optional[str]:
+    """Resolve a ``$ref`` to its registry namespace path, or ``None`` if it is not one.
+
+    A same-document fragment (``#/$defs/X``) targets the type itself and is never a
+    cross-namespace reference. A relative ``$ref`` is resolved against ``base_uri``
+    using ordinary URL semantics (so ``../`` walks up the namespace tree). Only refs
+    that land under :data:`app.schema_validation.REGISTRY_BASE_URL` name a registry
+    namespace; anything else (``https://json-schema.org/...``, vendor URLs) is
+    external and out of scope.
+
+    Args:
+        ref: The ``$ref`` value as written in the document.
+        base_uri: The base URI the owning type's relative refs resolve against.
+
+    Returns:
+        The registry path the ref targets (e.g. ``tenant/acme/v1/types/money``),
+        or ``None`` when the ref is a fragment or points outside the registry.
+    """
+    if not isinstance(ref, str) or not ref or ref.startswith("#"):
+        return None
+    absolute = urljoin(base_uri or "", ref)
+    if not absolute.startswith(REGISTRY_BASE_URL):
+        return None
+    # Drop any fragment so a path-plus-anchor ref still classifies by its path.
+    path = absolute[len(REGISTRY_BASE_URL):]
+    path = path.split("#", 1)[0]
+    return path.strip("/")
+
+
+def tenant_segment_of(path: Optional[str]) -> Optional[str]:
+    """Return the ``tenant/<slug>`` owner segment of a registry path, if any.
+
+    Tenant namespaces are rooted at ``tenant/<slug>/...``; that two-segment prefix
+    identifies the owning tenant and is what cross-tenant comparisons key on.
+
+    Args:
+        path: A registry namespace path (e.g. ``tenant/acme/v1/types/money``).
+
+    Returns:
+        ``tenant/<slug>`` (e.g. ``tenant/acme``), or ``None`` when the path is not
+        tenant-rooted (``std/*``, ``vendor/*``, …) or has no slug segment.
+    """
+    if not path:
+        return None
+    segments = path.strip("/").split("/")
+    if len(segments) >= 2 and segments[0] == "tenant":
+        return f"tenant/{segments[1]}"
+    return None
+
+
+def is_core_namespace(namespace: Optional[str]) -> bool:
+    """Return whether a namespace path belongs to the system-core (``std/*``) scope.
+
+    Args:
+        namespace: A registry namespace path, or ``None``.
+
+    Returns:
+        True when the path is ``std`` or rooted at ``std/``.
+    """
+    if not namespace:
+        return False
+    norm = namespace.strip().strip("/")
+    return norm == "std" or norm.startswith("std/")
+
+
+def find_forbidden_refs(
+    schema: Dict[str, Any],
+    *,
+    is_core: bool,
+    base_uri: Optional[str],
+    own_tenant_segment: Optional[str],
+) -> List[Dict[str, str]]:
+    """Return the ``$ref`` values in ``schema`` that violate a registry scope rule.
+
+    Args:
+        schema: The JSON Schema document being saved.
+        is_core: Whether the owning type is system-core (shared, read-only). A core
+            type may not reference any tenant namespace.
+        base_uri: The base URI the document's relative refs resolve against.
+        own_tenant_segment: The owning type's ``tenant/<slug>`` segment, or ``None``
+            for a core type or when it cannot be derived. A tenant type may not
+            reference a *different* tenant's namespace.
+
+    Returns:
+        One entry per offending ref (``$ref`` / ``target`` / ``reason``), in
+        document order, de-duplicated by the ref value. Empty when all refs are
+        allowed.
+    """
+    violations: List[Dict[str, str]] = []
+    seen: set = set()
+    for ref in iter_refs(schema):
+        if ref in seen:
+            continue
+        target = registry_namespace_of_ref(ref, base_uri)
+        target_tenant = tenant_segment_of(target)
+        if target_tenant is None:
+            # External, fragment, or a non-tenant (std/vendor) registry target — allowed.
+            continue
+        if is_core:
+            seen.add(ref)
+            violations.append({"$ref": ref, "target": target or "", "reason": "core-to-tenant"})
+        elif own_tenant_segment is not None and target_tenant != own_tenant_segment:
+            seen.add(ref)
+            violations.append({"$ref": ref, "target": target or "", "reason": "cross-tenant"})
+    return violations
+
+
+def enforce_ref_scope(
+    schema: Dict[str, Any],
+    *,
+    is_core: bool,
+    base_uri: Optional[str],
+    own_tenant_segment: Optional[str],
+) -> None:
+    """Enforce the registry reference-direction rules, raising on any violation.
+
+    Args:
+        schema: The JSON Schema document being saved.
+        is_core: Whether the owning type is system-core (see :func:`find_forbidden_refs`).
+        base_uri: The base URI relative refs resolve against.
+        own_tenant_segment: The owning type's ``tenant/<slug>`` segment, or ``None``.
+
+    Raises:
+        ScopeViolationError: When one or more ``$ref`` values violate a scope rule;
+            the exception carries the per-ref ``violations`` list.
+    """
+    violations = find_forbidden_refs(
+        schema,
+        is_core=is_core,
+        base_uri=base_uri,
+        own_tenant_segment=own_tenant_segment,
+    )
+    if not violations:
+        return
+    if any(v["reason"] == "core-to-tenant" for v in violations):
+        message = "A system-core type may not $ref a tenant namespace"
+    else:
+        message = "A type may not $ref another tenant's namespace"
+    raise ScopeViolationError(message, violations)

--- a/objectified-rest/tests/test_primitives_scope.py
+++ b/objectified-rest/tests/test_primitives_scope.py
@@ -1,0 +1,225 @@
+"""Unit tests for the pure registry scope-enforcement helpers (#3453).
+
+Covers ``$ref`` discovery, registry-namespace resolution (absolute, relative, fragment,
+external), tenant-segment extraction, core detection, and the two reference-direction
+rules: a system-core type may not ``$ref`` a tenant namespace, and a tenant type may not
+``$ref`` another tenant's namespace (tenant→core stays allowed).
+"""
+
+import pytest
+
+from app.primitives_scope import (
+    ScopeViolationError,
+    enforce_ref_scope,
+    find_forbidden_refs,
+    is_core_namespace,
+    iter_refs,
+    registry_namespace_of_ref,
+    tenant_segment_of,
+)
+
+BASE = "https://api.objectified.dev/types/"
+STD_BASE = BASE + "std/v0/primitives/"
+ACME_BASE = BASE + "tenant/acme/v1/types/"
+
+
+# ===========================================================================
+# iter_refs
+# ===========================================================================
+
+
+def test_iter_refs_walks_nested_objects_and_arrays():
+    schema = {
+        "type": "object",
+        "properties": {
+            "a": {"$ref": "./money"},
+            "b": {"items": {"$ref": "#/$defs/X"}},
+        },
+        "allOf": [{"$ref": ACME_BASE + "other"}],
+    }
+    assert sorted(iter_refs(schema)) == sorted(
+        ["./money", "#/$defs/X", ACME_BASE + "other"]
+    )
+
+
+def test_iter_refs_ignores_non_string_ref_values():
+    # A malformed (non-string) $ref is left for the meta-validator, not yielded here.
+    assert list(iter_refs({"$ref": {"not": "a string"}})) == []
+
+
+def test_iter_refs_empty_for_schema_without_refs():
+    assert list(iter_refs({"type": "string", "maxLength": 5})) == []
+
+
+# ===========================================================================
+# registry_namespace_of_ref
+# ===========================================================================
+
+
+def test_absolute_ref_under_registry_resolves_to_path():
+    ref = BASE + "tenant/acme/v1/types/money"
+    assert registry_namespace_of_ref(ref, STD_BASE) == "tenant/acme/v1/types/money"
+
+
+def test_relative_ref_resolves_against_base():
+    assert registry_namespace_of_ref("./uuid", STD_BASE) == "std/v0/primitives/uuid"
+
+
+def test_relative_dotdot_ref_walks_up_namespace_tree():
+    # From std/v0/primitives/, walking up two levels then into tenant stays under std.
+    assert (
+        registry_namespace_of_ref("../../tenant/acme/x", STD_BASE)
+        == "std/tenant/acme/x"
+    )
+
+
+def test_fragment_ref_is_same_document_not_a_namespace():
+    assert registry_namespace_of_ref("#/$defs/Money", STD_BASE) is None
+
+
+def test_external_ref_is_not_a_registry_namespace():
+    assert registry_namespace_of_ref("https://json-schema.org/x", STD_BASE) is None
+
+
+def test_ref_with_trailing_fragment_classifies_by_path():
+    ref = BASE + "tenant/acme/v1/types/money#/$defs/Cents"
+    assert registry_namespace_of_ref(ref, STD_BASE) == "tenant/acme/v1/types/money"
+
+
+# ===========================================================================
+# tenant_segment_of / is_core_namespace
+# ===========================================================================
+
+
+@pytest.mark.parametrize(
+    "path,expected",
+    [
+        ("tenant/acme/v1/types/money", "tenant/acme"),
+        ("tenant/acme", "tenant/acme"),
+        ("std/v0/primitives/string", None),
+        ("vendor/fhir/r4/patient", None),
+        ("tenant", None),  # no slug segment
+        (None, None),
+    ],
+)
+def test_tenant_segment_of(path, expected):
+    assert tenant_segment_of(path) == expected
+
+
+@pytest.mark.parametrize(
+    "namespace,expected",
+    [
+        ("std", True),
+        ("std/v0/types", True),
+        ("std/v0/primitives/", True),
+        ("standard/v0", False),  # not the std root
+        ("tenant/acme/v1", False),
+        (None, False),
+    ],
+)
+def test_is_core_namespace(namespace, expected):
+    assert is_core_namespace(namespace) is expected
+
+
+# ===========================================================================
+# find_forbidden_refs — core → tenant
+# ===========================================================================
+
+
+def test_core_type_referencing_tenant_namespace_is_forbidden():
+    schema = {"type": "object", "properties": {"m": {"$ref": ACME_BASE + "money"}}}
+    violations = find_forbidden_refs(
+        schema, is_core=True, base_uri=STD_BASE, own_tenant_segment=None
+    )
+    assert len(violations) == 1
+    assert violations[0]["reason"] == "core-to-tenant"
+    assert violations[0]["target"] == "tenant/acme/v1/types/money"
+
+
+def test_core_type_referencing_core_namespace_is_allowed():
+    schema = {"$ref": STD_BASE + "uuid"}
+    assert find_forbidden_refs(
+        schema, is_core=True, base_uri=STD_BASE, own_tenant_segment=None
+    ) == []
+
+
+def test_core_type_with_internal_and_external_refs_is_allowed():
+    schema = {
+        "allOf": [{"$ref": "#/$defs/X"}, {"$ref": "https://json-schema.org/y"}],
+        "$defs": {"X": {"type": "string"}},
+    }
+    assert find_forbidden_refs(
+        schema, is_core=True, base_uri=STD_BASE, own_tenant_segment=None
+    ) == []
+
+
+# ===========================================================================
+# find_forbidden_refs — tenant → other tenant (cross-tenant isolation)
+# ===========================================================================
+
+
+def test_tenant_type_referencing_other_tenant_is_forbidden():
+    schema = {"$ref": BASE + "tenant/globex/v1/types/widget"}
+    violations = find_forbidden_refs(
+        schema, is_core=False, base_uri=ACME_BASE, own_tenant_segment="tenant/acme"
+    )
+    assert len(violations) == 1
+    assert violations[0]["reason"] == "cross-tenant"
+
+
+def test_tenant_type_referencing_own_namespace_is_allowed():
+    schema = {"$ref": ACME_BASE + "address"}
+    assert find_forbidden_refs(
+        schema, is_core=False, base_uri=ACME_BASE, own_tenant_segment="tenant/acme"
+    ) == []
+
+
+def test_tenant_type_referencing_core_is_allowed():
+    schema = {"$ref": STD_BASE + "uuid"}
+    assert find_forbidden_refs(
+        schema, is_core=False, base_uri=ACME_BASE, own_tenant_segment="tenant/acme"
+    ) == []
+
+
+def test_unknown_own_tenant_does_not_flag_cross_tenant():
+    # When the owning tenant can't be derived, cross-tenant comparison is skipped.
+    schema = {"$ref": BASE + "tenant/globex/v1/types/widget"}
+    assert find_forbidden_refs(
+        schema, is_core=False, base_uri=BASE + "vendor/x/", own_tenant_segment=None
+    ) == []
+
+
+def test_duplicate_refs_reported_once():
+    ref = ACME_BASE + "money"
+    schema = {"allOf": [{"$ref": ref}, {"$ref": ref}]}
+    violations = find_forbidden_refs(
+        schema, is_core=True, base_uri=STD_BASE, own_tenant_segment=None
+    )
+    assert len(violations) == 1
+
+
+# ===========================================================================
+# enforce_ref_scope
+# ===========================================================================
+
+
+def test_enforce_raises_for_core_to_tenant_with_message():
+    schema = {"$ref": ACME_BASE + "money"}
+    with pytest.raises(ScopeViolationError) as exc:
+        enforce_ref_scope(schema, is_core=True, base_uri=STD_BASE, own_tenant_segment=None)
+    assert "system-core" in exc.value.message
+    assert exc.value.violations[0]["reason"] == "core-to-tenant"
+
+
+def test_enforce_raises_for_cross_tenant_with_message():
+    schema = {"$ref": BASE + "tenant/globex/v1/types/widget"}
+    with pytest.raises(ScopeViolationError) as exc:
+        enforce_ref_scope(
+            schema, is_core=False, base_uri=ACME_BASE, own_tenant_segment="tenant/acme"
+        )
+    assert "another tenant" in exc.value.message
+
+
+def test_enforce_is_silent_when_all_refs_allowed():
+    schema = {"$ref": STD_BASE + "uuid"}
+    enforce_ref_scope(schema, is_core=False, base_uri=ACME_BASE, own_tenant_segment="tenant/acme")

--- a/objectified-rest/tests/test_primitives_scope_routes.py
+++ b/objectified-rest/tests/test_primitives_scope_routes.py
@@ -1,0 +1,188 @@
+"""API tests for registry scope & visibility enforcement on the Primitives CRUD (#3453).
+
+Covers create / update / import: a system-core type that ``$ref``s a tenant namespace is
+rejected at the REST boundary with structured violations, a tenant type that ``$ref``s
+another tenant's namespace is rejected, and the allowed directions (tenant→core, tenant→own)
+persist. The read-scope half of #3453 is enforced in the DB layer and unit-tested separately.
+"""
+
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.auth import validate_authentication
+from app.main import app
+
+client = TestClient(app)
+
+_JWT = {"tenant_id": "t1", "user_id": "u1", "auth_method": "jwt"}
+_NOW = datetime(2026, 6, 22, 12, 0, 0, tzinfo=timezone.utc)
+
+BASE = "https://api.objectified.dev/types/"
+STD_REF = BASE + "std/v0/primitives/uuid"
+ACME_REF = BASE + "tenant/acme/v1/types/money"
+GLOBEX_REF = BASE + "tenant/globex/v1/types/widget"
+
+
+def _row(**overrides):
+    """A representative odb.primitives row as returned by the DB layer."""
+    row = {
+        "id": "p1",
+        "tenant_id": "t1",
+        "name": "My Type",
+        "description": None,
+        "category": "object",
+        "schema": {"type": "object"},
+        "tags": [],
+        "created_by": "u1",
+        "is_system": False,
+        "is_public": False,
+        "usage_count": 0,
+        "source": "human",
+        "schema_id": None,
+        "draft": "2020-12",
+        "namespace": None,
+        "base_uri": None,
+        "created_at": _NOW,
+        "updated_at": _NOW,
+        "enabled": True,
+    }
+    row.update(overrides)
+    return row
+
+
+@pytest.fixture(autouse=True)
+def _auth():
+    app.dependency_overrides[validate_authentication] = lambda: _JWT
+    yield
+    app.dependency_overrides.pop(validate_authentication, None)
+
+
+# ===========================================================================
+# CREATE — core → tenant is rejected
+# ===========================================================================
+
+
+def test_create_core_type_referencing_tenant_namespace_rejected():
+    with patch("app.primitives_routes.db") as mdb:
+        r = client.post(
+            "/v1/primitives/acme",
+            json={
+                "name": "CoreThing",
+                "category": "object",
+                "namespace": "std/v0/primitives",
+                "schema": {"type": "object", "properties": {"m": {"$ref": ACME_REF}}},
+            },
+        )
+    assert r.status_code == 422
+    detail = r.json()["detail"]
+    assert "system-core" in detail["message"]
+    assert detail["violations"][0]["reason"] == "core-to-tenant"
+    assert detail["violations"][0]["$ref"] == ACME_REF
+    # A scope violation never reaches the database.
+    mdb.create_primitive.assert_not_called()
+
+
+def test_create_tenant_type_referencing_core_is_allowed():
+    with patch("app.primitives_routes.db") as mdb:
+        mdb.create_primitive.return_value = _row(name="Order")
+        r = client.post(
+            "/v1/primitives/acme",
+            json={
+                "name": "Order",
+                "category": "object",
+                "schema": {"type": "object", "properties": {"id": {"$ref": STD_REF}}},
+            },
+        )
+    assert r.status_code == 200
+    mdb.create_primitive.assert_called_once()
+
+
+def test_create_tenant_type_referencing_other_tenant_rejected():
+    with patch("app.primitives_routes.db") as mdb:
+        r = client.post(
+            "/v1/primitives/acme",
+            json={
+                "name": "Order",
+                "category": "object",
+                "schema": {"type": "object", "properties": {"w": {"$ref": GLOBEX_REF}}},
+            },
+        )
+    assert r.status_code == 422
+    detail = r.json()["detail"]
+    assert "another tenant" in detail["message"]
+    assert detail["violations"][0]["reason"] == "cross-tenant"
+    mdb.create_primitive.assert_not_called()
+
+
+def test_create_tenant_type_referencing_own_namespace_is_allowed():
+    with patch("app.primitives_routes.db") as mdb:
+        mdb.create_primitive.return_value = _row(name="Invoice")
+        r = client.post(
+            "/v1/primitives/acme",
+            json={
+                "name": "Invoice",
+                "category": "object",
+                "namespace": "tenant/acme/v1/types",
+                "schema": {"type": "object", "properties": {"m": {"$ref": ACME_REF}}},
+            },
+        )
+    assert r.status_code == 200
+    mdb.create_primitive.assert_called_once()
+
+
+# ===========================================================================
+# UPDATE — re-placing into core enforces the rule
+# ===========================================================================
+
+
+def test_update_into_core_namespace_with_tenant_ref_rejected():
+    with patch("app.primitives_routes.db") as mdb:
+        mdb.get_primitive_by_id.return_value = _row(name="My Type")
+        r = client.put(
+            "/v1/primitives/acme/p1",
+            json={
+                "namespace": "std/v0/primitives",
+                "schema": {"type": "object", "properties": {"m": {"$ref": ACME_REF}}},
+            },
+        )
+    assert r.status_code == 422
+    assert r.json()["detail"]["violations"][0]["reason"] == "core-to-tenant"
+    mdb.update_primitive.assert_not_called()
+
+
+# ===========================================================================
+# IMPORT — same enforcement per definition
+# ===========================================================================
+
+
+def test_import_rejects_scope_violating_definition_but_imports_valid():
+    def _create(**kwargs):
+        return {"name": kwargs["name"]}
+
+    with patch("app.primitives_routes.db") as mdb:
+        mdb.create_primitive.side_effect = _create
+        mdb.create_primitive_import.return_value = {"id": "imp1"}
+        r = client.post(
+            "/v1/primitives/acme/import",
+            json={
+                "schema": {
+                    "$defs": {
+                        "Good": {"type": "object", "properties": {"id": {"$ref": STD_REF}}},
+                        "Bad": {"type": "object", "properties": {"m": {"$ref": ACME_REF}}},
+                    }
+                },
+                "import_all": True,
+                "target_namespace": "std/v0/primitives",
+            },
+        )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["imported"] == ["Good"]
+    err = next(e for e in body["errors"] if e["name"] == "Bad")
+    assert err["error"] == "scope_violation"
+    assert err["details"][0]["reason"] == "core-to-tenant"
+    # Only the allowed definition is created.
+    assert mdb.create_primitive.call_count == 1


### PR DESCRIPTION
## What & why

Implements **[2.4] Scope & visibility enforcement** for the Primitives type registry (extends `odb.primitives` in `objectified-db`). Closes the gap left after #3451/#3452: namespace/cross-tenant read isolation and the core→tenant `$ref` prohibition.

Two halves, both centralized so create / update / import share one implementation:

**Read scope — `is_system ∪ current tenant`** (`objectified-rest/src/app/database.py`)
- `get_primitives_for_tenant` and `get_primitive_by_id` now return `WHERE (tenant_id = <caller> OR is_system = true)`.
- A different tenant's *private* types are never returned → **Tenant A cannot read Tenant B's custom types**.
- System-core types are visible to **every** tenant → **all tenants see `std/*`** (even tenants created after the per-tenant seed migration).
- System-core types are seeded per tenant, so `DISTINCT ON (category, name)` collapses duplicates, preferring the caller's own row. System rows stay read-only (the route layer already 403s writes to `is_system`).

**Reference direction — new `objectified-rest/src/app/primitives_scope.py`**
- A **system-core** type may not `$ref` a tenant namespace (a shared type may not depend on a private one).
- A **tenant** type may not `$ref` a *different* tenant's namespace (cross-tenant isolation at the reference layer).
- **tenant→core** and **tenant→own** references stay allowed.
- Handles absolute, relative (`../` walks the namespace tree via `urljoin`), fragment (`#/...`), and external refs. Core-ness comes from `is_system` or a `std/*` placement; the owning tenant is derived from the resolved base URI.
- Enforced inside `resolve_primitive_identity`, so create/update/import all reject identically with a structured **422** `{message, violations}` (the import path records a per-definition `scope_violation` error and continues with valid definitions).

## How to test

```
cd objectified-rest
.venv/bin/python -m pytest tests/test_primitives_scope.py tests/test_primitives_scope_routes.py tests/test_primitives_validation_routes.py -q
```

- **`test_primitives_scope.py`** — 30 unit tests of the pure helpers (ref discovery, namespace resolution, tenant-segment extraction, core detection, both rule directions).
- **`test_primitives_scope_routes.py`** — create/update/import: core→tenant and tenant→other-tenant rejected (422 with violations); tenant→core and tenant→own persist.

Manual: as a tenant, **POST** `/v1/primitives/<slug>` with `namespace: "std/v0/primitives"` and a schema whose `$ref` is `https://api.objectified.dev/types/tenant/acme/v1/types/money` → **422**, message "A system-core type may not $ref a tenant namespace". The same schema **without** the std namespace (a plain tenant type referencing `std/v0/primitives/uuid`) **persists**.

## Risk / notes

- Read-scope change is SQL-only in the primitives funnel; no schema/migration change. Full REST suite: **633 passed**, 2 skipped; the 18 failures are pre-existing DB-dependent integration tests unrelated to primitives (verified on clean `main`).
- Cross-tenant ref check is best-effort when the owning tenant can't be derived from the base URI; the resolve layer (#3456) reinforces it.
- New module + tests pass `ruff` clean; REST version bumped (`1.0.81→1.0.82` / `1.0.11→1.0.12`); ROADMAP 2.4 marked done.

Closes #3453

Work performed by Claude Code via model claude-opus-4-8[1m]