### PR TITLE
Fix #3478 - Primitives entitlement & feature gating

### DIFF
--- a/docs/ROADMAP_TYPE_REGISTRY_GOVERNANCE.md
+++ b/docs/ROADMAP_TYPE_REGISTRY_GOVERNANCE.md
@@ -767,18 +767,30 @@ Governance controls around the registry: entitlements, publish gates, promotion,
 
 | Issue | Title | Summary | Labels | Parallel | MVP | Complexity | Affected Modules |
 |---|---|---|---|:---:|:---:|---|---|
-| 7.1 #3478 | Entitlement & feature gating | Gate Type Registry behind tenant entitlement | `type-registry`,`governance`,`rest`,`ui`,`mvp`,`roadmap-type-registry` | Y | Y | S | objectified-rest, objectified-ui |
+| 7.1 #3478 ✅ | Entitlement & feature gating | **DONE** — optional `primitives-registry` entitlement gates the advanced Type Registry surface (resolver, namespaces, settings, stats, import) in `objectified-rest`; baseline primitives CRUD + `/health` stay always-on | `type-registry`,`governance`,`rest`,`ui`,`mvp`,`roadmap-type-registry` | Y | Y | S | objectified-rest, objectified-ui |
 | 7.2 #3479 | Type publishing & validation gate | Validate on save; block publish on errors | `type-registry`,`governance`,`rest`,`mvp`,`roadmap-type-registry` | Y | Y | M | objectified-rest |
 | 7.3 #3480 | Promote tenant type → core (CAB) | Governed promotion of a vetted tenant type to `std/*` | `type-registry`,`governance`,`rest`,`ui`,`roadmap-type-registry` | Y | N | M | objectified-rest, objectified-ui |
 | 7.4 #3481 | Registry audit log | Record create/update/import/publish/bind events | `type-registry`,`governance`,`rest`,`mvp`,`roadmap-type-registry` | Y | Y | S | objectified-rest |
 | 7.5 #3482 | Version roots & deprecation lifecycle | Manage `v0`/`v1` roots; deprecate/sunset types | `type-registry`,`versions`,`governance`,`roadmap-type-registry` | Y | N | M | objectified-rest, objectified-ui |
 
-### Issue 7.1 — Entitlement & feature gating
+### Issue 7.1 — Entitlement & feature gating ✅ DONE (#3478)
 - **Solution/Scope.** Add a `type-registry` entitlement; gate nav, routes, and API. Source:
   `governance/README.md`.
 - **Acceptance Criteria.** Non-entitled tenants cannot see/reach the feature; entitled can.
 - **Parallelism/Dependencies.** Parallel; soft-blocks 5.1 visibility.
 - **Technical Stack.** FastAPI entitlements, Next.js checks.
+- **DONE.** The `primitives-registry` feature flag (seeded by objectified-db migration
+  `20260623-130000.sql`; bundled into the Paid and Sponsor plans, not Free) is the entitlement,
+  managed through the existing admin Feature-Flag panel (per-user / per-tenant overrides on top of
+  the license default). Enforcement is authoritative in `objectified-rest`: a reusable
+  `require_primitives_registry` dependency (`app/feature_gating.py`) gates the **advanced** surface —
+  every `/v1/types/*` route (resolver, namespaces, settings, stats) plus the `/v1/primitives/*`
+  import pipeline and `/unresolved` resolver — while baseline primitives CRUD and `/health` remain
+  always-on. The gate is itself behind an operator switch
+  (`OBJECTIFIED_PRIMITIVES_REGISTRY_GATING`, default **off**): when off, behavior is unchanged and
+  every authenticated tenant reaches the advanced routes; when on, non-entitled tenants get `403`.
+  Entitlement resolves with precedence per-user override → per-tenant override → license default
+  (`Database.tenant_has_feature_flag`), honoring the flag's global master switch.
 
 ### Issue 7.2 — Type publishing & validation gate
 - **Solution/Scope.** Validate on save (2020-12); block publish on validation errors per Settings

--- a/objectified-db/package.json
+++ b/objectified-db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-db",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "Objectified database migrations and the direct-to-database admin CLI (objectified-db).",
   "author": "Objectified",
   "type": "module",

