### PR TITLE
Fix #3460 - Import pipeline core + ingestion

### DIFF
--- a/docs/ROADMAP_TYPE_REGISTRY_GOVERNANCE.md
+++ b/docs/ROADMAP_TYPE_REGISTRY_GOVERNANCE.md
@@ -480,7 +480,7 @@ flowchart LR
 
 | Issue | Title | Summary | Labels | Parallel | MVP | Complexity | Affected Modules |
 |---|---|---|---|:---:|:---:|---|---|
-| 4.1 #3460 | Import pipeline core + ingestion | Orchestrator + file/paste/URL/git source intake | `type-registry`,`import`,`rest`,`mvp`,`roadmap-type-registry` | N | Y | M | objectified-rest |
+| 4.1 #3460 ✅ | ~~Import pipeline core + ingestion~~ | **DONE** — `POST /v1/primitives/{tenant_slug}/import/stage` orchestrator: ingests paste/file/url/git, parses JSON/YAML, stages candidate types per kind (json-schema/type-def-bundle/openapi), records a `staged` `odb.primitive_imports` row; legacy paste `/import` retained | `type-registry`,`import`,`rest`,`mvp`,`roadmap-type-registry` | N | Y | M | objectified-rest |
 | 4.2 #3461 | JSON Schema 2020-12 parser | Parse single doc + `$defs` into discrete types | `type-registry`,`import`,`rest`,`mvp`,`roadmap-type-registry` | Y | Y | L | objectified-rest |
 | 4.3 #3462 | Type-definition bundle importer | Expand `.zip`/`.json` bundle into many interlinked types | `type-registry`,`import`,`rest`,`mvp`,`roadmap-type-registry` | Y | Y | L | objectified-rest |
 | 4.4 #3463 | `$ref` rewrite + namespace/scope mapping | Rewrite refs relative to import source; map to namespace/scope | `type-registry`,`import`,`rest`,`mvp`,`roadmap-type-registry` | N | Y | L | objectified-rest |

