### PR TITLE
Fix #3476 - Resolved-type display in Designer/Paths

### DIFF
--- a/docs/ROADMAP_TYPE_REGISTRY_GOVERNANCE.md
+++ b/docs/ROADMAP_TYPE_REGISTRY_GOVERNANCE.md
@@ -696,7 +696,7 @@ flowchart LR
 |---|---|---|---|:---:|:---:|---|---|
 | 6.1 #3474 ✅ | Type picker component | **DONE** — `PrimitiveSelector` evolved into the full type picker (`Select Type`): Standard / Core / Tenant / Custom tabs that classify `odb.primitives` by `is_system` / `tenant_id` / `source` (`classifyPrimitive`), per-tab counts, scope chips + per-row scope badges, search across name/namespace/`$ref`/tags, and a per-row resolved `$ref` preview. Selecting a registry type emits a stable `$ref` (`buildTypeRef`, e.g. `std/v0/types/date`) onto `PropertyFormData.$ref` and fires `onTypeBound`; legacy namespace-less primitives still bind by inline schema (no `$ref`). A bound-type chip on the trigger shows/clears the current binding. Persisting the binding is #3475 | `type-registry`,`ui`,`schema-designer`,`mvp`,`roadmap-type-registry` | Y | Y | M | objectified-ui |
 | 6.2 #3475 ✅ | Property→type `$ref` binding storage | **DONE** — the Designer persists a bound property's type reference to dedicated `odb.class_properties` columns (`primitive_id` FK to `odb.primitives` + the stored `primitive_ref` `$ref`, #3448 model), sent top-level on class-property create/update and rehydrated into the bound-type chip on reload. Binding a primitive increments its `usage_count` (create always; update only on a changed binding, so re-saves don't inflate it). Clearing the chip writes NULL/NULL — distinct from the legacy inline-primitive merge (the migration path for namespace-less primitives) | `type-registry`,`ui`,`rest`,`mvp`,`roadmap-type-registry` | N | Y | M | objectified-ui, objectified-rest |
-| 6.3 #3476 | Resolved-type display in Designer/Paths | Show resolved schema + validate against it | `type-registry`,`ui`,`schema-designer`,`mvp`,`roadmap-type-registry` | Y | Y | M | objectified-ui |
+| 6.3 #3476 ✅ | Resolved-type display in Designer/Paths | **DONE** — a bound property's persisted binding (`$ref` + resolved `primitive_id`, #3475) resolves to the primitive's *effective* JSON Schema for display in the Designer's class-property editor: `ResolvedTypePreview` fetches the primitive by its FK (`/api/primitives/{id}`, or accepts a pre-resolved schema for reuse in Paths), `summarizeEffectiveSchema` renders the resolved type/format/constraint pills, and a live example-value field coerces free text to the schema's JSON type and validates it with AJV (2020-12) via `validateExampleAgainstSchema`. Pure resolver/summary/coercion helpers live in `resolvedTypeModel.ts` | `type-registry`,`ui`,`schema-designer`,`mvp`,`roadmap-type-registry` | Y | Y | M | objectified-ui |
 | 6.4 #3477 | "Used by properties" dependents/impact | Reverse index: which properties use a type | `type-registry`,`rest`,`roadmap-type-registry` | Y | N | M | objectified-rest, objectified-ui |
 
 ### Issue 6.1 — Type picker component
@@ -731,7 +731,18 @@ flowchart LR
 - **Parallelism/Dependencies.** Depends on 1.3, 3.1, 6.1; blocks 6.3.
 - **Technical Stack.** Next.js, FastAPI, PostgreSQL.
 