--- a/objectified-db/scripts/20260623-130000.sql
+++ b/objectified-db/scripts/20260623-130000.sql
@@ -1,0 +1,47 @@
+-- Primitives type-registry entitlement & feature gating (#3478)
+--
+-- Seeds the `primitives-registry` feature flag that gates the advanced Type Registry
+-- surface (relative-$ref resolver, namespaces, registry settings, coverage stats, and the
+-- import pipeline). Baseline primitives CRUD and /health are never gated.
+--
+-- Enforcement lives in objectified-rest: when OBJECTIFIED_PRIMITIVES_REGISTRY_GATING is on,
+-- the advanced routes require the calling tenant/user to hold this flag (per-user override >
+-- per-tenant override > license default). When that operator switch is off (the default),
+-- the flag is inert and every authenticated tenant reaches the advanced routes — so seeding
+-- it here is safe and changes no behavior on its own.
+--
+-- Product default: bundle the entitlement into the Paid and Sponsor plans; the Free plan does
+-- not include it. Admins can still grant/revoke it per-user or per-tenant via the existing
+-- Feature-Flag panel, which lists this row automatically.
+SET search_path TO odb, public;
+
+-- ─── Seed: primitives-registry feature flag ──────────────────────────────────
+
+INSERT INTO odb.feature_flags (name, label, description, url_patterns, is_preview, enabled)
+VALUES
+    ('primitives-registry',
+     'Primitives Type Registry',
+     'Advanced JSON Schema type registry: $ref resolver, namespaces, registry settings, '
+     'coverage stats, and the import pipeline. Baseline primitives CRUD is always available.',
+     '["/ade/dashboard/primitives", "/api/types", "/api/primitives/import", "/api/primitives/unresolved", "/api/primitives/imports"]',
+     true, true)
+ON CONFLICT (name) DO NOTHING;
+
+-- ─── Seed: license ↔ feature flag associations ───────────────────────────────
+-- Paid and Sponsor plans include the type registry; Free does not.
+
+INSERT INTO odb.license_feature_flags (license_id, feature_flag_id)
+SELECT l.id, ff.id
+FROM   odb.licenses l
+CROSS  JOIN odb.feature_flags ff
+WHERE  l.name = 'Paid'
+  AND  ff.name = 'primitives-registry'
+ON CONFLICT DO NOTHING;
+
+INSERT INTO odb.license_feature_flags (license_id, feature_flag_id)
+SELECT l.id, ff.id
+FROM   odb.licenses l
+CROSS  JOIN odb.feature_flags ff
+WHERE  l.name = 'Sponsor'
+  AND  ff.name = 'primitives-registry'
+ON CONFLICT DO NOTHING;

--- a/objectified-db/test/primitives-registry-entitlement.test.ts
+++ b/objectified-db/test/primitives-registry-entitlement.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Structural assertions over the primitives-registry entitlement seed migration (#3478).
+ *
+ * The migration seeds the `primitives-registry` feature flag (which gates the advanced Type
+ * Registry surface in objectified-rest) and bundles it into the Paid and Sponsor license
+ * plans — but not Free. These tests verify the seed contract without a live database (the
+ * package's test suite is DB-free).
+ */
+
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import { describe, expect, it, beforeAll } from "vitest";
+
+import { listMigrationFiles } from "../src/migrate.js";
+
+const SCRIPTS_DIR = new URL("../scripts", import.meta.url).pathname;
+const MIGRATION = "20260623-130000.sql";
+
+let sql = "";
+
+beforeAll(async () => {
+  sql = (await fs.readFile(path.join(SCRIPTS_DIR, MIGRATION), "utf8")).toLowerCase();
+});
+
+describe("primitives-registry entitlement seed migration", () => {
+  it("is present in scripts/", async () => {
+    const files = await listMigrationFiles(SCRIPTS_DIR);
+    expect(files).toContain(MIGRATION);
+  });
+
+  it("seeds the primitives-registry feature flag into odb.feature_flags", () => {
+    expect(sql).toMatch(/insert into odb\.feature_flags/);
+    expect(sql).toContain("'primitives-registry'");
+    // Idempotent re-seed — must not clobber admin edits on re-run.
+    expect(sql).toMatch(/on conflict \(name\) do nothing/);
+  });
+
+  it("bundles the flag into the Paid and Sponsor plans but not Free", () => {
+    expect(sql).toMatch(/insert into odb\.license_feature_flags/);
+    expect(sql).toMatch(/l\.name = 'paid'/);
+    expect(sql).toMatch(/l\.name = 'sponsor'/);
+    // Free is intentionally excluded — no association row references it.
+    expect(sql).not.toMatch(/l\.name = 'free'/);
+  });
+
+  it("extends existing tables in place — defines no new tables or schema", () => {
+    expect(sql).not.toMatch(/create table/);
+    expect(sql).not.toMatch(/create schema/);
+  });
+});

--- a/objectified-rest/CHANGELOG.md
+++ b/objectified-rest/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to the Objectified REST API will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.23] - 2026-06-23
+
+### Added
+- **Primitives type-registry entitlement & feature gating (#3478)** — the advanced Type Registry
+  surface can now be gated behind a per-tenant `primitives-registry` entitlement. A reusable
+  `require_primitives_registry` dependency (`app/feature_gating.py`) guards every `/v1/types/*`
+  route (resolver, namespaces, settings, stats) plus the `/v1/primitives/*` import pipeline
+  (`/import`, `/import/review`, `/import/stage`, `/imports`, `/imports/{id}`) and the `/unresolved`
+  resolver. Baseline primitives CRUD (list/get/create/update/delete) and `/health` are never gated.
+- **`Database.tenant_has_feature_flag(tenant_id, user_id, flag_name)`** — resolves a named feature
+  flag for a tenant/user with precedence per-user override → per-tenant override → license default,
+  honoring the flag's global master switch (`odb.feature_flags.enabled`).
+
+### Changed
+- **`OBJECTIFIED_PRIMITIVES_REGISTRY_GATING` operator switch (default off)** — when off, the gate is
+  a pass-through and behavior is unchanged (every authenticated tenant reaches the advanced routes);
+  when on, non-entitled tenants receive `403`. The `primitives-registry` flag is seeded by
+  objectified-db migration `20260623-130000.sql` (bundled into the Paid and Sponsor plans, not Free)
+  and is managed through the existing admin Feature-Flag panel.
+
 ## [1.0.20] - 2026-06-22
 
 ### Added

--- a/objectified-rest/package.json
+++ b/objectified-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-rest",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "private": true,
   "description": "Trigger file for Objectified REST Docker publish workflow; app is Python (pyproject.toml).",
   "scripts": {

--- a/objectified-rest/pyproject.toml
+++ b/objectified-rest/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "objectified-rest"
-version = "1.0.92"
+version = "1.0.93"
 description = "REST API for serving OpenAPI specifications from the Objectified database"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/objectified-rest/src/app/config.py
+++ b/objectified-rest/src/app/config.py
@@ -59,6 +59,20 @@ class Settings(BaseSettings):
         ),
     )
 
+    # Primitives type-registry entitlement gating (#3478). When False (default), the
+    # advanced Type Registry surface (resolver, namespaces, settings, stats, import) is
+    # open to every authenticated tenant — current behavior, unchanged. When True, those
+    # routes require the calling tenant/user to hold the ``primitives-registry`` feature
+    # flag (per-user override > per-tenant override > license default); non-entitled
+    # callers get 403. Baseline primitives CRUD and /health are never gated.
+    primitives_registry_gating_enabled: bool = Field(
+        default=False,
+        validation_alias=AliasChoices(
+            "OBJECTIFIED_PRIMITIVES_REGISTRY_GATING",
+            "primitives_registry_gating_enabled",
+        ),
+    )
+
     # Global auto-refresh kill switch (RAR-3.3, #3524). When False, the refresh
     # sweep halts entirely (no repository is auto-refreshed) regardless of per-repo
     # auto_refresh_enabled. Intended for incident response. Manual "Refresh Now"

--- a/objectified-rest/src/app/database.py
+++ b/objectified-rest/src/app/database.py
@@ -3399,6 +3399,74 @@ class Database:
         """
         return bool(self.execute_query(q, (tenant_id, user_id)))
 
+    def tenant_has_feature_flag(
+        self,
+        tenant_id: Optional[str],
+        user_id: Optional[str],
+        flag_name: str,
+    ) -> bool:
+        """Resolve whether a tenant/user is entitled to a named feature flag (#3478).
+
+        Effective entitlement layers, highest precedence first:
+
+        1. Per-user override (``odb.user_feature_flags.enabled``) — an admin explicitly
+           granting or revoking the flag for this user.
+        2. Per-tenant override (``odb.tenant_feature_flags.enabled``) — all members of the
+           tenant inherit this unless a user override exists.
+        3. License default (``odb.license_feature_flags`` via ``user_entitlements.license_id``)
+           — the flag is bundled into the user's assigned plan.
+
+        The flag's global master switch (``odb.feature_flags.enabled``) is honored: a missing
+        or globally-disabled flag is never entitled, regardless of overrides. ``user_id`` may be
+        ``None`` (e.g. a legacy API key without an attributed user), in which case only the
+        tenant-level override is consulted.
+
+        Args:
+            tenant_id: The acting tenant's id (``None`` skips the tenant-override lookup).
+            user_id: The acting user's id (``None`` skips user-override and license lookups).
+            flag_name: The feature flag slug, e.g. ``"primitives-registry"``.
+
+        Returns:
+            True when the flag is globally enabled and the resolved entitlement grants it.
+        """
+        row = self.execute_query(
+            """
+            WITH ff AS (
+                SELECT id, enabled FROM odb.feature_flags WHERE name = %s
+            )
+            SELECT
+                ff.enabled                          AS flag_enabled,
+                uff.enabled                         AS user_override,
+                tff.enabled                         AS tenant_override,
+                (lff.feature_flag_id IS NOT NULL)   AS license_grant
+            FROM ff
+            LEFT JOIN odb.user_feature_flags uff
+                   ON uff.feature_flag_id = ff.id AND uff.user_id = %s::uuid
+            LEFT JOIN odb.tenant_feature_flags tff
+                   ON tff.feature_flag_id = ff.id AND tff.tenant_id = %s::uuid
+            LEFT JOIN odb.user_entitlements ue
+                   ON ue.user_id = %s::uuid
+            LEFT JOIN odb.license_feature_flags lff
+                   ON lff.feature_flag_id = ff.id AND lff.license_id = ue.license_id
+            LIMIT 1
+            """,
+            (flag_name, user_id, tenant_id, user_id),
+        )
+        if not row:
+            # Flag is not defined in the registry — treat as not entitled.
+            return False
+
+        record = row[0]
+        if not record["flag_enabled"]:
+            # Globally disabled master switch — off for everyone.
+            return False
+
+        if record["user_override"] is not None:
+            return bool(record["user_override"])
+        if record["tenant_override"] is not None:
+            return bool(record["tenant_override"])
+        return bool(record["license_grant"])
+
     def get_active_tenant_auth_row(self, tenant_slug: str) -> Optional[Dict[str, Any]]:
         """Resolve a non-deleted tenant slug to id/slug/name for auth checks."""
         query = """

--- a/objectified-rest/src/app/feature_gating.py
+++ b/objectified-rest/src/app/feature_gating.py
@@ -1,0 +1,84 @@
+"""Feature-entitlement gating dependencies for the Primitives type registry (#3478).
+
+The advanced Type Registry surface — relative-``$ref`` resolver, namespaces, registry
+settings, coverage stats, and the import pipeline — can optionally be gated behind a
+per-tenant ``primitives-registry`` entitlement. Baseline primitives CRUD and ``/health``
+are never gated.
+
+The gate is itself controlled by an operator switch
+(``settings.primitives_registry_gating_enabled``, default ``False``):
+
+* **Gating disabled (default):** these dependencies are pure pass-throughs that return the
+  authenticated ``auth_data`` unchanged — current behavior, every authenticated tenant
+  reaches the advanced routes.
+* **Gating enabled:** the calling tenant/user must hold the ``primitives-registry`` feature
+  flag (per-user override > per-tenant override > license default, see
+  ``Database.tenant_has_feature_flag``). Non-entitled callers receive ``403``.
+
+Each gated route swaps its ``Depends(validate_authentication)`` for
+``Depends(require_primitives_registry)``. Because the gate depends on
+``validate_authentication`` and returns the same ``auth_data`` dict, route handlers are
+otherwise unchanged, and tests that override ``validate_authentication`` keep working (the
+override resolves the sub-dependency).
+"""
+
+from typing import Any, Callable, Dict
+
+from fastapi import Depends, HTTPException
+
+from .auth import validate_authentication
+from .config import settings
+from .database import db
+
+# Canonical feature-flag slug for the Primitives type registry (matches the seed in
+# objectified-db migration 20260623-130000.sql and the admin Feature-Flag panel).
+PRIMITIVES_REGISTRY_FLAG = "primitives-registry"
+
+
+def require_feature_flag(
+    flag_name: str,
+    *,
+    gating_enabled: Callable[[], bool],
+) -> Callable[[Dict[str, Any]], Dict[str, Any]]:
+    """Build a FastAPI dependency that gates a route behind a named feature flag.
+
+    Args:
+        flag_name: The feature-flag slug the caller must hold when gating is on.
+        gating_enabled: Zero-arg predicate read at request time deciding whether the gate
+            is active. Read lazily (not captured as a bool) so the operator switch can be
+            toggled — and patched in tests — without rebuilding the dependency.
+
+    Returns:
+        A dependency callable that returns the authenticated ``auth_data`` when the caller
+        is allowed, or raises ``HTTPException(403)`` when gating is on and the caller is not
+        entitled.
+    """
+
+    def _dependency(
+        auth_data: Dict[str, Any] = Depends(validate_authentication),
+    ) -> Dict[str, Any]:
+        if not gating_enabled():
+            return auth_data
+
+        if db.tenant_has_feature_flag(
+            auth_data.get("tenant_id"), auth_data.get("user_id"), flag_name
+        ):
+            return auth_data
+
+        raise HTTPException(
+            status_code=403,
+            detail=(
+                f"This tenant is not entitled to the '{flag_name}' feature. "
+                "Ask an administrator to grant it to continue."
+            ),
+        )
+
+    return _dependency
+
+
+# Gate for the advanced Primitives type-registry routes (resolver, namespaces, settings,
+# stats, import). Pass-through unless ``primitives_registry_gating_enabled`` is set.
+require_primitives_registry = require_feature_flag(
+    PRIMITIVES_REGISTRY_FLAG,
+    gating_enabled=lambda: settings.primitives_registry_gating_enabled,
+)

--- a/objectified-rest/src/app/primitives_routes.py
+++ b/objectified-rest/src/app/primitives_routes.py
@@ -11,6 +11,7 @@ from typing import Any, Dict, List, Optional
 from fastapi import APIRouter, Depends, HTTPException, Query
 
 from .auth import get_authenticated_user_id, validate_authentication
+from .feature_gating import require_primitives_registry
 from .database import db
 from .import_ingestion import IngestionError, ingest_source
 from .import_pipeline import VALID_SOURCE_KINDS, build_staged_import
@@ -364,7 +365,7 @@ async def list_primitives(
 async def list_primitive_imports(
     tenant_slug: str,
     limit: int = Query(50, ge=1, le=500, description="Max number of records to return"),
-    auth_data: Dict[str, Any] = Depends(validate_authentication)
+    auth_data: Dict[str, Any] = Depends(require_primitives_registry)
 ) -> List[PrimitiveImportRecord]:
     """
     List primitive import provenance records for a tenant, newest first (#3448).
@@ -388,7 +389,7 @@ async def list_primitive_imports(
 async def get_primitive_import(
     tenant_slug: str,
     import_id: str,
-    auth_data: Dict[str, Any] = Depends(validate_authentication)
+    auth_data: Dict[str, Any] = Depends(require_primitives_registry)
 ) -> PrimitiveImportRecord:
     """
     Get a single primitive import provenance record, including its report JSON (#3448).
@@ -413,7 +414,7 @@ async def get_primitive_import(
 @router.get("/{tenant_slug}/unresolved", response_model=UnresolvedRefsResponse)
 async def list_unresolved_refs(
     tenant_slug: str,
-    auth_data: Dict[str, Any] = Depends(validate_authentication)
+    auth_data: Dict[str, Any] = Depends(require_primitives_registry)
 ) -> UnresolvedRefsResponse:
     """Report the tenant's unresolved relative-``$ref`` edges and counts (#3457).
 
@@ -1296,7 +1297,7 @@ def _normalize_resolutions(
 async def review_import_primitives(
     tenant_slug: str,
     request: PrimitiveImportRequest,
-    auth_data: Dict[str, Any] = Depends(validate_authentication)
+    auth_data: Dict[str, Any] = Depends(require_primitives_registry)
 ) -> Dict[str, Any]:
     """Dry-run review of an import: conflicts, dedupe, and a validation report (#3464).
 
@@ -1339,7 +1340,7 @@ async def review_import_primitives(
 async def import_primitives(
     tenant_slug: str,
     request: PrimitiveImportRequest,
-    auth_data: Dict[str, Any] = Depends(validate_authentication)
+    auth_data: Dict[str, Any] = Depends(require_primitives_registry)
 ) -> Dict[str, Any]:
     """
     Import primitives from a JSON Schema document or an Objectified type-def bundle.
@@ -1460,7 +1461,7 @@ async def import_primitives(
 async def stage_import(
     tenant_slug: str,
     request: PrimitiveImportStageRequest,
-    auth_data: Dict[str, Any] = Depends(validate_authentication)
+    auth_data: Dict[str, Any] = Depends(require_primitives_registry)
 ) -> PrimitiveImportStageResult:
     """Stage an import through the unified pipeline (#3460).
 

--- a/objectified-rest/src/app/type_namespaces_routes.py
+++ b/objectified-rest/src/app/type_namespaces_routes.py
@@ -18,8 +18,9 @@ from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException
 
-from .auth import get_authenticated_user_id, validate_authentication
+from .auth import get_authenticated_user_id
 from .database import db
+from .feature_gating import require_primitives_registry
 from .models import (
     RegistryCoverageStatsResponse,
     ResolvedPrimitiveRefs,
@@ -108,7 +109,7 @@ def _to_schema(row: Dict[str, Any]) -> TypeNamespaceSchema:
 @router.get("/{tenant_slug}/stats", response_model=RegistryCoverageStatsResponse)
 async def get_registry_coverage_stats(
     tenant_slug: str,
-    auth_data: Dict[str, Any] = Depends(validate_authentication),
+    auth_data: Dict[str, Any] = Depends(require_primitives_registry),
 ) -> RegistryCoverageStatsResponse:
     """Return aggregate registry coverage KPIs for the Primitives overview (#3454).
 
@@ -129,7 +130,7 @@ async def get_registry_coverage_stats(
 @router.get("/{tenant_slug}/namespaces")
 async def list_namespaces(
     tenant_slug: str,
-    auth_data: Dict[str, Any] = Depends(validate_authentication),
+    auth_data: Dict[str, Any] = Depends(require_primitives_registry),
 ) -> List[TypeNamespaceSchema]:
     """List namespaces visible to the tenant: system-core (``std/*``) plus the tenant's own.
 
@@ -148,7 +149,7 @@ async def list_namespaces(
 async def create_namespace(
     tenant_slug: str,
     request: TypeNamespaceCreateRequest,
-    auth_data: Dict[str, Any] = Depends(validate_authentication),
+    auth_data: Dict[str, Any] = Depends(require_primitives_registry),
 ) -> TypeNamespaceSchema:
     """Create a namespace.
 
@@ -224,7 +225,7 @@ async def update_namespace(
     tenant_slug: str,
     namespace_id: str,
     request: TypeNamespaceUpdateRequest,
-    auth_data: Dict[str, Any] = Depends(validate_authentication),
+    auth_data: Dict[str, Any] = Depends(require_primitives_registry),
 ) -> TypeNamespaceSchema:
     """Update a tenant namespace's base URI, version root, description, visibility, or default flag.
 
@@ -306,7 +307,7 @@ def _settings_to_schema(row: Dict[str, Any]) -> TypeRegistrySettingsSchema:
 @router.get("/{tenant_slug}/settings", response_model=TypeRegistrySettingsSchema)
 async def get_registry_settings(
     tenant_slug: str,
-    auth_data: Dict[str, Any] = Depends(validate_authentication),
+    auth_data: Dict[str, Any] = Depends(require_primitives_registry),
 ) -> TypeRegistrySettingsSchema:
     """Return the tenant's type-registry settings (#3472).
 
@@ -332,7 +333,7 @@ async def get_registry_settings(
 async def update_registry_settings(
     tenant_slug: str,
     request: TypeRegistrySettingsUpdateRequest,
-    auth_data: Dict[str, Any] = Depends(validate_authentication),
+    auth_data: Dict[str, Any] = Depends(require_primitives_registry),
 ) -> TypeRegistrySettingsSchema:
     """Save the tenant's type-registry settings (#3472).
 
@@ -373,7 +374,7 @@ async def update_registry_settings(
 @router.post("/{tenant_slug}/resolve", response_model=ResolveResponse)
 async def resolve_refs(
     tenant_slug: str,
-    auth_data: Dict[str, Any] = Depends(validate_authentication),
+    auth_data: Dict[str, Any] = Depends(require_primitives_registry),
 ) -> ResolveResponse:
     """Re-resolve the tenant's ``$ref`` edges and return the dependency listing (#3459).
 

--- a/objectified-rest/tests/test_primitives_entitlement_gating.py
+++ b/objectified-rest/tests/test_primitives_entitlement_gating.py
@@ -1,0 +1,188 @@
+"""Entitlement & feature gating for the Primitives type registry (#3478).
+
+Two layers are exercised:
+
+* ``Database.tenant_has_feature_flag`` — the precedence resolver
+  (per-user override > per-tenant override > license default), honoring the flag's global
+  master switch.
+* The ``require_primitives_registry`` route gate — pass-through when the operator switch
+  ``settings.primitives_registry_gating_enabled`` is off (default), and a 403 wall around the
+  advanced Type Registry routes when it is on and the caller is not entitled. Baseline
+  primitives CRUD is never gated.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.auth import validate_authentication
+from app.config import settings
+from app.database import db as real_db
+from app.main import app
+
+client = TestClient(app)
+
+_JWT = {"tenant_id": "t1", "user_id": "u1", "auth_method": "jwt"}
+
+_STATS = {
+    "core_type_count": 36,
+    "tenant_type_count": 12,
+    "imported_count": 5,
+    "properties_bound_count": 42,
+    "bound_class_count": 8,
+    "unresolved_ref_count": 3,
+    "namespace_count": 4,
+}
+
+
+@pytest.fixture(autouse=True)
+def _auth():
+    app.dependency_overrides[validate_authentication] = lambda: _JWT
+    yield
+    app.dependency_overrides.pop(validate_authentication, None)
+
+
+@pytest.fixture
+def _gating_on(monkeypatch):
+    """Turn the operator gating switch on for the duration of a test."""
+    monkeypatch.setattr(settings, "primitives_registry_gating_enabled", True)
+    yield
+
+
+# ===========================================================================
+# Database.tenant_has_feature_flag — precedence resolver
+# ===========================================================================
+
+
+def _resolve(**row):
+    """Run the helper with execute_query returning a single layered-entitlement row."""
+    with patch.object(real_db, "execute_query") as q:
+        q.return_value = [row]
+        result = real_db.tenant_has_feature_flag("t1", "u1", "primitives-registry")
+    return result, q
+
+
+def test_user_override_takes_precedence_over_tenant_and_license():
+    # User explicitly revoked — wins even though tenant + license would grant.
+    result, _ = _resolve(
+        flag_enabled=True, user_override=False, tenant_override=True, license_grant=True
+    )
+    assert result is False
+
+
+def test_tenant_override_used_when_no_user_override():
+    result, _ = _resolve(
+        flag_enabled=True, user_override=None, tenant_override=True, license_grant=False
+    )
+    assert result is True
+
+
+def test_license_default_used_when_no_overrides():
+    result, _ = _resolve(
+        flag_enabled=True, user_override=None, tenant_override=None, license_grant=True
+    )
+    assert result is True
+
+
+def test_not_entitled_when_no_overrides_and_no_license_grant():
+    result, _ = _resolve(
+        flag_enabled=True, user_override=None, tenant_override=None, license_grant=False
+    )
+    assert result is False
+
+
+def test_globally_disabled_flag_is_never_entitled():
+    # Master switch off — overrides and license grants are irrelevant.
+    result, _ = _resolve(
+        flag_enabled=False, user_override=True, tenant_override=True, license_grant=True
+    )
+    assert result is False
+
+
+def test_undefined_flag_returns_false():
+    with patch.object(real_db, "execute_query") as q:
+        q.return_value = []  # no such flag in the registry
+        assert real_db.tenant_has_feature_flag("t1", "u1", "nope") is False
+
+
+def test_resolver_binds_params_in_order():
+    _, q = _resolve(
+        flag_enabled=True, user_override=None, tenant_override=None, license_grant=True
+    )
+    # params: (flag_name, user_id, tenant_id, user_id)
+    assert q.call_args.args[1] == ("primitives-registry", "u1", "t1", "u1")
+
+
+# ===========================================================================
+# Route gate — advanced Type Registry routes (e.g. GET /v1/types/{slug}/stats)
+# ===========================================================================
+
+
+def test_gating_disabled_allows_advanced_route_without_entitlement():
+    # Default: operator switch off -> pass-through, entitlement never consulted.
+    with patch("app.type_namespaces_routes.db") as mdb, patch("app.feature_gating.db") as gdb:
+        mdb.get_registry_coverage_stats.return_value = _STATS
+        r = client.get("/v1/types/acme/stats")
+    assert r.status_code == 200
+    gdb.tenant_has_feature_flag.assert_not_called()
+
+
+def test_gating_enabled_entitled_tenant_allowed(_gating_on):
+    with patch("app.type_namespaces_routes.db") as mdb, patch("app.feature_gating.db") as gdb:
+        gdb.tenant_has_feature_flag.return_value = True
+        mdb.get_registry_coverage_stats.return_value = _STATS
+        r = client.get("/v1/types/acme/stats")
+    assert r.status_code == 200
+    gdb.tenant_has_feature_flag.assert_called_once_with("t1", "u1", "primitives-registry")
+
+
+def test_gating_enabled_non_entitled_tenant_blocked(_gating_on):
+    with patch("app.feature_gating.db") as gdb:
+        gdb.tenant_has_feature_flag.return_value = False
+        r = client.get("/v1/types/acme/stats")
+    assert r.status_code == 403
+    assert "primitives-registry" in r.json()["detail"]
+
+
+def test_gating_enabled_blocks_primitives_import(_gating_on):
+    # An advanced /v1/primitives route (import pipeline) is gated too.
+    with patch("app.feature_gating.db") as gdb:
+        gdb.tenant_has_feature_flag.return_value = False
+        r = client.post(
+            "/v1/primitives/acme/import",
+            json={"schema": {"type": "string"}, "import_all": True, "target_namespace": "std/v0/types"},
+        )
+    assert r.status_code == 403
+
+
+def test_gating_enabled_blocks_unresolved_refs(_gating_on):
+    with patch("app.feature_gating.db") as gdb:
+        gdb.tenant_has_feature_flag.return_value = False
+        r = client.get("/v1/primitives/acme/unresolved")
+    assert r.status_code == 403
+
+
+# ===========================================================================
+# Baseline primitives CRUD is never gated
+# ===========================================================================
+
+
+def test_baseline_list_open_even_when_gating_on_and_not_entitled(_gating_on):
+    with patch("app.feature_gating.db") as gdb, patch("app.primitives_routes.db") as mdb:
+        gdb.tenant_has_feature_flag.return_value = False
+        mdb.get_primitives_for_tenant.return_value = []
+        r = client.get("/v1/primitives/acme")
+    assert r.status_code == 200
+    # The baseline route does not consult the entitlement gate at all.
+    gdb.tenant_has_feature_flag.assert_not_called()
+
+
+def test_health_open_even_when_gating_on(_gating_on):
+    with patch("app.feature_gating.db") as gdb, patch("app.primitives_routes.db") as mdb:
+        gdb.tenant_has_feature_flag.return_value = False
+        mdb.registry_ping.return_value = {"connection": "connected", "storage_present": True}
+        r = client.get("/v1/primitives/health")
+    # /health is ungated; status code is driven by the handler, never 403 from the gate.
+    assert r.status_code != 403
+    gdb.tenant_has_feature_flag.assert_not_called()


### PR DESCRIPTION
## What & why

Closes #3478. Adds an **optional `primitives-registry` entitlement** that gates the *advanced* Primitives type-registry surface, while keeping baseline CRUD always-on — satisfying the acceptance criterion: *"Non-entitled tenants blocked from gated routes/APIs only if flag enabled."*

The existing DB-backed feature-flag system (`odb.feature_flags` + per-user / per-tenant / per-license overrides) is reused as the entitlement source — no new entitlement model. Enforcement is authoritative in **objectified-rest**.

### Gated (advanced) vs always-on (baseline)

| Always-on (never gated) | Gated when entitlement enforced |
|---|---|
| `GET /v1/primitives/health` | All `/v1/types/*` (resolver, namespaces, settings, stats) |
| `GET/POST /v1/primitives/{slug}` | `/v1/primitives/{slug}/import`, `/import/review`, `/import/stage` |
| `GET/PUT/DELETE /v1/primitives/{slug}/{id}` | `/v1/primitives/{slug}/imports`, `/imports/{id}`, `/unresolved` |

### How it works
- **Operator switch** `OBJECTIFIED_PRIMITIVES_REGISTRY_GATING` (config, **default off**). Off → the gate is a pass-through and behavior is unchanged. On → non-entitled tenants get `403`.
- **`require_primitives_registry`** dependency (`app/feature_gating.py`) wraps `validate_authentication` and returns the same `auth_data`, so route handlers are otherwise untouched and existing auth-override tests keep working.
- **`Database.tenant_has_feature_flag`** resolves entitlement with precedence **per-user override → per-tenant override → license default**, honoring the flag's global master switch.
- **Migration `20260623-130000.sql`** seeds the `primitives-registry` flag (bundled into Paid and Sponsor plans, not Free). It auto-appears in the admin Feature-Flag panel, so admins can grant/revoke per-user or per-tenant with no UI code change.

## How to test
- `cd objectified-rest && python -m pytest tests/test_primitives_entitlement_gating.py` — 14 tests covering the precedence resolver, gating off→open, on+entitled→200, on+not-entitled→403, and baseline CRUD/health always-on.
- `cd objectified-db && yarn test` — structural seed-migration test.
- Manual: set `OBJECTIFIED_PRIMITIVES_REGISTRY_GATING=true`, assign a tenant a **Free** license (no `primitives-registry`), then **call `GET /v1/types/{slug}/stats`** → expect `403`; **call `GET /v1/primitives/{slug}`** → expect `200`. Grant the flag via the admin panel → advanced route now `200`.

## Risk / notes
- **Default off** ⇒ zero behavior change until an operator opts in; existing primitives/types tests pass unchanged (261 passed).
- API keys without an attributed user resolve entitlement via the **tenant-level** override only (license/user layers need a user id) — documented in `tenant_has_feature_flag`.
- No UI code change: the seeded flag surfaces in the existing admin Feature-Flag panel automatically.
- Pre-existing unrelated failures in `test_merge_*` / `test_version_*` reproduce on `main` and are untouched by this change.

Work performed by Claude Code via model claude-opus-4-8[1m].