### PR TITLE
Fix #3468 - Primitives type detail page

### DIFF
--- a/docs/ROADMAP_TYPE_REGISTRY_GOVERNANCE.md
+++ b/docs/ROADMAP_TYPE_REGISTRY_GOVERNANCE.md
@@ -585,7 +585,7 @@ The in-app surface under **Control Panel → Governance**, matching the `governa
 |---|---|---|---|:---:|:---:|---|---|
 | 5.1 #3466 | ~~Governance nav entry + route group~~ | **CLOSED — duplicate** (`/ade/dashboard/primitives` in nav) | `type-registry`,`ui`,`governance`,`mvp`,`roadmap-type-registry` | N | Y | S | objectified-ui |
 | 5.2 #3467 ✅ | Enhance Primitives overview (registry KPIs) | **DONE** — KPI strip from stats API, namespace collections, recent import activity, row click → type detail | `type-registry`,`ui`,`mvp`,`roadmap-type-registry` | Y | Y | M | objectified-ui |
-| 5.3 #3468 | Type detail page | Schema, resolved refs, dependents, metadata | `type-registry`,`ui`,`mvp`,`roadmap-type-registry` | Y | Y | M | objectified-ui |
+| 5.3 #3468 ✅ | Type detail page | **DONE** — read-only detail at `/ade/dashboard/primitives/[id]`: JSON Schema, reference-resolution table (#3456), generated example instance, dependents (graceful empty-state until #3477 reverse index), metadata (scope/namespace/version-root/owner/mutability), base chain, used-in mini-stats, Export-schema download + gated Deprecate (lifecycle #3482) | `type-registry`,`ui`,`mvp`,`roadmap-type-registry` | Y | Y | M | objectified-ui |
 | 5.4 #3469 | Import UI (wizard) | Source/options/review wired to Epic 4 | `type-registry`,`ui`,`import`,`mvp`,`roadmap-type-registry` | Y | Y | L | objectified-ui |
 | 5.5 #3470 | Reference Resolver UI | Graph + table, base, unresolved/circular | `type-registry`,`ui`,`mvp`,`roadmap-type-registry` | Y | Y | M | objectified-ui |
 | 5.6 #3471 | Namespaces & Scopes UI | Manage namespaces, scope, base URI, version root | `type-registry`,`ui`,`registry`,`mvp`,`roadmap-type-registry` | Y | Y | M | objectified-ui |
@@ -862,7 +862,7 @@ epic.
 | #3440 E2 | #3450 (2.1) · #3451 (2.2) · #3452 (2.3) · #3453 (2.4) · #3454 (2.5) · ~~#3455 (2.6)~~ ✅ closed |
 | #3441 E3 | #3456 (3.1) · #3457 (3.2) · #3458 (3.3) · #3459 (3.4) |
 | #3442 E4 | #3460 (4.1) · #3461 (4.2) · #3462 (4.3) · #3463 (4.4) · #3464 (4.5) · #3465 (4.6) |
-| #3443 E5 | ~~#3466 (5.1)~~ ✅ closed · ~~#3467 (5.2)~~ ✅ · #3468 (5.3) · #3469 (5.4) · #3470 (5.5) · #3471 (5.6) · #3472 (5.7) · #3473 (5.8) |
+| #3443 E5 | ~~#3466 (5.1)~~ ✅ closed · ~~#3467 (5.2)~~ ✅ · ~~#3468 (5.3)~~ ✅ · #3469 (5.4) · #3470 (5.5) · #3471 (5.6) · #3472 (5.7) · #3473 (5.8) |
 | #3444 E6 | #3474 (6.1) · #3475 (6.2) · #3476 (6.3) · #3477 (6.4) |
 | #3445 E7 | #3478 (7.1) · #3479 (7.2) · #3480 (7.3) · #3481 (7.4) · #3482 (7.5) |
 

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.126",
+  "version": "0.11.127",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/src/app/ade/dashboard/primitives/[id]/PrimitiveDetailClient.tsx
+++ b/objectified-ui/src/app/ade/dashboard/primitives/[id]/PrimitiveDetailClient.tsx
@@ -1,9 +1,25 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
-import { useParams, useRouter } from 'next/navigation';
-import { ArrowLeft, FileCode, AlertCircle, Shield } from 'lucide-react';
+import { useParams } from 'next/navigation';
+import {
+  ArrowLeft,
+  Library,
+  AlertCircle,
+  Shield,
+  Lock,
+  Pencil,
+  Upload,
+  Archive,
+  Braces,
+  Waypoints,
+  FileJson,
+  GitFork,
+  Info,
+  BarChart3,
+  GitCommitVertical,
+} from 'lucide-react';
 import { Alert } from '@/app/components/ui/Alert';
 import { LoadingState } from '@/app/components/ui/LoadingState';
 import { Button } from '@/app/components/ui/Button';
@@ -12,6 +28,18 @@ import {
   dashboardPanelClass,
   dashboardPanelPaddedClass,
 } from '@/app/components/ade/dashboard/dashboardScreenClasses';
+import {
+  buildBaseChain,
+  buildExampleInstance,
+  deriveOwner,
+  deriveVersionRoot,
+  exportFileName,
+  scopeLabel,
+  serializeSchemaExport,
+  summarizeUsage,
+  type DependentRef,
+  type RefEdge,
+} from '../primitiveDetailModel';
 
 interface PrimitiveDetail {
   id: string;
@@ -20,19 +48,33 @@ interface PrimitiveDetail {
   category: string;
   schema: Record<string, unknown>;
   is_system: boolean;
+  is_public?: boolean;
   namespace?: string | null;
   schema_id?: string | null;
   base_uri?: string | null;
   draft?: string;
   source?: string;
-  refs?: Array<{ relative_ref?: string; resolved_target?: string; status?: string }>;
+  refs?: RefEdge[];
+  dependents?: DependentRef[];
   usage_count: number;
   tags?: string[];
+  created_at?: string | null;
+}
+
+const badgeBase = 'text-[10px] uppercase tracking-wider px-1.5 py-0.5 rounded inline-flex items-center gap-1';
+const codeBlockClass =
+  'rounded-lg bg-gray-900 dark:bg-black/40 p-4 font-mono text-[11px] leading-relaxed text-gray-200 overflow-x-auto whitespace-pre';
+const sectionHeadClass = 'px-5 py-4 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900 flex items-center gap-3';
+
+function formatDate(iso: string | null | undefined): string {
+  if (!iso) return '—';
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return '—';
+  return date.toISOString().slice(0, 10);
 }
 
 export default function PrimitiveDetailClient() {
   const params = useParams<{ id: string }>();
-  const router = useRouter();
   const [primitive, setPrimitive] = useState<PrimitiveDetail | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -63,23 +105,112 @@ export default function PrimitiveDetailClient() {
     }
   }, [params.id, loadPrimitive]);
 
+  const handleExport = useCallback(() => {
+    if (!primitive) return;
+    const blob = new Blob([serializeSchemaExport(primitive.schema)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = exportFileName(primitive.name);
+    document.body.appendChild(anchor);
+    anchor.click();
+    anchor.remove();
+    URL.revokeObjectURL(url);
+  }, [primitive]);
+
+  const baseChain = useMemo(
+    () => (primitive ? buildBaseChain(primitive.name, primitive.refs) : []),
+    [primitive]
+  );
+  const usage = useMemo(
+    () => (primitive ? summarizeUsage(primitive.dependents, primitive.usage_count) : null),
+    [primitive]
+  );
+  const exampleInstance = useMemo(
+    () => (primitive ? buildExampleInstance(primitive.schema) : null),
+    [primitive]
+  );
+
+  const namespacePath = primitive?.namespace ?? null;
+  const versionRoot = primitive ? deriveVersionRoot(primitive.namespace, primitive.base_uri) : null;
+  const dependents = primitive?.dependents ?? [];
+
   return (
     <>
       <header className="border-b border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800">
-        <div className="px-6 py-4">
-          <div className="flex items-center gap-3 mb-2">
-            <Button variant="secondary" size="sm" onClick={() => router.push('/ade/dashboard/primitives')}>
-              <ArrowLeft className="w-4 h-4 mr-1" />
-              Back
-            </Button>
+        <div className="px-6 py-4 flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <div className="min-w-0">
+            <Link
+              href="/ade/dashboard/primitives"
+              className="text-xs text-indigo-600 dark:text-indigo-400 hover:underline inline-flex items-center gap-1 mb-2"
+            >
+              <ArrowLeft className="w-3.5 h-3.5" /> Primitives
+            </Link>
+            {namespacePath ? (
+              <p className="text-xs text-gray-500 dark:text-gray-400 font-mono mb-1">{namespacePath}</p>
+            ) : null}
+            <h2 className="text-2xl font-bold text-gray-900 dark:text-white flex items-center gap-2">
+              <Library className="w-6 h-6 text-indigo-600 dark:text-indigo-400" />
+              {loading ? 'Loading type…' : primitive?.name ?? 'Type detail'}
+            </h2>
+            {primitive ? (
+              <div className="flex flex-wrap items-center gap-2 mt-2">
+                {primitive.is_system ? (
+                  <span className={`${badgeBase} bg-teal-100 text-teal-700 dark:bg-teal-900/40 dark:text-teal-300`}>
+                    <Shield className="w-3 h-3" /> {scopeLabel(true)}
+                  </span>
+                ) : (
+                  <span className={`${badgeBase} bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300`}>
+                    {scopeLabel(false)}
+                  </span>
+                )}
+                <span className={`${badgeBase} bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-300`}>
+                  {primitive.category}
+                </span>
+                <span className={`${badgeBase} bg-indigo-100 text-indigo-700 dark:bg-indigo-900/40 dark:text-indigo-300 font-mono`}>
+                  draft {primitive.draft ?? '2020-12'}
+                </span>
+                {primitive.is_system ? (
+                  <span className={`${badgeBase} bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300`}>
+                    <Lock className="w-3 h-3" /> immutable (core)
+                  </span>
+                ) : null}
+              </div>
+            ) : null}
           </div>
-          <h2 className="text-2xl font-bold text-gray-900 dark:text-white flex items-center gap-2">
-            <FileCode className="w-6 h-6 text-indigo-600 dark:text-indigo-400" />
-            {loading ? 'Loading type…' : primitive?.name ?? 'Type detail'}
-          </h2>
-          <p className="text-gray-600 dark:text-gray-400 text-sm mt-1">
-            Registry type detail · schema, references, and metadata
-          </p>
+
+          {primitive ? (
+            <div className="flex items-center gap-2 flex-shrink-0 flex-wrap">
+              {primitive.is_system ? (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled
+                  title="System primitives are immutable and cannot be edited"
+                >
+                  <Pencil className="w-4 h-4" /> Edit
+                </Button>
+              ) : (
+                <Link href={`/ade/dashboard/primitives?edit=${primitive.id}`}>
+                  <Button variant="outline" size="sm">
+                    <Pencil className="w-4 h-4" /> Edit
+                  </Button>
+                </Link>
+              )}
+              <Button variant="outline" size="sm" onClick={handleExport}>
+                <Upload className="w-4 h-4" /> Export
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled
+                title="Deprecation lifecycle (sunset dates) arrives with version roots — see #3482"
+                className="border-rose-200 text-rose-600 hover:bg-rose-50 dark:border-rose-800/60 dark:text-rose-400 dark:hover:bg-rose-900/20"
+              >
+                <Archive className="w-4 h-4" /> Deprecate
+              </Button>
+            </div>
+          ) : null}
         </div>
       </header>
 
@@ -92,76 +223,54 @@ export default function PrimitiveDetailClient() {
             <span>{error}</span>
           </Alert>
         ) : primitive ? (
-          <div className="space-y-6">
-            <section className={`${dashboardPanelClass} ${dashboardPanelPaddedClass}`}>
-              <div className="flex flex-wrap items-center gap-2 mb-4">
-                {primitive.is_system ? (
-                  <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300">
-                    <Shield className="w-3 h-3 mr-1" />
-                    System
-                  </span>
-                ) : (
-                  <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300">
-                    Tenant
-                  </span>
-                )}
-                <span className="text-xs font-mono text-gray-500 dark:text-gray-400">
-                  {primitive.namespace ?? 'no namespace'}
-                </span>
-                {primitive.schema_id ? (
-                  <span className="text-xs font-mono text-gray-500 dark:text-gray-400">{primitive.schema_id}</span>
-                ) : null}
-              </div>
-              <dl className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
-                <div>
-                  <dt className="text-gray-500 dark:text-gray-400">Category</dt>
-                  <dd className="font-medium text-gray-900 dark:text-white">{primitive.category}</dd>
-                </div>
-                <div>
-                  <dt className="text-gray-500 dark:text-gray-400">Draft</dt>
-                  <dd className="font-mono text-gray-900 dark:text-white">{primitive.draft ?? '2020-12'}</dd>
-                </div>
-                <div>
-                  <dt className="text-gray-500 dark:text-gray-400">Source</dt>
-                  <dd className="text-gray-900 dark:text-white">{primitive.source ?? 'human'}</dd>
-                </div>
-                <div>
-                  <dt className="text-gray-500 dark:text-gray-400">Usage</dt>
-                  <dd className="text-gray-900 dark:text-white">{primitive.usage_count}</dd>
-                </div>
-                {primitive.description ? (
-                  <div className="md:col-span-2">
-                    <dt className="text-gray-500 dark:text-gray-400">Description</dt>
-                    <dd className="text-gray-900 dark:text-white">{primitive.description}</dd>
-                  </div>
-                ) : null}
-              </dl>
-            </section>
+          <div className="grid grid-cols-1 xl:grid-cols-3 gap-6">
+            {/* Main column */}
+            <div className="xl:col-span-2 space-y-6">
+              {primitive.description ? (
+                <section className={dashboardPanelPaddedClass}>
+                  <p className="text-sm text-gray-700 dark:text-gray-300">{primitive.description}</p>
+                </section>
+              ) : null}
 
-            {(primitive.refs?.length ?? 0) > 0 ? (
+              <section className={`${dashboardPanelClass} p-5`}>
+                <h3 className="text-sm font-semibold mb-3 flex items-center gap-2 text-gray-900 dark:text-white">
+                  <Braces className="w-4 h-4 text-indigo-500" /> JSON Schema{' '}
+                  <span className="font-mono text-gray-400 font-normal">({primitive.draft ?? '2020-12'})</span>
+                </h3>
+                <pre className={codeBlockClass}>{JSON.stringify(primitive.schema, null, 2)}</pre>
+              </section>
+
               <section className={`${dashboardPanelClass} overflow-hidden`}>
-                <div className="px-5 py-4 border-b border-gray-200 dark:border-gray-700">
-                  <h3 className="text-base font-semibold text-gray-900 dark:text-white">Reference resolution</h3>
+                <div className={sectionHeadClass}>
+                  <Waypoints className="w-5 h-5 text-indigo-500" />
+                  <div>
+                    <h3 className="text-base font-semibold text-gray-900 dark:text-white">Reference resolution</h3>
+                    <p className="text-xs text-gray-500 dark:text-gray-400">
+                      Relative <span className="font-mono">$ref</span> values resolved against the type&apos;s base URL
+                    </p>
+                  </div>
                 </div>
-                <div className="overflow-x-auto">
+                {(primitive.refs?.length ?? 0) > 0 ? (
                   <table className="w-full text-sm">
-                    <thead className="bg-gray-50 dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700">
+                    <thead className="text-[10px] uppercase tracking-wider text-gray-500 dark:text-gray-400 bg-gray-50/60 dark:bg-gray-900/40">
                       <tr>
-                        <th className="px-5 py-2 text-left text-xs uppercase text-gray-500">$ref</th>
-                        <th className="px-5 py-2 text-left text-xs uppercase text-gray-500">Target</th>
-                        <th className="px-5 py-2 text-right text-xs uppercase text-gray-500">Status</th>
+                        <th className="text-left px-5 py-2 font-semibold">Relative $ref</th>
+                        <th className="text-left px-3 py-2 font-semibold">Resolved target</th>
+                        <th className="text-right px-5 py-2 font-semibold">Status</th>
                       </tr>
                     </thead>
-                    <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
+                    <tbody className="divide-y divide-gray-100 dark:divide-gray-700/60">
                       {primitive.refs?.map((edge, index) => (
-                        <tr key={`${edge.relative_ref}-${index}`}>
-                          <td className="px-5 py-3 font-mono text-xs">{edge.relative_ref ?? '—'}</td>
-                          <td className="px-5 py-3 font-mono text-xs text-gray-600 dark:text-gray-400">
+                        <tr key={`${edge.relative_ref}-${index}`} className="hover:bg-gray-50/60 dark:hover:bg-gray-900/30">
+                          <td className="px-5 py-3 font-mono text-xs text-emerald-600 dark:text-emerald-400">
+                            {edge.relative_ref ?? '—'}
+                          </td>
+                          <td className="px-3 py-3 font-mono text-xs text-gray-600 dark:text-gray-300">
                             {edge.resolved_target ?? '—'}
                           </td>
                           <td className="px-5 py-3 text-right">
                             <span
-                              className={`text-[10px] uppercase tracking-wider px-1.5 py-0.5 rounded ${
+                              className={`${badgeBase} ${
                                 edge.status === 'unresolved'
                                   ? 'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300'
                                   : 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300'
@@ -174,24 +283,199 @@ export default function PrimitiveDetailClient() {
                       ))}
                     </tbody>
                   </table>
-                </div>
+                ) : (
+                  <p className="px-5 py-4 text-sm text-gray-500 dark:text-gray-400">
+                    This type has no relative <span className="font-mono">$ref</span> values — it resolves to a flat schema.
+                  </p>
+                )}
+                {primitive.base_uri ? (
+                  <div className="px-5 py-3 border-t border-gray-100 dark:border-gray-700/60 text-[11px] text-gray-500 font-mono">
+                    Base: {primitive.base_uri}
+                  </div>
+                ) : null}
               </section>
-            ) : null}
 
-            <section className={`${dashboardPanelClass} overflow-hidden`}>
-              <div className="px-5 py-4 border-b border-gray-200 dark:border-gray-700 flex items-center justify-between">
-                <h3 className="text-base font-semibold text-gray-900 dark:text-white">JSON Schema</h3>
-                <Link
-                  href={`/ade/dashboard/primitives?edit=${primitive.id}`}
-                  className="text-xs text-indigo-600 dark:text-indigo-400 hover:underline"
-                >
-                  Edit in overview →
-                </Link>
-              </div>
-              <pre className="p-5 text-xs font-mono overflow-x-auto text-gray-800 dark:text-gray-200 bg-gray-50 dark:bg-gray-900/40">
-                {JSON.stringify(primitive.schema, null, 2)}
-              </pre>
-            </section>
+              {exampleInstance !== null ? (
+                <section className={`${dashboardPanelClass} p-5`}>
+                  <h3 className="text-sm font-semibold mb-3 flex items-center gap-2 text-gray-900 dark:text-white">
+                    <FileJson className="w-4 h-4 text-indigo-500" /> Example instance
+                  </h3>
+                  <pre className={codeBlockClass}>{JSON.stringify(exampleInstance, null, 2)}</pre>
+                </section>
+              ) : null}
+
+              <section className={`${dashboardPanelClass} overflow-hidden`}>
+                <div className={sectionHeadClass}>
+                  <GitFork className="w-5 h-5 text-indigo-500" />
+                  <div>
+                    <h3 className="text-base font-semibold text-gray-900 dark:text-white">Dependents</h3>
+                    <p className="text-xs text-gray-500 dark:text-gray-400">
+                      Types referencing <span className="font-mono">{primitive.schema_id ?? primitive.name}</span>
+                    </p>
+                  </div>
+                </div>
+                {dependents.length > 0 ? (
+                  <table className="w-full text-sm">
+                    <thead className="text-[10px] uppercase tracking-wider text-gray-500 dark:text-gray-400 bg-gray-50/60 dark:bg-gray-900/40">
+                      <tr>
+                        <th className="text-left px-5 py-2 font-semibold">Type</th>
+                        <th className="text-left px-3 py-2 font-semibold">Property</th>
+                        <th className="text-right px-5 py-2 font-semibold">Scope</th>
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-gray-100 dark:divide-gray-700/60">
+                      {dependents.map((dep, index) => (
+                        <tr key={`${dep.schema_id ?? dep.name}-${index}`} className="hover:bg-gray-50/60 dark:hover:bg-gray-900/30">
+                          <td className="px-5 py-3 font-mono text-xs text-gray-600 dark:text-gray-300">
+                            {dep.namespace ? `${dep.namespace}/${dep.name ?? ''}` : dep.name ?? dep.schema_id ?? '—'}
+                          </td>
+                          <td className="px-3 py-3 font-mono text-xs text-gray-500">{dep.property ?? '—'}</td>
+                          <td className="px-5 py-3 text-right">
+                            <span
+                              className={`${badgeBase} ${
+                                dep.scope === 'system'
+                                  ? 'bg-teal-100 text-teal-700 dark:bg-teal-900/40 dark:text-teal-300'
+                                  : 'bg-indigo-100 text-indigo-700 dark:bg-indigo-900/40 dark:text-indigo-300'
+                              }`}
+                            >
+                              {dep.scope === 'system' ? 'System · core' : `Tenant${dep.tenant_label ? ` · ${dep.tenant_label}` : ''}`}
+                            </span>
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                ) : (
+                  <p className="px-5 py-4 text-sm text-gray-500 dark:text-gray-400">
+                    No types reference this primitive yet. The reverse index (used-by properties) populates this list
+                    as bindings are added.
+                  </p>
+                )}
+              </section>
+            </div>
+
+            {/* Right rail */}
+            <div className="space-y-6">
+              <section className={`${dashboardPanelClass} p-5`}>
+                <h3 className="text-sm font-semibold mb-3 flex items-center gap-2 text-gray-900 dark:text-white">
+                  <Info className="w-4 h-4 text-indigo-500" /> Metadata
+                </h3>
+                <dl className="space-y-3 text-xs">
+                  <div>
+                    <dt className="text-gray-500 dark:text-gray-400 mb-0.5">$id</dt>
+                    <dd className="font-mono text-[10px] break-all text-gray-700 dark:text-gray-300">
+                      {primitive.schema_id ?? '—'}
+                    </dd>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <dt className="text-gray-500 dark:text-gray-400">Scope</dt>
+                    <dd>
+                      <span
+                        className={`${badgeBase} ${
+                          primitive.is_system
+                            ? 'bg-teal-100 text-teal-700 dark:bg-teal-900/40 dark:text-teal-300'
+                            : 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300'
+                        }`}
+                      >
+                        {scopeLabel(primitive.is_system)}
+                      </span>
+                    </dd>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <dt className="text-gray-500 dark:text-gray-400">Namespace</dt>
+                    <dd className="font-mono text-gray-700 dark:text-gray-300">{namespacePath ?? '—'}</dd>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <dt className="text-gray-500 dark:text-gray-400">Version root</dt>
+                    <dd className="font-mono text-gray-700 dark:text-gray-300">{versionRoot ?? '—'}</dd>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <dt className="text-gray-500 dark:text-gray-400">Owner</dt>
+                    <dd className="font-mono text-gray-700 dark:text-gray-300">
+                      {deriveOwner(primitive.is_system, primitive.namespace)}
+                    </dd>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <dt className="text-gray-500 dark:text-gray-400">Source</dt>
+                    <dd className="font-mono text-gray-700 dark:text-gray-300">{primitive.source ?? 'human'}</dd>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <dt className="text-gray-500 dark:text-gray-400">Created</dt>
+                    <dd className="font-mono text-gray-700 dark:text-gray-300">{formatDate(primitive.created_at)}</dd>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <dt className="text-gray-500 dark:text-gray-400">Mutability</dt>
+                    <dd
+                      className={`inline-flex items-center gap-1 font-mono ${
+                        primitive.is_system ? 'text-amber-600 dark:text-amber-400' : 'text-gray-700 dark:text-gray-300'
+                      }`}
+                    >
+                      {primitive.is_system ? (
+                        <>
+                          <Lock className="w-3 h-3" /> immutable · core
+                        </>
+                      ) : (
+                        'editable · tenant'
+                      )}
+                    </dd>
+                  </div>
+                </dl>
+              </section>
+
+              {usage ? (
+                <section className={`${dashboardPanelClass} p-5`}>
+                  <h3 className="text-sm font-semibold mb-3 flex items-center gap-2 text-gray-900 dark:text-white">
+                    <BarChart3 className="w-4 h-4 text-indigo-500" /> Used in
+                  </h3>
+                  <div className="grid grid-cols-3 gap-2 text-center">
+                    <div className="rounded-lg bg-gray-50 dark:bg-gray-900/40 p-3">
+                      <p className="text-2xl font-bold font-mono text-indigo-600 dark:text-indigo-400">{usage.dependentTypes}</p>
+                      <p className="text-[10px] text-gray-500 mt-1">dependent types</p>
+                    </div>
+                    <div className="rounded-lg bg-gray-50 dark:bg-gray-900/40 p-3">
+                      <p className="text-2xl font-bold font-mono text-gray-900 dark:text-white">{usage.properties}</p>
+                      <p className="text-[10px] text-gray-500 mt-1">properties</p>
+                    </div>
+                    <div className="rounded-lg bg-gray-50 dark:bg-gray-900/40 p-3">
+                      <p className="text-2xl font-bold font-mono text-gray-900 dark:text-white">{usage.tenants}</p>
+                      <p className="text-[10px] text-gray-500 mt-1">tenants</p>
+                    </div>
+                  </div>
+                </section>
+              ) : null}
+
+              <section className={`${dashboardPanelClass} p-5`}>
+                <h3 className="text-sm font-semibold mb-1 flex items-center gap-2 text-gray-900 dark:text-white">
+                  <GitCommitVertical className="w-4 h-4 text-indigo-500" /> Base chain
+                </h3>
+                <p className="text-[11px] text-gray-500 dark:text-gray-400 mb-3">
+                  Relative-ref chain down to a primitive.
+                </p>
+                <ol className="relative ml-1.5 border-l border-gray-200 dark:border-gray-700 space-y-4 text-xs">
+                  {baseChain.map((node, index) => (
+                    <li key={`${node.label}-${index}`} className="pl-4 relative">
+                      <span
+                        className={`absolute -left-[5px] top-1 w-2.5 h-2.5 rounded-full ${
+                          node.kind === 'self'
+                            ? 'bg-teal-500'
+                            : node.status === 'unresolved'
+                              ? 'bg-amber-500'
+                              : 'bg-indigo-500'
+                        }`}
+                      />
+                      <p className="font-mono font-medium text-gray-700 dark:text-gray-200">{node.label}</p>
+                      <p className="text-[10px] text-gray-400 font-mono">
+                        {node.kind === 'self'
+                          ? `${primitive.category} · this type`
+                          : node.target
+                            ? `→ ${node.target}${node.status === 'unresolved' ? ' · unresolved' : ''}`
+                            : 'unresolved'}
+                      </p>
+                    </li>
+                  ))}
+                </ol>
+              </section>
+            </div>
           </div>
         ) : null}
       </main>

--- a/objectified-ui/src/app/ade/dashboard/primitives/primitiveDetailModel.ts
+++ b/objectified-ui/src/app/ade/dashboard/primitives/primitiveDetailModel.ts
@@ -1,0 +1,253 @@
+/**
+ * Pure, view-model helpers for the Primitives type-detail page (#3468).
+ *
+ * The detail page renders a single registry type "beyond the edit dialog": its
+ * resolved `$ref` table, base chain, dependents, metadata and a generated example
+ * instance. The presentation-free derivations live here so they can be unit-tested
+ * without rendering React, and reused by the client component.
+ */
+
+/** A single outgoing relative-`$ref` edge as persisted on `odb.primitives.refs`. */
+export interface RefEdge {
+  relative_ref?: string;
+  resolved_target?: string;
+  status?: string;
+}
+
+/**
+ * A type that references this primitive. Populated by the reverse-index endpoint
+ * once #3477 ("Used by properties" dependents/impact) lands; until then the detail
+ * page renders an empty-state and these helpers degrade to zero/empty results.
+ */
+export interface DependentRef {
+  schema_id?: string | null;
+  namespace?: string | null;
+  name?: string | null;
+  property?: string | null;
+  scope?: 'system' | 'tenant';
+  tenant_label?: string | null;
+}
+
+/** One node in the base chain: the type itself, then each of its ref edges. */
+export interface BaseChainNode {
+  /** The display label — the type name for the head node, else the relative `$ref`. */
+  label: string;
+  /** The absolute/registry target a ref edge resolves to (undefined for the head). */
+  target?: string;
+  /** `self` for the head node, `ref` for each edge. */
+  kind: 'self' | 'ref';
+  /** Resolution status carried from the edge (`resolved` / `unresolved`). */
+  status?: string;
+}
+
+/** Aggregate "used in" counters shown in the right-rail mini-stats. */
+export interface UsageSummary {
+  /** Number of distinct types that reference this primitive. */
+  dependentTypes: number;
+  /** Number of property bindings (the primitive's `usage_count`). */
+  properties: number;
+  /** Number of distinct tenants among the dependents. */
+  tenants: number;
+}
+
+/**
+ * Build the base chain for a type: the type itself followed by one node per
+ * outgoing `$ref` edge, in declaration order.
+ *
+ * @param typeName - The primitive's display name (head node).
+ * @param refs - The primitive's resolved `$ref` edges (may be undefined/empty).
+ * @returns Ordered chain nodes, always beginning with the type's own `self` node.
+ */
+export function buildBaseChain(typeName: string, refs?: RefEdge[]): BaseChainNode[] {
+  const head: BaseChainNode = { label: typeName, kind: 'self' };
+  const edges = (refs ?? [])
+    .filter((edge) => Boolean(edge.relative_ref))
+    .map<BaseChainNode>((edge) => ({
+      label: edge.relative_ref as string,
+      target: edge.resolved_target ?? undefined,
+      status: edge.status ?? undefined,
+      kind: 'ref',
+    }));
+  return [head, ...edges];
+}
+
+/**
+ * Derive the version-root segment (e.g. `v0`, `v1`) from a namespace path or base
+ * URI. The registry organizes types under a version root; this reads the first
+ * `v<digits>` path segment it finds.
+ *
+ * @param namespace - The namespace path (e.g. `std/v0/types`), if known.
+ * @param baseUri - The absolute base URI, used as a fallback source.
+ * @returns The version-root segment, or `null` when none is present.
+ */
+export function deriveVersionRoot(
+  namespace?: string | null,
+  baseUri?: string | null
+): string | null {
+  const source = namespace || baseUri || '';
+  const match = source.match(/(?:^|[/])(v\d+)(?:[/]|$)/);
+  return match ? match[1] : null;
+}
+
+/**
+ * The human label for a type's storage scope.
+ *
+ * @param isSystem - Whether the primitive is a system-core type.
+ * @returns `System · core` for system types, otherwise `Tenant`.
+ */
+export function scopeLabel(isSystem: boolean): string {
+  return isSystem ? 'System · core' : 'Tenant';
+}
+
+/**
+ * Derive the owning principal of a type for the metadata panel.
+ *
+ * @param isSystem - Whether the primitive is system-core (owned by `system`).
+ * @param namespace - The namespace path; a `tenant/<slug>/…` path yields the slug.
+ * @returns `system` for core types, the tenant slug when derivable, else `tenant`.
+ */
+export function deriveOwner(isSystem: boolean, namespace?: string | null): string {
+  if (isSystem) {
+    return 'system';
+  }
+  const match = (namespace ?? '').match(/^tenant\/([^/]+)/);
+  return match ? match[1] : 'tenant';
+}
+
+/**
+ * Aggregate the "used in" counters from the dependents list and binding count.
+ *
+ * Dependents come from the reverse-index endpoint (#3477); until it lands the list
+ * is empty and only `properties` (from `usage_count`) is non-zero.
+ *
+ * @param dependents - Types referencing this primitive (may be undefined/empty).
+ * @param usageCount - The primitive's property-binding `usage_count`.
+ * @returns Counts of dependent types, bound properties, and distinct tenants.
+ */
+export function summarizeUsage(
+  dependents: DependentRef[] | undefined,
+  usageCount: number
+): UsageSummary {
+  const list = dependents ?? [];
+  const tenants = new Set(
+    list
+      .filter((dep) => dep.scope !== 'system')
+      .map((dep) => dep.tenant_label || dep.namespace || '')
+      .filter((label) => label.length > 0)
+  );
+  return {
+    dependentTypes: list.length,
+    properties: Math.max(0, usageCount),
+    tenants: tenants.size,
+  };
+}
+
+/**
+ * The filename used when exporting a type's JSON Schema. The name is slugified so
+ * the download is filesystem-safe regardless of the primitive's display name.
+ *
+ * @param name - The primitive's display name.
+ * @returns A `<slug>.schema.json` filename (falls back to `primitive.schema.json`).
+ */
+export function exportFileName(name: string): string {
+  const slug = (name || '')
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return `${slug || 'primitive'}.schema.json`;
+}
+
+/**
+ * Serialize a type's JSON Schema document for export as pretty-printed JSON.
+ *
+ * @param schema - The primitive's JSON Schema document.
+ * @returns A 2-space-indented JSON string (empty object when schema is absent).
+ */
+export function serializeSchemaExport(schema: Record<string, unknown> | undefined): string {
+  return JSON.stringify(schema ?? {}, null, 2);
+}
+
+/** Internal: depth-bounded example generation guard to avoid runaway recursion. */
+const MAX_EXAMPLE_DEPTH = 6;
+
+/**
+ * Best-effort generation of an example instance from a JSON Schema document.
+ *
+ * Resolution order at each node: an explicit `examples[0]`, then `default`, then
+ * `const`, then `enum[0]`, then a value derived from `type`. Object properties are
+ * walked recursively (depth-bounded); a property whose schema is only a `$ref` is
+ * omitted because the target cannot be resolved client-side. Returns `null` when no
+ * meaningful example can be produced, so the caller can hide the section.
+ *
+ * @param schema - The JSON Schema document (or sub-schema) to derive an example for.
+ * @returns A representative instance value, or `null` when none can be produced.
+ */
+export function buildExampleInstance(schema: unknown): unknown {
+  return generateExample(schema, 0);
+}
+
+function generateExample(schema: unknown, depth: number): unknown {
+  if (depth > MAX_EXAMPLE_DEPTH || schema === null || typeof schema !== 'object') {
+    return null;
+  }
+  const node = schema as Record<string, unknown>;
+
+  if (Array.isArray(node.examples) && node.examples.length > 0) {
+    return node.examples[0];
+  }
+  if ('default' in node) {
+    return node.default;
+  }
+  if ('const' in node) {
+    return node.const;
+  }
+  if (Array.isArray(node.enum) && node.enum.length > 0) {
+    return node.enum[0];
+  }
+
+  // A property that is purely a `$ref` cannot be resolved here — signal "no example".
+  if (typeof node.$ref === 'string' && node.type === undefined && node.properties === undefined) {
+    return null;
+  }
+
+  const type = Array.isArray(node.type) ? node.type[0] : node.type;
+  switch (type) {
+    case 'string':
+      return typeof node.format === 'string' ? node.format : 'string';
+    case 'integer':
+    case 'number':
+      return 0;
+    case 'boolean':
+      return true;
+    case 'null':
+      return null;
+    case 'array':
+      return [];
+    case 'object':
+    default: {
+      const properties = node.properties;
+      if (properties === null || typeof properties !== 'object') {
+        return null;
+      }
+      const result: Record<string, unknown> = {};
+      for (const [key, propSchema] of Object.entries(properties as Record<string, unknown>)) {
+        const value = generateExample(propSchema, depth + 1);
+        if (value !== null || isExplicitNull(propSchema)) {
+          result[key] = value;
+        }
+      }
+      return Object.keys(result).length > 0 ? result : null;
+    }
+  }
+}
+
+/** Whether a sub-schema legitimately produces a `null` example (vs. "unknown"). */
+function isExplicitNull(schema: unknown): boolean {
+  if (schema === null || typeof schema !== 'object') {
+    return false;
+  }
+  const node = schema as Record<string, unknown>;
+  const type = Array.isArray(node.type) ? node.type[0] : node.type;
+  return type === 'null' || node.default === null || node.const === null;
+}

--- a/objectified-ui/tests/PrimitiveDetailClient.test.tsx
+++ b/objectified-ui/tests/PrimitiveDetailClient.test.tsx
@@ -1,0 +1,130 @@
+/**
+ * Type detail page (#3468).
+ *
+ * Verifies the read-only registry-type detail renders schema, resolved refs,
+ * dependents (graceful empty-state), metadata, base chain, and the export action.
+ */
+
+import React from 'react';
+import { render, screen, waitFor, fireEvent, within } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+const mockPush = jest.fn();
+jest.mock('next/navigation', () => ({
+  useParams: () => ({ id: 'prim-1' }),
+  useRouter: () => ({ push: mockPush }),
+}));
+
+import PrimitiveDetailClient from '../src/app/ade/dashboard/primitives/[id]/PrimitiveDetailClient';
+
+const SYSTEM_MONEY = {
+  id: 'prim-1',
+  name: 'money',
+  description: 'A monetary amount with a currency.',
+  category: 'object',
+  is_system: true,
+  namespace: 'std/v0/types',
+  schema_id: 'https://api.objectified.dev/types/std/v0/types/money',
+  base_uri: 'https://api.objectified.dev/types/std/v0/types/',
+  draft: '2020-12',
+  source: 'system',
+  usage_count: 11,
+  created_at: '2025-11-02T00:00:00.000Z',
+  refs: [
+    { relative_ref: './decimal', resolved_target: 'std/v0/types/decimal', status: 'resolved' },
+    { relative_ref: './currency-code', resolved_target: 'std/v0/types/currency-code', status: 'unresolved' },
+  ],
+  schema: {
+    $id: 'https://api.objectified.dev/types/std/v0/types/money',
+    type: 'object',
+    properties: {
+      amount: { $ref: './decimal' },
+      currency: { type: 'string', examples: ['USD'] },
+    },
+    required: ['amount', 'currency'],
+  },
+};
+
+function mockFetchOk(primitive: unknown) {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ success: true, primitive }),
+  }) as unknown as typeof fetch;
+}
+
+describe('PrimitiveDetailClient', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    mockPush.mockReset();
+  });
+
+  it('renders schema, refs, metadata, base chain, and a graceful dependents empty-state', async () => {
+    mockFetchOk(SYSTEM_MONEY);
+    render(<PrimitiveDetailClient />);
+
+    await waitFor(() => expect(screen.getByRole('heading', { name: 'money' })).toBeInTheDocument());
+
+    // Reference resolution shows both edges with their status (the relative refs
+    // also appear in the base-chain rail, hence getAllByText).
+    expect(screen.getAllByText('./decimal').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText('std/v0/types/currency-code')).toBeInTheDocument();
+    expect(screen.getByText('resolved')).toBeInTheDocument();
+    expect(screen.getByText('unresolved')).toBeInTheDocument();
+
+    // Metadata right-rail derives version root + owner; namespace appears in the
+    // breadcrumb and the metadata panel.
+    expect(screen.getAllByText('std/v0/types').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText('v0')).toBeInTheDocument();
+    expect(screen.getAllByText('system').length).toBeGreaterThanOrEqual(1);
+
+    // Dependents empty-state (reverse index #3477 not yet populated).
+    expect(screen.getByText(/No types reference this primitive yet/i)).toBeInTheDocument();
+
+    // System type → immutable badge + disabled Edit.
+    expect(screen.getByText(/immutable \(core\)/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Edit/i })).toBeDisabled();
+  });
+
+  it('exports the schema as a downloadable JSON file', async () => {
+    mockFetchOk(SYSTEM_MONEY);
+    const createObjectURL = jest.fn().mockReturnValue('blob:mock');
+    const revokeObjectURL = jest.fn();
+    (URL as unknown as { createObjectURL: unknown }).createObjectURL = createObjectURL;
+    (URL as unknown as { revokeObjectURL: unknown }).revokeObjectURL = revokeObjectURL;
+    const clickSpy = jest.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
+
+    render(<PrimitiveDetailClient />);
+    await waitFor(() => expect(screen.getByRole('heading', { name: 'money' })).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole('button', { name: /Export/i }));
+    expect(createObjectURL).toHaveBeenCalledTimes(1);
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:mock');
+  });
+
+  it('lists dependents when the reverse index returns them', async () => {
+    mockFetchOk({
+      ...SYSTEM_MONEY,
+      dependents: [
+        { schema_id: 'a', namespace: 'tenant/acme/v1/payments', name: 'charge', property: 'amount', scope: 'tenant', tenant_label: 'acme' },
+      ],
+    });
+    render(<PrimitiveDetailClient />);
+
+    await waitFor(() => expect(screen.getByRole('heading', { name: 'money' })).toBeInTheDocument());
+    const dependentsTable = screen.getByText('tenant/acme/v1/payments/charge').closest('table');
+    expect(dependentsTable).not.toBeNull();
+    expect(within(dependentsTable as HTMLElement).getByText('amount')).toBeInTheDocument();
+    expect(within(dependentsTable as HTMLElement).getByText(/Tenant · acme/i)).toBeInTheDocument();
+  });
+
+  it('shows an error alert when the primitive fails to load', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      json: async () => ({ success: false, error: 'Primitive not found' }),
+    }) as unknown as typeof fetch;
+    render(<PrimitiveDetailClient />);
+
+    await waitFor(() => expect(screen.getByText('Primitive not found')).toBeInTheDocument());
+  });
+});

--- a/objectified-ui/tests/primitiveDetailModel.test.ts
+++ b/objectified-ui/tests/primitiveDetailModel.test.ts
@@ -1,0 +1,145 @@
+import {
+  buildBaseChain,
+  buildExampleInstance,
+  deriveOwner,
+  deriveVersionRoot,
+  exportFileName,
+  scopeLabel,
+  serializeSchemaExport,
+  summarizeUsage,
+} from '../src/app/ade/dashboard/primitives/primitiveDetailModel';
+
+describe('primitiveDetailModel helpers', () => {
+  describe('buildBaseChain', () => {
+    it('starts with the type itself then one node per ref edge', () => {
+      const chain = buildBaseChain('money', [
+        { relative_ref: './decimal', resolved_target: 'std/v0/types/decimal', status: 'resolved' },
+        { relative_ref: './currency-code', resolved_target: 'std/v0/types/currency-code', status: 'resolved' },
+      ]);
+      expect(chain).toHaveLength(3);
+      expect(chain[0]).toEqual({ label: 'money', kind: 'self' });
+      expect(chain[1]).toMatchObject({ label: './decimal', target: 'std/v0/types/decimal', kind: 'ref', status: 'resolved' });
+      expect(chain[2].label).toBe('./currency-code');
+    });
+
+    it('returns only the self node when there are no refs', () => {
+      expect(buildBaseChain('decimal')).toEqual([{ label: 'decimal', kind: 'self' }]);
+      expect(buildBaseChain('decimal', [])).toEqual([{ label: 'decimal', kind: 'self' }]);
+    });
+
+    it('skips edges that have no relative_ref', () => {
+      const chain = buildBaseChain('money', [{ resolved_target: 'x' }, { relative_ref: './ok' }]);
+      expect(chain).toHaveLength(2);
+      expect(chain[1].label).toBe('./ok');
+    });
+  });
+
+  describe('deriveVersionRoot', () => {
+    it('reads the version segment from a namespace path', () => {
+      expect(deriveVersionRoot('std/v0/types')).toBe('v0');
+      expect(deriveVersionRoot('tenant/acme/v12/payments')).toBe('v12');
+    });
+
+    it('falls back to the base URI when namespace is empty', () => {
+      expect(deriveVersionRoot(null, 'https://api.objectified.dev/types/std/v0/types/')).toBe('v0');
+    });
+
+    it('returns null when no version root is present', () => {
+      expect(deriveVersionRoot('std/types')).toBeNull();
+      expect(deriveVersionRoot(null, null)).toBeNull();
+    });
+  });
+
+  describe('scopeLabel / deriveOwner', () => {
+    it('labels scope by system flag', () => {
+      expect(scopeLabel(true)).toBe('System · core');
+      expect(scopeLabel(false)).toBe('Tenant');
+    });
+
+    it('derives owner from system flag or tenant namespace', () => {
+      expect(deriveOwner(true, 'std/v0/types')).toBe('system');
+      expect(deriveOwner(false, 'tenant/acme/v1/payments')).toBe('acme');
+      expect(deriveOwner(false, null)).toBe('tenant');
+    });
+  });
+
+  describe('summarizeUsage', () => {
+    it('counts dependent types, properties, and distinct tenants', () => {
+      const summary = summarizeUsage(
+        [
+          { scope: 'tenant', tenant_label: 'acme', property: 'amount' },
+          { scope: 'tenant', tenant_label: 'acme', property: 'total' },
+          { scope: 'tenant', tenant_label: 'globex', property: 'grandTotal' },
+          { scope: 'system', name: 'core-type' },
+        ],
+        11
+      );
+      expect(summary).toEqual({ dependentTypes: 4, properties: 11, tenants: 2 });
+    });
+
+    it('degrades to zero dependents/tenants when the reverse index is empty', () => {
+      expect(summarizeUsage(undefined, 3)).toEqual({ dependentTypes: 0, properties: 3, tenants: 0 });
+      expect(summarizeUsage([], -5)).toEqual({ dependentTypes: 0, properties: 0, tenants: 0 });
+    });
+  });
+
+  describe('exportFileName / serializeSchemaExport', () => {
+    it('slugifies the type name into a safe filename', () => {
+      expect(exportFileName('Money')).toBe('money.schema.json');
+      expect(exportFileName('US Dollar (amount)')).toBe('us-dollar-amount.schema.json');
+      expect(exportFileName('   ')).toBe('primitive.schema.json');
+    });
+
+    it('pretty-prints the schema document', () => {
+      expect(serializeSchemaExport({ type: 'string' })).toBe('{\n  "type": "string"\n}');
+      expect(serializeSchemaExport(undefined)).toBe('{}');
+    });
+  });
+
+  describe('buildExampleInstance', () => {
+    it('prefers an explicit examples entry', () => {
+      expect(buildExampleInstance({ type: 'string', examples: ['USD', 'EUR'] })).toBe('USD');
+    });
+
+    it('falls back to default, then const, then enum', () => {
+      expect(buildExampleInstance({ type: 'number', default: 42 })).toBe(42);
+      expect(buildExampleInstance({ const: 'fixed' })).toBe('fixed');
+      expect(buildExampleInstance({ enum: ['a', 'b'] })).toBe('a');
+    });
+
+    it('derives values from primitive types', () => {
+      expect(buildExampleInstance({ type: 'string' })).toBe('string');
+      expect(buildExampleInstance({ type: 'string', format: 'date' })).toBe('date');
+      expect(buildExampleInstance({ type: 'integer' })).toBe(0);
+      expect(buildExampleInstance({ type: 'boolean' })).toBe(true);
+      expect(buildExampleInstance({ type: 'array' })).toEqual([]);
+      expect(buildExampleInstance({ type: 'null' })).toBeNull();
+    });
+
+    it('walks object properties and omits unresolvable $ref-only properties', () => {
+      const example = buildExampleInstance({
+        type: 'object',
+        properties: {
+          label: { type: 'string' },
+          amount: { $ref: './decimal' },
+        },
+      });
+      expect(example).toEqual({ label: 'string' });
+    });
+
+    it('keeps an explicit null-typed property', () => {
+      const example = buildExampleInstance({
+        type: 'object',
+        properties: { note: { type: 'null' }, name: { type: 'string' } },
+      });
+      expect(example).toEqual({ note: null, name: 'string' });
+    });
+
+    it('returns null when no meaningful example can be produced', () => {
+      expect(buildExampleInstance({ $ref: './decimal' })).toBeNull();
+      expect(buildExampleInstance({ type: 'object', properties: { a: { $ref: './x' } } })).toBeNull();
+      expect(buildExampleInstance(null)).toBeNull();
+      expect(buildExampleInstance('not-an-object')).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## What & why

Builds out the **read-only type detail page** at `/ade/dashboard/primitives/[id]` so a registry type can be inspected fully — *beyond* the edit dialog. Closes the gaps the issue calls out (resolved `$ref` table, **dependents**, **base chain**, **deprecate/export** actions) and matches `docs/planning/mockups/governance/type-detail.html`.

Added/changed:
- **Two-column detail layout** (main + right rail).
- **JSON Schema** source + **generated example instance** (best-effort, hidden when nothing meaningful can be produced).
- **Reference-resolution** table (#3456) with resolved/unresolved status and the base URI footer.
- **Dependents** table with a graceful empty-state — it lights up automatically once the #3477 reverse index returns a `dependents` array.
- **Metadata** rail: `$id`, scope, namespace, derived **version root**, owner, source, created, mutability.
- **Used-in** mini-stats (dependent types / properties / tenants).
- **Base chain** rail derived from the type's `$ref` edges.
- **Actions:** working **Export** (downloads the JSON Schema), **Edit** (disabled for immutable system types), and a **Deprecate** affordance gated with a tooltip pending the deprecation lifecycle (#3482).
- New `primitiveDetailModel.ts` holds all presentation-free derivations (base chain, version root, scope/owner labels, usage summary, example generation, export filename/serialize) so they're unit-tested in isolation.

## How to test
- `cd objectified-ui && yarn jest primitiveDetailModel PrimitiveDetailClient` → 22 tests pass.
- `yarn build` → compiles; `/ade/dashboard/primitives/[id]` route builds.
- In the app: **browse to Control Panel → Governance → Primitives**, **click any primitive row** to open its detail page. **Click Export** to download `<name>.schema.json`. System types show the **immutable** badge with **Edit disabled**; tenant types link **Edit** back to the overview editor.

## Risk / notes
- UI-only (objectified-ui); no REST/DB changes. No new endpoints — dependents read from an optional `dependents` field that the GET proxy will pass through once #3477 supplies it.
- Deprecate is intentionally a disabled, tooltip-explained affordance until the lifecycle work (#3482).
- objectified-ui bumped to 0.11.127; ROADMAP 5.3 marked done.

Closes #3468

Work performed by Claude Code via model claude-opus-4-8[1m]