### PR TITLE
Fix #3474 - Type picker component (Standard/Core/Tenant/Custom)

### DIFF
--- a/docs/ROADMAP_TYPE_REGISTRY_GOVERNANCE.md
+++ b/docs/ROADMAP_TYPE_REGISTRY_GOVERNANCE.md
@@ -44,7 +44,7 @@ Before implementing net-new registry mechanics, account for what is **already li
 | REST | `/v1/primitives/{tenant_slug}` CRUD + `/import` from `$defs` | No namespaces, resolver, stats, or server-side draft 2020-12 gate |
 | UI proxy | `/api/primitives/*` | ✅ **Done** — closed as duplicate (#3455) |
 | Management UI | `/ade/dashboard/primitives` — stats, table, CRUD, import dialog | ✅ Nav done (#3466 closed); overview/import are **partial** — extend, don't rebuild |
-| Designer | `PrimitiveSelector` — merges primitive schema onto property | No persisted `$ref` binding (#3475); picker lacks namespace tabs (#3474) |
+| Designer | `PrimitiveSelector` — full type picker with Standard/Core/Tenant/Custom tabs + scope chips; emits a stable `$ref` (#3474 ✅) | Persisted `$ref` binding still pending (#3475) |
 | Validation | AJV in `PrimitiveEditorDialog` (client) | ✅ **Done** — REST persist strictly validated against draft 2020-12 with field-level errors (#3452) |
 | Scope | `is_system` immutability, tenant rows | ✅ **Done** — reads resolve `is_system ∪ tenant` (cross-tenant isolation; all tenants see `std/*`); core→tenant and tenant→other-tenant `$ref` rejected on save/import (#3453) |
 
@@ -694,7 +694,7 @@ flowchart LR
 
 | Issue | Title | Summary | Labels | Parallel | MVP | Complexity | Affected Modules |
 |---|---|---|---|:---:|:---:|---|---|
-| 6.1 #3474 | Type picker component | Standard/Core/Tenant/Custom tabs, search, scope chips | `type-registry`,`ui`,`schema-designer`,`mvp`,`roadmap-type-registry` | Y | Y | M | objectified-ui |
+| 6.1 #3474 ✅ | Type picker component | **DONE** — `PrimitiveSelector` evolved into the full type picker (`Select Type`): Standard / Core / Tenant / Custom tabs that classify `odb.primitives` by `is_system` / `tenant_id` / `source` (`classifyPrimitive`), per-tab counts, scope chips + per-row scope badges, search across name/namespace/`$ref`/tags, and a per-row resolved `$ref` preview. Selecting a registry type emits a stable `$ref` (`buildTypeRef`, e.g. `std/v0/types/date`) onto `PropertyFormData.$ref` and fires `onTypeBound`; legacy namespace-less primitives still bind by inline schema (no `$ref`). A bound-type chip on the trigger shows/clears the current binding. Persisting the binding is #3475 | `type-registry`,`ui`,`schema-designer`,`mvp`,`roadmap-type-registry` | Y | Y | M | objectified-ui |
 | 6.2 #3475 | Property→type `$ref` binding storage | Persist & read property bindings (1.3) | `type-registry`,`ui`,`rest`,`mvp`,`roadmap-type-registry` | N | Y | M | objectified-ui, objectified-rest |
 | 6.3 #3476 | Resolved-type display in Designer/Paths | Show resolved schema + validate against it | `type-registry`,`ui`,`schema-designer`,`mvp`,`roadmap-type-registry` | Y | Y | M | objectified-ui |
 | 6.4 #3477 | "Used by properties" dependents/impact | Reverse index: which properties use a type | `type-registry`,`rest`,`roadmap-type-registry` | Y | N | M | objectified-rest, objectified-ui |

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.131",
+  "version": "0.11.132",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/src/app/components/ade/studio/ClassPropertyEditDialog.tsx
+++ b/objectified-ui/src/app/components/ade/studio/ClassPropertyEditDialog.tsx
@@ -168,10 +168,10 @@ const BasicsSection: React.FC<BasicsSectionProps> = ({
             </span>
             <div className="min-w-0">
               <h4 className="text-sm font-semibold text-slate-900 dark:text-slate-100">
-                Apply from Primitive
+                Bind to a Type
               </h4>
               <p className="mt-0.5 text-xs leading-5 text-slate-500 dark:text-slate-400">
-                Quickly apply format, pattern, and constraints from a predefined primitive type.
+                Bind this property to a Standard, Core, Tenant, or Custom registry type. The type&apos;s constraints are applied and a stable <code>$ref</code> is recorded.
               </p>
             </div>
           </div>

--- a/objectified-ui/src/app/components/ade/studio/PrimitiveSelector.tsx
+++ b/objectified-ui/src/app/components/ade/studio/PrimitiveSelector.tsx
@@ -12,18 +12,19 @@ import {
 } from '../../ui/Dialog';
 import { Button } from '../../ui/Button';
 import { Input } from '../../ui/Input';
-import { Checkbox } from '../../ui/Checkbox';
 import { useDarkMode } from '@/app/hooks/useDarkMode';
 import { PropertyFormData } from './PropertyFormFields';
 import { cn } from '../../../../../lib/utils';
 import {
   Search,
   X,
-  Shield,
-  User,
-  Sparkles,
+  ShieldCheck,
+  Lock,
+  Download,
+  Boxes,
   Database,
   Loader2,
+  Link2,
 } from 'lucide-react';
 
 export interface Primitive {
@@ -41,11 +42,44 @@ export interface Primitive {
   enabled: boolean;
   created_at: string;
   updated_at: string;
+
+  // JSON Schema 2020-12 type-registry columns (#3447 — extended odb.primitives).
+  // Optional so older API payloads (pre-registry) still satisfy the type.
+  /** Registry namespace path, e.g. `std/v0/types` or `tenant/<slug>/types`. */
+  namespace?: string | null;
+  /** Import-source base URL relative `$ref` values resolve against. */
+  base_uri?: string | null;
+  /** Computed/stored JSON Schema `$id`. */
+  schema_id?: string | null;
+  /** JSON Schema dialect/draft (default `2020-12`). */
+  draft?: string | null;
+  /** Provenance: `human` (authored in-app) or `imported` (from a JSON Schema / bundle). */
+  source?: string | null;
+  /** Relative `$ref` edges recorded for this primitive. */
+  refs?: Array<Record<string, unknown>>;
+}
+
+/**
+ * Type-picker scope tabs. The four tabs map onto `odb.primitives` rows by
+ * `is_system` / `tenant_id` / `source`:
+ *   - standard → system rows in a `.../primitives` namespace (the JSON base types)
+ *   - core     → all other system rows (the `std/v0/types` derived/composite types)
+ *   - tenant   → tenant-owned rows authored in-app (`source !== 'imported'`)
+ *   - custom   → tenant-owned rows that were imported (`source === 'imported'`)
+ */
+export type TypePickerTab = 'standard' | 'core' | 'tenant' | 'custom';
+
+export interface TypeBinding {
+  /** Stable registry `$ref`, e.g. `std/v0/types/date`. */
+  ref: string;
+  /** The primitive the property was bound to. */
+  primitive: Primitive;
 }
 
 export interface PrimitiveSelectorProps {
   // Form data and update handler
   formData: PropertyFormData;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- value spans every PropertyFormData field type
   onChange: (field: keyof PropertyFormData, value: any) => void;
 
   // Current property type (to filter primitives by category)
@@ -53,6 +87,10 @@ export interface PrimitiveSelectorProps {
 
   // Optional: callback when a primitive is applied
   onPrimitiveApplied?: (primitive: Primitive) => void;
+
+  // Optional: callback when a registry type is bound (emits the stable `$ref`).
+  // Fires only when the selected primitive resolves to a registry `$ref`.
+  onTypeBound?: (binding: TypeBinding) => void;
 
   // Optional: callback when the selection dialog opens or closes (e.g. to dim parent form)
   onOpenChange?: (open: boolean) => void;
@@ -71,11 +109,55 @@ const propertyTypeToPrimitiveCategory: Record<string, string> = {
   'object': 'object',
 };
 
+interface TabMeta {
+  id: TypePickerTab;
+  label: string;
+  icon: React.ReactNode;
+  /** Short scope description shown under the tab strip. */
+  scope: string;
+}
+
+const TABS: TabMeta[] = [
+  { id: 'standard', label: 'Standard', icon: <Boxes size={14} />, scope: 'JSON Schema base types · available to all tenants' },
+  { id: 'core', label: 'Core System Types', icon: <ShieldCheck size={14} />, scope: 'System · core — visible to every tenant' },
+  { id: 'tenant', label: 'Tenant Types', icon: <Lock size={14} />, scope: 'Private to your tenant' },
+  { id: 'custom', label: 'Custom · Imported', icon: <Download size={14} />, scope: 'Imported into your tenant from a JSON Schema or bundle' },
+];
+
+/**
+ * Classify a primitive into one of the four type-picker tabs based on its scope
+ * columns. System rows in a `.../primitives` namespace are the JSON base types
+ * ("Standard"); all other system rows are "Core". Tenant rows split on
+ * provenance: imported rows are "Custom", everything else is "Tenant".
+ */
+export function classifyPrimitive(p: Primitive): TypePickerTab {
+  if (p.is_system) {
+    return p.namespace && p.namespace.replace(/\/+$/, '').endsWith('/primitives')
+      ? 'standard'
+      : 'core';
+  }
+  return p.source === 'imported' ? 'custom' : 'tenant';
+}
+
+/**
+ * Build the stable registry `$ref` for a primitive, e.g.
+ * `std/v0/types` + `date` → `std/v0/types/date`. Returns `null` for legacy flat
+ * primitives that have no namespace (those bind by inline schema only).
+ */
+export function buildTypeRef(p: Primitive): string | null {
+  if (p.namespace && p.namespace.trim()) {
+    const ns = p.namespace.replace(/\/+$/, '');
+    return `${ns}/${p.name}`;
+  }
+  return null;
+}
+
 export const PrimitiveSelector: React.FC<PrimitiveSelectorProps> = ({
   formData,
   onChange,
   propertyType,
   onPrimitiveApplied,
+  onTypeBound,
   onOpenChange,
   size = 'small',
 }) => {
@@ -85,8 +167,7 @@ export const PrimitiveSelector: React.FC<PrimitiveSelectorProps> = ({
   const [loading, setLoading] = useState(false);
   const [primitives, setPrimitives] = useState<Primitive[]>([]);
   const [searchQuery, setSearchQuery] = useState('');
-  const [showSystemPrimitives, setShowSystemPrimitives] = useState(true);
-  const [showTenantPrimitives, setShowTenantPrimitives] = useState(true);
+  const [activeTab, setActiveTab] = useState<TypePickerTab>('core');
   const [selectedPrimitive, setSelectedPrimitive] = useState<Primitive | null>(null);
   const [error, setError] = useState<string | null>(null);
 
@@ -95,7 +176,7 @@ export const PrimitiveSelector: React.FC<PrimitiveSelectorProps> = ({
     if (dialogOpen) {
       fetchPrimitives();
     }
-  }, [dialogOpen]);
+  }, [dialogOpen]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const fetchPrimitives = async () => {
     setLoading(true);
@@ -123,36 +204,52 @@ export const PrimitiveSelector: React.FC<PrimitiveSelectorProps> = ({
     }
   };
 
-  // Filter primitives based on search and visibility settings
+  // Group primitives by tab once per fetch.
+  const grouped = useMemo(() => {
+    const buckets: Record<TypePickerTab, Primitive[]> = {
+      standard: [],
+      core: [],
+      tenant: [],
+      custom: [],
+    };
+    for (const p of primitives) {
+      buckets[classifyPrimitive(p)].push(p);
+    }
+    return buckets;
+  }, [primitives]);
+
+  // When the dialog opens, land on the first tab that actually has types so the
+  // user is not greeted with an empty list.
+  useEffect(() => {
+    if (!dialogOpen) return;
+    if (grouped[activeTab].length > 0) return;
+    const firstNonEmpty = TABS.find((t) => grouped[t.id].length > 0);
+    if (firstNonEmpty) {
+      setActiveTab(firstNonEmpty.id);
+    }
+  }, [dialogOpen, grouped]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Filter the active tab by the search query. Search spans name, namespace,
+  // description and tags so namespaces are searchable ("search across namespaces").
   const filteredPrimitives = useMemo(() => {
-    let filtered = primitives;
+    let filtered = grouped[activeTab];
 
-    // Filter by system/tenant
-    if (!showSystemPrimitives) {
-      filtered = filtered.filter(p => !p.is_system);
-    }
-    if (!showTenantPrimitives) {
-      filtered = filtered.filter(p => p.is_system);
-    }
-
-    // Filter by search query
     if (searchQuery.trim()) {
       const query = searchQuery.toLowerCase();
       filtered = filtered.filter(p =>
         p.name.toLowerCase().includes(query) ||
+        (p.namespace || '').toLowerCase().includes(query) ||
+        (buildTypeRef(p) || '').toLowerCase().includes(query) ||
         p.description?.toLowerCase().includes(query) ||
         p.tags.some(tag => tag.toLowerCase().includes(query))
       );
     }
 
-    // Sort: tenant primitives first, then alphabetically
-    return filtered.sort((a, b) => {
-      if (a.is_system !== b.is_system) {
-        return a.is_system ? 1 : -1; // Tenant primitives first
-      }
-      return a.name.localeCompare(b.name);
-    });
-  }, [primitives, searchQuery, showSystemPrimitives, showTenantPrimitives]);
+    // Sort alphabetically by ref (falls back to name) for a stable order.
+    return [...filtered].sort((a, b) =>
+      (buildTypeRef(a) || a.name).localeCompare(buildTypeRef(b) || b.name)
+    );
+  }, [grouped, activeTab, searchQuery]);
 
   // Apply primitive schema to form data
   const applyPrimitive = (primitive: Primitive) => {
@@ -253,15 +350,32 @@ export const PrimitiveSelector: React.FC<PrimitiveSelectorProps> = ({
       onChange('description', schema.description as string);
     }
 
+    // Persist the stable registry `$ref` binding (or clear it for legacy
+    // primitives that have no namespace and thus no stable ref).
+    const ref = buildTypeRef(primitive);
+    onChange('$ref', ref || '');
+    if (ref && onTypeBound) {
+      onTypeBound({ ref, primitive });
+    }
+
     // Notify callback
     if (onPrimitiveApplied) {
       onPrimitiveApplied(primitive);
     }
 
+    closeDialog();
+  };
+
+  const closeDialog = () => {
     setDialogOpen(false);
     setSelectedPrimitive(null);
     setSearchQuery('');
     onOpenChange?.(false);
+  };
+
+  // Clear the current registry binding without opening the picker.
+  const clearBinding = () => {
+    onChange('$ref', '');
   };
 
   // Render schema preview
@@ -288,10 +402,30 @@ export const PrimitiveSelector: React.FC<PrimitiveSelectorProps> = ({
     return constraints.length > 0 ? constraints.join(', ') : 'No constraints defined';
   };
 
+  const activeScope = TABS.find((t) => t.id === activeTab)?.scope ?? '';
+  const boundRef = formData.$ref;
+
   return (
     <>
-      {/* Trigger Button */}
-      <div className="flex items-center gap-2">
+      {/* Trigger Button + current binding chip */}
+      <div className="flex items-center gap-2 flex-wrap justify-end">
+        {boundRef && (
+          <span
+            className="inline-flex items-center gap-1.5 rounded-md border border-teal-200 bg-teal-50 px-2 py-1 text-xs font-mono text-teal-700 dark:border-teal-800 dark:bg-teal-900/30 dark:text-teal-300"
+            title={`Bound to registry type ${boundRef}`}
+          >
+            <Link2 size={12} />
+            {boundRef}
+            <button
+              type="button"
+              onClick={clearBinding}
+              aria-label="Clear type binding"
+              className="ml-0.5 rounded-sm opacity-70 hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-teal-500"
+            >
+              <X size={12} />
+            </button>
+          </span>
+        )}
         <Button
           variant="outline"
           size={size === 'small' ? 'sm' : 'default'}
@@ -301,12 +435,12 @@ export const PrimitiveSelector: React.FC<PrimitiveSelectorProps> = ({
           }}
           className="gap-2"
         >
-          <Sparkles size={14} />
-          Select
+          <Boxes size={14} />
+          {boundRef ? 'Change Type' : 'Select Type'}
         </Button>
         <span
           className="text-xs text-gray-500 dark:text-gray-400 cursor-help"
-          title="Apply a predefined primitive type to automatically set format, pattern, and constraints"
+          title="Bind this property to a Standard, Core, Tenant, or Custom registry type. A registry type writes a stable $ref; constraints are applied from the type's schema."
         >
           ⓘ
         </span>
@@ -315,10 +449,7 @@ export const PrimitiveSelector: React.FC<PrimitiveSelectorProps> = ({
       {/* Selection Dialog — uses z-[10000]/[10001] to sit above any parent Dialog (z-9999) */}
       <Dialog open={dialogOpen} onOpenChange={(isOpen) => {
         if (!isOpen) {
-          setDialogOpen(false);
-          setSelectedPrimitive(null);
-          setSearchQuery('');
-          onOpenChange?.(false);
+          closeDialog();
         }
       }} modal={true}>
         <DialogPortal>
@@ -334,8 +465,8 @@ export const PrimitiveSelector: React.FC<PrimitiveSelectorProps> = ({
           <DialogHeader className="px-6 py-4 border-b border-gray-200 dark:border-gray-700 shrink-0">
             <div className="flex items-center justify-between gap-2">
               <div className="flex items-center gap-2">
-                <Sparkles size={20} className="text-indigo-500" />
-                <DialogTitle className="text-lg font-semibold">Apply Primitive</DialogTitle>
+                <Boxes size={20} className="text-indigo-500" />
+                <DialogTitle className="text-lg font-semibold">Select Type</DialogTitle>
               </div>
               <DialogPrimitive.Close className="rounded-sm opacity-70 ring-offset-white transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:pointer-events-none dark:ring-offset-gray-800">
                 <X className="h-4 w-4 text-gray-500 dark:text-gray-400" />
@@ -344,12 +475,12 @@ export const PrimitiveSelector: React.FC<PrimitiveSelectorProps> = ({
             </div>
           </DialogHeader>
 
-          {/* Search and Filters */}
-          <div className="px-4 py-3 border-b border-gray-200 dark:border-gray-700 space-y-3">
-            <div className="relative">
+          {/* Search */}
+          <div className="px-4 pt-3 border-b border-gray-200 dark:border-gray-700">
+            <div className="relative mb-3">
               <Search size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" />
               <Input
-                placeholder="Search primitives by name, description, or tags..."
+                placeholder="Search standard & custom types by name, namespace, or tag..."
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
                 className="pl-9 pr-9"
@@ -358,36 +489,59 @@ export const PrimitiveSelector: React.FC<PrimitiveSelectorProps> = ({
                 <button
                   onClick={() => setSearchQuery('')}
                   className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600"
+                  aria-label="Clear search"
                 >
                   <X size={14} />
                 </button>
               )}
             </div>
 
-            <div className="flex items-center gap-4 flex-wrap">
-              <label className="flex items-center gap-2 cursor-pointer">
-                <Checkbox
-                  checked={showSystemPrimitives}
-                  onCheckedChange={(checked) => setShowSystemPrimitives(!!checked)}
-                />
-                <Shield size={14} className="text-emerald-500" />
-                <span className="text-sm">System Primitives</span>
-              </label>
-              <label className="flex items-center gap-2 cursor-pointer">
-                <Checkbox
-                  checked={showTenantPrimitives}
-                  onCheckedChange={(checked) => setShowTenantPrimitives(!!checked)}
-                />
-                <User size={14} className="text-indigo-500" />
-                <span className="text-sm">Tenant Primitives</span>
-              </label>
-              <span className="ml-auto text-xs text-gray-500 dark:text-gray-400 px-2 py-1 rounded border border-gray-200 dark:border-gray-700">
-                Showing {filteredPrimitives.length} primitive{filteredPrimitives.length !== 1 ? 's' : ''}
-              </span>
+            {/* Tabs */}
+            <div role="tablist" aria-label="Type scope" className="flex items-center gap-1 overflow-x-auto">
+              {TABS.map((tab) => {
+                const count = grouped[tab.id].length;
+                const isActive = activeTab === tab.id;
+                return (
+                  <button
+                    key={tab.id}
+                    role="tab"
+                    aria-selected={isActive}
+                    onClick={() => { setActiveTab(tab.id); setSelectedPrimitive(null); }}
+                    className={cn(
+                      'flex items-center gap-1.5 whitespace-nowrap border-b-2 px-3 py-2 text-sm transition-colors',
+                      isActive
+                        ? 'border-indigo-500 text-indigo-600 dark:text-indigo-400 font-medium'
+                        : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-indigo-500',
+                    )}
+                  >
+                    {tab.icon}
+                    {tab.label}
+                    <span className={cn(
+                      'ml-1 rounded-full px-1.5 py-0.5 text-[10px]',
+                      isActive
+                        ? 'bg-indigo-100 text-indigo-700 dark:bg-indigo-900/40 dark:text-indigo-300'
+                        : 'bg-gray-100 text-gray-500 dark:bg-gray-700 dark:text-gray-400',
+                    )}>
+                      {count}
+                    </span>
+                  </button>
+                );
+              })}
             </div>
           </div>
 
-          {/* Primitives List */}
+          {/* Scope chip + count */}
+          <div className="flex items-center justify-between gap-2 px-4 py-2 border-b border-gray-200 dark:border-gray-700">
+            <span className="inline-flex items-center gap-1.5 text-xs text-gray-500 dark:text-gray-400">
+              {TABS.find((t) => t.id === activeTab)?.icon}
+              {activeScope}
+            </span>
+            <span className="text-xs text-gray-500 dark:text-gray-400 px-2 py-1 rounded border border-gray-200 dark:border-gray-700">
+              Showing {filteredPrimitives.length} type{filteredPrimitives.length !== 1 ? 's' : ''}
+            </span>
+          </div>
+
+          {/* Types List */}
           <div className="flex-1 overflow-y-auto min-h-0">
             {loading ? (
               <div className="flex justify-center items-center py-16">
@@ -402,85 +556,94 @@ export const PrimitiveSelector: React.FC<PrimitiveSelectorProps> = ({
               <div className="p-8 text-center">
                 <Database size={48} className="mx-auto text-gray-300 dark:text-gray-600 mb-4" />
                 <p className="text-gray-600 dark:text-gray-400">
-                  {searchQuery ? 'No primitives match your search' : `No ${propertyType} primitives available`}
+                  {searchQuery ? 'No types match your search' : `No ${propertyType} types in this scope`}
                 </p>
                 <p className="text-sm text-gray-500 dark:text-gray-500 mt-2">
-                  {searchQuery ? 'Try a different search term' : 'Create primitives in the Primitives Management section'}
+                  {searchQuery ? 'Try a different search term' : 'Try another tab, or create types in the Primitives section'}
                 </p>
               </div>
             ) : (
               <div className="divide-y divide-gray-100 dark:divide-gray-800">
-                {filteredPrimitives.map((primitive) => (
-                  <button
-                    key={primitive.id}
-                    onClick={() => setSelectedPrimitive(primitive)}
-                    onDoubleClick={() => applyPrimitive(primitive)}
-                    className={`w-full text-left px-4 py-3 transition-colors ${
-                      selectedPrimitive?.id === primitive.id
-                        ? 'bg-indigo-50 dark:bg-indigo-900/20'
-                        : 'hover:bg-gray-50 dark:hover:bg-gray-800/50'
-                    }`}
-                  >
-                    <div className="flex items-center gap-2 mb-1">
-                      {primitive.is_system ? (
-                        <span title="System Primitive">
-                          <Shield size={14} className="text-emerald-500" />
-                        </span>
-                      ) : (
-                        <span title="Tenant Primitive">
-                          <User size={14} className="text-indigo-500" />
-                        </span>
+                {filteredPrimitives.map((primitive) => {
+                  const ref = buildTypeRef(primitive);
+                  const tab = classifyPrimitive(primitive);
+                  return (
+                    <button
+                      key={primitive.id}
+                      onClick={() => setSelectedPrimitive(primitive)}
+                      onDoubleClick={() => applyPrimitive(primitive)}
+                      className={cn(
+                        'w-full text-left px-4 py-3 transition-colors',
+                        selectedPrimitive?.id === primitive.id
+                          ? 'bg-indigo-50 dark:bg-indigo-900/20'
+                          : 'hover:bg-gray-50 dark:hover:bg-gray-800/50',
                       )}
-                      <span className="font-semibold text-gray-900 dark:text-gray-100">
-                        {primitive.name}
-                      </span>
-                      <span className="text-xs px-1.5 py-0.5 rounded bg-indigo-100 dark:bg-indigo-900/30 text-indigo-600 dark:text-indigo-400">
-                        {primitive.category}
-                      </span>
-                      {primitive.usage_count > 0 && (
-                        <span className="ml-auto text-xs text-gray-500">
-                          Used {primitive.usage_count}×
+                    >
+                      <div className="flex items-center gap-2 mb-1">
+                        <ScopeIcon tab={tab} />
+                        <span className="font-semibold text-gray-900 dark:text-gray-100 font-mono text-sm truncate">
+                          {ref || primitive.name}
                         </span>
-                      )}
-                    </div>
-
-                    {primitive.description && (
-                      <p className="text-sm text-gray-600 dark:text-gray-400 truncate mb-1">
-                        {primitive.description}
-                      </p>
-                    )}
-
-                    <p className="text-xs text-gray-500 dark:text-gray-500 font-mono truncate">
-                      {renderSchemaPreview(primitive.schema)}
-                    </p>
-
-                    {primitive.tags.length > 0 && (
-                      <div className="flex gap-1 mt-1.5 flex-wrap">
-                        {primitive.tags.slice(0, 5).map((tag) => (
-                          <span
-                            key={tag}
-                            className="text-xs px-1.5 py-0.5 rounded bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400"
-                          >
-                            {tag}
-                          </span>
-                        ))}
-                        {primitive.tags.length > 5 && (
-                          <span className="text-xs text-gray-500">
-                            +{primitive.tags.length - 5} more
+                        <ScopeBadge tab={tab} />
+                        {primitive.usage_count > 0 && (
+                          <span className="ml-auto text-xs text-gray-500">
+                            Used {primitive.usage_count}×
                           </span>
                         )}
                       </div>
-                    )}
-                  </button>
-                ))}
+
+                      {primitive.description && (
+                        <p className="text-sm text-gray-600 dark:text-gray-400 truncate mb-1">
+                          {primitive.description}
+                        </p>
+                      )}
+
+                      {ref ? (
+                        <p className="text-xs text-gray-500 dark:text-gray-500 font-mono truncate">
+                          $ref {ref}
+                        </p>
+                      ) : (
+                        <p className="text-xs text-gray-500 dark:text-gray-500 font-mono truncate">
+                          {renderSchemaPreview(primitive.schema)}
+                        </p>
+                      )}
+
+                      {primitive.tags.length > 0 && (
+                        <div className="flex gap-1 mt-1.5 flex-wrap">
+                          {primitive.tags.slice(0, 5).map((tag) => (
+                            <span
+                              key={tag}
+                              className="text-xs px-1.5 py-0.5 rounded bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400"
+                            >
+                              {tag}
+                            </span>
+                          ))}
+                          {primitive.tags.length > 5 && (
+                            <span className="text-xs text-gray-500">
+                              +{primitive.tags.length - 5} more
+                            </span>
+                          )}
+                        </div>
+                      )}
+                    </button>
+                  );
+                })}
               </div>
             )}
           </div>
 
-          {/* Selected Primitive Preview */}
+          {/* Selected Type Preview */}
           {selectedPrimitive && (
             <div className={`px-4 py-3 border-t border-gray-200 dark:border-gray-700 ${isDark ? 'bg-indigo-900/10' : 'bg-indigo-50/50'}`}>
-              <p className="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-2">Schema Preview</p>
+              <div className="flex items-center justify-between mb-2">
+                <p className="text-sm font-semibold text-gray-900 dark:text-gray-100">Schema Preview</p>
+                {buildTypeRef(selectedPrimitive) && (
+                  <span className="inline-flex items-center gap-1.5 text-xs font-mono text-teal-700 dark:text-teal-300">
+                    <Link2 size={12} />
+                    $ref {buildTypeRef(selectedPrimitive)}
+                  </span>
+                )}
+              </div>
               <pre className={`text-xs font-mono p-3 rounded-lg overflow-auto max-h-32 ${isDark ? 'bg-slate-900 text-gray-300' : 'bg-gray-100 text-gray-800'}`}>
                 {JSON.stringify(selectedPrimitive.schema, null, 2)}
               </pre>
@@ -492,12 +655,7 @@ export const PrimitiveSelector: React.FC<PrimitiveSelectorProps> = ({
             <div className="flex justify-end gap-2 w-full">
               <Button
                 variant="outline"
-                onClick={() => {
-                  setDialogOpen(false);
-                  setSelectedPrimitive(null);
-                  setSearchQuery('');
-                  onOpenChange?.(false);
-                }}
+                onClick={closeDialog}
               >
                 Cancel
               </Button>
@@ -505,7 +663,7 @@ export const PrimitiveSelector: React.FC<PrimitiveSelectorProps> = ({
                 disabled={!selectedPrimitive}
                 onClick={() => selectedPrimitive && applyPrimitive(selectedPrimitive)}
               >
-                Apply Primitive
+                Apply Type
               </Button>
             </div>
           </DialogFooter>
@@ -513,6 +671,41 @@ export const PrimitiveSelector: React.FC<PrimitiveSelectorProps> = ({
         </DialogPortal>
       </Dialog>
     </>
+  );
+};
+
+/** Per-scope leading icon for a type row. */
+const ScopeIcon: React.FC<{ tab: TypePickerTab }> = ({ tab }) => {
+  switch (tab) {
+    case 'standard':
+      return <span title="Standard JSON type"><Boxes size={14} className="text-sky-500" /></span>;
+    case 'core':
+      return <span title="System · core type"><ShieldCheck size={14} className="text-teal-500" /></span>;
+    case 'tenant':
+      return <span title="Tenant type"><Lock size={14} className="text-indigo-500" /></span>;
+    case 'custom':
+      return <span title="Imported type"><Download size={14} className="text-amber-500" /></span>;
+  }
+};
+
+/** Per-scope text badge for a type row. */
+const ScopeBadge: React.FC<{ tab: TypePickerTab }> = ({ tab }) => {
+  const styles: Record<TypePickerTab, string> = {
+    standard: 'bg-sky-100 text-sky-700 dark:bg-sky-900/40 dark:text-sky-300',
+    core: 'bg-teal-100 text-teal-700 dark:bg-teal-900/40 dark:text-teal-300',
+    tenant: 'bg-indigo-100 text-indigo-700 dark:bg-indigo-900/40 dark:text-indigo-300',
+    custom: 'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300',
+  };
+  const labels: Record<TypePickerTab, string> = {
+    standard: 'Standard',
+    core: 'System · core',
+    tenant: 'Tenant',
+    custom: 'Imported',
+  };
+  return (
+    <span className={cn('text-[10px] uppercase tracking-wider px-1.5 py-0.5 rounded whitespace-nowrap', styles[tab])}>
+      {labels[tab]}
+    </span>
   );
 };
 

--- a/objectified-ui/src/app/components/ade/studio/PropertyDialog.tsx
+++ b/objectified-ui/src/app/components/ade/studio/PropertyDialog.tsx
@@ -328,10 +328,10 @@ const BasicsSection: React.FC<BasicsSectionProps> = ({
             </span>
             <div className="min-w-0">
               <h4 className="text-sm font-semibold text-slate-900 dark:text-slate-100">
-                Apply from Primitive
+                Bind to a Type
               </h4>
               <p className="mt-0.5 text-xs leading-5 text-slate-500 dark:text-slate-400">
-                Quickly apply format, pattern, and constraints from a predefined primitive type.
+                Bind this property to a Standard, Core, Tenant, or Custom registry type. The type&apos;s constraints are applied and a stable <code>$ref</code> is recorded.
               </p>
             </div>
           </div>

--- a/objectified-ui/src/app/components/ade/studio/PropertyFormFields.tsx
+++ b/objectified-ui/src/app/components/ade/studio/PropertyFormFields.tsx
@@ -317,6 +317,14 @@ export interface PropertyFormData {
 
   // Schema Metadata (JSON Schema 2020-12)
   $comment?: string; // Internal comments for schema authors
+
+  // Type Registry binding (#3474 type picker / #3475 persisted binding)
+  /**
+   * Stable registry `$ref` to an `odb.primitives` type selected via the type
+   * picker (e.g. `std/v0/types/date`). Empty/undefined when the property is not
+   * bound to a registry type. Persistence of this binding is handled by #3475.
+   */
+  $ref?: string;
 }
 
 interface SortableEnumItemProps {
@@ -654,7 +662,7 @@ export const PropertyFormFields: React.FC<PropertyFormFieldsProps> = ({
   // State for dependent schemas form
   const [newDepPropName, setNewDepPropName] = React.useState('');
 
-  // When "Apply from Primitive" dialog is open, dim the parent form
+  // When the "Bind to a Type" picker dialog is open, dim the parent form
   const [primitiveDialogOpen, setPrimitiveDialogOpen] = React.useState(false);
 
   // DnD sensors for enum reordering
@@ -1300,10 +1308,10 @@ export const PropertyFormFields: React.FC<PropertyFormFieldsProps> = ({
         }}>
           <Box sx={{ flex: 1 }}>
             <Typography variant="body2" sx={{ fontWeight: 600, color: isDark ? '#e2e8f0' : '#1e293b', mb: 0.25 }}>
-              Apply from Primitive
+              Bind to a Type
             </Typography>
             <Typography variant="caption" sx={{ color: isDark ? '#94a3b8' : '#64748b' }}>
-              Quickly apply format, pattern, and constraints from a predefined primitive type
+              Bind this property to a Standard, Core, Tenant, or Custom registry type — applies its constraints and records a stable $ref
             </Typography>
           </Box>
           <PrimitiveSelector

--- a/objectified-ui/tests/PrimitiveSelector.test.tsx
+++ b/objectified-ui/tests/PrimitiveSelector.test.tsx
@@ -1,232 +1,298 @@
 /**
- * Tests for PrimitiveSelector Component
+ * Tests for the PrimitiveSelector type picker (#3474).
+ *
+ * Covers the scope-classification + `$ref` helpers and the rendered picker:
+ * Standard / Core / Tenant / Custom tabs, selecting `std/v0/types/date` emitting
+ * a stable `$ref`, tenant scoping, the bound-type chip, and legacy (namespace-less)
+ * primitives that bind by inline schema only.
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import {
+  PrimitiveSelector,
+  classifyPrimitive,
+  buildTypeRef,
+  Primitive,
+} from '../src/app/components/ade/studio/PrimitiveSelector';
+import { PropertyFormData } from '../src/app/components/ade/studio/PropertyFormFields';
 
-// Mock the useDarkMode hook using src path
+// Mock the useDarkMode hook (same module the component imports via `@/`).
 jest.mock('../src/app/hooks/useDarkMode', () => ({
   useDarkMode: () => false,
 }));
 
-// Mock fetch
-const mockPrimitives = [
-  {
-    id: '1',
-    tenant_id: 'tenant-1',
-    name: 'Email Address',
-    description: 'A valid email address format',
-    category: 'string',
-    schema: {
-      type: 'string',
-      format: 'email',
-      pattern: '^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$',
-    },
-    tags: ['email', 'contact'],
-    created_by: null,
-    is_system: true,
-    is_public: true,
-    usage_count: 42,
-    enabled: true,
-    created_at: '2026-01-22T10:00:00Z',
-    updated_at: '2026-01-22T10:00:00Z',
-  },
-  {
-    id: '2',
-    tenant_id: 'tenant-1',
-    name: 'Custom Phone Number',
-    description: 'Phone number format for US',
-    category: 'string',
-    schema: {
-      type: 'string',
-      pattern: '^\\+1\\d{10}$',
-      minLength: 12,
-      maxLength: 12,
-    },
-    tags: ['phone', 'contact'],
-    created_by: 'user-1',
-    is_system: false,
-    is_public: false,
-    usage_count: 5,
-    enabled: true,
-    created_at: '2026-01-22T11:00:00Z',
-    updated_at: '2026-01-22T11:00:00Z',
-  },
-  {
-    id: '3',
-    tenant_id: 'tenant-1',
-    name: 'Age',
-    description: 'A valid age (0-150)',
-    category: 'integer',
-    schema: {
-      type: 'integer',
-      minimum: 0,
-      maximum: 150,
-    },
-    tags: ['age', 'person'],
-    created_by: null,
-    is_system: true,
-    is_public: true,
-    usage_count: 20,
-    enabled: true,
-    created_at: '2026-01-22T10:00:00Z',
-    updated_at: '2026-01-22T10:00:00Z',
-  },
-];
+// Radix Dialog needs a few browser APIs jsdom does not implement.
+beforeAll(() => {
+  global.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+  if (!Element.prototype.hasPointerCapture) {
+    Element.prototype.hasPointerCapture = () => false;
+  }
+  if (!Element.prototype.setPointerCapture) {
+    Element.prototype.setPointerCapture = () => {};
+  }
+  if (!Element.prototype.releasePointerCapture) {
+    Element.prototype.releasePointerCapture = () => {};
+  }
+  Element.prototype.scrollIntoView = () => {};
+});
 
-// Simple mock for PrimitiveSelector tests
-describe('PrimitiveSelector Component', () => {
+// Helper to build a fully-populated Primitive with sensible defaults.
+const makePrimitive = (overrides: Partial<Primitive>): Primitive => ({
+  id: 'id-' + Math.random().toString(36).slice(2),
+  tenant_id: 'tenant-1',
+  name: 'thing',
+  description: 'A thing',
+  category: 'string',
+  schema: { type: 'string' },
+  tags: [],
+  created_by: null,
+  is_system: false,
+  is_public: false,
+  usage_count: 0,
+  enabled: true,
+  created_at: '2026-06-01T00:00:00Z',
+  updated_at: '2026-06-01T00:00:00Z',
+  namespace: null,
+  base_uri: null,
+  schema_id: null,
+  draft: '2020-12',
+  source: 'human',
+  refs: [],
+  ...overrides,
+});
+
+// A string-category type for each of the four scopes.
+const stdString = makePrimitive({
+  id: 'std-string',
+  name: 'string',
+  description: 'JSON Schema base string type.',
+  is_system: true,
+  is_public: true,
+  namespace: 'std/v0/primitives',
+  schema: { type: 'string' },
+});
+
+const coreDate = makePrimitive({
+  id: 'core-date',
+  name: 'date',
+  description: 'Calendar date (ISO 8601).',
+  is_system: true,
+  is_public: true,
+  namespace: 'std/v0/types',
+  schema: { type: 'string', format: 'date' },
+});
+
+const legacyEmail = makePrimitive({
+  id: 'legacy-email',
+  name: 'Email Address',
+  description: 'RFC 5322 email address.',
+  is_system: true,
+  is_public: true,
+  namespace: null, // legacy flat primitive — no stable $ref
+  schema: { type: 'string', format: 'email' },
+});
+
+const tenantSku = makePrimitive({
+  id: 'tenant-sku',
+  name: 'sku',
+  description: 'Stock keeping unit.',
+  is_system: false,
+  source: 'human',
+  namespace: 'tenant/acme/types',
+  schema: { type: 'string', pattern: '^[A-Z0-9-]+$' },
+});
+
+const customHumanName = makePrimitive({
+  id: 'custom-humanname',
+  name: 'HumanName',
+  description: 'Imported FHIR HumanName.',
+  is_system: false,
+  source: 'imported',
+  namespace: 'vendor/fhir/r4',
+  schema: { type: 'string' },
+});
+
+const ALL = [stdString, coreDate, legacyEmail, tenantSku, customHumanName];
+
+// Stateful harness so the bound-type chip reflects onChange updates.
+const Harness: React.FC<{
+  onChangeSpy?: (field: keyof PropertyFormData, value: unknown) => void;
+  onTypeBound?: jest.Mock;
+  initial?: PropertyFormData;
+}> = ({ onChangeSpy, onTypeBound, initial }) => {
+  const [formData, setFormData] = useState<PropertyFormData>(initial || {});
+  return (
+    <PrimitiveSelector
+      formData={formData}
+      onChange={(field, value) => {
+        onChangeSpy?.(field, value);
+        setFormData((prev) => ({ ...prev, [field]: value }));
+      }}
+      propertyType="string"
+      onTypeBound={onTypeBound}
+    />
+  );
+};
+
+const mockFetchOk = (primitives: Primitive[]) => {
+  (global.fetch as jest.Mock).mockResolvedValue({
+    ok: true,
+    json: async () => ({ success: true, primitives }),
+  });
+};
+
+describe('classifyPrimitive', () => {
+  it('classifies system /primitives rows as standard', () => {
+    expect(classifyPrimitive(stdString)).toBe('standard');
+  });
+
+  it('classifies other system rows as core (incl. legacy flat ones)', () => {
+    expect(classifyPrimitive(coreDate)).toBe('core');
+    expect(classifyPrimitive(legacyEmail)).toBe('core');
+  });
+
+  it('classifies tenant-authored rows as tenant', () => {
+    expect(classifyPrimitive(tenantSku)).toBe('tenant');
+  });
+
+  it('classifies imported tenant rows as custom', () => {
+    expect(classifyPrimitive(customHumanName)).toBe('custom');
+  });
+});
+
+describe('buildTypeRef', () => {
+  it('joins namespace and name into a stable $ref', () => {
+    expect(buildTypeRef(coreDate)).toBe('std/v0/types/date');
+    expect(buildTypeRef(tenantSku)).toBe('tenant/acme/types/sku');
+    expect(buildTypeRef(customHumanName)).toBe('vendor/fhir/r4/HumanName');
+  });
+
+  it('tolerates trailing slashes on the namespace', () => {
+    expect(buildTypeRef(makePrimitive({ namespace: 'std/v0/types/', name: 'uuid' }))).toBe('std/v0/types/uuid');
+  });
+
+  it('returns null for primitives with no namespace', () => {
+    expect(buildTypeRef(legacyEmail)).toBeNull();
+  });
+});
+
+describe('PrimitiveSelector type picker', () => {
   beforeAll(() => {
     global.fetch = jest.fn();
   });
 
   beforeEach(() => {
     jest.clearAllMocks();
-    (global.fetch as jest.Mock).mockResolvedValue({
-      ok: true,
-      json: async () => ({ success: true, primitives: mockPrimitives }),
-    });
+    mockFetchOk(ALL);
   });
 
-  it('should apply primitive format constraints correctly', () => {
-    const emailPrimitive = mockPrimitives[0];
-    expect(emailPrimitive.schema.format).toBe('email');
-    expect(emailPrimitive.schema.pattern).toBeDefined();
-    expect(emailPrimitive.is_system).toBe(true);
+  const openPicker = async () => {
+    fireEvent.click(screen.getByRole('button', { name: /select type/i }));
+    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+  };
+
+  it('renders the four scope tabs when opened', async () => {
+    render(<Harness />);
+    await openPicker();
+
+    expect(await screen.findByRole('tab', { name: /standard/i })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /core system types/i })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /tenant types/i })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /custom · imported/i })).toBeInTheDocument();
   });
 
-  it('should distinguish between system and tenant primitives', () => {
-    const systemPrimitives = mockPrimitives.filter(p => p.is_system);
-    const tenantPrimitives = mockPrimitives.filter(p => !p.is_system);
-
-    expect(systemPrimitives.length).toBe(2);
-    expect(tenantPrimitives.length).toBe(1);
-    expect(tenantPrimitives[0].name).toBe('Custom Phone Number');
-  });
-
-  it('should filter primitives by category', () => {
-    const stringPrimitives = mockPrimitives.filter(p => p.category === 'string');
-    const integerPrimitives = mockPrimitives.filter(p => p.category === 'integer');
-
-    expect(stringPrimitives.length).toBe(2);
-    expect(integerPrimitives.length).toBe(1);
-  });
-
-  it('should apply numeric constraints from primitive', () => {
-    const agePrimitive = mockPrimitives.find(p => p.name === 'Age');
-    expect(agePrimitive?.schema.minimum).toBe(0);
-    expect(agePrimitive?.schema.maximum).toBe(150);
-    expect(agePrimitive?.category).toBe('integer');
-  });
-
-  it('should support searching by name', () => {
-    const searchQuery = 'phone';
-    const filtered = mockPrimitives.filter(p =>
-      p.name.toLowerCase().includes(searchQuery.toLowerCase())
-    );
-
-    expect(filtered.length).toBe(1);
-    expect(filtered[0].name).toBe('Custom Phone Number');
-  });
-
-  it('should support searching by tag', () => {
-    const searchQuery = 'contact';
-    const filtered = mockPrimitives.filter(p =>
-      p.tags.some(tag => tag.toLowerCase().includes(searchQuery.toLowerCase()))
-    );
-
-    expect(filtered.length).toBe(2);
-  });
-
-  it('should fetch primitives with category filter', async () => {
-    await fetch('/api/primitives?category=string');
-
+  it('fetches primitives filtered by the property category', async () => {
+    render(<Harness />);
+    await openPicker();
     expect(global.fetch).toHaveBeenCalledWith('/api/primitives?category=string');
   });
 
-  it('should render constraint preview correctly', () => {
-    const emailPrimitive = mockPrimitives[0];
-    const schema = emailPrimitive.schema;
+  it('selecting std/v0/types/date sets the $ref on the property and emits a binding', async () => {
+    const onChangeSpy = jest.fn();
+    const onTypeBound = jest.fn();
+    render(<Harness onChangeSpy={onChangeSpy} onTypeBound={onTypeBound} />);
+    await openPicker();
 
-    const constraints: string[] = [];
-    if (schema.format) constraints.push(`format: ${schema.format}`);
-    if (schema.pattern) constraints.push(`pattern: ${schema.pattern}`);
+    // Core tab is the default landing tab and holds std/v0/types/date.
+    const dateRow = await screen.findByRole('button', { name: /std\/v0\/types\/date/i });
+    fireEvent.click(dateRow);
+    fireEvent.click(screen.getByRole('button', { name: /apply type/i }));
 
-    expect(constraints.join(', ')).toContain('format: email');
-    expect(constraints.join(', ')).toContain('pattern:');
+    await waitFor(() =>
+      expect(onChangeSpy).toHaveBeenCalledWith('$ref', 'std/v0/types/date'),
+    );
+    expect(onTypeBound).toHaveBeenCalledWith(
+      expect.objectContaining({ ref: 'std/v0/types/date' }),
+    );
   });
 
-  it('should sort primitives with tenant first', () => {
-    const sorted = [...mockPrimitives].sort((a, b) => {
-      if (a.is_system !== b.is_system) {
-        return a.is_system ? 1 : -1;
-      }
-      return a.name.localeCompare(b.name);
-    });
+  it('scopes tenant types under the Tenant tab and emits a tenant $ref', async () => {
+    const onChangeSpy = jest.fn();
+    render(<Harness onChangeSpy={onChangeSpy} />);
+    await openPicker();
 
-    // Tenant primitive should be first
-    expect(sorted[0].is_system).toBe(false);
-    expect(sorted[0].name).toBe('Custom Phone Number');
+    fireEvent.click(await screen.findByRole('tab', { name: /tenant types/i }));
+    const skuRow = await screen.findByRole('button', { name: /tenant\/acme\/types\/sku/i });
+    fireEvent.click(skuRow);
+    fireEvent.click(screen.getByRole('button', { name: /apply type/i }));
+
+    await waitFor(() =>
+      expect(onChangeSpy).toHaveBeenCalledWith('$ref', 'tenant/acme/types/sku'),
+    );
   });
 
-  it('should clear existing constraints when applying a primitive', () => {
-    // Simulate existing form data with various constraints
-    const existingFormData = {
-      title: 'My Field',
-      description: 'My description',
-      format: 'uuid',
-      pattern: '^[0-9]+$',
-      minLength: '5',
-      maxLength: '50',
-      minimum: '10',
-      maximum: '100',
-      enum: ['a', 'b', 'c'],
-    };
+  it('lists imported types under the Custom tab', async () => {
+    render(<Harness />);
+    await openPicker();
 
-    // The fields that should be cleared when applying a primitive
-    const fieldsToClear = [
-      'format',
-      'pattern',
-      'minLength',
-      'maxLength',
-      'minimum',
-      'maximum',
-      'minimumType',
-      'maximumType',
-      'multipleOf',
-      'minItems',
-      'maxItems',
-      'uniqueItems',
-      'enum',
-      'default',
-      'const',
-    ];
-
-    // Verify that when applying a primitive, all constraint fields get cleared
-    // (simulating what happens before applying new values)
-    fieldsToClear.forEach(field => {
-      expect(existingFormData).toBeDefined();
-    });
-
-    // Title and description should be preserved (not in the clear list)
-    expect(existingFormData.title).toBe('My Field');
-    expect(existingFormData.description).toBe('My description');
+    fireEvent.click(await screen.findByRole('tab', { name: /custom · imported/i }));
+    expect(await screen.findByRole('button', { name: /vendor\/fhir\/r4\/HumanName/i })).toBeInTheDocument();
   });
 
-  it('should apply only the constraints defined in the primitive schema', () => {
-    const phonePrimitive = mockPrimitives[1]; // Custom Phone Number
+  it('clears the $ref when binding a legacy primitive that has no namespace', async () => {
+    const onChangeSpy = jest.fn();
+    const onTypeBound = jest.fn();
+    render(<Harness onChangeSpy={onChangeSpy} onTypeBound={onTypeBound} />);
+    await openPicker();
 
-    // Verify this primitive only has pattern, minLength, maxLength
-    expect(phonePrimitive.schema.pattern).toBeDefined();
-    expect(phonePrimitive.schema.minLength).toBe(12);
-    expect(phonePrimitive.schema.maxLength).toBe(12);
+    // legacyEmail lives under Core (system, no namespace). It still applies its
+    // schema inline but records no stable $ref.
+    const emailRow = await screen.findByRole('button', { name: /Email Address/i });
+    fireEvent.click(emailRow);
+    fireEvent.click(screen.getByRole('button', { name: /apply type/i }));
 
-    // Verify it doesn't have format, minimum, maximum, etc.
-    expect(phonePrimitive.schema.format).toBeUndefined();
-    expect(phonePrimitive.schema.minimum).toBeUndefined();
-    expect(phonePrimitive.schema.maximum).toBeUndefined();
-    expect(phonePrimitive.schema.enum).toBeUndefined();
+    await waitFor(() => expect(onChangeSpy).toHaveBeenCalledWith('format', 'email'));
+    expect(onChangeSpy).toHaveBeenCalledWith('$ref', '');
+    expect(onTypeBound).not.toHaveBeenCalled();
+  });
+
+  it('shows a bound-type chip and clears the binding on demand', async () => {
+    const onChangeSpy = jest.fn();
+    render(<Harness onChangeSpy={onChangeSpy} initial={{ $ref: 'std/v0/types/date' }} />);
+
+    // The chip shows the current binding without opening the picker.
+    expect(screen.getByText('std/v0/types/date')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /change type/i })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /clear type binding/i }));
+    await waitFor(() => expect(onChangeSpy).toHaveBeenCalledWith('$ref', ''));
+  });
+
+  it('searches across namespaces within the active tab', async () => {
+    render(<Harness />);
+    await openPicker();
+
+    const search = await screen.findByPlaceholderText(/search standard & custom types/i);
+    // Core tab holds date + Email Address; searching the namespace narrows to date.
+    fireEvent.change(search, { target: { value: 'std/v0/types' } });
+
+    expect(await screen.findByRole('button', { name: /std\/v0\/types\/date/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Email Address/i })).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## What & why

Evolves the Designer's `PrimitiveSelector` from a flat "Apply Primitive" list into the full **type picker** the type-registry roadmap calls for (#3474, Epic 6.1). It now binds a property to a registry type and emits a **stable `$ref`** instead of only copying schema inline.

### Picker (`PrimitiveSelector`)
- **Standard / Core / Tenant / Custom tabs** — classifies `odb.primitives` rows by `is_system` / `tenant_id` / `source` (`classifyPrimitive`):
  - **Standard** — system rows in a `.../primitives` namespace (JSON base types)
  - **Core** — all other system rows (`std/v0/types/*`, plus legacy flat system primitives)
  - **Tenant** — tenant-owned, authored in-app (`source !== 'imported'`)
  - **Custom** — tenant-owned, imported (`source === 'imported'`)
- **Per-tab counts**, **scope chips**, and **per-row scope badges**.
- **Search across namespaces** — matches name / namespace / `$ref` / description / tags.
- **Stable `$ref` emission** — `buildTypeRef` joins `namespace` + `name` (e.g. `std/v0/types/date`); selection writes `PropertyFormData.$ref` and fires the new `onTypeBound` callback. Legacy primitives without a namespace still apply their schema inline and record no `$ref`.
- **Bound-type chip** on the trigger shows the current binding and clears it on demand.

### Supporting changes
- `PropertyFormData.$ref` added (the binding field; persistence is #3475).
- The three picker hosts (`PropertyFormFields`, `PropertyDialog`, `ClassPropertyEditDialog`) updated from "Apply from Primitive" → "Bind to a Type".

## How to test
1. In the Schema Designer, **edit a `string` property** and find the **Bind to a Type** panel.
2. **Click "Select Type"** — the picker opens on the **Core System Types** tab.
3. **Select `std/v0/types/date`** and **click "Apply Type"** — the property's `$ref` is set to `std/v0/types/date` and the format/constraints from the type are applied; a teal `$ref` chip appears on the trigger.
4. **Switch to the Tenant / Custom tabs** to confirm tenant-owned and imported types are scoped correctly; **type into search** (e.g. `std/v0/types`) to filter within a tab.
5. **Click the chip's ×** to clear the binding.

Automated: `yarn jest PrimitiveSelector` (15 tests) — classification, `$ref` building, tab rendering, `$ref` emission, tenant scoping, bound chip, search.

## Risk / notes
- Picker props are backward-compatible (`onTypeBound` is optional); existing callers keep working.
- Persisting `$ref`/`primitive_id` on `class_properties` is **out of scope** here — tracked by #3475. This ticket delivers the picker and the in-form binding.
- Pre-existing lint errors in `PropertyFormFields.tsx` (MUI stubs) are untouched; new code is lint-clean, `tsc --noEmit` passes, and the UI build succeeds.

Closes #3474

Work performed by Claude Code via model claude-opus-4-8[1m]