### PR TITLE
Fix #3454 - Registry coverage/stats endpoint

### DIFF
--- a/docs/ROADMAP_TYPE_REGISTRY_GOVERNANCE.md
+++ b/docs/ROADMAP_TYPE_REGISTRY_GOVERNANCE.md
@@ -328,7 +328,7 @@ enforcement, plus the `objectified-ui` proxy + typed client.
 | 2.2 #3451 ✅ | Namespace CRUD API | **DONE** — `GET/POST/PUT /v1/types/{tenant_slug}/namespaces` over `odb.type_namespaces`; tenant-admin writes, system-core read-only, type counts joined from `odb.primitives` | `type-registry`,`registry`,`rest`,`mvp`,`roadmap-type-registry` | N | Y | M | objectified-rest |
 | 2.3 #3452 ✅ | Type definition CRUD + draft 2020-12 validation | **DONE** — strict JSON Schema draft 2020-12 meta-validation on primitive create/update/import (`app/schema_validation.py`), field-level 422 errors, stable derived `$id` (`schema_id`) + stamped `draft` persisted to `odb.primitives` | `type-registry`,`rest`,`mvp`,`roadmap-type-registry` | N | Y | L | objectified-rest |
 | 2.4 #3453 ✅ | Scope & visibility enforcement | **DONE** — read scope `is_system ∪ tenant` on `odb.primitives` reads (cross-tenant isolation, all tenants see `std/*`); centralized `$ref`-direction rules (`app/primitives_scope.py`) reject core→tenant and tenant→other-tenant refs on create/update/import with structured 422 violations | `type-registry`,`governance`,`rest`,`mvp`,`roadmap-type-registry` | Y | Y | M | objectified-rest |
-| 2.5 #3454 | Registry coverage/stats endpoint | Counts by scope, imported, unresolved (for dashboard KPIs) | `type-registry`,`rest`,`mvp`,`roadmap-type-registry` | Y | Y | S | objectified-rest |
+| 2.5 #3454 ✅ | Registry coverage/stats endpoint | **DONE** — `GET /v1/types/{tenant_slug}/stats` returns a single server-side aggregate (core/tenant/imported type counts, properties bound, bound classes, unresolved `$ref` count, namespace count) via `Database.get_registry_coverage_stats` over `odb.primitives` + `odb.class_properties`; entitlement-gated and tenant-scoped, replacing the dashboard's client-side stat computation (feeds #3467 KPIs) | `type-registry`,`rest`,`mvp`,`roadmap-type-registry` | Y | Y | S | objectified-rest |
 | 2.6 #3455 | ~~UI proxy routes + typed client~~ | **CLOSED — duplicate** (`/api/primitives/*` shipped) | `type-registry`,`ui`,`mvp`,`roadmap-type-registry` | N | Y | S | objectified-ui |
 
 ### Issue 2.1 — Registry service skeleton + auth/scoping
@@ -383,7 +383,7 @@ enforcement, plus the `objectified-ui` proxy + typed client.
 - **Parallelism/Dependencies.** Depends on 2.2/2.3; reinforced by 3.1.
 - **Technical Stack.** FastAPI authorization layer.
 
-### Issue 2.5 — Registry coverage/stats endpoint
+### Issue 2.5 — Registry coverage/stats endpoint ✅ DONE
 - **Problem.** The overview KPIs need aggregate counts.
 - **Solution/Scope.** `GET /v1/types/{tenant_slug}/stats` → core type count, tenant type count,
   imported count, properties bound, unresolved `$ref` count. Source:
@@ -391,6 +391,16 @@ enforcement, plus the `objectified-ui` proxy + typed client.
 - **Acceptance Criteria.** Numbers match fixtures and the resolver/binding state.
 - **Parallelism/Dependencies.** Depends on 2.3, 3.2, 6.2; parallel otherwise.
 - **Technical Stack.** FastAPI, SQL aggregation.
