### PR TITLE
Fix #3456 - Relative $ref resolution against import-source base

### DIFF
--- a/docs/ROADMAP_TYPE_REGISTRY_GOVERNANCE.md
+++ b/docs/ROADMAP_TYPE_REGISTRY_GOVERNANCE.md
@@ -415,7 +415,7 @@ resolved  = api.objectified.dev/types/std/v0/primitives/string   ✓
 
 | Issue | Title | Summary | Labels | Parallel | MVP | Complexity | Affected Modules |
 |---|---|---|---|:---:|:---:|---|---|
-| 3.1 #3456 | Relative `$ref` resolution against base | Resolve relative refs to absolute registry targets | `type-registry`,`rest`,`mvp`,`roadmap-type-registry` | N | Y | L | objectified-rest |
+| 3.1 #3456 ✅ | Relative `$ref` resolution against base | **DONE** — `app/primitives_resolver.py` resolves each relative `$ref` against the source `base_uri` (`./`, `../`, cross-scope `../../std/...`) to an absolute registry URI, maps it to a primitive by `schema_id` within read scope (#3453), and persists `{relative_ref, resolved_target, status}` edges to `odb.primitives.refs` on create/update/import | `type-registry`,`rest`,`mvp`,`roadmap-type-registry` | N | Y | L | objectified-rest |
 | 3.2 #3457 | Unresolved-reference detection & flags | Detect & persist unresolved refs (status on `type_ref`) | `type-registry`,`rest`,`mvp`,`roadmap-type-registry` | Y | Y | M | objectified-rest |
 | 3.3 #3458 | Circular-reference detection | Detect cycles (A→B→A) and flag | `type-registry`,`rest`,`roadmap-type-registry` | Y | N | M | objectified-rest |
 | 3.4 #3459 | Resolver API + dependency listing | `/resolve` + dependency edges for resolver UI | `type-registry`,`rest`,`mvp`,`roadmap-type-registry` | Y | Y | M | objectified-rest |

--- a/objectified-rest/package.json
+++ b/objectified-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-rest",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "private": true,
   "description": "Trigger file for Objectified REST Docker publish workflow; app is Python (pyproject.toml).",
   "scripts": {

--- a/objectified-rest/pyproject.toml
+++ b/objectified-rest/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "objectified-rest"
-version = "1.0.82"
+version = "1.0.83"
 description = "REST API for serving OpenAPI specifications from the Objectified database"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/objectified-rest/src/app/database.py
+++ b/objectified-rest/src/app/database.py
@@ -1174,7 +1174,7 @@ class Database:
             SELECT DISTINCT ON (category, name)
                    id, tenant_id, name, description, category, schema, tags,
                    created_by, is_system, is_public, usage_count, source,
-                   schema_id, draft, namespace, base_uri,
+                   schema_id, draft, namespace, base_uri, refs,
                    created_at, updated_at
             FROM odb.primitives
             WHERE (tenant_id = %s OR is_system = true)
@@ -1209,12 +1209,43 @@ class Database:
         query = """
             SELECT id, tenant_id, name, description, category, schema, tags,
                    created_by, is_system, is_public, usage_count, source,
-                   schema_id, draft, namespace, base_uri,
+                   schema_id, draft, namespace, base_uri, refs,
                    created_at, updated_at
             FROM odb.primitives
             WHERE id = %s AND (tenant_id = %s OR is_system = true)
         """
         results = self.execute_query(query, (primitive_id, tenant_id))
+        return results[0] if results else None
+
+    def get_primitive_by_schema_id(
+        self, schema_id: str, tenant_id: str
+    ) -> Optional[Dict[str, Any]]:
+        """Resolve a primitive by its JSON Schema ``$id`` within the tenant's read scope (#3456).
+
+        Backs relative ``$ref`` resolution: a resolved absolute registry URI is matched
+        against ``odb.primitives.schema_id``. Scope is the same as the other reads —
+        system-core ∪ the caller's own — so a tenant resolves only to shared system-core
+        or its own types, never to another tenant's private type (honoring #3453). When
+        system-core types are seeded per tenant, the caller's own copy is preferred.
+
+        Args:
+            schema_id: The absolute ``$id`` to resolve (the ref's resolved target URI).
+            tenant_id: The caller's tenant id (scopes visibility).
+
+        Returns:
+            The matching primitive row, or None when no visible type has that ``$id``.
+        """
+        query = """
+            SELECT id, tenant_id, name, description, category, schema, tags,
+                   created_by, is_system, is_public, usage_count, source,
+                   schema_id, draft, namespace, base_uri, refs,
+                   created_at, updated_at
+            FROM odb.primitives
+            WHERE schema_id = %s AND (tenant_id = %s OR is_system = true)
+            ORDER BY (tenant_id = %s) DESC
+            LIMIT 1
+        """
+        results = self.execute_query(query, (schema_id, tenant_id, tenant_id))
         return results[0] if results else None
 
     def create_primitive(
@@ -1230,7 +1261,8 @@ class Database:
         schema_id: Optional[str] = None,
         draft: str = '2020-12',
         namespace: Optional[str] = None,
-        base_uri: Optional[str] = None
+        base_uri: Optional[str] = None,
+        refs: Optional[List[Dict[str, Any]]] = None
     ) -> Dict[str, Any]:
         """Create a new primitive.
 
@@ -1241,20 +1273,23 @@ class Database:
             draft: The JSON Schema dialect/draft, default '2020-12' (#3452).
             namespace: Optional registry namespace path locating the primitive (#3452).
             base_uri: Optional namespace base URI the ``$id`` was computed against (#3452).
+            refs: Resolved relative-``$ref`` edges for the schema, each
+                ``{relative_ref, resolved_target, status}`` (#3456). Defaults to ``[]``.
         """
         query = """
             INSERT INTO odb.primitives
             (tenant_id, name, description, category, schema, tags, created_by, source,
-             schema_id, draft, namespace, base_uri)
-            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+             schema_id, draft, namespace, base_uri, refs)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
             RETURNING id, tenant_id, name, description, category, schema, tags,
                       created_by, is_system, is_public, usage_count, source,
-                      schema_id, draft, namespace, base_uri,
+                      schema_id, draft, namespace, base_uri, refs,
                       created_at, updated_at
         """
 
         import json
         schema_json = json.dumps(schema)
+        refs_json = json.dumps(refs or [])
 
         conn = self.connect()
         try:
@@ -1262,7 +1297,7 @@ class Database:
                 cursor.execute(
                     query,
                     (tenant_id, name, description, category, schema_json, tags or [],
-                     created_by, source, schema_id, draft, namespace, base_uri)
+                     created_by, source, schema_id, draft, namespace, base_uri, refs_json)
                 )
                 result = cursor.fetchone()
                 conn.commit()
