### PR TITLE
Fix #3467 - Enhance Primitives overview (registry KPIs)

### DIFF
--- a/docs/ROADMAP_TYPE_REGISTRY_GOVERNANCE.md
+++ b/docs/ROADMAP_TYPE_REGISTRY_GOVERNANCE.md
@@ -584,7 +584,7 @@ The in-app surface under **Control Panel → Governance**, matching the `governa
 | Issue | Title | Summary | Labels | Parallel | MVP | Complexity | Affected Modules |
 |---|---|---|---|:---:|:---:|---|---|
 | 5.1 #3466 | ~~Governance nav entry + route group~~ | **CLOSED — duplicate** (`/ade/dashboard/primitives` in nav) | `type-registry`,`ui`,`governance`,`mvp`,`roadmap-type-registry` | N | Y | S | objectified-ui |
-| 5.2 #3467 | Enhance Primitives overview (registry KPIs) | Extend existing page: KPIs, namespace collections, activity | `type-registry`,`ui`,`mvp`,`roadmap-type-registry` | Y | Y | M | objectified-ui |
+| 5.2 #3467 ✅ | Enhance Primitives overview (registry KPIs) | **DONE** — KPI strip from stats API, namespace collections, recent import activity, row click → type detail | `type-registry`,`ui`,`mvp`,`roadmap-type-registry` | Y | Y | M | objectified-ui |
 | 5.3 #3468 | Type detail page | Schema, resolved refs, dependents, metadata | `type-registry`,`ui`,`mvp`,`roadmap-type-registry` | Y | Y | M | objectified-ui |
 | 5.4 #3469 | Import UI (wizard) | Source/options/review wired to Epic 4 | `type-registry`,`ui`,`import`,`mvp`,`roadmap-type-registry` | Y | Y | L | objectified-ui |
 | 5.5 #3470 | Reference Resolver UI | Graph + table, base, unresolved/circular | `type-registry`,`ui`,`mvp`,`roadmap-type-registry` | Y | Y | M | objectified-ui |
@@ -862,7 +862,7 @@ epic.
 | #3440 E2 | #3450 (2.1) · #3451 (2.2) · #3452 (2.3) · #3453 (2.4) · #3454 (2.5) · ~~#3455 (2.6)~~ ✅ closed |
 | #3441 E3 | #3456 (3.1) · #3457 (3.2) · #3458 (3.3) · #3459 (3.4) |
 | #3442 E4 | #3460 (4.1) · #3461 (4.2) · #3462 (4.3) · #3463 (4.4) · #3464 (4.5) · #3465 (4.6) |
-| #3443 E5 | ~~#3466 (5.1)~~ ✅ closed · #3467 (5.2) · #3468 (5.3) · #3469 (5.4) · #3470 (5.5) · #3471 (5.6) · #3472 (5.7) · #3473 (5.8) |
+| #3443 E5 | ~~#3466 (5.1)~~ ✅ closed · ~~#3467 (5.2)~~ ✅ · #3468 (5.3) · #3469 (5.4) · #3470 (5.5) · #3471 (5.6) · #3472 (5.7) · #3473 (5.8) |
 | #3444 E6 | #3474 (6.1) · #3475 (6.2) · #3476 (6.3) · #3477 (6.4) |
 | #3445 E7 | #3478 (7.1) · #3479 (7.2) · #3480 (7.3) · #3481 (7.4) · #3482 (7.5) |
 

--- a/objectified-rest/pyproject.toml
+++ b/objectified-rest/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "objectified-rest"
-version = "1.0.90"
+version = "1.0.91"
 description = "REST API for serving OpenAPI specifications from the Objectified database"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/objectified-rest/src/app/database.py
+++ b/objectified-rest/src/app/database.py
@@ -1457,6 +1457,73 @@ class Database:
             "affected_primitive_count": int(row.get("affected_primitive_count") or 0),
         }
 
+    def get_registry_coverage_stats(self, tenant_id: str) -> Dict[str, int]:
+        """Aggregate registry coverage KPIs for the Primitives overview (#3454).
+
+        Type counts use the tenant's own ``odb.primitives`` rows (system-core types are
+        seeded per tenant). Property bindings count ``class_properties`` rows in the
+        tenant's projects that carry a ``primitive_id`` or ``primitive_ref``.
+
+        Args:
+            tenant_id: The caller's tenant id.
+
+        Returns:
+            Counts for core/tenant/imported types, bindings, unresolved refs, and namespaces.
+        """
+        query = """
+            WITH type_counts AS (
+                SELECT
+                    COUNT(*) FILTER (WHERE is_system) AS core_type_count,
+                    COUNT(*) FILTER (WHERE NOT is_system) AS tenant_type_count,
+                    COUNT(*) FILTER (WHERE source = 'imported') AS imported_count,
+                    COUNT(DISTINCT namespace) FILTER (WHERE namespace IS NOT NULL)
+                        AS namespace_count
+                FROM odb.primitives
+                WHERE tenant_id = %s
+            ),
+            binding_counts AS (
+                SELECT
+                    COUNT(*) AS properties_bound_count,
+                    COUNT(DISTINCT cp.class_id) AS bound_class_count
+                FROM odb.class_properties cp
+                JOIN odb.classes c ON cp.class_id = c.id
+                JOIN odb.versions v ON c.version_id = v.id
+                JOIN odb.projects p ON v.project_id = p.id
+                WHERE p.tenant_id = %s
+                  AND (cp.primitive_id IS NOT NULL OR cp.primitive_ref IS NOT NULL)
+            ),
+            unresolved AS (
+                SELECT
+                    COUNT(*) FILTER (WHERE edge->>'status' = 'unresolved')
+                        AS unresolved_ref_count
+                FROM odb.primitives p
+                LEFT JOIN LATERAL jsonb_array_elements(p.refs) AS edge ON true
+                WHERE p.tenant_id = %s
+            )
+            SELECT
+                tc.core_type_count,
+                tc.tenant_type_count,
+                tc.imported_count,
+                tc.namespace_count,
+                bc.properties_bound_count,
+                bc.bound_class_count,
+                u.unresolved_ref_count
+            FROM type_counts tc
+            CROSS JOIN binding_counts bc
+            CROSS JOIN unresolved u
+        """
+        results = self.execute_query(query, (tenant_id, tenant_id, tenant_id))
+        row = results[0] if results else {}
+        return {
+            "core_type_count": int(row.get("core_type_count") or 0),
+            "tenant_type_count": int(row.get("tenant_type_count") or 0),
+            "imported_count": int(row.get("imported_count") or 0),
+            "namespace_count": int(row.get("namespace_count") or 0),
+            "properties_bound_count": int(row.get("properties_bound_count") or 0),
+            "bound_class_count": int(row.get("bound_class_count") or 0),
+            "unresolved_ref_count": int(row.get("unresolved_ref_count") or 0),
+        }
+
     def get_primitives_with_unresolved_refs(self, tenant_id: str) -> List[Dict[str, Any]]:
         """List the tenant's primitives that have at least one unresolved ``$ref`` edge (#3457).
 

--- a/objectified-rest/src/app/models.py
+++ b/objectified-rest/src/app/models.py
@@ -424,6 +424,28 @@ class ResolveResponse(BaseModel):
         from_attributes = True
 
 
+# ==================== Registry coverage/stats (#3454) ====================
+
+
+class RegistryCoverageStatsResponse(BaseModel):
+    """Aggregate registry coverage KPIs for the Primitives overview (#3454).
+
+    Counts are scoped to the caller's tenant: system-core types are seeded per tenant
+    (``is_system = true`` rows owned by the tenant), tenant types are private rows
+    (``is_system = false``). ``unresolved_ref_count`` mirrors ``GET …/unresolved`` (#3457).
+    """
+    core_type_count: int = 0
+    tenant_type_count: int = 0
+    imported_count: int = 0
+    properties_bound_count: int = 0
+    bound_class_count: int = 0
+    unresolved_ref_count: int = 0
+    namespace_count: int = 0
+
+    class Config:
+        from_attributes = True
+
+
 # ==================== Type-registry namespaces (#3451) ====================
 
 

--- a/objectified-rest/src/app/type_namespaces_routes.py
+++ b/objectified-rest/src/app/type_namespaces_routes.py
@@ -21,6 +21,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from .auth import get_authenticated_user_id, validate_authentication
 from .database import db
 from .models import (
+    RegistryCoverageStatsResponse,
     ResolvedPrimitiveRefs,
     ResolvedRefEdge,
     ResolveResponse,
@@ -100,6 +101,27 @@ def _to_schema(row: Dict[str, Any]) -> TypeNamespaceSchema:
         created_at=row.get("created_at"),
         updated_at=row.get("updated_at"),
     )
+
+
+@router.get("/{tenant_slug}/stats", response_model=RegistryCoverageStatsResponse)
+async def get_registry_coverage_stats(
+    tenant_slug: str,
+    auth_data: Dict[str, Any] = Depends(validate_authentication),
+) -> RegistryCoverageStatsResponse:
+    """Return aggregate registry coverage KPIs for the Primitives overview (#3454).
+
+    Counts core vs tenant types, imported schemas, property bindings, unresolved ``$ref``
+    edges, and distinct namespaces. Feeds the Governance → Primitives KPI strip (#3467).
+
+    Args:
+        tenant_slug: The tenant slug.
+        auth_data: Authentication data (injected by dependency).
+
+    Returns:
+        ``RegistryCoverageStatsResponse`` with the tenant's registry coverage counts.
+    """
+    stats = db.get_registry_coverage_stats(auth_data["tenant_id"])
+    return RegistryCoverageStatsResponse(**stats)
 
 
 @router.get("/{tenant_slug}/namespaces")

--- a/objectified-rest/tests/test_primitives_registry_stats.py
+++ b/objectified-rest/tests/test_primitives_registry_stats.py
@@ -1,0 +1,50 @@
+"""API tests for registry coverage/stats endpoint (#3454)."""
+
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.auth import validate_authentication
+from app.main import app
+
+client = TestClient(app)
+
+_JWT_ADMIN = {"tenant_id": "t1", "user_id": "admin-user", "auth_method": "jwt"}
+
+
+@pytest.fixture(autouse=True)
+def _default_auth():
+    app.dependency_overrides[validate_authentication] = lambda: _JWT_ADMIN
+    yield
+    app.dependency_overrides.pop(validate_authentication, None)
+
+
+def test_registry_stats_ok():
+    with patch("app.type_namespaces_routes.db") as mdb:
+        mdb.get_registry_coverage_stats.return_value = {
+            "core_type_count": 36,
+            "tenant_type_count": 12,
+            "imported_count": 5,
+            "properties_bound_count": 42,
+            "bound_class_count": 8,
+            "unresolved_ref_count": 3,
+            "namespace_count": 4,
+        }
+        r = client.get("/v1/types/acme/stats")
+    assert r.status_code == 200
+    data = r.json()
+    assert data["core_type_count"] == 36
+    assert data["tenant_type_count"] == 12
+    assert data["imported_count"] == 5
+    assert data["properties_bound_count"] == 42
+    assert data["bound_class_count"] == 8
+    assert data["unresolved_ref_count"] == 3
+    assert data["namespace_count"] == 4
+    mdb.get_registry_coverage_stats.assert_called_once_with("t1")
+
+
+def test_registry_stats_requires_auth():
+    app.dependency_overrides.pop(validate_authentication, None)
+    r = client.get("/v1/types/acme/stats")
+    assert r.status_code in (401, 403)

--- a/objectified-rest/tests/test_primitives_registry_stats_db.py
+++ b/objectified-rest/tests/test_primitives_registry_stats_db.py
@@ -1,0 +1,49 @@
+"""Database tests for registry coverage/stats aggregation (#3454)."""
+
+from unittest.mock import MagicMock, patch
+
+from app.database import Database
+
+
+def test_get_registry_coverage_stats_maps_row():
+    db = Database()
+    db.execute_query = MagicMock(
+        return_value=[
+            {
+                "core_type_count": 10,
+                "tenant_type_count": 4,
+                "imported_count": 2,
+                "namespace_count": 3,
+                "properties_bound_count": 15,
+                "bound_class_count": 5,
+                "unresolved_ref_count": 1,
+            }
+        ]
+    )
+    out = db.get_registry_coverage_stats("tenant-1")
+    assert out == {
+        "core_type_count": 10,
+        "tenant_type_count": 4,
+        "imported_count": 2,
+        "namespace_count": 3,
+        "properties_bound_count": 15,
+        "bound_class_count": 5,
+        "unresolved_ref_count": 1,
+    }
+    db.execute_query.assert_called_once()
+    assert db.execute_query.call_args[0][1] == ("tenant-1", "tenant-1", "tenant-1")
+
+
+def test_get_registry_coverage_stats_empty():
+    db = Database()
+    db.execute_query = MagicMock(return_value=[])
+    out = db.get_registry_coverage_stats("tenant-1")
+    assert out == {
+        "core_type_count": 0,
+        "tenant_type_count": 0,
+        "imported_count": 0,
+        "namespace_count": 0,
+        "properties_bound_count": 0,
+        "bound_class_count": 0,
+        "unresolved_ref_count": 0,
+    }

--- a/objectified-rest/uv.lock
+++ b/objectified-rest/uv.lock
@@ -550,7 +550,7 @@ wheels = [
 
 [[package]]
 name = "objectified-rest"
-version = "1.0.85"
+version = "1.0.90"
 source = { editable = "." }
 dependencies = [
     { name = "bcrypt" },

--- a/objectified-ui/lib/primitives-api-proxy.ts
+++ b/objectified-ui/lib/primitives-api-proxy.ts
@@ -1,0 +1,62 @@
+/**
+ * Shared helpers for /api/primitives/* and /api/types/* proxy routes.
+ */
+
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/app/api/auth/[...nextauth]/route';
+import { getTenantById } from '@lib/db/helper';
+import { createRestAuthHeaders, REST_API_BASE_URL } from '@lib/rest-auth';
+
+export interface SessionUser {
+  user_id?: string;
+  email?: string | null;
+  name?: string | null;
+  current_tenant_id?: string;
+}
+
+export async function getAuthenticatedTenantContext(): Promise<
+  | { ok: true; user: SessionUser; tenantSlug: string }
+  | { ok: false; status: number; error: string }
+> {
+  const session = await getServerSession(authOptions);
+  const user = session?.user as SessionUser | undefined;
+
+  if (!user?.user_id) {
+    return { ok: false, status: 401, error: 'Unauthorized' };
+  }
+  if (!user.current_tenant_id) {
+    return { ok: false, status: 400, error: 'No tenant selected' };
+  }
+
+  const tenant = await getTenantById(user.current_tenant_id);
+  if (!tenant?.slug) {
+    return { ok: false, status: 404, error: 'Tenant not found' };
+  }
+
+  return { ok: true, user, tenantSlug: tenant.slug };
+}
+
+export async function proxyRestGet(
+  user: SessionUser,
+  path: string
+): Promise<{ data: unknown; error: string | null; status: number }> {
+  const response = await fetch(`${REST_API_BASE_URL}${path}`, {
+    method: 'GET',
+    headers: createRestAuthHeaders(user),
+    cache: 'no-store',
+  });
+
+  const contentType = response.headers.get('content-type');
+  if (!contentType?.includes('application/json')) {
+    const text = await response.text();
+    return { data: null, error: text || 'Request failed', status: response.status || 500 };
+  }
+
+  const data = await response.json();
+  if (!response.ok) {
+    const detail = typeof data?.detail === 'string' ? data.detail : 'Request failed';
+    return { data: null, error: detail, status: response.status };
+  }
+
+  return { data, error: null, status: response.status };
+}

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.125",
+  "version": "0.11.126",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/public/WHATS_NEW.md
+++ b/objectified-ui/public/WHATS_NEW.md
@@ -44,6 +44,9 @@ We continue to improve the platform based on your feedback with improvements and
 - **`objectified-cli`**: TOML config with XDG / Windows paths, `default_profile`, `objectified config path|get|set|list`, auto-created `config.toml` (`0600` on Unix), strict profile validation, env-based API keys only, and tenant slug from config/env (#3188).
 - **`objectified-cli`**: shared output layer (`lib/output.ts`) with `this.output` on `BaseCommand` — tables (`cli-table3`), stable sorted JSON/YAML, ora spinners, stderr warnings/errors, and TTY / `--json` / `--quiet` / `--no-color` / `LANG=C` behavior; Vitest snapshots cover render modes (#3189).
 
+## Governance
+- **Primitives overview** (`objectified-ui`): Governance → Primitives now shows registry KPIs (core/tenant/imported/bound/unresolved), namespace collections with scope filters, a recent-import activity feed, and row click-through to a type detail page — backed by `GET /v1/types/{tenant}/stats` (#3454) and new `/api/primitives/*` proxies (#3467).
+
 ## Import
 - **Primitives import review** (`objectified-rest`): `POST /v1/primitives/{tenant}/import/review` dry-runs an import and classifies each definition as **New**, **Identical**, or **Conflict** against the registry, with a draft 2020-12 validation report, `$ref` rewrites, and resolution choices; `POST …/import` honors `dedupe` (default on) and per-type `resolutions` (`keep` / `overwrite` / `rename`) so conflicts are surfaced instead of skipped silently (#3464).
 - Import supports Swagger 2.0 format

--- a/objectified-ui/src/app/ade/dashboard/primitives/PrimitivesManagementClient.tsx
+++ b/objectified-ui/src/app/ade/dashboard/primitives/PrimitivesManagementClient.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useCallback, useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
 import { useSession } from 'next-auth/react';
 import {
   Database,
@@ -9,7 +10,6 @@ import {
   Trash2,
   Search,
   FileCode,
-  Tag,
   AlertCircle,
   CheckCircle,
   Upload,
@@ -24,10 +24,19 @@ import { LoadingState } from '@/app/components/ui/LoadingState';
 import { useDialog } from '@/app/components/providers/DialogProvider';
 import PrimitiveEditorDialog from './PrimitiveEditorDialog';
 import PrimitiveImportDialog from './PrimitiveImportDialog';
+import PrimitivesRegistryKpiStrip from './PrimitivesRegistryKpiStrip';
+import PrimitivesNamespaceCollections from './PrimitivesNamespaceCollections';
+import PrimitivesRecentActivity from './PrimitivesRecentActivity';
+import {
+  countUnresolvedByNamespace,
+  type NamespaceScopeFilter,
+  type PrimitiveImportActivity,
+  type RegistryCoverageStats,
+  type TypeNamespaceCollection,
+} from './primitivesRegistryTypes';
 import {
   dashboardContentStackClass,
   dashboardMainClass,
-  dashboardPanelClass,
   dashboardPanelPaddedClass,
   dashboardTableWrapClass,
   dashboardTableTheadClass,
@@ -50,25 +59,36 @@ interface Primitive {
   is_public: boolean;
   usage_count: number;
   enabled: boolean;
+  source?: string;
+  namespace?: string | null;
+  schema_id?: string | null;
+  draft?: string;
   created_at: string;
   updated_at: string;
 }
 
 export default function PrimitivesManagementClient() {
+  const router = useRouter();
   const { data: session } = useSession();
   const { confirm } = useDialog();
 
   const [primitives, setPrimitives] = useState<Primitive[]>([]);
   const [filteredPrimitives, setFilteredPrimitives] = useState<Primitive[]>([]);
   const [loading, setLoading] = useState(true);
+  const [registryLoading, setRegistryLoading] = useState(true);
   const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
 
-  // Filters
+  const [stats, setStats] = useState<RegistryCoverageStats | null>(null);
+  const [namespaces, setNamespaces] = useState<TypeNamespaceCollection[]>([]);
+  const [imports, setImports] = useState<PrimitiveImportActivity[]>([]);
+  const [unresolvedByNamespace, setUnresolvedByNamespace] = useState<Record<string, number>>({});
+
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedCategory, setSelectedCategory] = useState<string>('all');
   const [showSystemPrimitives, setShowSystemPrimitives] = useState(true);
+  const [namespaceScopeFilter, setNamespaceScopeFilter] = useState<NamespaceScopeFilter>('all');
+  const [selectedNamespace, setSelectedNamespace] = useState<string | null>(null);
 
-  // Dialogs
   const [showEditorDialog, setShowEditorDialog] = useState(false);
   const [showImportDialog, setShowImportDialog] = useState(false);
   const [editingPrimitive, setEditingPrimitive] = useState<Primitive | null>(null);
@@ -77,6 +97,51 @@ export default function PrimitivesManagementClient() {
 
   const sortByName = (items: Primitive[]) =>
     [...items].sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }));
+
+  const showMessage = useCallback((type: 'success' | 'error', text: string) => {
+    setMessage({ type, text });
+    setTimeout(() => setMessage(null), 5000);
+  }, []);
+
+  const loadRegistryOverview = useCallback(async () => {
+    setRegistryLoading(true);
+    try {
+      const [statsRes, namespacesRes, importsRes, unresolvedRes] = await Promise.all([
+        fetch('/api/primitives/stats'),
+        fetch('/api/types/namespaces'),
+        fetch('/api/primitives/imports?limit=8'),
+        fetch('/api/primitives/unresolved'),
+      ]);
+
+      const [statsData, namespacesData, importsData, unresolvedData] = await Promise.all([
+        statsRes.json(),
+        namespacesRes.json(),
+        importsRes.json(),
+        unresolvedRes.json(),
+      ]);
+
+      if (statsData.success) {
+        setStats(statsData.stats as RegistryCoverageStats);
+      }
+      if (namespacesData.success) {
+        setNamespaces(namespacesData.namespaces as TypeNamespaceCollection[]);
+      }
+      if (importsData.success) {
+        setImports(importsData.imports as PrimitiveImportActivity[]);
+      }
+      if (unresolvedData.success && unresolvedData.unresolved?.primitives) {
+        setUnresolvedByNamespace(
+          countUnresolvedByNamespace(unresolvedData.unresolved.primitives)
+        );
+      } else {
+        setUnresolvedByNamespace({});
+      }
+    } catch (error) {
+      console.error('Error loading registry overview:', error);
+    } finally {
+      setRegistryLoading(false);
+    }
+  }, []);
 
   const loadPrimitives = useCallback(async () => {
     if (!currentTenantId) {
@@ -88,7 +153,6 @@ export default function PrimitivesManagementClient() {
     try {
       const response = await fetch('/api/primitives');
 
-      // Check if response is ok before parsing
       if (!response.ok) {
         const text = await response.text();
         console.error('API error:', response.status, text);
@@ -110,48 +174,50 @@ export default function PrimitivesManagementClient() {
     } finally {
       setLoading(false);
     }
-  }, [currentTenantId]);
+  }, [currentTenantId, showMessage]);
+
+  const refreshAll = useCallback(async () => {
+    await Promise.all([loadPrimitives(), loadRegistryOverview()]);
+  }, [loadPrimitives, loadRegistryOverview]);
 
   const filterPrimitives = useCallback(() => {
     let filtered = [...primitives];
 
-    // Filter by system/tenant
     if (!showSystemPrimitives) {
-      filtered = filtered.filter(p => !p.is_system);
+      filtered = filtered.filter((p) => !p.is_system);
     }
 
-    // Filter by category
     if (selectedCategory !== 'all') {
-      filtered = filtered.filter(p => p.category === selectedCategory);
+      filtered = filtered.filter((p) => p.category === selectedCategory);
     }
 
-    // Filter by search query
+    if (selectedNamespace) {
+      filtered = filtered.filter((p) => (p.namespace ?? '') === selectedNamespace);
+    }
+
     if (searchQuery.trim()) {
       const query = searchQuery.toLowerCase();
-      filtered = filtered.filter(p =>
-        p.name.toLowerCase().includes(query) ||
-        p.description?.toLowerCase().includes(query) ||
-        p.tags.some(tag => tag.toLowerCase().includes(query))
+      filtered = filtered.filter(
+        (p) =>
+          p.name.toLowerCase().includes(query) ||
+          p.description?.toLowerCase().includes(query) ||
+          p.tags.some((tag) => tag.toLowerCase().includes(query)) ||
+          p.namespace?.toLowerCase().includes(query)
       );
     }
 
     setFilteredPrimitives(sortByName(filtered));
-  }, [primitives, searchQuery, selectedCategory, showSystemPrimitives]);
+  }, [primitives, searchQuery, selectedCategory, showSystemPrimitives, selectedNamespace]);
 
   useEffect(() => {
     if (currentTenantId) {
-      loadPrimitives();
+      void refreshAll();
     }
-  }, [currentTenantId, loadPrimitives]);
+  }, [currentTenantId, refreshAll]);
 
   useEffect(() => {
     filterPrimitives();
   }, [filterPrimitives]);
-
-  const showMessage = (type: 'success' | 'error', text: string) => {
-    setMessage({ type, text });
-    setTimeout(() => setMessage(null), 5000);
-  };
 
   const handleCreatePrimitive = () => {
     setEditingPrimitive(null);
@@ -167,7 +233,8 @@ export default function PrimitivesManagementClient() {
     setShowEditorDialog(true);
   };
 
-  const handleDeletePrimitive = async (primitive: Primitive) => {
+  const handleDeletePrimitive = async (primitive: Primitive, event: React.MouseEvent) => {
+    event.stopPropagation();
     if (primitive.is_system) {
       showMessage('error', 'System primitives cannot be deleted');
       return;
@@ -192,7 +259,7 @@ export default function PrimitivesManagementClient() {
 
       if (data.success) {
         showMessage('success', 'Primitive deleted successfully');
-        await loadPrimitives();
+        await refreshAll();
       } else {
         showMessage('error', data.error || 'Failed to delete primitive');
       }
@@ -203,22 +270,24 @@ export default function PrimitivesManagementClient() {
   };
 
   const handleSavePrimitive = async () => {
-    await loadPrimitives();
+    await refreshAll();
     setShowEditorDialog(false);
   };
 
   const handleImportComplete = async () => {
-    await loadPrimitives();
+    await refreshAll();
     setShowImportDialog(false);
   };
 
-  const categories = Array.from(new Set(primitives.map(p => p.category))).sort();
-  const stats = {
-    total: primitives.length,
-    system: primitives.filter(p => p.is_system).length,
-    tenant: primitives.filter(p => !p.is_system).length,
-    categories: categories.length,
+  const handleRowClick = (primitive: Primitive) => {
+    router.push(`/ade/dashboard/primitives/${primitive.id}`);
   };
+
+  const handleNamespaceSelect = (namespace: string) => {
+    setSelectedNamespace((current) => (current === namespace ? null : namespace));
+  };
+
+  const categories = Array.from(new Set(primitives.map((p) => p.category))).sort();
 
   if (!currentTenantId) {
     return (
@@ -233,7 +302,6 @@ export default function PrimitivesManagementClient() {
 
   return (
     <>
-      {/* Header */}
       <header className="border-b border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800">
         <div className="px-6 py-4">
           <div className="flex items-center justify-between">