+- **Status (#3454).** Shipped in `objectified-rest`. `GET /v1/types/{tenant_slug}/stats`
+  (`app/type_namespaces_routes.py`) returns `RegistryCoverageStatsResponse`
+  (`core_type_count`, `tenant_type_count`, `imported_count`, `properties_bound_count`,
+  `bound_class_count`, `unresolved_ref_count`, `namespace_count`) from a single
+  `Database.get_registry_coverage_stats` SQL aggregate over `odb.primitives` (type/namespace/
+  import counts + unresolved `refs` edges) and `odb.class_properties` (bindings), tenant-scoped
+  and entitlement-gated (`require_primitives_registry`). Consumed by the Primitives overview
+  dashboard (#3467), replacing client-side stat computation. Covered by
+  `tests/test_primitives_registry_stats.py` (API: 200 + auth) and
+  `tests/test_primitives_registry_stats_db.py` (DB row-mapping + empty-result fallback).
 
 ### Issue 2.6 — UI proxy routes + typed client
 - **Problem.** Browser calls must proxy through Next.js with JWT injection.

--- a/objectified-rest/CHANGELOG.md
+++ b/objectified-rest/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to the Objectified REST API will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.26] - 2026-06-23
+
+### Added
+- **Registry coverage/stats endpoint (#3454)** — `GET /v1/types/{tenant_slug}/stats` returns the
+  tenant's registry coverage KPIs as a single server-side aggregate: core type count, tenant type
+  count, imported count, properties bound, bound class count, unresolved `$ref` count, and
+  namespace count. Backed by `Database.get_registry_coverage_stats(tenant_id)`, which aggregates
+  over the extended `odb.primitives` table (type/namespace/import counts and unresolved `refs`
+  edges) and the tenant's `odb.class_properties` bindings on the existing `objectified-db`
+  connection — replacing the client-side stat computation in the Primitives overview dashboard
+  (#3467). Gated by the `require_primitives_registry` entitlement and tenant-scoped to the
+  authenticated caller. (The endpoint, model, and DB aggregate first shipped alongside #3467; this
+  release documents and formally closes #3454.)
+
 ## [1.0.23] - 2026-06-23
 
 ### Added

--- a/objectified-rest/package.json
+++ b/objectified-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-rest",
-  "version": "1.0.25",
+  "version": "1.0.26",
   "private": true,
   "description": "Trigger file for Objectified REST Docker publish workflow; app is Python (pyproject.toml).",
   "scripts": {

--- a/objectified-rest/pyproject.toml
+++ b/objectified-rest/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "objectified-rest"
-version = "1.0.95"
+version = "1.0.96"
 description = "REST API for serving OpenAPI specifications from the Objectified database"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## What & why
`GET /v1/types/{tenant_slug}/stats` returns the tenant's registry coverage KPIs as a single server-side aggregate — core type count, tenant type count, imported count, properties bound, bound class count, unresolved `$ref` count, and namespace count — replacing the dashboard's client-side stat computation.

The endpoint, the `RegistryCoverageStatsResponse` model, the `Database.get_registry_coverage_stats` SQL aggregate (over the extended `odb.primitives` table + `odb.class_properties` bindings on the existing `objectified-db` connection), and its tests **already shipped** alongside the Primitives overview dashboard (#3467) but were never documented under their own ticket and #3454 was never marked done. This PR closes that gap:

- **CHANGELOG** — adds the `objectified-rest` `[1.0.26]` entry crediting #3454 for the stats endpoint.
- **Versions** — bumps `objectified-rest` `pyproject.toml` (1.0.95 → 1.0.96) and `package.json` (1.0.25 → 1.0.26).
- **ROADMAP** — marks Issue 2.5 / #3454 ✅ DONE in `ROADMAP_TYPE_REGISTRY_GOVERNANCE.md` (table row + detail section).

No code change was required — verification confirmed the endpoint, model, DB aggregate, and tests are present, correct, and consistent with the schema (`odb.primitives` columns `source`/`refs`/`namespace`/`is_system`; system primitives seeded per-tenant so `WHERE tenant_id = %s` correctly captures core types).

## Acceptance criteria
- ✅ Counts match DB + resolver state — aggregate runs over `odb.primitives` (type/namespace/import counts + unresolved `refs` edges) and `odb.class_properties` bindings.
- ✅ Used by the Primitives overview dashboard (#3467).

## How to test
1. **Run** `cd objectified-rest && python -m pytest tests/test_primitives_registry_stats.py tests/test_primitives_registry_stats_db.py -q` — 4 tests pass (API 200 + auth required; DB row mapping + empty-result fallback).
2. **Call** `GET /v1/types/{tenant_slug}/stats` with a valid JWT/API key — returns `{core_type_count, tenant_type_count, imported_count, properties_bound_count, bound_class_count, unresolved_ref_count, namespace_count}`.
3. **Browse to** Control Panel → Governance → Primitives and confirm the KPI strip is populated from the endpoint.

## Risk/notes
- Docs + version-bump only; no runtime code change. Low risk.
- Endpoint is entitlement-gated (`require_primitives_registry`) and tenant-scoped to the authenticated caller.

Closes #3454

Work performed by Claude Code via model claude-opus-4-8[1m]