@@ -1316,6 +1351,12 @@ class Database:
         if 'base_uri' in updates and updates['base_uri'] is not None:
             update_fields.append("base_uri = %s")
             params.append(updates['base_uri'])
+        # Resolved relative-$ref edges, re-derived by the route whenever the schema or
+        # registry placement changes (#3456). May be an empty list (no edges), so the
+        # presence of the key — not its truthiness — drives the write.
+        if 'refs' in updates and updates['refs'] is not None:
+            update_fields.append("refs = %s")
+            params.append(json.dumps(updates['refs']))
 
         if not update_fields:
             # Nothing to update, return current primitive
@@ -1328,7 +1369,7 @@ class Database:
             WHERE id = %s AND tenant_id = %s
             RETURNING id, tenant_id, name, description, category, schema, tags,
                       created_by, is_system, is_public, usage_count, source,
-                      schema_id, draft, namespace, base_uri,
+                      schema_id, draft, namespace, base_uri, refs,
                       created_at, updated_at
         """
 

--- a/objectified-rest/src/app/models.py
+++ b/objectified-rest/src/app/models.py
@@ -131,6 +131,9 @@ class PrimitiveSchema(BaseModel):
     draft: str = '2020-12'
     namespace: Optional[str] = None
     base_uri: Optional[str] = None
+    # Resolved relative-`$ref` edges for this primitive's schema (#3456). Each edge is
+    # {relative_ref, resolved_target, status} with status resolved|unresolved|circular.
+    refs: List[Dict[str, Any]] = []
     created_at: Optional[Union[datetime, str]] = None
     updated_at: Optional[Union[datetime, str]] = None
     enabled: bool = True

--- a/objectified-rest/src/app/primitives_resolver.py
+++ b/objectified-rest/src/app/primitives_resolver.py
@@ -1,0 +1,83 @@
+"""Relative ``$ref`` resolution for the Primitives type registry (#3456).
+
+A primitive's JSON Schema may reference other registry types by *relative* ``$ref``
+rooted at the type's import-source ``base_uri`` — the defining mechanic of the registry:
+
+    base   = https://api.objectified.dev/types/std/v0/types/   (source: date)
+    $ref   = ../primitives/string
+    target = https://api.objectified.dev/types/std/v0/primitives/string
+
+This module turns each relative ``$ref`` in a schema into a persisted **edge** stored on
+``odb.primitives.refs`` (a JSONB array). Each edge is
+``{"relative_ref", "resolved_target", "status"}`` where:
+
+* ``relative_ref`` is the ``$ref`` exactly as written in the document;
+* ``resolved_target`` is the absolute registry URI it resolves to (``base + relative``);
+* ``status`` is ``"resolved"`` when a primitive with that ``$id`` exists within the
+  source's read scope (system-core ∪ tenant, honoring #3453), else ``"unresolved"``.
+
+Scope is honored by the injected ``target_exists`` lookup, which the route backs with a
+tenant-scoped DB query — a tenant therefore resolves only to system-core or its own types,
+never to another tenant's private types.
+
+The URL resolution itself (``./``, ``../``, cross-scope ``../../std/...``, fragment and
+external-ref handling) is delegated to :func:`app.primitives_scope.resolve_registry_uri`,
+the single resolver shared with scope classification. Fragment (``#/...``) and external
+(non-registry) refs are intentionally *not* recorded as registry edges.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, List
+
+from .primitives_scope import iter_refs, resolve_registry_uri
+
+__all__ = ["STATUS_RESOLVED", "STATUS_UNRESOLVED", "build_ref_edges"]
+
+# Edge status values. ``circular`` (cycle detection) is a later ticket (#3458); this
+# engine emits only resolved / unresolved.
+STATUS_RESOLVED = "resolved"
+STATUS_UNRESOLVED = "unresolved"
+
+
+def build_ref_edges(
+    schema: Dict[str, Any],
+    *,
+    base_uri: str,
+    target_exists: Callable[[str], bool],
+) -> List[Dict[str, str]]:
+    """Resolve a schema's relative ``$ref`` values into persisted registry edges (#3456).
+
+    Walks every ``$ref`` in ``schema``, resolves each relative reference against
+    ``base_uri`` to an absolute registry URI, and records an edge with its resolution
+    status. Same-document fragment refs and external (non-registry) refs are skipped —
+    only cross-type registry references become edges. Duplicate ``$ref`` values are
+    recorded once, in first-seen document order.
+
+    Args:
+        schema: The (identity-stamped) JSON Schema document of the source primitive.
+        base_uri: The source primitive's base URI; relative refs resolve against it.
+        target_exists: Predicate mapping an absolute registry URI to whether a
+            primitive with that ``$id`` exists within the source's read scope. The
+            route backs this with a tenant-scoped lookup so scope (#3453) is honored.
+
+    Returns:
+        The list of ``{"relative_ref", "resolved_target", "status"}`` edges, suitable
+        for persisting to ``odb.primitives.refs``. Empty when the schema has no
+        cross-type registry references.
+    """
+    edges: List[Dict[str, str]] = []
+    seen: set = set()
+    for ref in iter_refs(schema):
+        if ref in seen:
+            continue
+        target = resolve_registry_uri(ref, base_uri)
+        if target is None:
+            # Fragment (#/...) or external ref — not a registry edge.
+            continue
+        seen.add(ref)
+        status = STATUS_RESOLVED if target_exists(target) else STATUS_UNRESOLVED
+        edges.append(
+            {"relative_ref": ref, "resolved_target": target, "status": status}
+        )
+    return edges

--- a/objectified-rest/src/app/primitives_routes.py
+++ b/objectified-rest/src/app/primitives_routes.py
@@ -34,6 +34,7 @@ from .primitives_scope import (
     is_core_namespace,
     tenant_segment_of,
 )
+from .primitives_resolver import build_ref_edges
 
 router = APIRouter(prefix="/v1/primitives", tags=["primitives"])
 
@@ -77,6 +78,30 @@ def _scope_violation_http_error(error: ScopeViolationError) -> HTTPException:
             "violations": error.violations,
         },
     )
