### PR TITLE
Fix #3472 - Type Registry Settings UI

### DIFF
--- a/docs/ROADMAP_TYPE_REGISTRY_GOVERNANCE.md
+++ b/docs/ROADMAP_TYPE_REGISTRY_GOVERNANCE.md
@@ -589,7 +589,7 @@ The in-app surface under **Control Panel → Governance**, matching the `governa
 | 5.4 #3469 ✅ | Import UI (wizard) | **DONE** — 3-step wizard (`PrimitiveImportDialog`): source-kind cards (JSON Schema / type-def bundle / OpenAPI) + file/URL/paste tabs + options (target namespace, `$ref` rewrite, dedupe); review step wired to `POST /import/review` showing New/Identical/Conflict/Invalid classification with per-conflict keep/overwrite/rename resolution; commit via `POST /import` with `resolutions`; result step with per-bucket outcome. New `/api/primitives/import/review` proxy; pure model in `primitiveImportModel.ts` | `type-registry`,`ui`,`import`,`mvp`,`roadmap-type-registry` | Y | Y | L | objectified-ui |
 | 5.5 #3470 ✅ | Reference Resolver UI | **DONE** — Resolver tab under Primitives (`/ade/dashboard/primitives`): read-only resolution-base control, namespace filter, Re-resolve action wired to `POST /api/types/resolve` → REST `POST /v1/types/{slug}/resolve` (3.4/#3459), summary chips (resolved/unresolved/circular), reference graph (cross-scope tenant→core highlighted), and the per-edge resolution table with status filter. First load and Re-resolve hit the same endpoint so statuses persist/update; `circular` already wired for #3458. New `/api/types/resolve` proxy + `proxyRestPost`; pure model in `primitivesResolverModel.ts` | `type-registry`,`ui`,`mvp`,`roadmap-type-registry` | Y | Y | M | objectified-ui |
 | 5.6 #3471 ✅ | Namespaces & Scopes UI | **DONE** — Namespaces & Scopes tab under Primitives (`/ade/dashboard/primitives`): scope-model explainer cards (system `std/*` vs tenant), namespaces table (scope, base URI, version root, types, visibility, default) with create/edit for tenant rows (system-core read-only), scope precedence/resolution-order card, and a governed promote-to-core card (gated on platform admin, 7.3). Create/edit wired to new `POST /api/types/namespaces` + `PUT /api/types/namespaces/[id]` proxies → REST `/v1/types/{slug}/namespaces` (#3451); new `proxyRestPut`; pure model in `namespaceModel.ts` | `type-registry`,`ui`,`registry`,`mvp`,`roadmap-type-registry` | Y | Y | M | objectified-ui |
-| 5.7 #3472 | Type Registry Settings UI | DB status, dialect, resolution & validation policy | `type-registry`,`ui`,`mvp`,`roadmap-type-registry` | Y | Y | S | objectified-ui |
+| 5.7 #3472 ✅ | Type Registry Settings UI | **DONE** — Settings tab under Primitives (`/ade/dashboard/primitives`): live registry storage status (from `GET /api/primitives/health` → REST `/v1/primitives/health`, #3450 — shared `objectified-db`, no separate DB), JSON Schema dialect (default draft + strict/annotation/coerce toggles), `$ref` resolution policy (base URL, ref style, remote allowlist, max depth 1–64, circular policy), import defaults (scope, target namespace, rewrite, accepted formats, dedupe), and validation/publishing governance (validate-on-save, block-publish-on-errors, core publish role — read by #3479). Settings persist server-side: new `odb.type_registry_settings` table (per-tenant, defaults when unsaved), REST `GET`/`PUT /v1/types/{slug}/settings` (tenant-admin write, enum/range validated), `/api/types/settings` proxy, pure model in `primitivesSettingsModel.ts` (minimal-diff PUT) | `type-registry`,`ui`,`mvp`,`roadmap-type-registry` | Y | Y | S | objectified-ui, objectified-rest, objectified-db |
 | 5.8 #3473 | Governance area overview page | Governance landing positioning Type Registry + tools | `type-registry`,`ui`,`governance`,`roadmap-type-registry` | Y | N | S | objectified-ui |
 
 ### Issue 5.1 — Governance nav entry + route group
@@ -793,7 +793,7 @@ Governance controls around the registry: entitlements, publish gates, promotion,
 
 ## 13. MVP vs V2 Summary
 
-**MVP issues (open):** 1.1–1.4, 2.1–2.5, 3.1, 3.2, 3.4, 4.1–4.5, 5.2–5.7, 6.1–6.3, 7.1, 7.2, 7.4.
+**MVP issues (open):** 1.1–1.4, 2.1–2.5, 3.1, 3.2, 3.4, 4.1–4.5, 6.1–6.3, 7.1, 7.2, 7.4.
 
 **Closed duplicates (shipped):** 2.6 (#3455 UI proxy), 5.1 (#3466 nav entry).
 
@@ -874,7 +874,7 @@ epic.
 | #3440 E2 | #3450 (2.1) · #3451 (2.2) · #3452 (2.3) · #3453 (2.4) · #3454 (2.5) · ~~#3455 (2.6)~~ ✅ closed |
 | #3441 E3 | #3456 (3.1) · #3457 (3.2) · #3458 (3.3) · #3459 (3.4) |
 | #3442 E4 | #3460 (4.1) · #3461 (4.2) · #3462 (4.3) · #3463 (4.4) · #3464 (4.5) · #3465 (4.6) |
-| #3443 E5 | ~~#3466 (5.1)~~ ✅ closed · ~~#3467 (5.2)~~ ✅ · ~~#3468 (5.3)~~ ✅ · ~~#3469 (5.4)~~ ✅ · ~~#3470 (5.5)~~ ✅ · ~~#3471 (5.6)~~ ✅ · #3472 (5.7) · #3473 (5.8) |
+| #3443 E5 | ~~#3466 (5.1)~~ ✅ closed · ~~#3467 (5.2)~~ ✅ · ~~#3468 (5.3)~~ ✅ · ~~#3469 (5.4)~~ ✅ · ~~#3470 (5.5)~~ ✅ · ~~#3471 (5.6)~~ ✅ · ~~#3472 (5.7)~~ ✅ · #3473 (5.8) |
 | #3444 E6 | #3474 (6.1) · #3475 (6.2) · #3476 (6.3) · #3477 (6.4) |
 | #3445 E7 | #3478 (7.1) · #3479 (7.2) · #3480 (7.3) · #3481 (7.4) · #3482 (7.5) |
 

--- a/objectified-db/package.json
+++ b/objectified-db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-db",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "Objectified database migrations and the direct-to-database admin CLI (objectified-db).",
   "author": "Objectified",
   "type": "module",

--- a/objectified-db/scripts/20260623-120000.sql
+++ b/objectified-db/scripts/20260623-120000.sql
@@ -1,0 +1,74 @@
+-- Type-registry settings — #3472, ROADMAP_TYPE_REGISTRY_GOVERNANCE.md §7 Issue 5.7.
+--
+-- The Type Registry Settings UI (Governance → Primitives → Settings) configures registry-wide
+-- behavior: the default JSON Schema dialect, the `$ref` resolution policy (base URL, ref style,
+-- remote allowlist, max depth, circular-ref policy), import defaults, and the validation/publishing
+-- governance toggles read by the validation gate (#3479). These are per-tenant preferences that do
+-- not belong on any individual `odb.primitives` row, so they get one durable home: this small
+-- `odb.type_registry_settings` table, in the SAME database / `odb` schema (single database — §1a;
+-- there is no separate registry database to configure, so there is no DB-connection setting here).
+--
+-- One row per tenant, keyed by `tenant_id`. A tenant with no row yet uses the column defaults below
+-- (the REST layer returns those defaults for a tenant that has never saved settings), so the table
+-- is created empty and populated lazily on the first save.
+
+SET search_path TO odb, public;
+
+CREATE TABLE IF NOT EXISTS odb.type_registry_settings (
+  tenant_id UUID PRIMARY KEY REFERENCES odb.tenants(id) ON DELETE CASCADE,
+
+  -- JSON Schema dialect
+  default_draft TEXT NOT NULL DEFAULT '2020-12',          -- '2020-12' | '2019-09' | 'draft-07'
+  strict_validation BOOLEAN NOT NULL DEFAULT true,        -- reject unknown formats
+  allow_annotation_keywords BOOLEAN NOT NULL DEFAULT true,-- permit title/description/examples/etc.
+  coerce_imported_drafts BOOLEAN NOT NULL DEFAULT true,   -- upgrade older drafts to default on import
+
+  -- Reference resolution
+  resolution_base_url TEXT NOT NULL DEFAULT 'https://api.objectified.dev/types/',
+  ref_style TEXT NOT NULL DEFAULT 'relative',             -- 'relative' | 'absolute' | 'anchor'
+  allow_remote_refs BOOLEAN NOT NULL DEFAULT false,       -- fetch schemas from external hosts
+  remote_host_allowlist TEXT[] NOT NULL DEFAULT ARRAY['json-schema.org', 'spec.openapis.org'],
+  max_resolution_depth INTEGER NOT NULL DEFAULT 12,       -- 1..64
+  circular_ref_policy TEXT NOT NULL DEFAULT 'error',      -- 'error' | 'warn'
+
+  -- Import defaults
+  default_import_scope TEXT NOT NULL DEFAULT 'tenant',    -- 'tenant' | 'system'
+  default_target_namespace TEXT,                          -- NULL = no preselected namespace
+  rewrite_refs_on_import BOOLEAN NOT NULL DEFAULT true,   -- convert absolute $ref to base-relative
+  accepted_formats TEXT[] NOT NULL
+    DEFAULT ARRAY['json-schema-2020-12', 'type-def-bundle', 'openapi-3.1'],
+  dedupe_identical_types BOOLEAN NOT NULL DEFAULT true,   -- reuse a byte-for-byte identical type
+
+  -- Validation & publishing governance (read by the validation gate, #3479)
+  validate_on_save BOOLEAN NOT NULL DEFAULT true,         -- run dialect & $ref checks before persist
+  block_publish_on_errors BOOLEAN NOT NULL DEFAULT true,  -- block publish on unresolved $ref / errors
+  core_publish_role TEXT NOT NULL DEFAULT 'platform_admin', -- 'platform_admin'|'tenant_admin'|'maintainer'
+
+  updated_by UUID REFERENCES odb.users(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+  -- Enum guards mirror the REST request-model validation so a bad value can never be persisted,
+  -- even by a direct SQL write.
+  CONSTRAINT ck_trs_default_draft CHECK (default_draft IN ('2020-12', '2019-09', 'draft-07')),
+  CONSTRAINT ck_trs_ref_style CHECK (ref_style IN ('relative', 'absolute', 'anchor')),
+  CONSTRAINT ck_trs_circular_policy CHECK (circular_ref_policy IN ('error', 'warn')),
+  CONSTRAINT ck_trs_import_scope CHECK (default_import_scope IN ('tenant', 'system')),
+  CONSTRAINT ck_trs_core_publish_role
+    CHECK (core_publish_role IN ('platform_admin', 'tenant_admin', 'maintainer')),
+  CONSTRAINT ck_trs_max_depth CHECK (max_resolution_depth BETWEEN 1 AND 64)
+);
+
+COMMENT ON TABLE odb.type_registry_settings IS
+  'Per-tenant type-registry behavior settings (#3472): dialect, $ref resolution policy, import defaults, validation/publishing governance. One row per tenant; absent row means defaults.';
+COMMENT ON COLUMN odb.type_registry_settings.default_draft IS 'Default JSON Schema dialect for new/imported types.';
+COMMENT ON COLUMN odb.type_registry_settings.resolution_base_url IS 'Base URL relative $ref values resolve against.';
+COMMENT ON COLUMN odb.type_registry_settings.remote_host_allowlist IS 'Hosts permitted for remote $ref fetches when allow_remote_refs is true.';
+COMMENT ON COLUMN odb.type_registry_settings.max_resolution_depth IS 'Maximum $ref resolution depth (1..64) before the resolver bails.';
+COMMENT ON COLUMN odb.type_registry_settings.validate_on_save IS 'Run dialect & $ref checks before persisting a type (validation gate #3479).';
+COMMENT ON COLUMN odb.type_registry_settings.block_publish_on_errors IS 'Block publishing a type with unresolved $ref or schema errors (#3479).';
+
+DO $$
+BEGIN
+    RAISE NOTICE 'odb.type_registry_settings created (#3472).';
+END $$;

--- a/objectified-rest/package.json
+++ b/objectified-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-rest",
-  "version": "1.0.20",
+  "version": "1.0.21",
   "private": true,
   "description": "Trigger file for Objectified REST Docker publish workflow; app is Python (pyproject.toml).",
   "scripts": {

--- a/objectified-rest/src/app/database.py
+++ b/objectified-rest/src/app/database.py
@@ -1910,6 +1910,106 @@ class Database:
                 (tenant_id,),
             )
 
+    # ==================== Type-registry settings (#3472) ====================
+
+    # The mutable settings columns, in one place so the read projection and the upsert write
+    # list stay in lock-step (a column added to one but not the other would silently drop).
+    TYPE_REGISTRY_SETTINGS_COLUMNS = (
+        "default_draft",
+        "strict_validation",
+        "allow_annotation_keywords",
+        "coerce_imported_drafts",
+        "resolution_base_url",
+        "ref_style",
+        "allow_remote_refs",
+        "remote_host_allowlist",
+        "max_resolution_depth",
+        "circular_ref_policy",
+        "default_import_scope",
+        "default_target_namespace",
+        "rewrite_refs_on_import",
+        "accepted_formats",
+        "dedupe_identical_types",
+        "validate_on_save",
+        "block_publish_on_errors",
+        "core_publish_role",
+    )
+
+    def get_type_registry_settings(self, tenant_id: str) -> Optional[Dict[str, Any]]:
+        """Get a tenant's persisted type-registry settings (#3472).
+
+        Returns the saved row when one exists. A tenant that has never saved settings has no
+        row; this returns ``None`` and the route layer serves the model defaults (the GET is a
+        pure read and never materializes a row).
+
+        Args:
+            tenant_id: The caller's tenant id.
+
+        Returns:
+            The settings row, or None when the tenant has not saved settings yet.
+        """
+        columns = ", ".join(self.TYPE_REGISTRY_SETTINGS_COLUMNS)
+        query = f"""
+            SELECT {columns}, updated_by, created_at, updated_at
+            FROM odb.type_registry_settings
+            WHERE tenant_id = %s::uuid
+        """
+        results = self.execute_query(query, (tenant_id,))
+        return results[0] if results else None
+
+    def upsert_type_registry_settings(
+        self, tenant_id: str, updates: Dict[str, Any], updated_by: Optional[str] = None
+    ) -> Dict[str, Any]:
+        """Insert or update a tenant's type-registry settings (#3472).
+
+        The first save for a tenant inserts a row; subsequent saves update only the supplied
+        fields and leave the rest untouched (``COALESCE`` keeps the stored value when a column
+        is omitted, falling back to the table default on the initial insert). Runs as a single
+        upsert keyed on ``tenant_id``.
+
+        Args:
+            tenant_id: The owning tenant id.
+            updates: Subset of {@link TYPE_REGISTRY_SETTINGS_COLUMNS} to persist; omitted
+                columns keep their current value (or the table default on first save).
+            updated_by: The authenticated user id making the change (None for API-key auth).
+
+        Returns:
+            The full persisted settings row after the write.
+        """
+        columns = list(self.TYPE_REGISTRY_SETTINGS_COLUMNS)
+        # Only the supplied columns get an explicit value; omitted ones fall to their table default
+        # on first insert. On conflict we update *only* the supplied columns — an omitted column is
+        # left exactly as stored. (We cannot COALESCE over EXCLUDED here: for a column absent from
+        # the INSERT list, EXCLUDED.<col> is that column's DEFAULT, not NULL, so a partial update
+        # would otherwise reset every untouched column back to its default.)
+        supplied = [col for col in columns if col in updates]
+        insert_cols = ["tenant_id", "updated_by", *supplied]
+        insert_vals: List[Any] = [tenant_id, updated_by, *(updates[col] for col in supplied)]
+
+        set_clauses = [f"{col} = EXCLUDED.{col}" for col in supplied]
+        set_clauses.append("updated_by = EXCLUDED.updated_by")
+        set_clauses.append("updated_at = CURRENT_TIMESTAMP")
+
+        placeholders = ", ".join(["%s"] * len(insert_vals))
+        select_cols = ", ".join(columns)
+        query = f"""
+            INSERT INTO odb.type_registry_settings ({", ".join(insert_cols)})
+            VALUES ({placeholders})
+            ON CONFLICT (tenant_id) DO UPDATE SET {", ".join(set_clauses)}
+            RETURNING {select_cols}, updated_by, created_at, updated_at
+        """
+
+        conn = self.connect()
+        try:
+            with conn.cursor() as cursor:
+                cursor.execute(query, tuple(insert_vals))
+                result = cursor.fetchone()
+                conn.commit()
+                return result
+        except Exception as e:
+            conn.rollback()
+            raise e
+
     # ==================== Project CRUD Operations ====================
     # NOTE: queries below select `change_report_template_version_id`, which requires
     # migration 20260414-150000.sql. Ensure that migration is applied before deploying.

--- a/objectified-rest/src/app/models.py
+++ b/objectified-rest/src/app/models.py
@@ -504,6 +504,93 @@ class TypeNamespaceUpdateRequest(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
 
+# ==================== Type-registry settings (#3472) ====================
+
+
+# Allowed enum values, shared by the request/response models and asserted against the
+# DB CHECK constraints in 20260623-120000.sql.
+DefaultDraft = Literal["2020-12", "2019-09", "draft-07"]
+RefStyle = Literal["relative", "absolute", "anchor"]
+CircularRefPolicy = Literal["error", "warn"]
+ImportScope = Literal["tenant", "system"]
+CorePublishRole = Literal["platform_admin", "tenant_admin", "maintainer"]
+
+
+class TypeRegistrySettingsSchema(BaseModel):
+    """Per-tenant type-registry behavior settings (#3472).
+
+    Configures the default JSON Schema dialect, the ``$ref`` resolution policy, import
+    defaults, and the validation/publishing governance toggles read by the validation gate
+    (#3479). A tenant that has never saved settings receives the column defaults below.
+    """
+    # JSON Schema dialect
+    default_draft: DefaultDraft = "2020-12"
+    strict_validation: bool = True
+    allow_annotation_keywords: bool = True
+    coerce_imported_drafts: bool = True
+
+    # Reference resolution
+    resolution_base_url: str = "https://api.objectified.dev/types/"
+    ref_style: RefStyle = "relative"
+    allow_remote_refs: bool = False
+    remote_host_allowlist: List[str] = ["json-schema.org", "spec.openapis.org"]
+    max_resolution_depth: int = 12
+    circular_ref_policy: CircularRefPolicy = "error"
+
+    # Import defaults
+    default_import_scope: ImportScope = "tenant"
+    default_target_namespace: Optional[str] = None
+    rewrite_refs_on_import: bool = True
+    accepted_formats: List[str] = ["json-schema-2020-12", "type-def-bundle", "openapi-3.1"]
+    dedupe_identical_types: bool = True
+
+    # Validation & publishing governance
+    validate_on_save: bool = True
+    block_publish_on_errors: bool = True
+    core_publish_role: CorePublishRole = "platform_admin"
+
+    # Provenance — null until the tenant first saves settings (defaults are unsaved).
+    is_default: bool = True  # True when no row exists yet (these are the unsaved defaults)
+    updated_by: Optional[str] = None
+    created_at: Optional[Union[datetime, str]] = None
+    updated_at: Optional[Union[datetime, str]] = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class TypeRegistrySettingsUpdateRequest(BaseModel):
+    """Request model for saving a tenant's type-registry settings (#3472).
+
+    Every field is optional so the UI may send a partial update; omitted fields keep their
+    current persisted value (or the default when no row exists yet). Enum and range checks
+    here mirror the ``odb.type_registry_settings`` CHECK constraints so an invalid value is
+    rejected with a clean 422 before it ever reaches the database.
+    """
+    default_draft: Optional[DefaultDraft] = None
+    strict_validation: Optional[bool] = None
+    allow_annotation_keywords: Optional[bool] = None
+    coerce_imported_drafts: Optional[bool] = None
+
+    resolution_base_url: Optional[str] = None
+    ref_style: Optional[RefStyle] = None
+    allow_remote_refs: Optional[bool] = None
+    remote_host_allowlist: Optional[List[str]] = None
+    max_resolution_depth: Optional[int] = Field(default=None, ge=1, le=64)
+    circular_ref_policy: Optional[CircularRefPolicy] = None
+
+    default_import_scope: Optional[ImportScope] = None
+    default_target_namespace: Optional[str] = None
+    rewrite_refs_on_import: Optional[bool] = None
+    accepted_formats: Optional[List[str]] = None
+    dedupe_identical_types: Optional[bool] = None
+
+    validate_on_save: Optional[bool] = None
+    block_publish_on_errors: Optional[bool] = None
+    core_publish_role: Optional[CorePublishRole] = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
 # ==================== Specification import job (CLI / REST contract) ====================
 #
 # Today the dashboard runs imports via Next.js server actions (see objectified-ui/lib/db/import-helper.ts).

--- a/objectified-rest/src/app/type_namespaces_routes.py
+++ b/objectified-rest/src/app/type_namespaces_routes.py
@@ -28,6 +28,8 @@ from .models import (
     TypeNamespaceCreateRequest,
     TypeNamespaceSchema,
     TypeNamespaceUpdateRequest,
+    TypeRegistrySettingsSchema,
+    TypeRegistrySettingsUpdateRequest,
 )
 from .type_resolver import STATUS_RESOLVED, STATUS_UNRESOLVED, reresolve_edges
 
@@ -268,6 +270,104 @@ async def update_namespace(
         raise HTTPException(status_code=404, detail=f"Namespace not found: {namespace_id}")
 
     return _to_schema(row)
+
+
+def _settings_to_schema(row: Dict[str, Any]) -> TypeRegistrySettingsSchema:
+    """Map a persisted ``odb.type_registry_settings`` row to its API model.
+
+    A persisted row is, by definition, not the defaults, so ``is_default`` is False.
+    """
+    return TypeRegistrySettingsSchema(
+        default_draft=row["default_draft"],
+        strict_validation=bool(row["strict_validation"]),
+        allow_annotation_keywords=bool(row["allow_annotation_keywords"]),
+        coerce_imported_drafts=bool(row["coerce_imported_drafts"]),
+        resolution_base_url=row["resolution_base_url"],
+        ref_style=row["ref_style"],
+        allow_remote_refs=bool(row["allow_remote_refs"]),
+        remote_host_allowlist=list(row.get("remote_host_allowlist") or []),
+        max_resolution_depth=int(row["max_resolution_depth"]),
+        circular_ref_policy=row["circular_ref_policy"],
+        default_import_scope=row["default_import_scope"],
+        default_target_namespace=row.get("default_target_namespace"),
+        rewrite_refs_on_import=bool(row["rewrite_refs_on_import"]),
+        accepted_formats=list(row.get("accepted_formats") or []),
+        dedupe_identical_types=bool(row["dedupe_identical_types"]),
+        validate_on_save=bool(row["validate_on_save"]),
+        block_publish_on_errors=bool(row["block_publish_on_errors"]),
+        core_publish_role=row["core_publish_role"],
+        is_default=False,
+        updated_by=str(row["updated_by"]) if row.get("updated_by") is not None else None,
+        created_at=row.get("created_at"),
+        updated_at=row.get("updated_at"),
+    )
+
+
+@router.get("/{tenant_slug}/settings", response_model=TypeRegistrySettingsSchema)
+async def get_registry_settings(
+    tenant_slug: str,
+    auth_data: Dict[str, Any] = Depends(validate_authentication),
+) -> TypeRegistrySettingsSchema:
+    """Return the tenant's type-registry settings (#3472).
+
+    Serves the saved row when one exists. A tenant that has never saved settings receives the
+    model defaults with ``is_default = true`` (a pure read never materializes a row), so the
+    Settings UI always has a complete, effective configuration to render.
+
+    Args:
+        tenant_slug: The tenant slug (caller scope comes from the authenticated token).
+        auth_data: Authentication data (injected by dependency).
+
+    Returns:
+        The tenant's effective type-registry settings.
+    """
+    row = db.get_type_registry_settings(auth_data["tenant_id"])
+    if not row:
+        # No saved row yet — return the defaults, flagged so the UI can show "using defaults".
+        return TypeRegistrySettingsSchema()
+    return _settings_to_schema(row)
+
+
+@router.put("/{tenant_slug}/settings", response_model=TypeRegistrySettingsSchema)
+async def update_registry_settings(
+    tenant_slug: str,
+    request: TypeRegistrySettingsUpdateRequest,
+    auth_data: Dict[str, Any] = Depends(validate_authentication),
+) -> TypeRegistrySettingsSchema:
+    """Save the tenant's type-registry settings (#3472).
+
+    Tenant-administrator only. The request may be partial — omitted fields keep their current
+    persisted value (or the table default on the first save). Enum and range validation happens
+    on the request model, so an invalid value is rejected with 422 before the upsert. The saved
+    settings become the source of truth the resolver and the validation gate (#3479) read.
+
+    Args:
+        tenant_slug: The tenant slug.
+        request: The settings to persist (partial allowed).
+        auth_data: Authentication data (injected by dependency).
+
+    Returns:
+        The full persisted settings after the write.
+    """
+    tenant_id = auth_data["tenant_id"]
+    user_id = _assert_jwt_user(auth_data)
+    _assert_tenant_admin(tenant_id, user_id)
+
+    updates = request.model_dump(exclude_unset=True)
+
+    # A non-empty base URL is required when supplied; an empty string would break $ref resolution.
+    if "resolution_base_url" in updates:
+        base = (updates["resolution_base_url"] or "").strip()
+        if not base:
+            raise HTTPException(status_code=400, detail="resolution_base_url may not be empty")
+        updates["resolution_base_url"] = base
+
+    try:
+        row = db.upsert_type_registry_settings(tenant_id, updates, updated_by=user_id)
+    except Exception as e:  # pragma: no cover - defensive
+        raise HTTPException(status_code=500, detail=str(e))
+
+    return _settings_to_schema(row)
 
 
 @router.post("/{tenant_slug}/resolve", response_model=ResolveResponse)

--- a/objectified-rest/tests/test_type_registry_settings_routes.py
+++ b/objectified-rest/tests/test_type_registry_settings_routes.py
@@ -1,0 +1,266 @@
+"""API tests for the type-registry Settings endpoints (#3472).
+
+Covers GET / PUT for ``/v1/types/{tenant_slug}/settings``: auth requirements, tenant scoping,
+the defaults-when-unsaved contract, tenant-admin write rule, partial updates, enum/range
+validation, and base-URL validation.
+"""
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.auth import validate_authentication
+from app.database import db
+from app.main import app
+
+client = TestClient(app)
+
+_JWT_ADMIN = {"tenant_id": "t1", "user_id": "admin-user", "auth_method": "jwt"}
+_JWT_NON_ADMIN = {"tenant_id": "t1", "user_id": "plain-user", "auth_method": "jwt"}
+
+_NOW = datetime(2026, 6, 23, 12, 0, 0, tzinfo=timezone.utc)
+
+# A fully-populated persisted row, as the DB layer would return it.
+_SETTINGS_ROW = {
+    "default_draft": "2019-09",
+    "strict_validation": False,
+    "allow_annotation_keywords": True,
+    "coerce_imported_drafts": False,
+    "resolution_base_url": "https://types.acme.example/",
+    "ref_style": "absolute",
+    "allow_remote_refs": True,
+    "remote_host_allowlist": ["json-schema.org", "acme.example"],
+    "max_resolution_depth": 24,
+    "circular_ref_policy": "warn",
+    "default_import_scope": "tenant",
+    "default_target_namespace": "tenant/acme/v1/types",
+    "rewrite_refs_on_import": False,
+    "accepted_formats": ["json-schema-2020-12"],
+    "dedupe_identical_types": False,
+    "validate_on_save": False,
+    "block_publish_on_errors": False,
+    "core_publish_role": "tenant_admin",
+    "updated_by": "admin-user",
+    "created_at": _NOW,
+    "updated_at": _NOW,
+}
+
+
+@pytest.fixture(autouse=True)
+def _default_auth():
+    """Default to JWT admin; individual tests may override."""
+    app.dependency_overrides[validate_authentication] = lambda: _JWT_ADMIN
+    yield
+    app.dependency_overrides.pop(validate_authentication, None)
+
+
+# ===========================================================================
+# GET
+# ===========================================================================
+
+
+def test_get_settings_returns_defaults_when_unsaved():
+    """A tenant with no saved row gets the model defaults flagged is_default=true."""
+    with patch("app.type_namespaces_routes.db") as mdb:
+        mdb.get_type_registry_settings.return_value = None
+        r = client.get("/v1/types/acme/settings")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["is_default"] is True
+    assert body["default_draft"] == "2020-12"
+    assert body["ref_style"] == "relative"
+    assert body["max_resolution_depth"] == 12
+    assert body["remote_host_allowlist"] == ["json-schema.org", "spec.openapis.org"]
+    assert body["validate_on_save"] is True
+
+
+def test_get_settings_returns_saved_row():
+    with patch("app.type_namespaces_routes.db") as mdb:
+        mdb.get_type_registry_settings.return_value = _SETTINGS_ROW
+        r = client.get("/v1/types/acme/settings")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["is_default"] is False
+    assert body["default_draft"] == "2019-09"
+    assert body["ref_style"] == "absolute"
+    assert body["max_resolution_depth"] == 24
+    assert body["circular_ref_policy"] == "warn"
+    assert body["updated_by"] == "admin-user"
+
+
+def test_get_settings_scoped_to_caller_tenant():
+    """The DB layer is queried with the token tenant_id, not the URL slug."""
+    with patch("app.type_namespaces_routes.db") as mdb:
+        mdb.get_type_registry_settings.return_value = None
+        client.get("/v1/types/some-other-slug/settings")
+        mdb.get_type_registry_settings.assert_called_once_with("t1")
+
+
+def test_get_settings_requires_authentication():
+    app.dependency_overrides.pop(validate_authentication, None)
+    r = client.get("/v1/types/acme/settings")
+    assert r.status_code == 401
+
+
+# ===========================================================================
+# PUT
+# ===========================================================================
+
+
+def test_put_settings_ok_partial_update():
+    with patch("app.type_namespaces_routes.db") as mdb:
+        mdb.is_user_tenant_admin.return_value = True
+        mdb.upsert_type_registry_settings.return_value = {**_SETTINGS_ROW, "default_draft": "draft-07"}
+        r = client.put("/v1/types/acme/settings", json={"default_draft": "draft-07"})
+    assert r.status_code == 200
+    assert r.json()["default_draft"] == "draft-07"
+    # Only the supplied field is forwarded to the DB layer.
+    args = mdb.upsert_type_registry_settings.call_args
+    assert args.args[0] == "t1"
+    assert args.args[1] == {"default_draft": "draft-07"}
+    assert args.kwargs["updated_by"] == "admin-user"
+
+
+def test_put_settings_requires_admin():
+    app.dependency_overrides[validate_authentication] = lambda: _JWT_NON_ADMIN
+    with patch("app.type_namespaces_routes.db") as mdb:
+        mdb.is_user_tenant_admin.return_value = False
+        r = client.put("/v1/types/acme/settings", json={"default_draft": "2020-12"})
+    assert r.status_code == 403
+    mdb.upsert_type_registry_settings.assert_not_called()
+
+
+def test_put_settings_invalid_draft_422():
+    with patch("app.type_namespaces_routes.db") as mdb:
+        mdb.is_user_tenant_admin.return_value = True
+        r = client.put("/v1/types/acme/settings", json={"default_draft": "draft-99"})
+    assert r.status_code == 422
+    mdb.upsert_type_registry_settings.assert_not_called()
+
+
+def test_put_settings_depth_out_of_range_422():
+    with patch("app.type_namespaces_routes.db") as mdb:
+        mdb.is_user_tenant_admin.return_value = True
+        r = client.put("/v1/types/acme/settings", json={"max_resolution_depth": 999})
+    assert r.status_code == 422
+    mdb.upsert_type_registry_settings.assert_not_called()
+
+
+def test_put_settings_invalid_ref_style_422():
+    with patch("app.type_namespaces_routes.db") as mdb:
+        mdb.is_user_tenant_admin.return_value = True
+        r = client.put("/v1/types/acme/settings", json={"ref_style": "sideways"})
+    assert r.status_code == 422
+    mdb.upsert_type_registry_settings.assert_not_called()
+
+
+def test_put_settings_empty_base_url_400():
+    with patch("app.type_namespaces_routes.db") as mdb:
+        mdb.is_user_tenant_admin.return_value = True
+        r = client.put("/v1/types/acme/settings", json={"resolution_base_url": "   "})
+    assert r.status_code == 400
+    mdb.upsert_type_registry_settings.assert_not_called()
+
+
+def test_put_settings_trims_base_url():
+    with patch("app.type_namespaces_routes.db") as mdb:
+        mdb.is_user_tenant_admin.return_value = True
+        mdb.upsert_type_registry_settings.return_value = _SETTINGS_ROW
+        r = client.put(
+            "/v1/types/acme/settings",
+            json={"resolution_base_url": "  https://types.acme.example/  "},
+        )
+    assert r.status_code == 200
+    assert mdb.upsert_type_registry_settings.call_args.args[1]["resolution_base_url"] == (
+        "https://types.acme.example/"
+    )
+
+
+def test_put_settings_full_payload_roundtrips_all_fields():
+    """A full save forwards every field and echoes the persisted row back."""
+    payload = {
+        "default_draft": "2019-09",
+        "strict_validation": False,
+        "allow_annotation_keywords": True,
+        "coerce_imported_drafts": False,
+        "resolution_base_url": "https://types.acme.example/",
+        "ref_style": "absolute",
+        "allow_remote_refs": True,
+        "remote_host_allowlist": ["json-schema.org", "acme.example"],
+        "max_resolution_depth": 24,
+        "circular_ref_policy": "warn",
+        "default_import_scope": "tenant",
+        "default_target_namespace": "tenant/acme/v1/types",
+        "rewrite_refs_on_import": False,
+        "accepted_formats": ["json-schema-2020-12"],
+        "dedupe_identical_types": False,
+        "validate_on_save": False,
+        "block_publish_on_errors": False,
+        "core_publish_role": "tenant_admin",
+    }
+    with patch("app.type_namespaces_routes.db") as mdb:
+        mdb.is_user_tenant_admin.return_value = True
+        mdb.upsert_type_registry_settings.return_value = _SETTINGS_ROW
+        r = client.put("/v1/types/acme/settings", json=payload)
+    assert r.status_code == 200
+    assert mdb.upsert_type_registry_settings.call_args.args[1] == payload
+    body = r.json()
+    assert body["is_default"] is False
+    assert body["allow_remote_refs"] is True
+    assert body["accepted_formats"] == ["json-schema-2020-12"]
+
+
+# ===========================================================================
+# DB layer: upsert SQL construction (partial-update preservation)
+# ===========================================================================
+
+
+def _mock_cursor_conn(returned_row):
+    """A (conn, cursor) pair where the cursor records the last execute() and returns a row."""
+    cursor = MagicMock()
+    cursor.__enter__ = MagicMock(return_value=cursor)
+    cursor.__exit__ = MagicMock(return_value=False)
+    cursor.fetchone.return_value = returned_row
+    conn = MagicMock()
+    conn.cursor.return_value = cursor
+    return conn, cursor
+
+
+def test_upsert_partial_update_only_writes_supplied_columns():
+    """A partial save must touch only the supplied columns; omitted ones are left as stored.
+
+    Guards the ON CONFLICT path: EXCLUDED.<col> for a column absent from the INSERT list is that
+    column's DEFAULT (not NULL), so a COALESCE-everything update would silently reset untouched
+    columns. The SET clause must therefore name only the supplied columns.
+    """
+    conn, cursor = _mock_cursor_conn({**_SETTINGS_ROW})
+    with patch.object(db, "connect", return_value=conn):
+        db.upsert_type_registry_settings("t1", {"default_draft": "draft-07"}, updated_by="u1")
+
+    sql, params = cursor.execute.call_args.args
+    # Only the supplied column appears in the INSERT column list and the SET clause...
+    assert "default_draft" in sql
+    assert "default_draft = EXCLUDED.default_draft" in sql
+    # ...no untouched column is written back on conflict.
+    assert "strict_validation = EXCLUDED" not in sql
+    assert "ref_style = EXCLUDED" not in sql
+    # updated_by / updated_at are always refreshed.
+    assert "updated_by = EXCLUDED.updated_by" in sql
+    assert "updated_at = CURRENT_TIMESTAMP" in sql
+    # Params: tenant_id, updated_by, then the single supplied value.
+    assert params == ("t1", "u1", "draft-07")
+    conn.commit.assert_called_once()
+
+
+def test_upsert_empty_update_still_upserts_provenance():
+    """An empty save inserts a defaults row (or refreshes provenance) without naming data columns."""
+    conn, cursor = _mock_cursor_conn({**_SETTINGS_ROW})
+    with patch.object(db, "connect", return_value=conn):
+        db.upsert_type_registry_settings("t1", {}, updated_by="u1")
+
+    sql, params = cursor.execute.call_args.args
+    assert "EXCLUDED.default_draft" not in sql
+    assert "updated_by = EXCLUDED.updated_by" in sql
+    assert params == ("t1", "u1")

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.130",
+  "version": "0.11.131",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/src/app/ade/dashboard/primitives/PrimitivesManagementClient.tsx
+++ b/objectified-ui/src/app/ade/dashboard/primitives/PrimitivesManagementClient.tsx
@@ -18,6 +18,7 @@ import {
   GitFork,
   Library,
   FolderTree,
+  Settings,
 } from 'lucide-react';
 import { Button } from '@/app/components/ui/Button';
 import { Input } from '@/app/components/ui/Input';
@@ -32,6 +33,7 @@ import PrimitivesNamespaceCollections from './PrimitivesNamespaceCollections';
 import PrimitivesRecentActivity from './PrimitivesRecentActivity';
 import PrimitivesResolverView from './PrimitivesResolverView';
 import PrimitivesNamespacesView from './PrimitivesNamespacesView';
+import PrimitivesSettingsView from './PrimitivesSettingsView';
 import {
   countUnresolvedByNamespace,
   type NamespaceScopeFilter,
@@ -94,7 +96,9 @@ export default function PrimitivesManagementClient() {
   const [namespaceScopeFilter, setNamespaceScopeFilter] = useState<NamespaceScopeFilter>('all');
   const [selectedNamespace, setSelectedNamespace] = useState<string | null>(null);
 
-  const [activeView, setActiveView] = useState<'registry' | 'namespaces' | 'resolver'>('registry');
+  const [activeView, setActiveView] = useState<
+    'registry' | 'namespaces' | 'resolver' | 'settings'
+  >('registry');
 
   const [showEditorDialog, setShowEditorDialog] = useState(false);
   const [showImportDialog, setShowImportDialog] = useState(false);
@@ -395,10 +399,26 @@ export default function PrimitivesManagementClient() {
                 <GitFork className="w-4 h-4" />
                 Resolver
               </button>
+              <button
+                type="button"
+                role="tab"
+                aria-selected={activeView === 'settings'}
+                onClick={() => setActiveView('settings')}
+                className={`flex items-center gap-2 px-1 py-3 text-sm font-medium border-b-2 transition-colors ${
+                  activeView === 'settings'
+                    ? 'border-indigo-500 text-indigo-600 dark:text-indigo-400'
+                    : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-indigo-500'
+                }`}
+              >
+                <Settings className="w-4 h-4" />
+                Settings
+              </button>
             </nav>
           </div>
 
-          {activeView === 'resolver' ? (
+          {activeView === 'settings' ? (
+            <PrimitivesSettingsView onMessage={showMessage} />
+          ) : activeView === 'resolver' ? (
             <PrimitivesResolverView onMessage={showMessage} />
           ) : activeView === 'namespaces' ? (
             <PrimitivesNamespacesView

--- a/objectified-ui/src/app/ade/dashboard/primitives/PrimitivesSettingsView.tsx
+++ b/objectified-ui/src/app/ade/dashboard/primitives/PrimitivesSettingsView.tsx
@@ -1,0 +1,551 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  Database,
+  CheckCircle2,
+  AlertTriangle,
+  Save,
+  RotateCcw,
+  FileJson,
+  GitFork,
+  Upload,
+  ShieldCheck,
+} from 'lucide-react';
+import { Button } from '@/app/components/ui/Button';
+import { Input } from '@/app/components/ui/Input';
+import { LoadingState } from '@/app/components/ui/LoadingState';
+import {
+  dashboardPanelClass,
+  dashboardPanelPaddedClass,
+} from '@/app/components/ade/dashboard/dashboardScreenClasses';
+import {
+  ACCEPTED_FORMAT_OPTIONS,
+  CIRCULAR_POLICY_OPTIONS,
+  CORE_PUBLISH_ROLE_OPTIONS,
+  DEFAULT_SETTINGS,
+  DRAFT_OPTIONS,
+  IMPORT_SCOPE_OPTIONS,
+  MAX_RESOLUTION_DEPTH,
+  MIN_RESOLUTION_DEPTH,
+  REF_STYLE_OPTIONS,
+  clampDepth,
+  coerceSettings,
+  diffSettings,
+  formatAllowlist,
+  hasChanges,
+  parseAllowlist,
+  toggleInList,
+  type CircularRefPolicy,
+  type CorePublishRole,
+  type DefaultDraft,
+  type ImportScope,
+  type RefStyle,
+  type RegistryHealth,
+  type TypeRegistrySettings,
+  type TypeRegistrySettingsResponse,
+} from './primitivesSettingsModel';
+
+interface PrimitivesSettingsViewProps {
+  /** Surface success/error notices through the parent screen's alert. */
+  onMessage?: (type: 'success' | 'error', text: string) => void;
+}
+
+/** Shared classes for the section <select> controls (CSS-only, no inline values). */
+const selectClass =
+  'w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-sm text-gray-900 dark:text-white';
+const sectionTitleClass =
+  'flex items-center gap-2 text-sm font-semibold text-gray-900 dark:text-white';
+const fieldLabelClass = 'block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1';
+const helpTextClass = 'text-xs text-gray-400 mt-1';
+
+/** A labelled checkbox toggle with a short description, used throughout the form. */
+function ToggleRow({
+  id,
+  label,
+  description,
+  checked,
+  onChange,
+}: {
+  id: string;
+  label: string;
+  description: string;
+  checked: boolean;
+  onChange: (value: boolean) => void;
+}) {
+  return (
+    <label htmlFor={id} className="flex items-start gap-3 cursor-pointer py-1.5">
+      <input
+        id={id}
+        type="checkbox"
+        checked={checked}
+        onChange={(e) => onChange(e.target.checked)}
+        className="mt-0.5 w-4 h-4 text-indigo-600 rounded"
+      />
+      <span className="min-w-0">
+        <span className="block text-sm text-gray-800 dark:text-gray-200">{label}</span>
+        <span className="block text-xs text-gray-400">{description}</span>
+      </span>
+    </label>
+  );
+}
+
+/** A titled settings card wrapping a group of related controls. */
+function SettingsSection({
+  icon,
+  title,
+  children,
+}: {
+  icon: React.ReactNode;
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className={dashboardPanelPaddedClass}>
+      <h3 className={sectionTitleClass}>
+        {icon}
+        {title}
+      </h3>
+      <div className="mt-4 space-y-4">{children}</div>
+    </section>
+  );
+}
+
+/**
+ * Type Registry Settings view (#3472).
+ *
+ * Renders the registry storage status (live, from `GET /api/primitives/health`) plus the
+ * editable registry settings (`GET`/`PUT /api/types/settings`): JSON Schema dialect, `$ref`
+ * resolution policy, import defaults, and validation/publishing governance. Saving sends only
+ * the changed fields; the persisted settings become the source of truth the resolver and the
+ * validation gate (#3479) read. There is no separate registry database — storage is the shared
+ * `objectified-db` (single-DB design), which the status section makes explicit.
+ */
+export default function PrimitivesSettingsView({ onMessage }: PrimitivesSettingsViewProps) {
+  // `baseline` is the last-saved state; `form` is the in-progress edit. Save diffs the two.
+  const [baseline, setBaseline] = useState<TypeRegistrySettings>(DEFAULT_SETTINGS);
+  const [form, setForm] = useState<TypeRegistrySettings>(DEFAULT_SETTINGS);
+  const [usingDefaults, setUsingDefaults] = useState(true);
+  const [health, setHealth] = useState<RegistryHealth | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  // The allowlist textarea is edited as free text and parsed into the form on change.
+  const [allowlistText, setAllowlistText] = useState(
+    formatAllowlist(DEFAULT_SETTINGS.remote_host_allowlist)
+  );
+
+  const applyLoaded = useCallback((settings: TypeRegistrySettings) => {
+    setBaseline(settings);
+    setForm(settings);
+    setAllowlistText(formatAllowlist(settings.remote_host_allowlist));
+  }, []);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const [settingsRes, healthRes] = await Promise.all([
+        fetch('/api/types/settings'),
+        fetch('/api/primitives/health'),
+      ]);
+      const [settingsData, healthData] = await Promise.all([
+        settingsRes.json(),
+        healthRes.json(),
+      ]);
+
+      if (settingsData.success && settingsData.settings) {
+        const payload = settingsData.settings as TypeRegistrySettingsResponse;
+        setUsingDefaults(Boolean(payload.is_default));
+        applyLoaded(coerceSettings(payload));
+      } else {
+        onMessage?.('error', settingsData.error || 'Failed to load settings');
+      }
+
+      if (healthData.success && healthData.health) {
+        setHealth(healthData.health as RegistryHealth);
+      } else {
+        setHealth(null);
+      }
+    } catch (error) {
+      console.error('Error loading registry settings:', error);
+      onMessage?.('error', 'Failed to load settings');
+    } finally {
+      setLoading(false);
+    }
+  }, [applyLoaded, onMessage]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const dirty = useMemo(() => hasChanges(baseline, form), [baseline, form]);
+
+  /** Patch one field of the in-progress form. */
+  const setField = useCallback(
+    <K extends keyof TypeRegistrySettings>(key: K, value: TypeRegistrySettings[K]) => {
+      setForm((current) => ({ ...current, [key]: value }));
+    },
+    []
+  );
+
+  const handleAllowlistChange = useCallback((text: string) => {
+    setAllowlistText(text);
+    setForm((current) => ({ ...current, remote_host_allowlist: parseAllowlist(text) }));
+  }, []);
+
+  const handleReset = useCallback(() => {
+    setForm(DEFAULT_SETTINGS);
+    setAllowlistText(formatAllowlist(DEFAULT_SETTINGS.remote_host_allowlist));
+  }, []);
+
+  const handleSave = useCallback(async () => {
+    const payload = diffSettings(baseline, form);
+    if (Object.keys(payload).length === 0) {
+      onMessage?.('error', 'No changes to save');
+      return;
+    }
+
+    setSaving(true);
+    try {
+      const res = await fetch('/api/types/settings', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      const data = await res.json();
+      if (data.success && data.settings) {
+        const saved = data.settings as TypeRegistrySettingsResponse;
+        setUsingDefaults(Boolean(saved.is_default));
+        applyLoaded(coerceSettings(saved));
+        onMessage?.('success', 'Registry settings saved');
+      } else {
+        onMessage?.('error', data.error || 'Failed to save settings');
+      }
+    } catch (error) {
+      console.error('Error saving registry settings:', error);
+      onMessage?.('error', 'Failed to save settings');
+    } finally {
+      setSaving(false);
+    }
+  }, [applyLoaded, baseline, form, onMessage]);
+
+  if (loading) {
+    return <LoadingState minHeightClassName="min-h-[320px]" message="Loading settings…" />;
+  }
+
+  const connected = health?.connection === 'connected' && health?.status === 'healthy';
+
+  return (
+    <div className="space-y-6">
+      {usingDefaults && (
+        <div className="flex items-center gap-2 text-xs text-indigo-700 dark:text-indigo-300 bg-indigo-50 dark:bg-indigo-900/30 border border-indigo-200 dark:border-indigo-800 rounded-lg px-3 py-2">
+          <AlertTriangle className="w-3.5 h-3.5 flex-shrink-0" />
+          <span>
+            This tenant is using the registry defaults. Save to persist a tenant-specific
+            configuration.
+          </span>
+        </div>
+      )}
+
+      {/* Registry storage status — live from the registry health probe (#3450). */}
+      <section className={dashboardPanelPaddedClass}>
+        <div className="flex items-center justify-between gap-4">
+          <h3 className={sectionTitleClass}>
+            <Database className="w-4 h-4 text-indigo-600 dark:text-indigo-400" />
+            Registry storage
+          </h3>
+          {health ? (
+            <span
+              className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium ${
+                connected
+                  ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300'
+                  : 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300'
+              }`}
+            >
+              {connected ? (
+                <CheckCircle2 className="w-3.5 h-3.5" />
+              ) : (
+                <AlertTriangle className="w-3.5 h-3.5" />
+              )}
+              {connected ? 'Connected' : 'Unavailable'}
+            </span>
+          ) : (
+            <span className="text-xs text-gray-400">status unknown</span>
+          )}
+        </div>
+        <p className="text-xs text-gray-500 dark:text-gray-400 mt-2">
+          The registry is stored in the shared <span className="font-mono">objectified-db</span>{' '}
+          (<span className="font-mono">odb.primitives</span>) — there is no separate registry
+          database. Storage table present:{' '}
+          <span className="font-mono">{health?.storage_present ? 'yes' : 'no'}</span>.
+        </p>
+        {health?.error && (
+          <p className="text-xs text-red-600 dark:text-red-400 mt-1 font-mono">{health.error}</p>
+        )}
+      </section>
+
+      {/* JSON Schema dialect */}
+      <SettingsSection
+        icon={<FileJson className="w-4 h-4 text-indigo-600 dark:text-indigo-400" />}
+        title="JSON Schema dialect"
+      >
+        <div>
+          <label htmlFor="default-draft" className={fieldLabelClass}>
+            Default draft
+          </label>
+          <select
+            id="default-draft"
+            value={form.default_draft}
+            onChange={(e) => setField('default_draft', e.target.value as DefaultDraft)}
+            className={selectClass}
+          >
+            {DRAFT_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </div>
+        <ToggleRow
+          id="strict-validation"
+          label="Strict validation"
+          description="Reject unknown formats."
+          checked={form.strict_validation}
+          onChange={(value) => setField('strict_validation', value)}
+        />
+        <ToggleRow
+          id="allow-annotations"
+          label="Allow annotation keywords"
+          description="Permit title, description, examples, etc."
+          checked={form.allow_annotation_keywords}
+          onChange={(value) => setField('allow_annotation_keywords', value)}
+        />
+        <ToggleRow
+          id="coerce-drafts"
+          label="Coerce imported drafts to default"
+          description="Upgrade older drafts to the default dialect on import."
+          checked={form.coerce_imported_drafts}
+          onChange={(value) => setField('coerce_imported_drafts', value)}
+        />
+      </SettingsSection>
+
+      {/* Reference resolution */}
+      <SettingsSection
+        icon={<GitFork className="w-4 h-4 text-indigo-600 dark:text-indigo-400" />}
+        title="Reference resolution"
+      >
+        <div>
+          <label htmlFor="resolution-base" className={fieldLabelClass}>
+            Resolution base URL
+          </label>
+          <Input
+            id="resolution-base"
+            type="text"
+            value={form.resolution_base_url}
+            onChange={(e) => setField('resolution_base_url', e.target.value)}
+          />
+          <p className={helpTextClass}>Relative $ref resolve against this base.</p>
+        </div>
+        <div>
+          <label htmlFor="ref-style" className={fieldLabelClass}>
+            $ref style
+          </label>
+          <select
+            id="ref-style"
+            value={form.ref_style}
+            onChange={(e) => setField('ref_style', e.target.value as RefStyle)}
+            className={selectClass}
+          >
+            {REF_STYLE_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </div>
+        <ToggleRow
+          id="allow-remote-refs"
+          label="Allow remote $ref"
+          description="Fetch schemas from external hosts during resolution."
+          checked={form.allow_remote_refs}
+          onChange={(value) => setField('allow_remote_refs', value)}
+        />
+        <div>
+          <label htmlFor="remote-allowlist" className={fieldLabelClass}>
+            Remote host allowlist
+          </label>
+          <textarea
+            id="remote-allowlist"
+            value={allowlistText}
+            onChange={(e) => handleAllowlistChange(e.target.value)}
+            disabled={!form.allow_remote_refs}
+            rows={3}
+            placeholder="json-schema.org&#10;spec.openapis.org"
+            className={`${selectClass} font-mono disabled:opacity-50 disabled:cursor-not-allowed`}
+          />
+          <p className={helpTextClass}>One host per line. Only used when remote $ref is allowed.</p>
+        </div>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <div>
+            <label htmlFor="max-depth" className={fieldLabelClass}>
+              Max resolution depth
+            </label>
+            <Input
+              id="max-depth"
+              type="number"
+              min={MIN_RESOLUTION_DEPTH}
+              max={MAX_RESOLUTION_DEPTH}
+              value={form.max_resolution_depth}
+              onChange={(e) => setField('max_resolution_depth', clampDepth(Number(e.target.value)))}
+            />
+          </div>
+          <div>
+            <label htmlFor="circular-policy" className={fieldLabelClass}>
+              Circular ref policy
+            </label>
+            <select
+              id="circular-policy"
+              value={form.circular_ref_policy}
+              onChange={(e) => setField('circular_ref_policy', e.target.value as CircularRefPolicy)}
+              className={selectClass}
+            >
+              {CIRCULAR_POLICY_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+      </SettingsSection>
+
+      {/* Import defaults */}
+      <SettingsSection
+        icon={<Upload className="w-4 h-4 text-indigo-600 dark:text-indigo-400" />}
+        title="Import defaults"
+      >
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <div>
+            <label htmlFor="import-scope" className={fieldLabelClass}>
+              Default scope
+            </label>
+            <select
+              id="import-scope"
+              value={form.default_import_scope}
+              onChange={(e) => setField('default_import_scope', e.target.value as ImportScope)}
+              className={selectClass}
+            >
+              {IMPORT_SCOPE_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label htmlFor="default-namespace" className={fieldLabelClass}>
+              Default target namespace
+            </label>
+            <Input
+              id="default-namespace"
+              type="text"
+              value={form.default_target_namespace ?? ''}
+              placeholder="(none)"
+              onChange={(e) =>
+                setField('default_target_namespace', e.target.value.trim() ? e.target.value : null)
+              }
+            />
+          </div>
+        </div>
+        <ToggleRow
+          id="rewrite-refs"
+          label="Rewrite refs to relative on import"
+          description="Convert absolute $ref to base-relative paths."
+          checked={form.rewrite_refs_on_import}
+          onChange={(value) => setField('rewrite_refs_on_import', value)}
+        />
+        <div>
+          <span className={fieldLabelClass}>Accepted formats</span>
+          <div className="space-y-1">
+            {ACCEPTED_FORMAT_OPTIONS.map((option) => {
+              const id = `format-${option.value}`;
+              return (
+                <label key={option.value} htmlFor={id} className="flex items-center gap-2 cursor-pointer">
+                  <input
+                    id={id}
+                    type="checkbox"
+                    checked={form.accepted_formats.includes(option.value)}
+                    onChange={() =>
+                      setField('accepted_formats', toggleInList(form.accepted_formats, option.value))
+                    }
+                    className="w-4 h-4 text-indigo-600 rounded"
+                  />
+                  <span className="text-sm text-gray-800 dark:text-gray-200">{option.label}</span>
+                </label>
+              );
+            })}
+          </div>
+        </div>
+        <ToggleRow
+          id="dedupe-types"
+          label="Dedupe identical types"
+          description="Reuse an existing type when an import matches it byte-for-byte."
+          checked={form.dedupe_identical_types}
+          onChange={(value) => setField('dedupe_identical_types', value)}
+        />
+      </SettingsSection>
+
+      {/* Validation & publishing */}
+      <SettingsSection
+        icon={<ShieldCheck className="w-4 h-4 text-indigo-600 dark:text-indigo-400" />}
+        title="Validation & publishing"
+      >
+        <ToggleRow
+          id="validate-on-save"
+          label="Validate on save"
+          description="Run dialect & $ref checks before persisting."
+          checked={form.validate_on_save}
+          onChange={(value) => setField('validate_on_save', value)}
+        />
+        <ToggleRow
+          id="block-publish"
+          label="Block publish on validation errors"
+          description="Prevent publishing types with unresolved $ref or schema errors."
+          checked={form.block_publish_on_errors}
+          onChange={(value) => setField('block_publish_on_errors', value)}
+        />
+        <div>
+          <label htmlFor="core-publish-role" className={fieldLabelClass}>
+            Who can publish core (std/*) types
+          </label>
+          <select
+            id="core-publish-role"
+            value={form.core_publish_role}
+            onChange={(e) => setField('core_publish_role', e.target.value as CorePublishRole)}
+            className={selectClass}
+          >
+            {CORE_PUBLISH_ROLE_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+          <p className={helpTextClass}>
+            Core system types are shared with all tenants; publishing is governed.
+          </p>
+        </div>
+      </SettingsSection>
+
+      {/* Footer actions */}
+      <div className={`${dashboardPanelClass} p-4 flex items-center justify-between gap-4`}>
+        <Button variant="secondary" onClick={handleReset} disabled={saving}>
+          <RotateCcw className="w-4 h-4 mr-2" />
+          Reset to defaults
+        </Button>
+        <Button onClick={handleSave} disabled={saving || !dirty}>
+          <Save className="w-4 h-4 mr-2" />
+          {saving ? 'Saving…' : 'Save settings'}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/objectified-ui/src/app/ade/dashboard/primitives/primitivesSettingsModel.ts
+++ b/objectified-ui/src/app/ade/dashboard/primitives/primitivesSettingsModel.ts
@@ -1,0 +1,231 @@
+/**
+ * Pure model + helpers for the Type Registry Settings view (#3472).
+ *
+ * Mirrors the REST settings contract (`GET`/`PUT /v1/types/{tenant_slug}/settings`, #3472) and
+ * provides the option lists, defaults, allowlist (de)serialization, and change-diffing the
+ * Settings view needs. Kept free of React/DOM so it is unit-testable.
+ */
+
+export type DefaultDraft = '2020-12' | '2019-09' | 'draft-07';
+export type RefStyle = 'relative' | 'absolute' | 'anchor';
+export type CircularRefPolicy = 'error' | 'warn';
+export type ImportScope = 'tenant' | 'system';
+export type CorePublishRole = 'platform_admin' | 'tenant_admin' | 'maintainer';
+
+/** The full set of type-registry settings (mirrors REST `TypeRegistrySettingsSchema`). */
+export interface TypeRegistrySettings {
+  // JSON Schema dialect
+  default_draft: DefaultDraft;
+  strict_validation: boolean;
+  allow_annotation_keywords: boolean;
+  coerce_imported_drafts: boolean;
+
+  // Reference resolution
+  resolution_base_url: string;
+  ref_style: RefStyle;
+  allow_remote_refs: boolean;
+  remote_host_allowlist: string[];
+  max_resolution_depth: number;
+  circular_ref_policy: CircularRefPolicy;
+
+  // Import defaults
+  default_import_scope: ImportScope;
+  default_target_namespace: string | null;
+  rewrite_refs_on_import: boolean;
+  accepted_formats: string[];
+  dedupe_identical_types: boolean;
+
+  // Validation & publishing governance
+  validate_on_save: boolean;
+  block_publish_on_errors: boolean;
+  core_publish_role: CorePublishRole;
+}
+
+/** Settings plus the server-provided provenance/`is_default` flags (the GET response shape). */
+export interface TypeRegistrySettingsResponse extends TypeRegistrySettings {
+  is_default: boolean;
+  updated_by?: string | null;
+  created_at?: string | null;
+  updated_at?: string | null;
+}
+
+/** Registry storage health (mirrors REST `RegistryHealthResponse`, #3450). */
+export interface RegistryHealth {
+  status: 'healthy' | 'unhealthy';
+  service?: string;
+  database?: string;
+  connection: 'connected' | 'disconnected';
+  storage_present: boolean;
+  error?: string | null;
+}
+
+/** The registry defaults, byte-for-byte the REST/DB defaults so the UI matches an unsaved tenant. */
+export const DEFAULT_SETTINGS: TypeRegistrySettings = {
+  default_draft: '2020-12',
+  strict_validation: true,
+  allow_annotation_keywords: true,
+  coerce_imported_drafts: true,
+  resolution_base_url: 'https://api.objectified.dev/types/',
+  ref_style: 'relative',
+  allow_remote_refs: false,
+  remote_host_allowlist: ['json-schema.org', 'spec.openapis.org'],
+  max_resolution_depth: 12,
+  circular_ref_policy: 'error',
+  default_import_scope: 'tenant',
+  default_target_namespace: null,
+  rewrite_refs_on_import: true,
+  accepted_formats: ['json-schema-2020-12', 'type-def-bundle', 'openapi-3.1'],
+  dedupe_identical_types: true,
+  validate_on_save: true,
+  block_publish_on_errors: true,
+  core_publish_role: 'platform_admin',
+};
+
+/** Inclusive bounds for the max-resolution-depth control (mirrors the DB CHECK constraint). */
+export const MIN_RESOLUTION_DEPTH = 1;
+export const MAX_RESOLUTION_DEPTH = 64;
+
+export const DRAFT_OPTIONS: { value: DefaultDraft; label: string }[] = [
+  { value: '2020-12', label: '2020-12' },
+  { value: '2019-09', label: '2019-09' },
+  { value: 'draft-07', label: 'draft-07 (import compatibility)' },
+];
+
+export const REF_STYLE_OPTIONS: { value: RefStyle; label: string }[] = [
+  { value: 'relative', label: 'Relative (recommended)' },
+  { value: 'absolute', label: 'Absolute $id' },
+  { value: 'anchor', label: 'Anchor (#/$defs)' },
+];
+
+export const CIRCULAR_POLICY_OPTIONS: { value: CircularRefPolicy; label: string }[] = [
+  { value: 'error', label: 'Error' },
+  { value: 'warn', label: 'Warn' },
+];
+
+export const IMPORT_SCOPE_OPTIONS: { value: ImportScope; label: string }[] = [
+  { value: 'tenant', label: 'Tenant' },
+  { value: 'system', label: 'System · core' },
+];
+
+export const CORE_PUBLISH_ROLE_OPTIONS: { value: CorePublishRole; label: string }[] = [
+  { value: 'platform_admin', label: 'Platform admin' },
+  { value: 'tenant_admin', label: 'Tenant admin' },
+  { value: 'maintainer', label: 'Maintainer' },
+];
+
+/** The selectable import formats (the checkbox set), with stable values matching the DB defaults. */
+export const ACCEPTED_FORMAT_OPTIONS: { value: string; label: string }[] = [
+  { value: 'json-schema-2020-12', label: 'JSON Schema 2020-12' },
+  { value: 'type-def-bundle', label: 'Type-definition bundle (.zip/.json)' },
+  { value: 'openapi-3.1', label: 'OpenAPI 3.1 components' },
+  { value: 'avro-protobuf', label: 'Avro / Protobuf (experimental)' },
+];
+
+/** The keys that make up the persistable settings (everything except server provenance). */
+export const SETTINGS_KEYS: (keyof TypeRegistrySettings)[] = [
+  'default_draft',
+  'strict_validation',
+  'allow_annotation_keywords',
+  'coerce_imported_drafts',
+  'resolution_base_url',
+  'ref_style',
+  'allow_remote_refs',
+  'remote_host_allowlist',
+  'max_resolution_depth',
+  'circular_ref_policy',
+  'default_import_scope',
+  'default_target_namespace',
+  'rewrite_refs_on_import',
+  'accepted_formats',
+  'dedupe_identical_types',
+  'validate_on_save',
+  'block_publish_on_errors',
+  'core_publish_role',
+];
+
+/**
+ * Normalize an arbitrary API payload into a complete {@link TypeRegistrySettings}, filling any
+ * missing field from {@link DEFAULT_SETTINGS}. Tolerant of a `null`/partial response so the form
+ * always has a complete, valid starting state.
+ */
+export function coerceSettings(raw: Partial<TypeRegistrySettings> | null | undefined): TypeRegistrySettings {
+  const source = raw ?? {};
+  return {
+    ...DEFAULT_SETTINGS,
+    ...source,
+    // Arrays must be copied (never share the DEFAULT_SETTINGS references) and coerced to arrays.
+    remote_host_allowlist: Array.isArray(source.remote_host_allowlist)
+      ? [...source.remote_host_allowlist]
+      : [...DEFAULT_SETTINGS.remote_host_allowlist],
+    accepted_formats: Array.isArray(source.accepted_formats)
+      ? [...source.accepted_formats]
+      : [...DEFAULT_SETTINGS.accepted_formats],
+  };
+}
+
+/** Split a textarea value (newline- or comma-separated) into a trimmed, de-duplicated host list. */
+export function parseAllowlist(text: string): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const token of text.split(/[\n,]/)) {
+    const host = token.trim();
+    if (host && !seen.has(host)) {
+      seen.add(host);
+      result.push(host);
+    }
+  }
+  return result;
+}
+
+/** Render a host allowlist back into newline-separated textarea text. */
+export function formatAllowlist(hosts: string[]): string {
+  return hosts.join('\n');
+}
+
+/** Clamp a (possibly out-of-range or NaN) depth into the allowed bounds. */
+export function clampDepth(value: number): number {
+  if (Number.isNaN(value)) return DEFAULT_SETTINGS.max_resolution_depth;
+  return Math.min(MAX_RESOLUTION_DEPTH, Math.max(MIN_RESOLUTION_DEPTH, Math.trunc(value)));
+}
+
+/** Toggle a value's membership in a list, preserving order (used for the accepted-formats checkboxes). */
+export function toggleInList(list: string[], value: string): string[] {
+  return list.includes(value) ? list.filter((item) => item !== value) : [...list, value];
+}
+
+/** Order-insensitive equality for two string lists (so checkbox/host reordering is not a "change"). */
+function sameStringSet(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false;
+  const setB = new Set(b);
+  return a.every((item) => setB.has(item));
+}
+
+/** True when two settings field values are equal (sets compared order-insensitively). */
+function fieldEquals(key: keyof TypeRegistrySettings, a: TypeRegistrySettings, b: TypeRegistrySettings): boolean {
+  if (key === 'remote_host_allowlist' || key === 'accepted_formats') {
+    return sameStringSet(a[key] as string[], b[key] as string[]);
+  }
+  return a[key] === b[key];
+}
+
+/**
+ * Build the minimal PUT payload: only the fields that differ between the saved baseline and the
+ * current form. Returns an empty object when nothing changed (the view can then skip the save).
+ */
+export function diffSettings(
+  baseline: TypeRegistrySettings,
+  current: TypeRegistrySettings
+): Partial<TypeRegistrySettings> {
+  const payload: Partial<TypeRegistrySettings> = {};
+  for (const key of SETTINGS_KEYS) {
+    if (!fieldEquals(key, baseline, current)) {
+      (payload[key] as unknown) = current[key];
+    }
+  }
+  return payload;
+}
+
+/** True when the current form differs from the saved baseline. */
+export function hasChanges(baseline: TypeRegistrySettings, current: TypeRegistrySettings): boolean {
+  return SETTINGS_KEYS.some((key) => !fieldEquals(key, baseline, current));
+}

--- a/objectified-ui/src/app/api/primitives/health/route.ts
+++ b/objectified-ui/src/app/api/primitives/health/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from 'next/server';
+import { getAuthenticatedTenantContext, proxyRestGet } from '@lib/primitives-api-proxy';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET /api/primitives/health — registry storage status (#3450), surfaced by the Settings UI
+ * #3472 "Registry storage" section.
+ *
+ * Proxies the anonymous REST registry probe `GET /v1/primitives/health`, which reports whether
+ * the shared `objectified-db` connection backing `odb.primitives` is reachable. There is no
+ * separate registry database (single-DB design, §1a), so this reflects the application DB's
+ * registry layer rather than a distinct store.
+ */
+export async function GET() {
+  try {
+    const ctx = await getAuthenticatedTenantContext();
+    if (!ctx.ok) {
+      return NextResponse.json({ success: false, error: ctx.error }, { status: ctx.status });
+    }
+
+    const { data, error, status } = await proxyRestGet(ctx.user, `/primitives/health`);
+
+    if (error) {
+      return NextResponse.json({ success: false, error }, { status });
+    }
+
+    return NextResponse.json({ success: true, health: data });
+  } catch (error) {
+    console.error('Error fetching registry health:', error);
+    const message = error instanceof Error ? error.message : 'Internal server error';
+    return NextResponse.json({ success: false, error: message }, { status: 500 });
+  }
+}

--- a/objectified-ui/src/app/api/types/settings/route.ts
+++ b/objectified-ui/src/app/api/types/settings/route.ts
@@ -1,0 +1,73 @@
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  getAuthenticatedTenantContext,
+  proxyRestGet,
+  proxyRestPut,
+} from '@lib/primitives-api-proxy';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET /api/types/settings — the tenant's type-registry settings (Settings UI #3472,
+ * backed by REST #3472 `GET /v1/types/{tenant_slug}/settings`).
+ *
+ * Returns the saved settings, or the registry defaults (flagged `is_default: true`) when the
+ * tenant has never saved any — so the Settings view always renders a complete configuration.
+ */
+export async function GET() {
+  try {
+    const ctx = await getAuthenticatedTenantContext();
+    if (!ctx.ok) {
+      return NextResponse.json({ success: false, error: ctx.error }, { status: ctx.status });
+    }
+
+    const { data, error, status } = await proxyRestGet(
+      ctx.user,
+      `/types/${encodeURIComponent(ctx.tenantSlug)}/settings`
+    );
+
+    if (error) {
+      return NextResponse.json({ success: false, error }, { status });
+    }
+
+    return NextResponse.json({ success: true, settings: data });
+  } catch (error) {
+    console.error('Error fetching type-registry settings:', error);
+    const message = error instanceof Error ? error.message : 'Internal server error';
+    return NextResponse.json({ success: false, error: message }, { status: 500 });
+  }
+}
+
+/**
+ * PUT /api/types/settings — save the tenant's type-registry settings (#3472).
+ *
+ * Tenant-administrator only (enforced by the REST layer). The body may be a partial update;
+ * omitted fields keep their current persisted value. The REST layer validates enum/range
+ * values and returns the full persisted settings.
+ */
+export async function PUT(request: NextRequest) {
+  try {
+    const ctx = await getAuthenticatedTenantContext();
+    if (!ctx.ok) {
+      return NextResponse.json({ success: false, error: ctx.error }, { status: ctx.status });
+    }
+
+    const body = await request.json();
+
+    const { data, error, status } = await proxyRestPut(
+      ctx.user,
+      `/types/${encodeURIComponent(ctx.tenantSlug)}/settings`,
+      body
+    );
+
+    if (error) {
+      return NextResponse.json({ success: false, error }, { status });
+    }
+
+    return NextResponse.json({ success: true, settings: data });
+  } catch (error) {
+    console.error('Error saving type-registry settings:', error);
+    const message = error instanceof Error ? error.message : 'Internal server error';
+    return NextResponse.json({ success: false, error: message }, { status: 500 });
+  }
+}

--- a/objectified-ui/tests/PrimitivesSettingsView.test.tsx
+++ b/objectified-ui/tests/PrimitivesSettingsView.test.tsx
@@ -1,0 +1,158 @@
+/**
+ * Type Registry Settings view (#3472).
+ *
+ * Verifies the view loads settings + storage health, renders the registry-defaults banner,
+ * persists only changed fields via a PUT, resets to defaults, and surfaces load/save errors.
+ */
+
+import React from 'react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import PrimitivesSettingsView from '../src/app/ade/dashboard/primitives/PrimitivesSettingsView';
+import { DEFAULT_SETTINGS } from '../src/app/ade/dashboard/primitives/primitivesSettingsModel';
+
+const DEFAULTS_RESPONSE = { ...DEFAULT_SETTINGS, is_default: true };
+
+const HEALTH_HEALTHY = {
+  status: 'healthy',
+  service: 'primitives-registry',
+  database: 'objectified-db',
+  connection: 'connected',
+  storage_present: true,
+};
+
+/**
+ * Mock fetch routing by URL: GET /api/types/settings, GET /api/primitives/health, and
+ * PUT /api/types/settings. `settings` is the GET payload; `putResult` the PUT echo.
+ */
+function mockFetch({
+  settings = DEFAULTS_RESPONSE,
+  health = HEALTH_HEALTHY,
+  putResult,
+}: {
+  settings?: Record<string, unknown>;
+  health?: Record<string, unknown> | null;
+  putResult?: Record<string, unknown>;
+} = {}) {
+  const put = jest.fn();
+  const fetchMock = jest.fn((url: string, init?: RequestInit) => {
+    if (url === '/api/types/settings' && init?.method === 'PUT') {
+      put(JSON.parse(init.body as string));
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({ success: true, settings: putResult ?? { ...settings, is_default: false } }),
+      });
+    }
+    if (url === '/api/types/settings') {
+      return Promise.resolve({ ok: true, json: async () => ({ success: true, settings }) });
+    }
+    if (url === '/api/primitives/health') {
+      return Promise.resolve({
+        ok: true,
+        json: async () =>
+          health ? { success: true, health } : { success: false, error: 'no health' },
+      });
+    }
+    throw new Error(`Unexpected fetch: ${url}`);
+  });
+  return { fetchMock, put };
+}
+
+describe('PrimitivesSettingsView', () => {
+  afterEach(() => jest.restoreAllMocks());
+
+  it('loads settings + health, shows the defaults banner and Connected status', async () => {
+    const { fetchMock } = mockFetch();
+    global.fetch = fetchMock as unknown as typeof fetch;
+    render(<PrimitivesSettingsView />);
+
+    await waitFor(() =>
+      expect(screen.getByRole('heading', { name: 'Registry storage' })).toBeInTheDocument()
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/types/settings');
+    expect(fetchMock).toHaveBeenCalledWith('/api/primitives/health');
+    expect(screen.getByText(/using the registry defaults/i)).toBeInTheDocument();
+    expect(screen.getByText('Connected')).toBeInTheDocument();
+    // Default draft control reflects the loaded value.
+    expect((screen.getByLabelText('Default draft') as HTMLSelectElement).value).toBe('2020-12');
+  });
+
+  it('disables Save until a field changes, then PUTs only the changed field', async () => {
+    const { fetchMock, put } = mockFetch();
+    global.fetch = fetchMock as unknown as typeof fetch;
+    const onMessage = jest.fn();
+    render(<PrimitivesSettingsView onMessage={onMessage} />);
+
+    await waitFor(() => expect(screen.getByLabelText('Default draft')).toBeInTheDocument());
+
+    const save = screen.getByRole('button', { name: /Save settings/i });
+    expect(save).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText('Default draft'), { target: { value: '2019-09' } });
+    expect(save).toBeEnabled();
+
+    fireEvent.click(save);
+
+    await waitFor(() => expect(put).toHaveBeenCalledWith({ default_draft: '2019-09' }));
+    await waitFor(() =>
+      expect(onMessage).toHaveBeenCalledWith('success', 'Registry settings saved')
+    );
+  });
+
+  it('toggles the remote allowlist enable/disable state with the remote-$ref checkbox', async () => {
+    const { fetchMock } = mockFetch();
+    global.fetch = fetchMock as unknown as typeof fetch;
+    render(<PrimitivesSettingsView />);
+
+    await waitFor(() => expect(screen.getByLabelText('Remote host allowlist')).toBeInTheDocument());
+
+    const allowlist = screen.getByLabelText('Remote host allowlist') as HTMLTextAreaElement;
+    expect(allowlist).toBeDisabled(); // allow_remote_refs defaults to false
+
+    fireEvent.click(screen.getByRole('checkbox', { name: /Allow remote \$ref/i }));
+    expect(allowlist).toBeEnabled();
+  });
+
+  it('resets edited fields back to the registry defaults', async () => {
+    const saved = { ...DEFAULT_SETTINGS, default_draft: 'draft-07', is_default: false };
+    const { fetchMock } = mockFetch({ settings: saved });
+    global.fetch = fetchMock as unknown as typeof fetch;
+    render(<PrimitivesSettingsView />);
+
+    await waitFor(() =>
+      expect((screen.getByLabelText('Default draft') as HTMLSelectElement).value).toBe('draft-07')
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Reset to defaults/i }));
+    expect((screen.getByLabelText('Default draft') as HTMLSelectElement).value).toBe('2020-12');
+    // Reset is a local change vs the saved baseline → Save becomes enabled.
+    expect(screen.getByRole('button', { name: /Save settings/i })).toBeEnabled();
+  });
+
+  it('surfaces a load error through onMessage', async () => {
+    const fetchMock = jest.fn((url: string) => {
+      if (url === '/api/types/settings') {
+        return Promise.resolve({ ok: false, json: async () => ({ success: false, error: 'No tenant' }) });
+      }
+      return Promise.resolve({ ok: true, json: async () => ({ success: true, health: HEALTH_HEALTHY }) });
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+    const onMessage = jest.fn();
+    render(<PrimitivesSettingsView onMessage={onMessage} />);
+
+    await waitFor(() => expect(onMessage).toHaveBeenCalledWith('error', 'No tenant'));
+  });
+
+  it('shows Unavailable when the registry storage probe is unhealthy', async () => {
+    const { fetchMock } = mockFetch({
+      health: { status: 'unhealthy', connection: 'disconnected', storage_present: false, error: 'boom' },
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+    render(<PrimitivesSettingsView />);
+
+    await waitFor(() => expect(screen.getByText('Unavailable')).toBeInTheDocument());
+    expect(screen.getByText('boom')).toBeInTheDocument();
+  });
+});

--- a/objectified-ui/tests/primitivesSettingsModel.test.ts
+++ b/objectified-ui/tests/primitivesSettingsModel.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Unit tests for the Type Registry Settings model (#3472).
+ *
+ * Covers defaults coercion, allowlist (de)serialization, depth clamping, list toggling, and the
+ * change-diffing the Settings view relies on to send minimal PUT payloads.
+ */
+
+import {
+  DEFAULT_SETTINGS,
+  MAX_RESOLUTION_DEPTH,
+  MIN_RESOLUTION_DEPTH,
+  clampDepth,
+  coerceSettings,
+  diffSettings,
+  formatAllowlist,
+  hasChanges,
+  parseAllowlist,
+  toggleInList,
+  type TypeRegistrySettings,
+} from '../src/app/ade/dashboard/primitives/primitivesSettingsModel';
+
+describe('coerceSettings', () => {
+  it('returns a complete defaults object for null/empty input', () => {
+    expect(coerceSettings(null)).toEqual(DEFAULT_SETTINGS);
+    expect(coerceSettings(undefined)).toEqual(DEFAULT_SETTINGS);
+    expect(coerceSettings({})).toEqual(DEFAULT_SETTINGS);
+  });
+
+  it('fills missing fields from defaults and keeps provided ones', () => {
+    const result = coerceSettings({ default_draft: '2019-09', max_resolution_depth: 5 });
+    expect(result.default_draft).toBe('2019-09');
+    expect(result.max_resolution_depth).toBe(5);
+    expect(result.ref_style).toBe(DEFAULT_SETTINGS.ref_style);
+  });
+
+  it('copies arrays so the returned object never shares the DEFAULT_SETTINGS references', () => {
+    const result = coerceSettings({});
+    expect(result.remote_host_allowlist).toEqual(DEFAULT_SETTINGS.remote_host_allowlist);
+    expect(result.remote_host_allowlist).not.toBe(DEFAULT_SETTINGS.remote_host_allowlist);
+    expect(result.accepted_formats).not.toBe(DEFAULT_SETTINGS.accepted_formats);
+  });
+
+  it('coerces non-array allowlist/formats to defaults', () => {
+    const result = coerceSettings({
+      remote_host_allowlist: undefined,
+      accepted_formats: undefined,
+    });
+    expect(result.remote_host_allowlist).toEqual(DEFAULT_SETTINGS.remote_host_allowlist);
+    expect(result.accepted_formats).toEqual(DEFAULT_SETTINGS.accepted_formats);
+  });
+});
+
+describe('parseAllowlist / formatAllowlist', () => {
+  it('splits on newlines and commas, trims, and de-duplicates', () => {
+    expect(parseAllowlist('json-schema.org\n spec.openapis.org , json-schema.org\n\n')).toEqual([
+      'json-schema.org',
+      'spec.openapis.org',
+    ]);
+  });
+
+  it('returns an empty list for blank text', () => {
+    expect(parseAllowlist('   \n  ')).toEqual([]);
+  });
+
+  it('round-trips through format → parse', () => {
+    const hosts = ['a.example', 'b.example'];
+    expect(parseAllowlist(formatAllowlist(hosts))).toEqual(hosts);
+  });
+});
+
+describe('clampDepth', () => {
+  it('clamps to the inclusive bounds', () => {
+    expect(clampDepth(0)).toBe(MIN_RESOLUTION_DEPTH);
+    expect(clampDepth(999)).toBe(MAX_RESOLUTION_DEPTH);
+    expect(clampDepth(12)).toBe(12);
+  });
+
+  it('truncates fractions and falls back to the default for NaN', () => {
+    expect(clampDepth(8.9)).toBe(8);
+    expect(clampDepth(Number.NaN)).toBe(DEFAULT_SETTINGS.max_resolution_depth);
+  });
+});
+
+describe('toggleInList', () => {
+  it('adds a missing value and removes a present one, preserving order', () => {
+    expect(toggleInList(['a', 'b'], 'c')).toEqual(['a', 'b', 'c']);
+    expect(toggleInList(['a', 'b', 'c'], 'b')).toEqual(['a', 'c']);
+  });
+});
+
+describe('diffSettings / hasChanges', () => {
+  it('returns an empty payload when nothing changed', () => {
+    expect(diffSettings(DEFAULT_SETTINGS, { ...DEFAULT_SETTINGS })).toEqual({});
+    expect(hasChanges(DEFAULT_SETTINGS, { ...DEFAULT_SETTINGS })).toBe(false);
+  });
+
+  it('includes only the changed scalar fields', () => {
+    const current: TypeRegistrySettings = {
+      ...DEFAULT_SETTINGS,
+      default_draft: '2019-09',
+      max_resolution_depth: 20,
+    };
+    expect(diffSettings(DEFAULT_SETTINGS, current)).toEqual({
+      default_draft: '2019-09',
+      max_resolution_depth: 20,
+    });
+    expect(hasChanges(DEFAULT_SETTINGS, current)).toBe(true);
+  });
+
+  it('treats list reordering as no change but membership changes as a change', () => {
+    const reordered: TypeRegistrySettings = {
+      ...DEFAULT_SETTINGS,
+      remote_host_allowlist: [...DEFAULT_SETTINGS.remote_host_allowlist].reverse(),
+    };
+    expect(diffSettings(DEFAULT_SETTINGS, reordered)).toEqual({});
+
+    const changed: TypeRegistrySettings = {
+      ...DEFAULT_SETTINGS,
+      accepted_formats: ['json-schema-2020-12'],
+    };
+    expect(diffSettings(DEFAULT_SETTINGS, changed)).toEqual({
+      accepted_formats: ['json-schema-2020-12'],
+    });
+  });
+
+  it('detects a null ↔ value change on default_target_namespace', () => {
+    const current: TypeRegistrySettings = {
+      ...DEFAULT_SETTINGS,
+      default_target_namespace: 'tenant/acme/v1/types',
+    };
+    expect(diffSettings(DEFAULT_SETTINGS, current)).toEqual({
+      default_target_namespace: 'tenant/acme/v1/types',
+    });
+  });
+});


### PR DESCRIPTION
## What & why

Implements **5.7 Type Registry Settings UI** (#3472): a new **Settings** tab under Control Panel → Governance → Primitives (`/ade/dashboard/primitives`) that configures registry-wide behavior and **persists it server-side**. Full stack (UI + REST + DB), single-database design (storage is `odb.primitives` in `objectified-db`; there is no separate registry DB).

> This revision replaces the prior implementation that was on this branch.

### UI (`objectified-ui`)
- **`PrimitivesSettingsView`** — live **registry storage status** (`GET /api/primitives/health` → REST `/v1/primitives/health`, #3450), **JSON Schema dialect** (default draft + strict / annotation / coerce toggles), **`$ref` resolution policy** (base URL, ref style, remote allowlist, max depth 1–64, circular policy), **import defaults** (scope, target namespace, rewrite, accepted formats, dedupe), and **validation/publishing governance** (validate-on-save, block-publish-on-errors, core publish role — read by #3479).
- Pure, unit-tested **`primitivesSettingsModel.ts`**: defaults, allowlist parse/format, depth clamp, and a **minimal-diff PUT** so only changed fields are sent.
- New **`/api/types/settings`** (GET/PUT) and **`/api/primitives/health`** proxies; Settings tab wired into `PrimitivesManagementClient`. All styling via CSS classes.

### REST (`objectified-rest`)
- **`GET`/`PUT /v1/types/{slug}/settings`**: GET serves the saved row, or the registry **defaults flagged `is_default=true`** for an unsaved tenant (a read never materializes a row). PUT is **tenant-admin-only**, partial, and **enum/range validated (422)** before the DB.
- `db.get_type_registry_settings` / `upsert_type_registry_settings`. The upsert `SET` clause names **only the supplied columns** — `EXCLUDED.<col>` for an omitted column is its *DEFAULT*, not NULL, so a COALESCE-everything update would silently reset untouched columns. Covered by a DB-layer test and verified live.

### DB (`objectified-db`)
- **`20260623-120000.sql`**: `odb.type_registry_settings` (one row per tenant, CHECK-guarded enums/range, defaults matching REST/UI).

## How to test
1. **Browse to** Control Panel → Governance → **Primitives**, then **click the Settings tab**.
2. Confirm **Registry storage** shows **Connected** and notes the shared `objectified-db` / `odb.primitives` (no separate DB).
3. As an unsaved tenant, confirm the **"using the registry defaults"** banner and that **Save** is disabled until a change.
4. **Change Default draft** to `2019-09`, **Save settings** → success; reload → value persists, banner gone.
5. Set **strict validation off**, save; then change only **Max resolution depth** and save → confirm strict validation **stays off** (partial-update preservation).
6. **Toggle Allow remote $ref** → the **Remote host allowlist** textarea enables/disables.
7. As a non-admin tenant member, a save returns **403**; an out-of-range depth or bad enum returns **422/400**.

Example data: Default draft `2019-09`, Resolution base URL `https://api.objectified.dev/types/`, allowlist `json-schema.org` / `spec.openapis.org`, max depth `24`, circular policy `warn`.

## Risk / notes
- New migration must be applied (`odb.type_registry_settings`); idempotent (`IF NOT EXISTS`) and verified against the local dev DB.
- Settings become the source of truth the resolver and the **validation gate (#3479)** will read; this PR persists + validates them but does not change the resolver/validation engines.
- Versions bumped: objectified-ui 0.11.131, objectified-rest 1.0.21, objectified-db 0.1.13. ROADMAP 5.7 marked done.
- Verification: UI build green; **3418 UI tests** pass; **16 REST settings tests** pass; pre-existing unrelated REST failures (merge/publish/version) confirmed present on `main`.

Closes #3472

Work performed by Claude Code via model Claude Opus 4.8 (1M context)