### PR TITLE
Fix #3469 - Primitives import wizard (source/review/result)

### DIFF
--- a/docs/ROADMAP_TYPE_REGISTRY_GOVERNANCE.md
+++ b/docs/ROADMAP_TYPE_REGISTRY_GOVERNANCE.md
@@ -586,7 +586,7 @@ The in-app surface under **Control Panel → Governance**, matching the `governa
 | 5.1 #3466 | ~~Governance nav entry + route group~~ | **CLOSED — duplicate** (`/ade/dashboard/primitives` in nav) | `type-registry`,`ui`,`governance`,`mvp`,`roadmap-type-registry` | N | Y | S | objectified-ui |
 | 5.2 #3467 ✅ | Enhance Primitives overview (registry KPIs) | **DONE** — KPI strip from stats API, namespace collections, recent import activity, row click → type detail | `type-registry`,`ui`,`mvp`,`roadmap-type-registry` | Y | Y | M | objectified-ui |
 | 5.3 #3468 ✅ | Type detail page | **DONE** — read-only detail at `/ade/dashboard/primitives/[id]`: JSON Schema, reference-resolution table (#3456), generated example instance, dependents (graceful empty-state until #3477 reverse index), metadata (scope/namespace/version-root/owner/mutability), base chain, used-in mini-stats, Export-schema download + gated Deprecate (lifecycle #3482) | `type-registry`,`ui`,`mvp`,`roadmap-type-registry` | Y | Y | M | objectified-ui |
-| 5.4 #3469 | Import UI (wizard) | Source/options/review wired to Epic 4 | `type-registry`,`ui`,`import`,`mvp`,`roadmap-type-registry` | Y | Y | L | objectified-ui |
+| 5.4 #3469 ✅ | Import UI (wizard) | **DONE** — 3-step wizard (`PrimitiveImportDialog`): source-kind cards (JSON Schema / type-def bundle / OpenAPI) + file/URL/paste tabs + options (target namespace, `$ref` rewrite, dedupe); review step wired to `POST /import/review` showing New/Identical/Conflict/Invalid classification with per-conflict keep/overwrite/rename resolution; commit via `POST /import` with `resolutions`; result step with per-bucket outcome. New `/api/primitives/import/review` proxy; pure model in `primitiveImportModel.ts` | `type-registry`,`ui`,`import`,`mvp`,`roadmap-type-registry` | Y | Y | L | objectified-ui |
 | 5.5 #3470 | Reference Resolver UI | Graph + table, base, unresolved/circular | `type-registry`,`ui`,`mvp`,`roadmap-type-registry` | Y | Y | M | objectified-ui |
 | 5.6 #3471 | Namespaces & Scopes UI | Manage namespaces, scope, base URI, version root | `type-registry`,`ui`,`registry`,`mvp`,`roadmap-type-registry` | Y | Y | M | objectified-ui |
 | 5.7 #3472 | Type Registry Settings UI | DB status, dialect, resolution & validation policy | `type-registry`,`ui`,`mvp`,`roadmap-type-registry` | Y | Y | S | objectified-ui |
@@ -621,7 +621,7 @@ The in-app surface under **Control Panel → Governance**, matching the `governa
 - **Parallelism/Dependencies.** Depends on 5.1, 2.3, 3.4; parallel.
 - **Technical Stack.** Next.js, Tailwind.
 
-### Issue 5.4 — Import UI (wizard)
+### Issue 5.4 — Import UI (wizard) ✅ DONE (#3469)
 - **Problem.** Users need to drive imports.
 - **Solution/Scope.** Source-type cards (JSON Schema / type-def bundle / OpenAPI), method tabs,
   target namespace/scope, options (`$ref` rewrite, dedupe, etc.), and a review step wired to
