### PR TITLE
Fix objectified-mcp Docker build: copy README.md into build context

### DIFF
--- a/objectified-mcp/Dockerfile
+++ b/objectified-mcp/Dockerfile
@@ -8,9 +8,13 @@
 FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim AS builder
 WORKDIR /build
 
+# READMEs are copied alongside each pyproject because both packages declare
+# `readme = "README.md"`; hatchling reads it while building the (non-editable) wheels.
 COPY objectified-rest/pyproject.toml /build/objectified-rest/pyproject.toml
+COPY objectified-rest/README.md /build/objectified-rest/README.md
 COPY objectified-rest/src /build/objectified-rest/src
 COPY objectified-mcp/pyproject.toml /build/objectified-mcp/pyproject.toml
+COPY objectified-mcp/README.md /build/objectified-mcp/README.md
 COPY objectified-mcp/uv.lock /build/objectified-mcp/uv.lock
 COPY objectified-mcp/src /build/objectified-mcp/src
 


### PR DESCRIPTION
## What & why

The **Objectified MCP** Docker build is failing on `main` ([run 27998992696](https://github.com/objectified-project/objectified/actions/runs/27998992696/job/82867160012)):

```
× Failed to build `objectified-mcp @ file:///build/objectified-mcp`
  ╰─▶ Call to `hatchling.build.build_wheel` failed
      OSError: Readme file does not exist: README.md
```

`uv sync --frozen --no-dev --compile-bytecode --no-editable` builds **non-editable wheels** for both `objectified-mcp` and its path dependency `objectified-rest`. Both `pyproject.toml` files declare `readme = "README.md"`, so hatchling reads each README while building the wheel — but the Dockerfile copied only `pyproject.toml`, `uv.lock`, and `src/`, so the README was absent from the build context.

## Fix

Copy each package's `README.md` next to its `pyproject.toml` in the builder stage. License is declared inline (`{ text = "MIT" }`) and the wheel `packages` dirs are already copied, so the README was the only missing input.

## How to test

From the repo root: `docker build -f objectified-mcp/Dockerfile .` — the `uv sync` builder step now completes. (CI will rebuild and push on merge.)

## Risk/notes

Build-context-only change; no source, dependency, or runtime change. Both READMEs already exist in the repo.

Work performed by Claude Code via model claude-opus-4-8[1m].

🤖 Generated with [Claude Code](https://claude.com/claude-code)