### PR TITLE
Fix #3464 - Import review: conflicts, dedupe, validation report

### DIFF
--- a/docs/ROADMAP_TYPE_REGISTRY_GOVERNANCE.md
+++ b/docs/ROADMAP_TYPE_REGISTRY_GOVERNANCE.md
@@ -484,7 +484,7 @@ flowchart LR
 | 4.2 #3461 ✅ | ~~JSON Schema 2020-12 parser~~ | **DONE** — `primitives_parser.parse_json_schema_document`: each `$defs`/`definitions` entry → a discrete type (single-root doc → one type), captures intra-doc `#/$defs` refs as `internal` `refs` edges for rewrite (#3463), per-type draft 2020-12 validation report; wired through the `/import/stage` pipeline and the legacy `/import` commit path | `type-registry`,`import`,`rest`,`mvp`,`roadmap-type-registry` | Y | Y | L | objectified-rest |
 | 4.3 #3462 ✅ | ~~Type-definition bundle importer~~ | **DONE** — `primitives_bundle.parse_type_def_bundle` expands a `.json`/`.yaml` bundle's `types` (or `$defs`/`definitions`) container into discrete types, capturing inter-type `#/types`/`#/$defs` refs as `internal` `refs` edges for rewrite (#3463) with per-type draft 2020-12 validation; `expand_zip_bundle` merges a `.zip` of per-type files into a bundle document. Wired through `/import/stage` (deep candidates) and the `/import` commit path (`source_kind='type-def-bundle'` → N types commit N `odb.primitives` rows with refs intact); malformed bundle → clear 400 | `type-registry`,`import`,`rest`,`mvp`,`roadmap-type-registry` | Y | Y | L | objectified-rest |
 | 4.4 #3463 ✅ | ~~`$ref` rewrite + namespace/scope mapping~~ | **DONE** — `primitives_rewrite.rewrite_import_schema` rewrites each imported definition's intra-source pointers (`#/$defs/Money`, `#/definitions/Money`, `#/types/Money`) to relative registry refs at the sibling's committed `$id` (`./money`, preserving any deeper pointer as `./money#/...`), and maps recognized string formats (email, uuid, uri, date, date-time, time) to the seeded `std/v0/types` core types by injecting a relative `$ref` (author refs never overridden). Both rewrites yield ordinary registry-relative refs, so the existing resolver (#3456) persists them as `refs` edges — imported refs are stored relative and resolve via Epic 3; no `internal` edges remain on committed rows. Applied on commit (`POST /import`) for the JSON Schema and bundle paths; `map_core_formats` flag (default on) toggles format mapping; import report gains a per-type `rewrites` map | `type-registry`,`import`,`rest`,`mvp`,`roadmap-type-registry` | N | Y | L | objectified-rest |
-| 4.5 #3464 | Import review: conflicts, dedupe, report | Conflict resolution, dedupe identical, validation report | `type-registry`,`import`,`rest`,`mvp`,`roadmap-type-registry` | Y | Y | M | objectified-rest |
+| 4.5 #3464 ✅ | ~~Import review: conflicts, dedupe, report~~ | **DONE** — `primitives_review.py` classifies each imported definition New/Identical/Conflict against the registry (by derived `$id`), and `decide()` turns a per-type resolution (keep/overwrite/rename) into a commit action. New `POST /import/review` dry-run returns the classification + draft 2020-12 validation report + `$ref` rewrites + unresolved-ref mapping + allowed resolutions (writes nothing); the same classification drives `POST /import` so the committed outcome matches the review. `/import` gains `dedupe` (default on → Identical skipped) and `resolutions` request fields; conflicts resolved `overwrite` update the existing row, `rename` creates a slugified copy, default `keep` surfaces the conflict instead of dropping it silently. Report gains `overwritten`/`renamed`/`identical` buckets + per-type `reviews` | `type-registry`,`import`,`rest`,`mvp`,`roadmap-type-registry` | Y | Y | M | objectified-rest |
 | 4.6 #3465 | OpenAPI 3.1 components importer | Extract `components/schemas` as types | `type-registry`,`import`,`rest`,`roadmap-type-registry` | Y | N | M | objectified-rest |
 
 ### Issue 4.1 — Import pipeline core + ingestion
@@ -540,7 +540,24 @@ flowchart LR
 - **Parallelism/Dependencies.** Depends on 4.2/4.3; uses 3.1.
 - **Technical Stack.** FastAPI.
 
-### Issue 4.5 — Import review: conflicts, dedupe, report
+### Issue 4.5 — Import review: conflicts, dedupe, report ✅ DONE (#3464)
+- **Delivered.** `objectified-rest/src/app/primitives_review.py` holds the pure review logic:
+  `classify_status()` labels each imported definition **New** (no visible type holds its derived
+  `$id`), **Identical** (an existing type has the same `$id` and a deep-equal schema), or
+  **Conflict** (same `$id`, different schema), and `decide()` turns a per-type resolution
+  (`keep` / `overwrite` / `rename`, with `dedupe` controlling whether Identical is auto-skipped)
+  into a concrete commit action. A new `POST /v1/primitives/{tenant_slug}/import/review` dry-run
+  resolves the source exactly as the commit would but **writes nothing**, returning per-type
+  classification, the draft 2020-12 validation report, the `$ref` rewrites (#3463), the
+  unresolved-ref mapping, and the allowed resolutions for each conflict. The same
+  `_prepare_imported_definition` pipeline drives the commit, so the committed outcome can't disagree
+  with the review. `POST /import` gains `dedupe` (default on) and `resolutions` request fields:
+  `overwrite` updates the existing row in place, `rename` creates a slugified copy (erroring if the
+  target name is taken), and the default `keep` **surfaces** the conflict (`skipped`) rather than
+  dropping it silently. The import report gains `overwritten` / `renamed` / `identical` buckets and
+  their totals plus a per-type `reviews` list, and provenance counts reflect rows written vs. passed
+  over. Unit tests in `tests/test_primitives_review.py`, route tests in
+  `tests/test_primitives_import_review_routes.py`.
 - **Problem.** Imports collide with existing types and may duplicate.
 - **Solution/Scope.** Detect New/Conflict/Identical per type; offer keep/overwrite/rename; dedupe
   identical; produce a validation report (draft 2020-12: valid/errors/warnings) and unresolved-ref

--- a/objectified-rest/CHANGELOG.md
+++ b/objectified-rest/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to the Objectified REST API will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.20] - 2026-06-22
+
+### Added
+- **Import review: conflicts, dedupe, validation report (#3464)** — the Primitives import path no
+  longer skips duplicates silently. New `app/primitives_review.py` provides the pure review logic:
+  each imported definition is classified against the registry as **New** (nothing shares its `$id`),
+  **Identical** (an existing type has the same `$id` and an identical schema), or **Conflict** (same
+  `$id`, different schema), and a caller's per-type resolution choice (**keep** / **overwrite** /
+  **rename**) is turned into a concrete commit decision by `decide()`.
+- **`POST /v1/primitives/{tenant_slug}/import/review`** — a dry-run that writes nothing and returns
+  the classification, a draft 2020-12 validation report, the `$ref` rewrites, the unresolved-ref
+  mapping, and the resolution choices each conflict offers. This is the report the import wizard
+  (#3469) renders before commit; the same classification drives the commit, so the committed result
+  matches the review.
+
+### Changed
+- **`POST /v1/primitives/{tenant_slug}/import`** now honors review choices. New request fields:
+  `dedupe` (default `true` — an Identical definition is skipped as a duplicate) and `resolutions`
+  (a `name -> {action, new_name}` map). On commit, a conflict resolved `overwrite` updates the
+  existing row in place, `rename` creates a copy under a new (slugified) name, and the default
+  `keep` leaves the existing type but **surfaces** the conflict instead of dropping it. The import
+  report gains `overwritten` / `renamed` / `identical` buckets (and their totals) plus a per-type
+  `reviews` list, so the report can be shown to match the outcome; provenance counts reflect rows
+  written (created + overwritten + renamed) vs. passed over (deduped + kept).
+- Regenerated `openapi.{json,yaml}` for the new endpoint, request fields, and `ImportResolution`
+  model; bumped to 1.0.20 (npm) / 1.0.90 (py).
+
 ## [1.0.19] - 2026-06-22
 
 ### Added

--- a/objectified-rest/openapi.json
+++ b/objectified-rest/openapi.json
@@ -1579,6 +1579,93 @@
         }
       }
     },