--- a/objectified-rest/CHANGELOG.md
+++ b/objectified-rest/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to the Objectified REST API will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.16] - 2026-06-22
+
+### Added
+- **Import pipeline core + ingestion (#3460)** — new `POST /v1/primitives/{tenant_slug}/import/stage`,
+  the single orchestration path for all import sources. It ingests a document by one of four
+  methods — `paste` / `file` (inline text), `url` (http/https fetch), or `git` (a file from a public
+  github.com repo, reusing the repository-scan fetcher) — parses it as JSON **or** YAML, and detects
+  the candidate types it carries, dispatched on source kind: `$defs`/`definitions` for `json-schema`
+  (a bare document is one candidate), the `types`/`$defs` container for `type-def-bundle`, and
+  `components.schemas` for `openapi`. The result is *staged*, not committed — each candidate carries
+  its JSON Pointer and `$ref` count for the downstream parse (#3461/#3462), `$ref` rewrite (#3463),
+  and conflict review (#3464) stages. Every staged import records an auditable `staged`
+  `odb.primitive_imports` row (reusing #3448; no new table). The legacy paste-and-commit
+  `POST /v1/primitives/{tenant_slug}/import` is unchanged. New `app/import_ingestion.py` (per-method
+  fetch + JSON/YAML parse), `app/import_pipeline.py` (pure detection + staging), and
+  `PrimitiveImportStageRequest` / `PrimitiveImportStageResult` / `StagedTypeCandidate` /
+  `GitSourceLocator` models.
+
 ## [1.0.13] - 2026-06-22
 
 ### Added

--- a/objectified-rest/openapi.json
+++ b/objectified-rest/openapi.json
@@ -1666,6 +1666,91 @@
         }
       }
     },
+    "/v1/primitives/{tenant_slug}/import/stage": {
+      "post": {
+        "tags": [
+          "primitives"
+        ],
+        "summary": "Stage Import",
+        "description": "Stage an import through the unified pipeline (#3460).\n\nThe single orchestration path for all source kinds and intake methods: it\nfetches the source (paste / file / url / git), parses it (JSON or YAML),\ndetects the candidate types it carries (json-schema / type-def-bundle /\nopenapi), records a provenance row on ``odb.primitive_imports`` marked\n``staged``, and returns the staged candidates.\n\nNothing is committed to the registry here \u2014 parsing into discrete types\n(#3461/#3462), ``$ref`` rewrite (#3463), and conflict/dedupe review (#3464)\noperate on the staged result in the subsequent pipeline stages. The legacy\n``POST /{tenant_slug}/import`` (paste, commit) remains supported alongside it.\n\nArgs:\n    tenant_slug: The tenant slug.\n    request: The staging request (source kind/method + a method locator).\n    auth_data: Authentication data (injected by dependency).\n\nReturns:\n    The staged result: detected candidates plus the recorded ``import_id``.\n\nRaises:\n    HTTPException: 400 for an invalid source kind/method or missing locator,\n        422 for an unparseable source, 502 for a fetch failure.",
+        "operationId": "stage_import_v1_primitives__tenant_slug__import_stage_post",
+        "parameters": [
+          {
+            "name": "tenant_slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Tenant Slug"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "name": "X-API-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PrimitiveImportStageRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PrimitiveImportStageResult"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/types/{tenant_slug}/namespaces": {
       "get": {
         "tags": [
@@ -16432,6 +16517,36 @@
         ],
         "title": "DataRecordUpdateBody"
       },
+      "GitSourceLocator": {
+        "properties": {
+          "repo_url": {
+            "type": "string",
+            "title": "Repo Url"
+          },
+          "path": {
+            "type": "string",
+            "title": "Path"
+          },
+          "ref": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ref"
+          }
+        },
+        "type": "object",
+        "required": [
+          "repo_url",
+          "path"
+        ],
+        "title": "GitSourceLocator",
+        "description": "Locator for the ``git`` import method \u2014 a single file in a Git repository (#3460).\n\nMVP supports public ``github.com`` repositories; the file is fetched via the\nGitHub contents API."
+      },
       "HTTPValidationError": {
         "properties": {
           "detail": {
@@ -17098,6 +17213,155 @@
         ],
         "title": "PrimitiveImportRequest",
         "description": "Request model for importing primitives from JSON Schema."
+      },
+      "PrimitiveImportStageRequest": {
+        "properties": {
+          "source_kind": {
+            "type": "string",
+            "title": "Source Kind",
+            "default": "json-schema"
+          },
+          "source_method": {
+            "type": "string",
+            "title": "Source Method",
+            "default": "paste"
+          },
+          "source_label": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Label"
+          },
+          "target_namespace": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Target Namespace"
+          },
+          "content": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Content"
+          },
+          "url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Url"
+          },
+          "git": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/GitSourceLocator"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "type": "object",
+        "title": "PrimitiveImportStageRequest",
+        "description": "Request to stage an import through the pipeline (#3460).\n\nThe pipeline accepts a source ``kind`` (json-schema / type-def-bundle / openapi)\nby one of four ``method``s (paste / file / url / git), fetches and parses it, and\nreturns a *staged* result \u2014 candidate types ready for parsing (#3461/#3462),\nref-rewrite (#3463), and review (#3464). Nothing is committed to the registry.\n\nLocator fields are method-specific: ``content`` carries paste/file text, ``url``\nthe http(s) source, and ``git`` the repository locator."
+      },
+      "PrimitiveImportStageResult": {
+        "properties": {
+          "import_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Import Id"
+          },
+          "status": {
+            "type": "string",
+            "title": "Status",
+            "default": "staged"
+          },
+          "source_kind": {
+            "type": "string",
+            "title": "Source Kind"
+          },
+          "source_method": {
+            "type": "string",
+            "title": "Source Method"
+          },
+          "source_label": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Label"
+          },
+          "target_namespace": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Target Namespace"
+          },
+          "detected_count": {
+            "type": "integer",
+            "title": "Detected Count",
+            "default": 0
+          },
+          "candidates": {
+            "items": {
+              "$ref": "#/components/schemas/StagedTypeCandidate"
+            },
+            "type": "array",
+            "title": "Candidates",
+            "default": []
+          },
+          "warnings": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Warnings",
+            "default": []
+          }
+        },
+        "type": "object",
+        "required": [
+          "source_kind",
+          "source_method"
+        ],
+        "title": "PrimitiveImportStageResult",
+        "description": "The staged result of an import plus the id of its provenance record (#3460)."
       },
       "PrimitiveSchema": {
         "properties": {
@@ -20146,6 +20410,30 @@
         ],
         "title": "SpecImportVersionTarget",
         "description": "Target catalog revision for an import job."
+      },
+      "StagedTypeCandidate": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "pointer": {
+            "type": "string",
+            "title": "Pointer"
+          },
+          "ref_count": {
+            "type": "integer",
+            "title": "Ref Count",
+            "default": 0
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "pointer"
+        ],
+        "title": "StagedTypeCandidate",
+        "description": "One candidate type detected in a staged import (#3460)."
       },
       "SunsetTimelineEntryOut": {
         "properties": {

--- a/objectified-rest/openapi.yaml
+++ b/objectified-rest/openapi.yaml
@@ -1066,6 +1066,69 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /v1/primitives/{tenant_slug}/import/stage:
+    post:
+      tags:
+      - primitives
+      summary: Stage Import
+      description: "Stage an import through the unified pipeline (#3460).\n\nThe single\
+        \ orchestration path for all source kinds and intake methods: it\nfetches\
+        \ the source (paste / file / url / git), parses it (JSON or YAML),\ndetects\
+        \ the candidate types it carries (json-schema / type-def-bundle /\nopenapi),\
+        \ records a provenance row on ``odb.primitive_imports`` marked\n``staged``,\
+        \ and returns the staged candidates.\n\nNothing is committed to the registry\
+        \ here — parsing into discrete types\n(#3461/#3462), ``$ref`` rewrite (#3463),\
+        \ and conflict/dedupe review (#3464)\noperate on the staged result in the\
+        \ subsequent pipeline stages. The legacy\n``POST /{tenant_slug}/import`` (paste,\
+        \ commit) remains supported alongside it.\n\nArgs:\n    tenant_slug: The tenant\
+        \ slug.\n    request: The staging request (source kind/method + a method locator).\n\
+        \    auth_data: Authentication data (injected by dependency).\n\nReturns:\n\
+        \    The staged result: detected candidates plus the recorded ``import_id``.\n\
+        \nRaises:\n    HTTPException: 400 for an invalid source kind/method or missing\
+        \ locator,\n        422 for an unparseable source, 502 for a fetch failure."
+      operationId: stage_import_v1_primitives__tenant_slug__import_stage_post
+      parameters:
+      - name: tenant_slug
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Tenant Slug
+      - name: authorization
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Authorization
+      - name: X-API-Key
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Api-Key
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PrimitiveImportStageRequest'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PrimitiveImportStageResult'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /v1/types/{tenant_slug}/namespaces:
     get:
       tags:
@@ -10460,6 +10523,31 @@ components:
       - class_schema_id
       - data
       title: DataRecordUpdateBody
+    GitSourceLocator:
+      properties:
+        repo_url:
+          type: string
+          title: Repo Url
+        path:
+          type: string
+          title: Path
+        ref:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Ref
+      type: object
+      required:
+      - repo_url
+      - path
+      title: GitSourceLocator
+      description: 'Locator for the ``git`` import method — a single file in a Git
+        repository (#3460).
+
+
+        MVP supports public ``github.com`` repositories; the file is fetched via the
+
+        GitHub contents API.'
     HTTPValidationError:
       properties:
         detail:
@@ -10862,6 +10950,108 @@ components:
       - schema
       title: PrimitiveImportRequest
       description: Request model for importing primitives from JSON Schema.
+    PrimitiveImportStageRequest:
+      properties:
+        source_kind:
+          type: string
+          title: Source Kind
+          default: json-schema
+        source_method:
+          type: string
+          title: Source Method
+          default: paste
+        source_label:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Source Label
+        target_namespace:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Target Namespace
+        content:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Content
+        url:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Url
+        git:
+          anyOf:
+          - $ref: '#/components/schemas/GitSourceLocator'
+          - type: 'null'
+      type: object
+      title: PrimitiveImportStageRequest
+      description: 'Request to stage an import through the pipeline (#3460).
+
+
+        The pipeline accepts a source ``kind`` (json-schema / type-def-bundle / openapi)
+
+        by one of four ``method``s (paste / file / url / git), fetches and parses
+        it, and
+
+        returns a *staged* result — candidate types ready for parsing (#3461/#3462),
+
+        ref-rewrite (#3463), and review (#3464). Nothing is committed to the registry.
+
+
+        Locator fields are method-specific: ``content`` carries paste/file text, ``url``
+
+        the http(s) source, and ``git`` the repository locator.'
+    PrimitiveImportStageResult:
+      properties:
+        import_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Import Id
+        status:
+          type: string
+          title: Status
+          default: staged
+        source_kind:
+          type: string
+          title: Source Kind
+        source_method:
+          type: string
+          title: Source Method
+        source_label:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Source Label
+        target_namespace:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Target Namespace
+        detected_count:
+          type: integer
+          title: Detected Count
+          default: 0
+        candidates:
+          items:
+            $ref: '#/components/schemas/StagedTypeCandidate'
+          type: array
+          title: Candidates
+          default: []
+        warnings:
+          items:
+            type: string
+          type: array
+          title: Warnings
+          default: []
+      type: object
+      required:
+      - source_kind
+      - source_method
+      title: PrimitiveImportStageResult
+      description: The staged result of an import plus the id of its provenance record
+        (#3460).
     PrimitiveSchema:
       properties:
         id:
@@ -12843,6 +13033,24 @@ components:
       - version_id
       title: SpecImportVersionTarget
       description: Target catalog revision for an import job.
+    StagedTypeCandidate:
+      properties:
+        name:
+          type: string
+          title: Name
+        pointer:
+          type: string
+          title: Pointer
+        ref_count:
+          type: integer
+          title: Ref Count
+          default: 0
+      type: object
+      required:
+      - name
+      - pointer
+      title: StagedTypeCandidate
+      description: One candidate type detected in a staged import (#3460).
     SunsetTimelineEntryOut:
       properties:
         revisionId:

--- a/objectified-rest/package.json
+++ b/objectified-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-rest",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "private": true,
   "description": "Trigger file for Objectified REST Docker publish workflow; app is Python (pyproject.toml).",
   "scripts": {

--- a/objectified-rest/pyproject.toml
+++ b/objectified-rest/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "objectified-rest"
-version = "1.0.85"
+version = "1.0.86"
 description = "REST API for serving OpenAPI specifications from the Objectified database"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/objectified-rest/src/app/import_ingestion.py
+++ b/objectified-rest/src/app/import_ingestion.py
@@ -1,0 +1,254 @@
+"""Import source ingestion for the Primitives import pipeline (#3460).
+
+The import pipeline accepts a source document by one of four **methods** — paste,
+file, URL, or git — and normalizes it to a parsed document that the staging step
+(#3461/#3462) turns into candidate types. This module is the ingestion layer: one
+fetcher per method, each returning the raw text plus the parsed (JSON or YAML)
+document.
+
+Only ingestion lives here; detection/staging of candidate types is in
+``import_pipeline``. Network and subprocess access are isolated to the URL and
+git fetchers so a caller (or a test) can mock a single, well-defined boundary.
+"""
+
+import json
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+from urllib.parse import urlparse
+
+import httpx
+import yaml
+
+from .repository_file_scan import fetch_github_repository_file_text
+from .repository_validation import parse_github_owner_repo_from_url
+
+# Source intake methods the pipeline understands.
+VALID_SOURCE_METHODS = {"paste", "file", "url", "git"}
+
+# Cap on ingested document size, so a runaway URL/git target cannot exhaust memory.
+DEFAULT_MAX_BYTES = 2_000_000
+
+# Network timeout for URL ingestion.
+_HTTP_TIMEOUT = httpx.Timeout(30.0, connect=15.0)
+_UA = "Objectified-ImportPipeline/1.0"
+
+
+class IngestionError(Exception):
+    """A source document could not be fetched or parsed.
+
+    Carries a human-readable ``message`` so the route can surface it directly
+    (e.g. a 400/422 detail) without leaking stack traces.
+    """
+
+    def __init__(self, message: str):
+        self.message = message
+        super().__init__(message)
+
+
+@dataclass
+class IngestedDocument:
+    """The normalized result of ingesting one source document.
+
+    Attributes:
+        document: The parsed document as a mapping (JSON or YAML).
+        text: The raw source text, retained for re-parsing by later stages.
+        resolved_label: A human label for the source (filename / URL / git path),
+            falling back to the caller-supplied label when one is not derivable.
+    """
+
+    document: Dict[str, Any]
+    text: str
+    resolved_label: Optional[str] = None
+
+
+def parse_document(text: str, *, source_label: Optional[str] = None) -> Dict[str, Any]:
+    """Parse a source document, accepting either JSON or YAML.
+
+    JSON is tried first (the common case and stricter); YAML is the fallback so
+    YAML-authored OpenAPI / JSON Schema documents ingest without a separate flag.
+    A YAML document is itself a superset of JSON, so this never loses a JSON parse.
+
+    Args:
+        text: The raw document text.
+        source_label: Optional label used only to make error messages specific.
+
+    Returns:
+        The parsed document as a mapping.
+
+    Raises:
+        IngestionError: If the text is empty, unparseable as JSON or YAML, or
+            does not parse to a JSON object / YAML mapping at the top level.
+    """
+    if text is None or not text.strip():
+        raise IngestionError("Source document is empty")
+
+    parsed: Any
+    try:
+        parsed = json.loads(text)
+    except (json.JSONDecodeError, ValueError):
+        try:
+            parsed = yaml.safe_load(text)
+        except yaml.YAMLError as exc:
+            where = f" ({source_label})" if source_label else ""
+            raise IngestionError(f"Source document is not valid JSON or YAML{where}: {exc}")
+
+    if not isinstance(parsed, dict):
+        where = f" ({source_label})" if source_label else ""
+        raise IngestionError(
+            f"Source document must be a JSON object / YAML mapping at the top level{where}"
+        )
+    return parsed
+
+
+def _fetch_url_text(url: str, *, max_bytes: int) -> str:
+    """Fetch a document over http/https, capping the read at ``max_bytes``.
+
+    Args:
+        url: The source URL. Only ``http`` and ``https`` schemes are accepted.
+        max_bytes: Hard cap on bytes read from the response body.
+
+    Returns:
+        The response body decoded as UTF-8 (invalid bytes replaced).
+
+    Raises:
+        IngestionError: For a non-http(s) scheme, a network failure, or a non-2xx
+            response.
+    """
+    try:
+        scheme = (urlparse(url.strip()).scheme or "").lower()
+    except Exception:
+        raise IngestionError(f"Malformed URL: {url}")
+    if scheme not in ("http", "https"):
+        raise IngestionError("URL ingestion supports only http/https URLs")
+
+    headers = {"User-Agent": _UA, "Accept": "application/json, application/yaml, text/plain, */*"}
+    try:
+        with httpx.Client(timeout=_HTTP_TIMEOUT, follow_redirects=True) as client:
+            with client.stream("GET", url, headers=headers) as resp:
+                if resp.status_code >= 400:
+                    raise IngestionError(
+                        f"URL returned HTTP {resp.status_code}; it may be private or invalid"
+                    )
+                chunks = []
+                total = 0
+                for chunk in resp.iter_bytes():
+                    if not chunk:
+                        continue
+                    chunks.append(chunk)
+                    total += len(chunk)
+                    if total > max_bytes:
+                        raise IngestionError(
+                            f"Source document exceeds the {max_bytes}-byte ingestion limit"
+                        )
+    except httpx.HTTPError as exc:
+        raise IngestionError(f"Failed to fetch URL: {exc}")
+
+    return b"".join(chunks).decode("utf-8", errors="replace")
+
+
+def _fetch_git_text(git: Dict[str, Any], *, max_bytes: int) -> str:
+    """Fetch a single file from a Git repository.
+
+    MVP supports public GitHub repositories via the GitHub contents API, reusing
+    the repository-scan fetcher (private repos are served by the dedicated
+    repository-store import path, not this ad-hoc pipeline).
+
+    Args:
+        git: A locator mapping with ``repo_url`` (a github.com URL), ``path`` (the
+            file path within the repo), and optional ``ref`` (branch/tag/SHA,
+            default ``main``).
+        max_bytes: Hard cap on bytes read from the file.
+
+    Returns:
+        The file text (UTF-8, invalid bytes replaced).
+
+    Raises:
+        IngestionError: For a missing/unsupported locator or a fetch failure.
+    """
+    repo_url = str(git.get("repo_url") or "").strip()
+    path = str(git.get("path") or "").strip()
+    ref = str(git.get("ref") or "main").strip() or "main"
+    if not repo_url or not path:
+        raise IngestionError("git ingestion requires both 'repo_url' and 'path'")
+
+    owner_repo = parse_github_owner_repo_from_url(repo_url)
+    if not owner_repo:
+        raise IngestionError(
+            "git ingestion currently supports github.com repositories only"
+        )
+    owner, repo = owner_repo
+
+    try:
+        text, truncated = fetch_github_repository_file_text(
+            owner, repo, path, ref, access_token=None, max_bytes=max_bytes
+        )
+    except ValueError as exc:
+        raise IngestionError(f"Failed to fetch git file: {exc}")
+
+    if truncated:
+        raise IngestionError(
+            f"git file exceeds the {max_bytes}-byte ingestion limit"
+        )
+    return text
+
+
+def ingest_source(
+    method: str,
+    *,
+    content: Optional[str] = None,
+    url: Optional[str] = None,
+    git: Optional[Dict[str, Any]] = None,
+    source_label: Optional[str] = None,
+    max_bytes: int = DEFAULT_MAX_BYTES,
+) -> IngestedDocument:
+    """Fetch and parse a source document by intake method.
+
+    Dispatches on ``method`` and returns a parsed, normalized document:
+
+    - ``paste`` / ``file``: the document text is already in hand (``content``).
+      Both share the same intake; they differ only in provenance — ``file`` names
+      an uploaded file via ``source_label`` while ``paste`` is inline text.
+    - ``url``: fetched over http/https.
+    - ``git``: a single file fetched from a (public) GitHub repository.
+
+    Args:
+        method: One of :data:`VALID_SOURCE_METHODS`.
+        content: Raw document text, required for ``paste`` / ``file``.
+        url: Source URL, required for ``url``.
+        git: Git locator (``repo_url`` / ``path`` / ``ref``), required for ``git``.
+        source_label: Caller-supplied label (filename / human name) used as the
+            fallback ``resolved_label`` and to make parse errors specific.
+        max_bytes: Hard cap on ingested document size.
+
+    Returns:
+        The :class:`IngestedDocument` (parsed mapping + raw text + resolved label).
+
+    Raises:
+        IngestionError: For an unknown method, a missing locator, a fetch failure,
+            or an unparseable document.
+    """
+    if method not in VALID_SOURCE_METHODS:
+        raise IngestionError(
+            f"Invalid source_method '{method}'. "
+            f"Expected one of: {', '.join(sorted(VALID_SOURCE_METHODS))}"
+        )
+
+    resolved_label = source_label
+
+    if method in ("paste", "file"):
+        if content is None or not content.strip():
+            raise IngestionError(f"source_method '{method}' requires non-empty 'content'")
+        text = content
+    elif method == "url":
+        if not url or not url.strip():
+            raise IngestionError("source_method 'url' requires a 'url'")
+        text = _fetch_url_text(url, max_bytes=max_bytes)
+        resolved_label = resolved_label or url
+    else:  # git
+        if not git:
+            raise IngestionError("source_method 'git' requires a 'git' locator")
+        text = _fetch_git_text(git, max_bytes=max_bytes)
+        resolved_label = resolved_label or f"{git.get('repo_url')}#{git.get('path')}"
+
+    document = parse_document(text, source_label=resolved_label)
+    return IngestedDocument(document=document, text=text, resolved_label=resolved_label)

--- a/objectified-rest/src/app/import_pipeline.py
+++ b/objectified-rest/src/app/import_pipeline.py
@@ -1,0 +1,272 @@
+"""Staging orchestrator for the Primitives import pipeline (#3460).
+
+The import pipeline's job in this ticket is *staging*: take an ingested source
+document (see :mod:`import_ingestion`), detect the candidate types it carries,
+and produce a **staged result** — a list of candidates that a later step parses
+into discrete types (#3461/#3462), rewrites refs for (#3463), and reviews for
+conflicts (#3464). Nothing is committed to the registry here.
+
+Detection is intentionally *shallow*: it locates the candidate type fragments and
+records a cheap per-candidate ref count, but it does not parse, validate, or
+rewrite them — those are the downstream tickets. Detection is dispatched on the
+source **kind**:
+
+- ``json-schema``: each ``$defs`` / ``definitions`` entry is a candidate; a bare
+  document with neither is itself a single candidate.
+- ``type-def-bundle``: each entry under ``types`` (or ``$defs`` / ``definitions``)
+  is a candidate.
+- ``openapi``: each ``components.schemas`` entry is a candidate.
+"""
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Tuple
+
+from .primitives_scope import iter_refs
+
+# Source document shapes the pipeline understands. Must stay in sync with the
+# odb.primitive_imports.source_kind CHECK constraint.
+VALID_SOURCE_KINDS = {"json-schema", "type-def-bundle", "openapi"}
+
+
+@dataclass
+class StagedCandidate:
+    """One candidate type detected in a source document, staged for later parsing.
+
+    Attributes:
+        name: The candidate's name (the ``$defs`` / schema key, or a derived name
+            for a single bare document).
+        pointer: A JSON Pointer locating the fragment within the source document
+            (e.g. ``#/$defs/Money``), so a later stage can re-read it.
+        ref_count: How many ``$ref`` values the fragment contains — a cheap signal
+            of how much ref rewriting (#3463) the candidate will need.
+    """
+
+    name: str
+    pointer: str
+    ref_count: int = 0
+
+    def as_dict(self) -> Dict[str, Any]:
+        """Return the candidate as a plain JSON-serializable mapping."""
+        return {"name": self.name, "pointer": self.pointer, "ref_count": self.ref_count}
+
+
+@dataclass
+class StagedImport:
+    """The staged result of one import: candidates plus their provenance context.
+
+    This is what the staging endpoint returns and (in summarized form) records on
+    the ``odb.primitive_imports`` row, so every source kind/method reaches a staged
+    result with an import record (the ticket's acceptance criterion).
+    """
+
+    source_kind: str
+    source_method: str
+    source_label: Optional[str]
+    target_namespace: Optional[str]
+    candidates: List[StagedCandidate] = field(default_factory=list)
+    warnings: List[str] = field(default_factory=list)
+    status: str = "staged"
+
+    @property
+    def detected_count(self) -> int:
+        """Number of candidate types detected in the source."""
+        return len(self.candidates)
+
+    def report(self) -> Dict[str, Any]:
+        """Build the JSON report persisted on the import provenance record.
+
+        Kept lean — candidate metadata (name / pointer / ref_count) and warnings,
+        not the full schema fragments, which a later stage re-reads from source.
+        """
+        return {
+            "status": self.status,
+            "detected_count": self.detected_count,
+            "staged": [c.as_dict() for c in self.candidates],
+            "warnings": self.warnings,
+        }
+
+
+def _ref_count(fragment: Any) -> int:
+    """Count the ``$ref`` values anywhere within a schema fragment."""
+    return sum(1 for _ in iter_refs(fragment))
+
+
+def _derive_single_name(document: Dict[str, Any], source_label: Optional[str]) -> str:
+    """Derive a name for a bare single-document import.
+
+    Prefers the document's ``title``, then the last path segment of its ``$id``,
+    then the source label; falls back to ``"document"``.
+    """
+    title = document.get("title")
+    if isinstance(title, str) and title.strip():
+        return title.strip()
+
+    doc_id = document.get("$id")
+    if isinstance(doc_id, str) and doc_id.strip():
+        tail = doc_id.rstrip("/").rsplit("/", 1)[-1]
+        if tail:
+            return tail
+
+    if source_label and source_label.strip():
+        # Strip a trailing filename extension for a cleaner name.
+        return source_label.strip().rsplit("/", 1)[-1].rsplit(".", 1)[0] or source_label.strip()
+
+    return "document"
+
+
+def _candidates_from_mapping(
+    mapping: Dict[str, Any], pointer_prefix: str
+) -> List[StagedCandidate]:
+    """Turn a name→fragment mapping into staged candidates under a pointer prefix.
+
+    Non-mapping members (a malformed bundle entry) are skipped by the caller via
+    the returned warnings; here every string-keyed member becomes a candidate.
+    """
+    candidates: List[StagedCandidate] = []
+    for name, fragment in mapping.items():
+        candidates.append(
+            StagedCandidate(
+                name=str(name),
+                pointer=f"{pointer_prefix}/{name}",
+                ref_count=_ref_count(fragment),
+            )
+        )
+    return candidates
+
+
+def _detect_json_schema(
+    document: Dict[str, Any], source_label: Optional[str]
+) -> Tuple[List[StagedCandidate], List[str]]:
+    """Detect candidates in a JSON Schema document.
+
+    ``$defs`` / ``definitions`` entries become candidates; a document with neither
+    is itself a single candidate (a single-schema import).
+    """
+    warnings: List[str] = []
+    candidates: List[StagedCandidate] = []
+
+    defs = document.get("$defs")
+    if isinstance(defs, dict) and defs:
+        candidates.extend(_candidates_from_mapping(defs, "#/$defs"))
+
+    legacy = document.get("definitions")
+    if isinstance(legacy, dict) and legacy:
+        candidates.extend(_candidates_from_mapping(legacy, "#/definitions"))
+
+    if not candidates:
+        # No $defs/definitions: treat the whole document as one candidate.
+        candidates.append(
+            StagedCandidate(
+                name=_derive_single_name(document, source_label),
+                pointer="#",
+                ref_count=_ref_count(document),
+            )
+        )
+    return candidates, warnings
+
+
+def _detect_type_def_bundle(
+    document: Dict[str, Any], source_label: Optional[str]
+) -> Tuple[List[StagedCandidate], List[str]]:
+    """Detect candidates in an Objectified type-definition bundle.
+
+    A bundle carries many interlinked types under a ``types`` mapping; ``$defs`` /
+    ``definitions`` are accepted as equivalent containers. The full expansion that
+    preserves inter-type refs is #3462 — here we only enumerate the candidates.
+    """
+    warnings: List[str] = []
+    for key, pointer in (("types", "#/types"), ("$defs", "#/$defs"), ("definitions", "#/definitions")):
+        container = document.get(key)
+        if isinstance(container, dict) and container:
+            return _candidates_from_mapping(container, pointer), warnings
+
+    warnings.append(
+        "No 'types', '$defs', or 'definitions' container found in the bundle"
+    )
+    return [], warnings
+
+
+def _detect_openapi(
+    document: Dict[str, Any], source_label: Optional[str]
+) -> Tuple[List[StagedCandidate], List[str]]:
+    """Detect candidates in an OpenAPI document: each ``components/schemas`` entry."""
+    warnings: List[str] = []
+    components = document.get("components")
+    schemas = components.get("schemas") if isinstance(components, dict) else None
+    if isinstance(schemas, dict) and schemas:
+        return _candidates_from_mapping(schemas, "#/components/schemas"), warnings
+
+    warnings.append("No 'components.schemas' found in the OpenAPI document")
+    return [], warnings
+
+
+_DETECTORS = {
+    "json-schema": _detect_json_schema,
+    "type-def-bundle": _detect_type_def_bundle,
+    "openapi": _detect_openapi,
+}
+
+
+def detect_candidates(
+    document: Dict[str, Any], source_kind: str, source_label: Optional[str] = None
+) -> Tuple[List[StagedCandidate], List[str]]:
+    """Detect the candidate types in a parsed document for a given source kind.
+
+    Args:
+        document: The parsed source document (a mapping).
+        source_kind: One of :data:`VALID_SOURCE_KINDS`.
+        source_label: Optional label used to derive a single-document name.
+
+    Returns:
+        ``(candidates, warnings)`` — the detected candidates and any non-fatal
+        warnings (e.g. an empty container).
+
+    Raises:
+        ValueError: If ``source_kind`` is not recognized.
+    """
+    detector = _DETECTORS.get(source_kind)
+    if detector is None:
+        raise ValueError(
+            f"Invalid source_kind '{source_kind}'. "
+            f"Expected one of: {', '.join(sorted(VALID_SOURCE_KINDS))}"
+        )
+    return detector(document, source_label)
+
+
+def build_staged_import(
+    document: Dict[str, Any],
+    *,
+    source_kind: str,
+    source_method: str,
+    source_label: Optional[str] = None,
+    target_namespace: Optional[str] = None,
+) -> StagedImport:
+    """Stage a parsed document: detect candidates and assemble the staged result.
+
+    This is the pipeline core — pure (no network/DB), so it is unit-testable on a
+    parsed document. The route pairs it with :func:`import_ingestion.ingest_source`
+    (fetch) and ``db.create_primitive_import`` (record).
+
+    Args:
+        document: The parsed source document.
+        source_kind: One of :data:`VALID_SOURCE_KINDS`.
+        source_method: The intake method (paste/file/url/git), recorded for
+            provenance.
+        source_label: Optional human label (filename / URL / git path).
+        target_namespace: Optional registry namespace the import targets.
+
+    Returns:
+        The :class:`StagedImport` result.
+
+    Raises:
+        ValueError: If ``source_kind`` is not recognized.
+    """
+    candidates, warnings = detect_candidates(document, source_kind, source_label)
+    return StagedImport(
+        source_kind=source_kind,
+        source_method=source_method,
+        source_label=source_label,
+        target_namespace=target_namespace,
+        candidates=candidates,
+        warnings=warnings,
+    )

--- a/objectified-rest/src/app/models.py
+++ b/objectified-rest/src/app/models.py
@@ -1,6 +1,7 @@
 from datetime import datetime
-from pydantic import BaseModel, Field, AliasChoices, ConfigDict, model_validator
-from typing import Callable, Optional, Dict, Any, List, Union, Literal
+from typing import Any, Callable, Dict, List, Literal, Optional, Union
+
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field, model_validator
 
 from .repository_refresh_status import RefreshStatus, compute_refresh_status
 
@@ -220,6 +221,72 @@ class PrimitiveImportRecord(BaseModel):
     error_count: int = 0
     imported_by: Optional[str] = None
     created_at: Optional[Union[datetime, str]] = None
+
+    class Config:
+        from_attributes = True
+
+
+# ==================== Import pipeline staging (#3460) ====================
+
+
+class GitSourceLocator(BaseModel):
+    """Locator for the ``git`` import method — a single file in a Git repository (#3460).
+
+    MVP supports public ``github.com`` repositories; the file is fetched via the
+    GitHub contents API.
+    """
+    repo_url: str  # A github.com repository URL.
+    path: str  # Path to the file within the repository.
+    ref: Optional[str] = None  # Branch / tag / SHA; defaults to 'main' when omitted.
+
+    class Config:
+        from_attributes = True
+
+
+class PrimitiveImportStageRequest(BaseModel):
+    """Request to stage an import through the pipeline (#3460).
+
+    The pipeline accepts a source ``kind`` (json-schema / type-def-bundle / openapi)
+    by one of four ``method``s (paste / file / url / git), fetches and parses it, and
+    returns a *staged* result — candidate types ready for parsing (#3461/#3462),
+    ref-rewrite (#3463), and review (#3464). Nothing is committed to the registry.
+
+    Locator fields are method-specific: ``content`` carries paste/file text, ``url``
+    the http(s) source, and ``git`` the repository locator.
+    """
+    source_kind: str = 'json-schema'  # 'json-schema' | 'type-def-bundle' | 'openapi'
+    source_method: str = 'paste'  # 'paste' | 'file' | 'url' | 'git'
+    source_label: Optional[str] = None  # Human label / filename for provenance.
+    target_namespace: Optional[str] = None  # Registry namespace the import targets.
+    content: Optional[str] = None  # Raw document text (paste/file); JSON or YAML.
+    url: Optional[str] = None  # Source URL (url method).
+    git: Optional[GitSourceLocator] = None  # Git locator (git method).
+
+    class Config:
+        from_attributes = True
+
+
+class StagedTypeCandidate(BaseModel):
+    """One candidate type detected in a staged import (#3460)."""
+    name: str  # The candidate's name (schema key or derived single-doc name).
+    pointer: str  # JSON Pointer to the fragment within the source (e.g. #/$defs/Money).
+    ref_count: int = 0  # Number of $ref values in the fragment (rewrite signal).
+
+    class Config:
+        from_attributes = True
+
+
+class PrimitiveImportStageResult(BaseModel):
+    """The staged result of an import plus the id of its provenance record (#3460)."""
+    import_id: Optional[str] = None  # The recorded odb.primitive_imports row id.
+    status: str = 'staged'  # Lifecycle status of the import (always 'staged' here).
+    source_kind: str
+    source_method: str
+    source_label: Optional[str] = None
+    target_namespace: Optional[str] = None
+    detected_count: int = 0  # Number of candidate types detected.
+    candidates: List[StagedTypeCandidate] = []
+    warnings: List[str] = []  # Non-fatal notes (e.g. an empty container).
 
     class Config:
         from_attributes = True

--- a/objectified-rest/src/app/primitives_routes.py
+++ b/objectified-rest/src/app/primitives_routes.py
@@ -5,43 +5,48 @@ Provides CRUD endpoints for managing primitive type definitions.
 All endpoints are tenant-scoped and require authentication via JWT token or API key.
 """
 
-from fastapi import APIRouter, HTTPException, Header, Query, Depends
-from typing import Optional, List, Dict, Any
-import json
+from typing import Any, Dict, List, Optional
 
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from .auth import get_authenticated_user_id, validate_authentication
 from .database import db
+from .import_ingestion import IngestionError, ingest_source
+from .import_pipeline import VALID_SOURCE_KINDS, build_staged_import
 from .models import (
-    PrimitiveSchema,
     PrimitiveCreateRequest,
-    PrimitiveUpdateRequest,
-    PrimitiveImportRequest,
     PrimitiveImportRecord,
+    PrimitiveImportRequest,
+    PrimitiveImportStageRequest,
+    PrimitiveImportStageResult,
+    PrimitiveSchema,
+    PrimitiveUpdateRequest,
     RegistryHealthResponse,
     UnresolvedRefPrimitive,
     UnresolvedRefsResponse,
 )
-from .auth import validate_authentication, get_authenticated_user_id
-from .schema_validation import (
-    SchemaValidationError,
-    validate_schema_document,
-    derive_base_uri,
-    derive_draft,
-    derive_schema_id,
-    stamp_identity,
-    REGISTRY_BASE_URL,
-)
+from .primitives_resolver import build_ref_edges
 from .primitives_scope import (
     ScopeViolationError,
     enforce_ref_scope,
     is_core_namespace,
     tenant_segment_of,
 )
-from .primitives_resolver import build_ref_edges
+from .schema_validation import (
+    REGISTRY_BASE_URL,
+    SchemaValidationError,
+    derive_base_uri,
+    derive_draft,
+    derive_schema_id,
+    stamp_identity,
+    validate_schema_document,
+)
 
 router = APIRouter(prefix="/v1/primitives", tags=["primitives"])
 
-# Allowed import source shapes — must match the odb.primitive_imports CHECK constraint.
-VALID_IMPORT_SOURCE_KINDS = {"json-schema", "type-def-bundle", "openapi"}
+# Allowed import source shapes — must match the odb.primitive_imports CHECK
+# constraint. Sourced from the pipeline so the staging and legacy paths agree.
+VALID_IMPORT_SOURCE_KINDS = VALID_SOURCE_KINDS
 
 
 def _schema_validation_http_error(errors: List[Dict[str, str]]) -> HTTPException:
@@ -672,7 +677,7 @@ async def update_primitive(
         if "unique constraint" in str(e).lower():
             raise HTTPException(
                 status_code=409,
-                detail=f"A primitive with that name already exists in the category"
+                detail="A primitive with that name already exists in the category"
             )
         raise HTTPException(status_code=500, detail=str(e))
 
@@ -891,3 +896,110 @@ async def import_primitives(
         "import_id": import_id,
         **report,
     }
+
+
+@router.post("/{tenant_slug}/import/stage", response_model=PrimitiveImportStageResult)
+async def stage_import(
+    tenant_slug: str,
+    request: PrimitiveImportStageRequest,
+    auth_data: Dict[str, Any] = Depends(validate_authentication)
+) -> PrimitiveImportStageResult:
+    """Stage an import through the unified pipeline (#3460).
+
+    The single orchestration path for all source kinds and intake methods: it
+    fetches the source (paste / file / url / git), parses it (JSON or YAML),
+    detects the candidate types it carries (json-schema / type-def-bundle /
+    openapi), records a provenance row on ``odb.primitive_imports`` marked
+    ``staged``, and returns the staged candidates.
+
+    Nothing is committed to the registry here — parsing into discrete types
+    (#3461/#3462), ``$ref`` rewrite (#3463), and conflict/dedupe review (#3464)
+    operate on the staged result in the subsequent pipeline stages. The legacy
+    ``POST /{tenant_slug}/import`` (paste, commit) remains supported alongside it.
+
+    Args:
+        tenant_slug: The tenant slug.
+        request: The staging request (source kind/method + a method locator).
+        auth_data: Authentication data (injected by dependency).
+
+    Returns:
+        The staged result: detected candidates plus the recorded ``import_id``.
+
+    Raises:
+        HTTPException: 400 for an invalid source kind/method or missing locator,
+            422 for an unparseable source, 502 for a fetch failure.
+    """
+    if request.source_kind not in VALID_IMPORT_SOURCE_KINDS:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Invalid source_kind '{request.source_kind}'. "
+                f"Expected one of: {', '.join(sorted(VALID_IMPORT_SOURCE_KINDS))}"
+            )
+        )
+
+    # Ingest (fetch + parse) the source document for the declared method. A bad
+    # locator or empty/invalid document is a 400/422; a remote fetch failure is a
+    # 502 (the source, not the request, is at fault).
+    git_locator = request.git.model_dump() if request.git is not None else None
+    try:
+        ingested = ingest_source(
+            request.source_method,
+            content=request.content,
+            url=request.url,
+            git=git_locator,
+            source_label=request.source_label,
+        )
+    except IngestionError as e:
+        # A network/remote failure is a 502; a client-side locator/parse problem is a 400.
+        is_remote = request.source_method in ("url", "git") and (
+            "fetch" in e.message.lower() or "http" in e.message.lower()
+        )
+        raise HTTPException(status_code=502 if is_remote else 400, detail=e.message)
+
+    # Detect candidate types and assemble the staged result (pure; no commit).
+    try:
+        staged = build_staged_import(
+            ingested.document,
+            source_kind=request.source_kind,
+            source_method=request.source_method,
+            source_label=ingested.resolved_label,
+            target_namespace=request.target_namespace,
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    # Record an auditable provenance row for the staged import (#3448 reuse). The
+    # report carries the staged candidates and warnings; counts stay zero because
+    # nothing was committed. Best-effort: a record failure must not lose the
+    # staged result, but it is surfaced as a warning so the audit gap is visible.
+    created_by = get_authenticated_user_id(auth_data)
+    import_id = None
+    try:
+        import_record = db.create_primitive_import(
+            tenant_id=auth_data['tenant_id'],
+            report=staged.report(),
+            source_kind=staged.source_kind,
+            source_label=staged.source_label,
+            target_namespace=staged.target_namespace,
+            options={"source_method": staged.source_method, "staged": True},
+            imported_count=0,
+            skipped_count=0,
+            error_count=0,
+            imported_by=created_by,
+        )
+        import_id = str(import_record['id'])
+    except Exception as e:
+        staged.warnings.append(f"Failed to record import provenance: {e}")
+
+    return PrimitiveImportStageResult(
+        import_id=import_id,
+        status=staged.status,
+        source_kind=staged.source_kind,
+        source_method=staged.source_method,
+        source_label=staged.source_label,
+        target_namespace=staged.target_namespace,
+        detected_count=staged.detected_count,
+        candidates=[c.as_dict() for c in staged.candidates],
+        warnings=staged.warnings,
+    )

--- a/objectified-rest/tests/test_import_ingestion.py
+++ b/objectified-rest/tests/test_import_ingestion.py
@@ -1,0 +1,163 @@
+"""Unit tests for the import pipeline ingestion layer (#3460).
+
+Covers ``parse_document`` (JSON/YAML) and ``ingest_source`` for each intake
+method. The URL and git fetchers are the only network/subprocess boundary, so
+they are mocked here; everything else runs in-process.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from app import import_ingestion
+from app.import_ingestion import (
+    IngestionError,
+    ingest_source,
+    parse_document,
+)
+
+# ===========================================================================
+# parse_document
+# ===========================================================================
+
+
+def test_parse_document_json_object():
+    doc = parse_document('{"type": "object", "title": "X"}')
+    assert doc["type"] == "object"
+    assert doc["title"] == "X"
+
+
+def test_parse_document_yaml_object():
+    doc = parse_document("type: object\ntitle: X\n")
+    assert doc == {"type": "object", "title": "X"}
+
+
+def test_parse_document_empty_raises():
+    with pytest.raises(IngestionError, match="empty"):
+        parse_document("   ")
+
+
+def test_parse_document_non_mapping_raises():
+    # A JSON array is valid JSON but not a top-level object/mapping.
+    with pytest.raises(IngestionError, match="mapping"):
+        parse_document('["a", "b"]')
+
+
+def test_parse_document_invalid_text_raises():
+    with pytest.raises(IngestionError, match="not valid JSON or YAML"):
+        # Unbalanced braces / bad indentation that neither parser accepts.
+        parse_document("{ not: valid: : :")
+
+
+# ===========================================================================
+# ingest_source — paste / file
+# ===========================================================================
+
+
+def test_ingest_paste_returns_parsed_document():
+    result = ingest_source("paste", content='{"type": "string"}')
+    assert result.document == {"type": "string"}
+    assert result.text == '{"type": "string"}'
+
+
+def test_ingest_file_uses_label_as_resolved_label():
+    result = ingest_source(
+        "file", content='{"type": "string"}', source_label="money.json"
+    )
+    assert result.resolved_label == "money.json"
+
+
+def test_ingest_paste_without_content_raises():
+    with pytest.raises(IngestionError, match="requires non-empty 'content'"):
+        ingest_source("paste", content=None)
+
+
+def test_ingest_invalid_method_raises():
+    with pytest.raises(IngestionError, match="Invalid source_method"):
+        ingest_source("carrier-pigeon", content="{}")
+
+
+# ===========================================================================
+# ingest_source — url
+# ===========================================================================
+
+
+def test_ingest_url_fetches_and_parses():
+    with patch.object(
+        import_ingestion, "_fetch_url_text", return_value='{"type": "object"}'
+    ) as m:
+        result = ingest_source("url", url="https://example.com/schema.json")
+    m.assert_called_once()
+    assert result.document == {"type": "object"}
+    assert result.resolved_label == "https://example.com/schema.json"
+
+
+def test_ingest_url_without_url_raises():
+    with pytest.raises(IngestionError, match="requires a 'url'"):
+        ingest_source("url", url=None)
+
+
+def test_fetch_url_rejects_non_http_scheme():
+    with pytest.raises(IngestionError, match="only http/https"):
+        import_ingestion._fetch_url_text("ftp://example.com/x", max_bytes=1000)
+
+
+# ===========================================================================
+# ingest_source — git
+# ===========================================================================
+
+
+def test_ingest_git_fetches_and_parses():
+    with patch.object(
+        import_ingestion, "_fetch_git_text", return_value="type: object\n"
+    ) as m:
+        result = ingest_source(
+            "git",
+            git={"repo_url": "https://github.com/acme/types", "path": "money.yaml"},
+        )
+    m.assert_called_once()
+    assert result.document == {"type": "object"}
+    assert "github.com/acme/types#money.yaml" in result.resolved_label
+
+
+def test_ingest_git_without_locator_raises():
+    with pytest.raises(IngestionError, match="requires a 'git' locator"):
+        ingest_source("git", git=None)
+
+
+def test_fetch_git_requires_repo_and_path():
+    with pytest.raises(IngestionError, match="requires both 'repo_url' and 'path'"):
+        import_ingestion._fetch_git_text({"repo_url": "https://github.com/a/b"}, max_bytes=1000)
+
+
+def test_fetch_git_rejects_non_github_host():
+    with pytest.raises(IngestionError, match="github.com"):
+        import_ingestion._fetch_git_text(
+            {"repo_url": "https://gitlab.com/a/b", "path": "x.json"}, max_bytes=1000
+        )
+
+
+def test_fetch_git_delegates_to_github_fetcher():
+    with patch.object(
+        import_ingestion, "fetch_github_repository_file_text", return_value=("{}", False)
+    ) as m:
+        text = import_ingestion._fetch_git_text(
+            {"repo_url": "https://github.com/acme/types", "path": "a/b.json", "ref": "dev"},
+            max_bytes=5000,
+        )
+    assert text == "{}"
+    # owner, repo, path, ref forwarded correctly.
+    args, kwargs = m.call_args
+    assert args[0] == "acme" and args[1] == "types"
+    assert args[2] == "a/b.json" and args[3] == "dev"
+
+
+def test_fetch_git_truncated_raises():
+    with patch.object(
+        import_ingestion, "fetch_github_repository_file_text", return_value=("partial", True)
+    ):
+        with pytest.raises(IngestionError, match="exceeds"):
+            import_ingestion._fetch_git_text(
+                {"repo_url": "https://github.com/acme/types", "path": "big.json"},
+                max_bytes=10,
+            )

--- a/objectified-rest/tests/test_import_pipeline.py
+++ b/objectified-rest/tests/test_import_pipeline.py
@@ -1,0 +1,123 @@
+"""Unit tests for the import pipeline staging core (#3460).
+
+Covers ``detect_candidates`` per source kind and ``build_staged_import``. These
+run on parsed documents (no network/DB), so they assert the staged candidates,
+pointers, ref counts, and warnings directly.
+"""
+
+import pytest
+
+from app.import_pipeline import (
+    build_staged_import,
+    detect_candidates,
+)
+
+# ===========================================================================
+# json-schema detection
+# ===========================================================================
+
+
+def test_json_schema_defs_become_candidates():
+    doc = {
+        "$defs": {
+            "Money": {"type": "object", "properties": {"c": {"$ref": "../primitives/string"}}},
+            "Date": {"type": "string"},
+        }
+    }
+    candidates, warnings = detect_candidates(doc, "json-schema")
+    by_name = {c.name: c for c in candidates}
+    assert set(by_name) == {"Money", "Date"}
+    assert by_name["Money"].pointer == "#/$defs/Money"
+    assert by_name["Money"].ref_count == 1
+    assert by_name["Date"].ref_count == 0
+    assert warnings == []
+
+
+def test_json_schema_legacy_definitions_become_candidates():
+    doc = {"definitions": {"A": {"type": "string"}}}
+    candidates, _ = detect_candidates(doc, "json-schema")
+    assert candidates[0].name == "A"
+    assert candidates[0].pointer == "#/definitions/A"
+
+
+def test_json_schema_bare_document_is_single_candidate():
+    doc = {"type": "object", "title": "Customer", "properties": {"id": {"$ref": "x"}}}
+    candidates, _ = detect_candidates(doc, "json-schema")
+    assert len(candidates) == 1
+    assert candidates[0].name == "Customer"
+    assert candidates[0].pointer == "#"
+    assert candidates[0].ref_count == 1
+
+
+def test_json_schema_bare_name_falls_back_to_label():
+    doc = {"type": "object"}
+    candidates, _ = detect_candidates(doc, "json-schema", source_label="path/widget.json")
+    assert candidates[0].name == "widget"
+
+
+# ===========================================================================
+# type-def-bundle detection
+# ===========================================================================
+
+
+def test_bundle_types_container_becomes_candidates():
+    doc = {"types": {"Order": {"type": "object"}, "Line": {"type": "object"}}}
+    candidates, warnings = detect_candidates(doc, "type-def-bundle")
+    assert {c.name for c in candidates} == {"Order", "Line"}
+    assert candidates[0].pointer.startswith("#/types/")
+    assert warnings == []
+
+
+def test_bundle_empty_warns_with_no_candidates():
+    candidates, warnings = detect_candidates({"meta": "x"}, "type-def-bundle")
+    assert candidates == []
+    assert warnings and "types" in warnings[0]
+
+
+# ===========================================================================
+# openapi detection
+# ===========================================================================
+
+
+def test_openapi_components_schemas_become_candidates():
+    doc = {"openapi": "3.1.0", "components": {"schemas": {"Pet": {"type": "object"}}}}
+    candidates, warnings = detect_candidates(doc, "openapi")
+    assert candidates[0].name == "Pet"
+    assert candidates[0].pointer == "#/components/schemas/Pet"
+    assert warnings == []
+
+
+def test_openapi_without_components_warns():
+    candidates, warnings = detect_candidates({"openapi": "3.1.0"}, "openapi")
+    assert candidates == []
+    assert warnings and "components.schemas" in warnings[0]
+
+
+# ===========================================================================
+# unknown kind / build_staged_import
+# ===========================================================================
+
+
+def test_detect_unknown_kind_raises():
+    with pytest.raises(ValueError, match="Invalid source_kind"):
+        detect_candidates({}, "rdf")
+
+
+def test_build_staged_import_assembles_result_and_report():
+    doc = {"$defs": {"A": {"type": "string"}, "B": {"type": "object"}}}
+    staged = build_staged_import(
+        doc,
+        source_kind="json-schema",
+        source_method="paste",
+        source_label="bundle.json",
+        target_namespace="acme/v0/types",
+    )
+    assert staged.status == "staged"
+    assert staged.detected_count == 2
+    assert staged.source_method == "paste"
+    assert staged.target_namespace == "acme/v0/types"
+
+    report = staged.report()
+    assert report["status"] == "staged"
+    assert report["detected_count"] == 2
+    assert {s["name"] for s in report["staged"]} == {"A", "B"}

--- a/objectified-rest/tests/test_primitives_import_stage_routes.py
+++ b/objectified-rest/tests/test_primitives_import_stage_routes.py
@@ -1,0 +1,229 @@
+"""API tests for the import-pipeline staging endpoint (#3460).
+
+``POST /v1/primitives/{tenant_slug}/import/stage`` is the unified orchestrator:
+fetch (paste/file/url/git) → parse → detect candidates → record provenance →
+return the staged result. The DB and the network fetchers are mocked, so these
+assert the staged response and the provenance row written per source kind/method.
+"""
+
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app import import_ingestion
+from app.auth import validate_authentication
+from app.main import app
+
+client = TestClient(app)
+
+_JWT = {"tenant_id": "t1", "user_id": "u1", "auth_method": "jwt"}
+_NOW = datetime(2026, 6, 22, 12, 0, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture(autouse=True)
+def _auth():
+    app.dependency_overrides[validate_authentication] = lambda: _JWT
+    yield
+    app.dependency_overrides.pop(validate_authentication, None)
+
+
+def _import_row(**overrides):
+    row = {"id": "imp-1", "tenant_id": "t1", "created_at": _NOW}
+    row.update(overrides)
+    return row
+
+
+# ===========================================================================
+# Source KIND coverage — each reaches a staged result + import record
+# ===========================================================================
+
+
+def test_stage_json_schema_paste():
+    with patch("app.primitives_routes.db") as mdb:
+        mdb.create_primitive_import.return_value = _import_row()
+        r = client.post(
+            "/v1/primitives/std/import/stage",
+            json={
+                "source_kind": "json-schema",
+                "source_method": "paste",
+                "content": '{"$defs": {"Money": {"type": "object"}, "Date": {"type": "string"}}}',
+                "target_namespace": "std/v0/types",
+            },
+        )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["status"] == "staged"
+    assert body["import_id"] == "imp-1"
+    assert body["detected_count"] == 2
+    assert {c["name"] for c in body["candidates"]} == {"Money", "Date"}
+
+    # An import record was recorded with the staged report and zero commit counts.
+    _, kwargs = mdb.create_primitive_import.call_args
+    assert kwargs["source_kind"] == "json-schema"
+    assert kwargs["imported_count"] == 0
+    assert kwargs["report"]["status"] == "staged"
+    assert kwargs["options"]["source_method"] == "paste"
+
+
+def test_stage_type_def_bundle_paste():
+    with patch("app.primitives_routes.db") as mdb:
+        mdb.create_primitive_import.return_value = _import_row(id="imp-2")
+        r = client.post(
+            "/v1/primitives/std/import/stage",
+            json={
+                "source_kind": "type-def-bundle",
+                "source_method": "paste",
+                "content": '{"types": {"Order": {"type": "object"}, "Line": {"type": "object"}}}',
+            },
+        )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["detected_count"] == 2
+    assert body["import_id"] == "imp-2"
+
+
+def test_stage_openapi_paste():
+    with patch("app.primitives_routes.db") as mdb:
+        mdb.create_primitive_import.return_value = _import_row(id="imp-3")
+        r = client.post(
+            "/v1/primitives/std/import/stage",
+            json={
+                "source_kind": "openapi",
+                "source_method": "paste",
+                "content": '{"openapi": "3.1.0", "components": {"schemas": {"Pet": {"type": "object"}}}}',
+            },
+        )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["candidates"][0]["name"] == "Pet"
+
+
+# ===========================================================================
+# Source METHOD coverage — file / url / git all reach a staged result
+# ===========================================================================
+
+
+def test_stage_file_method_records_label():
+    with patch("app.primitives_routes.db") as mdb:
+        mdb.create_primitive_import.return_value = _import_row()
+        r = client.post(
+            "/v1/primitives/std/import/stage",
+            json={
+                "source_kind": "json-schema",
+                "source_method": "file",
+                "source_label": "money.json",
+                "content": '{"type": "object", "title": "Money"}',
+            },
+        )
+    assert r.status_code == 200
+    assert r.json()["source_label"] == "money.json"
+    assert r.json()["candidates"][0]["name"] == "Money"
+
+
+def test_stage_url_method_mocks_fetch():
+    with patch("app.primitives_routes.db") as mdb, patch.object(
+        import_ingestion, "_fetch_url_text", return_value='{"$defs": {"A": {"type": "string"}}}'
+    ):
+        mdb.create_primitive_import.return_value = _import_row()
+        r = client.post(
+            "/v1/primitives/std/import/stage",
+            json={
+                "source_kind": "json-schema",
+                "source_method": "url",
+                "url": "https://example.com/schema.json",
+            },
+        )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["detected_count"] == 1
+    assert body["source_label"] == "https://example.com/schema.json"
+
+
+def test_stage_git_method_mocks_fetch():
+    with patch("app.primitives_routes.db") as mdb, patch.object(
+        import_ingestion, "_fetch_git_text", return_value="types:\n  A:\n    type: string\n"
+    ):
+        mdb.create_primitive_import.return_value = _import_row()
+        r = client.post(
+            "/v1/primitives/std/import/stage",
+            json={
+                "source_kind": "type-def-bundle",
+                "source_method": "git",
+                "git": {"repo_url": "https://github.com/acme/types", "path": "bundle.yaml"},
+            },
+        )
+    assert r.status_code == 200
+    assert r.json()["candidates"][0]["name"] == "A"
+
+
+# ===========================================================================
+# Validation / error mapping
+# ===========================================================================
+
+
+def test_stage_invalid_source_kind_400():
+    r = client.post(
+        "/v1/primitives/std/import/stage",
+        json={"source_kind": "rdf", "source_method": "paste", "content": "{}"},
+    )
+    assert r.status_code == 400
+    assert "Invalid source_kind" in r.json()["detail"]
+
+
+def test_stage_missing_content_400():
+    r = client.post(
+        "/v1/primitives/std/import/stage",
+        json={"source_kind": "json-schema", "source_method": "paste"},
+    )
+    assert r.status_code == 400
+    assert "content" in r.json()["detail"]
+
+
+def test_stage_unparseable_content_400():
+    r = client.post(
+        "/v1/primitives/std/import/stage",
+        json={
+            "source_kind": "json-schema",
+            "source_method": "paste",
+            "content": "{ not valid : : :",
+        },
+    )
+    assert r.status_code == 400
+    assert "JSON or YAML" in r.json()["detail"]
+
+
+def test_stage_url_fetch_failure_502():
+    from app.import_ingestion import IngestionError
+
+    with patch.object(
+        import_ingestion, "_fetch_url_text", side_effect=IngestionError("Failed to fetch URL: boom")
+    ):
+        r = client.post(
+            "/v1/primitives/std/import/stage",
+            json={
+                "source_kind": "json-schema",
+                "source_method": "url",
+                "url": "https://example.com/down.json",
+            },
+        )
+    assert r.status_code == 502
+
+
+def test_stage_provenance_failure_is_surfaced_as_warning():
+    # A record-write failure must not lose the staged result; it becomes a warning.
+    with patch("app.primitives_routes.db") as mdb:
+        mdb.create_primitive_import.side_effect = Exception("db down")
+        r = client.post(
+            "/v1/primitives/std/import/stage",
+            json={
+                "source_kind": "json-schema",
+                "source_method": "paste",
+                "content": '{"type": "object", "title": "X"}',
+            },
+        )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["import_id"] is None
+    assert any("provenance" in w for w in body["warnings"])


### PR DESCRIPTION
## What & why

Implements **[4.1] Import pipeline core + ingestion (#3460)** — the single orchestration path all type-registry import sources flow through, the foundation the rest of Epic 4 (#3461–#3465) builds on.

New endpoint **`POST /v1/primitives/{tenant_slug}/import/stage`**:

1. **Ingest** a source document by one of four methods:
   - `paste` / `file` — inline text (file additionally carries a filename label for provenance)
   - `url` — fetched over http/https (size-capped)
   - `git` — a single file from a public **github.com** repo, reusing the existing repository-scan fetcher
2. **Parse** the document as JSON **or** YAML.
3. **Detect** candidate types, dispatched on source kind:
   - `json-schema` → `$defs` / `definitions` entries (a bare document is itself one candidate)
   - `type-def-bundle` → the `types` / `$defs` container
   - `openapi` → `components.schemas`
4. **Stage** the result — nothing is committed to the registry. Each candidate carries its JSON Pointer and `$ref` count for the downstream parse (#3461/#3462), `$ref` rewrite (#3463), and conflict review (#3464) stages.
5. **Record** an auditable `staged` row on `odb.primitive_imports` (reusing the #3448 provenance table — no new table).

The legacy paste-and-commit `POST /v1/primitives/{tenant_slug}/import` is unchanged, so existing paste import remains supported.

### Acceptance criteria
- ✅ Each source **kind** (json-schema / type-def-bundle / openapi) reaches a staged result + import record
- ✅ Each source **method** (paste / file / url / git) reaches a staged result + import record
- ✅ Existing paste import remains supported

### Files
- `src/app/import_ingestion.py` — per-method fetch + JSON/YAML parse (the only network boundary; cleanly mockable)
- `src/app/import_pipeline.py` — pure candidate detection + staging (no network/DB)
- `src/app/primitives_routes.py` — the `/import/stage` endpoint
- `src/app/models.py` — `PrimitiveImportStageRequest` / `PrimitiveImportStageResult` / `StagedTypeCandidate` / `GitSourceLocator`
- `openapi.{yaml,json}` — regenerated from the app
- ROADMAP / CHANGELOG / version bump (1.0.85 → 1.0.86 pyproject, 1.0.15 → 1.0.16 package.json)

## How to test

```bash
cd objectified-rest
PYTHONPATH=src .venv/bin/python -m pytest \
  tests/test_import_ingestion.py \
  tests/test_import_pipeline.py \
  tests/test_primitives_import_stage_routes.py -q
```

39 new tests cover ingestion (each method, with url/git fetch mocked), detection per source kind, and the route across every kind/method plus error mapping (400 invalid kind / missing locator / unparseable, 502 remote fetch failure, provenance-failure-as-warning).

Example request body (paste, JSON Schema with `$defs`):

```json
{
  "source_kind": "json-schema",
  "source_method": "paste",
  "content": "{\"$defs\": {\"Money\": {\"type\": \"object\"}, \"Date\": {\"type\": \"string\"}}}",
  "target_namespace": "std/v0/types"
}
```

## Risk / notes

- Scope is deliberately limited to *staging*: detection is shallow (locates candidates + counts refs); per-type parsing, `$ref` rewrite, and conflict review are the explicit follow-on tickets #3461–#3464.
- `git` ingestion is public-github.com only in this MVP (private repos are served by the dedicated repository-store import path); other hosts return a clear error.
- Pre-existing, unrelated DB-dependent test failures (merge/change-report/draft-lock suites) are present on `main` and are not affected by this change.

Closes #3460

Work performed by Claude Code via model claude-opus-4-8[1m]

🤖 Generated with [Claude Code](https://claude.com/claude-code)