-### Issue 6.3 — Resolved-type display in Designer/Paths
+### Issue 6.3 — Resolved-type display in Designer/Paths ✅ DONE (#3476)
+- **Delivered.** A bound property's persisted binding (`$ref` + resolved `primitive_id`, #3475)
+  resolves to its primitive's *effective* JSON Schema for display in the Designer's class-property
+  editor. New `ResolvedTypePreview` component fetches the primitive by its stored FK
+  (`/api/primitives/{id}`) — or takes a pre-resolved schema so the Paths editor can reuse it —
+  and renders the resolved type, format and constraint pills via `summarizeEffectiveSchema`. A
+  live "try an example value" field coerces free text to the schema's JSON type
+  (`coerceExampleValue`) and validates it against the resolved schema with AJV 2020-12
+  (`validateExampleAgainstSchema`, reusing `lib/database/validateSchema`). The pure
+  resolver/summary/coercion/validation helpers live in `resolvedTypeModel.ts`. Tests:
+  `objectified-ui` `tests/resolvedTypeModel.test.ts` (resolve/summarize/coerce/validate) and
+  `tests/ResolvedTypePreview.test.tsx` (fetch-by-FK render + valid/invalid example validation).
 - **Problem.** The Designer must render the resolved type and validate values against it.
 - **Solution/Scope.** Resolve a property's `$ref` to its effective schema and display it (type,
   format, constraints); use it for client-side validation/preview. Source: property-binding +

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.133",
+  "version": "0.11.134",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/src/app/components/ade/studio/ClassPropertyEditDialog.tsx
+++ b/objectified-ui/src/app/components/ade/studio/ClassPropertyEditDialog.tsx
@@ -16,6 +16,7 @@ import { Badge } from '../../ui/Badge';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../../ui/Select';
 import { PropertyFormFields, PropertyFormData } from './PropertyFormFields';
 import { PrimitiveSelector } from './PrimitiveSelector';
