### PR TITLE
Fix #3475 - Property→type $ref binding storage

### DIFF
--- a/docs/ROADMAP_TYPE_REGISTRY_GOVERNANCE.md
+++ b/docs/ROADMAP_TYPE_REGISTRY_GOVERNANCE.md
@@ -44,7 +44,7 @@ Before implementing net-new registry mechanics, account for what is **already li
 | REST | `/v1/primitives/{tenant_slug}` CRUD + `/import` from `$defs` | No namespaces, resolver, stats, or server-side draft 2020-12 gate |
 | UI proxy | `/api/primitives/*` | ✅ **Done** — closed as duplicate (#3455) |
 | Management UI | `/ade/dashboard/primitives` — stats, table, CRUD, import dialog | ✅ Nav done (#3466 closed); overview/import are **partial** — extend, don't rebuild |
-| Designer | `PrimitiveSelector` — full type picker with Standard/Core/Tenant/Custom tabs + scope chips; emits a stable `$ref` (#3474 ✅) | Persisted `$ref` binding still pending (#3475) |
+| Designer | `PrimitiveSelector` — full type picker with Standard/Core/Tenant/Custom tabs + scope chips; emits a stable `$ref` (#3474 ✅); the binding is persisted to `class_properties.primitive_id`/`primitive_ref` and rehydrates on reload (#3475 ✅) | — |
 | Validation | AJV in `PrimitiveEditorDialog` (client) | ✅ **Done** — REST persist strictly validated against draft 2020-12 with field-level errors (#3452) |
 | Scope | `is_system` immutability, tenant rows | ✅ **Done** — reads resolve `is_system ∪ tenant` (cross-tenant isolation; all tenants see `std/*`); core→tenant and tenant→other-tenant `$ref` rejected on save/import (#3453) |
 
@@ -695,7 +695,7 @@ flowchart LR
 | Issue | Title | Summary | Labels | Parallel | MVP | Complexity | Affected Modules |
 |---|---|---|---|:---:|:---:|---|---|
 | 6.1 #3474 ✅ | Type picker component | **DONE** — `PrimitiveSelector` evolved into the full type picker (`Select Type`): Standard / Core / Tenant / Custom tabs that classify `odb.primitives` by `is_system` / `tenant_id` / `source` (`classifyPrimitive`), per-tab counts, scope chips + per-row scope badges, search across name/namespace/`$ref`/tags, and a per-row resolved `$ref` preview. Selecting a registry type emits a stable `$ref` (`buildTypeRef`, e.g. `std/v0/types/date`) onto `PropertyFormData.$ref` and fires `onTypeBound`; legacy namespace-less primitives still bind by inline schema (no `$ref`). A bound-type chip on the trigger shows/clears the current binding. Persisting the binding is #3475 | `type-registry`,`ui`,`schema-designer`,`mvp`,`roadmap-type-registry` | Y | Y | M | objectified-ui |
-| 6.2 #3475 | Property→type `$ref` binding storage | Persist & read property bindings (1.3) | `type-registry`,`ui`,`rest`,`mvp`,`roadmap-type-registry` | N | Y | M | objectified-ui, objectified-rest |
+| 6.2 #3475 ✅ | Property→type `$ref` binding storage | **DONE** — the Designer persists a bound property's type reference to dedicated `odb.class_properties` columns (`primitive_id` FK to `odb.primitives` + the stored `primitive_ref` `$ref`, #3448 model), sent top-level on class-property create/update and rehydrated into the bound-type chip on reload. Binding a primitive increments its `usage_count` (create always; update only on a changed binding, so re-saves don't inflate it). Clearing the chip writes NULL/NULL — distinct from the legacy inline-primitive merge (the migration path for namespace-less primitives) | `type-registry`,`ui`,`rest`,`mvp`,`roadmap-type-registry` | N | Y | M | objectified-ui, objectified-rest |
 | 6.3 #3476 | Resolved-type display in Designer/Paths | Show resolved schema + validate against it | `type-registry`,`ui`,`schema-designer`,`mvp`,`roadmap-type-registry` | Y | Y | M | objectified-ui |
 | 6.4 #3477 | "Used by properties" dependents/impact | Reverse index: which properties use a type | `type-registry`,`rest`,`roadmap-type-registry` | Y | N | M | objectified-rest, objectified-ui |
 
@@ -710,7 +710,19 @@ flowchart LR
 - **Parallelism/Dependencies.** Depends on 2.6; parallel with 6.3.
 - **Technical Stack.** Next.js, Tailwind, Radix.
 
-### Issue 6.2 — Property→type `$ref` binding storage
+### Issue 6.2 — Property→type `$ref` binding storage ✅ DONE (#3475)
+- **Delivered.** The type picker (#3474) emits both the stable `$ref` and the resolved
+  primitive id onto the property form; the class-property editor sends them top-level
+  (`primitive_id`, `primitive_ref`) on save and reads them back into the bound-type chip on
+  reload. The REST class-property create/update/read path already carried these dedicated
+  `odb.class_properties` columns (the #3448 model — a real FK to `odb.primitives` plus the stored
+  `$ref`); this ticket wires the Designer write/read ends and the `PropertySchema` contract, and
+  increments the bound primitive's `usage_count` (on create, and on update only when the binding
+  target changes — repeated saves of an unchanged binding don't inflate it). Clearing the chip
+  persists NULL/NULL, keeping a registry binding distinct from the legacy inline-primitive merge
+  (the migration path for namespace-less primitives). Tests: `objectified-rest`
+  `tests/test_class_property_binding.py` (route passthrough/clear/read + model contract) and the
+  `objectified-ui` `PrimitiveSelector` binding-persistence cases.
 - **Problem.** A bound property must persist its type reference.
 - **Solution/Scope.** Write/read the property↔type binding (1.3), storing the `$ref` + resolved
   target on the `objectified-db` `class_property` (or the binding link). Source:

--- a/objectified-rest/package.json
+++ b/objectified-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-rest",
-  "version": "1.0.21",
+  "version": "1.0.22",
   "private": true,
   "description": "Trigger file for Objectified REST Docker publish workflow; app is Python (pyproject.toml).",
   "scripts": {

--- a/objectified-rest/pyproject.toml
+++ b/objectified-rest/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "objectified-rest"
-version = "1.0.91"
+version = "1.0.92"
 description = "REST API for serving OpenAPI specifications from the Objectified database"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/objectified-rest/src/app/database.py
+++ b/objectified-rest/src/app/database.py
@@ -542,6 +542,15 @@ class Database:
                      parent_id, primitive_id, primitive_ref)
                 )
                 result = cursor.fetchone()
+                # Binding a property to a registry type counts as a use of that
+                # primitive (#3475 — increment usage via the existing usage_count
+                # pattern). Done in the same transaction so the count and the
+                # binding commit atomically.
+                if primitive_id:
+                    cursor.execute(
+                        "UPDATE odb.primitives SET usage_count = usage_count + 1 WHERE id = %s",
+                        (primitive_id,)
+                    )
                 conn.commit()
                 # Parse JSON data if it's a string
                 if result and isinstance(result.get('data'), str):
@@ -564,9 +573,11 @@ class Database:
         """Update a class property, ensuring it belongs to the class and tenant."""
         import json
         
-        # First verify the class property belongs to a class that belongs to the tenant
+        # First verify the class property belongs to a class that belongs to the tenant.
+        # Also fetch the current primitive binding so we can tell whether this update
+        # newly binds the property to a primitive (for the usage_count increment, #3475).
         verify_query = """
-            SELECT cp.id, cp.class_id
+            SELECT cp.id, cp.class_id, cp.primitive_id
             FROM odb.class_properties cp
             JOIN odb.classes c ON cp.class_id = c.id
             JOIN odb.versions v ON c.version_id = v.id
@@ -578,6 +589,7 @@ class Database:
         verify_result = self.execute_query(verify_query, (class_property_id, class_id, tenant_id))
         if not verify_result:
             return None
+        old_primitive_id = verify_result[0].get('primitive_id')
         
         # Build dynamic update query
         update_fields = []
@@ -622,6 +634,17 @@ class Database:
             with conn.cursor() as cursor:
                 cursor.execute(query, tuple(params))
                 result = cursor.fetchone()
+                # If this update binds the property to a *different* primitive than
+                # before, count it as a new use of that primitive (#3475). Comparing
+                # against the prior value keeps repeated saves of an unchanged binding
+                # from inflating usage_count. Same transaction as the update.
+                if 'primitive_id' in updates:
+                    new_primitive_id = updates['primitive_id']
+                    if new_primitive_id and str(new_primitive_id) != str(old_primitive_id):
+                        cursor.execute(
+                            "UPDATE odb.primitives SET usage_count = usage_count + 1 WHERE id = %s",
+                            (new_primitive_id,)
+                        )
                 conn.commit()
                 if result and isinstance(result.get('data'), str):
                     result['data'] = json.loads(result['data'])

--- a/objectified-rest/src/app/models.py
+++ b/objectified-rest/src/app/models.py
@@ -84,6 +84,11 @@ class PropertySchema(BaseModel):
     property_source_id: Optional[str] = None
     property_source_name: Optional[str] = None
     parent_id: Optional[str] = None  # New: nested properties support
+    # Property→type registry binding (#3448 model, persisted by #3475). A real FK
+    # to the resolved odb.primitives row plus the stored registry $ref string.
+    # Both NULL for inline/library-only properties that are not bound to a type.
+    primitive_id: Optional[str] = None
+    primitive_ref: Optional[str] = None
 
     class Config:
         from_attributes = True

--- a/objectified-rest/tests/test_class_property_binding.py
+++ b/objectified-rest/tests/test_class_property_binding.py
@@ -1,0 +1,195 @@
+"""Tests for property→type `$ref` binding persistence on class properties (#3475).
+
+The binding lives in dedicated `odb.class_properties` columns — `primitive_id`
+(a real FK to the resolved `odb.primitives` row) and `primitive_ref` (the stored
+registry `$ref` string) — *not* inside the property's JSON Schema `data`. These
+DB-free route tests assert the create/update/read handlers carry the binding
+through to the data layer, that a present-but-null value clears the binding, and
+that the `PropertySchema` contract exposes both fields.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.auth import validate_authentication
+from app.main import app
+from app.models import PropertySchema
+
+client = TestClient(app)
+
+_TENANT_ID = "550e8400-e29b-41d4-a716-446655440000"
+_CLASS_ID = "880e8400-e29b-41d4-a716-446655440003"
+_PROP_ID = "990e8400-e29b-41d4-a716-446655440009"
+_PRIMITIVE_ID = "110e8400-e29b-41d4-a716-446655440111"
+_PRIMITIVE_REF = "std/v0/types/date"
+
+_API_KEY_AUTH = {
+    "tenant_id": _TENANT_ID,
+    "tenant_slug": "acme",
+    "auth_method": "api_key",
+}
+
+
+@pytest.fixture(autouse=True)
+def _auth_api_key():
+    app.dependency_overrides[validate_authentication] = lambda: _API_KEY_AUTH
+    yield
+    app.dependency_overrides.pop(validate_authentication, None)
+
+
+def _bound_property_row(**overrides):
+    """A class-property row as the DAO returns it once bound to a registry type."""
+    row = {
+        "id": _PROP_ID,
+        "class_id": _CLASS_ID,
+        "property_id": None,
+        "name": "birthDate",
+        "description": "Date of birth",
+        "data": {"type": "string", "format": "date"},
+        "parent_id": None,
+        "primitive_id": _PRIMITIVE_ID,
+        "primitive_ref": _PRIMITIVE_REF,
+    }
+    row.update(overrides)
+    return row
+
+
+# ---------------------------------------------------------------------------
+# Create (POST) — the binding reaches the data layer
+# ---------------------------------------------------------------------------
+
+def test_create_property_forwards_binding():
+    """POST passes primitive_id/primitive_ref straight through to the DAO."""
+    with patch("app.classes_routes.db") as mdb:
+        mdb.get_class_by_id.return_value = {"id": _CLASS_ID}
+        mdb.add_property_to_class.return_value = _bound_property_row()
+        r = client.post(
+            f"/v1/classes/acme/{_CLASS_ID}/properties",
+            json={
+                "name": "birthDate",
+                "data": {"type": "string", "format": "date"},
+                "primitive_id": _PRIMITIVE_ID,
+                "primitive_ref": _PRIMITIVE_REF,
+            },
+        )
+    assert r.status_code == 200
+    kwargs = mdb.add_property_to_class.call_args.kwargs
+    assert kwargs["primitive_id"] == _PRIMITIVE_ID
+    assert kwargs["primitive_ref"] == _PRIMITIVE_REF
+    body = r.json()
+    assert body["primitive_id"] == _PRIMITIVE_ID
+    assert body["primitive_ref"] == _PRIMITIVE_REF
+
+
+def test_create_property_without_binding_passes_none():
+    """An unbound property forwards None for both binding columns."""
+    with patch("app.classes_routes.db") as mdb:
+        mdb.get_class_by_id.return_value = {"id": _CLASS_ID}
+        mdb.add_property_to_class.return_value = _bound_property_row(
+            primitive_id=None, primitive_ref=None
+        )
+        r = client.post(
+            f"/v1/classes/acme/{_CLASS_ID}/properties",
+            json={"name": "nickname", "data": {"type": "string"}},
+        )
+    assert r.status_code == 200
+    kwargs = mdb.add_property_to_class.call_args.kwargs
+    assert kwargs["primitive_id"] is None
+    assert kwargs["primitive_ref"] is None
+
+
+# ---------------------------------------------------------------------------
+# Update (PUT) — bind, clear, and read-back
+# ---------------------------------------------------------------------------
+
+def test_update_property_persists_binding():
+    """PUT routes primitive_id/primitive_ref into the DAO's updates dict."""
+    with patch("app.classes_routes.db") as mdb:
+        mdb.get_class_by_id.return_value = {"id": _CLASS_ID}
+        mdb.update_class_property.return_value = _bound_property_row()
+        r = client.put(
+            f"/v1/classes/acme/{_CLASS_ID}/properties/{_PROP_ID}",
+            json={
+                "name": "birthDate",
+                "data": {"type": "string", "format": "date"},
+                "primitive_id": _PRIMITIVE_ID,
+                "primitive_ref": _PRIMITIVE_REF,
+            },
+        )
+    assert r.status_code == 200
+    updates = mdb.update_class_property.call_args.kwargs["updates"]
+    assert updates["primitive_id"] == _PRIMITIVE_ID
+    assert updates["primitive_ref"] == _PRIMITIVE_REF
+
+
+def test_update_property_clears_binding_with_null():
+    """A present-but-null binding clears it (the value still reaches updates)."""
+    with patch("app.classes_routes.db") as mdb:
+        mdb.get_class_by_id.return_value = {"id": _CLASS_ID}
+        mdb.update_class_property.return_value = _bound_property_row(
+            primitive_id=None, primitive_ref=None
+        )
+        r = client.put(
+            f"/v1/classes/acme/{_CLASS_ID}/properties/{_PROP_ID}",
+            json={
+                "name": "birthDate",
+                "data": {"type": "string", "format": "date"},
+                "primitive_id": None,
+                "primitive_ref": None,
+            },
+        )
+    assert r.status_code == 200
+    updates = mdb.update_class_property.call_args.kwargs["updates"]
+    assert "primitive_id" in updates and updates["primitive_id"] is None
+    assert "primitive_ref" in updates and updates["primitive_ref"] is None
+
+
+def test_update_property_omits_binding_when_not_sent():
+    """When the client sends no binding keys, the DAO updates omit them entirely
+    (so an unrelated edit never touches the binding columns)."""
+    with patch("app.classes_routes.db") as mdb:
+        mdb.get_class_by_id.return_value = {"id": _CLASS_ID}
+        mdb.update_class_property.return_value = _bound_property_row()
+        r = client.put(
+            f"/v1/classes/acme/{_CLASS_ID}/properties/{_PROP_ID}",
+            json={"description": "tweak only"},
+        )
+    assert r.status_code == 200
+    updates = mdb.update_class_property.call_args.kwargs["updates"]
+    assert "primitive_id" not in updates
+    assert "primitive_ref" not in updates
+
+
+def test_get_properties_returns_binding():
+    """GET surfaces the persisted binding columns so the Designer can rehydrate."""
+    with patch("app.classes_routes.db") as mdb:
+        mdb.get_class_by_id.return_value = {"id": _CLASS_ID}
+        mdb.get_properties_for_class.return_value = [_bound_property_row()]
+        r = client.get(f"/v1/classes/acme/{_CLASS_ID}/properties")
+    assert r.status_code == 200
+    item = r.json()[0]
+    assert item["primitive_id"] == _PRIMITIVE_ID
+    assert item["primitive_ref"] == _PRIMITIVE_REF
+
+
+# ---------------------------------------------------------------------------
+# Model contract
+# ---------------------------------------------------------------------------
+
+def test_property_schema_exposes_binding_fields():
+    """PropertySchema carries the binding fields and defaults them to None."""
+    bare = PropertySchema(id=_PROP_ID, class_id=_CLASS_ID, name="x")
+    assert bare.primitive_id is None
+    assert bare.primitive_ref is None
+
+    bound = PropertySchema(
+        id=_PROP_ID,
+        class_id=_CLASS_ID,
+        name="birthDate",
+        primitive_id=_PRIMITIVE_ID,
+        primitive_ref=_PRIMITIVE_REF,
+    )
+    assert bound.primitive_id == _PRIMITIVE_ID
+    assert bound.primitive_ref == _PRIMITIVE_REF

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.132",
+  "version": "0.11.133",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/src/app/components/ade/studio/ClassPropertyEditDialog.tsx
+++ b/objectified-ui/src/app/components/ade/studio/ClassPropertyEditDialog.tsx
@@ -842,6 +842,11 @@ export default function ClassPropertyEditDialog({
     // Populate form data
     setFormData({
       description: editingClassProperty.description || '',
+      // Rehydrate the persisted type-registry binding (#3475) so the bound-type
+      // chip and resolved target survive a reload. These live in dedicated
+      // class_properties columns, not in the property's JSON Schema `data`.
+      $ref: editingClassProperty.primitive_ref || '',
+      primitive_id: editingClassProperty.primitive_id || '',
       required: !!propData.required,
       nullable: isNullable,
       deprecated: !!propData.deprecated,
@@ -1582,6 +1587,11 @@ export default function ClassPropertyEditDialog({
           name: editPropName.trim(),
           description: formData.description || null,
           data: updatedData,
+          // Persist the type-registry binding (#3475) as dedicated columns: the
+          // resolved primitive id (FK) and the stored registry $ref. Sent as
+          // null when unbound/cleared so the binding can be removed.
+          primitive_id: formData.primitive_id || null,
+          primitive_ref: formData.$ref || null,
         }),
       });
 

--- a/objectified-ui/src/app/components/ade/studio/PrimitiveSelector.tsx
+++ b/objectified-ui/src/app/components/ade/studio/PrimitiveSelector.tsx
@@ -350,10 +350,13 @@ export const PrimitiveSelector: React.FC<PrimitiveSelectorProps> = ({
       onChange('description', schema.description as string);
     }
 
-    // Persist the stable registry `$ref` binding (or clear it for legacy
-    // primitives that have no namespace and thus no stable ref).
+    // Persist the stable registry `$ref` binding plus the resolved target
+    // (the primitive's id) so the binding survives reload (#3475). Legacy
+    // primitives have no namespace and thus no stable ref — clear both so they
+    // fall back to inline-schema merge (the migration path for existing props).
     const ref = buildTypeRef(primitive);
     onChange('$ref', ref || '');
+    onChange('primitive_id', ref ? primitive.id : '');
     if (ref && onTypeBound) {
       onTypeBound({ ref, primitive });
     }
@@ -373,9 +376,11 @@ export const PrimitiveSelector: React.FC<PrimitiveSelectorProps> = ({
     onOpenChange?.(false);
   };
 
-  // Clear the current registry binding without opening the picker.
+  // Clear the current registry binding without opening the picker. Drops both
+  // the stored `$ref` and the resolved primitive id (#3475).
   const clearBinding = () => {
     onChange('$ref', '');
+    onChange('primitive_id', '');
   };
 
   // Render schema preview

--- a/objectified-ui/src/app/components/ade/studio/PropertyFormFields.tsx
+++ b/objectified-ui/src/app/components/ade/studio/PropertyFormFields.tsx
@@ -322,9 +322,15 @@ export interface PropertyFormData {
   /**
    * Stable registry `$ref` to an `odb.primitives` type selected via the type
    * picker (e.g. `std/v0/types/date`). Empty/undefined when the property is not
-   * bound to a registry type. Persistence of this binding is handled by #3475.
+   * bound to a registry type. Persisted to `class_properties.primitive_ref` (#3475).
    */
   $ref?: string;
+  /**
+   * Resolved target of the `$ref` binding: the `id` of the `odb.primitives` row
+   * the property is bound to. Set alongside `$ref` by the type picker and
+   * persisted to `class_properties.primitive_id` (#3475). Empty when unbound.
+   */
+  primitive_id?: string;
 }
 
 interface SortableEnumItemProps {

--- a/objectified-ui/tests/PrimitiveSelector.test.tsx
+++ b/objectified-ui/tests/PrimitiveSelector.test.tsx
@@ -284,6 +284,51 @@ describe('PrimitiveSelector type picker', () => {
     await waitFor(() => expect(onChangeSpy).toHaveBeenCalledWith('$ref', ''));
   });
 
+  it('persists the resolved primitive id alongside the $ref when binding (#3475)', async () => {
+    const onChangeSpy = jest.fn();
+    render(<Harness onChangeSpy={onChangeSpy} />);
+    await openPicker();
+
+    const dateRow = await screen.findByRole('button', { name: /std\/v0\/types\/date/i });
+    fireEvent.click(dateRow);
+    fireEvent.click(screen.getByRole('button', { name: /apply type/i }));
+
+    // Both the $ref string and the FK target (the primitive's id) are recorded
+    // so the binding can round-trip through class_properties.primitive_ref/_id.
+    await waitFor(() =>
+      expect(onChangeSpy).toHaveBeenCalledWith('$ref', 'std/v0/types/date'),
+    );
+    expect(onChangeSpy).toHaveBeenCalledWith('primitive_id', 'core-date');
+  });
+
+  it('clears the primitive id for a legacy namespace-less primitive (#3475)', async () => {
+    const onChangeSpy = jest.fn();
+    render(<Harness onChangeSpy={onChangeSpy} />);
+    await openPicker();
+
+    const emailRow = await screen.findByRole('button', { name: /Email Address/i });
+    fireEvent.click(emailRow);
+    fireEvent.click(screen.getByRole('button', { name: /apply type/i }));
+
+    // No stable $ref → no FK binding either; falls back to inline-schema merge.
+    await waitFor(() => expect(onChangeSpy).toHaveBeenCalledWith('$ref', ''));
+    expect(onChangeSpy).toHaveBeenCalledWith('primitive_id', '');
+  });
+
+  it('drops both the $ref and the primitive id when the binding is cleared (#3475)', async () => {
+    const onChangeSpy = jest.fn();
+    render(
+      <Harness
+        onChangeSpy={onChangeSpy}
+        initial={{ $ref: 'std/v0/types/date', primitive_id: 'core-date' }}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /clear type binding/i }));
+    await waitFor(() => expect(onChangeSpy).toHaveBeenCalledWith('$ref', ''));
+    expect(onChangeSpy).toHaveBeenCalledWith('primitive_id', '');
+  });
+
   it('searches across namespaces within the active tab', async () => {
     render(<Harness />);
     await openPicker();


### PR DESCRIPTION
## What & why

Closes #3475 (Epic 6.2 — Designer Property Binding).

When a property is bound to a registry type in the Designer, the binding must **persist and survive reload**. The type picker (#3474) already emits a stable `$ref`, and the `odb.class_properties` binding columns (`primitive_id` FK to `odb.primitives` + `primitive_ref`) plus the full REST create/update/read/copy path shipped with #3448 — but the Designer dropped the binding on save and never read it back. This PR wires the two open ends.

### Changes
- **objectified-ui**
  - `PropertyFormData` gains `primitive_id` (the resolved target) alongside the existing `$ref`.
  - `PrimitiveSelector` records both the `$ref` and the primitive id on bind, and clears both when the binding chip is cleared (legacy namespace-less primitives still bind by inline-schema merge only — the migration path for existing properties).
  - `ClassPropertyEditDialog` sends `primitive_id`/`primitive_ref` **top-level** on save (not inside the JSON Schema `data`) and rehydrates them into the bound-type chip on load.
- **objectified-rest**
  - Binding a property increments the primitive's `usage_count` (existing pattern): on create when bound, and on update **only when the binding target changes**, so re-saving an unchanged binding doesn't inflate the count. Both run in the same transaction as the write.
  - `PropertySchema` exposes `primitive_id`/`primitive_ref`.

No new DB migration — the columns already exist (`20260622-235000.sql`, #3448).

## How to test
1. Open the Designer and **edit a class property** of type string/number/integer/array.
2. Click **Select Type** and **pick a registry type** (e.g. `std/v0/types/date`). A bound-type chip shows the `$ref`.
3. Click **Save**, then **reopen the property** — the chip still shows `std/v0/types/date` (binding survived reload).
4. **Clear the chip** (the × button) and **Save** again — reopening shows no binding.
5. Check the bound primitive's **usage_count** rose by one per new binding; re-saving the same binding does not increase it further.

Automated: `objectified-rest/tests/test_class_property_binding.py` (route passthrough / clear / read + `PropertySchema` contract) and the new `PrimitiveSelector` binding cases in `objectified-ui/tests/PrimitiveSelector.test.tsx`.

## Risk / notes
- Scope is `class_property` bindings (where the FK columns live). Standalone library properties (`odb.properties`) are out of scope — they have no binding columns.
- `ClassPropertyEditDialog` is not unit-rendered: it enters an infinite setState loop in jsdom (pre-existing scroll-spy/wizard behavior; the repo has no render tests for it). The binding contract is covered at the picker and REST boundaries instead.
- Pre-existing unrelated REST test failures (merge/publish/version suites) and lint warnings in these files are unchanged by this PR.

Work performed by Claude Code via model Claude Opus 4.8 (1M context).

🤖 Generated with [Claude Code](https://claude.com/claude-code)