### PR TITLE
Fix #3463 - $ref rewrite + namespace/scope mapping

### DIFF
--- a/docs/ROADMAP_TYPE_REGISTRY_GOVERNANCE.md
+++ b/docs/ROADMAP_TYPE_REGISTRY_GOVERNANCE.md
@@ -483,7 +483,7 @@ flowchart LR
 | 4.1 #3460 ✅ | ~~Import pipeline core + ingestion~~ | **DONE** — `POST /v1/primitives/{tenant_slug}/import/stage` orchestrator: ingests paste/file/url/git, parses JSON/YAML, stages candidate types per kind (json-schema/type-def-bundle/openapi), records a `staged` `odb.primitive_imports` row; legacy paste `/import` retained | `type-registry`,`import`,`rest`,`mvp`,`roadmap-type-registry` | N | Y | M | objectified-rest |
 | 4.2 #3461 ✅ | ~~JSON Schema 2020-12 parser~~ | **DONE** — `primitives_parser.parse_json_schema_document`: each `$defs`/`definitions` entry → a discrete type (single-root doc → one type), captures intra-doc `#/$defs` refs as `internal` `refs` edges for rewrite (#3463), per-type draft 2020-12 validation report; wired through the `/import/stage` pipeline and the legacy `/import` commit path | `type-registry`,`import`,`rest`,`mvp`,`roadmap-type-registry` | Y | Y | L | objectified-rest |
 | 4.3 #3462 ✅ | ~~Type-definition bundle importer~~ | **DONE** — `primitives_bundle.parse_type_def_bundle` expands a `.json`/`.yaml` bundle's `types` (or `$defs`/`definitions`) container into discrete types, capturing inter-type `#/types`/`#/$defs` refs as `internal` `refs` edges for rewrite (#3463) with per-type draft 2020-12 validation; `expand_zip_bundle` merges a `.zip` of per-type files into a bundle document. Wired through `/import/stage` (deep candidates) and the `/import` commit path (`source_kind='type-def-bundle'` → N types commit N `odb.primitives` rows with refs intact); malformed bundle → clear 400 | `type-registry`,`import`,`rest`,`mvp`,`roadmap-type-registry` | Y | Y | L | objectified-rest |
-| 4.4 #3463 | `$ref` rewrite + namespace/scope mapping | Rewrite refs relative to import source; map to namespace/scope | `type-registry`,`import`,`rest`,`mvp`,`roadmap-type-registry` | N | Y | L | objectified-rest |
+| 4.4 #3463 ✅ | ~~`$ref` rewrite + namespace/scope mapping~~ | **DONE** — `primitives_rewrite.rewrite_import_schema` rewrites each imported definition's intra-source pointers (`#/$defs/Money`, `#/definitions/Money`, `#/types/Money`) to relative registry refs at the sibling's committed `$id` (`./money`, preserving any deeper pointer as `./money#/...`), and maps recognized string formats (email, uuid, uri, date, date-time, time) to the seeded `std/v0/types` core types by injecting a relative `$ref` (author refs never overridden). Both rewrites yield ordinary registry-relative refs, so the existing resolver (#3456) persists them as `refs` edges — imported refs are stored relative and resolve via Epic 3; no `internal` edges remain on committed rows. Applied on commit (`POST /import`) for the JSON Schema and bundle paths; `map_core_formats` flag (default on) toggles format mapping; import report gains a per-type `rewrites` map | `type-registry`,`import`,`rest`,`mvp`,`roadmap-type-registry` | N | Y | L | objectified-rest |
 | 4.5 #3464 | Import review: conflicts, dedupe, report | Conflict resolution, dedupe identical, validation report | `type-registry`,`import`,`rest`,`mvp`,`roadmap-type-registry` | Y | Y | M | objectified-rest |
 | 4.6 #3465 | OpenAPI 3.1 components importer | Extract `components/schemas` as types | `type-registry`,`import`,`rest`,`roadmap-type-registry` | Y | N | M | objectified-rest |
 
@@ -515,7 +515,21 @@ flowchart LR
 - **Parallelism/Dependencies.** Depends on 4.1; parallel with 4.2.
 - **Technical Stack.** FastAPI, zip/json.
 
-### Issue 4.4 — `$ref` rewrite + namespace/scope mapping
+### Issue 4.4 — `$ref` rewrite + namespace/scope mapping ✅ DONE (#3463)
+- **Delivered.** `objectified-rest/src/app/primitives_rewrite.py` (`rewrite_import_schema`) rewrites
+  each imported definition's intra-source pointers — `#/$defs/Money` / `#/definitions/Money` /
+  `#/types/Money` → `./money` (the sibling's committed `$id` leaf-slug, deeper pointers preserved as
+  `./money#/properties/c`) — and maps recognized string formats (email, uuid, uri, date, date-time,
+  time) to the seeded `std/v0/types` core types by injecting a relative `$ref` (mirroring the seed's
+  `{"$ref": "../primitives/string", "format": "email"}` shape; an author's explicit `$ref` is never
+  overridden). Both rewrites produce ordinary registry-relative refs, so the existing resolver
+  (#3456) persists them as `refs` edges — committed rows carry only `resolved`/`unresolved` edges, no
+  `internal` ones. Applied on commit (`POST /v1/primitives/{tenant_slug}/import`) for the JSON Schema
+  and type-def-bundle paths via the shared `_commit_imported_definitions`; the `map_core_formats`
+  request flag (default on) toggles format mapping, and the import report gains a per-type `rewrites`
+  map for the review table. Unit tests in `tests/test_primitives_rewrite.py` (round-trip each
+  rewritten ref through the resolver's URL semantics) and route tests in
+  `tests/test_primitives_import_rewrite_routes.py`.
 - **Problem.** External refs (`#/$defs/Money`, absolute URLs) must become **relative** refs
   rooted at the import source, mapped into a target namespace + scope.
 - **Solution/Scope.** Rewrite engine: `#/$defs/Money → ./money`, external known refs → core

--- a/objectified-rest/CHANGELOG.md
+++ b/objectified-rest/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to the Objectified REST API will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.19] - 2026-06-22
+
+### Added
+- **`$ref` rewrite + namespace/scope mapping (#3463)** — imported definitions now have their refs
+  rewritten for their committed place in the registry instead of carrying document-local pointers.
+  New `app/primitives_rewrite.py` provides `rewrite_import_schema()`, which (1) rewrites every
+  intra-source pointer (`#/$defs/Money`, `#/definitions/Money`, `#/types/Money`) to a relative
+  registry ref at the sibling's committed `$id` (`./money`, matching the `$id` leaf-slug; a deeper
+  pointer like `#/$defs/Money/properties/c` is preserved as `./money#/properties/c`), and (2) maps a
+  recognized string `format` (`email`, `uuid`, `uri`, `date`, `date-time`, `time`) to its seeded
+  `std/v0/types` core type by injecting a relative `$ref` (mirroring the seed's
+  `{"$ref": "../primitives/string", "format": "email"}` shape; an author's explicit `$ref` is never
+  overridden). Because both rewrites produce ordinary registry-relative `$ref` values, the existing
+  resolver (#3456) turns them into persisted `refs` edges with no separate internal-edge bookkeeping
+  — so imported refs are stored relative and resolve via Epic 3, and core-format mapping resolves to
+  the core type. `POST /v1/primitives/{tenant_slug}/import` applies this on commit for both the JSON
+  Schema and type-def-bundle paths; a new `map_core_formats` request flag (default `true`) toggles
+  the format mapping, and the import report gains a per-type `rewrites` map for the review table.
+
+### Changed
+- **Import commit no longer persists `internal` ref edges (#3463).** The `$defs`/`types` sibling
+  pointers that #3461/#3462 captured as `{status: "internal"}` edges are now rewritten to relative
+  registry refs and resolved like any other edge, so a committed primitive's `refs` carries only
+  `resolved`/`unresolved` edges. (The staging path's per-candidate `internal_refs` metadata is
+  unchanged.)
+
 ## [1.0.18] - 2026-06-22
 
 ### Added

--- a/objectified-rest/openapi.json
+++ b/objectified-rest/openapi.json
@@ -17205,6 +17205,11 @@
               }
             ],
             "title": "Target Namespace"
+          },
+          "map_core_formats": {
+            "type": "boolean",
+            "title": "Map Core Formats",
+            "default": true
           }
         },
         "type": "object",