+    "/v1/primitives/{tenant_slug}/import/review": {
+      "post": {
+        "tags": [
+          "primitives"
+        ],
+        "summary": "Review Import Primitives",
+        "description": "Dry-run review of an import: conflicts, dedupe, and a validation report (#3464).\n\nResolves the source exactly as ``POST /import`` would, but **writes nothing** \u2014 it\nclassifies each definition against the registry (New / Identical / Conflict), attaches its\ndraft 2020-12 validation report and unresolved-ref mapping, and lists the resolution\nchoices each conflict offers. This is the report the import wizard (#3469) renders so the\nuser can pick keep / overwrite / rename before committing; the same classification drives\nthe commit, so the committed result matches the review.\n\nArgs:\n    tenant_slug: The tenant slug.\n    request: The import request (source document + options); ``resolutions`` is ignored.\n    auth_data: Authentication data (injected by dependency).\n\nReturns:\n    A ``{\"status\": \"review\", \"summary\", \"types\", ...}`` report.",
+        "operationId": "review_import_primitives_v1_primitives__tenant_slug__import_review_post",
+        "parameters": [
+          {
+            "name": "tenant_slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Tenant Slug"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "name": "X-API-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PrimitiveImportRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Review Import Primitives V1 Primitives  Tenant Slug  Import Review Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/primitives/{tenant_slug}/import": {
       "post": {
         "tags": [
@@ -16560,6 +16647,29 @@
         "type": "object",
         "title": "HTTPValidationError"
       },
+      "ImportResolution": {
+        "properties": {
+          "action": {
+            "type": "string",
+            "title": "Action",
+            "default": "keep"
+          },
+          "new_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "New Name"
+          }
+        },
+        "type": "object",
+        "title": "ImportResolution",
+        "description": "How to resolve one conflicting type during import (#3464).\n\nKeyed by definition name in :attr:`PrimitiveImportRequest.resolutions`. Applies only to a\ntype the review classified as a **Conflict** (an existing type with the same registry\nidentity but a different schema); New and Identical types ignore any resolution."
+      },
       "LinkOperationRequest": {
         "properties": {
           "metadata": {
@@ -17210,6 +17320,25 @@
             "type": "boolean",
             "title": "Map Core Formats",
             "default": true
+          },
+          "dedupe": {
+            "type": "boolean",
+            "title": "Dedupe",
+            "default": true
+          },
+          "resolutions": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "$ref": "#/components/schemas/ImportResolution"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Resolutions"
           }
         },
         "type": "object",

--- a/objectified-rest/openapi.yaml
+++ b/objectified-rest/openapi.yaml
@@ -1007,6 +1007,69 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /v1/primitives/{tenant_slug}/import/review:
+    post:
+      tags:
+      - primitives
+      summary: Review Import Primitives
+      description: "Dry-run review of an import: conflicts, dedupe, and a validation\
+        \ report (#3464).\n\nResolves the source exactly as ``POST /import`` would,\
+        \ but **writes nothing** — it\nclassifies each definition against the registry\
+        \ (New / Identical / Conflict), attaches its\ndraft 2020-12 validation report\
+        \ and unresolved-ref mapping, and lists the resolution\nchoices each conflict\
+        \ offers. This is the report the import wizard (#3469) renders so the\nuser\
+        \ can pick keep / overwrite / rename before committing; the same classification\
+        \ drives\nthe commit, so the committed result matches the review.\n\nArgs:\n\
+        \    tenant_slug: The tenant slug.\n    request: The import request (source\
+        \ document + options); ``resolutions`` is ignored.\n    auth_data: Authentication\
+        \ data (injected by dependency).\n\nReturns:\n    A ``{\"status\": \"review\"\
+        , \"summary\", \"types\", ...}`` report."
+      operationId: review_import_primitives_v1_primitives__tenant_slug__import_review_post
+      parameters:
+      - name: tenant_slug
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Tenant Slug
+      - name: authorization
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Authorization
+      - name: X-API-Key
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Api-Key
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PrimitiveImportRequest'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+                title: Response Review Import Primitives V1 Primitives  Tenant Slug  Import
+                  Review Post
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /v1/primitives/{tenant_slug}/import:
     post:
       tags:
@@ -10564,6 +10627,29 @@ components:
           title: Detail
       type: object
       title: HTTPValidationError
+    ImportResolution:
+      properties:
+        action:
+          type: string
+          title: Action
+          default: keep
+        new_name:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: New Name
+      type: object
+      title: ImportResolution
+      description: 'How to resolve one conflicting type during import (#3464).
+
+
+        Keyed by definition name in :attr:`PrimitiveImportRequest.resolutions`. Applies
+        only to a
+
+        type the review classified as a **Conflict** (an existing type with the same
+        registry
+
+        identity but a different schema); New and Identical types ignore any resolution.'
     LinkOperationRequest:
       properties:
         metadata:
@@ -10956,6 +11042,17 @@ components:
           type: boolean
           title: Map Core Formats
           default: true
+        dedupe:
+          type: boolean
+          title: Dedupe
+          default: true
+        resolutions:
+          anyOf:
+          - additionalProperties:
+              $ref: '#/components/schemas/ImportResolution'
+            type: object
+          - type: 'null'
+          title: Resolutions
       type: object
       required:
       - schema

--- a/objectified-rest/package.json
+++ b/objectified-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-rest",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "private": true,
   "description": "Trigger file for Objectified REST Docker publish workflow; app is Python (pyproject.toml).",
   "scripts": {

--- a/objectified-rest/pyproject.toml
+++ b/objectified-rest/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "objectified-rest"
-version = "1.0.89"
+version = "1.0.90"
 description = "REST API for serving OpenAPI specifications from the Objectified database"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/objectified-rest/src/app/models.py
+++ b/objectified-rest/src/app/models.py
@@ -183,7 +183,13 @@ class ImportResolution(BaseModel):
     type the review classified as a **Conflict** (an existing type with the same registry
     identity but a different schema); New and Identical types ignore any resolution.
     """
-    action: str = 'keep'  # 'keep' (leave existing) | 'overwrite' | 'rename'
+    # One of 'keep' (leave existing) | 'overwrite' | 'rename'. Kept a plain ``str`` rather than an
+    # ``Enum`` deliberately: ``_normalize_resolutions`` validates it against
+    # ``primitives_review.VALID_ACTIONS`` and rejects an unknown action with a domain-specific
+    # **400** ("Invalid resolution action ..."). A Pydantic ``Enum`` field would instead reject it
+    # with a generic **422** before that handler runs, so a typo like 'Overwrite' is *not* silently
+    # accepted today — it is surfaced as a clear 400.
+    action: str = 'keep'
     new_name: Optional[str] = None  # Required when action == 'rename'.
 
     class Config:

--- a/objectified-rest/src/app/models.py
+++ b/objectified-rest/src/app/models.py
@@ -176,6 +176,20 @@ class PrimitiveUpdateRequest(BaseModel):
         from_attributes = True
 
 
+class ImportResolution(BaseModel):
+    """How to resolve one conflicting type during import (#3464).
+
+    Keyed by definition name in :attr:`PrimitiveImportRequest.resolutions`. Applies only to a
+    type the review classified as a **Conflict** (an existing type with the same registry
+    identity but a different schema); New and Identical types ignore any resolution.
+    """
+    action: str = 'keep'  # 'keep' (leave existing) | 'overwrite' | 'rename'
+    new_name: Optional[str] = None  # Required when action == 'rename'.
+
+    class Config:
+        from_attributes = True
+
+
 class PrimitiveImportRequest(BaseModel):
     """Request model for importing primitives from JSON Schema."""
     schema: Dict[str, Any]  # Full JSON Schema document
@@ -188,6 +202,11 @@ class PrimitiveImportRequest(BaseModel):
     # Map recognized string formats (email, uuid, uri, date, date-time, time) to the seeded
     # std/v0/types core types by injecting a relative $ref during rewrite (#3463). Default on.
     map_core_formats: bool = True
+    # Import review controls (#3464). When dedupe is on (default), a definition identical to an
+    # existing type is silently skipped; resolutions carries per-type conflict choices
+    # (keep / overwrite / rename), keyed by definition name.
+    dedupe: bool = True
+    resolutions: Optional[Dict[str, ImportResolution]] = None
 
     class Config:
         from_attributes = True

--- a/objectified-rest/src/app/primitives_review.py
+++ b/objectified-rest/src/app/primitives_review.py
@@ -60,6 +60,11 @@ def schemas_equivalent(a: Any, b: Any) -> bool:
     derived ``$id`` whenever they share a registry identity, so a plain deep comparison
     distinguishes a true duplicate (Identical) from a divergent redefinition (Conflict).
 
+    Python ``==`` on ``dict``/``list`` is recursive and *key-order independent* — two dicts
+    are equal when they hold the same key/value pairs regardless of insertion order — so this
+    is robust to the non-deterministic key ordering JSON/YAML deserialization can produce and
+    needs no canonical (``sort_keys``) serialization to compare correctly.
+
     Args:
         a: One schema document (e.g. the existing row's ``schema``).
         b: The other schema document (e.g. the stamped candidate).
@@ -180,8 +185,12 @@ def decide(
             )
         return CommitDecision(action="rename", outcome=OUTCOME_RENAMED, new_name=new_name)
 
-    # ACTION_KEEP (and any unrecognized action defaulting to keep): leave the existing
-    # type in place, but report the conflict rather than dropping it silently.
+    # ACTION_KEEP is the explicit default. The HTTP layer rejects any non-``VALID_ACTIONS``
+    # value with a 400 (see ``_normalize_resolutions``) before reaching here, so an unrecognized
+    # action is unreachable from a request; this pure function nonetheless degrades to the safe
+    # default (keep) rather than raising, so a direct caller that forgets to validate still gets
+    # a defined, non-destructive outcome. Either way: leave the existing type in place, but
+    # report the conflict rather than dropping it silently.
     return CommitDecision(
         action="skip",
         outcome=OUTCOME_SKIPPED,

--- a/objectified-rest/src/app/primitives_review.py
+++ b/objectified-rest/src/app/primitives_review.py
@@ -1,0 +1,189 @@
+"""Import review: conflict / dedupe classification and resolution (#3464).
+
+The earlier import path committed every parsed definition blindly: a definition whose
+registry identity (``$id``) already existed silently landed in a ``skipped`` bucket with
+no signal to the caller and no way to act on it. This module supplies the *review* layer
+the ticket asks for — it classifies each imported definition against the existing registry
+(**New / Identical / Conflict**), and turns a caller's per-type **resolution choice**
+(keep / overwrite / rename) into a concrete commit decision.
+
+The logic here is intentionally **pure** — no database, no FastAPI — so it is unit-testable
+in isolation. The route layer (:mod:`app.primitives_routes`) supplies the existing-row
+lookup and executes the decisions (create / update / skip); this module only decides.
+"""
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+# ---------------------------------------------------------------------------
+# Per-type classification against the existing registry.
+# ---------------------------------------------------------------------------
+
+#: No existing visible type shares this definition's registry identity (``$id``).
+STATUS_NEW = "new"
+#: An existing type has the same identity *and* an identical schema — a true duplicate.
+STATUS_IDENTICAL = "identical"
+#: An existing type has the same identity but a *different* schema — needs resolution.
+STATUS_CONFLICT = "conflict"
+#: The definition is not a valid draft 2020-12 schema (or violates scope) — cannot commit.
+STATUS_INVALID = "invalid"
+
+# ---------------------------------------------------------------------------
+# Conflict-resolution actions a caller may choose per type.
+# ---------------------------------------------------------------------------
+
+#: Leave the existing type untouched and do not import this definition (the default).
+ACTION_KEEP = "keep"
+#: Replace the existing type's schema with the imported definition.
+ACTION_OVERWRITE = "overwrite"
+#: Import the definition under a new name, giving it a fresh registry identity.
+ACTION_RENAME = "rename"
+#: The set of resolution actions the commit path accepts.
+VALID_ACTIONS = {ACTION_KEEP, ACTION_OVERWRITE, ACTION_RENAME}
+
+# ---------------------------------------------------------------------------
+# What the commit actually did with a definition (report buckets — one per type).
+# ---------------------------------------------------------------------------
+
+OUTCOME_IMPORTED = "imported"        # A new row was created.
+OUTCOME_OVERWRITTEN = "overwritten"  # An existing row's schema was replaced.
+OUTCOME_RENAMED = "renamed"          # A new row was created under a different name.
+OUTCOME_IDENTICAL = "identical"      # Deduped — skipped because already present unchanged.
+OUTCOME_SKIPPED = "skipped"          # A conflict left unresolved / explicitly kept.
+OUTCOME_ERROR = "error"              # The decision could not be carried out.
+
+
+def schemas_equivalent(a: Any, b: Any) -> bool:
+    """Return whether two stored schema documents are structurally identical.
+
+    Both the candidate (after identity stamping) and the existing row carry the same
+    derived ``$id`` whenever they share a registry identity, so a plain deep comparison
+    distinguishes a true duplicate (Identical) from a divergent redefinition (Conflict).
+
+    Args:
+        a: One schema document (e.g. the existing row's ``schema``).
+        b: The other schema document (e.g. the stamped candidate).
+
+    Returns:
+        ``True`` when the two documents are deep-equal, ``False`` otherwise.
+    """
+    return a == b
+
+
+def classify_status(existing: Optional[Dict[str, Any]], candidate_schema: Dict[str, Any]) -> str:
+    """Classify a candidate against the existing registry row sharing its identity.
+
+    Args:
+        existing: The primitive row already holding the candidate's ``$id`` within the
+            caller's read scope, or ``None`` when no such row exists.
+        candidate_schema: The stamped candidate schema being imported.
+
+    Returns:
+        :data:`STATUS_NEW` when nothing exists at the identity, :data:`STATUS_IDENTICAL`
+        when the existing schema matches, otherwise :data:`STATUS_CONFLICT`.
+    """
+    if not existing:
+        return STATUS_NEW
+    if schemas_equivalent(existing.get("schema"), candidate_schema):
+        return STATUS_IDENTICAL
+    return STATUS_CONFLICT
+
+
+def allowed_resolutions(status: str) -> list:
+    """Return the resolution actions that make sense for a given classification.
+
+    Used by the review report so a UI can present only the meaningful choices: a New or
+    Identical type needs no resolution, while a Conflict offers keep / overwrite / rename.
+
+    Args:
+        status: One of the ``STATUS_*`` classifications.
+
+    Returns:
+        The ordered list of applicable ``ACTION_*`` values (empty when none apply).
+    """
+    if status == STATUS_CONFLICT:
+        return [ACTION_KEEP, ACTION_OVERWRITE, ACTION_RENAME]
+    return []
+
+
+@dataclass
+class CommitDecision:
+    """The concrete action the commit path should take for one definition.
+
+    Attributes:
+        action: The mechanical step to perform — ``create`` (new row), ``update``
+            (overwrite the existing row), ``rename`` (create under ``new_name``),
+            ``skip`` (do nothing), or ``error`` (the resolution was unusable).
+        outcome: The report bucket the definition lands in (an ``OUTCOME_*`` value).
+        reason: A human-readable note for ``skip`` / ``error`` decisions, or ``None``.
+        new_name: The target name when ``action == 'rename'``, else ``None``.
+    """
+
+    action: str
+    outcome: str
+    reason: Optional[str] = None
+    new_name: Optional[str] = None
+
+
+def decide(
+    status: str,
+    *,
+    action: str = ACTION_KEEP,
+    new_name: Optional[str] = None,
+    dedupe: bool = True,
+) -> CommitDecision:
+    """Turn a classification plus a caller's resolution choice into a commit decision.
+
+    The decision rules:
+
+    - **New** → create the row.
+    - **Identical** with ``dedupe`` on (the default) → skip as a deduplicated duplicate.
+      With ``dedupe`` off, an identical type is treated like a conflict so the caller's
+      explicit resolution still applies.
+    - **Conflict** (or Identical with ``dedupe`` off) → apply the resolution:
+      ``overwrite`` updates the existing row, ``rename`` creates a copy under ``new_name``
+      (an error if ``new_name`` is missing), and ``keep`` (the default) skips it while
+      surfacing the unresolved conflict.
+
+    Invalid definitions are filtered out by the caller before reaching this function.
+
+    Args:
+        status: The candidate's classification (a ``STATUS_*`` value, never INVALID).
+        action: The caller's chosen resolution action (a ``VALID_ACTIONS`` member).
+        new_name: The rename target, required only when ``action == 'rename'``.
+        dedupe: Whether an Identical type is auto-skipped (``True``) or surfaced for
+            resolution (``False``).
+
+    Returns:
+        The :class:`CommitDecision` describing what to do.
+    """
+    if status == STATUS_NEW:
+        return CommitDecision(action="create", outcome=OUTCOME_IMPORTED)
+
+    if status == STATUS_IDENTICAL and dedupe:
+        return CommitDecision(
+            action="skip",
+            outcome=OUTCOME_IDENTICAL,
+            reason="identical to an existing type",
+        )
+
+    # Conflict (or an identical type the caller opted not to dedupe): apply the resolution.
+    if action == ACTION_OVERWRITE:
+        return CommitDecision(action="update", outcome=OUTCOME_OVERWRITTEN)
+
+    if action == ACTION_RENAME:
+        if not new_name:
+            return CommitDecision(
+                action="error",
+                outcome=OUTCOME_ERROR,
+                reason="rename resolution requires a new_name",
+            )
+        return CommitDecision(action="rename", outcome=OUTCOME_RENAMED, new_name=new_name)
+
+    # ACTION_KEEP (and any unrecognized action defaulting to keep): leave the existing
+    # type in place, but report the conflict rather than dropping it silently.
+    return CommitDecision(
+        action="skip",
+        outcome=OUTCOME_SKIPPED,
+        reason="conflict left unresolved (existing type kept)",
+    )

--- a/objectified-rest/src/app/primitives_routes.py
+++ b/objectified-rest/src/app/primitives_routes.py
@@ -752,9 +752,19 @@ class _PreparedDefinition:
     New / Identical / Conflict. The same prepared state drives the dry-run review endpoint and
     the commit path, so a committed outcome can never disagree with the review that preceded it.
 
+    The ``status`` field carries two related-but-distinct ideas under one ``STATUS_*`` value:
+    a *registry* classification (``STATUS_NEW`` / ``STATUS_IDENTICAL`` / ``STATUS_CONFLICT``)
+    for a committable definition, or ``STATUS_INVALID`` when the definition can't be committed
+    at all. Use ``valid`` to disambiguate the latter: ``status == STATUS_INVALID`` covers both a
+    malformed draft 2020-12 schema (``valid is False``, with ``validation_errors``) *and* a
+    well-formed schema that violates scope (``valid is True``, with a ``scope_violation`` error).
+    A caller that only cares about the New/Identical/Conflict classification should first gate on
+    ``status == STATUS_INVALID`` (as the commit and review paths do) before reading the rest.
+
     Attributes:
         name: The definition's name (its registry-identity leaf).
-        status: The classification — a ``primitives_review.STATUS_*`` value.
+        status: The classification — a ``primitives_review.STATUS_*`` value (``STATUS_INVALID``
+            when the definition cannot be committed; see the note above on ``valid``).
         valid: Whether the fragment is a valid draft 2020-12 schema (scope violations are
             valid schemas, so this stays ``True`` for them).
         validation_errors: Field-level draft 2020-12 errors when ``valid`` is ``False``.
@@ -1046,6 +1056,12 @@ def _commit_imported_definitions(
             elif decision.action == "rename":
                 # Re-prepare under the new name so it gets its own registry identity, then
                 # create it — unless that name is itself already taken (a fresh conflict).
+                # A rename only re-derives *this* definition's $id; sibling definitions in the
+                # same bundle keep their own identities. A sibling's ``$ref`` therefore resolves
+                # against the name it was authored to point at, not this new name — renaming one
+                # type does not silently re-point its siblings' edges. An edge that pointed at
+                # this type's original name lands in that sibling's ``unresolved_refs`` (the
+                # review surfaces it), exactly as it would for any other unresolved registry ref.
                 renamed_prep = _prepare_imported_definition(
                     decision.new_name,
                     def_schema,

--- a/objectified-rest/src/app/primitives_routes.py
+++ b/objectified-rest/src/app/primitives_routes.py
@@ -5,6 +5,7 @@ Provides CRUD endpoints for managing primitive type definitions.
 All endpoints are tenant-scoped and require authentication via JWT token or API key.
 """
 
+from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -30,6 +31,14 @@ from .primitives_bundle import (
     parse_type_def_bundle,
 )
 from .primitives_resolver import build_ref_edges
+from .primitives_review import (
+    ACTION_RENAME,
+    STATUS_INVALID,
+    VALID_ACTIONS,
+    allowed_resolutions,
+    classify_status,
+    decide,
+)
 from .primitives_rewrite import rewrite_import_schema
 from .primitives_scope import (
     ScopeViolationError,
@@ -733,6 +742,180 @@ async def delete_primitive(
     return {"message": "Primitive deleted successfully"}
 
 
+@dataclass
+class _PreparedDefinition:
+    """A single imported definition resolved far enough to be reviewed or committed (#3464).
+
+    Produced by :func:`_prepare_imported_definition`, which applies the ``$ref`` rewrite
+    (#3463), validates + derives identity (#3452/#3453), resolves the ``refs`` edges (#3456),
+    and looks the derived ``$id`` up against the registry so the definition can be classified
+    New / Identical / Conflict. The same prepared state drives the dry-run review endpoint and
+    the commit path, so a committed outcome can never disagree with the review that preceded it.
+
+    Attributes:
+        name: The definition's name (its registry-identity leaf).
+        status: The classification — a ``primitives_review.STATUS_*`` value.
+        valid: Whether the fragment is a valid draft 2020-12 schema (scope violations are
+            valid schemas, so this stays ``True`` for them).
+        validation_errors: Field-level draft 2020-12 errors when ``valid`` is ``False``.
+        error: A ``{"error", "details"}`` record when the definition cannot be committed
+            (invalid schema or scope violation), else ``None``.
+        schema_id: The derived ``$id`` (``None`` when the definition is invalid).
+        identity: The full identity dict (stamped ``schema``/``schema_id``/``draft``/``base_uri``)
+            when valid, else ``None``.
+        rewritten: The rewritten schema (carries description/tags/category), or the original.
+        refs: The resolved relative-``$ref`` edges to persist, or ``None`` when invalid.
+        rewrites: The applied ``{"from", "to", "kind"}`` ref rewrites for the report.
+        existing: The existing primitive row sharing this ``$id`` (Identical/Conflict), else ``None``.
+    """
+
+    name: str
+    status: str
+    valid: bool = True
+    validation_errors: List[Dict[str, Any]] = field(default_factory=list)
+    error: Optional[Dict[str, Any]] = None
+    schema_id: Optional[str] = None
+    identity: Optional[Dict[str, Any]] = None
+    rewritten: Optional[Dict[str, Any]] = None
+    refs: Optional[List[Dict[str, str]]] = None
+    rewrites: List[Dict[str, str]] = field(default_factory=list)
+    existing: Optional[Dict[str, Any]] = None
+
+
+def _prepare_imported_definition(
+    def_name: str,
+    def_schema: Any,
+    *,
+    tenant_id: str,
+    tenant_slug: str,
+    target_namespace: Optional[str],
+    map_core_formats: bool,
+) -> _PreparedDefinition:
+    """Rewrite, validate, resolve, and classify one imported definition (#3464).
+
+    Runs the same registry pipeline a commit would — ``$ref`` rewrite (#3463), draft
+    2020-12 validation + ``$id`` derivation + scope enforcement (#3452/#3453), and ``refs``
+    resolution (#3456) — then looks the derived ``$id`` up in the caller's read scope to
+    classify the definition New / Identical / Conflict (:func:`classify_status`). It never
+    writes; the returned :class:`_PreparedDefinition` is consumed by both the review endpoint
+    and the commit path. An invalid or scope-violating definition is returned with
+    ``status == STATUS_INVALID`` and a populated ``error`` rather than raising, so one bad
+    definition never blocks the rest of a bundle.
+
+    Args:
+        def_name: The definition's name (drives its derived ``$id`` leaf).
+        def_schema: The raw definition fragment from the source document.
+        tenant_id: The caller's tenant id (scopes ref resolution and the existing-row lookup).
+        tenant_slug: The tenant slug (used for the default base URI).
+        target_namespace: Optional registry namespace the definition is imported into.
+        map_core_formats: Whether to map recognized formats to core types (#3463).
+
+    Returns:
+        The :class:`_PreparedDefinition` for this definition.
+    """
+    # Rewrite the definition's refs for its committed place in the registry before
+    # validating/persisting (#3463). The base URI a definition's refs resolve against is the
+    # same one resolve_primitive_identity derives, so the rewrite and the $id agree.
+    if isinstance(def_schema, dict):
+        base_uri = derive_base_uri(target_namespace, None, tenant_slug)
+        rewritten_schema, applied = rewrite_import_schema(
+            def_schema, base_uri=base_uri, map_core_formats=map_core_formats
+        )
+    else:
+        # A non-object definition cannot be rewritten; let validation reject it below.
+        rewritten_schema, applied = def_schema, []
+
+    try:
+        identity = resolve_primitive_identity(
+            rewritten_schema,
+            name=def_name,
+            namespace=target_namespace,
+            base_uri=None,
+            tenant_slug=tenant_slug,
+        )
+    except SchemaValidationError as e:
+        # Not a valid draft 2020-12 schema — the validation report records the field errors.
+        return _PreparedDefinition(
+            name=def_name,
+            status=STATUS_INVALID,
+            valid=False,
+            validation_errors=e.errors,
+            error={"error": "invalid_schema", "details": e.errors},
+            rewritten=rewritten_schema if isinstance(rewritten_schema, dict) else None,
+        )
+    except ScopeViolationError as e:
+        # A valid schema that crosses a forbidden scope boundary — valid stays True.
+        return _PreparedDefinition(
+            name=def_name,
+            status=STATUS_INVALID,
+            valid=True,
+            error={"error": "scope_violation", "details": e.violations},
+            rewritten=rewritten_schema if isinstance(rewritten_schema, dict) else None,
+        )
+
+    # The rewrite turned every intra-source/core ref into an ordinary registry-relative ref,
+    # so the standard resolver (#3456) produces the full edge set — no internal-edge appending.
+    refs = resolve_primitive_refs(
+        identity['schema'], base_uri=identity['base_uri'], tenant_id=tenant_id
+    )
+
+    # Classify against the registry: does a visible type already hold this $id, and if so is
+    # its schema identical (a dedupe) or divergent (a conflict the caller must resolve)?
+    existing = db.get_primitive_by_schema_id(identity['schema_id'], tenant_id)
+    status = classify_status(existing, identity['schema'])
+
+    return _PreparedDefinition(
+        name=def_name,
+        status=status,
+        valid=True,
+        schema_id=identity['schema_id'],
+        identity=identity,
+        rewritten=rewritten_schema,
+        refs=refs,
+        rewrites=applied,
+        existing=existing,
+    )
+
+
+def _create_primitive_from_prepared(
+    prep: _PreparedDefinition,
+    *,
+    name: str,
+    tenant_id: str,
+    target_namespace: Optional[str],
+    created_by: Optional[str],
+) -> None:
+    """Persist a prepared definition as a new ``odb.primitives`` row and reconcile dependents.
+
+    Shared by the New-import and rename paths so both create rows identically. After the row
+    lands, any of the tenant's dangling edges that pointed at this ``$id`` are reconciled (#3457).
+
+    Args:
+        prep: The prepared definition (must be valid, i.e. carry an ``identity``).
+        name: The name to create under (the original name, or a rename target).
+        tenant_id: The owning tenant id.
+        target_namespace: The registry namespace the row is placed in.
+        created_by: The authenticated user id (None for API-key auth).
+    """
+    identity = prep.identity
+    db.create_primitive(
+        tenant_id=tenant_id,
+        name=name,
+        category=determine_category_from_schema(prep.rewritten),
+        schema=identity['schema'],
+        description=prep.rewritten.get('description'),
+        tags=prep.rewritten.get('tags', []),
+        created_by=created_by,
+        source='imported',
+        schema_id=identity['schema_id'],
+        draft=identity['draft'],
+        namespace=target_namespace,
+        base_uri=identity['base_uri'],
+        refs=prep.refs,
+    )
+    reconcile_dependents_for_target(identity['schema_id'], tenant_id=tenant_id)
+
+
 def _commit_imported_definitions(
     definitions: Dict[str, Any],
     *,
@@ -741,22 +924,25 @@ def _commit_imported_definitions(
     target_namespace: Optional[str],
     created_by: Optional[str],
     map_core_formats: bool = True,
+    dedupe: bool = True,
+    resolutions: Optional[Dict[str, Dict[str, Any]]] = None,
 ) -> Dict[str, Any]:
-    """Commit a ``name -> schema`` map of imported definitions as primitive rows.
+    """Commit a ``name -> schema`` map of imported definitions, honoring review choices (#3464).
 
-    Shared by the JSON Schema ``$defs`` import and the type-definition bundle import
-    (#3462) so both create rows identically. Each definition is first **rewritten** for its
-    place in the registry (#3463): its intra-source pointers (``#/$defs/Money`` /
-    ``#/definitions/Money`` / ``#/types/Money``) become relative registry refs at the sibling's
-    committed ``$id`` (``./money``), and — when ``map_core_formats`` — a recognized string
-    ``format`` (email, uuid, uri, date, date-time, time) is mapped to its seeded ``std/v0/types``
-    core type. The rewritten schema then goes through the same draft 2020-12 validator, ``$id``
-    derivation, and scope enforcement as create/update (#3452, #3453), and its now registry-relative
-    ``$ref`` values are resolved against the registry into persisted ``refs`` edges by the existing
-    resolver (#3456) — so rewritten refs resolve via Epic 3 with no separate edge bookkeeping. Any
-    dependents' dangling refs are reconciled (#3457). An invalid or scope-violating definition is
-    recorded under ``errors`` and skipped without blocking the others, so a bundle of N valid types
-    commits N rows.
+    Shared by the JSON Schema ``$defs`` import and the type-definition bundle import (#3462).
+    Each definition is prepared (rewrite #3463, validate/derive identity #3452/#3453, resolve
+    refs #3456) and classified against the registry, then committed according to its
+    classification and the caller's per-type resolution:
+
+    - **New** → a row is created (``imported``).
+    - **Identical** → deduped and skipped when ``dedupe`` is on (``identical``); otherwise it
+      is treated like a conflict so an explicit resolution still applies.
+    - **Conflict** → the caller's resolution decides: ``overwrite`` replaces the existing row
+      (``overwritten``), ``rename`` creates a copy under a new name (``renamed``), and the
+      default ``keep`` leaves the existing type in place but **surfaces** the conflict
+      (``skipped``) instead of dropping it silently.
+    - **Invalid** / scope-violating definitions are recorded under ``errors`` without blocking
+      the rest.
 
     Args:
         definitions: The ``name -> schema fragment`` map to import.
@@ -765,79 +951,372 @@ def _commit_imported_definitions(
         target_namespace: Optional registry namespace each definition is imported into.
         created_by: The authenticated user id (None for API-key auth).
         map_core_formats: Whether to map recognized formats to core types (#3463).
+        dedupe: Whether Identical definitions are auto-skipped (default) or surfaced.
+        resolutions: Optional ``name -> {"action", "new_name"}`` conflict resolutions.
 
     Returns:
-        A ``{"imported", "skipped", "errors", "rewrites"}`` outcome, where each error is
-        ``{"name", "error"[, "details"]}`` and ``rewrites`` maps each imported definition's name
-        to its list of applied ``{"from", "to", "kind"}`` ref rewrites (for the import report).
+        A ``{"imported", "overwritten", "renamed", "identical", "skipped", "errors",
+        "rewrites", "reviews"}`` outcome. ``reviews`` carries each definition's classification
+        and validation report so the report can be shown to match the committed outcome.
     """
+    resolutions = resolutions or {}
     imported: List[str] = []
+    overwritten: List[str] = []
+    renamed: List[Dict[str, str]] = []
+    identical: List[str] = []
     skipped: List[str] = []
     errors: List[Dict[str, Any]] = []
     rewrites: Dict[str, List[Dict[str, str]]] = {}
+    reviews: List[Dict[str, Any]] = []
 
     for def_name, def_schema in definitions.items():
-        # Rewrite the definition's refs for its committed place in the registry before
-        # validating/persisting (#3463). The base URI a definition's refs resolve against is the
-        # same one resolve_primitive_identity derives, so the rewrite and the $id agree.
-        if isinstance(def_schema, dict):
-            base_uri = derive_base_uri(target_namespace, None, tenant_slug)
-            rewritten_schema, applied = rewrite_import_schema(
-                def_schema, base_uri=base_uri, map_core_formats=map_core_formats
-            )
-        else:
-            # A non-object definition cannot be rewritten; let validation reject it below.
-            rewritten_schema, applied = def_schema, []
+        prep = _prepare_imported_definition(
+            def_name,
+            def_schema,
+            tenant_id=tenant_id,
+            tenant_slug=tenant_slug,
+            target_namespace=target_namespace,
+            map_core_formats=map_core_formats,
+        )
 
-        try:
-            identity = resolve_primitive_identity(
-                rewritten_schema,
-                name=def_name,
-                namespace=target_namespace,
-                base_uri=None,
-                tenant_slug=tenant_slug,
-            )
-        except SchemaValidationError as e:
-            errors.append({"name": def_name, "error": "invalid_schema", "details": e.errors})
-            continue
-        except ScopeViolationError as e:
-            errors.append({"name": def_name, "error": "scope_violation", "details": e.violations})
+        # Record the per-type classification + validation report (mirrors the review endpoint).
+        reviews.append({
+            "name": def_name,
+            "status": prep.status,
+            "valid": prep.valid,
+            "validation_errors": prep.validation_errors,
+            "existing_id": str(prep.existing["id"]) if prep.existing else None,
+        })
+
+        if prep.status == STATUS_INVALID:
+            errors.append({"name": def_name, **prep.error})
             continue
 
-        # The rewrite turned every intra-source/core ref into an ordinary registry-relative ref,
-        # so the standard resolver (#3456) produces the full edge set — no internal-edge appending.
-        refs = resolve_primitive_refs(
-            identity['schema'], base_uri=identity['base_uri'], tenant_id=tenant_id
+        resolution = resolutions.get(def_name) or {}
+        decision = decide(
+            prep.status,
+            action=resolution.get("action", "keep"),
+            new_name=resolution.get("new_name"),
+            dedupe=dedupe,
         )
 
         try:
-            schema_type = determine_category_from_schema(rewritten_schema)
-            db.create_primitive(
-                tenant_id=tenant_id,
-                name=def_name,
-                category=schema_type,
-                schema=identity['schema'],
-                description=rewritten_schema.get('description'),
-                tags=rewritten_schema.get('tags', []),
-                created_by=created_by,
-                source='imported',
-                schema_id=identity['schema_id'],
-                draft=identity['draft'],
-                namespace=target_namespace,
-                base_uri=identity['base_uri'],
-                refs=refs,
-            )
-            imported.append(def_name)
-            if applied:
-                rewrites[def_name] = applied
-            reconcile_dependents_for_target(identity['schema_id'], tenant_id=tenant_id)
+            if decision.action == "create":
+                _create_primitive_from_prepared(
+                    prep,
+                    name=def_name,
+                    tenant_id=tenant_id,
+                    target_namespace=target_namespace,
+                    created_by=created_by,
+                )
+                imported.append(def_name)
+                if prep.rewrites:
+                    rewrites[def_name] = prep.rewrites
+
+            elif decision.action == "update":
+                # A conflict against a shared system-core type can't be overwritten by a tenant
+                # import — the row isn't tenant-owned, so the update would silently match nothing.
+                # Reject it explicitly rather than report a phantom overwrite.
+                if prep.existing.get("is_system"):
+                    errors.append({
+                        "name": def_name,
+                        "error": "cannot_overwrite_system",
+                        "details": "A system-core type cannot be overwritten by an import",
+                    })
+                else:
+                    # Overwrite the existing row's schema/refs in place; identity is unchanged
+                    # (same name + namespace → same $id), so the edge graph stays consistent.
+                    db.update_primitive(
+                        str(prep.existing["id"]),
+                        tenant_id,
+                        {
+                            "schema": prep.identity['schema'],
+                            "category": determine_category_from_schema(prep.rewritten),
+                            "description": prep.rewritten.get('description'),
+                            "tags": prep.rewritten.get('tags', []),
+                            "draft": prep.identity['draft'],
+                            "refs": prep.refs,
+                        },
+                    )
+                    reconcile_dependents_for_target(prep.schema_id, tenant_id=tenant_id)
+                    overwritten.append(def_name)
+                    if prep.rewrites:
+                        rewrites[def_name] = prep.rewrites
+
+            elif decision.action == "rename":
+                # Re-prepare under the new name so it gets its own registry identity, then
+                # create it — unless that name is itself already taken (a fresh conflict).
+                renamed_prep = _prepare_imported_definition(
+                    decision.new_name,
+                    def_schema,
+                    tenant_id=tenant_id,
+                    tenant_slug=tenant_slug,
+                    target_namespace=target_namespace,
+                    map_core_formats=map_core_formats,
+                )
+                if renamed_prep.status == STATUS_INVALID:
+                    errors.append({"name": def_name, **renamed_prep.error})
+                elif renamed_prep.existing is not None:
+                    errors.append({
+                        "name": def_name,
+                        "error": "rename_conflict",
+                        "details": f"A type named '{decision.new_name}' already exists",
+                    })
+                else:
+                    _create_primitive_from_prepared(
+                        renamed_prep,
+                        name=decision.new_name,
+                        tenant_id=tenant_id,
+                        target_namespace=target_namespace,
+                        created_by=created_by,
+                    )
+                    renamed.append({"from": def_name, "to": decision.new_name})
+                    if renamed_prep.rewrites:
+                        rewrites[decision.new_name] = renamed_prep.rewrites
+
+            elif decision.action == "skip":
+                if decision.outcome == "identical":
+                    identical.append(def_name)
+                else:
+                    skipped.append(def_name)
+
+            else:  # decision.action == "error"
+                errors.append({"name": def_name, "error": decision.reason})
+
         except Exception as e:
+            # A unique-constraint hit means another writer won the race for this identity;
+            # surface it as a skip rather than a hard failure, mirroring prior behavior.
             if "unique constraint" in str(e).lower():
                 skipped.append(def_name)
             else:
                 errors.append({"name": def_name, "error": str(e)})
 
-    return {"imported": imported, "skipped": skipped, "errors": errors, "rewrites": rewrites}
+    return {
+        "imported": imported,
+        "overwritten": overwritten,
+        "renamed": renamed,
+        "identical": identical,
+        "skipped": skipped,
+        "errors": errors,
+        "rewrites": rewrites,
+        "reviews": reviews,
+    }
+
+
+def _review_imported_definitions(
+    definitions: Dict[str, Any],
+    *,
+    tenant_id: str,
+    tenant_slug: str,
+    target_namespace: Optional[str],
+    map_core_formats: bool,
+    dedupe: bool,
+) -> Dict[str, Any]:
+    """Build a dry-run review of a ``name -> schema`` map without writing anything (#3464).
+
+    Classifies each definition New / Identical / Conflict, attaches its draft 2020-12
+    validation report and unresolved-ref mapping, and lists the resolution choices a
+    Conflict offers — the report the import UI (#3469) renders before the user commits.
+
+    Args:
+        definitions: The ``name -> schema fragment`` map to review.
+        tenant_id: The caller's tenant id (scopes the existing-row lookup).
+        tenant_slug: The tenant slug (used for the default base URI).
+        target_namespace: Optional registry namespace the import targets.
+        map_core_formats: Whether recognized formats would be mapped to core types (#3463).
+        dedupe: Whether Identical definitions would be auto-skipped — reflected in the summary.
+
+    Returns:
+        A ``{"status", "summary", "types"}`` review report (plus echoed source context added
+        by the caller). Each ``types`` entry carries name, status, validation report,
+        rewrites, ref counts, the existing row's id, and the allowed resolutions.
+    """
+    types: List[Dict[str, Any]] = []
+    summary = {"new": 0, "identical": 0, "conflict": 0, "invalid": 0}
+
+    for def_name, def_schema in definitions.items():
+        prep = _prepare_imported_definition(
+            def_name,
+            def_schema,
+            tenant_id=tenant_id,
+            tenant_slug=tenant_slug,
+            target_namespace=target_namespace,
+            map_core_formats=map_core_formats,
+        )
+        summary[prep.status] = summary.get(prep.status, 0) + 1
+
+        unresolved = [e for e in (prep.refs or []) if e.get("status") == "unresolved"]
+        types.append({
+            "name": def_name,
+            "status": prep.status,
+            "valid": prep.valid,
+            "validation_errors": prep.validation_errors,
+            "error": prep.error,
+            "schema_id": prep.schema_id,
+            "existing_id": str(prep.existing["id"]) if prep.existing else None,
+            "rewrites": prep.rewrites,
+            "ref_count": len(prep.refs or []),
+            "unresolved_refs": unresolved,
+            "allowed_resolutions": allowed_resolutions(prep.status),
+        })
+
+    return {
+        "status": "review",
+        "dedupe": dedupe,
+        "summary": {**summary, "total": len(types)},
+        "types": types,
+    }
+
+
+def _resolve_import_definitions(
+    request: PrimitiveImportRequest,
+) -> tuple[Dict[str, Any], List[str]]:
+    """Resolve an import request's source document into a ``name -> schema`` map.
+
+    Shared by the commit (``/import``) and review (``/import/review``) endpoints so both
+    interpret the source identically. A type-def bundle is expanded by the bundle importer
+    (#3462) — a malformed bundle is a clear 400 — while JSON Schema / OpenAPI documents
+    extract their ``$defs`` / ``definitions``. The ``selected_definitions`` filter is applied
+    here when ``import_all`` is false.
+
+    Args:
+        request: The import request carrying the source document and selection options.
+
+    Returns:
+        ``(definitions, warnings)`` — the resolved definitions and any non-fatal warnings
+        (e.g. from bundle expansion).
+
+    Raises:
+        HTTPException: 400 for an invalid source kind, a malformed bundle, a document with no
+            definitions, or a selection that matches nothing.
+    """
+    if request.source_kind not in VALID_IMPORT_SOURCE_KINDS:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Invalid source_kind '{request.source_kind}'. "
+                f"Expected one of: {', '.join(sorted(VALID_IMPORT_SOURCE_KINDS))}"
+            )
+        )
+
+    warnings: List[str] = []
+    if request.source_kind == 'type-def-bundle':
+        try:
+            parsed_types, warnings = parse_type_def_bundle(
+                request.schema, source_label=request.source_label
+            )
+        except BundleError as e:
+            raise HTTPException(status_code=400, detail=e.message)
+        definitions: Dict[str, Any] = {p.name: p.schema for p in parsed_types}
+    else:
+        definitions = {}
+        # Check for $defs (JSON Schema 2020-12)
+        if '$defs' in request.schema:
+            definitions.update(request.schema['$defs'])
+        # Check for definitions (older JSON Schema versions)
+        if 'definitions' in request.schema:
+            definitions.update(request.schema['definitions'])
+
+        if not definitions:
+            raise HTTPException(
+                status_code=400,
+                detail="No definitions found in JSON Schema. Schema must contain $defs or definitions."
+            )
+
+    # Filter definitions if specific ones are requested.
+    if not request.import_all and request.selected_definitions:
+        definitions = {
+            k: v for k, v in definitions.items()
+            if k in request.selected_definitions
+        }
+
+    if not definitions:
+        raise HTTPException(
+            status_code=400,
+            detail="No matching definitions found to import"
+        )
+
+    return definitions, warnings
+
+
+def _normalize_resolutions(
+    request: PrimitiveImportRequest,
+) -> Optional[Dict[str, Dict[str, Any]]]:
+    """Validate and flatten a request's per-type conflict resolutions (#3464).
+
+    Args:
+        request: The import request whose ``resolutions`` map is being applied.
+
+    Returns:
+        A ``name -> {"action", "new_name"}`` map of plain dicts, or ``None`` when the
+        request carries no resolutions.
+
+    Raises:
+        HTTPException: 400 if a resolution names an unknown action, or a ``rename`` omits
+            its ``new_name``.
+    """
+    if not request.resolutions:
+        return None
+    normalized: Dict[str, Dict[str, Any]] = {}
+    for name, resolution in request.resolutions.items():
+        if resolution.action not in VALID_ACTIONS:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"Invalid resolution action '{resolution.action}' for '{name}'. "
+                    f"Expected one of: {', '.join(sorted(VALID_ACTIONS))}"
+                )
+            )
+        if resolution.action == ACTION_RENAME and not resolution.new_name:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Resolution for '{name}' is 'rename' but no new_name was provided",
+            )
+        normalized[name] = {"action": resolution.action, "new_name": resolution.new_name}
+    return normalized
+
+
+@router.post("/{tenant_slug}/import/review")
+async def review_import_primitives(
+    tenant_slug: str,
+    request: PrimitiveImportRequest,
+    auth_data: Dict[str, Any] = Depends(validate_authentication)
+) -> Dict[str, Any]:
+    """Dry-run review of an import: conflicts, dedupe, and a validation report (#3464).
+
+    Resolves the source exactly as ``POST /import`` would, but **writes nothing** — it
+    classifies each definition against the registry (New / Identical / Conflict), attaches its
+    draft 2020-12 validation report and unresolved-ref mapping, and lists the resolution
+    choices each conflict offers. This is the report the import wizard (#3469) renders so the
+    user can pick keep / overwrite / rename before committing; the same classification drives
+    the commit, so the committed result matches the review.
+
+    Args:
+        tenant_slug: The tenant slug.
+        request: The import request (source document + options); ``resolutions`` is ignored.
+        auth_data: Authentication data (injected by dependency).
+
+    Returns:
+        A ``{"status": "review", "summary", "types", ...}`` report.
+    """
+    definitions, warnings = _resolve_import_definitions(request)
+
+    review = _review_imported_definitions(
+        definitions,
+        tenant_id=auth_data['tenant_id'],
+        tenant_slug=tenant_slug,
+        target_namespace=request.target_namespace,
+        map_core_formats=request.map_core_formats,
+        dedupe=request.dedupe,
+    )
+
+    return {
+        "source_kind": request.source_kind,
+        "source_label": request.source_label,
+        "target_namespace": request.target_namespace,
+        "warnings": warnings,
+        **review,
+    }
 
 
 @router.post("/{tenant_slug}/import")
@@ -869,63 +1348,18 @@ async def import_primitives(
     Returns:
         Summary of imported primitives plus the id of the recorded provenance row.
     """
-    # Validate the declared source shape against the persisted CHECK constraint.
-    if request.source_kind not in VALID_IMPORT_SOURCE_KINDS:
-        raise HTTPException(
-            status_code=400,
-            detail=(
-                f"Invalid source_kind '{request.source_kind}'. "
-                f"Expected one of: {', '.join(sorted(VALID_IMPORT_SOURCE_KINDS))}"
-            )
-        )
-
-    # Resolve the source into a {name: schema} map of definitions. A type-def bundle is
-    # expanded by the bundle importer (#3462), and a malformed bundle is a clear 400. JSON
-    # Schema / OpenAPI documents extract their $defs / definitions. Each definition's intra-source
-    # and core-format refs are rewritten during commit (#3463), so no source-specific edge
-    # builder is needed here — the rewrite handles #/$defs, #/definitions, and #/types alike.
-    warnings: List[str] = []
-    if request.source_kind == 'type-def-bundle':
-        try:
-            parsed_types, warnings = parse_type_def_bundle(
-                request.schema, source_label=request.source_label
-            )
-        except BundleError as e:
-            raise HTTPException(status_code=400, detail=e.message)
-        definitions = {p.name: p.schema for p in parsed_types}
-    else:
-        definitions = {}
-        # Check for $defs (JSON Schema 2020-12)
-        if '$defs' in request.schema:
-            definitions.update(request.schema['$defs'])
-        # Check for definitions (older JSON Schema versions)
-        if 'definitions' in request.schema:
-            definitions.update(request.schema['definitions'])
-
-        if not definitions:
-            raise HTTPException(
-                status_code=400,
-                detail="No definitions found in JSON Schema. Schema must contain $defs or definitions."
-            )
-
-    # Filter definitions if specific ones are requested
-    if not request.import_all and request.selected_definitions:
-        definitions = {
-            k: v for k, v in definitions.items()
-            if k in request.selected_definitions
-        }
-
-    if not definitions:
-        raise HTTPException(
-            status_code=400,
-            detail="No matching definitions found to import"
-        )
+    # Resolve the source into a {name: schema} map of definitions (shared with /import/review).
+    # A malformed bundle / empty document is a clear 400. Each definition's intra-source and
+    # core-format refs are rewritten during commit (#3463).
+    definitions, warnings = _resolve_import_definitions(request)
+    resolutions = _normalize_resolutions(request)
 
     # Get user_id from auth data (will be None for API key auth)
     created_by = get_authenticated_user_id(auth_data)
 
-    # Commit each definition as a primitive (shared by JSON Schema and bundle imports). Each
-    # definition's refs are rewritten relative + mapped to core types during commit (#3463).
+    # Commit each definition as a primitive (shared by JSON Schema and bundle imports), honoring
+    # the caller's conflict/dedupe resolutions (#3464). Each definition's refs are rewritten
+    # relative + mapped to core types during commit (#3463).
     outcome = _commit_imported_definitions(
         definitions,
         tenant_id=auth_data['tenant_id'],
@@ -933,21 +1367,36 @@ async def import_primitives(
         target_namespace=request.target_namespace,
         created_by=created_by,
         map_core_formats=request.map_core_formats,
+        dedupe=request.dedupe,
+        resolutions=resolutions,
     )
     imported = outcome["imported"]
+    overwritten = outcome["overwritten"]
+    renamed = outcome["renamed"]
+    identical = outcome["identical"]
     skipped = outcome["skipped"]
     errors = outcome["errors"]
     rewrites = outcome["rewrites"]
+    reviews = outcome["reviews"]
 
     # Build the auditable report and persist a provenance record (#3448). The rewrites map
-    # records the $ref rewrites applied per type (#3463) for the import-review table.
+    # records the $ref rewrites applied per type (#3463) for the import-review table, and the
+    # reviews list records each type's New/Identical/Conflict classification so the report can
+    # be shown to match the committed outcome (#3464).
     report = {
         "imported": imported,
+        "overwritten": overwritten,
+        "renamed": renamed,
+        "identical": identical,
         "skipped": skipped,
         "errors": errors,
         "warnings": warnings,
         "rewrites": rewrites,
+        "reviews": reviews,
         "total_imported": len(imported),
+        "total_overwritten": len(overwritten),
+        "total_renamed": len(renamed),
+        "total_identical": len(identical),
         "total_skipped": len(skipped),
         "total_errors": len(errors),
     }
@@ -955,7 +1404,14 @@ async def import_primitives(
         "import_all": request.import_all,
         "selected_definitions": request.selected_definitions,
         "map_core_formats": request.map_core_formats,
+        "dedupe": request.dedupe,
+        "resolutions": resolutions,
     }
+
+    # Rows written = newly created + overwritten + renamed; rows passed over = deduped
+    # identical + kept conflicts. This keeps the provenance counts matching the outcome.
+    written_count = len(imported) + len(overwritten) + len(renamed)
+    passed_over_count = len(identical) + len(skipped)
 
     import_id = None
     try:
@@ -966,8 +1422,8 @@ async def import_primitives(
             source_label=request.source_label,
             target_namespace=request.target_namespace,
             options=options,
-            imported_count=len(imported),
-            skipped_count=len(skipped),
+            imported_count=written_count,
+            skipped_count=passed_over_count,
             error_count=len(errors),
             imported_by=created_by,
         )

--- a/objectified-rest/tests/test_primitives_import_review_routes.py
+++ b/objectified-rest/tests/test_primitives_import_review_routes.py
@@ -270,14 +270,18 @@ def test_commit_dedupes_identical_definitions():
 
 
 def test_commit_invalid_resolution_action_is_400():
+    # Resolution validation (_normalize_resolutions) runs before any registry lookup, so no
+    # get_primitive_by_schema_id stub is needed — the 400 is raised before the commit loop. The
+    # db is patched only to guarantee the route can't reach a real database if that order ever
+    # changed; the lookup is asserted untouched below.
     with patch("app.primitives_routes.db") as mdb:
-        mdb.get_primitive_by_schema_id.return_value = None
         r = _import(
             {"$defs": {"Money": {"type": "object"}}},
             resolutions={"Money": {"action": "explode"}},
         )
     assert r.status_code == 400
     assert "Invalid resolution action" in r.json()["detail"]
+    mdb.get_primitive_by_schema_id.assert_not_called()
 
 
 def test_commit_rename_without_new_name_is_400():

--- a/objectified-rest/tests/test_primitives_import_review_routes.py
+++ b/objectified-rest/tests/test_primitives_import_review_routes.py
@@ -1,0 +1,337 @@
+"""API tests for import review: conflicts, dedupe, validation report, resolutions (#3464).
+
+``POST /v1/primitives/{tenant_slug}/import/review`` classifies each definition against the
+registry without writing, and ``POST .../import`` honors the caller's per-type resolutions on
+commit. The DB is mocked, so these assert on the classification surfaced by the review and on
+the create/update calls the commit makes for each resolution.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.auth import validate_authentication
+from app.main import app
+from app.schema_validation import DRAFT_2020_12_META_URI
+
+client = TestClient(app)
+
+_JWT = {"tenant_id": "t1", "user_id": "u1", "auth_method": "jwt"}
+
+# The $id a Money type imported into tenant acme's default namespace derives.
+MONEY_ID = "https://api.objectified.dev/types/tenant/acme/money"
+
+
+@pytest.fixture(autouse=True)
+def _auth():
+    app.dependency_overrides[validate_authentication] = lambda: _JWT
+    yield
+    app.dependency_overrides.pop(validate_authentication, None)
+
+
+def _stamped(schema, schema_id):
+    """Build the stamped form an imported schema is stored as (matches stamp_identity)."""
+    return {**schema, "$id": schema_id, "$schema": DRAFT_2020_12_META_URI}
+
+
+def _existing_money(schema):
+    """An existing registry row at MONEY_ID carrying the given (stamped) schema."""
+    return {"id": "e-money", "name": "Money", "schema": _stamped(schema, MONEY_ID)}
+
+
+def _review(schema, **extra):
+    body = {"schema": schema, "import_all": True}
+    body.update(extra)
+    return client.post("/v1/primitives/acme/import/review", json=body)
+
+
+def _import(schema, **extra):
+    body = {"schema": schema, "import_all": True}
+    body.update(extra)
+    return client.post("/v1/primitives/acme/import", json=body)
+
+
+# =========================================================================== #
+# Review endpoint — classification & report (writes nothing)
+# =========================================================================== #
+
+
+def test_review_classifies_new_identical_and_conflict():
+    """Three defs against a registry that already holds two of them are classified correctly."""
+    money_schema = {"type": "object"}
+
+    def _lookup(schema_id, tenant_id):
+        if schema_id == MONEY_ID:
+            # Money exists with the SAME schema → identical.
+            return _existing_money(money_schema)
+        if schema_id == "https://api.objectified.dev/types/tenant/acme/invoice":
+            # Invoice exists with a DIFFERENT schema → conflict.
+            return {"id": "e-inv", "schema": {"type": "string"}}
+        return None  # Customer is new
+
+    with patch("app.primitives_routes.db") as mdb:
+        mdb.get_primitive_by_schema_id.side_effect = _lookup
+        r = _review(
+            {
+                "$defs": {
+                    "Money": money_schema,
+                    "Invoice": {"type": "object"},
+                    "Customer": {"type": "object"},
+                }
+            }
+        )
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body["status"] == "review"
+    # Nothing was written.
+    mdb.create_primitive.assert_not_called()
+    mdb.update_primitive.assert_not_called()
+
+    by_name = {t["name"]: t for t in body["types"]}
+    assert by_name["Money"]["status"] == "identical"
+    assert by_name["Invoice"]["status"] == "conflict"
+    assert by_name["Customer"]["status"] == "new"
+    # Only the conflict offers resolution choices.
+    assert by_name["Invoice"]["allowed_resolutions"] == ["keep", "overwrite", "rename"]
+    assert by_name["Customer"]["allowed_resolutions"] == []
+    # The conflict points at the existing row.
+    assert by_name["Invoice"]["existing_id"] == "e-inv"
+
+    assert body["summary"] == {
+        "new": 1,
+        "identical": 1,
+        "conflict": 1,
+        "invalid": 0,
+        "total": 3,
+    }
+
+
+def test_review_reports_validation_errors_for_invalid_definition():
+    with patch("app.primitives_routes.db") as mdb:
+        mdb.get_primitive_by_schema_id.return_value = None
+        r = _review({"$defs": {"Bad": {"type": "stringg"}}})
+
+    assert r.status_code == 200
+    body = r.json()
+    bad = body["types"][0]
+    assert bad["status"] == "invalid"
+    assert bad["valid"] is False
+    assert bad["error"]["error"] == "invalid_schema"
+    assert bad["validation_errors"][0]["path"] == "type"
+    assert body["summary"]["invalid"] == 1
+
+
+# =========================================================================== #
+# Commit — resolutions applied
+# =========================================================================== #
+
+
+def test_commit_conflict_default_keep_surfaces_not_silently_skipped():
+    """A conflict with no resolution is reported (not silently dropped) and nothing is written."""
+    with patch("app.primitives_routes.db") as mdb:
+        mdb.get_primitive_by_schema_id.side_effect = (
+            lambda sid, tid: _existing_money({"type": "string"}) if sid == MONEY_ID else None
+        )
+        mdb.create_primitive_import.return_value = {"id": "imp1"}
+        r = _import({"$defs": {"Money": {"type": "object"}}})
+
+    assert r.status_code == 200
+    body = r.json()
+    mdb.create_primitive.assert_not_called()
+    mdb.update_primitive.assert_not_called()
+    assert body["skipped"] == ["Money"]
+    assert body["imported"] == []
+    # The conflict is surfaced in the per-type review.
+    review = next(t for t in body["reviews"] if t["name"] == "Money")
+    assert review["status"] == "conflict"
+    assert review["existing_id"] == "e-money"
+
+
+def test_commit_overwrite_updates_existing_row():
+    updated = []
+
+    with patch("app.primitives_routes.db") as mdb:
+        mdb.get_primitive_by_schema_id.side_effect = (
+            lambda sid, tid: _existing_money({"type": "string"}) if sid == MONEY_ID else None
+        )
+        mdb.update_primitive.side_effect = lambda pid, tid, updates: updated.append(
+            (pid, updates)
+        ) or {"id": pid}
+        mdb.create_primitive_import.return_value = {"id": "imp1"}
+        r = _import(
+            {"$defs": {"Money": {"type": "object"}}},
+            resolutions={"Money": {"action": "overwrite"}},
+        )
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body["overwritten"] == ["Money"]
+    assert body["total_overwritten"] == 1
+    mdb.create_primitive.assert_not_called()
+    # The existing row was updated with the new (stamped) schema.
+    assert len(updated) == 1
+    pid, updates = updated[0]
+    assert pid == "e-money"
+    assert updates["schema"]["$id"] == MONEY_ID
+    assert updates["schema"]["type"] == "object"
+
+
+def test_commit_rename_creates_under_new_name():
+    created = []
+
+    def _lookup(sid, tid):
+        # Money exists (conflict); the rename target money_v2 does not.
+        if sid == MONEY_ID:
+            return _existing_money({"type": "string"})
+        return None
+
+    with patch("app.primitives_routes.db") as mdb:
+        mdb.get_primitive_by_schema_id.side_effect = _lookup
+        mdb.create_primitive.side_effect = lambda **k: created.append(k) or {"name": k["name"]}
+        mdb.create_primitive_import.return_value = {"id": "imp1"}
+        r = _import(
+            {"$defs": {"Money": {"type": "object"}}},
+            resolutions={"Money": {"action": "rename", "new_name": "money_v2"}},
+        )
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body["renamed"] == [{"from": "Money", "to": "money_v2"}]
+    assert body["total_renamed"] == 1
+    # The new row is created under the renamed identity.
+    assert len(created) == 1
+    assert created[0]["name"] == "money_v2"
+    # The renamed leaf is slugified (lowercased, '_' → '-') the same as any derived $id.
+    assert created[0]["schema_id"] == "https://api.objectified.dev/types/tenant/acme/money-v2"
+
+
+def test_commit_rename_into_existing_name_is_an_error():
+    def _lookup(sid, tid):
+        # Both Money and the rename target already exist → rename collides.
+        if sid == MONEY_ID:
+            return _existing_money({"type": "string"})
+        if sid == "https://api.objectified.dev/types/tenant/acme/money-v2":
+            return {"id": "e-v2", "schema": {"type": "boolean"}}
+        return None
+
+    with patch("app.primitives_routes.db") as mdb:
+        mdb.get_primitive_by_schema_id.side_effect = _lookup
+        mdb.create_primitive_import.return_value = {"id": "imp1"}
+        r = _import(
+            {"$defs": {"Money": {"type": "object"}}},
+            resolutions={"Money": {"action": "rename", "new_name": "money_v2"}},
+        )
+
+    assert r.status_code == 200
+    body = r.json()
+    mdb.create_primitive.assert_not_called()
+    err = next(e for e in body["errors"] if e["name"] == "Money")
+    assert err["error"] == "rename_conflict"
+
+
+def test_commit_overwrite_of_system_type_is_rejected():
+    """A tenant import cannot overwrite a shared system-core type (no phantom overwrite)."""
+    system_row = {"id": "sys-money", "is_system": True, "schema": {"type": "string"}}
+
+    with patch("app.primitives_routes.db") as mdb:
+        mdb.get_primitive_by_schema_id.side_effect = (
+            lambda sid, tid: system_row if sid == MONEY_ID else None
+        )
+        mdb.create_primitive_import.return_value = {"id": "imp1"}
+        r = _import(
+            {"$defs": {"Money": {"type": "object"}}},
+            resolutions={"Money": {"action": "overwrite"}},
+        )
+
+    assert r.status_code == 200
+    body = r.json()
+    mdb.update_primitive.assert_not_called()
+    assert body["overwritten"] == []
+    err = next(e for e in body["errors"] if e["name"] == "Money")
+    assert err["error"] == "cannot_overwrite_system"
+
+
+def test_commit_dedupes_identical_definitions():
+    with patch("app.primitives_routes.db") as mdb:
+        mdb.get_primitive_by_schema_id.side_effect = (
+            lambda sid, tid: _existing_money({"type": "object"}) if sid == MONEY_ID else None
+        )
+        mdb.create_primitive_import.return_value = {"id": "imp1"}
+        r = _import({"$defs": {"Money": {"type": "object"}}})
+
+    assert r.status_code == 200
+    body = r.json()
+    mdb.create_primitive.assert_not_called()
+    assert body["identical"] == ["Money"]
+    assert body["total_identical"] == 1
+    assert body["imported"] == []
+
+
+def test_commit_invalid_resolution_action_is_400():
+    with patch("app.primitives_routes.db") as mdb:
+        mdb.get_primitive_by_schema_id.return_value = None
+        r = _import(
+            {"$defs": {"Money": {"type": "object"}}},
+            resolutions={"Money": {"action": "explode"}},
+        )
+    assert r.status_code == 400
+    assert "Invalid resolution action" in r.json()["detail"]
+
+
+def test_commit_rename_without_new_name_is_400():
+    with patch("app.primitives_routes.db") as mdb:
+        mdb.get_primitive_by_schema_id.return_value = None
+        r = _import(
+            {"$defs": {"Money": {"type": "object"}}},
+            resolutions={"Money": {"action": "rename"}},
+        )
+    assert r.status_code == 400
+    assert "new_name" in r.json()["detail"]
+
+
+def test_commit_report_counts_match_mixed_outcome():
+    """A mixed batch's counts equal its per-type outcomes (report matches outcomes)."""
+    created = []
+    updated = []
+
+    invoice_id = "https://api.objectified.dev/types/tenant/acme/invoice"
+
+    def _lookup(sid, tid):
+        if sid == MONEY_ID:
+            return _existing_money({"type": "string"})  # conflict → overwrite
+        if sid == invoice_id:
+            # Same schema as imported → identical → deduped.
+            return {"id": "e-inv", "schema": _stamped({"type": "object"}, invoice_id)}
+        return None  # Customer → new
+
+    with patch("app.primitives_routes.db") as mdb:
+        mdb.get_primitive_by_schema_id.side_effect = _lookup
+        mdb.create_primitive.side_effect = lambda **k: created.append(k["name"]) or {"name": k["name"]}
+        mdb.update_primitive.side_effect = lambda pid, tid, u: updated.append(pid) or {"id": pid}
+        mdb.create_primitive_import.return_value = {"id": "imp1"}
+        r = _import(
+            {
+                "$defs": {
+                    "Money": {"type": "object"},
+                    "Invoice": {"type": "object"},
+                    "Customer": {"type": "object"},
+                }
+            },
+            resolutions={"Money": {"action": "overwrite"}},
+        )
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body["imported"] == ["Customer"]
+    assert body["overwritten"] == ["Money"]
+    assert body["identical"] == ["Invoice"]
+    assert body["total_imported"] == 1
+    assert body["total_overwritten"] == 1
+    assert body["total_identical"] == 1
+    assert body["total_errors"] == 0
+    # Provenance counts: 2 written (created + overwritten), 1 passed over (deduped).
+    _, kwargs = mdb.create_primitive_import.call_args
+    assert kwargs["imported_count"] == 2
+    assert kwargs["skipped_count"] == 1

--- a/objectified-rest/tests/test_primitives_review.py
+++ b/objectified-rest/tests/test_primitives_review.py
@@ -1,0 +1,122 @@
+"""Unit tests for the pure import-review logic (#3464).
+
+:mod:`app.primitives_review` classifies an imported definition against the existing registry
+(New / Identical / Conflict) and turns a caller's resolution choice (keep / overwrite / rename)
+into a concrete commit decision. These tests exercise that logic in isolation — no DB, no HTTP.
+"""
+
+from app.primitives_review import (
+    ACTION_KEEP,
+    ACTION_OVERWRITE,
+    ACTION_RENAME,
+    OUTCOME_IDENTICAL,
+    OUTCOME_IMPORTED,
+    OUTCOME_OVERWRITTEN,
+    OUTCOME_RENAMED,
+    OUTCOME_SKIPPED,
+    STATUS_CONFLICT,
+    STATUS_IDENTICAL,
+    STATUS_NEW,
+    allowed_resolutions,
+    classify_status,
+    decide,
+    schemas_equivalent,
+)
+
+
+# --------------------------------------------------------------------------- #
+# Classification
+# --------------------------------------------------------------------------- #
+
+
+def test_classify_new_when_no_existing():
+    assert classify_status(None, {"type": "string"}) == STATUS_NEW
+
+
+def test_classify_identical_when_schema_matches():
+    existing = {"schema": {"type": "string", "$id": "x"}}
+    assert classify_status(existing, {"type": "string", "$id": "x"}) == STATUS_IDENTICAL
+
+
+def test_classify_conflict_when_schema_differs():
+    existing = {"schema": {"type": "string", "$id": "x"}}
+    assert classify_status(existing, {"type": "number", "$id": "x"}) == STATUS_CONFLICT
+
+
+def test_schemas_equivalent_is_deep():
+    a = {"type": "object", "properties": {"a": {"type": "string"}}}
+    b = {"type": "object", "properties": {"a": {"type": "string"}}}
+    c = {"type": "object", "properties": {"a": {"type": "number"}}}
+    assert schemas_equivalent(a, b)
+    assert not schemas_equivalent(a, c)
+
+
+# --------------------------------------------------------------------------- #
+# Allowed resolutions (for the review UI)
+# --------------------------------------------------------------------------- #
+
+
+def test_only_conflicts_offer_resolutions():
+    assert allowed_resolutions(STATUS_CONFLICT) == [
+        ACTION_KEEP,
+        ACTION_OVERWRITE,
+        ACTION_RENAME,
+    ]
+    assert allowed_resolutions(STATUS_NEW) == []
+    assert allowed_resolutions(STATUS_IDENTICAL) == []
+
+
+# --------------------------------------------------------------------------- #
+# Decision logic
+# --------------------------------------------------------------------------- #
+
+
+def test_new_decides_create():
+    d = decide(STATUS_NEW)
+    assert d.action == "create"
+    assert d.outcome == OUTCOME_IMPORTED
+
+
+def test_identical_dedupes_by_default():
+    d = decide(STATUS_IDENTICAL, dedupe=True)
+    assert d.action == "skip"
+    assert d.outcome == OUTCOME_IDENTICAL
+
+
+def test_identical_without_dedupe_falls_through_to_resolution():
+    # With dedupe off, an identical type honors the caller's resolution (here: overwrite).
+    d = decide(STATUS_IDENTICAL, action=ACTION_OVERWRITE, dedupe=False)
+    assert d.action == "update"
+    assert d.outcome == OUTCOME_OVERWRITTEN
+
+
+def test_conflict_keep_is_the_default_and_surfaces_as_skipped():
+    d = decide(STATUS_CONFLICT)
+    assert d.action == "skip"
+    assert d.outcome == OUTCOME_SKIPPED
+    assert "unresolved" in (d.reason or "")
+
+
+def test_conflict_overwrite_decides_update():
+    d = decide(STATUS_CONFLICT, action=ACTION_OVERWRITE)
+    assert d.action == "update"
+    assert d.outcome == OUTCOME_OVERWRITTEN
+
+
+def test_conflict_rename_decides_rename_with_new_name():
+    d = decide(STATUS_CONFLICT, action=ACTION_RENAME, new_name="money_v2")
+    assert d.action == "rename"
+    assert d.outcome == OUTCOME_RENAMED
+    assert d.new_name == "money_v2"
+
+
+def test_rename_without_new_name_is_an_error():
+    d = decide(STATUS_CONFLICT, action=ACTION_RENAME, new_name=None)
+    assert d.action == "error"
+    assert "new_name" in (d.reason or "")
+
+
+def test_unknown_action_defaults_to_keep():
+    d = decide(STATUS_CONFLICT, action="bogus")
+    assert d.action == "skip"
+    assert d.outcome == OUTCOME_SKIPPED

--- a/objectified-rest/tests/test_primitives_review.py
+++ b/objectified-rest/tests/test_primitives_review.py
@@ -120,3 +120,12 @@ def test_unknown_action_defaults_to_keep():
     d = decide(STATUS_CONFLICT, action="bogus")
     assert d.action == "skip"
     assert d.outcome == OUTCOME_SKIPPED
+
+
+def test_empty_string_action_defaults_to_keep():
+    # An empty action string is just another unrecognized value: it degrades to the safe
+    # default (keep → surfaced as skipped), never overwrite/rename. The HTTP layer rejects it
+    # upstream with a 400; this documents the pure function's defensive fallback explicitly.
+    d = decide(STATUS_CONFLICT, action="")
+    assert d.action == "skip"
+    assert d.outcome == OUTCOME_SKIPPED

--- a/objectified-rest/tests/test_primitives_scope_routes.py
+++ b/objectified-rest/tests/test_primitives_scope_routes.py
@@ -165,6 +165,7 @@ def test_import_rejects_scope_violating_definition_but_imports_valid():
     with patch("app.primitives_routes.db") as mdb:
         mdb.create_primitive.side_effect = _create
         mdb.create_primitive_import.return_value = {"id": "imp1"}
+        mdb.get_primitive_by_schema_id.return_value = None  # clean registry — all New (#3464)
         r = client.post(
             "/v1/primitives/acme/import",
             json={

--- a/objectified-rest/tests/test_primitives_validation_routes.py
+++ b/objectified-rest/tests/test_primitives_validation_routes.py
@@ -192,6 +192,7 @@ def test_import_rejects_invalid_definition_but_imports_valid():
     with patch("app.primitives_routes.db") as mdb:
         mdb.create_primitive.side_effect = _create
         mdb.create_primitive_import.return_value = {"id": "imp1"}
+        mdb.get_primitive_by_schema_id.return_value = None  # clean registry — all New (#3464)
         r = client.post(
             "/v1/primitives/acme/import",
             json={
@@ -262,6 +263,7 @@ def test_import_stamps_identity_using_target_namespace():
     with patch("app.primitives_routes.db") as mdb:
         mdb.create_primitive.return_value = {"name": "Good"}
         mdb.create_primitive_import.return_value = {"id": "imp1"}
+        mdb.get_primitive_by_schema_id.return_value = None  # clean registry — all New (#3464)
         r = client.post(
             "/v1/primitives/acme/import",
             json={

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -45,6 +45,7 @@ We continue to improve the platform based on your feedback with improvements and
 - **`objectified-cli`**: shared output layer (`lib/output.ts`) with `this.output` on `BaseCommand` — tables (`cli-table3`), stable sorted JSON/YAML, ora spinners, stderr warnings/errors, and TTY / `--json` / `--quiet` / `--no-color` / `LANG=C` behavior; Vitest snapshots cover render modes (#3189).
 
 ## Import
+- **Primitives import review** (`objectified-rest`): `POST /v1/primitives/{tenant}/import/review` dry-runs an import and classifies each definition as **New**, **Identical**, or **Conflict** against the registry, with a draft 2020-12 validation report, `$ref` rewrites, and resolution choices; `POST …/import` honors `dedupe` (default on) and per-type `resolutions` (`keep` / `overwrite` / `rename`) so conflicts are surfaced instead of skipped silently (#3464).
 - Import supports Swagger 2.0 format
 - Adds the ability to import multiple versions of the same project 
 


### PR DESCRIPTION
## What & why

Sub-issue of Epic 4 (#3442). Closes the import-review gap: imports used to skip duplicates
silently (a `skipped` bucket) with no conflict/dedupe/validation UX. This adds **New / Conflict /
Identical** detection, **keep / overwrite / rename** resolution, and a **draft 2020-12 validation
report** — wired so the committed outcome matches the review the user saw.

### New `app/primitives_review.py` (pure logic)
- `classify_status(existing, candidate)` → **New** (no visible type holds the derived `$id`),
  **Identical** (same `$id` + deep-equal schema), or **Conflict** (same `$id`, different schema).
- `decide(status, action, new_name, dedupe)` → a concrete commit decision
  (`create` / `update` / `rename` / `skip` / `error`). No DB, no FastAPI — fully unit-tested.

### New `POST /v1/primitives/{tenant_slug}/import/review`
A dry-run that resolves the source exactly as `POST /import` would but **writes nothing**,
returning per-type classification, the draft 2020-12 validation report, the `$ref` rewrites
(#3463), the unresolved-ref mapping, and the resolution choices each conflict offers. The shared
`_prepare_imported_definition` pipeline drives the commit too, so the committed result can't
disagree with the review (the import wizard #3469 renders this report).

### `POST /v1/primitives/{tenant_slug}/import` now honors review choices
- New request fields: `dedupe` (default `true` → Identical skipped) and `resolutions`
  (`name -> {action, new_name}`).
- `overwrite` updates the existing row in place; `rename` creates a slugified copy (errors if the
  target name is taken); default `keep` **surfaces** the conflict (`skipped`) instead of dropping it.
- A system-core type cannot be overwritten by a tenant import (explicit error, no phantom overwrite).
- Report gains `overwritten` / `renamed` / `identical` buckets + totals and a per-type `reviews`
  list; provenance counts reflect rows written (created+overwritten+renamed) vs. passed over
  (deduped+kept).

## How to test
- `cd objectified-rest && PYTHONPATH=src .venv/bin/python -m pytest tests/test_primitives_review.py tests/test_primitives_import_review_routes.py -q`
- **Manual review:** `POST /v1/primitives/{tenant}/import/review` with
  `{"schema": {"$defs": {"Money": {"type": "object"}}}, "import_all": true}` against a tenant that
  already has a different `money` → the response shows `Money` as a **conflict** with
  `allowed_resolutions: ["keep","overwrite","rename"]` and writes nothing.
- **Manual commit:** repeat against `POST /import` with
  `"resolutions": {"Money": {"action": "overwrite"}}` → the existing row is updated and the report
  lists `Money` under `overwritten`; or `{"action":"rename","new_name":"money_v2"}` → a new
  `money-v2` row, reported under `renamed`. Importing an identical `Money` → reported under
  `identical` (deduped), nothing written.

## Risk / notes
- **Behavior change:** a name collision is no longer a silent `skipped`. New (clean registry) imports
  are unaffected — every definition classifies as New and imports as before. Three existing import
  route tests now declare an empty registry (`get_primitive_by_schema_id -> None`) to express that.
- Regenerated `openapi.{json,yaml}`; bumped `objectified-rest` to 1.0.20 (npm) / 1.0.90 (py); updated
  CHANGELOG and ROADMAP.
- Pre-existing, unrelated failures in the merge/publish/version/change-report suites are present on
  `main` (confirmed via `git stash`) and untouched by this change.

Closes #3464

Work performed by Claude Code via model claude-opus-4-8[1m]

🤖 Generated with [Claude Code](https://claude.com/claude-code)