@@ -243,14 +311,12 @@ export default function PrimitivesManagementClient() {
                 Primitives
               </h2>
               <p className="text-gray-600 dark:text-gray-400 text-sm mt-1">
-                Manage your tenant&apos;s reusable JSON Schema primitive definitions
+                JSON Schema 2020-12 type registry · core system &amp; tenant scopes · relative{' '}
+                <span className="font-mono">$ref</span> resolution
               </p>
             </div>
             <div className="flex items-center gap-3">
-              <Button
-                onClick={() => setShowImportDialog(true)}
-                variant="secondary"
-              >
+              <Button onClick={() => setShowImportDialog(true)} variant="secondary">
                 <Upload className="w-4 h-4 mr-2" />
                 Import from Schema
               </Button>
@@ -263,10 +329,8 @@ export default function PrimitivesManagementClient() {
         </div>
       </header>
 
-      {/* Main Content */}
-      <main className={dashboardMainClass} aria-busy={loading}>
+      <main className={dashboardMainClass} aria-busy={loading || registryLoading}>
         <div className={dashboardContentStackClass}>
-          {/* Message Banner */}
           {message && (
             <Alert variant={message.type === 'success' ? 'default' : 'error'}>
               {message.type === 'success' ? (
@@ -278,56 +342,20 @@ export default function PrimitivesManagementClient() {
             </Alert>
           )}
 
-          {loading ? (
-            <div className={dashboardTableWrapClass}>
-              <LoadingState minHeightClassName="min-h-[220px]" message="Loading primitives…" />
-            </div>
-          ) : (
-            <>
-          {/* Statistics */}
-          <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-            <div className={`${dashboardPanelClass} p-4`}>
-              <div className="flex items-center justify-between">
-                <div>
-                  <p className="text-sm text-gray-600 dark:text-gray-400">Total Primitives</p>
-                  <p className="text-2xl font-bold text-gray-900 dark:text-white mt-1">{stats.total}</p>
-                </div>
-                <Database className="w-8 h-8 text-indigo-600 dark:text-indigo-400 opacity-50" />
-              </div>
-            </div>
+          <PrimitivesRegistryKpiStrip stats={stats} loading={registryLoading} />
 
-            <div className={`${dashboardPanelClass} p-4`}>
-              <div className="flex items-center justify-between">
-                <div>
-                  <p className="text-sm text-gray-600 dark:text-gray-400">System</p>
-                  <p className="text-2xl font-bold text-gray-900 dark:text-white mt-1">{stats.system}</p>
-                </div>
-                <Shield className="w-8 h-8 text-blue-600 dark:text-blue-400 opacity-50" />
-              </div>
-            </div>
-
-            <div className={`${dashboardPanelClass} p-4`}>
-              <div className="flex items-center justify-between">
-                <div>
-                  <p className="text-sm text-gray-600 dark:text-gray-400">Tenant</p>
-                  <p className="text-2xl font-bold text-gray-900 dark:text-white mt-1">{stats.tenant}</p>
-                </div>
-                <FileCode className="w-8 h-8 text-green-600 dark:text-green-400 opacity-50" />
-              </div>
-            </div>
-
-            <div className={`${dashboardPanelClass} p-4`}>
-              <div className="flex items-center justify-between">
-                <div>
-                  <p className="text-sm text-gray-600 dark:text-gray-400">Categories</p>
-                  <p className="text-2xl font-bold text-gray-900 dark:text-white mt-1">{stats.categories}</p>
-                </div>
-                <Tag className="w-8 h-8 text-purple-600 dark:text-purple-400 opacity-50" />
-              </div>
-            </div>
+          <div className="grid grid-cols-1 xl:grid-cols-3 gap-6">
+            <PrimitivesNamespaceCollections
+              namespaces={namespaces}
+              unresolvedByNamespace={unresolvedByNamespace}
+              scopeFilter={namespaceScopeFilter}
+              onScopeFilterChange={setNamespaceScopeFilter}
+              onNamespaceSelect={handleNamespaceSelect}
+              loading={registryLoading}
+            />
+            <PrimitivesRecentActivity imports={imports} loading={registryLoading} />
           </div>
 
-          {/* Filters */}
           <div className={dashboardPanelPaddedClass}>
             <div className="flex flex-col md:flex-row gap-4">
               <div className="flex-1">
@@ -343,15 +371,27 @@ export default function PrimitivesManagementClient() {
                 </div>
               </div>
 
-              <div className="flex items-center gap-4">
+              <div className="flex items-center gap-4 flex-wrap">
+                {selectedNamespace ? (
+                  <button
+                    type="button"
+                    onClick={() => setSelectedNamespace(null)}
+                    className="text-xs px-2 py-1 rounded-full bg-indigo-100 text-indigo-700 dark:bg-indigo-900/40 dark:text-indigo-300"
+                  >
+                    Namespace: {selectedNamespace} ×
+                  </button>
+                ) : null}
+
                 <select
                   value={selectedCategory}
                   onChange={(e) => setSelectedCategory(e.target.value)}
                   className="px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
                 >
                   <option value="all">All Categories</option>
-                  {categories.map(cat => (
-                    <option key={cat} value={cat}>{cat}</option>
+                  {categories.map((cat) => (
+                    <option key={cat} value={cat}>
+                      {cat}
+                    </option>
                   ))}
                 </select>
 
@@ -365,21 +405,17 @@ export default function PrimitivesManagementClient() {
                   <span className="text-sm text-gray-700 dark:text-gray-300">Show System</span>
                 </label>
 
-                <Button
-                  variant="secondary"
-                  size="sm"
-                  onClick={loadPrimitives}
-                  disabled={loading}
-                >
-                  <RefreshCw className={`w-4 h-4 ${loading ? 'animate-spin' : ''}`} />
+                <Button variant="secondary" size="sm" onClick={refreshAll} disabled={loading || registryLoading}>
+                  <RefreshCw className={`w-4 h-4 ${loading || registryLoading ? 'animate-spin' : ''}`} />
                 </Button>
               </div>
             </div>
           </div>
 
-          {/* Primitives Table */}
           <div className={dashboardTableWrapClass}>
-            {filteredPrimitives.length === 0 ? (
+            {loading ? (
+              <LoadingState minHeightClassName="min-h-[220px]" message="Loading primitives…" />
+            ) : filteredPrimitives.length === 0 ? (
               <div className="p-6">
                 <EmptyState
                   icon={<Database className="h-8 w-8" />}
@@ -395,34 +431,21 @@ export default function PrimitivesManagementClient() {
                 <table className="w-full">
                   <thead className={dashboardTableTheadClass}>
                     <tr>
-                      <th className={dashboardThClass}>
-                        Name
-                      </th>
-                      <th className={dashboardThClass}>
-                        Category
-                      </th>
-                      <th className={dashboardThClass}>
-                        Description
-                      </th>
-                      <th className={dashboardThClass}>
-                        Tags
-                      </th>
-                      <th className={dashboardThClass}>
-                        Usage
-                      </th>
-                      <th className={dashboardThClass}>
-                        Type
-                      </th>
-                      <th className={dashboardThRightClass}>
-                        Actions
-                      </th>
+                      <th className={dashboardThClass}>Name</th>
+                      <th className={dashboardThClass}>Namespace</th>
+                      <th className={dashboardThClass}>Category</th>
+                      <th className={dashboardThClass}>Description</th>
+                      <th className={dashboardThClass}>Usage</th>
+                      <th className={dashboardThClass}>Type</th>
+                      <th className={dashboardThRightClass}>Actions</th>
                     </tr>
                   </thead>
                   <tbody className={dashboardTbodyClass}>
                     {filteredPrimitives.map((primitive) => (
                       <tr
                         key={primitive.id}
-                        className={dashboardTrHoverClass}
+                        className={`${dashboardTrHoverClass} cursor-pointer`}
+                        onClick={() => handleRowClick(primitive)}
                       >
                         <td className="px-6 py-4 whitespace-nowrap">
                           <div className="flex items-center">
@@ -433,28 +456,21 @@ export default function PrimitivesManagementClient() {
                           </div>
                         </td>
                         <td className="px-6 py-4 whitespace-nowrap">
+                          <span className="text-xs font-mono text-gray-600 dark:text-gray-400">
+                            {primitive.namespace ?? '—'}
+                          </span>
+                        </td>
+                        <td className="px-6 py-4 whitespace-nowrap">
                           <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-indigo-100 text-indigo-800 dark:bg-indigo-900/30 dark:text-indigo-300">
                             {primitive.category}
                           </span>
                         </td>
                         <td className="px-6 py-4">
-                          <div className="text-sm text-gray-600 dark:text-gray-400 max-w-xs line-clamp-3" title={primitive.description || undefined}>
+                          <div
+                            className="text-sm text-gray-600 dark:text-gray-400 max-w-xs line-clamp-3"
+                            title={primitive.description || undefined}
+                          >
                             {primitive.description || '—'}
-                          </div>
-                        </td>
-                        <td className="px-6 py-4">
-                          <div className="flex flex-wrap gap-1">
-                            {primitive.tags.slice(0, 3).map((tag, idx) => (
-                              <span
-                                key={idx}
-                                className="inline-flex items-center px-2 py-0.5 rounded text-xs bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300"
-                              >
-                                {tag}
-                              </span>
-                            ))}
-                            {primitive.tags.length > 3 && (
-                              <span className="text-xs text-gray-500">+{primitive.tags.length - 3}</span>
-                            )}
                           </div>
                         </td>
                         <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-600 dark:text-gray-400">
@@ -475,7 +491,10 @@ export default function PrimitivesManagementClient() {
                         <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
                           <div className="flex items-center justify-end gap-2">
                             <button
-                              onClick={() => handleEditPrimitive(primitive)}
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                handleEditPrimitive(primitive);
+                              }}
                               disabled={primitive.is_system}
                               className="text-indigo-600 hover:text-indigo-900 dark:text-indigo-400 dark:hover:text-indigo-300 disabled:opacity-50 disabled:cursor-not-allowed"
                               title={primitive.is_system ? 'System primitives cannot be edited' : 'Edit primitive'}
@@ -483,7 +502,7 @@ export default function PrimitivesManagementClient() {
                               <Edit className="w-4 h-4" />
                             </button>
                             <button
-                              onClick={() => handleDeletePrimitive(primitive)}
+                              onClick={(e) => handleDeletePrimitive(primitive, e)}
                               disabled={primitive.is_system}
                               className="text-red-600 hover:text-red-900 dark:text-red-400 dark:hover:text-red-300 disabled:opacity-50 disabled:cursor-not-allowed"
                               title={primitive.is_system ? 'System primitives cannot be deleted' : 'Delete primitive'}
@@ -499,12 +518,9 @@ export default function PrimitivesManagementClient() {
               </div>
             )}
           </div>
-            </>
-          )}
         </div>
       </main>
 
-      {/* Dialogs */}
       {showEditorDialog && (
         <PrimitiveEditorDialog
           primitive={editingPrimitive}

--- a/objectified-ui/src/app/ade/dashboard/primitives/PrimitivesNamespaceCollections.tsx
+++ b/objectified-ui/src/app/ade/dashboard/primitives/PrimitivesNamespaceCollections.tsx
@@ -1,0 +1,189 @@
+'use client';
+
+import {
+  FolderTree,
+  Shapes,
+  Library,
+  Building2,
+  Download,
+} from 'lucide-react';
+import {
+  dashboardPanelClass,
+  dashboardTableTheadClass,
+  dashboardThClass,
+  dashboardThRightClass,
+  dashboardTbodyClass,
+  dashboardTrHoverClass,
+} from '@/app/components/ade/dashboard/dashboardScreenClasses';
+import type { NamespaceScopeFilter, TypeNamespaceCollection } from './primitivesRegistryTypes';
+
+interface PrimitivesNamespaceCollectionsProps {
+  namespaces: TypeNamespaceCollection[];
+  unresolvedByNamespace: Record<string, number>;
+  scopeFilter: NamespaceScopeFilter;
+  onScopeFilterChange: (filter: NamespaceScopeFilter) => void;
+  onNamespaceSelect: (namespace: string) => void;
+  loading: boolean;
+}
+
+const SCOPE_FILTERS: { id: NamespaceScopeFilter; label: string }[] = [
+  { id: 'all', label: 'All' },
+  { id: 'system', label: 'System · core' },
+  { id: 'tenant', label: 'Tenant' },
+  { id: 'imported', label: 'Imported' },
+];
+
+function namespaceIcon(namespace: string, isImported: boolean) {
+  if (isImported) return Download;
+  if (namespace.startsWith('std/')) return namespace.includes('primitives') ? Shapes : Library;
+  return Building2;
+}
+
+function scopeBadge(scope: 'system' | 'tenant') {
+  if (scope === 'system') {
+    return (
+      <span className="text-[10px] uppercase tracking-wider px-1.5 py-0.5 rounded bg-teal-100 text-teal-700 dark:bg-teal-900/40 dark:text-teal-300">
+        System · core
+      </span>
+    );
+  }
+  return (
+    <span className="text-[10px] uppercase tracking-wider px-1.5 py-0.5 rounded bg-indigo-100 text-indigo-700 dark:bg-indigo-900/40 dark:text-indigo-300">
+      Tenant
+    </span>
+  );
+}
+
+function statusBadge(unresolvedCount: number) {
+  if (unresolvedCount > 0) {
+    return (
+      <span className="text-[10px] uppercase tracking-wider px-1.5 py-0.5 rounded bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300">
+        {unresolvedCount} unresolved
+      </span>
+    );
+  }
+  return (
+    <span className="text-[10px] uppercase tracking-wider px-1.5 py-0.5 rounded bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300">
+      Resolved
+    </span>
+  );
+}
+
+export default function PrimitivesNamespaceCollections({
+  namespaces,
+  unresolvedByNamespace,
+  scopeFilter,
+  onScopeFilterChange,
+  onNamespaceSelect,
+  loading,
+}: PrimitivesNamespaceCollectionsProps) {
+  const filtered = namespaces.filter((ns) => {
+    if (scopeFilter === 'system') return ns.scope === 'system';
+    if (scopeFilter === 'tenant') return ns.scope === 'tenant';
+    if (scopeFilter === 'imported') {
+      return ns.scope === 'tenant' && !ns.is_default && !ns.namespace.startsWith('tenant/');
+    }
+    return true;
+  });
+
+  return (
+    <section className={`${dashboardPanelClass} xl:col-span-2 overflow-hidden`}>
+      <div className="px-5 py-4 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900 flex flex-col sm:flex-row sm:items-center justify-between gap-3">
+        <div className="flex items-center gap-3">
+          <FolderTree className="w-5 h-5 text-indigo-600 dark:text-indigo-400" />
+          <div>
+            <h3 className="text-base font-semibold text-gray-900 dark:text-white">Type collections</h3>
+            <p className="text-xs text-gray-500 dark:text-gray-400">
+              Grouped by namespace · click a row to filter types below
+            </p>
+          </div>
+        </div>
+        <div className="flex items-center gap-1 border border-gray-200 dark:border-gray-700 rounded-md p-0.5 text-xs">
+          {SCOPE_FILTERS.map(({ id, label }) => (
+            <button
+              key={id}
+              type="button"
+              onClick={() => onScopeFilterChange(id)}
+              className={`px-2 py-1 rounded transition-colors ${
+                scopeFilter === id
+                  ? 'bg-indigo-500/10 text-indigo-600 dark:text-indigo-400 font-medium'
+                  : 'text-gray-500 dark:text-gray-400 hover:text-indigo-500'
+              }`}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {loading ? (
+        <div className="p-6 text-sm text-gray-500 dark:text-gray-400">Loading namespaces…</div>
+      ) : filtered.length === 0 ? (
+        <div className="p-6 text-sm text-gray-500 dark:text-gray-400">No namespace collections match this filter.</div>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead className={dashboardTableTheadClass}>
+              <tr>
+                <th className={dashboardThClass}>Namespace</th>
+                <th className={dashboardThClass}>Scope</th>
+                <th className={dashboardThRightClass}>Types</th>
+                <th className={dashboardThClass}>Draft</th>
+                <th className={dashboardThRightClass}>Status</th>
+              </tr>
+            </thead>
+            <tbody className={dashboardTbodyClass}>
+              {filtered.map((ns) => {
+                const unresolved = unresolvedByNamespace[ns.namespace] ?? 0;
+                const isImported =
+                  scopeFilter === 'imported' ||
+                  (!ns.is_system && !ns.namespace.startsWith('std/') && !ns.namespace.startsWith('tenant/'));
+                const Icon = namespaceIcon(ns.namespace, isImported);
+                return (
+                  <tr
+                    key={ns.id}
+                    className={`${dashboardTrHoverClass} cursor-pointer`}
+                    onClick={() => onNamespaceSelect(ns.namespace)}
+                  >
+                    <td className="px-5 py-3">
+                      <div className="flex items-center gap-3">
+                        <span className="w-8 h-8 rounded-md bg-indigo-100 dark:bg-indigo-900/40 inline-flex items-center justify-center text-indigo-600 dark:text-indigo-300">
+                          <Icon className="w-4 h-4" />
+                        </span>
+                        <div>
+                          <p className="font-medium font-mono text-gray-900 dark:text-white">
+                            {ns.namespace}
+                            {isImported ? (
+                              <span className="ml-2 text-[9px] px-1 rounded bg-sky-100 dark:bg-sky-900/40 text-sky-600 dark:text-sky-300 uppercase">
+                                imported
+                              </span>
+                            ) : null}
+                          </p>
+                          {ns.description ? (
+                            <p className="text-[10px] text-gray-400 line-clamp-1">{ns.description}</p>
+                          ) : null}
+                        </div>
+                      </div>
+                    </td>
+                    <td className="px-3 py-3">{scopeBadge(ns.scope)}</td>
+                    <td className="px-3 py-3 text-right font-mono text-xs text-gray-700 dark:text-gray-300">
+                      {ns.type_count}
+                    </td>
+                    <td className="px-3 py-3 font-mono text-xs text-gray-400">2020-12</td>
+                    <td className="px-5 py-3 text-right">{statusBadge(unresolved)}</td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <div className="px-5 py-3 border-t border-gray-100 dark:border-gray-700/60 text-xs text-gray-500 dark:text-gray-400 flex items-center justify-between">
+        <span>
+          {filtered.length} of {namespaces.length} collection{namespaces.length === 1 ? '' : 's'}
+        </span>
+      </div>
+    </section>
+  );
+}

--- a/objectified-ui/src/app/ade/dashboard/primitives/PrimitivesRecentActivity.tsx
+++ b/objectified-ui/src/app/ade/dashboard/primitives/PrimitivesRecentActivity.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import Link from 'next/link';
+import { Waypoints } from 'lucide-react';
+import { dashboardPanelClass } from '@/app/components/ade/dashboard/dashboardScreenClasses';
+import {
+  formatRelativeTime,
+  sourceKindLabel,
+  type PrimitiveImportActivity,
+} from './primitivesRegistryTypes';
+
+interface PrimitivesRecentActivityProps {
+  imports: PrimitiveImportActivity[];
+  loading: boolean;
+}
+
+function activityDot(sourceKind: string) {
+  if (sourceKind === 'type-def-bundle') return 'bg-teal-400';
+  if (sourceKind === 'openapi') return 'bg-purple-400';
+  return 'bg-sky-400';
+}
+
+export default function PrimitivesRecentActivity({ imports, loading }: PrimitivesRecentActivityProps) {
+  return (
+    <div className="space-y-6">
+      <section className={`${dashboardPanelClass} p-5`}>
+        <h3 className="text-sm font-semibold mb-2 flex items-center gap-2 text-gray-900 dark:text-white">
+          <Waypoints className="w-4 h-4 text-indigo-600 dark:text-indigo-400" />
+          Relative <span className="font-mono">$ref</span> resolution
+        </h3>
+        <p className="text-[11px] text-gray-500 dark:text-gray-400 mb-2">
+          References resolve against the type&apos;s import-source base URL in the API server.
+        </p>
+        <div className="rounded-lg bg-gray-900 dark:bg-black/40 p-3 font-mono text-[10px] leading-relaxed text-gray-300 overflow-x-auto">
+          <span className="text-gray-500"># std/v0/types/date</span>
+          <br />
+          &quot;$ref&quot;: <span className="text-emerald-300">&quot;../primitives/string&quot;</span>
+          <br />
+          <span className="text-gray-500"># base</span> api.objectified.dev/types/
+          <span className="text-indigo-300">std/v0/types/</span>
+          <br />
+          <span className="text-gray-500"># resolves →</span>{' '}
+          <span className="text-indigo-300">std/v0/primitives/string</span>
+        </div>
+        <Link
+          href="/ade/dashboard/primitives?focus=resolver"
+          className="text-[11px] text-indigo-600 dark:text-indigo-400 hover:underline mt-2 inline-block"
+        >
+          Open reference resolver →
+        </Link>
+      </section>
+
+      <section className={`${dashboardPanelClass} p-5`}>
+        <h3 className="text-sm font-semibold mb-3 text-gray-900 dark:text-white">Recent activity</h3>
+        {loading ? (
+          <p className="text-xs text-gray-500 dark:text-gray-400">Loading activity…</p>
+        ) : imports.length === 0 ? (
+          <p className="text-xs text-gray-500 dark:text-gray-400">No import activity yet.</p>
+        ) : (
+          <ul className="space-y-3 text-xs">
+            {imports.map((item) => (
+              <li key={item.id} className="flex gap-2 items-start">
+                <span className={`w-1.5 h-1.5 rounded-full mt-1.5 shrink-0 ${activityDot(item.source_kind)}`} />
+                <div>
+                  <p className="font-medium text-gray-700 dark:text-gray-300">
+                    Imported{' '}
+                    <span className="font-mono">{item.source_label ?? 'schema'}</span>
+                    {item.imported_count > 0 ? ` (${item.imported_count} type${item.imported_count === 1 ? '' : 's'})` : ''}
+                  </p>
+                  <p className="text-gray-400">
+                    {sourceKindLabel(item.source_kind)}
+                    {item.target_namespace ? ` · ${item.target_namespace}` : ''}
+                    {item.created_at ? ` · ${formatRelativeTime(item.created_at)}` : ''}
+                  </p>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/objectified-ui/src/app/ade/dashboard/primitives/PrimitivesRegistryKpiStrip.tsx
+++ b/objectified-ui/src/app/ade/dashboard/primitives/PrimitivesRegistryKpiStrip.tsx
@@ -1,0 +1,120 @@
+'use client';
+
+import Link from 'next/link';
+import {
+  Shield,
+  Building2,
+  Download,
+  Link2,
+  AlertTriangle,
+} from 'lucide-react';
+import { dashboardPanelClass } from '@/app/components/ade/dashboard/dashboardScreenClasses';
+import type { RegistryCoverageStats } from './primitivesRegistryTypes';
+
+interface PrimitivesRegistryKpiStripProps {
+  stats: RegistryCoverageStats | null;
+  loading: boolean;
+}
+
+function KpiCard({
+  label,
+  value,
+  subtitle,
+  icon,
+  valueClassName,
+  href,
+}: {
+  label: string;
+  value: string | number;
+  subtitle?: string;
+  icon: React.ReactNode;
+  valueClassName?: string;
+  href?: string;
+}) {
+  const content = (
+    <div className={`${dashboardPanelClass} p-4 h-full`}>
+      <div className="flex items-center justify-between">
+        <p className="text-xs text-gray-600 dark:text-gray-400">{label}</p>
+        {icon}
+      </div>
+      <p className={`text-2xl font-bold mt-2 font-mono ${valueClassName ?? 'text-gray-900 dark:text-white'}`}>
+        {value}
+      </p>
+      {subtitle ? (
+        <p className="text-[10px] text-gray-500 dark:text-gray-400 mt-1 font-mono">{subtitle}</p>
+      ) : null}
+      {href ? (
+        <span className="text-[10px] text-indigo-600 dark:text-indigo-400 mt-1 inline-block font-mono">
+          open resolver →
+        </span>
+      ) : null}
+    </div>
+  );
+
+  if (href) {
+    return (
+      <Link href={href} className="block hover:opacity-90 transition-opacity">
+        {content}
+      </Link>
+    );
+  }
+
+  return content;
+}
+
+export default function PrimitivesRegistryKpiStrip({ stats, loading }: PrimitivesRegistryKpiStripProps) {
+  if (loading || !stats) {
+    return (
+      <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <div key={i} className={`${dashboardPanelClass} p-4 animate-pulse h-24`} />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
+      <KpiCard
+        label="Core system types"
+        value={stats.core_type_count}
+        subtitle="std/* · all tenants"
+        icon={<Shield className="w-4 h-4 text-teal-500 opacity-70" />}
+        valueClassName="text-indigo-600 dark:text-indigo-400"
+      />
+      <KpiCard
+        label="Tenant types"
+        value={stats.tenant_type_count}
+        subtitle={`${stats.namespace_count} namespace${stats.namespace_count === 1 ? '' : 's'}`}
+        icon={<Building2 className="w-4 h-4 text-emerald-500 opacity-70" />}
+      />
+      <KpiCard
+        label="Imported schemas"
+        value={stats.imported_count}
+        subtitle="JSON Schema + bundles"
+        icon={<Download className="w-4 h-4 text-sky-500 opacity-70" />}
+      />
+      <KpiCard
+        label="Properties bound"
+        value={stats.properties_bound_count.toLocaleString()}
+        subtitle={
+          stats.bound_class_count > 0
+            ? `across ${stats.bound_class_count.toLocaleString()} class${stats.bound_class_count === 1 ? '' : 'es'}`
+            : 'no bindings yet'
+        }
+        icon={<Link2 className="w-4 h-4 text-indigo-500 opacity-70" />}
+      />
+      <KpiCard
+        label="Unresolved $ref"
+        value={stats.unresolved_ref_count}
+        icon={<AlertTriangle className="w-4 h-4 text-amber-500 opacity-70" />}
+        valueClassName={
+          stats.unresolved_ref_count > 0
+            ? 'text-amber-600 dark:text-amber-400'
+            : 'text-gray-900 dark:text-white'
+        }
+        href={stats.unresolved_ref_count > 0 ? '/ade/dashboard/primitives?focus=resolver' : undefined}
+      />
+    </div>
+  );
+}

--- a/objectified-ui/src/app/ade/dashboard/primitives/[id]/PrimitiveDetailClient.tsx
+++ b/objectified-ui/src/app/ade/dashboard/primitives/[id]/PrimitiveDetailClient.tsx
@@ -1,0 +1,200 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import Link from 'next/link';
+import { useParams, useRouter } from 'next/navigation';
+import { ArrowLeft, FileCode, AlertCircle, Shield } from 'lucide-react';
+import { Alert } from '@/app/components/ui/Alert';
+import { LoadingState } from '@/app/components/ui/LoadingState';
+import { Button } from '@/app/components/ui/Button';
+import {
+  dashboardMainClass,
+  dashboardPanelClass,
+  dashboardPanelPaddedClass,
+} from '@/app/components/ade/dashboard/dashboardScreenClasses';
+
+interface PrimitiveDetail {
+  id: string;
+  name: string;
+  description: string | null;
+  category: string;
+  schema: Record<string, unknown>;
+  is_system: boolean;
+  namespace?: string | null;
+  schema_id?: string | null;
+  base_uri?: string | null;
+  draft?: string;
+  source?: string;
+  refs?: Array<{ relative_ref?: string; resolved_target?: string; status?: string }>;
+  usage_count: number;
+  tags?: string[];
+}
+
+export default function PrimitiveDetailClient() {
+  const params = useParams<{ id: string }>();
+  const router = useRouter();
+  const [primitive, setPrimitive] = useState<PrimitiveDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadPrimitive = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await fetch(`/api/primitives/${params.id}`);
+      const data = await response.json();
+      if (!response.ok || !data.success) {
+        setError(data.error || 'Failed to load primitive');
+        setPrimitive(null);
+        return;
+      }
+      setPrimitive(data.primitive as PrimitiveDetail);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load primitive');
+      setPrimitive(null);
+    } finally {
+      setLoading(false);
+    }
+  }, [params.id]);
+
+  useEffect(() => {
+    if (params.id) {
+      void loadPrimitive();
+    }
+  }, [params.id, loadPrimitive]);
+
+  return (
+    <>
+      <header className="border-b border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800">
+        <div className="px-6 py-4">
+          <div className="flex items-center gap-3 mb-2">
+            <Button variant="secondary" size="sm" onClick={() => router.push('/ade/dashboard/primitives')}>
+              <ArrowLeft className="w-4 h-4 mr-1" />
+              Back
+            </Button>
+          </div>
+          <h2 className="text-2xl font-bold text-gray-900 dark:text-white flex items-center gap-2">
+            <FileCode className="w-6 h-6 text-indigo-600 dark:text-indigo-400" />
+            {loading ? 'Loading type…' : primitive?.name ?? 'Type detail'}
+          </h2>
+          <p className="text-gray-600 dark:text-gray-400 text-sm mt-1">
+            Registry type detail · schema, references, and metadata
+          </p>
+        </div>
+      </header>
+
+      <main className={dashboardMainClass}>
+        {loading ? (
+          <LoadingState minHeightClassName="min-h-[240px]" message="Loading type detail…" />
+        ) : error ? (
+          <Alert variant="error">
+            <AlertCircle className="h-4 w-4" />
+            <span>{error}</span>
+          </Alert>
+        ) : primitive ? (
+          <div className="space-y-6">
+            <section className={`${dashboardPanelClass} ${dashboardPanelPaddedClass}`}>
+              <div className="flex flex-wrap items-center gap-2 mb-4">
+                {primitive.is_system ? (
+                  <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300">
+                    <Shield className="w-3 h-3 mr-1" />
+                    System
+                  </span>
+                ) : (
+                  <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300">
+                    Tenant
+                  </span>
+                )}
+                <span className="text-xs font-mono text-gray-500 dark:text-gray-400">
+                  {primitive.namespace ?? 'no namespace'}
+                </span>
+                {primitive.schema_id ? (
+                  <span className="text-xs font-mono text-gray-500 dark:text-gray-400">{primitive.schema_id}</span>
+                ) : null}
+              </div>
+              <dl className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
+                <div>
+                  <dt className="text-gray-500 dark:text-gray-400">Category</dt>
+                  <dd className="font-medium text-gray-900 dark:text-white">{primitive.category}</dd>
+                </div>
+                <div>
+                  <dt className="text-gray-500 dark:text-gray-400">Draft</dt>
+                  <dd className="font-mono text-gray-900 dark:text-white">{primitive.draft ?? '2020-12'}</dd>
+                </div>
+                <div>
+                  <dt className="text-gray-500 dark:text-gray-400">Source</dt>
+                  <dd className="text-gray-900 dark:text-white">{primitive.source ?? 'human'}</dd>
+                </div>
+                <div>
+                  <dt className="text-gray-500 dark:text-gray-400">Usage</dt>
+                  <dd className="text-gray-900 dark:text-white">{primitive.usage_count}</dd>
+                </div>
+                {primitive.description ? (
+                  <div className="md:col-span-2">
+                    <dt className="text-gray-500 dark:text-gray-400">Description</dt>
+                    <dd className="text-gray-900 dark:text-white">{primitive.description}</dd>
+                  </div>
+                ) : null}
+              </dl>
+            </section>
+
+            {(primitive.refs?.length ?? 0) > 0 ? (
+              <section className={`${dashboardPanelClass} overflow-hidden`}>
+                <div className="px-5 py-4 border-b border-gray-200 dark:border-gray-700">
+                  <h3 className="text-base font-semibold text-gray-900 dark:text-white">Reference resolution</h3>
+                </div>
+                <div className="overflow-x-auto">
+                  <table className="w-full text-sm">
+                    <thead className="bg-gray-50 dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700">
+                      <tr>
+                        <th className="px-5 py-2 text-left text-xs uppercase text-gray-500">$ref</th>
+                        <th className="px-5 py-2 text-left text-xs uppercase text-gray-500">Target</th>
+                        <th className="px-5 py-2 text-right text-xs uppercase text-gray-500">Status</th>
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
+                      {primitive.refs?.map((edge, index) => (
+                        <tr key={`${edge.relative_ref}-${index}`}>
+                          <td className="px-5 py-3 font-mono text-xs">{edge.relative_ref ?? '—'}</td>
+                          <td className="px-5 py-3 font-mono text-xs text-gray-600 dark:text-gray-400">
+                            {edge.resolved_target ?? '—'}
+                          </td>
+                          <td className="px-5 py-3 text-right">
+                            <span
+                              className={`text-[10px] uppercase tracking-wider px-1.5 py-0.5 rounded ${
+                                edge.status === 'unresolved'
+                                  ? 'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300'
+                                  : 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300'
+                              }`}
+                            >
+                              {edge.status ?? 'unknown'}
+                            </span>
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </section>
+            ) : null}
+
+            <section className={`${dashboardPanelClass} overflow-hidden`}>
+              <div className="px-5 py-4 border-b border-gray-200 dark:border-gray-700 flex items-center justify-between">
+                <h3 className="text-base font-semibold text-gray-900 dark:text-white">JSON Schema</h3>
+                <Link
+                  href={`/ade/dashboard/primitives?edit=${primitive.id}`}
+                  className="text-xs text-indigo-600 dark:text-indigo-400 hover:underline"
+                >
+                  Edit in overview →
+                </Link>
+              </div>
+              <pre className="p-5 text-xs font-mono overflow-x-auto text-gray-800 dark:text-gray-200 bg-gray-50 dark:bg-gray-900/40">
+                {JSON.stringify(primitive.schema, null, 2)}
+              </pre>
+            </section>
+          </div>
+        ) : null}
+      </main>
+    </>
+  );
+}

--- a/objectified-ui/src/app/ade/dashboard/primitives/[id]/page.tsx
+++ b/objectified-ui/src/app/ade/dashboard/primitives/[id]/page.tsx
@@ -1,0 +1,5 @@
+import PrimitiveDetailClient from './PrimitiveDetailClient';
+
+export default function PrimitiveDetailPage() {
+  return <PrimitiveDetailClient />;
+}

--- a/objectified-ui/src/app/ade/dashboard/primitives/primitivesRegistryTypes.ts
+++ b/objectified-ui/src/app/ade/dashboard/primitives/primitivesRegistryTypes.ts
@@ -1,0 +1,78 @@
+export interface RegistryCoverageStats {
+  core_type_count: number;
+  tenant_type_count: number;
+  imported_count: number;
+  properties_bound_count: number;
+  bound_class_count: number;
+  unresolved_ref_count: number;
+  namespace_count: number;
+}
+
+export interface TypeNamespaceCollection {
+  id: string;
+  tenant_id: string | null;
+  namespace: string;
+  base_uri: string;
+  version_root: string | null;
+  description: string | null;
+  scope: 'system' | 'tenant';
+  is_system: boolean;
+  is_public: boolean;
+  is_default: boolean;
+  type_count: number;
+  created_at?: string | null;
+  updated_at?: string | null;
+}
+
+export interface PrimitiveImportActivity {
+  id: string;
+  tenant_id: string;
+  source_kind: string;
+  source_label: string | null;
+  target_namespace: string | null;
+  imported_count: number;
+  skipped_count: number;
+  error_count: number;
+  created_at: string | null;
+}
+
+export type NamespaceScopeFilter = 'all' | 'system' | 'tenant' | 'imported';
+
+export function countUnresolvedByNamespace(
+  unresolvedPrimitives: Array<{ namespace?: string | null; unresolved_count?: number }>
+): Record<string, number> {
+  const counts: Record<string, number> = {};
+  for (const row of unresolvedPrimitives) {
+    const key = row.namespace ?? '';
+    counts[key] = (counts[key] ?? 0) + (row.unresolved_count ?? 0);
+  }
+  return counts;
+}
+
+export function formatRelativeTime(iso: string | null | undefined): string {
+  if (!iso) return '';
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return '';
+  const diffMs = Date.now() - date.getTime();
+  const minutes = Math.floor(diffMs / 60000);
+  if (minutes < 1) return 'just now';
+  if (minutes < 60) return `${minutes} min ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours} hr ago`;
+  const days = Math.floor(hours / 24);
+  if (days === 1) return '1 d ago';
+  return `${days} d ago`;
+}
+
+export function sourceKindLabel(kind: string): string {
+  switch (kind) {
+    case 'json-schema':
+      return 'JSON Schema';
+    case 'type-def-bundle':
+      return 'Type definitions';
+    case 'openapi':
+      return 'OpenAPI';
+    default:
+      return kind;
+  }
+}

--- a/objectified-ui/src/app/api/primitives/imports/route.ts
+++ b/objectified-ui/src/app/api/primitives/imports/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getAuthenticatedTenantContext, proxyRestGet } from '@lib/primitives-api-proxy';
+
+export const dynamic = 'force-dynamic';
+
+/** GET /api/primitives/imports — recent import provenance records (#3467 activity feed). */
+export async function GET(request: NextRequest) {
+  try {
+    const ctx = await getAuthenticatedTenantContext();
+    if (!ctx.ok) {
+      return NextResponse.json({ success: false, error: ctx.error }, { status: ctx.status });
+    }
+
+    const limit = request.nextUrl.searchParams.get('limit') ?? '10';
+    const path = `/primitives/${encodeURIComponent(ctx.tenantSlug)}/imports?limit=${encodeURIComponent(limit)}`;
+
+    const { data, error, status } = await proxyRestGet(ctx.user, path);
+
+    if (error) {
+      return NextResponse.json({ success: false, error }, { status });
+    }
+
+    return NextResponse.json({ success: true, imports: data });
+  } catch (error) {
+    console.error('Error fetching primitive imports:', error);
+    const message = error instanceof Error ? error.message : 'Internal server error';
+    return NextResponse.json({ success: false, error: message }, { status: 500 });
+  }
+}

--- a/objectified-ui/src/app/api/primitives/stats/route.ts
+++ b/objectified-ui/src/app/api/primitives/stats/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from 'next/server';
+import { getAuthenticatedTenantContext, proxyRestGet } from '@lib/primitives-api-proxy';
+
+export const dynamic = 'force-dynamic';
+
+/** GET /api/primitives/stats — registry coverage KPIs (#3454 / #3467). */
+export async function GET() {
+  try {
+    const ctx = await getAuthenticatedTenantContext();
+    if (!ctx.ok) {
+      return NextResponse.json({ success: false, error: ctx.error }, { status: ctx.status });
+    }
+
+    const { data, error, status } = await proxyRestGet(
+      ctx.user,
+      `/types/${encodeURIComponent(ctx.tenantSlug)}/stats`
+    );
+
+    if (error) {
+      return NextResponse.json({ success: false, error }, { status });
+    }
+
+    return NextResponse.json({ success: true, stats: data });
+  } catch (error) {
+    console.error('Error fetching primitive registry stats:', error);
+    const message = error instanceof Error ? error.message : 'Internal server error';
+    return NextResponse.json({ success: false, error: message }, { status: 500 });
+  }
+}

--- a/objectified-ui/src/app/api/primitives/unresolved/route.ts
+++ b/objectified-ui/src/app/api/primitives/unresolved/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from 'next/server';
+import { getAuthenticatedTenantContext, proxyRestGet } from '@lib/primitives-api-proxy';
+
+export const dynamic = 'force-dynamic';
+
+/** GET /api/primitives/unresolved — unresolved $ref summary (#3467 namespace status). */
+export async function GET() {
+  try {
+    const ctx = await getAuthenticatedTenantContext();
+    if (!ctx.ok) {
+      return NextResponse.json({ success: false, error: ctx.error }, { status: ctx.status });
+    }
+
+    const { data, error, status } = await proxyRestGet(
+      ctx.user,
+      `/primitives/${encodeURIComponent(ctx.tenantSlug)}/unresolved`
+    );
+
+    if (error) {
+      return NextResponse.json({ success: false, error }, { status });
+    }
+
+    return NextResponse.json({ success: true, unresolved: data });
+  } catch (error) {
+    console.error('Error fetching unresolved refs:', error);
+    const message = error instanceof Error ? error.message : 'Internal server error';
+    return NextResponse.json({ success: false, error: message }, { status: 500 });
+  }
+}

--- a/objectified-ui/src/app/api/types/namespaces/route.ts
+++ b/objectified-ui/src/app/api/types/namespaces/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from 'next/server';
+import { getAuthenticatedTenantContext, proxyRestGet } from '@lib/primitives-api-proxy';
+
+export const dynamic = 'force-dynamic';
+
+/** GET /api/types/namespaces — type-registry namespace collections (#3467). */
+export async function GET() {
+  try {
+    const ctx = await getAuthenticatedTenantContext();
+    if (!ctx.ok) {
+      return NextResponse.json({ success: false, error: ctx.error }, { status: ctx.status });
+    }
+
+    const { data, error, status } = await proxyRestGet(
+      ctx.user,
+      `/types/${encodeURIComponent(ctx.tenantSlug)}/namespaces`
+    );
+
+    if (error) {
+      return NextResponse.json({ success: false, error }, { status });
+    }
+
+    return NextResponse.json({ success: true, namespaces: data });
+  } catch (error) {
+    console.error('Error fetching type namespaces:', error);
+    const message = error instanceof Error ? error.message : 'Internal server error';
+    return NextResponse.json({ success: false, error: message }, { status: 500 });
+  }
+}

--- a/objectified-ui/tests/primitivesRegistryTypes.test.ts
+++ b/objectified-ui/tests/primitivesRegistryTypes.test.ts
@@ -1,0 +1,29 @@
+import {
+  countUnresolvedByNamespace,
+  formatRelativeTime,
+  sourceKindLabel,
+} from '../src/app/ade/dashboard/primitives/primitivesRegistryTypes';
+
+describe('primitivesRegistryTypes helpers', () => {
+  it('countUnresolvedByNamespace aggregates by namespace path', () => {
+    const counts = countUnresolvedByNamespace([
+      { namespace: 'tenant/acme/v1/payments', unresolved_count: 2 },
+      { namespace: 'tenant/acme/v1/payments', unresolved_count: 1 },
+      { namespace: null, unresolved_count: 1 },
+    ]);
+    expect(counts['tenant/acme/v1/payments']).toBe(3);
+    expect(counts['']).toBe(1);
+  });
+
+  it('formatRelativeTime returns human-readable deltas', () => {
+    const fiveMinutesAgo = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+    expect(formatRelativeTime(fiveMinutesAgo)).toBe('5 min ago');
+    expect(formatRelativeTime(null)).toBe('');
+  });
+
+  it('sourceKindLabel maps known import kinds', () => {
+    expect(sourceKindLabel('json-schema')).toBe('JSON Schema');
+    expect(sourceKindLabel('type-def-bundle')).toBe('Type definitions');
+    expect(sourceKindLabel('custom')).toBe('custom');
+  });
+});


### PR DESCRIPTION
## Summary
- Extends **Governance → Primitives** (`/ade/dashboard/primitives`) with a registry KPI strip (core/tenant/imported/bound/unresolved), namespace collections table, recent import activity feed, and `$ref` resolution explainer
- Adds row click-through to `/ade/dashboard/primitives/[id]` type detail (schema, refs, metadata)
- Implements `GET /v1/types/{tenant_slug}/stats` (#3454 — required dependency for KPI data) plus Next.js proxy routes: `/api/primitives/stats`, `/api/primitives/imports`, `/api/primitives/unresolved`, `/api/types/namespaces`

## How to test
1. Start `objectified-rest` and `objectified-ui`; sign in with a tenant selected
2. **Browse to** `/ade/dashboard/primitives`
3. Confirm the **five KPI cards** load (not client-computed totals from the table)
4. Confirm **Type collections** lists namespaces with scope filters; click a row to filter the primitives table below
5. Confirm **Recent activity** shows import provenance when imports exist
6. **Click a primitive row** → opens type detail with schema and reference resolution table

## Risk/notes
- Also delivers the open #3454 stats endpoint as a hard dependency; that issue can be closed separately once reviewed
- Resolver UI route (`?focus=resolver`) is a placeholder link until #3470 lands

Closes #3467

Made with [Cursor](https://cursor.com)