--- a/objectified-rest/openapi.yaml
+++ b/objectified-rest/openapi.yaml
@@ -10952,6 +10952,10 @@ components:
           - type: string
           - type: 'null'
           title: Target Namespace
+        map_core_formats:
+          type: boolean
+          title: Map Core Formats
+          default: true
       type: object
       required:
       - schema

--- a/objectified-rest/package.json
+++ b/objectified-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-rest",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "private": true,
   "description": "Trigger file for Objectified REST Docker publish workflow; app is Python (pyproject.toml).",
   "scripts": {

--- a/objectified-rest/pyproject.toml
+++ b/objectified-rest/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "objectified-rest"
-version = "1.0.88"
+version = "1.0.89"
 description = "REST API for serving OpenAPI specifications from the Objectified database"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/objectified-rest/src/app/models.py
+++ b/objectified-rest/src/app/models.py
@@ -185,6 +185,9 @@ class PrimitiveImportRequest(BaseModel):
     source_kind: str = 'json-schema'  # 'json-schema' | 'type-def-bundle' | 'openapi'
     source_label: Optional[str] = None  # Human label / filename / URL of the source
     target_namespace: Optional[str] = None  # Registry namespace imported into, if any
+    # Map recognized string formats (email, uuid, uri, date, date-time, time) to the seeded
+    # std/v0/types core types by injecting a relative $ref during rewrite (#3463). Default on.
+    map_core_formats: bool = True
 
     class Config:
         from_attributes = True

--- a/objectified-rest/src/app/primitives_rewrite.py
+++ b/objectified-rest/src/app/primitives_rewrite.py
@@ -1,0 +1,246 @@
+"""``$ref`` rewrite + core-format mapping for the Primitives import pipeline (#3463).
+
+The parser (#3461) and bundle importer (#3462) detect each imported definition and
+*capture* its intra-source ``$ref`` edges (``#/$defs/Money`` / ``#/definitions/Money`` /
+``#/types/Money``) as ``internal`` edges, marked for this stage. They do **not** change
+the refs themselves: an imported definition still points at its sibling by a *document*
+pointer, which means nothing about its place in the registry once each definition becomes
+its own ``odb.primitives`` row in a target namespace.
+
+This module closes that gap. Given an imported definition's schema and the base URI it is
+committed under, it produces the schema actually persisted, with two rewrites applied:
+
+* **Intra-source refs → relative registry refs.** Each sibling pointer is rewritten to a
+  registry-relative ref at the sibling's committed ``$id`` — ``#/$defs/Money`` → ``./money``
+  (``./<slug(name)>``, matching :func:`app.schema_validation.derive_schema_id`'s leaf), so a
+  bundle of N definitions committed into one namespace cross-references by relative ref. A
+  trailing JSON Pointer beyond the type name (``#/$defs/Money/properties/c``) is preserved as
+  a fragment on the rewritten ref (``./money#/properties/c``).
+* **Recognized formats → core types.** A string subschema carrying a recognized JSON Schema
+  ``format`` (``email``, ``uuid``, ``uri``, ``date``, ``date-time``, ``time``) and no ``$ref``
+  of its own is mapped to the seeded ``std/v0/types`` core type for that format by injecting a
+  registry-relative ``$ref`` to it (mirroring the seed's ``{"$ref": "../primitives/string",
+  "format": "email"}`` shape). This is the "map external known refs → core types where
+  recognized" half of the ticket.
+
+Both rewrites turn import-local structure into ordinary registry-relative ``$ref`` values, so
+the **existing** resolver (#3456, :func:`app.primitives_resolver.build_ref_edges`) — run by the
+commit path right after this — resolves them against the base URI into persisted
+``{relative_ref, resolved_target, status}`` edges. No separate edge bookkeeping is needed: the
+rewrite makes the refs first-class, and resolution is unchanged. This is the acceptance
+criterion — imported refs are stored relative and resolve via Epic 3, and core-format mapping
+works for recognized formats.
+
+Everything here is pure and side-effect free (no network/DB): it rewrites a parsed schema and
+reports what it changed, so it is unit-testable on a document and shared by every import path.
+"""
+
+from __future__ import annotations
+
+import posixpath
+from typing import Any, Dict, List, Optional, Tuple
+from urllib.parse import urlsplit
+
+from .primitives_parser import _unescape_pointer_token
+from .schema_validation import REGISTRY_BASE_URL, _slug
+
+__all__ = [
+    "CORE_TYPES_NAMESPACE",
+    "CORE_FORMAT_TO_TYPE",
+    "core_type_uri",
+    "registry_relative_ref",
+    "rewrite_internal_ref",
+    "rewrite_import_schema",
+]
+
+# Document pointer prefixes that name a sibling definition in an import source. ``$defs`` is
+# the draft 2020-12 keyword, ``definitions`` the pre-2020 equivalent, and ``types`` the
+# Objectified bundle container (#3462). A ``$ref`` under any of these targets a sibling that
+# becomes its own primitive, so it is rewritten to that sibling's relative registry ref.
+_INTERNAL_PREFIXES: Tuple[str, ...] = ("#/$defs/", "#/definitions/", "#/types/")
+
+# Namespace the seeded core ``std/v0`` derived types live under (#3449). A recognized
+# ``format`` maps to ``<this>/<leaf>`` — e.g. ``email`` → ``std/v0/types/email``.
+CORE_TYPES_NAMESPACE = "std/v0/types"
+
+# JSON Schema ``format`` value → core ``std/v0/types`` leaf name. Limited to the formats that
+# have a seeded core type so a mapped ref resolves; ``decimal`` / ``currency-code`` / ``money``
+# are core types too but are not expressed as ``format`` keywords, so they are not mapped here.
+CORE_FORMAT_TO_TYPE: Dict[str, str] = {
+    "email": "email",
+    "uuid": "uuid",
+    "uri": "uri",
+    "date": "date",
+    "date-time": "date-time",
+    "time": "time",
+}
+
+
+def core_type_uri(leaf: str) -> str:
+    """Return the absolute registry ``$id`` of a seeded core ``std/v0/types`` type.
+
+    Args:
+        leaf: The core type's leaf name (e.g. ``email``).
+
+    Returns:
+        The absolute registry URI (e.g.
+        ``https://api.objectified.dev/types/std/v0/types/email``).
+    """
+    return f"{REGISTRY_BASE_URL}{CORE_TYPES_NAMESPACE}/{leaf}"
+
+
+def registry_relative_ref(base_uri: str, target_uri: str) -> str:
+    """Compute a registry-relative ``$ref`` from a base URI to an absolute registry target.
+
+    Resolution is the inverse of :func:`app.primitives_scope.resolve_registry_uri`: the
+    returned ref, ``urljoin``-ed against ``base_uri``, yields ``target_uri`` again. A target
+    in the same namespace as the base resolves to ``./<leaf>``; one in another namespace walks
+    up with ``../`` segments (``../../std/v0/types/email``). When the two URIs do not share the
+    registry root (so no relative path is meaningful), the absolute ``target_uri`` is returned
+    unchanged — it still resolves, just not relatively.
+
+    Args:
+        base_uri: The base URI the owning type's relative refs resolve against (the type's
+            namespace; conventionally ends in a slash).
+        target_uri: The absolute registry URI to reference.
+
+    Returns:
+        A ``$ref`` value that resolves to ``target_uri`` against ``base_uri``.
+    """
+    base_path = urlsplit(base_uri).path
+    target_path = urlsplit(target_uri).path
+    if not base_path or not target_path:
+        return target_uri
+    # relpath needs a *directory* to resolve against; a base URI names the namespace dir, so
+    # drop a trailing slash to use it as the start directory (./ and ../ then walk from there).
+    start_dir = base_path.rstrip("/")
+    rel = posixpath.relpath(target_path, start_dir)
+    # Same-namespace targets come back bare (``email``); mark them as explicitly relative so the
+    # ref reads as a sibling reference and never as a network-path or scheme-relative URI.
+    if not rel.startswith("."):
+        rel = f"./{rel}"
+    return rel
+
+
+def rewrite_internal_ref(ref: str) -> Optional[str]:
+    """Rewrite an intra-source document pointer into a relative registry ref, or ``None``.
+
+    A ``$ref`` at a sibling definition (``#/$defs/Money``, ``#/definitions/Money``,
+    ``#/types/Money``) is rewritten to ``./<slug(name)>`` — the sibling's committed ``$id``
+    leaf, matching :func:`app.schema_validation.derive_schema_id`. Any JSON Pointer beyond the
+    type name is preserved as a fragment (``#/$defs/Money/properties/c`` → ``./money#/properties/c``).
+    A ref that is not an intra-source pointer (a registry-relative ref, an absolute URL, a bare
+    ``#`` root, or a pointer elsewhere in the document) is left for the resolver and yields ``None``.
+
+    Args:
+        ref: The ``$ref`` value exactly as written in the source document.
+
+    Returns:
+        The rewritten relative registry ref, or ``None`` when ``ref`` is not an intra-source
+        sibling pointer.
+    """
+    if not isinstance(ref, str):
+        return None
+    for prefix in _INTERNAL_PREFIXES:
+        if ref.startswith(prefix):
+            rest = ref[len(prefix):]
+            name, _, sub = rest.partition("/")
+            if not name:
+                return None
+            rewritten = f"./{_slug(_unescape_pointer_token(name))}"
+            if sub:
+                # Preserve a deeper pointer into the sibling as a fragment on the new ref.
+                rewritten = f"{rewritten}#/{sub}"
+            return rewritten
+    return None
+
+
+def _core_format_ref(node: Dict[str, Any], base_uri: str) -> Optional[str]:
+    """Return the relative core-type ``$ref`` a format-bearing subschema maps to, or ``None``.
+
+    A subschema is mapped when it carries a recognized string ``format`` (see
+    :data:`CORE_FORMAT_TO_TYPE`) and does not already declare a ``$ref`` of its own (an explicit
+    ref is the author's and is never overridden).
+
+    Args:
+        node: The (already ref-rewritten) subschema object.
+        base_uri: The base URI the owning type's refs resolve against.
+
+    Returns:
+        A registry-relative ``$ref`` to the core type for the node's format, or ``None`` when
+        the node has no recognized format or already carries a ``$ref``.
+    """
+    if "$ref" in node:
+        return None
+    fmt = node.get("format")
+    if not isinstance(fmt, str):
+        return None
+    leaf = CORE_FORMAT_TO_TYPE.get(fmt)
+    if leaf is None:
+        return None
+    return registry_relative_ref(base_uri, core_type_uri(leaf))
+
+
+def _rewrite_node(
+    node: Any, base_uri: str, map_core_formats: bool, rewrites: List[Dict[str, str]]
+) -> Any:
+    """Recursively rewrite one schema node, recording each change in ``rewrites``.
+
+    Args:
+        node: The schema node (object, array, or scalar).
+        base_uri: The base URI relative refs resolve against (for core-format mapping).
+        map_core_formats: Whether to map recognized formats to core types.
+        rewrites: The change log, appended to in place; each entry is
+            ``{"from", "to", "kind"}`` with ``kind`` ``"internal"`` or ``"core-format"``.
+
+    Returns:
+        A new node with rewrites applied; the input is not mutated.
+    """
+    if isinstance(node, dict):
+        new_node: Dict[str, Any] = {}
+        for key, value in node.items():
+            if key == "$ref" and isinstance(value, str):
+                rewritten = rewrite_internal_ref(value)
+                if rewritten is not None:
+                    rewrites.append({"from": value, "to": rewritten, "kind": "internal"})
+                    new_node[key] = rewritten
+                else:
+                    new_node[key] = value
+            else:
+                new_node[key] = _rewrite_node(value, base_uri, map_core_formats, rewrites)
+        if map_core_formats:
+            core_ref = _core_format_ref(new_node, base_uri)
+            if core_ref is not None:
+                rewrites.append(
+                    {"from": new_node["format"], "to": core_ref, "kind": "core-format"}
+                )
+                new_node["$ref"] = core_ref
+        return new_node
+    if isinstance(node, list):
+        return [_rewrite_node(item, base_uri, map_core_formats, rewrites) for item in node]
+    return node
+
+
+def rewrite_import_schema(
+    schema: Any, *, base_uri: str, map_core_formats: bool = True
+) -> Tuple[Any, List[Dict[str, str]]]:
+    """Rewrite an imported definition's schema for its place in the registry (#3463).
+
+    Applies both rewrites described in the module docstring — intra-source pointers to relative
+    registry refs, and (when ``map_core_formats``) recognized formats to core ``std/v0/types``
+    refs — returning the schema to persist plus a change log. The returned refs are ordinary
+    registry-relative ``$ref`` values, so the commit path's existing resolver (#3456) turns them
+    into persisted ``refs`` edges with no further bookkeeping.
+
+    Args:
+        schema: The parsed schema fragment of one imported definition.
+        base_uri: The base URI the committed primitive's refs resolve against (its namespace).
+        map_core_formats: Whether to map recognized formats to core types (default ``True``).
+
+    Returns:
+        ``(rewritten_schema, rewrites)`` — a new schema with rewrites applied (the input is not
+        mutated) and the list of ``{"from", "to", "kind"}`` changes, in document order.
+    """
+    rewrites: List[Dict[str, str]] = []
+    rewritten = _rewrite_node(schema, base_uri, map_core_formats, rewrites)
+    return rewritten, rewrites

--- a/objectified-rest/src/app/primitives_routes.py
+++ b/objectified-rest/src/app/primitives_routes.py
@@ -13,11 +13,6 @@ from .auth import get_authenticated_user_id, validate_authentication
 from .database import db
 from .import_ingestion import IngestionError, ingest_source
 from .import_pipeline import VALID_SOURCE_KINDS, build_staged_import
-from .primitives_bundle import (
-    BundleError,
-    build_bundle_internal_ref_edges,
-    parse_type_def_bundle,
-)
 from .models import (
     PrimitiveCreateRequest,
     PrimitiveImportRecord,
@@ -30,8 +25,12 @@ from .models import (
     UnresolvedRefPrimitive,
     UnresolvedRefsResponse,
 )
-from .primitives_parser import build_internal_ref_edges
+from .primitives_bundle import (
+    BundleError,
+    parse_type_def_bundle,
+)
 from .primitives_resolver import build_ref_edges
+from .primitives_rewrite import rewrite_import_schema
 from .primitives_scope import (
     ScopeViolationError,
     enforce_ref_scope,
@@ -736,47 +735,63 @@ async def delete_primitive(
 
 def _commit_imported_definitions(
     definitions: Dict[str, Any],
-    internal_edge_builder,
     *,
     tenant_id: str,
     tenant_slug: str,
     target_namespace: Optional[str],
     created_by: Optional[str],
-) -> Dict[str, List[Any]]:
+    map_core_formats: bool = True,
+) -> Dict[str, Any]:
     """Commit a ``name -> schema`` map of imported definitions as primitive rows.
 
     Shared by the JSON Schema ``$defs`` import and the type-definition bundle import
-    (#3462) so both create rows identically: each definition goes through the same draft
-    2020-12 validator, ``$id`` derivation, and scope enforcement as create/update (#3452,
-    #3453); its relative ``$ref`` edges are resolved against the registry (#3456) and its
-    intra-source refs appended as ``internal`` edges for the rewrite stage (#3463); and any
-    dependents' dangling refs are reconciled (#3457). An invalid or scope-violating
-    definition is recorded under ``errors`` and skipped without blocking the others, so a
-    bundle of N valid types commits N rows.
+    (#3462) so both create rows identically. Each definition is first **rewritten** for its
+    place in the registry (#3463): its intra-source pointers (``#/$defs/Money`` /
+    ``#/definitions/Money`` / ``#/types/Money``) become relative registry refs at the sibling's
+    committed ``$id`` (``./money``), and — when ``map_core_formats`` — a recognized string
+    ``format`` (email, uuid, uri, date, date-time, time) is mapped to its seeded ``std/v0/types``
+    core type. The rewritten schema then goes through the same draft 2020-12 validator, ``$id``
+    derivation, and scope enforcement as create/update (#3452, #3453), and its now registry-relative
+    ``$ref`` values are resolved against the registry into persisted ``refs`` edges by the existing
+    resolver (#3456) — so rewritten refs resolve via Epic 3 with no separate edge bookkeeping. Any
+    dependents' dangling refs are reconciled (#3457). An invalid or scope-violating definition is
+    recorded under ``errors`` and skipped without blocking the others, so a bundle of N valid types
+    commits N rows.
 
     Args:
         definitions: The ``name -> schema fragment`` map to import.
-        internal_edge_builder: Callable mapping an identity-stamped schema to its
-            ``internal`` ``$ref`` edges — ``build_internal_ref_edges`` for JSON Schema
-            (``#/$defs/...``) or ``build_bundle_internal_ref_edges`` for a bundle
-            (``#/types/...`` too).
         tenant_id: The caller's tenant id (scopes ref resolution and reconciliation).
         tenant_slug: The tenant slug (used for the default base URI).
         target_namespace: Optional registry namespace each definition is imported into.
         created_by: The authenticated user id (None for API-key auth).
+        map_core_formats: Whether to map recognized formats to core types (#3463).
 
     Returns:
-        A ``{"imported": [...names], "skipped": [...names], "errors": [...]}`` outcome,
-        where each error is ``{"name", "error"[, "details"]}``.
+        A ``{"imported", "skipped", "errors", "rewrites"}`` outcome, where each error is
+        ``{"name", "error"[, "details"]}`` and ``rewrites`` maps each imported definition's name
+        to its list of applied ``{"from", "to", "kind"}`` ref rewrites (for the import report).
     """
     imported: List[str] = []
     skipped: List[str] = []
     errors: List[Dict[str, Any]] = []
+    rewrites: Dict[str, List[Dict[str, str]]] = {}
 
     for def_name, def_schema in definitions.items():
+        # Rewrite the definition's refs for its committed place in the registry before
+        # validating/persisting (#3463). The base URI a definition's refs resolve against is the
+        # same one resolve_primitive_identity derives, so the rewrite and the $id agree.
+        if isinstance(def_schema, dict):
+            base_uri = derive_base_uri(target_namespace, None, tenant_slug)
+            rewritten_schema, applied = rewrite_import_schema(
+                def_schema, base_uri=base_uri, map_core_formats=map_core_formats
+            )
+        else:
+            # A non-object definition cannot be rewritten; let validation reject it below.
+            rewritten_schema, applied = def_schema, []
+
         try:
             identity = resolve_primitive_identity(
-                def_schema,
+                rewritten_schema,
                 name=def_name,
                 namespace=target_namespace,
                 base_uri=None,
@@ -789,24 +804,21 @@ def _commit_imported_definitions(
             errors.append({"name": def_name, "error": "scope_violation", "details": e.violations})
             continue
 
-        # Resolve relative registry refs (#3456), then append intra-source refs as
-        # 'internal' edges (#3461/#3462) so the committed row carries them for rewrite
-        # (#3463). Both kinds share the refs JSONB column; 'internal' status keeps the
-        # inter-type edges out of the unresolved aggregates.
+        # The rewrite turned every intra-source/core ref into an ordinary registry-relative ref,
+        # so the standard resolver (#3456) produces the full edge set — no internal-edge appending.
         refs = resolve_primitive_refs(
             identity['schema'], base_uri=identity['base_uri'], tenant_id=tenant_id
         )
-        refs = refs + internal_edge_builder(identity['schema'])
 
         try:
-            schema_type = determine_category_from_schema(def_schema)
+            schema_type = determine_category_from_schema(rewritten_schema)
             db.create_primitive(
                 tenant_id=tenant_id,
                 name=def_name,
                 category=schema_type,
                 schema=identity['schema'],
-                description=def_schema.get('description'),
-                tags=def_schema.get('tags', []),
+                description=rewritten_schema.get('description'),
+                tags=rewritten_schema.get('tags', []),
                 created_by=created_by,
                 source='imported',
                 schema_id=identity['schema_id'],
@@ -816,6 +828,8 @@ def _commit_imported_definitions(
                 refs=refs,
             )
             imported.append(def_name)
+            if applied:
+                rewrites[def_name] = applied
             reconcile_dependents_for_target(identity['schema_id'], tenant_id=tenant_id)
         except Exception as e:
             if "unique constraint" in str(e).lower():
@@ -823,7 +837,7 @@ def _commit_imported_definitions(
             else:
                 errors.append({"name": def_name, "error": str(e)})
 
-    return {"imported": imported, "skipped": skipped, "errors": errors}
+    return {"imported": imported, "skipped": skipped, "errors": errors, "rewrites": rewrites}
 
 
 @router.post("/{tenant_slug}/import")
@@ -865,10 +879,11 @@ async def import_primitives(
             )
         )
 
-    # Resolve the source into a {name: schema} map of definitions plus the internal-edge
-    # builder appropriate to its shape. A type-def bundle is expanded by the bundle importer
-    # (#3462) — capturing #/types/... inter-type refs — and a malformed bundle is a clear
-    # 400. JSON Schema / OpenAPI documents extract their $defs / definitions as before.
+    # Resolve the source into a {name: schema} map of definitions. A type-def bundle is
+    # expanded by the bundle importer (#3462), and a malformed bundle is a clear 400. JSON
+    # Schema / OpenAPI documents extract their $defs / definitions. Each definition's intra-source
+    # and core-format refs are rewritten during commit (#3463), so no source-specific edge
+    # builder is needed here — the rewrite handles #/$defs, #/definitions, and #/types alike.
     warnings: List[str] = []
     if request.source_kind == 'type-def-bundle':
         try:
@@ -878,7 +893,6 @@ async def import_primitives(
         except BundleError as e:
             raise HTTPException(status_code=400, detail=e.message)
         definitions = {p.name: p.schema for p in parsed_types}
-        internal_edge_builder = build_bundle_internal_ref_edges
     else:
         definitions = {}
         # Check for $defs (JSON Schema 2020-12)
@@ -893,7 +907,6 @@ async def import_primitives(
                 status_code=400,
                 detail="No definitions found in JSON Schema. Schema must contain $defs or definitions."
             )
-        internal_edge_builder = build_internal_ref_edges
 
     # Filter definitions if specific ones are requested
     if not request.import_all and request.selected_definitions:
@@ -911,25 +924,29 @@ async def import_primitives(
     # Get user_id from auth data (will be None for API key auth)
     created_by = get_authenticated_user_id(auth_data)
 
-    # Commit each definition as a primitive (shared by JSON Schema and bundle imports).
+    # Commit each definition as a primitive (shared by JSON Schema and bundle imports). Each
+    # definition's refs are rewritten relative + mapped to core types during commit (#3463).
     outcome = _commit_imported_definitions(
         definitions,
-        internal_edge_builder,
         tenant_id=auth_data['tenant_id'],
         tenant_slug=tenant_slug,
         target_namespace=request.target_namespace,
         created_by=created_by,
+        map_core_formats=request.map_core_formats,
     )
     imported = outcome["imported"]
     skipped = outcome["skipped"]
     errors = outcome["errors"]
+    rewrites = outcome["rewrites"]
 
-    # Build the auditable report and persist a provenance record (#3448).
+    # Build the auditable report and persist a provenance record (#3448). The rewrites map
+    # records the $ref rewrites applied per type (#3463) for the import-review table.
     report = {
         "imported": imported,
         "skipped": skipped,
         "errors": errors,
         "warnings": warnings,
+        "rewrites": rewrites,
         "total_imported": len(imported),
         "total_skipped": len(skipped),
         "total_errors": len(errors),
@@ -937,6 +954,7 @@ async def import_primitives(
     options = {
         "import_all": request.import_all,
         "selected_definitions": request.selected_definitions,
+        "map_core_formats": request.map_core_formats,
     }
 
     import_id = None

--- a/objectified-rest/tests/test_primitives_import_bundle_routes.py
+++ b/objectified-rest/tests/test_primitives_import_bundle_routes.py
@@ -68,13 +68,16 @@ def test_bundle_of_n_types_imports_n_rows_with_refs_intact():
     # Two rows created — one per bundle type.
     assert len(created) == 2
     by_name = {c["name"]: c for c in created}
-    # Order's inter-type ref is persisted as an 'internal' edge for the rewrite stage (#3463).
+    # Order's inter-type ref is rewritten to a relative registry ref (#3463) and resolved like
+    # any other registry edge (unresolved here, since the target is not yet committed) — no
+    # leftover 'internal' fragment pointer remains in the stored refs.
     order_refs = by_name["Order"]["refs"]
     assert {
-        "relative_ref": "#/types/Line",
-        "resolved_target": "Line",
-        "status": "internal",
+        "relative_ref": "./line",
+        "resolved_target": "https://api.objectified.dev/types/std/v0/types/line",
+        "status": "unresolved",
     } in order_refs
+    assert all(e["status"] != "internal" for e in order_refs)
     # Line's registry-relative ref is resolved (unresolved here) — kept distinct from internal.
     line_refs = by_name["Line"]["refs"]
     assert any(e["relative_ref"] == "../primitives/number" for e in line_refs)

--- a/objectified-rest/tests/test_primitives_import_rewrite_routes.py
+++ b/objectified-rest/tests/test_primitives_import_rewrite_routes.py
@@ -1,0 +1,119 @@
+"""API tests for ``$ref`` rewrite + core-format mapping on import commit (#3463).
+
+``POST /v1/primitives/{tenant_slug}/import`` rewrites each imported definition's intra-source
+pointers to relative registry refs and maps recognized formats to core ``std/v0/types`` types
+before persisting. The DB is mocked, so these assert on the ``refs`` payload each row is created
+with — that rewritten refs are stored relative and resolve via the registry (#3456), and that
+core-format mapping works for recognized formats.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.auth import validate_authentication
+from app.main import app
+
+client = TestClient(app)
+
+_JWT = {"tenant_id": "t1", "user_id": "u1", "auth_method": "jwt"}
+
+# Absolute $id of the seeded core email type — what a recognized `format: email` maps to.
+CORE_EMAIL = "https://api.objectified.dev/types/std/v0/types/email"
+
+
+@pytest.fixture(autouse=True)
+def _auth():
+    app.dependency_overrides[validate_authentication] = lambda: _JWT
+    yield
+    app.dependency_overrides.pop(validate_authentication, None)
+
+
+def _import(schema, **extra):
+    body = {"schema": schema, "import_all": True}
+    body.update(extra)
+    return client.post("/v1/primitives/acme/import", json=body)
+
+
+def test_internal_defs_ref_is_rewritten_relative_and_resolved():
+    """A `#/$defs/X` sibling pointer is stored as `./x` and resolves once the target exists."""
+    created = []
+
+    def _create(**kwargs):
+        created.append(kwargs)
+        return {"name": kwargs["name"], "refs": kwargs.get("refs", [])}
+
+    # The Money target resolves; Decimal does not (kept unresolved).
+    money_id = "https://api.objectified.dev/types/tenant/acme/money"
+
+    with patch("app.primitives_routes.db") as mdb:
+        mdb.create_primitive.side_effect = _create
+        mdb.get_primitive_by_schema_id.side_effect = (
+            lambda uri, tid: {"id": "x"} if uri == money_id else None
+        )
+        mdb.create_primitive_import.return_value = {"id": "imp-r1"}
+        r = _import(
+            {
+                "$defs": {
+                    "Money": {"type": "object"},
+                    "Invoice": {
+                        "type": "object",
+                        "properties": {"total": {"$ref": "#/$defs/Money"}},
+                    },
+                }
+            }
+        )
+
+    assert r.status_code == 200
+    by_name = {c["name"]: c for c in created}
+    invoice_refs = by_name["Invoice"]["refs"]
+    assert invoice_refs == [
+        {"relative_ref": "./money", "resolved_target": money_id, "status": "resolved"}
+    ]
+    # The rewrite is reported per type for the import-review table.
+    assert r.json()["rewrites"]["Invoice"] == [
+        {"from": "#/$defs/Money", "to": "./money", "kind": "internal"}
+    ]
+
+
+def test_core_format_mapping_resolves_to_core_type():
+    """A recognized `format: email` is mapped to the seeded core type and resolves."""
+    created = []
+
+    with patch("app.primitives_routes.db") as mdb:
+        mdb.create_primitive.side_effect = lambda **k: created.append(k) or {"name": k["name"]}
+        # Only the core email type exists in scope.
+        mdb.get_primitive_by_schema_id.side_effect = (
+            lambda uri, tid: {"id": "core"} if uri == CORE_EMAIL else None
+        )
+        mdb.create_primitive_import.return_value = {"id": "imp-r2"}
+        r = _import({"$defs": {"Contact": {"type": "string", "format": "email"}}})
+
+    assert r.status_code == 200
+    refs = created[0]["refs"]
+    # The mapped ref resolves to the core email type's $id.
+    assert any(
+        e["resolved_target"] == CORE_EMAIL and e["status"] == "resolved" for e in refs
+    )
+    assert r.json()["rewrites"]["Contact"][0]["kind"] == "core-format"
+
+
+def test_core_format_mapping_can_be_disabled():
+    created = []
+
+    with patch("app.primitives_routes.db") as mdb:
+        mdb.create_primitive.side_effect = lambda **k: created.append(k) or {"name": k["name"]}
+        mdb.get_primitive_by_schema_id.return_value = None
+        mdb.create_primitive_import.return_value = {"id": "imp-r3"}
+        r = _import(
+            {"$defs": {"Contact": {"type": "string", "format": "email"}}},
+            map_core_formats=False,
+        )
+
+    assert r.status_code == 200
+    # No $ref injected, so no registry edges recorded for the format.
+    assert created[0]["refs"] == []
+    assert "Contact" not in r.json()["rewrites"]
+    # The stored schema keeps the format but gains no $ref.
+    assert "$ref" not in created[0]["schema"]

--- a/objectified-rest/tests/test_primitives_rewrite.py
+++ b/objectified-rest/tests/test_primitives_rewrite.py
@@ -1,0 +1,177 @@
+"""Unit tests for the import ``$ref`` rewrite + core-format mapping engine (#3463).
+
+The rewrite engine (:mod:`app.primitives_rewrite`) is pure and side-effect free, so it is
+tested directly on parsed schemas: intra-source pointers become relative registry refs,
+recognized formats map to core ``std/v0/types`` types, and — critically — every rewritten ref
+round-trips through the resolver's URL semantics so it resolves via Epic 3 (#3456).
+"""
+
+from urllib.parse import urljoin
+
+import pytest
+
+from app.primitives_resolver import build_ref_edges
+from app.primitives_rewrite import (
+    CORE_FORMAT_TO_TYPE,
+    core_type_uri,
+    registry_relative_ref,
+    rewrite_import_schema,
+    rewrite_internal_ref,
+)
+from app.primitives_scope import resolve_registry_uri
+
+BASE = "https://api.objectified.dev/types/std/v0/types/"
+TENANT_BASE = "https://api.objectified.dev/types/tenant/acme/"
+
+
+# ---------------------------------------------------------------------------
+# rewrite_internal_ref
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "ref,expected",
+    [
+        ("#/$defs/Money", "./money"),
+        ("#/definitions/Money", "./money"),
+        ("#/types/Line", "./line"),
+        ("#/$defs/CurrencyCode", "./currencycode"),
+        ("#/types/Money/properties/amount", "./money#/properties/amount"),
+    ],
+)
+def test_rewrite_internal_ref_maps_each_container(ref, expected):
+    assert rewrite_internal_ref(ref) == expected
+
+
+@pytest.mark.parametrize(
+    "ref",
+    [
+        "../primitives/string",  # already a registry-relative ref
+        "https://json-schema.org/draft/2020-12/schema",  # external absolute
+        "#",  # bare root
+        "#/properties/x",  # a non-definitions pointer
+        "",
+    ],
+)
+def test_rewrite_internal_ref_leaves_non_intra_source_refs(ref):
+    assert rewrite_internal_ref(ref) is None
+
+
+def test_rewrite_internal_ref_unescapes_pointer_tokens():
+    # ~1 escapes a slash in a JSON Pointer token; the leaf name is decoded before slugging.
+    assert rewrite_internal_ref("#/$defs/a~1b") == "./a-b"
+
+
+# ---------------------------------------------------------------------------
+# registry_relative_ref — inverse of resolve_registry_uri
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "base,target",
+    [
+        (BASE, core_type_uri("email")),
+        (TENANT_BASE, core_type_uri("uuid")),
+        ("https://api.objectified.dev/types/tenant/acme/v3/types/", core_type_uri("date")),
+    ],
+)
+def test_registry_relative_ref_round_trips(base, target):
+    rel = registry_relative_ref(base, target)
+    # The computed relative ref, resolved against the base, returns the original target.
+    assert urljoin(base, rel) == target
+    # And it resolves under the registry root (i.e. Epic 3 will treat it as a registry edge).
+    assert resolve_registry_uri(rel, base) == target
+
+
+def test_registry_relative_ref_falls_back_to_absolute_when_no_common_root():
+    # A non-registry base has no meaningful relative path; the absolute target is returned.
+    assert registry_relative_ref("", core_type_uri("email")) == core_type_uri("email")
+
+
+# ---------------------------------------------------------------------------
+# rewrite_import_schema — full document rewrite
+# ---------------------------------------------------------------------------
+
+
+def test_rewrite_does_not_mutate_input():
+    original = {"$ref": "#/$defs/Money"}
+    snapshot = dict(original)
+    rewritten, _ = rewrite_import_schema(original, base_uri=BASE)
+    assert original == snapshot
+    assert rewritten == {"$ref": "./money"}
+
+
+def test_rewrite_internal_refs_resolve_via_epic_3():
+    schema = {
+        "type": "object",
+        "properties": {"line": {"$ref": "#/types/Line"}},
+    }
+    rewritten, changes = rewrite_import_schema(schema, base_uri=BASE)
+    assert rewritten["properties"]["line"]["$ref"] == "./line"
+    assert {"from": "#/types/Line", "to": "./line", "kind": "internal"} in changes
+
+    # The rewritten ref produces a resolved registry edge once the target exists.
+    target = urljoin(BASE, "./line")
+    edges = build_ref_edges(rewritten, base_uri=BASE, target_exists=lambda u: u == target)
+    assert edges == [
+        {"relative_ref": "./line", "resolved_target": target, "status": "resolved"}
+    ]
+
+
+@pytest.mark.parametrize("fmt,leaf", sorted(CORE_FORMAT_TO_TYPE.items()))
+def test_core_format_maps_to_core_type(fmt, leaf):
+    schema = {"type": "string", "format": fmt}
+    rewritten, changes = rewrite_import_schema(schema, base_uri=TENANT_BASE)
+    expected_ref = registry_relative_ref(TENANT_BASE, core_type_uri(leaf))
+    assert rewritten["$ref"] == expected_ref
+    assert {"from": fmt, "to": expected_ref, "kind": "core-format"} in changes
+    # The injected ref resolves to the seeded core type.
+    assert resolve_registry_uri(expected_ref, TENANT_BASE) == core_type_uri(leaf)
+
+
+def test_core_format_maps_nested_properties():
+    schema = {
+        "type": "object",
+        "properties": {
+            "id": {"type": "string", "format": "uuid"},
+            "contact": {"type": "string", "format": "email"},
+        },
+    }
+    rewritten, _ = rewrite_import_schema(schema, base_uri=BASE)
+    assert rewritten["properties"]["id"]["$ref"] == "./uuid"
+    assert rewritten["properties"]["contact"]["$ref"] == "./email"
+
+
+def test_core_format_does_not_override_existing_ref():
+    schema = {"type": "string", "format": "email", "$ref": "../custom/email"}
+    rewritten, changes = rewrite_import_schema(schema, base_uri=BASE)
+    # An author's explicit ref wins; no core mapping is injected.
+    assert rewritten["$ref"] == "../custom/email"
+    assert all(c["kind"] != "core-format" for c in changes)
+
+
+def test_unrecognized_format_is_left_alone():
+    schema = {"type": "string", "format": "hostname"}
+    rewritten, changes = rewrite_import_schema(schema, base_uri=BASE)
+    assert "$ref" not in rewritten
+    assert changes == []
+
+
+def test_format_disabled_when_map_core_formats_false():
+    schema = {"type": "string", "format": "email"}
+    rewritten, changes = rewrite_import_schema(
+        schema, base_uri=BASE, map_core_formats=False
+    )
+    assert "$ref" not in rewritten
+    assert changes == []
+
+
+def test_property_named_format_is_not_treated_as_a_keyword():
+    # A property literally named "format" is a sub-schema, not the format keyword.
+    schema = {
+        "type": "object",
+        "properties": {"format": {"type": "string"}},
+    }
+    rewritten, changes = rewrite_import_schema(schema, base_uri=BASE)
+    assert "$ref" not in rewritten["properties"]["format"]
+    assert changes == []

--- a/objectified-rest/tests/test_primitives_validation_routes.py
+++ b/objectified-rest/tests/test_primitives_validation_routes.py
@@ -215,8 +215,12 @@ def test_import_rejects_invalid_definition_but_imports_valid():
     assert mdb.create_primitive.call_count == 1
 
 
-def test_import_captures_internal_defs_refs_in_refs_jsonb():
-    """#3461: a committed primitive's refs JSONB carries its intra-doc #/$defs edges."""
+def test_import_rewrites_internal_defs_refs_to_relative_registry_edges():
+    """#3463: a committed primitive's intra-doc #/$defs edges are rewritten relative + resolved.
+
+    The #/$defs/Currency sibling pointer becomes ./currency and is resolved against the import's
+    base URI like any registry ref (#3456) — no leftover 'internal' fragment pointer remains.
+    """
     captured = {}
 
     def _create(**kwargs):
@@ -244,8 +248,12 @@ def test_import_captures_internal_defs_refs_in_refs_jsonb():
         )
     assert r.status_code == 200
     money_refs = captured["Money"]["refs"]
-    assert {"relative_ref": "#/$defs/Currency", "resolved_target": "Currency",
-            "status": "internal"} in money_refs
+    assert {
+        "relative_ref": "./currency",
+        "resolved_target": "https://api.objectified.dev/types/tenant/acme/currency",
+        "status": "unresolved",
+    } in money_refs
+    assert all(e["status"] != "internal" for e in money_refs)
     # A def with no internal refs commits an empty edge list.
     assert captured["Currency"]["refs"] == []
 


### PR DESCRIPTION
## What & why

Sub-issue of Epic 4 (#3442). Closes the `$ref` rewrite + namespace/scope-mapping gap in the
Primitives import pipeline.

Before this, the parser (#3461) and bundle importer (#3462) *captured* each imported definition's
intra-source `$ref` edges (`#/$defs/Money`, `#/types/Money`) as `internal` edges but left the refs
as document pointers — meaningless once each definition becomes its own `odb.primitives` row in a
target namespace. This ticket rewrites those refs for their committed place in the registry.

### New `app/primitives_rewrite.py` — `rewrite_import_schema()`
- **Intra-source pointers → relative registry refs.** `#/$defs/Money` / `#/definitions/Money` /
  `#/types/Money` → `./money` (the sibling's committed `$id` leaf-slug, matching
  `derive_schema_id`); a deeper pointer like `#/$defs/Money/properties/c` is preserved as
  `./money#/properties/c`.
- **Recognized formats → core types.** A string subschema with a recognized `format` (`email`,
  `uuid`, `uri`, `date`, `date-time`, `time`) and no `$ref` of its own is mapped to its seeded
  `std/v0/types` core type by injecting a relative `$ref` (mirroring the seed's
  `{"$ref": "../primitives/string", "format": "email"}` shape). An author's explicit `$ref` is
  never overridden.

Both rewrites produce ordinary registry-relative `$ref` values, so the **existing** resolver
(#3456, `build_ref_edges`) — already run on the commit path — turns them into persisted
`{relative_ref, resolved_target, status}` edges with no separate internal-edge bookkeeping. So
**imported refs are stored relative and resolve via Epic 3**, and **core-format mapping resolves
to the core type** (the two acceptance criteria). Committed rows no longer carry `internal` edges
(the staging path's per-candidate `internal_refs` metadata is unchanged).

`POST /v1/primitives/{tenant_slug}/import` applies this on commit for both the JSON Schema and
type-def-bundle paths (shared `_commit_imported_definitions`). New `map_core_formats` request flag
(default `true`) toggles format mapping; the import report gains a per-type `rewrites` map for the
import-review table (`types/import-review.html` $ref-rewrite table).

## How to test
- `cd objectified-rest && PYTHONPATH=src .venv/bin/python -m pytest tests/test_primitives_rewrite.py tests/test_primitives_import_rewrite_routes.py tests/test_primitives_import_bundle_routes.py tests/test_primitives_validation_routes.py -q`
- Unit tests round-trip each rewritten ref through the resolver's URL semantics
  (`urljoin(base, rewritten) == target`), proving they resolve via #3456.
- **Manual:** `POST /v1/primitives/{tenant}/import` with
  `{"schema": {"$defs": {"Money": {"type":"object"}, "Invoice": {"type":"object","properties":{"total":{"$ref":"#/$defs/Money"}}}}}, "import_all": true}`
  → `Invoice` is stored with `refs: [{"relative_ref":"./money", ...}]`. Import
  `{"$defs":{"Contact":{"type":"string","format":"email"}}}` → `Contact` gains a `$ref` to the
  core `std/v0/types/email` and a resolved edge.

## Risk / notes
- **Behavior change:** import commit no longer persists `{status:"internal"}` ref edges; they are
  rewritten to relative registry refs and resolved like any other edge. Tests for #3461/#3462 that
  asserted the old `internal` edges were updated accordingly.
- Core-format mapping is on by default; set `"map_core_formats": false` to disable.
- Regenerated `openapi.{json,yaml}`; bumped `objectified-rest` to 1.0.19 (npm) / 1.0.89 (py);
  updated CHANGELOG and ROADMAP.
- Pre-existing, unrelated test failures in merge/publish/change-report/draft-lock suites are not
  touched by this change (confirmed present on `main`).

Closes #3463

Work performed by Claude Code via model claude-opus-4-8[1m]