+import { ResolvedTypePreview } from './ResolvedTypePreview';
 import ExtractToClassDialog from './ExtractToClassDialog';
 import {
   GitBranch,
@@ -182,6 +183,15 @@ const BasicsSection: React.FC<BasicsSectionProps> = ({
             size="small"
           />
         </div>
+        {/* Resolve the bound registry type to its effective schema and let the
+            author validate an example value against it (#3476). */}
+        {formData.$ref && (
+          <ResolvedTypePreview
+            className="mt-4"
+            propertyRef={formData.$ref}
+            primitiveId={formData.primitive_id}
+          />
+        )}
       </div>
     )}
   </FormSection>

--- a/objectified-ui/src/app/components/ade/studio/ResolvedTypePreview.tsx
+++ b/objectified-ui/src/app/components/ade/studio/ResolvedTypePreview.tsx
@@ -1,0 +1,225 @@
+'use client';
+
+/**
+ * ResolvedTypePreview (#3476).
+ *
+ * Given a property's persisted type binding (`$ref` + resolved `primitive_id`,
+ * #3475), resolve it to the primitive's *effective* JSON Schema and display the
+ * resolved type, format and constraints, plus a live example-value validator
+ * (AJV 2020-12). Used by the Designer's class-property editor; reusable in the
+ * Paths editor since it only needs the binding identifiers (or a schema).
+ */
+
+import React, { useEffect, useMemo, useState } from 'react';
+import { Link2, Loader2, CheckCircle2, XCircle, FlaskConical } from 'lucide-react';
+import { Input } from '../../ui/Input';
+import {
+  summarizeEffectiveSchema,
+  validateExampleAgainstSchema,
+} from './resolvedTypeModel';
+
+export interface ResolvedTypePreviewProps {
+  /** The bound registry `$ref` (e.g. `std/v0/types/date`) — shown as the binding chip. */
+  propertyRef?: string | null;
+  /** The resolved primitive id (FK) used to fetch the effective schema. */
+  primitiveId?: string | null;
+  /**
+   * A pre-resolved effective schema. When supplied the component skips the
+   * fetch (useful for Paths/tests where the schema is already in hand).
+   */
+  schema?: Record<string, unknown> | null;
+  className?: string;
+}
+
+interface PrimitiveLite {
+  name?: string;
+  namespace?: string | null;
+  schema?: Record<string, unknown>;
+}
+
+/**
+ * Resolve and render a bound property's effective type. Renders nothing when the
+ * property has no registry binding (no `$ref`, no `primitiveId`, no schema).
+ */
+export const ResolvedTypePreview: React.FC<ResolvedTypePreviewProps> = ({
+  propertyRef,
+  primitiveId,
+  schema: providedSchema,
+  className,
+}) => {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [fetched, setFetched] = useState<PrimitiveLite | null>(null);
+  const [example, setExample] = useState('');
+
+  const hasBinding = Boolean(providedSchema || primitiveId || (propertyRef && propertyRef.trim()));
+
+  // Resolve the effective schema by fetching the primitive by its FK so the
+  // preview survives a reload (where only the stored ids are available). A
+  // directly-provided schema short-circuits the fetch (handled below).
+  useEffect(() => {
+    if (providedSchema || !primitiveId) {
+      setFetched(null);
+      setError(null);
+      setLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+
+    const resolvePrimitive = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const res = await fetch(`/api/primitives/${primitiveId}`);
+        if (!res.ok) throw new Error('Failed to resolve bound type');
+        const data = await res.json();
+        if (cancelled) return;
+        if (data.success && data.primitive) {
+          setFetched(data.primitive as PrimitiveLite);
+        } else {
+          setError(data.error || 'Bound type could not be resolved');
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Failed to resolve bound type');
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    resolvePrimitive();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [providedSchema, primitiveId]);
+
+  // A directly-provided schema wins; otherwise use the fetched primitive.
+  const resolved: PrimitiveLite | null = providedSchema ? { schema: providedSchema } : fetched;
+  const effectiveSchema = resolved?.schema;
+  const summary = useMemo(
+    () => (effectiveSchema ? summarizeEffectiveSchema(effectiveSchema) : null),
+    [effectiveSchema],
+  );
+
+  // Validate the example only when there is something to validate against.
+  const validation = useMemo(() => {
+    if (!effectiveSchema || example.trim() === '') return null;
+    return validateExampleAgainstSchema(example, effectiveSchema);
+  }, [effectiveSchema, example]);
+
+  if (!hasBinding) return null;
+
+  const resolvedRef =
+    propertyRef ||
+    (resolved?.namespace && resolved?.name
+      ? `${resolved.namespace.replace(/\/+$/, '')}/${resolved.name}`
+      : undefined);
+
+  return (
+    <div
+      className={`rounded-xl border border-teal-200 bg-teal-50/60 p-4 dark:border-teal-900/50 dark:bg-teal-950/30 ${className || ''}`}
+      data-testid="resolved-type-preview"
+    >
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <h4 className="flex items-center gap-2 text-sm font-semibold text-slate-900 dark:text-slate-100">
+          <Link2 className="h-4 w-4 text-teal-500" />
+          Resolved Type
+        </h4>
+        {resolvedRef && (
+          <span className="inline-flex items-center gap-1.5 rounded-md border border-teal-200 bg-white px-2 py-1 font-mono text-xs text-teal-700 dark:border-teal-800 dark:bg-teal-900/30 dark:text-teal-300">
+            {resolvedRef}
+          </span>
+        )}
+      </div>
+
+      {loading && (
+        <div className="mt-3 flex items-center gap-2 text-sm text-slate-500 dark:text-slate-400">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          Resolving bound type…
+        </div>
+      )}
+
+      {!loading && error && (
+        <p className="mt-3 text-sm text-red-600 dark:text-red-400">{error}</p>
+      )}
+
+      {!loading && !error && summary && (
+        <>
+          {/* Effective type + format */}
+          <div className="mt-3 flex flex-wrap items-center gap-2">
+            <span className="inline-flex items-center rounded-md bg-teal-100 px-2 py-1 font-mono text-xs font-medium text-teal-800 dark:bg-teal-900/40 dark:text-teal-200">
+              {summary.type}
+            </span>
+            {summary.format && (
+              <span className="inline-flex items-center rounded-md bg-sky-100 px-2 py-1 font-mono text-xs text-sky-700 dark:bg-sky-900/40 dark:text-sky-300">
+                format: {summary.format}
+              </span>
+            )}
+          </div>
+
+          {/* Constraints */}
+          {summary.constraints.length > 0 ? (
+            <div className="mt-2 flex flex-wrap gap-1.5">
+              {summary.constraints.map((c) => (
+                <span
+                  key={c.label}
+                  className="inline-flex items-center rounded bg-white px-1.5 py-0.5 font-mono text-[11px] text-slate-600 ring-1 ring-inset ring-slate-200 dark:bg-slate-800 dark:text-slate-300 dark:ring-slate-700"
+                >
+                  {c.label}: {c.value}
+                </span>
+              ))}
+            </div>
+          ) : (
+            <p className="mt-2 text-xs text-slate-500 dark:text-slate-400">
+              No additional constraints.
+            </p>
+          )}
+
+          {/* Example value validation */}
+          <div className="mt-4">
+            <label
+              htmlFor="resolved-type-example"
+              className="flex items-center gap-1.5 text-xs font-medium text-slate-600 dark:text-slate-300"
+            >
+              <FlaskConical className="h-3.5 w-3.5 text-teal-500" />
+              Try an example value
+            </label>
+            <Input
+              id="resolved-type-example"
+              value={example}
+              onChange={(e) => setExample(e.target.value)}
+              placeholder={summary.format ? `e.g. a valid ${summary.format}` : `Enter a ${summary.type} value`}
+              className="mt-1.5 font-mono text-sm"
+              aria-invalid={validation ? !validation.valid : undefined}
+            />
+            {validation && validation.valid && (
+              <p className="mt-1.5 flex items-center gap-1.5 text-xs text-emerald-600 dark:text-emerald-400">
+                <CheckCircle2 className="h-3.5 w-3.5" />
+                Valid against the resolved type.
+              </p>
+            )}
+            {validation && !validation.valid && (
+              <div className="mt-1.5 space-y-0.5">
+                {(validation.errors ?? [{ message: 'Invalid value' }]).map((err, i) => (
+                  <p
+                    key={i}
+                    className="flex items-center gap-1.5 text-xs text-red-600 dark:text-red-400"
+                  >
+                    <XCircle className="h-3.5 w-3.5 shrink-0" />
+                    {err.path ? `${err.path} ` : ''}
+                    {err.message}
+                  </p>
+                ))}
+              </div>
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  );
+};
+
+export default ResolvedTypePreview;

--- a/objectified-ui/src/app/components/ade/studio/resolvedTypeModel.ts
+++ b/objectified-ui/src/app/components/ade/studio/resolvedTypeModel.ts
@@ -1,0 +1,173 @@
+/**
+ * Resolved-type model (#3476).
+ *
+ * Pure helpers that turn a property's persisted type binding (`$ref` +
+ * `primitive_id`, #3475) into its *effective* JSON Schema and a human-readable
+ * summary, and that validate an example value against that schema. Kept free of
+ * React so they can be unit-tested directly and reused by both the Designer
+ * (class-property editor) and the Paths editor.
+ */
+
+import { validatePayloadAgainstSchema, type ValidationResult } from '@lib/database/validateSchema';
+import { buildTypeRef, type Primitive } from './PrimitiveSelector';
+
+/** One labelled constraint extracted from an effective schema (e.g. `minLength: 3`). */
+export interface SchemaConstraint {
+  label: string;
+  value: string;
+}
+
+/** Structured, display-ready summary of a resolved type's effective schema. */
+export interface ResolvedTypeSummary {
+  /** JSON Schema `type` (e.g. `string`); `unknown` when the schema omits it. */
+  type: string;
+  /** JSON Schema `format` (e.g. `date`, `email`) when present. */
+  format?: string;
+  /** The validation constraints declared on the schema, in display order. */
+  constraints: SchemaConstraint[];
+}
+
+/**
+ * Resolve a property's persisted binding to the primitive row it points at.
+ *
+ * Prefers the stored FK (`primitive_id`) — an exact, scope-safe match — and
+ * falls back to matching the stable registry `$ref` against `buildTypeRef`.
+ * Returns `null` when neither identifies a primitive in the supplied list.
+ *
+ * @param ref          the stored registry `$ref` (e.g. `std/v0/types/date`), if any
+ * @param primitiveId  the stored resolved primitive id (FK), if any
+ * @param primitives   the candidate primitives to resolve against
+ */
+export function resolvePrimitiveRef(
+  ref: string | null | undefined,
+  primitiveId: string | null | undefined,
+  primitives: Primitive[],
+): Primitive | null {
+  if (primitiveId) {
+    const byId = primitives.find((p) => p.id === primitiveId);
+    if (byId) return byId;
+  }
+  if (ref && ref.trim()) {
+    const target = ref.trim();
+    const byRef = primitives.find((p) => buildTypeRef(p) === target);
+    if (byRef) return byRef;
+  }
+  return null;
+}
+
+/**
+ * Summarize an effective JSON Schema into a type label, optional format and an
+ * ordered list of validation constraints for display. Mirrors the constraint
+ * set the type picker applies onto a property, so the preview matches what a
+ * bound type actually enforces.
+ */
+export function summarizeEffectiveSchema(schema: Record<string, unknown>): ResolvedTypeSummary {
+  const typeValue = schema.type;
+  const type = Array.isArray(typeValue)
+    ? typeValue.map(String).join(' | ')
+    : typeof typeValue === 'string'
+      ? typeValue
+      : 'unknown';
+  const format = typeof schema.format === 'string' ? schema.format : undefined;
+
+  const constraints: SchemaConstraint[] = [];
+  const push = (label: string, value: unknown) => constraints.push({ label, value: String(value) });
+
+  if (schema.pattern !== undefined) push('pattern', schema.pattern);
+  if (schema.minLength !== undefined) push('minLength', schema.minLength);
+  if (schema.maxLength !== undefined) push('maxLength', schema.maxLength);
+  if (schema.minimum !== undefined) push('minimum', schema.minimum);
+  if (schema.maximum !== undefined) push('maximum', schema.maximum);
+  if (schema.exclusiveMinimum !== undefined) push('exclusiveMinimum', schema.exclusiveMinimum);
+  if (schema.exclusiveMaximum !== undefined) push('exclusiveMaximum', schema.exclusiveMaximum);
+  if (schema.multipleOf !== undefined) push('multipleOf', schema.multipleOf);
+  if (schema.minItems !== undefined) push('minItems', schema.minItems);
+  if (schema.maxItems !== undefined) push('maxItems', schema.maxItems);
+  if (schema.uniqueItems) push('uniqueItems', true);
+  if (Array.isArray(schema.enum)) {
+    const items = schema.enum as unknown[];
+    const shown = items.slice(0, 5).map(String).join(', ');
+    push('enum', `[${shown}${items.length > 5 ? ', …' : ''}]`);
+  }
+  if (schema.const !== undefined) {
+    push('const', typeof schema.const === 'string' ? schema.const : JSON.stringify(schema.const));
+  }
+
+  return { type, format, constraints };
+}
+
+/** Result of coercing + validating an example value against an effective schema. */
+export interface ExampleValidationResult extends ValidationResult {
+  /** The example coerced to the schema's JSON type (what was actually validated). */
+  coerced?: unknown;
+}
+
+/**
+ * Coerce a raw text example to the JSON type implied by an effective schema.
+ *
+ * The Designer captures examples as free text. To validate them against a
+ * 2020-12 schema we first lift the string into the schema's expected JSON type:
+ * numbers/integers parse numerically, booleans parse `true`/`false`, and
+ * arrays/objects parse as JSON. Strings pass through untouched. Throws when the
+ * text cannot be coerced (e.g. non-numeric text for a `number`), so callers can
+ * surface a precise "not valid JSON / not a number" message.
+ */
+export function coerceExampleValue(raw: string, schema: Record<string, unknown>): unknown {
+  const type = Array.isArray(schema.type) ? schema.type[0] : schema.type;
+
+  switch (type) {
+    case 'number':
+    case 'integer': {
+      const trimmed = raw.trim();
+      const n = Number(trimmed);
+      if (trimmed === '' || Number.isNaN(n)) {
+        throw new Error(`"${raw}" is not a valid ${type}`);
+      }
+      return n;
+    }
+    case 'boolean': {
+      const lowered = raw.trim().toLowerCase();
+      if (lowered === 'true') return true;
+      if (lowered === 'false') return false;
+      throw new Error(`"${raw}" is not a valid boolean (use true or false)`);
+    }
+    case 'array':
+    case 'object': {
+      try {
+        return JSON.parse(raw);
+      } catch {
+        throw new Error(`"${raw}" is not valid JSON for a ${type}`);
+      }
+    }
+    case 'null':
+      return null;
+    default:
+      // string (and untyped) — keep the raw text.
+      return raw;
+  }
+}
+
+/**
+ * Validate a raw text example against a resolved effective schema.
+ *
+ * Coerces the example to the schema's JSON type first (see
+ * {@link coerceExampleValue}); a coercion failure is reported as a single
+ * validation error rather than thrown. Returns the AJV (2020-12) verdict plus
+ * the coerced value that was checked.
+ */
+export function validateExampleAgainstSchema(
+  raw: string,
+  schema: Record<string, unknown>,
+): ExampleValidationResult {
+  let coerced: unknown;
+  try {
+    coerced = coerceExampleValue(raw, schema);
+  } catch (err) {
+    return {
+      valid: false,
+      errors: [{ message: err instanceof Error ? err.message : 'Could not parse example value' }],
+    };
+  }
+  const result = validatePayloadAgainstSchema(coerced, schema);
+  return { ...result, coerced };
+}

--- a/objectified-ui/tests/ResolvedTypePreview.test.tsx
+++ b/objectified-ui/tests/ResolvedTypePreview.test.tsx
@@ -1,0 +1,95 @@
+/**
+ * Tests for ResolvedTypePreview (#3476).
+ *
+ * Covers resolving a bound type by its FK (fetching the primitive), rendering
+ * the effective type / format / constraints, validating an example value live
+ * (the acceptance criterion: "a bound property shows its resolved type; an
+ * example value validates"), and the no-binding / error paths.
+ *
+ * This is a thin standalone component (it is NOT the ClassPropertyEditDialog,
+ * which cannot be unit-rendered under jsdom), so it renders safely here.
+ */
+
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ResolvedTypePreview } from '../src/app/components/ade/studio/ResolvedTypePreview';
+
+const dateSchema = { type: 'string', format: 'date' };
+
+const mockFetchPrimitive = (schema: Record<string, unknown>, namespace = 'std/v0/types', name = 'date') => {
+  (global.fetch as jest.Mock).mockResolvedValue({
+    ok: true,
+    json: async () => ({
+      success: true,
+      primitive: { id: 'core-date', name, namespace, schema },
+    }),
+  });
+};
+
+describe('ResolvedTypePreview', () => {
+  beforeAll(() => {
+    global.fetch = jest.fn();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders nothing when the property has no binding', () => {
+    const { container } = render(<ResolvedTypePreview />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('fetches the primitive by id and shows the resolved type, format and ref', async () => {
+    mockFetchPrimitive(dateSchema);
+    render(<ResolvedTypePreview propertyRef="std/v0/types/date" primitiveId="core-date" />);
+
+    await waitFor(() =>
+      expect(global.fetch).toHaveBeenCalledWith('/api/primitives/core-date'),
+    );
+    expect(await screen.findByText('std/v0/types/date')).toBeInTheDocument();
+    expect(await screen.findByText('string')).toBeInTheDocument();
+    expect(screen.getByText('format: date')).toBeInTheDocument();
+  });
+
+  it('uses a directly-provided schema without fetching', async () => {
+    render(
+      <ResolvedTypePreview
+        propertyRef="tenant/acme/types/sku"
+        schema={{ type: 'string', pattern: '^[A-Z0-9-]+$' }}
+      />,
+    );
+    expect(await screen.findByText('pattern: ^[A-Z0-9-]+$')).toBeInTheDocument();
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('validates a valid example value against the resolved type', async () => {
+    render(<ResolvedTypePreview propertyRef="std/v0/types/date" schema={dateSchema} />);
+
+    const input = await screen.findByLabelText(/try an example value/i);
+    fireEvent.change(input, { target: { value: '2026-06-23' } });
+
+    expect(await screen.findByText(/valid against the resolved type/i)).toBeInTheDocument();
+  });
+
+  it('reports an invalid example value', async () => {
+    render(<ResolvedTypePreview propertyRef="std/v0/types/date" schema={dateSchema} />);
+
+    const input = await screen.findByLabelText(/try an example value/i);
+    fireEvent.change(input, { target: { value: 'not-a-date' } });
+
+    await waitFor(() =>
+      expect(input).toHaveAttribute('aria-invalid', 'true'),
+    );
+    // The valid message must not be shown for a bad value.
+    expect(screen.queryByText(/valid against the resolved type/i)).not.toBeInTheDocument();
+  });
+
+  it('surfaces a resolution error when the fetch fails', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({ ok: false, json: async () => ({}) });
+    render(<ResolvedTypePreview propertyRef="std/v0/types/date" primitiveId="core-date" />);
+
+    expect(await screen.findByText(/failed to resolve bound type/i)).toBeInTheDocument();
+  });
+});

--- a/objectified-ui/tests/resolvedTypeModel.test.ts
+++ b/objectified-ui/tests/resolvedTypeModel.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Tests for the resolved-type model (#3476).
+ *
+ * Covers resolving a property's persisted binding (`$ref` / `primitive_id`,
+ * #3475) to its primitive, summarizing the effective JSON Schema (type, format,
+ * constraints), coercing free-text examples to the schema's JSON type, and
+ * validating those examples against the resolved schema (AJV 2020-12).
+ */
+
+import {
+  resolvePrimitiveRef,
+  summarizeEffectiveSchema,
+  coerceExampleValue,
+  validateExampleAgainstSchema,
+} from '../src/app/components/ade/studio/resolvedTypeModel';
+import type { Primitive } from '../src/app/components/ade/studio/PrimitiveSelector';
+
+const makePrimitive = (overrides: Partial<Primitive>): Primitive => ({
+  id: 'id-1',
+  tenant_id: 'tenant-1',
+  name: 'thing',
+  description: null,
+  category: 'string',
+  schema: { type: 'string' },
+  tags: [],
+  created_by: null,
+  is_system: false,
+  is_public: false,
+  usage_count: 0,
+  enabled: true,
+  created_at: '2026-06-01T00:00:00Z',
+  updated_at: '2026-06-01T00:00:00Z',
+  namespace: null,
+  base_uri: null,
+  schema_id: null,
+  draft: '2020-12',
+  source: 'human',
+  refs: [],
+  ...overrides,
+});
+
+const coreDate = makePrimitive({
+  id: 'core-date',
+  name: 'date',
+  is_system: true,
+  namespace: 'std/v0/types',
+  schema: { type: 'string', format: 'date' },
+});
+
+const tenantSku = makePrimitive({
+  id: 'tenant-sku',
+  name: 'sku',
+  namespace: 'tenant/acme/types',
+  schema: { type: 'string', pattern: '^[A-Z0-9-]+$' },
+});
+
+describe('resolvePrimitiveRef', () => {
+  const all = [coreDate, tenantSku];
+
+  it('resolves by the stored primitive id (FK) first', () => {
+    expect(resolvePrimitiveRef('std/v0/types/date', 'tenant-sku', all)).toBe(tenantSku);
+  });
+
+  it('falls back to matching the stable $ref when no id matches', () => {
+    expect(resolvePrimitiveRef('std/v0/types/date', undefined, all)).toBe(coreDate);
+    expect(resolvePrimitiveRef('tenant/acme/types/sku', null, all)).toBe(tenantSku);
+  });
+
+  it('returns null when neither id nor ref resolves', () => {
+    expect(resolvePrimitiveRef('nope/v0/x', 'missing', all)).toBeNull();
+    expect(resolvePrimitiveRef(null, null, all)).toBeNull();
+    expect(resolvePrimitiveRef('', '', all)).toBeNull();
+  });
+});
+
+describe('summarizeEffectiveSchema', () => {
+  it('extracts type and format', () => {
+    const summary = summarizeEffectiveSchema({ type: 'string', format: 'date' });
+    expect(summary.type).toBe('string');
+    expect(summary.format).toBe('date');
+    expect(summary.constraints).toEqual([]);
+  });
+
+  it('collects string constraints in display order', () => {
+    const summary = summarizeEffectiveSchema({
+      type: 'string',
+      pattern: '^[A-Z]+$',
+      minLength: 2,
+      maxLength: 10,
+    });
+    expect(summary.constraints).toEqual([
+      { label: 'pattern', value: '^[A-Z]+$' },
+      { label: 'minLength', value: '2' },
+      { label: 'maxLength', value: '10' },
+    ]);
+  });
+
+  it('collects numeric and array constraints', () => {
+    const summary = summarizeEffectiveSchema({
+      type: 'integer',
+      minimum: 0,
+      exclusiveMaximum: 100,
+      multipleOf: 5,
+    });
+    expect(summary.constraints).toContainEqual({ label: 'minimum', value: '0' });
+    expect(summary.constraints).toContainEqual({ label: 'exclusiveMaximum', value: '100' });
+    expect(summary.constraints).toContainEqual({ label: 'multipleOf', value: '5' });
+  });
+
+  it('truncates long enums and renders const', () => {
+    const summary = summarizeEffectiveSchema({
+      type: 'string',
+      enum: ['a', 'b', 'c', 'd', 'e', 'f', 'g'],
+    });
+    expect(summary.constraints[0]).toEqual({ label: 'enum', value: '[a, b, c, d, e, …]' });
+
+    const constSummary = summarizeEffectiveSchema({ type: 'string', const: 'X' });
+    expect(constSummary.constraints).toContainEqual({ label: 'const', value: 'X' });
+  });
+
+  it('handles union types and missing type', () => {
+    expect(summarizeEffectiveSchema({ type: ['string', 'null'] }).type).toBe('string | null');
+    expect(summarizeEffectiveSchema({}).type).toBe('unknown');
+  });
+});
+
+describe('coerceExampleValue', () => {
+  it('keeps strings as-is', () => {
+    expect(coerceExampleValue('hello', { type: 'string' })).toBe('hello');
+  });
+
+  it('parses numbers and integers', () => {
+    expect(coerceExampleValue('42', { type: 'integer' })).toBe(42);
+    expect(coerceExampleValue('3.14', { type: 'number' })).toBe(3.14);
+  });
+
+  it('throws on non-numeric text for a number', () => {
+    expect(() => coerceExampleValue('abc', { type: 'number' })).toThrow(/not a valid number/);
+    expect(() => coerceExampleValue('', { type: 'integer' })).toThrow(/not a valid integer/);
+  });
+
+  it('parses booleans case-insensitively', () => {
+    expect(coerceExampleValue('TRUE', { type: 'boolean' })).toBe(true);
+    expect(coerceExampleValue('false', { type: 'boolean' })).toBe(false);
+    expect(() => coerceExampleValue('yes', { type: 'boolean' })).toThrow(/not a valid boolean/);
+  });
+
+  it('parses arrays and objects as JSON', () => {
+    expect(coerceExampleValue('[1, 2]', { type: 'array' })).toEqual([1, 2]);
+    expect(coerceExampleValue('{"a": 1}', { type: 'object' })).toEqual({ a: 1 });
+    expect(() => coerceExampleValue('[bad', { type: 'array' })).toThrow(/not valid JSON/);
+  });
+});
+
+describe('validateExampleAgainstSchema', () => {
+  it('accepts a valid example against a formatted type', () => {
+    const result = validateExampleAgainstSchema('2026-06-23', { type: 'string', format: 'date' });
+    expect(result.valid).toBe(true);
+    expect(result.coerced).toBe('2026-06-23');
+  });
+
+  it('rejects an example that violates the format', () => {
+    const result = validateExampleAgainstSchema('not-a-date', { type: 'string', format: 'date' });
+    expect(result.valid).toBe(false);
+    expect(result.errors && result.errors.length).toBeGreaterThan(0);
+  });
+
+  it('rejects a value that violates a constraint', () => {
+    const result = validateExampleAgainstSchema('ABCDEFG', { type: 'string', maxLength: 3 });
+    expect(result.valid).toBe(false);
+  });
+
+  it('validates coerced numbers against numeric constraints', () => {
+    expect(validateExampleAgainstSchema('5', { type: 'integer', minimum: 0 }).valid).toBe(true);
+    expect(validateExampleAgainstSchema('-1', { type: 'integer', minimum: 0 }).valid).toBe(false);
+  });
+
+  it('reports a coercion failure as a single validation error (not a throw)', () => {
+    const result = validateExampleAgainstSchema('abc', { type: 'number' });
+    expect(result.valid).toBe(false);
+    expect(result.errors?.[0].message).toMatch(/not a valid number/);
+  });
+});


### PR DESCRIPTION
## What & why
Implements **[6.3] Resolved-type display in Designer/Paths** (#3476, Epic 6 — Designer Property Binding).

A property bound to a registry type persists its `$ref` plus the resolved `primitive_id` (FK, #3475). This ticket resolves that binding to the primitive's **effective JSON Schema** and surfaces it in the Designer's class-property editor — showing the resolved type/format/constraints and letting the author validate an example value against the composed 2020-12 schema.

### Changes
- **`resolvedTypeModel.ts`** (pure, framework-free helpers):
  - `resolvePrimitiveRef` — resolves a binding to its primitive (stored FK first, stable `$ref` fallback).
  - `summarizeEffectiveSchema` — structured type / format / ordered constraint list.
  - `coerceExampleValue` — lifts free-text examples into the schema's JSON type (number/integer/boolean/array/object).
  - `validateExampleAgainstSchema` — AJV **2020-12** validation, reusing `lib/database/validateSchema`; coercion failures become a single inline error rather than a throw.
- **`ResolvedTypePreview.tsx`** — resolves a bound type by fetching the primitive via its FK (`/api/primitives/{id}`), or accepts a pre-resolved `schema` so the **Paths** editor can reuse it. Renders the resolved type/format/constraint pills and a live "try an example value" field. Renders nothing when there is no binding.
- **`ClassPropertyEditDialog.tsx`** — renders `ResolvedTypePreview` under the type picker when a property is bound to a registry type.
- ROADMAP marked 6.3 done; `objectified-ui` patch bump `0.11.133 → 0.11.134`.

## How to test
1. In the Schema Designer, **open a class property** of type `string`.
2. **Click "Select Type"** and **bind** a registry type, e.g. **`std/v0/types/date`**.
3. A **"Resolved Type"** card appears showing the resolved type (`string`), **`format: date`**, and any constraint pills.
4. In **"Try an example value"**, enter **`2026-06-23`** → shows **"Valid against the resolved type."**
5. Enter **`not-a-date`** → the field is marked invalid with the validation error.

Automated: `cd objectified-ui && yarn jest resolvedTypeModel ResolvedTypePreview PrimitiveSelector` (42 passing). `yarn tsc --noEmit` and `yarn build` are clean.

## Risk / notes
- UI-only; no REST/DB/schema changes. Reuses the existing `/api/primitives/{id}` proxy and the existing AJV validator.
- `ResolvedTypePreview` is deliberately decoupled (resolves by FK or accepts a schema) so it can be dropped into the Paths editor without threading the primitive object through dialog state.
- Per repo convention, `ClassPropertyEditDialog` is not unit-rendered (jsdom setState loop); logic is covered by the pure-model tests and the standalone `ResolvedTypePreview` render tests.

Closes #3476

Work performed by Claude Code via model claude-opus-4-8[1m]