+
+
+def resolve_primitive_refs(
+    schema: Dict[str, Any], *, base_uri: str, tenant_id: str
+) -> List[Dict[str, str]]:
+    """Resolve a primitive's relative ``$ref`` edges against the registry (#3456).
+
+    Walks the schema's ``$ref`` values, resolves each against ``base_uri``, and marks
+    each edge ``resolved`` / ``unresolved`` by looking the target ``$id`` up in the
+    tenant's read scope (system-core ∪ tenant), so resolution honors scope (#3453).
+
+    Args:
+        schema: The identity-stamped JSON Schema document of the source primitive.
+        base_uri: The source primitive's base URI (relative refs resolve against it).
+        tenant_id: The caller's tenant id, scoping target lookups.
+
+    Returns:
+        The ``{relative_ref, resolved_target, status}`` edge list to persist on
+        ``odb.primitives.refs``.
+    """
+    def _target_exists(absolute_uri: str) -> bool:
+        return db.get_primitive_by_schema_id(absolute_uri, tenant_id) is not None
+
+    return build_ref_edges(schema, base_uri=base_uri, target_exists=_target_exists)
 
 
 def resolve_primitive_identity(
@@ -405,6 +430,11 @@ async def create_primitive(
     except ScopeViolationError as e:
         raise _scope_violation_http_error(e)
 
+    # Resolve relative $ref edges against the registry and persist them (#3456).
+    refs = resolve_primitive_refs(
+        identity['schema'], base_uri=identity['base_uri'], tenant_id=auth_data['tenant_id']
+    )
+
     try:
         # Get user_id from auth data (will be None for API key auth)
         created_by = get_authenticated_user_id(auth_data)
@@ -422,6 +452,7 @@ async def create_primitive(
             draft=identity['draft'],
             namespace=request.namespace,
             base_uri=identity['base_uri'],
+            refs=refs,
         )
 
         return PrimitiveSchema(**primitive)
@@ -522,6 +553,10 @@ async def update_primitive(
         updates['schema_id'] = identity['schema_id']
         updates['draft'] = identity['draft']
         updates['base_uri'] = identity['base_uri']
+        # Re-resolve relative $ref edges whenever the schema or its base changes (#3456).
+        updates['refs'] = resolve_primitive_refs(
+            identity['schema'], base_uri=identity['base_uri'], tenant_id=auth_data['tenant_id']
+        )
 
     try:
         # Update primitive
@@ -687,6 +722,11 @@ async def import_primitives(
             errors.append({"name": def_name, "error": "scope_violation", "details": e.violations})
             continue
 
+        # Resolve relative $ref edges for the imported definition (#3456).
+        refs = resolve_primitive_refs(
+            identity['schema'], base_uri=identity['base_uri'], tenant_id=auth_data['tenant_id']
+        )
+
         try:
             # Determine category from schema
             schema_type = determine_category_from_schema(def_schema)
@@ -706,6 +746,7 @@ async def import_primitives(
                 draft=identity['draft'],
                 namespace=request.target_namespace,
                 base_uri=identity['base_uri'],
+                refs=refs,
             )
             imported.append(primitive['name'])
         except Exception as e:

--- a/objectified-rest/src/app/primitives_scope.py
+++ b/objectified-rest/src/app/primitives_scope.py
@@ -35,6 +35,7 @@ __all__ = [
     "iter_refs",
     "registry_namespace_of_ref",
     "tenant_segment_of",
+    "resolve_registry_uri",
     "is_core_namespace",
     "find_forbidden_refs",
     "enforce_ref_scope",
@@ -80,15 +81,42 @@ def iter_refs(node: Any) -> Iterator[str]:
             yield from iter_refs(item)
 
 
+def resolve_registry_uri(ref: str, base_uri: Optional[str]) -> Optional[str]:
+    """Resolve a ``$ref`` to its absolute registry URI, or ``None`` if it is not one.
+
+    A same-document fragment (``#/$defs/X``) targets the type itself and is never a
+    cross-type reference. A relative ``$ref`` is resolved against ``base_uri`` using
+    ordinary URL semantics (so ``./`` and ``../`` walk the namespace tree). Only refs
+    that land under :data:`app.schema_validation.REGISTRY_BASE_URL` are registry
+    targets; anything else (``https://json-schema.org/...``, vendor URLs) is external.
+    Any trailing fragment is dropped so a path-plus-anchor ref resolves by its path.
+
+    This is the single URL-resolution primitive shared by namespace classification
+    (#3453, :func:`registry_namespace_of_ref`) and reference resolution (#3456,
+    :func:`app.primitives_resolver.build_ref_edges`).
+
+    Args:
+        ref: The ``$ref`` value as written in the document.
+        base_uri: The base URI the owning type's relative refs resolve against.
+
+    Returns:
+        The absolute registry URI the ref targets (e.g.
+        ``https://api.objectified.dev/types/std/v0/primitives/string``), or ``None``
+        when the ref is a fragment or points outside the registry.
+    """
+    if not isinstance(ref, str) or not ref or ref.startswith("#"):
+        return None
+    absolute = urljoin(base_uri or "", ref)
+    if not absolute.startswith(REGISTRY_BASE_URL):
+        return None
+    return absolute.split("#", 1)[0]
+
+
 def registry_namespace_of_ref(ref: str, base_uri: Optional[str]) -> Optional[str]:
     """Resolve a ``$ref`` to its registry namespace path, or ``None`` if it is not one.
 
-    A same-document fragment (``#/$defs/X``) targets the type itself and is never a
-    cross-namespace reference. A relative ``$ref`` is resolved against ``base_uri``
-    using ordinary URL semantics (so ``../`` walks up the namespace tree). Only refs
-    that land under :data:`app.schema_validation.REGISTRY_BASE_URL` name a registry
-    namespace; anything else (``https://json-schema.org/...``, vendor URLs) is
-    external and out of scope.
+    A thin wrapper over :func:`resolve_registry_uri` that strips the registry root,
+    leaving the namespace-plus-leaf path used for scope classification.
 
     Args:
         ref: The ``$ref`` value as written in the document.
@@ -98,15 +126,10 @@ def registry_namespace_of_ref(ref: str, base_uri: Optional[str]) -> Optional[str
         The registry path the ref targets (e.g. ``tenant/acme/v1/types/money``),
         or ``None`` when the ref is a fragment or points outside the registry.
     """
-    if not isinstance(ref, str) or not ref or ref.startswith("#"):
+    absolute = resolve_registry_uri(ref, base_uri)
+    if absolute is None:
         return None
-    absolute = urljoin(base_uri or "", ref)
-    if not absolute.startswith(REGISTRY_BASE_URL):
-        return None
-    # Drop any fragment so a path-plus-anchor ref still classifies by its path.
-    path = absolute[len(REGISTRY_BASE_URL):]
-    path = path.split("#", 1)[0]
-    return path.strip("/")
+    return absolute[len(REGISTRY_BASE_URL):].strip("/")
 
 
 def tenant_segment_of(path: Optional[str]) -> Optional[str]:

--- a/objectified-rest/tests/test_primitives_resolver.py
+++ b/objectified-rest/tests/test_primitives_resolver.py
@@ -1,0 +1,163 @@
+"""Unit tests for relative ``$ref`` resolution into registry edges (#3456).
+
+Covers the canonical resolution cases from the roadmap (``../primitives/string``,
+``./decimal``, cross-scope ``../../std/...``), fragment/external ref handling, the
+resolved/unresolved status from the injected scope lookup, and edge de-duplication.
+The shared URL resolver (:func:`app.primitives_scope.resolve_registry_uri`) is exercised
+directly too.
+"""
+
+from app.primitives_resolver import (
+    STATUS_RESOLVED,
+    STATUS_UNRESOLVED,
+    build_ref_edges,
+)
+from app.primitives_scope import resolve_registry_uri
+
+BASE = "https://api.objectified.dev/types/"
+STD_TYPES_BASE = BASE + "std/v0/types/"
+STD_PRIMS = BASE + "std/v0/primitives/"
+ACME_BASE = BASE + "tenant/acme/v1/types/"
+
+
+def _always(exists):
+    """A target_exists predicate that returns a fixed verdict for every URI."""
+    return lambda _uri: exists
+
+
+def _known(*uris):
+    """A target_exists predicate that resolves only the given absolute URIs."""
+    known = set(uris)
+    return lambda uri: uri in known
+
+
+# ===========================================================================
+# resolve_registry_uri — URL mechanics
+# ===========================================================================
+
+
+def test_parent_ref_resolves_against_base():
+    # date (base std/v0/types/) -> ../primitives/string
+    assert (
+        resolve_registry_uri("../primitives/string", STD_TYPES_BASE)
+        == STD_PRIMS + "string"
+    )
+
+
+def test_sibling_ref_resolves_against_base():
+    # money (base std/v0/types/) -> ./decimal and ./currency-code
+    assert resolve_registry_uri("./decimal", STD_TYPES_BASE) == STD_TYPES_BASE + "decimal"
+    assert (
+        resolve_registry_uri("./currency-code", STD_TYPES_BASE)
+        == STD_TYPES_BASE + "currency-code"
+    )
+
+
+def test_cross_scope_ref_resolves_to_std():
+    # A tenant type at base .../tenant/acme/ references core via ../../std/v0/types/string.
+    base = BASE + "tenant/acme/"
+    assert (
+        resolve_registry_uri("../../std/v0/types/string", base)
+        == STD_TYPES_BASE + "string"
+    )
+
+
+def test_fragment_ref_is_not_a_registry_target():
+    assert resolve_registry_uri("#/$defs/Cents", STD_TYPES_BASE) is None
+
+
+def test_external_ref_is_not_a_registry_target():
+    assert resolve_registry_uri("https://json-schema.org/draft/2020-12/schema", STD_TYPES_BASE) is None
+
+
+# ===========================================================================
+# build_ref_edges — edge construction + status
+# ===========================================================================
+
+
+def test_resolved_edge_when_target_exists():
+    schema = {"type": "object", "properties": {"v": {"$ref": "../primitives/string"}}}
+    edges = build_ref_edges(
+        schema, base_uri=STD_TYPES_BASE, target_exists=_known(STD_PRIMS + "string")
+    )
+    assert edges == [
+        {
+            "relative_ref": "../primitives/string",
+            "resolved_target": STD_PRIMS + "string",
+            "status": STATUS_RESOLVED,
+        }
+    ]
+
+
+def test_unresolved_edge_when_target_missing():
+    schema = {"$ref": "./decimal"}
+    edges = build_ref_edges(schema, base_uri=STD_TYPES_BASE, target_exists=_always(False))
+    assert edges[0]["status"] == STATUS_UNRESOLVED
+    assert edges[0]["resolved_target"] == STD_TYPES_BASE + "decimal"
+
+
+def test_mixed_resolved_and_unresolved():
+    schema = {
+        "allOf": [
+            {"$ref": "./decimal"},
+            {"$ref": "./currency-code"},
+        ]
+    }
+    edges = build_ref_edges(
+        schema,
+        base_uri=STD_TYPES_BASE,
+        target_exists=_known(STD_TYPES_BASE + "decimal"),
+    )
+    by_ref = {e["relative_ref"]: e["status"] for e in edges}
+    assert by_ref == {"./decimal": STATUS_RESOLVED, "./currency-code": STATUS_UNRESOLVED}
+
+
+def test_fragment_and_external_refs_produce_no_edges():
+    schema = {
+        "allOf": [
+            {"$ref": "#/$defs/Cents"},
+            {"$ref": "https://json-schema.org/x"},
+        ],
+        "$defs": {"Cents": {"type": "integer"}},
+    }
+    assert build_ref_edges(schema, base_uri=STD_TYPES_BASE, target_exists=_always(True)) == []
+
+
+def test_duplicate_refs_recorded_once_in_document_order():
+    schema = {
+        "anyOf": [
+            {"$ref": "./decimal"},
+            {"items": {"$ref": "../primitives/string"}},
+            {"$ref": "./decimal"},
+        ]
+    }
+    edges = build_ref_edges(schema, base_uri=STD_TYPES_BASE, target_exists=_always(True))
+    assert [e["relative_ref"] for e in edges] == ["./decimal", "../primitives/string"]
+
+
+def test_no_refs_yields_empty_edges():
+    schema = {"type": "string", "maxLength": 10}
+    assert build_ref_edges(schema, base_uri=STD_TYPES_BASE, target_exists=_always(True)) == []
+
+
+def test_cross_scope_edge_resolves_to_core_target():
+    base = BASE + "tenant/acme/"
+    schema = {"$ref": "../../std/v0/types/string"}
+    edges = build_ref_edges(
+        schema, base_uri=base, target_exists=_known(STD_TYPES_BASE + "string")
+    )
+    assert edges[0]["resolved_target"] == STD_TYPES_BASE + "string"
+    assert edges[0]["status"] == STATUS_RESOLVED
+
+
+def test_target_exists_called_with_absolute_uri():
+    seen = []
+
+    def _spy(uri):
+        seen.append(uri)
+        return True
+
+    build_ref_edges(
+        {"$ref": "../primitives/string"}, base_uri=STD_TYPES_BASE, target_exists=_spy
+    )
+    assert seen == [STD_PRIMS + "string"]

--- a/objectified-rest/tests/test_primitives_resolver_routes.py
+++ b/objectified-rest/tests/test_primitives_resolver_routes.py
@@ -1,0 +1,185 @@
+"""API tests for relative ``$ref`` resolution + persistence on the Primitives CRUD (#3456).
+
+Covers create / update / import: each computes the schema's ``$ref`` edges, marks them
+resolved/unresolved by a tenant-scoped target lookup (``get_primitive_by_schema_id``), and
+persists them to ``odb.primitives.refs``. The DB is mocked, so these assert the edges passed
+to the DB layer; pure resolution mechanics are covered in ``test_primitives_resolver.py``.
+"""
+
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.auth import validate_authentication
+from app.main import app
+
+client = TestClient(app)
+
+_JWT = {"tenant_id": "t1", "user_id": "u1", "auth_method": "jwt"}
+_NOW = datetime(2026, 6, 22, 12, 0, 0, tzinfo=timezone.utc)
+
+BASE = "https://api.objectified.dev/types/"
+STD_PRIMS_STRING = BASE + "std/v0/primitives/string"
+
+
+def _row(**overrides):
+    row = {
+        "id": "p1",
+        "tenant_id": "t1",
+        "name": "Date",
+        "description": None,
+        "category": "object",
+        "schema": {"type": "object"},
+        "tags": [],
+        "created_by": "u1",
+        "is_system": False,
+        "is_public": False,
+        "usage_count": 0,
+        "source": "human",
+        "schema_id": None,
+        "draft": "2020-12",
+        "namespace": None,
+        "base_uri": None,
+        "refs": [],
+        "created_at": _NOW,
+        "updated_at": _NOW,
+        "enabled": True,
+    }
+    row.update(overrides)
+    return row
+
+
+@pytest.fixture(autouse=True)
+def _auth():
+    app.dependency_overrides[validate_authentication] = lambda: _JWT
+    yield
+    app.dependency_overrides.pop(validate_authentication, None)
+
+
+# ===========================================================================
+# CREATE
+# ===========================================================================
+
+
+def test_create_persists_resolved_ref_edge():
+    with patch("app.primitives_routes.db") as mdb:
+        # The referenced target exists in scope -> resolved.
+        mdb.get_primitive_by_schema_id.return_value = _row(id="target")
+        mdb.create_primitive.return_value = _row()
+        r = client.post(
+            "/v1/primitives/std",
+            json={
+                "name": "Date",
+                "category": "object",
+                "namespace": "std/v0/types",
+                "schema": {"type": "object", "properties": {"v": {"$ref": "../primitives/string"}}},
+            },
+        )
+    assert r.status_code == 200
+    refs = mdb.create_primitive.call_args.kwargs["refs"]
+    assert refs == [
+        {
+            "relative_ref": "../primitives/string",
+            "resolved_target": STD_PRIMS_STRING,
+            "status": "resolved",
+        }
+    ]
+    # The lookup is tenant-scoped (token tenant, not the URL slug).
+    mdb.get_primitive_by_schema_id.assert_called_once_with(STD_PRIMS_STRING, "t1")
+
+
+def test_create_persists_unresolved_ref_edge_when_target_missing():
+    with patch("app.primitives_routes.db") as mdb:
+        mdb.get_primitive_by_schema_id.return_value = None  # target not present
+        mdb.create_primitive.return_value = _row()
+        r = client.post(
+            "/v1/primitives/std",
+            json={
+                "name": "Date",
+                "category": "object",
+                "namespace": "std/v0/types",
+                "schema": {"type": "object", "properties": {"v": {"$ref": "../primitives/string"}}},
+            },
+        )
+    assert r.status_code == 200
+    refs = mdb.create_primitive.call_args.kwargs["refs"]
+    assert refs[0]["status"] == "unresolved"
+    assert refs[0]["resolved_target"] == STD_PRIMS_STRING
+
+
+def test_create_without_refs_persists_empty_edges():
+    with patch("app.primitives_routes.db") as mdb:
+        mdb.create_primitive.return_value = _row()
+        r = client.post(
+            "/v1/primitives/std",
+            json={"name": "Plain", "category": "string", "schema": {"type": "string"}},
+        )
+    assert r.status_code == 200
+    assert mdb.create_primitive.call_args.kwargs["refs"] == []
+    mdb.get_primitive_by_schema_id.assert_not_called()
+
+
+# ===========================================================================
+# UPDATE
+# ===========================================================================
+
+
+def test_update_reresolves_refs_on_schema_change():
+    with patch("app.primitives_routes.db") as mdb:
+        mdb.get_primitive_by_id.return_value = _row(name="Date", namespace="std/v0/types")
+        mdb.get_primitive_by_schema_id.return_value = _row(id="target")
+        mdb.update_primitive.return_value = _row()
+        r = client.put(
+            "/v1/primitives/std/p1",
+            json={"schema": {"type": "object", "properties": {"v": {"$ref": "../primitives/string"}}}},
+        )
+    assert r.status_code == 200
+    updates = mdb.update_primitive.call_args.args[2]
+    assert updates["refs"][0]["relative_ref"] == "../primitives/string"
+    assert updates["refs"][0]["status"] == "resolved"
+
+
+def test_update_metadata_only_does_not_touch_refs():
+    with patch("app.primitives_routes.db") as mdb:
+        mdb.get_primitive_by_id.return_value = _row()
+        mdb.update_primitive.return_value = _row(description="x")
+        r = client.put("/v1/primitives/std/p1", json={"description": "x"})
+    assert r.status_code == 200
+    updates = mdb.update_primitive.call_args.args[2]
+    assert "refs" not in updates
+    mdb.get_primitive_by_schema_id.assert_not_called()
+
+
+# ===========================================================================
+# IMPORT
+# ===========================================================================
+
+
+def test_import_persists_refs_per_definition():
+    created = []
+
+    def _create(**kwargs):
+        created.append(kwargs)
+        return {"name": kwargs["name"], "refs": kwargs.get("refs", [])}
+
+    with patch("app.primitives_routes.db") as mdb:
+        mdb.create_primitive.side_effect = _create
+        mdb.get_primitive_by_schema_id.return_value = None  # unresolved
+        mdb.create_primitive_import.return_value = {"id": "imp1"}
+        r = client.post(
+            "/v1/primitives/std/import",
+            json={
+                "schema": {
+                    "$defs": {
+                        "Date": {"type": "object", "properties": {"v": {"$ref": "../primitives/string"}}},
+                    }
+                },
+                "import_all": True,
+                "target_namespace": "std/v0/types",
+            },
+        )
+    assert r.status_code == 200
+    assert created[0]["refs"][0]["relative_ref"] == "../primitives/string"
+    assert created[0]["refs"][0]["status"] == "unresolved"


### PR DESCRIPTION
## What & why

Implements **[3.1] Relative `$ref` resolution against import-source base** — the defining mechanic of the type registry (Epic 3). Primitive schemas reference other registry types by *relative* `$ref` rooted at the type's import-source `base_uri`; this resolves each ref to an absolute registry target and records the result.

```
base   = https://api.objectified.dev/types/std/v0/types/   (source: date)
$ref   = ../primitives/string
target = https://api.objectified.dev/types/std/v0/primitives/string   ✓ resolved
```

**New `objectified-rest/src/app/primitives_resolver.py`**
- `build_ref_edges(schema, *, base_uri, target_exists)` walks every `$ref`, resolves each relative ref against `base_uri` (`./`, `../`, cross-scope `../../std/...`) to an absolute registry URI, and emits an edge `{relative_ref, resolved_target, status}`.
- `status` is `resolved` when a primitive with that `$id` exists within the source's read scope, else `unresolved` (the flag consumed by #3457).
- Same-document fragment (`#/...`) and external (non-registry) refs are intentionally **not** recorded as edges.

**Shared resolver** — refactored `primitives_scope.py` to expose `resolve_registry_uri()`, the single URL-resolution primitive now shared by scope classification (#3453) and ref resolution (#3456). `registry_namespace_of_ref()` is a thin wrapper over it (behavior unchanged).

**Persistence** (`odb.primitives.refs`, the JSONB column already added by #3447)
- New `db.get_primitive_by_schema_id(schema_id, tenant_id)` resolves a target by its `$id` within read scope (`is_system ∪ tenant`), so a tenant resolves only to system-core or its own types — **honoring scope (#3453)**; a ref into another tenant's namespace simply stays `unresolved`.
- `create_primitive` / `update_primitive` persist `refs`; the read selects and `PrimitiveSchema` now expose `refs`.
- Routes: **create**, **update** (re-resolved whenever the schema or base changes), and **import** (per definition) compute and store the edges.

## How to test

```
cd objectified-rest
.venv/bin/python -m pytest tests/test_primitives_resolver.py tests/test_primitives_resolver_routes.py -q
```

- **`test_primitives_resolver.py`** (13) — URL mechanics (`../primitives/string`, `./decimal`, cross-scope `../../std/...`), fragment/external skipping, resolved/unresolved status, de-dup, absolute-URI lookup.
- **`test_primitives_resolver_routes.py`** (6) — create/update/import persist the right edges; the target lookup is tenant-scoped; metadata-only updates leave `refs` untouched.

Manual: **POST** `/v1/primitives/<slug>` with `namespace: "std/v0/types"` and schema `{"type":"object","properties":{"v":{"$ref":"../primitives/string"}}}`. With a primitive whose `$id` is `https://api.objectified.dev/types/std/v0/primitives/string` present, the created row's `refs` is `[{relative_ref:"../primitives/string", resolved_target:".../std/v0/primitives/string", status:"resolved"}]`; without it, `status:"unresolved"`.

## Risk / notes

- No migration — the `refs` JSONB column already exists (`20260622-230000.sql`).
- Resolution runs only after draft-2020-12 validation + scope enforcement pass, so only valid, scope-allowed schemas are resolved. One scoped lookup per distinct `$ref`.
- Circular-reference detection (`status: circular`) is out of scope here — it's #3458 (V2). This engine emits only `resolved`/`unresolved`; the unresolved-flagging counts/list endpoint is #3457.
- Full REST suite: **652 passed**, 2 skipped; the 18 failures are pre-existing DB-dependent integration tests unrelated to primitives (verified on clean `main` in #3453). New code passes `ruff` clean; REST version bumped (`1.0.82→1.0.83` / `1.0.12→1.0.13`); ROADMAP 3.1 marked done.

Closes #3456

Work performed by Claude Code via model claude-opus-4-8[1m]