@@ -630,6 +630,18 @@ The in-app surface under **Control Panel → Governance**, matching the `governa
   result; conflicts resolvable.
 - **Parallelism/Dependencies.** Depends on 5.1, Epic 4; parallel.
 - **Technical Stack.** Next.js, Tailwind.
+- **DONE.** `PrimitiveImportDialog` is now a 3-step wizard — **Source** (source-kind cards +
+  file/URL/paste tabs + options: target namespace, format→core `$ref` rewrite, dedupe) →
+  **Review** (calls `POST /v1/primitives/{tenant}/import/review` via the new
+  `/api/primitives/import/review` proxy; each detected type shows its New/Identical/Conflict/Invalid
+  classification, validation errors, and unresolved-`$ref` count; conflicts offer keep / overwrite /
+  rename) → **Result** (commits via `POST …/import` with `selected_definitions` + `resolutions`,
+  then shows the imported/overwritten/renamed/identical/skipped/errors buckets and the provenance
+  import id). Pure logic lives in `primitiveImportModel.ts` (parse, container extraction per source
+  kind, request building, selection/resolution validation, result normalization) with unit tests in
+  `tests/primitiveImportModel.test.ts`. Bundle expansion, conflict classification, and `$ref` rewrite
+  remain server-side (Epic 4); the wizard wires the UI to them. Git intake (staging pipeline
+  `POST …/import/stage`) is deferred to a follow-up.
 
 ### Issue 5.5 — Reference Resolver UI
 - **Problem.** Users need to see/resolve references.
@@ -862,7 +874,7 @@ epic.
 | #3440 E2 | #3450 (2.1) · #3451 (2.2) · #3452 (2.3) · #3453 (2.4) · #3454 (2.5) · ~~#3455 (2.6)~~ ✅ closed |
 | #3441 E3 | #3456 (3.1) · #3457 (3.2) · #3458 (3.3) · #3459 (3.4) |
 | #3442 E4 | #3460 (4.1) · #3461 (4.2) · #3462 (4.3) · #3463 (4.4) · #3464 (4.5) · #3465 (4.6) |
-| #3443 E5 | ~~#3466 (5.1)~~ ✅ closed · ~~#3467 (5.2)~~ ✅ · ~~#3468 (5.3)~~ ✅ · #3469 (5.4) · #3470 (5.5) · #3471 (5.6) · #3472 (5.7) · #3473 (5.8) |
+| #3443 E5 | ~~#3466 (5.1)~~ ✅ closed · ~~#3467 (5.2)~~ ✅ · ~~#3468 (5.3)~~ ✅ · ~~#3469 (5.4)~~ ✅ · #3470 (5.5) · #3471 (5.6) · #3472 (5.7) · #3473 (5.8) |
 | #3444 E6 | #3474 (6.1) · #3475 (6.2) · #3476 (6.3) · #3477 (6.4) |
 | #3445 E7 | #3478 (7.1) · #3479 (7.2) · #3480 (7.3) · #3481 (7.4) · #3482 (7.5) |
 

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.127",
+  "version": "0.11.128",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/src/app/ade/dashboard/primitives/PrimitiveImportDialog.tsx
+++ b/objectified-ui/src/app/ade/dashboard/primitives/PrimitiveImportDialog.tsx
@@ -1,15 +1,46 @@
 'use client';
 
-import { useState, useCallback, useRef } from 'react';
-import { Upload, AlertCircle, CheckCircle, FileCode, FileJson, X, Link } from 'lucide-react';
+import { useCallback, useMemo, useRef, useState } from 'react';
+import {
+  Upload,
+  AlertCircle,
+  CheckCircle,
+  FileCode,
+  FileJson,
+  X,
+  Boxes,
+  FileText,
+  ArrowRight,
+} from 'lucide-react';
 import { Button } from '@/app/components/ui/Button';
 import { Label } from '@/app/components/ui/Label';
 import { Input } from '@/app/components/ui/Input';
 import { Alert } from '@/app/components/ui/Alert';
+import { Badge } from '@/app/components/ui/Badge';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/app/components/ui/Dialog';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/app/components/ui/Tabs';
 import dynamic from 'next/dynamic';
-import yaml from 'yaml';
+import {
+  type SourceKind,
+  type SourceMethod,
+  type ReviewResponse,
+  type ReviewType,
+  type ReviewStatus,
+  type ResolutionAction,
+  type ResolutionMap,
+  type ImportOptions,
+  type ImportResultSummary,
+  parseSchemaContent,
+  extractDefinitions,
+  determineCategoryFromSchema,
+  buildImportRequestBody,
+  defaultResolutions,
+  defaultSelectedNames,
+  validateSelection,
+  summarizeImportResult,
+  describeImportResult,
+  sourceKindLabel,
+} from './primitiveImportModel';
 
 const MonacoEditor = dynamic(() => import('@monaco-editor/react'), { ssr: false });
 
@@ -19,208 +50,129 @@ interface Props {
   onMessage: (type: 'success' | 'error', message: string) => void;
 }
 
+type WizardStep = 'source' | 'review' | 'result';
+
+/** Source-kind cards offered in the source step. */
+const SOURCE_KIND_CARDS: Array<{ kind: SourceKind; title: string; description: string; icon: typeof FileJson }> = [
+  {
+    kind: 'json-schema',
+    title: 'JSON Schema',
+    description: 'A draft 2020-12 document with $defs or definitions, or a standalone type.',
+    icon: FileJson,
+  },
+  {
+    kind: 'type-def-bundle',
+    title: 'Type-def bundle',
+    description: 'An Objectified bundle of interlinked types under a types container.',
+    icon: Boxes,
+  },
+  {
+    kind: 'openapi',
+    title: 'OpenAPI',
+    description: 'Reuse component schemas from an OpenAPI document’s $defs / definitions.',
+    icon: FileText,
+  },
+];
+
+/** Badge variant + label for a review classification. */
+const STATUS_BADGE: Record<ReviewStatus, { variant: 'success' | 'secondary' | 'warning' | 'error'; label: string }> = {
+  new: { variant: 'success', label: 'New' },
+  identical: { variant: 'secondary', label: 'Identical' },
+  conflict: { variant: 'warning', label: 'Conflict' },
+  invalid: { variant: 'error', label: 'Invalid' },
+};
+
 export default function PrimitiveImportDialog({ onClose, onComplete, onMessage }: Props) {
-  const [schemaJson, setSchemaJson] = useState('');
-  const [importing, setImporting] = useState(false);
-  const [definitions, setDefinitions] = useState<Record<string, Record<string, unknown>>>({});
-  const [selectedDefs, setSelectedDefs] = useState<Set<string>>(new Set());
+  const [step, setStep] = useState<WizardStep>('source');
+
+  // Source selection + options.
+  const [sourceKind, setSourceKind] = useState<SourceKind>('json-schema');
+  const [sourceMethod, setSourceMethod] = useState<SourceMethod>('file');
+  const [targetNamespace, setTargetNamespace] = useState('');
+  const [mapCoreFormats, setMapCoreFormats] = useState(true);
+  const [dedupe, setDedupe] = useState(true);
+
+  // Parsed source document + provenance label.
+  const [parsedDoc, setParsedDoc] = useState<Record<string, unknown> | null>(null);
+  const [sourceLabel, setSourceLabel] = useState<string | null>(null);
   const [parseError, setParseError] = useState<string | null>(null);
-  const [showPreview, setShowPreview] = useState(false);
-  const [importMethod, setImportMethod] = useState<'fileOrUrl' | 'paste'>('fileOrUrl');
+
+  // Source intake state (file / url / paste).
   const [file, setFile] = useState<File | null>(null);
   const [isDragging, setIsDragging] = useState(false);
   const [isLoadingFile, setIsLoadingFile] = useState(false);
   const [urlInput, setUrlInput] = useState('');
   const [isLoadingUrl, setIsLoadingUrl] = useState(false);
+  const [schemaText, setSchemaText] = useState('');
   const fileInputRef = useRef<HTMLInputElement>(null);
 
-  const handleSchemaChange = (value: string | undefined) => {
-    const newValue = value || '';
-    setSchemaJson(newValue);
+  // Review + commit state.
+  const [reviewing, setReviewing] = useState(false);
+  const [review, setReview] = useState<ReviewResponse | null>(null);
+  const [selectedNames, setSelectedNames] = useState<Set<string>>(new Set());
+  const [resolutions, setResolutions] = useState<ResolutionMap>({});
+  const [reviewError, setReviewError] = useState<string | null>(null);
+  const [importing, setImporting] = useState(false);
+  const [result, setResult] = useState<ImportResultSummary | null>(null);
+
+  const options: ImportOptions = useMemo(
+    () => ({ sourceKind, targetNamespace, mapCoreFormats, dedupe }),
+    [sourceKind, targetNamespace, mapCoreFormats, dedupe]
+  );
+
+  // Client-side preview of detected definitions (the server review is authoritative).
+  const previewDefinitions = useMemo(() => {
+    if (!parsedDoc) return {};
+    return extractDefinitions(parsedDoc, sourceKind, sourceLabel ?? undefined);
+  }, [parsedDoc, sourceKind, sourceLabel]);
+
+  /** Store a successfully parsed source document and reset downstream review state. */
+  const acceptDocument = useCallback((doc: Record<string, unknown>, label: string | null) => {
+    setParsedDoc(doc);
+    setSourceLabel(label);
     setParseError(null);
-    setShowPreview(false);
-    setDefinitions({});
-    setSelectedDefs(new Set());
-  };
-
-  const parseSchemaContent = (content: string): Record<string, unknown> | null => {
-    // First try to parse as JSON
-    try {
-      return JSON.parse(content);
-    } catch {
-      // If JSON parsing fails, try YAML
-      try {
-        const parsed = yaml.parse(content);
-        if (typeof parsed === 'object' && parsed !== null) {
-          return parsed as Record<string, unknown>;
-        }
-        return null;
-      } catch {
-        return null;
-      }
-    }
-  };
-
-  /**
-   * Extract a primitive name from a standalone JSON Schema.
-   * Priority: $id (last path segment) > title (slugified) > filename (without extension)
-   */
-  const extractPrimitiveNameFromSchema = (
-    schema: Record<string, unknown>,
-    filename?: string
-  ): string => {
-    // Try to extract from $id
-    if (schema.$id && typeof schema.$id === 'string') {
-      const idPath = schema.$id.split('/');
-      const lastSegment = idPath[idPath.length - 1];
-      if (lastSegment) {
-        // Convert to snake_case/camelCase if needed
-        return lastSegment.replace(/-/g, '_');
-      }
-    }
-
-    // Try to extract from title
-    if (schema.title && typeof schema.title === 'string') {
-      // Convert title to a valid identifier (snake_case)
-      return schema.title
-        .toLowerCase()
-        .replace(/[^a-z0-9\s]/g, '')
-        .replace(/\s+/g, '_')
-        .replace(/^_+|_+$/g, '');
-    }
-
-    // Fall back to filename
-    if (filename) {
-      const baseName = filename.replace(/\.(json|yaml|yml)$/i, '');
-      return baseName.replace(/-/g, '_').replace(/\s+/g, '_');
-    }
-
-    return 'imported_primitive';
-  };
-
-  /**
-   * Check if a schema is a standalone primitive schema (not a container with $defs)
-   * Handles schemas with: type, anyOf, oneOf, allOf, enum, or const
-   */
-  const isStandalonePrimitiveSchema = (schema: Record<string, unknown>): boolean => {
-    // If it has $defs or definitions, it's a container schema
-    const hasDefs = schema.$defs || schema.definitions;
-    if (hasDefs) {
-      return false;
-    }
-
-    // Check for various JSON Schema type indicators
-    const hasType = 'type' in schema;
-    const hasAnyOf = 'anyOf' in schema;
-    const hasOneOf = 'oneOf' in schema;
-    const hasAllOf = 'allOf' in schema;
-    const hasEnum = 'enum' in schema;
-    const hasConst = 'const' in schema;
-
-    return hasType || hasAnyOf || hasOneOf || hasAllOf || hasEnum || hasConst;
-  };
-
-  /**
-   * Determine the category for a schema (for primitives)
-   */
-  const determineCategoryFromSchema = (schema: Record<string, unknown>): string => {
-    // If type is explicitly set, use it
-    if (schema.type) {
-      const schemaType = schema.type;
-      if (typeof schemaType === 'string') {
-        return schemaType;
-      }
-      if (Array.isArray(schemaType) && schemaType.length > 0) {
-        return schemaType[0];
-      }
-    }
-
-    // For anyOf/oneOf with const values, it's typically a string enum
-    if (schema.anyOf || schema.oneOf) {
-      const options = (schema.anyOf || schema.oneOf) as Record<string, unknown>[];
-      if (options.length > 0 && 'const' in options[0]) {
-        const firstConst = options[0].const;
-        return typeof firstConst === 'string' ? 'string' : typeof firstConst;
-      }
-    }
-
-    // For enum, check the type of the first value
-    if (schema.enum && Array.isArray(schema.enum) && schema.enum.length > 0) {
-      return typeof schema.enum[0];
-    }
-
-    // For const, check its type
-    if ('const' in schema) {
-      return typeof schema.const;
-    }
-
-    // Default to object
-    return 'object';
-  };
-
-  const handleFileSelect = useCallback(async (selectedFile: File) => {
-    const fileName = selectedFile.name.toLowerCase();
-    if (!fileName.endsWith('.json') && !fileName.endsWith('.yaml') && !fileName.endsWith('.yml')) {
-      setParseError('Please select a JSON or YAML file');
-      return;
-    }
-
-    setFile(selectedFile);
-    setIsLoadingFile(true);
-    setParseError(null);
-
-    try {
-      const content = await selectedFile.text();
-      const parsed = parseSchemaContent(content);
-
-      if (!parsed) {
-        setParseError('Failed to parse file. Please ensure it contains valid JSON or YAML.');
-        setFile(null);
-        return;
-      }
-
-      // Convert to formatted JSON for the editor
-      const jsonString = JSON.stringify(parsed, null, 2);
-      setSchemaJson(jsonString);
-
-      // Check if this is a standalone primitive schema
-      if (isStandalonePrimitiveSchema(parsed)) {
-        // Extract a name for this primitive
-        const primitiveName = extractPrimitiveNameFromSchema(parsed, selectedFile.name);
-
-        // Use the entire schema as the definition
-        const defs = {
-          [primitiveName]: parsed
-        };
-
-        setDefinitions(defs as Record<string, Record<string, unknown>>);
-        setSelectedDefs(new Set([primitiveName]));
-        setShowPreview(true);
-        return;
-      }
-
-      // Otherwise, look for $defs or definitions
-      const defs = {
-        ...((parsed.$defs as Record<string, unknown>) || {}),
-        ...((parsed.definitions as Record<string, unknown>) || {})
-      };
-
-      if (Object.keys(defs).length === 0) {
-        setParseError('No definitions found. Schema must contain $defs, definitions, or be a standalone type definition.');
-        return;
-      }
-
-      setDefinitions(defs as Record<string, Record<string, unknown>>);
-      setSelectedDefs(new Set(Object.keys(defs)));
-      setShowPreview(true);
-    } catch (err) {
-      const error = err as Error;
-      setParseError(`Error reading file: ${error.message}`);
-      setFile(null);
-    } finally {
-      setIsLoadingFile(false);
-    }
+    setReview(null);
+    setResult(null);
   }, []);
+
+  const clearDocument = useCallback(() => {
+    setParsedDoc(null);
+    setSourceLabel(null);
+    setReview(null);
+    setResult(null);
+  }, []);
+
+  const handleFileSelect = useCallback(
+    async (selectedFile: File) => {
+      const fileName = selectedFile.name.toLowerCase();
+      if (!fileName.endsWith('.json') && !fileName.endsWith('.yaml') && !fileName.endsWith('.yml')) {
+        setParseError('Please select a JSON or YAML file');
+        return;
+      }
+
+      setFile(selectedFile);
+      setIsLoadingFile(true);
+      setParseError(null);
+
+      try {
+        const content = await selectedFile.text();
+        const parsed = parseSchemaContent(content);
+        if (!parsed) {
+          setParseError('Failed to parse file. Please ensure it contains valid JSON or YAML.');
+          setFile(null);
+          return;
+        }
+        setSchemaText(JSON.stringify(parsed, null, 2));
+        acceptDocument(parsed, selectedFile.name);
+      } catch (err) {
+        setParseError(`Error reading file: ${(err as Error).message}`);
+        setFile(null);
+      } finally {
+        setIsLoadingFile(false);
+      }
+    },
+    [acceptDocument]
+  );
 
   const handleDragOver = useCallback((e: React.DragEvent) => {
     e.preventDefault();
@@ -234,36 +186,34 @@ export default function PrimitiveImportDialog({ onClose, onComplete, onMessage }
     setIsDragging(false);
   }, []);
 
-  const handleDrop = useCallback((e: React.DragEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
-    setIsDragging(false);
+  const handleDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      setIsDragging(false);
+      const files = e.dataTransfer.files;
+      if (files.length > 0) {
+        void handleFileSelect(files[0]);
+      }
+    },
+    [handleFileSelect]
+  );
 
-    const files = e.dataTransfer.files;
-    if (files.length > 0) {
-      handleFileSelect(files[0]);
-    }
-  }, [handleFileSelect]);
-
-  const clearFile = () => {
+  const clearFile = useCallback(() => {
     setFile(null);
-    setSchemaJson('');
-    setDefinitions({});
-    setSelectedDefs(new Set());
-    setShowPreview(false);
+    setSchemaText('');
+    clearDocument();
     setParseError(null);
     if (fileInputRef.current) {
       fileInputRef.current.value = '';
     }
-  };
+  }, [clearDocument]);
 
-  const handleUrlFetch = async () => {
+  const handleUrlFetch = useCallback(async () => {
     if (!urlInput.trim()) {
       setParseError('Please enter a URL');
       return;
     }
-
-    // Basic URL validation
     try {
       new URL(urlInput);
     } catch {
@@ -276,452 +226,828 @@ export default function PrimitiveImportDialog({ onClose, onComplete, onMessage }
 
     try {
       const response = await fetch(urlInput);
-
       if (!response.ok) {
         throw new Error(`HTTP ${response.status}: ${response.statusText}`);
       }
-
       const content = await response.text();
       const parsed = parseSchemaContent(content);
-
       if (!parsed) {
         setParseError('Failed to parse response. Please ensure the URL returns valid JSON or YAML.');
         return;
       }
-
-      // Convert to formatted JSON for the editor
-      const jsonString = JSON.stringify(parsed, null, 2);
-      setSchemaJson(jsonString);
-
-      // Check if this is a standalone primitive schema
-      if (isStandalonePrimitiveSchema(parsed)) {
-        // Extract a name for this primitive from the URL or schema
-        const urlPath = new URL(urlInput).pathname;
-        const urlFilename = urlPath.split('/').pop() || '';
-        const primitiveName = extractPrimitiveNameFromSchema(parsed, urlFilename);
-
-        // Use the entire schema as the definition
-        const defs = {
-          [primitiveName]: parsed
-        };
-
-        setDefinitions(defs as Record<string, Record<string, unknown>>);
-        setSelectedDefs(new Set([primitiveName]));
-        setShowPreview(true);
-        return;
-      }
-
-      // Otherwise, look for $defs or definitions
-      const defs = {
-        ...((parsed.$defs as Record<string, unknown>) || {}),
-        ...((parsed.definitions as Record<string, unknown>) || {})
-      };
-
-      if (Object.keys(defs).length === 0) {
-        setParseError('No definitions found. The URL must return a schema with $defs, definitions, or be a standalone type definition.');
-        return;
-      }
-
-      setDefinitions(defs as Record<string, Record<string, unknown>>);
-      setSelectedDefs(new Set(Object.keys(defs)));
-      setShowPreview(true);
+      setSchemaText(JSON.stringify(parsed, null, 2));
+      const urlFilename = new URL(urlInput).pathname.split('/').pop() || urlInput;
+      acceptDocument(parsed, urlFilename);
     } catch (err) {
-      const error = err as Error;
-      setParseError(`Failed to fetch from URL: ${error.message}`);
+      setParseError(`Failed to fetch from URL: ${(err as Error).message}`);
     } finally {
       setIsLoadingUrl(false);
     }
-  };
+  }, [urlInput, acceptDocument]);
 
-  const handleParseSchema = () => {
-    try {
-      const parsed = JSON.parse(schemaJson);
+  const handleParsePasted = useCallback(() => {
+    const parsed = parseSchemaContent(schemaText);
+    if (!parsed) {
+      setParseError('Invalid document. Please paste valid JSON or YAML.');
+      return false;
+    }
+    acceptDocument(parsed, 'Pasted document');
+    return true;
+  }, [schemaText, acceptDocument]);
 
-      // Check if this is a standalone primitive schema
-      if (isStandalonePrimitiveSchema(parsed)) {
-        // Extract a name for this primitive
-        const primitiveName = extractPrimitiveNameFromSchema(parsed);
-
-        // Use the entire schema as the definition
-        const defs = {
-          [primitiveName]: parsed
-        };
-
-        setDefinitions(defs);
-        setSelectedDefs(new Set([primitiveName]));
-        setShowPreview(true);
-        setParseError(null);
-        return;
-      }
-
-      // Extract $defs or definitions
-      const defs = {
-        ...(parsed.$defs || {}),
-        ...(parsed.definitions || {})
-      };
-
-      if (Object.keys(defs).length === 0) {
-        setParseError('No definitions found. Schema must contain $defs, definitions, or be a standalone type definition.');
-        return;
-      }
-
-      setDefinitions(defs);
-      setSelectedDefs(new Set(Object.keys(defs))); // Select all by default
-      setShowPreview(true);
+  const handleSchemaTextChange = useCallback(
+    (value: string | undefined) => {
+      setSchemaText(value || '');
       setParseError(null);
+      // A new paste invalidates a previously parsed document until re-parsed.
+      if (sourceMethod === 'paste') {
+        clearDocument();
+      }
+    },
+    [sourceMethod, clearDocument]
+  );
+
+  /** Run the dry-run review and advance to the review step. */
+  const handleReview = useCallback(async () => {
+    let doc = parsedDoc;
+    if (!doc && sourceMethod === 'paste') {
+      const parsed = parseSchemaContent(schemaText);
+      if (!parsed) {
+        setParseError('Invalid document. Please paste valid JSON or YAML.');
+        return;
+      }
+      doc = parsed;
+      acceptDocument(parsed, 'Pasted document');
+    }
+    if (!doc) {
+      setParseError('Provide a source document first');
+      return;
+    }
+
+    setReviewing(true);
+    setReviewError(null);
+
+    try {
+      const body = buildImportRequestBody(doc, options, sourceLabel);
+      const response = await fetch('/api/primitives/import/review', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      const data = await response.json();
+
+      if (!response.ok || !data.success) {
+        setReviewError(data.error || 'Failed to review import');
+        return;
+      }
+
+      const reviewResult = data.review as ReviewResponse;
+      setReview(reviewResult);
+      setSelectedNames(new Set(defaultSelectedNames(reviewResult.types)));
+      setResolutions(defaultResolutions(reviewResult.types));
+      setStep('review');
     } catch (err) {
-      const error = err as Error;
-      setParseError(`Invalid JSON: ${error.message}`);
+      setReviewError(`Failed to review import: ${(err as Error).message}`);
+    } finally {
+      setReviewing(false);
     }
-  };
+  }, [parsedDoc, sourceMethod, schemaText, options, sourceLabel, acceptDocument]);
 
-  const toggleDefinition = (defName: string) => {
-    const newSelected = new Set(selectedDefs);
-    if (newSelected.has(defName)) {
-      newSelected.delete(defName);
-    } else {
-      newSelected.add(defName);
-    }
-    setSelectedDefs(newSelected);
-  };
+  const toggleSelected = useCallback((name: string) => {
+    setSelectedNames((current) => {
+      const next = new Set(current);
+      if (next.has(name)) {
+        next.delete(name);
+      } else {
+        next.add(name);
+      }
+      return next;
+    });
+  }, []);
 
-  const handleImport = async () => {
-    if (selectedDefs.size === 0) {
-      onMessage('error', 'Please select at least one definition to import');
+  const setResolutionAction = useCallback((name: string, action: ResolutionAction) => {
+    setResolutions((current) => ({
+      ...current,
+      [name]: { action, new_name: action === 'rename' ? current[name]?.new_name ?? '' : undefined },
+    }));
+  }, []);
+
+  const setResolutionNewName = useCallback((name: string, newName: string) => {
+    setResolutions((current) => ({
+      ...current,
+      [name]: { action: 'rename', new_name: newName },
+    }));
+  }, []);
+
+  /** Commit the selected types with their conflict resolutions and advance to the result step. */
+  const handleImport = useCallback(async () => {
+    if (!parsedDoc || !review) return;
+
+    const names = Array.from(selectedNames);
+    const validationError = validateSelection(names, review.types, resolutions);
+    if (validationError) {
+      setReviewError(validationError);
       return;
     }
 
     setImporting(true);
+    setReviewError(null);
 
     try {
-      // Construct a schema with $defs from our definitions
-      // This handles both standalone schemas (which we've already converted to definitions)
-      // and schemas that already had $defs/definitions
-      const schemaForApi = {
-        $defs: Object.fromEntries(
-          Array.from(selectedDefs).map(defName => [defName, definitions[defName]])
-        )
-      };
-
+      const body = buildImportRequestBody(parsedDoc, options, sourceLabel, {
+        selectedNames: names,
+        resolutions,
+      });
       const response = await fetch('/api/primitives/import', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          schema: schemaForApi,
-          selected_definitions: Array.from(selectedDefs),
-        }),
+        body: JSON.stringify(body),
       });
-
       const data = await response.json();
 
-      if (data.success) {
-        const imported = data.imported || [];
-        const skipped = data.skipped || [];
-        const errors = data.errors || [];
-
-        let message = `Imported ${imported.length} primitive(s)`;
-        if (skipped.length > 0) {
-          message += `, skipped ${skipped.length}`;
-        }
-        if (errors.length > 0) {
-          message += `, ${errors.length} error(s)`;
-        }
-
-        onMessage('success', message);
-        onComplete();
-      } else {
-        onMessage('error', data.error || 'Failed to import primitives');
+      if (!response.ok || !data.success) {
+        setReviewError(data.error || 'Failed to import primitives');
+        return;
       }
-    } catch (error) {
-      console.error('Error importing primitives:', error);
-      onMessage('error', 'Failed to import primitives');
+
+      const summary = summarizeImportResult(data);
+      setResult(summary);
+      setStep('result');
+      onMessage('success', describeImportResult(summary));
+    } catch (err) {
+      setReviewError(`Failed to import primitives: ${(err as Error).message}`);
     } finally {
       setImporting(false);
     }
-  };
+  }, [parsedDoc, review, selectedNames, resolutions, options, sourceLabel, onMessage]);
+
+  const detectedCount = Object.keys(previewDefinitions).length;
+  const canReview = Boolean(parsedDoc) || (sourceMethod === 'paste' && schemaText.trim().length > 0);
 
   return (
     <Dialog open onOpenChange={onClose}>
-      <DialogContent className="max-w-5xl h-[70vh] min-h-[70vh] flex flex-col overflow-hidden" aria-describedby={undefined}>
+      <DialogContent className="max-w-5xl h-[78vh] min-h-[78vh] flex flex-col overflow-hidden" aria-describedby={undefined}>
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <Upload className="w-5 h-5" />
-            Import Primitives from JSON Schema
+            Import Primitives
           </DialogTitle>
         </DialogHeader>
 
+        <WizardSteps step={step} />
+
         <div className="space-y-4 py-4 flex-1 min-h-0 overflow-y-auto">
-          {!showPreview ? (
-            <Tabs value={importMethod} onValueChange={(v) => setImportMethod(v as 'fileOrUrl' | 'paste')}>
-              <TabsList className="w-full h-auto p-0 rounded-none bg-transparent border-b border-gray-200 dark:border-gray-700 justify-start gap-0 mb-4">
-                <TabsTrigger
-                  value="fileOrUrl"
-                  className="flex items-center gap-2 rounded-none border-b-2 border-transparent bg-transparent px-4 py-3 text-sm font-medium text-gray-500 dark:text-gray-400 data-[state=active]:border-indigo-600 data-[state=active]:text-indigo-600 dark:data-[state=active]:text-indigo-400 data-[state=active]:bg-transparent data-[state=active]:shadow-none -mb-px"
-                >
-                  <Upload className="w-4 h-4" />
-                  File or URL
-                </TabsTrigger>
-                <TabsTrigger
-                  value="paste"
-                  className="flex items-center gap-2 rounded-none border-b-2 border-transparent bg-transparent px-4 py-3 text-sm font-medium text-gray-500 dark:text-gray-400 data-[state=active]:border-indigo-600 data-[state=active]:text-indigo-600 dark:data-[state=active]:text-indigo-400 data-[state=active]:bg-transparent data-[state=active]:shadow-none -mb-px"
-                >
-                  <FileCode className="w-4 h-4" />
-                  Paste JSON
-                </TabsTrigger>
-              </TabsList>
-
-              <TabsContent value="fileOrUrl" className="mt-0">
-                <div className="space-y-6">
-                  <div className="space-y-4">
-                    <Label className="text-base">Upload file</Label>
-                    {!file ? (
-                      <div
-                        className={`
-                          border-2 border-dashed rounded-lg p-8 text-center cursor-pointer
-                          transition-colors duration-200
-                          ${isDragging
-                            ? 'border-indigo-500 bg-indigo-50 dark:bg-indigo-900/20'
-                            : 'border-gray-300 dark:border-gray-600 hover:border-indigo-400 dark:hover:border-indigo-500'
-                          }
-                        `}
-                        onDragOver={handleDragOver}
-                        onDragLeave={handleDragLeave}
-                        onDrop={handleDrop}
-                        onClick={() => fileInputRef.current?.click()}
-                      >
-                        <Upload className="w-12 h-12 mx-auto mb-4 text-gray-400 dark:text-gray-500" />
-                        <p className="text-lg font-medium text-gray-900 dark:text-white mb-2">
-                          Drag & Drop or Click to Select
-                        </p>
-                        <p className="text-sm text-gray-500 dark:text-gray-400">
-                          JSON Schema file (.json, .yaml, .yml) with $defs or definitions
-                        </p>
-                        <input
-                          ref={fileInputRef}
-                          type="file"
-                          accept=".json,.yaml,.yml"
-                          className="hidden"
-                          onChange={(e) => {
-                            const selectedFile = e.target.files?.[0];
-                            if (selectedFile) {
-                              handleFileSelect(selectedFile);
-                            }
-                          }}
-                        />
-                      </div>
-                    ) : (
-                      <div className="border border-gray-200 dark:border-gray-700 rounded-lg p-4">
-                        <div className="flex items-center justify-between mb-2">
-                          <div className="flex items-center gap-3">
-                            <FileJson className="w-8 h-8 text-green-500" />
-                            <div>
-                              <p className="font-medium text-gray-900 dark:text-white">{file.name}</p>
-                              <p className="text-sm text-gray-500 dark:text-gray-400">
-                                {(file.size / 1024).toFixed(1)} KB
-                              </p>
-                            </div>
-                          </div>
-                          <Button variant="ghost" size="icon" onClick={clearFile}>
-                            <X className="w-4 h-4" />
-                          </Button>
-                        </div>
-                        {isLoadingFile && (
-                          <p className="text-sm text-indigo-600 dark:text-indigo-400">
-                            Processing file...
-                          </p>
-                        )}
-                      </div>
-                    )}
-                  </div>
-
-                  <div className="relative">
-                    <div className="absolute inset-0 flex items-center" aria-hidden="true">
-                      <div className="w-full border-t border-gray-200 dark:border-gray-600" />
-                    </div>
-                    <div className="relative flex justify-center text-sm">
-                      <span className="bg-white dark:bg-gray-800 px-2 text-gray-500 dark:text-gray-400">or</span>
-                    </div>
-                  </div>
-
-                  <div className="space-y-4">
-                    <Label htmlFor="schema-url" className="text-base">Fetch from URL</Label>
-                    <p className="text-sm text-gray-500 dark:text-gray-400">
-                      Enter the URL of a JSON Schema file to import primitives from
-                    </p>
-                    <div className="flex gap-2">
-                      <Input
-                        id="schema-url"
-                        type="url"
-                        placeholder="https://example.com/schema.json"
-                        value={urlInput}
-                        onChange={(e) => setUrlInput(e.target.value)}
-                        className="flex-1"
-                        disabled={isLoadingUrl}
-                      />
-                      <Button
-                        onClick={handleUrlFetch}
-                        disabled={!urlInput.trim() || isLoadingUrl}
-                      >
-                        {isLoadingUrl ? 'Fetching...' : 'Fetch'}
-                      </Button>
-                    </div>
-                  </div>
-
-                  {parseError && (
-                    <Alert variant="error">
-                      <AlertCircle className="h-4 w-4" />
-                      <span>{parseError}</span>
-                    </Alert>
-                  )}
-
-                  <div className="text-sm text-gray-500 dark:text-gray-400 space-y-1">
-                    <p className="font-medium">Supported formats:</p>
-                    <ul className="list-disc list-inside pl-2">
-                      <li>JSON Schema with $defs or definitions</li>
-                      <li>Standalone type definitions (e.g., ISO primitives)</li>
-                      <li>JSON or YAML format</li>
-                    </ul>
-                  </div>
-                </div>
-              </TabsContent>
-
-              <TabsContent value="paste" className="mt-0">
-                <div className="space-y-4">
-                  <div className="space-y-2">
-                    <Label>JSON Schema with $defs or definitions</Label>
-                    <div className="border border-gray-300 dark:border-gray-600 rounded-lg overflow-hidden">
-                      <MonacoEditor
-                        height="400px"
-                        language="json"
-                        theme="vs-dark"
-                        value={schemaJson}
-                        onChange={handleSchemaChange}
-                        options={{
-                          minimap: { enabled: false },
-                          scrollBeyondLastLine: false,
-                          fontSize: 13,
-                        }}
-                      />
-                    </div>
-                    {parseError && (
-                      <Alert variant="error">
-                        <AlertCircle className="h-4 w-4" />
-                        <span>{parseError}</span>
-                      </Alert>
-                    )}
-                  </div>
-
-                  <div className="flex justify-end">
-                    <Button onClick={handleParseSchema} disabled={!schemaJson.trim()}>
-                      Parse Schema
-                    </Button>
-                  </div>
-                </div>
-              </TabsContent>
-            </Tabs>
-          ) : (
-            <>
-              <Alert variant="default">
-                <CheckCircle className="h-4 w-4" />
-                <span>Found {Object.keys(definitions).length} definition(s). Select which ones to import:</span>
-              </Alert>
-
-              <div className="border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden">
-                <div className="max-h-96 overflow-y-auto">
-                  {Object.entries(definitions).map(([defName, defSchema]) => {
-                    const schema = defSchema as Record<string, unknown>;
-                    const schemaType = determineCategoryFromSchema(schema);
-                    const schemaDescription = schema.description as string | undefined;
-                    const schemaTitle = schema.title as string | undefined;
-
-                    return (
-                      <div
-                        key={defName}
-                        className="border-b border-gray-200 dark:border-gray-700 last:border-0 hover:bg-gray-50 dark:hover:bg-gray-900/50"
-                      >
-                        <label className="flex items-start gap-3 p-4 cursor-pointer">
-                          <input
-                            type="checkbox"
-                            checked={selectedDefs.has(defName)}
-                            onChange={() => toggleDefinition(defName)}
-                            className="mt-1 w-4 h-4 text-indigo-600 rounded"
-                          />
-                          <div className="flex-1 min-w-0">
-                            <div className="flex items-center gap-2 mb-1">
-                              <FileCode className="w-4 h-4 text-indigo-600" />
-                              <span className="font-medium text-gray-900 dark:text-white">{defName}</span>
-                              <span className="text-xs text-gray-500 dark:text-gray-400">
-                                ({schemaType})
-                              </span>
-                            </div>
-                            {schemaTitle && schemaTitle !== defName && (
-                              <p className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">{schemaTitle}</p>
-                            )}
-                            {schemaDescription && (
-                              <p className="text-sm text-gray-600 dark:text-gray-400 mb-2">{schemaDescription}</p>
-                            )}
-                            <pre className="text-xs bg-gray-100 dark:bg-gray-800 p-2 rounded overflow-x-auto max-h-48 overflow-y-auto">
-                              {JSON.stringify(defSchema, null, 2)}
-                            </pre>
-                          </div>
-                        </label>
-                      </div>
-                    );
-                  })}
-                </div>
-              </div>
-
-              <div className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400">
-                <span>{selectedDefs.size} of {Object.keys(definitions).length} selected</span>
-                <Button
-                  variant="secondary"
-                  size="sm"
-                  onClick={() => {
-                    if (selectedDefs.size === Object.keys(definitions).length) {
-                      setSelectedDefs(new Set());
-                    } else {
-                      setSelectedDefs(new Set(Object.keys(definitions)));
-                    }
-                  }}
-                >
-                  {selectedDefs.size === Object.keys(definitions).length ? 'Deselect All' : 'Select All'}
-                </Button>
-              </div>
-            </>
+          {step === 'source' && (
+            <SourceStep
+              sourceKind={sourceKind}
+              onSourceKindChange={(kind) => {
+                setSourceKind(kind);
+                setReview(null);
+              }}
+              sourceMethod={sourceMethod}
+              onSourceMethodChange={(method) => {
+                setSourceMethod(method);
+                setParseError(null);
+              }}
+              targetNamespace={targetNamespace}
+              onTargetNamespaceChange={setTargetNamespace}
+              mapCoreFormats={mapCoreFormats}
+              onMapCoreFormatsChange={setMapCoreFormats}
+              dedupe={dedupe}
+              onDedupeChange={setDedupe}
+              file={file}
+              isDragging={isDragging}
+              isLoadingFile={isLoadingFile}
+              fileInputRef={fileInputRef}
+              onFileSelect={handleFileSelect}
+              onDragOver={handleDragOver}
+              onDragLeave={handleDragLeave}
+              onDrop={handleDrop}
+              onClearFile={clearFile}
+              urlInput={urlInput}
+              onUrlInputChange={setUrlInput}
+              isLoadingUrl={isLoadingUrl}
+              onUrlFetch={handleUrlFetch}
+              schemaText={schemaText}
+              onSchemaTextChange={handleSchemaTextChange}
+              onParsePasted={handleParsePasted}
+              parseError={parseError}
+              reviewError={reviewError}
+              detectedCount={detectedCount}
+              hasDocument={Boolean(parsedDoc)}
+            />
           )}
+
+          {step === 'review' && review && (
+            <ReviewStep
+              review={review}
+              previewDefinitions={previewDefinitions}
+              selectedNames={selectedNames}
+              resolutions={resolutions}
+              onToggleSelected={toggleSelected}
+              onResolutionAction={setResolutionAction}
+              onResolutionNewName={setResolutionNewName}
+              reviewError={reviewError}
+            />
+          )}
+
+          {step === 'result' && result && <ResultStep result={result} />}
         </div>
 
         <DialogFooter>
-          {showPreview && (
+          {step === 'source' && (
+            <>
+              <Button variant="secondary" onClick={onClose}>
+                Cancel
+              </Button>
+              <Button onClick={handleReview} disabled={!canReview || reviewing}>
+                {reviewing ? 'Reviewing…' : 'Continue to Review'}
+                {!reviewing && <ArrowRight className="w-4 h-4 ml-2" />}
+              </Button>
+            </>
+          )}
+
+          {step === 'review' && review && (
+            <>
+              <Button variant="secondary" onClick={() => setStep('source')} disabled={importing}>
+                Back
+              </Button>
+              <Button variant="secondary" onClick={onClose} disabled={importing}>
+                Cancel
+              </Button>
+              <Button onClick={handleImport} disabled={importing || selectedNames.size === 0}>
+                {importing ? 'Importing…' : `Import ${selectedNames.size} Selected`}
+              </Button>
+            </>
+          )}
+
+          {step === 'result' && (
             <Button
-              variant="secondary"
               onClick={() => {
-                setShowPreview(false);
-                setDefinitions({});
-                setSelectedDefs(new Set());
-                setParseError(null);
-                if (importMethod === 'fileOrUrl') {
-                  clearFile();
-                  setUrlInput('');
-                  setSchemaJson('');
-                } else {
-                  setSchemaJson('');
-                }
+                onComplete();
               }}
             >
-              Back
-            </Button>
-          )}
-          <Button variant="secondary" onClick={onClose} disabled={importing}>
-            Cancel
-          </Button>
-          {showPreview && (
-            <Button onClick={handleImport} disabled={importing || selectedDefs.size === 0}>
-              {importing ? 'Importing...' : `Import ${selectedDefs.size} Selected`}
+              Done
             </Button>
           )}
         </DialogFooter>
       </DialogContent>
     </Dialog>
+  );
+}
+
+/** Step indicator across the top of the wizard. */
+function WizardSteps({ step }: { step: WizardStep }) {
+  const steps: Array<{ key: WizardStep; label: string }> = [
+    { key: 'source', label: '1 · Source' },
+    { key: 'review', label: '2 · Review' },
+    { key: 'result', label: '3 · Result' },
+  ];
+  const activeIndex = steps.findIndex((s) => s.key === step);
+
+  return (
+    <div className="flex items-center gap-2 border-b border-gray-200 dark:border-gray-700 pb-3">
+      {steps.map((s, index) => {
+        const isActive = index === activeIndex;
+        const isDone = index < activeIndex;
+        return (
+          <div
+            key={s.key}
+            className={`flex items-center gap-2 px-3 py-1 rounded-full text-sm font-medium ${
+              isActive
+                ? 'bg-indigo-100 text-indigo-700 dark:bg-indigo-900/40 dark:text-indigo-300'
+                : isDone
+                  ? 'text-emerald-600 dark:text-emerald-400'
+                  : 'text-gray-400 dark:text-gray-500'
+            }`}
+          >
+            {isDone ? <CheckCircle className="w-4 h-4" /> : null}
+            {s.label}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+interface SourceStepProps {
+  sourceKind: SourceKind;
+  onSourceKindChange: (kind: SourceKind) => void;
+  sourceMethod: SourceMethod;
+  onSourceMethodChange: (method: SourceMethod) => void;
+  targetNamespace: string;
+  onTargetNamespaceChange: (value: string) => void;
+  mapCoreFormats: boolean;
+  onMapCoreFormatsChange: (value: boolean) => void;
+  dedupe: boolean;
+  onDedupeChange: (value: boolean) => void;
+  file: File | null;
+  isDragging: boolean;
+  isLoadingFile: boolean;
+  fileInputRef: React.RefObject<HTMLInputElement | null>;
+  onFileSelect: (file: File) => void;
+  onDragOver: (e: React.DragEvent) => void;
+  onDragLeave: (e: React.DragEvent) => void;
+  onDrop: (e: React.DragEvent) => void;
+  onClearFile: () => void;
+  urlInput: string;
+  onUrlInputChange: (value: string) => void;
+  isLoadingUrl: boolean;
+  onUrlFetch: () => void;
+  schemaText: string;
+  onSchemaTextChange: (value: string | undefined) => void;
+  onParsePasted: () => boolean;
+  parseError: string | null;
+  reviewError: string | null;
+  detectedCount: number;
+  hasDocument: boolean;
+}
+
+/** Step 1: choose the source kind / method, set options, and provide the document. */
+function SourceStep(props: SourceStepProps) {
+  const {
+    sourceKind,
+    onSourceKindChange,
+    targetNamespace,
+    onTargetNamespaceChange,
+    mapCoreFormats,
+    onMapCoreFormatsChange,
+    dedupe,
+    onDedupeChange,
+    parseError,
+    reviewError,
+    detectedCount,
+    hasDocument,
+  } = props;
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-3">
+        <Label className="text-base">Source type</Label>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+          {SOURCE_KIND_CARDS.map((card) => {
+            const Icon = card.icon;
+            const isActive = sourceKind === card.kind;
+            return (
+              <button
+                key={card.kind}
+                type="button"
+                onClick={() => onSourceKindChange(card.kind)}
+                className={`text-left rounded-lg border p-4 transition-colors ${
+                  isActive
+                    ? 'border-indigo-500 bg-indigo-50 dark:bg-indigo-900/20 ring-1 ring-indigo-500'
+                    : 'border-gray-200 dark:border-gray-700 hover:border-indigo-300 dark:hover:border-indigo-600'
+                }`}
+              >
+                <div className="flex items-center gap-2 mb-1">
+                  <Icon className={`w-5 h-5 ${isActive ? 'text-indigo-600 dark:text-indigo-400' : 'text-gray-400'}`} />
+                  <span className="font-medium text-gray-900 dark:text-white">{card.title}</span>
+                </div>
+                <p className="text-xs text-gray-500 dark:text-gray-400">{card.description}</p>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <SourceMethodInput {...props} />
+
+      {detectedCount > 0 && (
+        <Alert variant="default">
+          <CheckCircle className="h-4 w-4" />
+          <span>
+            Detected {detectedCount} {sourceKindLabel(sourceKind)} type{detectedCount === 1 ? '' : 's'}. Continue to
+            review conflicts before importing.
+          </span>
+        </Alert>
+      )}
+
+      {!hasDocument && parseError && (
+        <Alert variant="error">
+          <AlertCircle className="h-4 w-4" />
+          <span>{parseError}</span>
+        </Alert>
+      )}
+
+      <div className="space-y-3 border-t border-gray-200 dark:border-gray-700 pt-4">
+        <Label className="text-base">Options</Label>
+        <div className="space-y-2">
+          <Label htmlFor="target-namespace">Target namespace (optional)</Label>
+          <Input
+            id="target-namespace"
+            placeholder="e.g. acme/v1/types"
+            value={targetNamespace}
+            onChange={(e) => onTargetNamespaceChange(e.target.value)}
+          />
+        </div>
+        <label className="flex items-center gap-2 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={mapCoreFormats}
+            onChange={(e) => onMapCoreFormatsChange(e.target.checked)}
+            className="w-4 h-4 text-indigo-600 rounded"
+          />
+          <span className="text-sm text-gray-700 dark:text-gray-300">
+            Map recognized formats to core types ($ref rewrite)
+          </span>
+        </label>
+        <label className="flex items-center gap-2 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={dedupe}
+            onChange={(e) => onDedupeChange(e.target.checked)}
+            className="w-4 h-4 text-indigo-600 rounded"
+          />
+          <span className="text-sm text-gray-700 dark:text-gray-300">Skip definitions identical to an existing type</span>
+        </label>
+      </div>
+
+      {reviewError && (
+        <Alert variant="error">
+          <AlertCircle className="h-4 w-4" />
+          <span>{reviewError}</span>
+        </Alert>
+      )}
+    </div>
+  );
+}
+
+/** The file / URL / paste intake tabs for the source step. */
+function SourceMethodInput(props: SourceStepProps) {
+  const {
+    sourceMethod,
+    onSourceMethodChange,
+    file,
+    isDragging,
+    isLoadingFile,
+    fileInputRef,
+    onFileSelect,
+    onDragOver,
+    onDragLeave,
+    onDrop,
+    onClearFile,
+    urlInput,
+    onUrlInputChange,
+    isLoadingUrl,
+    onUrlFetch,
+    schemaText,
+    onSchemaTextChange,
+    onParsePasted,
+    hasDocument,
+    parseError,
+  } = props;
+
+  const tabClass =
+    'flex items-center gap-2 rounded-none border-b-2 border-transparent bg-transparent px-4 py-3 text-sm font-medium text-gray-500 dark:text-gray-400 data-[state=active]:border-indigo-600 data-[state=active]:text-indigo-600 dark:data-[state=active]:text-indigo-400 data-[state=active]:bg-transparent data-[state=active]:shadow-none -mb-px';
+
+  return (
+    <Tabs value={sourceMethod} onValueChange={(v) => onSourceMethodChange(v as SourceMethod)}>
+      <TabsList className="w-full h-auto p-0 rounded-none bg-transparent border-b border-gray-200 dark:border-gray-700 justify-start gap-0 mb-4">
+        <TabsTrigger value="file" className={tabClass}>
+          <Upload className="w-4 h-4" />
+          File
+        </TabsTrigger>
+        <TabsTrigger value="url" className={tabClass}>
+          <FileCode className="w-4 h-4" />
+          URL
+        </TabsTrigger>
+        <TabsTrigger value="paste" className={tabClass}>
+          <FileText className="w-4 h-4" />
+          Paste
+        </TabsTrigger>
+      </TabsList>
+
+      <TabsContent value="file" className="mt-0">
+        {!file ? (
+          <div
+            className={`border-2 border-dashed rounded-lg p-8 text-center cursor-pointer transition-colors duration-200 ${
+              isDragging
+                ? 'border-indigo-500 bg-indigo-50 dark:bg-indigo-900/20'
+                : 'border-gray-300 dark:border-gray-600 hover:border-indigo-400 dark:hover:border-indigo-500'
+            }`}
+            onDragOver={onDragOver}
+            onDragLeave={onDragLeave}
+            onDrop={onDrop}
+            onClick={() => fileInputRef.current?.click()}
+          >
+            <Upload className="w-12 h-12 mx-auto mb-4 text-gray-400 dark:text-gray-500" />
+            <p className="text-lg font-medium text-gray-900 dark:text-white mb-2">Drag &amp; Drop or Click to Select</p>
+            <p className="text-sm text-gray-500 dark:text-gray-400">Schema or bundle file (.json, .yaml, .yml)</p>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept=".json,.yaml,.yml"
+              className="hidden"
+              onChange={(e) => {
+                const selectedFile = e.target.files?.[0];
+                if (selectedFile) {
+                  onFileSelect(selectedFile);
+                }
+              }}
+            />
+          </div>
+        ) : (
+          <div className="border border-gray-200 dark:border-gray-700 rounded-lg p-4">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-3">
+                <FileJson className="w-8 h-8 text-green-500" />
+                <div>
+                  <p className="font-medium text-gray-900 dark:text-white">{file.name}</p>
+                  <p className="text-sm text-gray-500 dark:text-gray-400">{(file.size / 1024).toFixed(1)} KB</p>
+                </div>
+              </div>
+              <Button variant="ghost" size="icon" onClick={onClearFile}>
+                <X className="w-4 h-4" />
+              </Button>
+            </div>
+            {isLoadingFile && <p className="mt-2 text-sm text-indigo-600 dark:text-indigo-400">Processing file…</p>}
+          </div>
+        )}
+      </TabsContent>
+
+      <TabsContent value="url" className="mt-0">
+        <div className="space-y-2">
+          <Label htmlFor="schema-url">Fetch from URL</Label>
+          <div className="flex gap-2">
+            <Input
+              id="schema-url"
+              type="url"
+              placeholder="https://example.com/schema.json"
+              value={urlInput}
+              onChange={(e) => onUrlInputChange(e.target.value)}
+              className="flex-1"
+              disabled={isLoadingUrl}
+            />
+            <Button onClick={onUrlFetch} disabled={!urlInput.trim() || isLoadingUrl}>
+              {isLoadingUrl ? 'Fetching…' : 'Fetch'}
+            </Button>
+          </div>
+          {hasDocument && <p className="text-sm text-emerald-600 dark:text-emerald-400">Document fetched.</p>}
+        </div>
+      </TabsContent>
+
+      <TabsContent value="paste" className="mt-0">
+        <div className="space-y-2">
+          <Label>Paste JSON or YAML</Label>
+          <div className="border border-gray-300 dark:border-gray-600 rounded-lg overflow-hidden">
+            <MonacoEditor
+              height="320px"
+              language="json"
+              theme="vs-dark"
+              value={schemaText}
+              onChange={onSchemaTextChange}
+              options={{ minimap: { enabled: false }, scrollBeyondLastLine: false, fontSize: 13 }}
+            />
+          </div>
+          <div className="flex items-center justify-between">
+            {hasDocument ? (
+              <p className="text-sm text-emerald-600 dark:text-emerald-400">Document parsed.</p>
+            ) : (
+              <span />
+            )}
+            <Button variant="secondary" size="sm" onClick={onParsePasted} disabled={!schemaText.trim()}>
+              Parse
+            </Button>
+          </div>
+          {!hasDocument && parseError && (
+            <Alert variant="error">
+              <AlertCircle className="h-4 w-4" />
+              <span>{parseError}</span>
+            </Alert>
+          )}
+        </div>
+      </TabsContent>
+    </Tabs>
+  );
+}
+
+interface ReviewStepProps {
+  review: ReviewResponse;
+  previewDefinitions: Record<string, Record<string, unknown>>;
+  selectedNames: Set<string>;
+  resolutions: ResolutionMap;
+  onToggleSelected: (name: string) => void;
+  onResolutionAction: (name: string, action: ResolutionAction) => void;
+  onResolutionNewName: (name: string, newName: string) => void;
+  reviewError: string | null;
+}
+
+/** Step 2: render the classification report and let the user resolve conflicts. */
+function ReviewStep(props: ReviewStepProps) {
+  const {
+    review,
+    previewDefinitions,
+    selectedNames,
+    resolutions,
+    onToggleSelected,
+    onResolutionAction,
+    onResolutionNewName,
+    reviewError,
+  } = props;
+
+  const { summary } = review;
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center gap-2">
+        <Badge variant="success">{summary.new} new</Badge>
+        <Badge variant="warning">{summary.conflict} conflict</Badge>
+        <Badge variant="secondary">{summary.identical} identical</Badge>
+        {summary.invalid > 0 && <Badge variant="error">{summary.invalid} invalid</Badge>}
+        <span className="text-sm text-gray-500 dark:text-gray-400">· {summary.total} total</span>
+      </div>
+
+      {review.warnings.length > 0 && (
+        <Alert variant="warning">
+          <AlertCircle className="h-4 w-4" />
+          <span>{review.warnings.join('; ')}</span>
+        </Alert>
+      )}
+
+      <div className="border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden">
+        <div className="max-h-[40vh] overflow-y-auto divide-y divide-gray-200 dark:divide-gray-700">
+          {review.types.map((type) => (
+            <ReviewTypeRow
+              key={type.name}
+              type={type}
+              schema={previewDefinitions[type.name]}
+              selected={selectedNames.has(type.name)}
+              resolution={resolutions[type.name]}
+              onToggleSelected={onToggleSelected}
+              onResolutionAction={onResolutionAction}
+              onResolutionNewName={onResolutionNewName}
+            />
+          ))}
+        </div>
+      </div>
+
+      {reviewError && (
+        <Alert variant="error">
+          <AlertCircle className="h-4 w-4" />
+          <span>{reviewError}</span>
+        </Alert>
+      )}
+    </div>
+  );
+}
+
+interface ReviewTypeRowProps {
+  type: ReviewType;
+  schema?: Record<string, unknown>;
+  selected: boolean;
+  resolution?: { action: ResolutionAction; new_name?: string };
+  onToggleSelected: (name: string) => void;
+  onResolutionAction: (name: string, action: ResolutionAction) => void;
+  onResolutionNewName: (name: string, newName: string) => void;
+}
+
+/** One reviewed type: classification, validation, and (for conflicts) resolution controls. */
+function ReviewTypeRow(props: ReviewTypeRowProps) {
+  const { type, schema, selected, resolution, onToggleSelected, onResolutionAction, onResolutionNewName } = props;
+  const badge = STATUS_BADGE[type.status];
+  const isInvalid = type.status === 'invalid';
+  const category = schema ? determineCategoryFromSchema(schema) : null;
+
+  return (
+    <div className="p-4 hover:bg-gray-50 dark:hover:bg-gray-900/50">
+      <div className="flex items-start gap-3">
+        <input
+          type="checkbox"
+          checked={selected}
+          disabled={isInvalid}
+          onChange={() => onToggleSelected(type.name)}
+          className="mt-1 w-4 h-4 text-indigo-600 rounded disabled:opacity-40"
+        />
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 mb-1 flex-wrap">
+            <FileCode className="w-4 h-4 text-indigo-600" />
+            <span className="font-medium text-gray-900 dark:text-white">{type.name}</span>
+            {category && <span className="text-xs text-gray-500 dark:text-gray-400">({category})</span>}
+            <Badge variant={badge.variant}>{badge.label}</Badge>
+            {type.unresolved_refs.length > 0 && (
+              <Badge variant="warning">
+                {type.unresolved_refs.length} unresolved $ref{type.unresolved_refs.length === 1 ? '' : 's'}
+              </Badge>
+            )}
+          </div>
+
+          {isInvalid && (
+            <div className="text-sm text-red-600 dark:text-red-400 mb-2">
+              {type.error?.error === 'scope_violation'
+                ? 'Scope violation — cannot be imported into this scope.'
+                : 'Not a valid draft 2020-12 schema — cannot be imported.'}
+              {type.validation_errors.length > 0 && (
+                <ul className="list-disc list-inside mt-1">
+                  {type.validation_errors.slice(0, 5).map((err, index) => (
+                    <li key={index}>
+                      {(err.field ? `${err.field}: ` : '') + (err.message || JSON.stringify(err))}
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          )}
+
+          {type.status === 'conflict' && (
+            <div className="flex flex-wrap items-center gap-2 mt-2">
+              <span className="text-sm text-gray-600 dark:text-gray-400">A different type already exists. Resolve:</span>
+              <select
+                value={resolution?.action ?? 'keep'}
+                onChange={(e) => onResolutionAction(type.name, e.target.value as ResolutionAction)}
+                className="px-3 py-1.5 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
+              >
+                <option value="keep">Keep existing</option>
+                <option value="overwrite">Overwrite</option>
+                <option value="rename">Import as new name</option>
+              </select>
+              {resolution?.action === 'rename' && (
+                <Input
+                  placeholder="new_name"
+                  value={resolution.new_name ?? ''}
+                  onChange={(e) => onResolutionNewName(type.name, e.target.value)}
+                  className="w-48"
+                />
+              )}
+            </div>
+          )}
+
+          {schema && (
+            <pre className="mt-2 text-xs bg-gray-100 dark:bg-gray-800 p-2 rounded overflow-x-auto max-h-40 overflow-y-auto">
+              {JSON.stringify(schema, null, 2)}
+            </pre>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/** Step 3: the committed outcome, bucketed by what the import did. */
+function ResultStep({ result }: { result: ImportResultSummary }) {
+  const buckets: Array<{ label: string; items: string[]; variant: 'success' | 'warning' | 'secondary' | 'error' }> = [
+    { label: 'Imported', items: result.imported, variant: 'success' },
+    {
+      label: 'Overwritten',
+      items: result.overwritten,
+      variant: 'warning',
+    },
+    {
+      label: 'Renamed',
+      items: result.renamed.map((r) => (typeof r === 'string' ? r : `${r.name} → ${r.new_name ?? ''}`)),
+      variant: 'warning',
+    },
+    { label: 'Identical (skipped)', items: result.identical, variant: 'secondary' },
+    {
+      label: 'Skipped',
+      items: result.skipped.map((s) => (typeof s === 'string' ? s : `${s.name}${s.reason ? ` — ${s.reason}` : ''}`)),
+      variant: 'secondary',
+    },
+    {
+      label: 'Errors',
+      items: result.errors.map((e) => (typeof e === 'string' ? e : `${e.name}${e.error ? ` — ${e.error}` : ''}`)),
+      variant: 'error',
+    },
+  ];
+
+  const hasErrors = result.errors.length > 0;
+
+  return (
+    <div className="space-y-4">
+      <Alert variant={hasErrors ? 'warning' : 'default'}>
+        {hasErrors ? <AlertCircle className="h-4 w-4" /> : <CheckCircle className="h-4 w-4" />}
+        <span>{describeImportResult(result)}</span>
+      </Alert>
+
+      {result.warnings.length > 0 && (
+        <Alert variant="warning">
+          <AlertCircle className="h-4 w-4" />
+          <span>{result.warnings.join('; ')}</span>
+        </Alert>
+      )}
+
+      <div className="space-y-3">
+        {buckets
+          .filter((bucket) => bucket.items.length > 0)
+          .map((bucket) => (
+            <div key={bucket.label} className="border border-gray-200 dark:border-gray-700 rounded-lg p-3">
+              <div className="flex items-center gap-2 mb-2">
+                <Badge variant={bucket.variant}>{bucket.items.length}</Badge>
+                <span className="text-sm font-medium text-gray-900 dark:text-white">{bucket.label}</span>
+              </div>
+              <ul className="text-sm text-gray-600 dark:text-gray-400 space-y-1">
+                {bucket.items.map((item, index) => (
+                  <li key={index} className="font-mono text-xs">
+                    {item}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+      </div>
+
+      {result.importId && (
+        <p className="text-xs text-gray-400 dark:text-gray-500">Import record: {result.importId}</p>
+      )}
+    </div>
   );
 }

--- a/objectified-ui/src/app/ade/dashboard/primitives/primitiveImportModel.ts
+++ b/objectified-ui/src/app/ade/dashboard/primitives/primitiveImportModel.ts
@@ -1,0 +1,462 @@
+/**
+ * Pure model + helpers for the Primitives import wizard (#3469).
+ *
+ * These functions carry no React/DOM state so they can be unit-tested in isolation and
+ * reused by both the wizard component and its tests. They mirror the REST import pipeline
+ * contract (`POST /v1/primitives/{tenant}/import/review` and `.../import`, see
+ * objectified-rest/src/app/primitives_routes.py): a source document is parsed into a
+ * `name -> schema` map of definitions, reviewed for New / Identical / Conflict / Invalid
+ * classification, and committed with per-conflict resolutions (keep / overwrite / rename).
+ */
+
+import yaml from 'yaml';
+
+/** Source-kind cards offered by the wizard — mirrors the REST `source_kind` values. */
+export type SourceKind = 'json-schema' | 'type-def-bundle' | 'openapi';
+
+/** Intake method tabs offered by the wizard's source step. */
+export type SourceMethod = 'file' | 'url' | 'paste';
+
+/** Per-type classification returned by the review endpoint. */
+export type ReviewStatus = 'new' | 'identical' | 'conflict' | 'invalid';
+
+/** Conflict-resolution action the commit path accepts for a conflicting type (#3464). */
+export type ResolutionAction = 'keep' | 'overwrite' | 'rename';
+
+/** One field-level validation error from the draft 2020-12 report. */
+export interface ValidationError {
+  field?: string;
+  message?: string;
+  [key: string]: unknown;
+}
+
+/** One reviewed type as returned by `POST .../import/review`. */
+export interface ReviewType {
+  name: string;
+  status: ReviewStatus;
+  valid: boolean;
+  validation_errors: ValidationError[];
+  error?: { error?: string; details?: unknown } | null;
+  schema_id?: string | null;
+  existing_id?: string | null;
+  ref_count: number;
+  unresolved_refs: Array<Record<string, unknown>>;
+  allowed_resolutions: ResolutionAction[];
+}
+
+/** Summary counts returned by the review endpoint. */
+export interface ReviewSummary {
+  new: number;
+  identical: number;
+  conflict: number;
+  invalid: number;
+  total: number;
+}
+
+/** Full review report returned by `POST .../import/review`. */
+export interface ReviewResponse {
+  status: string;
+  source_kind: string;
+  source_label?: string | null;
+  target_namespace?: string | null;
+  warnings: string[];
+  summary: ReviewSummary;
+  types: ReviewType[];
+  dedupe: boolean;
+}
+
+/** A user's resolution choice for one conflicting type. */
+export interface Resolution {
+  action: ResolutionAction;
+  new_name?: string;
+}
+
+/** Per-type resolution map keyed by definition name. */
+export type ResolutionMap = Record<string, Resolution>;
+
+/** Import options surfaced in the wizard's source step. */
+export interface ImportOptions {
+  sourceKind: SourceKind;
+  targetNamespace: string;
+  mapCoreFormats: boolean;
+  dedupe: boolean;
+}
+
+/** Outcome of a committed import, normalized from the REST `/import` report. */
+export interface ImportResultSummary {
+  imported: string[];
+  overwritten: string[];
+  renamed: Array<{ name: string; new_name?: string } | string>;
+  identical: string[];
+  skipped: Array<{ name: string; reason?: string } | string>;
+  errors: Array<{ name: string; error?: string } | string>;
+  warnings: string[];
+  importId: string | null;
+}
+
+/**
+ * Parse a raw source document as JSON, falling back to YAML.
+ *
+ * @param content Raw file / URL / paste text.
+ * @returns The parsed object, or `null` when neither parser yields an object.
+ */
+export function parseSchemaContent(content: string): Record<string, unknown> | null {
+  try {
+    const parsed = JSON.parse(content);
+    return typeof parsed === 'object' && parsed !== null
+      ? (parsed as Record<string, unknown>)
+      : null;
+  } catch {
+    try {
+      const parsed = yaml.parse(content);
+      return typeof parsed === 'object' && parsed !== null
+        ? (parsed as Record<string, unknown>)
+        : null;
+    } catch {
+      return null;
+    }
+  }
+}
+
+/**
+ * Whether a parsed document is a standalone primitive schema rather than a container.
+ *
+ * A document carrying `$defs`, `definitions`, or (for bundles) `types` is a container;
+ * otherwise a `type` / `anyOf` / `oneOf` / `allOf` / `enum` / `const` keyword marks a
+ * single standalone type definition (e.g. an ISO primitive).
+ *
+ * @param schema The parsed document.
+ * @returns True when the document is a single standalone type.
+ */
+export function isStandalonePrimitiveSchema(schema: Record<string, unknown>): boolean {
+  if (schema.$defs || schema.definitions || schema.types) {
+    return false;
+  }
+  return (
+    'type' in schema ||
+    'anyOf' in schema ||
+    'oneOf' in schema ||
+    'allOf' in schema ||
+    'enum' in schema ||
+    'const' in schema
+  );
+}
+
+/**
+ * Derive a primitive name for a standalone schema.
+ *
+ * Priority: `$id` (last path segment) > `title` (slugified) > filename (without
+ * extension) > a stable default.
+ *
+ * @param schema The standalone schema.
+ * @param filename Optional source filename used as a fallback.
+ * @returns A snake_case identifier for the primitive.
+ */
+export function extractPrimitiveNameFromSchema(
+  schema: Record<string, unknown>,
+  filename?: string
+): string {
+  if (typeof schema.$id === 'string' && schema.$id) {
+    const lastSegment = schema.$id.split('/').pop();
+    if (lastSegment) {
+      return lastSegment.replace(/-/g, '_');
+    }
+  }
+
+  if (typeof schema.title === 'string' && schema.title) {
+    return schema.title
+      .toLowerCase()
+      .replace(/[^a-z0-9\s]/g, '')
+      .replace(/\s+/g, '_')
+      .replace(/^_+|_+$/g, '');
+  }
+
+  if (filename) {
+    return filename
+      .replace(/\.(json|yaml|yml)$/i, '')
+      .replace(/-/g, '_')
+      .replace(/\s+/g, '_');
+  }
+
+  return 'imported_primitive';
+}
+
+/**
+ * Determine a display category (JSON Schema type) for a definition.
+ *
+ * @param schema The definition schema.
+ * @returns The resolved type label, defaulting to `object`.
+ */
+export function determineCategoryFromSchema(schema: Record<string, unknown>): string {
+  if (schema.type) {
+    if (typeof schema.type === 'string') {
+      return schema.type;
+    }
+    if (Array.isArray(schema.type) && schema.type.length > 0) {
+      return String(schema.type[0]);
+    }
+  }
+
+  if (schema.anyOf || schema.oneOf) {
+    const options = (schema.anyOf || schema.oneOf) as Record<string, unknown>[];
+    if (options.length > 0 && 'const' in options[0]) {
+      const firstConst = options[0].const;
+      return typeof firstConst === 'string' ? 'string' : typeof firstConst;
+    }
+  }
+
+  if (Array.isArray(schema.enum) && schema.enum.length > 0) {
+    return typeof schema.enum[0];
+  }
+
+  if ('const' in schema) {
+    return typeof schema.const;
+  }
+
+  return 'object';
+}
+
+/**
+ * Container keywords read for each source kind, in precedence order. A type-def bundle
+ * reads `types` first (its native container) before the JSON Schema equivalents; mirrors
+ * objectified-rest's `BUNDLE_CONTAINERS` and `_resolve_import_definitions`.
+ */
+const CONTAINER_KEYS: Record<SourceKind, string[]> = {
+  'json-schema': ['$defs', 'definitions'],
+  openapi: ['$defs', 'definitions'],
+  'type-def-bundle': ['types', '$defs', 'definitions'],
+};
+
+/**
+ * Extract the `name -> schema` definitions from a parsed source document for local preview.
+ *
+ * A standalone schema (no container) is wrapped under a derived name so the wizard can
+ * preview it the same way it previews container members. The authoritative classification
+ * still comes from the server review; this is only for the source-step preview.
+ *
+ * @param doc The parsed source document.
+ * @param sourceKind The selected source kind (selects which containers are read).
+ * @param filename Optional filename used when naming a standalone schema.
+ * @returns A `name -> schema` map (possibly empty when no definitions are found).
+ */
+export function extractDefinitions(
+  doc: Record<string, unknown>,
+  sourceKind: SourceKind,
+  filename?: string
+): Record<string, Record<string, unknown>> {
+  // A standalone (non-container) schema is only meaningful for JSON Schema / OpenAPI;
+  // a bundle is expected to be a container.
+  if (sourceKind !== 'type-def-bundle' && isStandalonePrimitiveSchema(doc)) {
+    const name = extractPrimitiveNameFromSchema(doc, filename);
+    return { [name]: doc };
+  }
+
+  const defs: Record<string, Record<string, unknown>> = {};
+  for (const key of CONTAINER_KEYS[sourceKind]) {
+    const container = doc[key];
+    if (container && typeof container === 'object') {
+      for (const [name, schema] of Object.entries(container as Record<string, unknown>)) {
+        if (schema && typeof schema === 'object') {
+          defs[name] = schema as Record<string, unknown>;
+        }
+      }
+    }
+  }
+  return defs;
+}
+
+/**
+ * Build the request body shared by the review and commit endpoints.
+ *
+ * For a standalone JSON Schema / OpenAPI document the single schema is wrapped under a
+ * `$defs` container so the server resolves it uniformly; a bundle document is sent as-is.
+ *
+ * @param doc The parsed source document.
+ * @param options The selected source kind, namespace, and import options.
+ * @param sourceLabel Human label / filename / URL recorded as provenance.
+ * @param selection When provided, the selected definition names and conflict resolutions
+ *   to commit; omit for a review of all detected definitions.
+ * @returns A request body for `/api/primitives/import` or `/api/primitives/import/review`.
+ */
+export function buildImportRequestBody(
+  doc: Record<string, unknown>,
+  options: ImportOptions,
+  sourceLabel: string | null,
+  selection?: { selectedNames: string[]; resolutions: ResolutionMap }
+): Record<string, unknown> {
+  let schema: Record<string, unknown> = doc;
+  if (options.sourceKind !== 'type-def-bundle' && isStandalonePrimitiveSchema(doc)) {
+    const name = extractPrimitiveNameFromSchema(doc, sourceLabel ?? undefined);
+    schema = { $defs: { [name]: doc } };
+  }
+
+  const body: Record<string, unknown> = {
+    schema,
+    source_kind: options.sourceKind,
+    source_label: sourceLabel,
+    map_core_formats: options.mapCoreFormats,
+    dedupe: options.dedupe,
+  };
+
+  if (options.targetNamespace.trim()) {
+    body.target_namespace = options.targetNamespace.trim();
+  }
+
+  if (selection) {
+    body.import_all = false;
+    body.selected_definitions = selection.selectedNames;
+    const resolutions = filterResolutions(selection.resolutions, selection.selectedNames);
+    if (Object.keys(resolutions).length > 0) {
+      body.resolutions = resolutions;
+    }
+  } else {
+    // Review every detected definition so the user sees the full classification.
+    body.import_all = true;
+  }
+
+  return body;
+}
+
+/**
+ * Keep only resolutions for names that are still selected, dropping empty rename targets.
+ *
+ * @param resolutions The full per-type resolution map.
+ * @param selectedNames Names the user chose to import.
+ * @returns A pruned resolution map safe to send to the commit endpoint.
+ */
+export function filterResolutions(
+  resolutions: ResolutionMap,
+  selectedNames: string[]
+): ResolutionMap {
+  const selected = new Set(selectedNames);
+  const out: ResolutionMap = {};
+  for (const [name, resolution] of Object.entries(resolutions)) {
+    if (!selected.has(name)) continue;
+    if (resolution.action === 'rename') {
+      out[name] = { action: 'rename', new_name: resolution.new_name?.trim() || '' };
+    } else {
+      out[name] = { action: resolution.action };
+    }
+  }
+  return out;
+}
+
+/**
+ * Seed a default resolution for every conflicting type (`keep` — surface, do not drop).
+ *
+ * @param types The reviewed types.
+ * @returns A resolution map with one `keep` entry per conflict.
+ */
+export function defaultResolutions(types: ReviewType[]): ResolutionMap {
+  const out: ResolutionMap = {};
+  for (const type of types) {
+    if (type.status === 'conflict') {
+      out[type.name] = { action: 'keep' };
+    }
+  }
+  return out;
+}
+
+/**
+ * The set of type names selected by default when the review opens: every valid type that
+ * is not an already-deduped identical (identical adds nothing) — i.e. New and Conflict.
+ *
+ * @param types The reviewed types.
+ * @returns The names to pre-select for import.
+ */
+export function defaultSelectedNames(types: ReviewType[]): string[] {
+  return types
+    .filter((type) => type.status === 'new' || type.status === 'conflict')
+    .map((type) => type.name);
+}
+
+/**
+ * Validate the user's selection + resolutions before committing.
+ *
+ * @param selectedNames Names chosen for import.
+ * @param types The reviewed types (for status lookup).
+ * @param resolutions The current resolution map.
+ * @returns An error string when the selection cannot be committed, else `null`.
+ */
+export function validateSelection(
+  selectedNames: string[],
+  types: ReviewType[],
+  resolutions: ResolutionMap
+): string | null {
+  if (selectedNames.length === 0) {
+    return 'Select at least one type to import';
+  }
+
+  const selected = new Set(selectedNames);
+  const byName = new Map(types.map((type) => [type.name, type]));
+
+  for (const name of selectedNames) {
+    const type = byName.get(name);
+    if (type && type.status === 'invalid') {
+      return `"${name}" is not a valid draft 2020-12 schema and cannot be imported`;
+    }
+  }
+
+  for (const [name, resolution] of Object.entries(resolutions)) {
+    if (!selected.has(name)) continue;
+    if (resolution.action === 'rename' && !resolution.new_name?.trim()) {
+      return `Enter a new name for the renamed type "${name}"`;
+    }
+  }
+
+  return null;
+}
+
+/** Coerce an unknown REST list field into a string/object array. */
+function asArray<T>(value: unknown): T[] {
+  return Array.isArray(value) ? (value as T[]) : [];
+}
+
+/**
+ * Normalize the REST `/import` response into an {@link ImportResultSummary}.
+ *
+ * @param data The parsed JSON body from `/api/primitives/import`.
+ * @returns A normalized result with stable array fields.
+ */
+export function summarizeImportResult(data: Record<string, unknown>): ImportResultSummary {
+  return {
+    imported: asArray<string>(data.imported),
+    overwritten: asArray<string>(data.overwritten),
+    renamed: asArray(data.renamed),
+    identical: asArray<string>(data.identical),
+    skipped: asArray(data.skipped),
+    errors: asArray(data.errors),
+    warnings: asArray<string>(data.warnings),
+    importId: typeof data.import_id === 'string' ? data.import_id : null,
+  };
+}
+
+/**
+ * One-line human summary of an import result for a toast message.
+ *
+ * @param result The normalized import result.
+ * @returns A short status line (e.g. "Imported 3, overwritten 1, 2 error(s)").
+ */
+export function describeImportResult(result: ImportResultSummary): string {
+  const parts: string[] = [`Imported ${result.imported.length}`];
+  if (result.overwritten.length > 0) parts.push(`overwritten ${result.overwritten.length}`);
+  if (result.renamed.length > 0) parts.push(`renamed ${result.renamed.length}`);
+  if (result.identical.length > 0) parts.push(`identical ${result.identical.length}`);
+  if (result.skipped.length > 0) parts.push(`skipped ${result.skipped.length}`);
+  if (result.errors.length > 0) parts.push(`${result.errors.length} error(s)`);
+  return parts.join(', ');
+}
+
+/** Human label for a source kind. */
+export function sourceKindLabel(kind: SourceKind): string {
+  switch (kind) {
+    case 'json-schema':
+      return 'JSON Schema';
+    case 'type-def-bundle':
+      return 'Type-def bundle';
+    case 'openapi':
+      return 'OpenAPI';
+    default:
+      return kind;
+  }
+}

--- a/objectified-ui/src/app/api/primitives/import/review/route.ts
+++ b/objectified-ui/src/app/api/primitives/import/review/route.ts
@@ -1,0 +1,127 @@
+/**
+ * API Proxy for Primitive Import Review (#3464 / #3469)
+ *
+ * Proxies the dry-run import review to the REST API with JWT authentication. The review
+ * classifies each definition New / Identical / Conflict / Invalid and lists the allowed
+ * conflict resolutions, writing nothing — it is the report the import wizard renders before
+ * the user commits.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import jwt from 'jsonwebtoken';
+import { authOptions } from '../../../auth/[...nextauth]/route';
+import { getTenantById } from '@lib/db/helper';
+
+const REST_API_BASE_URL = process.env.NEXT_PUBLIC_REST_API_BASE_URL || 'http://localhost:8000/v1';
+
+interface SessionUser {
+  user_id?: string;
+  email?: string | null;
+  name?: string | null;
+  current_tenant_id?: string;
+}
+
+/** Build a short-lived JWT bearer header from the session user for REST calls. */
+function createAuthHeaders(user: SessionUser): Record<string, string> {
+  if (!user.user_id) {
+    return { 'Content-Type': 'application/json' };
+  }
+
+  const secret = process.env.NEXTAUTH_SECRET;
+  if (!secret) {
+    return { 'Content-Type': 'application/json' };
+  }
+
+  const encodedToken = jwt.sign(
+    {
+      user_id: user.user_id,
+      sub: user.user_id,
+      email: user.email,
+      name: user.name,
+      current_tenant_id: user.current_tenant_id,
+    },
+    secret,
+    { algorithm: 'HS256', expiresIn: '1h' }
+  );
+
+  return {
+    'Content-Type': 'application/json',
+    Authorization: `Bearer ${encodedToken}`,
+  };
+}
+
+/** Normalize a REST response into `{ data, error, status }`. */
+async function handleRestResponse(
+  response: Response,
+  defaultError: string
+): Promise<{ data: unknown; error: string | null; status: number }> {
+  const contentType = response.headers.get('content-type');
+
+  if (!contentType || !contentType.includes('application/json')) {
+    const text = await response.text();
+    console.error('Non-JSON response from REST API:', text);
+    return { data: null, error: text || defaultError, status: response.status || 500 };
+  }
+
+  const data = await response.json();
+
+  if (!response.ok) {
+    return { data: null, error: (data as { detail?: string }).detail || defaultError, status: response.status };
+  }
+
+  return { data, error: null, status: response.status };
+}
+
+/**
+ * POST /api/primitives/import/review
+ * Dry-run review of an import: conflicts, dedupe, and a validation report.
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const session = await getServerSession(authOptions);
+
+    if (!session?.user) {
+      return NextResponse.json({ success: false, error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const user = session.user as { current_tenant_id?: string; user_id?: string };
+    const tenantId = user.current_tenant_id;
+
+    if (!tenantId) {
+      return NextResponse.json({ success: false, error: 'No tenant selected' }, { status: 400 });
+    }
+
+    const tenant = await getTenantById(tenantId);
+    if (!tenant || !tenant.slug) {
+      return NextResponse.json({ success: false, error: 'Tenant not found' }, { status: 404 });
+    }
+
+    const tenantSlug = tenant.slug;
+    const body = await request.json();
+    const headers = createAuthHeaders({
+      user_id: user.user_id,
+      email: session.user.email,
+      name: session.user.name,
+      current_tenant_id: tenantId,
+    });
+
+    const response = await fetch(`${REST_API_BASE_URL}/primitives/${tenantSlug}/import/review`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body),
+    });
+
+    const { data, error, status } = await handleRestResponse(response, 'Failed to review import');
+
+    if (error) {
+      return NextResponse.json({ success: false, error }, { status });
+    }
+
+    return NextResponse.json({ success: true, review: data });
+  } catch (error) {
+    console.error('Error reviewing primitive import:', error);
+    const errorMessage = error instanceof Error ? error.message : 'Internal server error';
+    return NextResponse.json({ success: false, error: errorMessage }, { status: 500 });
+  }
+}

--- a/objectified-ui/tests/primitiveImportModel.test.ts
+++ b/objectified-ui/tests/primitiveImportModel.test.ts
@@ -1,0 +1,281 @@
+/**
+ * Tests for the Primitives import wizard model (#3469).
+ *
+ * Exercises the pure parsing / request-building / review helpers that back the wizard so the
+ * source -> review -> commit flow stays aligned with the REST import pipeline contract.
+ */
+
+import {
+  parseSchemaContent,
+  isStandalonePrimitiveSchema,
+  extractPrimitiveNameFromSchema,
+  determineCategoryFromSchema,
+  extractDefinitions,
+  buildImportRequestBody,
+  filterResolutions,
+  defaultResolutions,
+  defaultSelectedNames,
+  validateSelection,
+  summarizeImportResult,
+  describeImportResult,
+  sourceKindLabel,
+  type ImportOptions,
+  type ReviewType,
+} from '../src/app/ade/dashboard/primitives/primitiveImportModel';
+
+const baseOptions: ImportOptions = {
+  sourceKind: 'json-schema',
+  targetNamespace: '',
+  mapCoreFormats: true,
+  dedupe: true,
+};
+
+const reviewType = (overrides: Partial<ReviewType>): ReviewType => ({
+  name: 'Type',
+  status: 'new',
+  valid: true,
+  validation_errors: [],
+  error: null,
+  schema_id: null,
+  existing_id: null,
+  ref_count: 0,
+  unresolved_refs: [],
+  allowed_resolutions: [],
+  ...overrides,
+});
+
+describe('parseSchemaContent', () => {
+  it('parses JSON', () => {
+    expect(parseSchemaContent('{"a":1}')).toEqual({ a: 1 });
+  });
+
+  it('falls back to YAML', () => {
+    const parsed = parseSchemaContent('$defs:\n  Email:\n    type: string');
+    expect((parsed?.$defs as Record<string, unknown>).Email).toEqual({ type: 'string' });
+  });
+
+  it('returns null for non-object content', () => {
+    expect(parseSchemaContent('"just a string"')).toBeNull();
+    expect(parseSchemaContent('42')).toBeNull();
+  });
+
+  it('returns null for unparseable content', () => {
+    expect(parseSchemaContent('not: : valid: yaml: {')).toBeNull();
+  });
+});
+
+describe('isStandalonePrimitiveSchema', () => {
+  it('treats a bare type as standalone', () => {
+    expect(isStandalonePrimitiveSchema({ type: 'string' })).toBe(true);
+    expect(isStandalonePrimitiveSchema({ enum: ['a', 'b'] })).toBe(true);
+    expect(isStandalonePrimitiveSchema({ anyOf: [{ const: 'a' }] })).toBe(true);
+  });
+
+  it('treats a container as not standalone', () => {
+    expect(isStandalonePrimitiveSchema({ $defs: { A: {} } })).toBe(false);
+    expect(isStandalonePrimitiveSchema({ definitions: { A: {} } })).toBe(false);
+    expect(isStandalonePrimitiveSchema({ types: { A: {} } })).toBe(false);
+  });
+
+  it('returns false for a schema with no type indicators', () => {
+    expect(isStandalonePrimitiveSchema({ properties: {} })).toBe(false);
+  });
+});
+
+describe('extractPrimitiveNameFromSchema', () => {
+  it('prefers the last $id segment', () => {
+    expect(extractPrimitiveNameFromSchema({ $id: 'https://x/iso/percentage', title: 'P' })).toBe('percentage');
+  });
+
+  it('slugifies the title when there is no $id', () => {
+    expect(extractPrimitiveNameFromSchema({ title: 'ISO 80000-1:2022 Percentage' })).toBe('iso_8000012022_percentage');
+  });
+
+  it('falls back to the filename', () => {
+    expect(extractPrimitiveNameFromSchema({ type: 'string' }, 'my-type.json')).toBe('my_type');
+  });
+
+  it('uses a stable default', () => {
+    expect(extractPrimitiveNameFromSchema({ type: 'object' })).toBe('imported_primitive');
+  });
+});
+
+describe('determineCategoryFromSchema', () => {
+  it('reads an explicit type', () => {
+    expect(determineCategoryFromSchema({ type: 'number' })).toBe('number');
+    expect(determineCategoryFromSchema({ type: ['string', 'null'] })).toBe('string');
+  });
+
+  it('infers from anyOf consts', () => {
+    expect(determineCategoryFromSchema({ anyOf: [{ const: 'a' }] })).toBe('string');
+    expect(determineCategoryFromSchema({ anyOf: [{ const: 1 }] })).toBe('number');
+  });
+
+  it('infers from enum', () => {
+    expect(determineCategoryFromSchema({ enum: ['a'] })).toBe('string');
+  });
+
+  it('defaults to object', () => {
+    expect(determineCategoryFromSchema({ properties: {} })).toBe('object');
+  });
+});
+
+describe('extractDefinitions', () => {
+  it('reads $defs and definitions for JSON Schema', () => {
+    const defs = extractDefinitions(
+      { $defs: { Email: { type: 'string' } }, definitions: { Phone: { type: 'string' } } },
+      'json-schema'
+    );
+    expect(Object.keys(defs).sort()).toEqual(['Email', 'Phone']);
+  });
+
+  it('reads the types container for a bundle', () => {
+    const defs = extractDefinitions({ types: { Money: { type: 'object' } } }, 'type-def-bundle');
+    expect(Object.keys(defs)).toEqual(['Money']);
+  });
+
+  it('wraps a standalone JSON Schema under a derived name', () => {
+    const defs = extractDefinitions({ $id: 'https://x/email', type: 'string' }, 'json-schema');
+    expect(Object.keys(defs)).toEqual(['email']);
+  });
+
+  it('does not treat a standalone document as a bundle member', () => {
+    // A bundle is expected to be a container; a bare type yields no definitions.
+    expect(extractDefinitions({ type: 'string' }, 'type-def-bundle')).toEqual({});
+  });
+});
+
+describe('buildImportRequestBody', () => {
+  it('builds a review body with import_all when no selection is given', () => {
+    const body = buildImportRequestBody({ $defs: { A: { type: 'string' } } }, baseOptions, 'file.json');
+    expect(body).toMatchObject({
+      source_kind: 'json-schema',
+      source_label: 'file.json',
+      map_core_formats: true,
+      dedupe: true,
+      import_all: true,
+    });
+    expect(body.selected_definitions).toBeUndefined();
+  });
+
+  it('wraps a standalone schema in $defs', () => {
+    const body = buildImportRequestBody({ $id: 'https://x/email', type: 'string' }, baseOptions, 'email');
+    expect(body.schema).toEqual({ $defs: { email: { $id: 'https://x/email', type: 'string' } } });
+  });
+
+  it('sends a bundle document unwrapped', () => {
+    const doc = { types: { Money: { type: 'object' } } };
+    const body = buildImportRequestBody(doc, { ...baseOptions, sourceKind: 'type-def-bundle' }, 'bundle.json');
+    expect(body.schema).toEqual(doc);
+  });
+
+  it('includes selection, resolutions, and namespace on commit', () => {
+    const body = buildImportRequestBody(
+      { $defs: { A: { type: 'string' }, B: { type: 'number' } } },
+      { ...baseOptions, targetNamespace: ' acme/v1 ' },
+      'file.json',
+      { selectedNames: ['A', 'B'], resolutions: { A: { action: 'overwrite' } } }
+    );
+    expect(body.import_all).toBe(false);
+    expect(body.selected_definitions).toEqual(['A', 'B']);
+    expect(body.resolutions).toEqual({ A: { action: 'overwrite' } });
+    expect(body.target_namespace).toBe('acme/v1');
+  });
+
+  it('omits an empty target namespace', () => {
+    const body = buildImportRequestBody({ $defs: { A: {} } }, baseOptions, null);
+    expect(body.target_namespace).toBeUndefined();
+  });
+});
+
+describe('filterResolutions', () => {
+  it('keeps only selected names and normalizes rename targets', () => {
+    const out = filterResolutions(
+      { A: { action: 'overwrite' }, B: { action: 'rename', new_name: ' b2 ' }, C: { action: 'keep' } },
+      ['A', 'B']
+    );
+    expect(out).toEqual({ A: { action: 'overwrite' }, B: { action: 'rename', new_name: 'b2' } });
+  });
+});
+
+describe('defaultResolutions / defaultSelectedNames', () => {
+  const types = [
+    reviewType({ name: 'New1', status: 'new' }),
+    reviewType({ name: 'Conf1', status: 'conflict', allowed_resolutions: ['keep', 'overwrite', 'rename'] }),
+    reviewType({ name: 'Same1', status: 'identical' }),
+    reviewType({ name: 'Bad1', status: 'invalid', valid: false }),
+  ];
+
+  it('seeds keep for each conflict only', () => {
+    expect(defaultResolutions(types)).toEqual({ Conf1: { action: 'keep' } });
+  });
+
+  it('selects new and conflict types by default', () => {
+    expect(defaultSelectedNames(types).sort()).toEqual(['Conf1', 'New1']);
+  });
+});
+
+describe('validateSelection', () => {
+  const types = [
+    reviewType({ name: 'New1', status: 'new' }),
+    reviewType({ name: 'Conf1', status: 'conflict' }),
+    reviewType({ name: 'Bad1', status: 'invalid', valid: false }),
+  ];
+
+  it('requires at least one selection', () => {
+    expect(validateSelection([], types, {})).toMatch(/at least one/i);
+  });
+
+  it('rejects selecting an invalid type', () => {
+    expect(validateSelection(['Bad1'], types, {})).toMatch(/not a valid/i);
+  });
+
+  it('requires a new name for a rename resolution', () => {
+    expect(validateSelection(['Conf1'], types, { Conf1: { action: 'rename', new_name: '' } })).toMatch(/new name/i);
+  });
+
+  it('passes for a valid selection', () => {
+    expect(validateSelection(['New1', 'Conf1'], types, { Conf1: { action: 'overwrite' } })).toBeNull();
+  });
+
+  it('ignores resolutions for unselected names', () => {
+    expect(validateSelection(['New1'], types, { Conf1: { action: 'rename', new_name: '' } })).toBeNull();
+  });
+});
+
+describe('summarizeImportResult / describeImportResult', () => {
+  it('normalizes the REST report into stable arrays', () => {
+    const result = summarizeImportResult({
+      imported: ['A', 'B'],
+      overwritten: ['C'],
+      renamed: [{ name: 'D', new_name: 'D2' }],
+      identical: ['E'],
+      skipped: [{ name: 'F', reason: 'kept' }],
+      errors: [{ name: 'G', error: 'boom' }],
+      warnings: ['w'],
+      import_id: 'imp-1',
+    });
+    expect(result.imported).toEqual(['A', 'B']);
+    expect(result.overwritten).toEqual(['C']);
+    expect(result.importId).toBe('imp-1');
+  });
+
+  it('defaults missing fields to empty arrays', () => {
+    const result = summarizeImportResult({ imported: ['A'] });
+    expect(result.overwritten).toEqual([]);
+    expect(result.importId).toBeNull();
+  });
+
+  it('describes the outcome', () => {
+    const result = summarizeImportResult({ imported: ['A', 'B'], overwritten: ['C'], errors: [{ name: 'G' }] });
+    expect(describeImportResult(result)).toBe('Imported 2, overwritten 1, 1 error(s)');
+  });
+});
+
+describe('sourceKindLabel', () => {
+  it('labels each kind', () => {
+    expect(sourceKindLabel('json-schema')).toBe('JSON Schema');
+    expect(sourceKindLabel('type-def-bundle')).toBe('Type-def bundle');
+    expect(sourceKindLabel('openapi')).toBe('OpenAPI');
+  });
+});


### PR DESCRIPTION
## What & why

Extends the existing `PrimitiveImportDialog` (paste JSON → preview `$defs` → import) into a **3-step import wizard** wired to the already-shipped Epic 4 import pipeline (#3460–#3464). Closes the #3469 gap: type-def **bundle** import, a **conflict review** step, and a committed **result** report.

### Step 1 — Source
- Source-kind cards: **JSON Schema**, **Type-def bundle**, **OpenAPI** (maps to the REST `source_kind`).
- Intake tabs: **File** (drag/drop + picker), **URL** (fetch), **Paste** (Monaco, JSON or YAML).
- Options: **target namespace**, **map recognized formats to core types** (`$ref` rewrite), **dedupe identical**.

### Step 2 — Review (conflicts resolvable)
- Calls `POST /v1/primitives/{tenant}/import/review` through a **new `/api/primitives/import/review` proxy** (JWT-authenticated, same pattern as the existing import proxy).
- Each detected type shows its **New / Identical / Conflict / Invalid** classification, draft 2020-12 validation errors, and unresolved-`$ref` count.
- Conflicts offer **keep / overwrite / rename** (rename takes a new name); invalid types are surfaced and cannot be selected.

### Step 3 — Result
- Commits via `POST .../import` with `selected_definitions` + `resolutions`, then shows the **imported / overwritten / renamed / identical / skipped / errors** buckets and the provenance import id.

### Structure
- Pure, testable logic lives in `primitiveImportModel.ts` (parse JSON/YAML, per-source-kind container extraction, request building, selection/resolution validation, result normalization).
- Bundle expansion, conflict classification, and `$ref` rewrite remain **server-side** (Epic 4); this PR wires the UI to them.
- **Out of scope / follow-up:** Git intake (the server `POST …/import/stage` staging pipeline) — not in the acceptance criteria; the wizard covers file/URL/paste.

## How to test
1. **Browse to** Control Panel → Governance → **Primitives** (`/ade/dashboard/primitives`).
2. **Click** "Import from Schema".
3. **Pick a source type** card (e.g. **JSON Schema**), **choose the Paste tab**, and paste:
   ```json
   { "$defs": { "Email": { "type": "string", "format": "email" }, "Percentage": { "type": "number", "minimum": 0, "maximum": 100 } } }
   ```
   **Click Parse**, then **Continue to Review**.
4. On the **Review** step, confirm each type shows a **New** badge; **click Import 2 Selected**.
5. On the **Result** step, confirm **Imported 2** and **click Done** — the table refreshes with the new primitives.
6. **Re-run** the same import with one definition changed (e.g. `Email` → add `"maxLength": 50`): the review now marks `Email` as **Conflict**; **set its resolution to Overwrite** (or **Rename** + a new name) and import.
7. **Type-def bundle:** pick the **Type-def bundle** card and paste a `{ "types": { "Money": { "type": "object", ... } } }` document — the wizard reviews and imports the bundle's types end-to-end.

## Risk/notes
- New proxy route is additive; the existing `/api/primitives/import` route already forwards the new fields (`source_kind`, `dedupe`, `resolutions`, …) unchanged.
- No REST/DB changes — the review/bundle/resolution endpoints already exist.
- Verified: `yarn build` (route registered), `tsc --noEmit` (0 errors), `eslint` (clean), and 114 primitives Jest tests pass (36 new model tests).

Closes #3469

Work performed by Claude Code via model Opus 4.8 (1M context)