### PR TITLE
Fix #3498 - Accept OpenAPI 3.2.0 documents (lift version gate + route to importer)

### DIFF
--- a/objectified-rest/package.json
+++ b/objectified-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-rest",
-  "version": "1.0.26",
+  "version": "1.0.27",
   "private": true,
   "description": "Trigger file for Objectified REST Docker publish workflow; app is Python (pyproject.toml).",
   "scripts": {

--- a/objectified-rest/pyproject.toml
+++ b/objectified-rest/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "objectified-rest"
-version = "1.0.96"
+version = "1.0.97"
 description = "REST API for serving OpenAPI specifications from the Objectified database"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/objectified-rest/tests/test_detected_kind_openapi_3_2.py
+++ b/objectified-rest/tests/test_detected_kind_openapi_3_2.py
@@ -1,0 +1,32 @@
+"""Scanner verification for OA1 (#3498) — OpenAPI 3.2 files are still classified.
+
+``detected_kind_from_path`` keys on the filename, not the document version, so an
+OpenAPI 3.2.0 file is expected to yield ``openapi-candidate`` with no code change.
+This test pins that behaviour so a future filename-classification change does not
+silently drop 3.2 specs before they reach the importer.
+"""
+
+import pytest
+
+from app.repository_file_scan import detected_kind_from_path
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "openapi.yaml",
+        "openapi.yml",
+        "openapi.json",
+        "api/openapi-3.2.0.yaml",
+        "specs/my-openapi.json",
+        "swagger.yaml",
+    ],
+)
+def test_openapi_filenames_are_candidates_regardless_of_version(path: str) -> None:
+    # Filename-only classification: version (3.0/3.1/3.2) is irrelevant here.
+    assert detected_kind_from_path(path) == "openapi-candidate"
+
+
+def test_non_openapi_filenames_are_not_openapi_candidates() -> None:
+    assert detected_kind_from_path("arazzo.yaml") == "arazzo-candidate"
+    assert detected_kind_from_path("README.md") is None

--- a/objectified-ui/examples/openapi/32-openapi-3.2.0-minimal.yaml
+++ b/objectified-ui/examples/openapi/32-openapi-3.2.0-minimal.yaml
@@ -1,0 +1,68 @@
+# Minimal OpenAPI 3.2.0 document (OA1, #3498).
+# Used to prove a 3.2.0 spec is accepted and routed to the importer, producing the
+# same classes/properties a 3.1 equivalent would. Only 3.1-compatible constructs are
+# used here; transforming new 3.2 keywords is out of scope for OA1 (OA2–OA6).
+openapi: 3.2.0
+info:
+  title: Minimal 3.2.0 API
+  version: 1.0.0
+  description: A minimal OpenAPI 3.2.0 document for import acceptance tests.
+servers:
+  - url: https://api.example.com
+paths:
+  /widgets:
+    get:
+      operationId: listWidgets
+      summary: List widgets
+      tags:
+        - widgets
+      responses:
+        '200':
+          description: A list of widgets
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Widget'
+    post:
+      operationId: createWidget
+      summary: Create a widget
+      tags:
+        - widgets
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Widget'
+      responses:
+        '201':
+          description: The created widget
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Widget'
+components:
+  securitySchemes:
+    apiKey:
+      type: apiKey
+      in: header
+      name: X-API-Key
+  schemas:
+    Widget:
+      type: object
+      description: A simple widget.
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: string
+          description: Unique widget identifier.
+        name:
+          type: string
+          description: Human-readable widget name.
+        quantity:
+          type: integer
+          description: Number of widgets in stock.

--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.134",
+  "version": "0.11.135",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/src/app/utils/openapi-analyzer.ts
+++ b/objectified-ui/src/app/utils/openapi-analyzer.ts
@@ -248,6 +248,42 @@ interface FormatDetectionResult {
 }
 
 /**
+ * Highest OpenAPI 3.x minor version this importer recognizes and routes natively (OA1, #3498).
+ *
+ * 3.0 → converted to 3.1; 3.1 / 3.2 → imported natively. Newer 3.x minors are still accepted
+ * (routed to the importer at OpenAPI 3.1 fidelity) but flagged with a non-blocking warning so
+ * they degrade gracefully as the OpenAPI spec evolves instead of being hard-rejected.
+ */
+export const MAX_KNOWN_OPENAPI_MINOR = 2;
+
+/**
+ * Classification of an OpenAPI `openapi` version string.
+ */
+export interface OpenAPIVersionClassification {
+  /** The 3.x minor version number, or null when the version is not in the 3.x line. */
+  minor: number | null;
+  /** Whether the version is part of the OpenAPI 3.x line (e.g. 3.0, 3.1, 3.2, 3.9). */
+  isThreeX: boolean;
+  /** Whether the 3.x minor is within the recognized range (<= MAX_KNOWN_OPENAPI_MINOR). */
+  isKnownMinor: boolean;
+}
+
+/**
+ * Classify an OpenAPI `openapi` version string into its 3.x minor and support tier (OA1, #3498).
+ *
+ * @param version - the raw `openapi` field value (e.g. "3.2.0").
+ * @returns the parsed minor number plus 3.x / known-minor flags. Non-3.x and malformed
+ *   versions yield `{ minor: null, isThreeX: false, isKnownMinor: false }`.
+ */
+export function classifyOpenAPIVersion(version: string): OpenAPIVersionClassification {
+  const match = typeof version === 'string' ? /^3\.(\d+)/.exec(version.trim()) : null;
+  const minor = match ? parseInt(match[1], 10) : null;
+  const isThreeX = minor !== null;
+  const isKnownMinor = minor !== null && minor <= MAX_KNOWN_OPENAPI_MINOR;
+  return { minor, isThreeX, isKnownMinor };
+}
+
+/**
  * Detect specification format and version
  */
 function detectFormat(doc: any): FormatDetectionResult {
@@ -294,13 +330,18 @@ function detectFormat(doc: any): FormatDetectionResult {
   // OpenAPI 3.x
   if (doc.openapi) {
     const version = doc.openapi;
-    // OpenAPI 3.0.x and 3.1.x are supported (3.0.x is converted to 3.1.x)
-    const isSupported = version.startsWith('3.0') || version.startsWith('3.1');
+    const { minor, isThreeX, isKnownMinor } = classifyOpenAPIVersion(version);
+    // Any 3.x document is accepted (OA1, #3498). 3.0.x is converted to 3.1.x; 3.1.x / 3.2.x
+    // import natively. Unknown future 3.x minors are accepted at OpenAPI 3.1 fidelity rather
+    // than hard-rejected, so the importer degrades gracefully as the spec evolves.
+    const isSupported = isThreeX;
     let displayName = `OpenAPI ${version}`;
 
-    if (version.startsWith('3.0')) {
+    if (minor === 0) {
       displayName = `OpenAPI ${version} (will be converted to OpenAPI 3.1.x)`;
-    } else if (!isSupported) {
+    } else if (isThreeX && !isKnownMinor) {
+      displayName = `OpenAPI ${version} (unrecognized 3.x minor — imported at OpenAPI 3.1 fidelity)`;
+    } else if (!isThreeX) {
       displayName = `OpenAPI ${version} (unsupported version)`;
     }
 
@@ -1215,19 +1256,38 @@ function findWarnings(doc: any): AnalysisIssue[] {
   const warnings: AnalysisIssue[] = [];
   const schemas = doc.components?.schemas || doc.definitions || {};
 
-  // Check for unsupported OpenAPI versions
-  if (doc.openapi && !doc.openapi.startsWith('3.1')) {
-    if (doc.openapi.startsWith('3.0')) {
+  // Check OpenAPI version handling (OA1, #3498). 3.1.x is native and produces no warning.
+  if (doc.openapi) {
+    const { minor, isThreeX, isKnownMinor } = classifyOpenAPIVersion(doc.openapi);
+    if (minor === 0) {
+      // 3.0.x: converted to 3.1.x for import.
       warnings.push({
         type: 'warning',
         message: `OpenAPI ${doc.openapi} was automatically converted to OpenAPI 3.1.x format for import.`,
         path: 'openapi',
         severity: 'low'
       });
-    } else {
+    } else if (isThreeX && minor !== null && minor > 1 && isKnownMinor) {
+      // 3.2.x (recognized post-3.1 minor): accepted and normalized for import — informational only.
       warnings.push({
         type: 'warning',
-        message: `OpenAPI ${doc.openapi} is not supported. Please upgrade to OpenAPI 3.0.x or 3.1.x.`,
+        message: `OpenAPI ${doc.openapi} was normalized to OpenAPI 3.1 fidelity for import. Newer 3.2 keywords are accepted but not yet transformed.`,
+        path: 'openapi',
+        severity: 'low'
+      });
+    } else if (isThreeX && !isKnownMinor) {
+      // Unknown future 3.x minor (e.g. 3.9.0): non-blocking warning, not a hard error.
+      warnings.push({
+        type: 'warning',
+        message: `OpenAPI ${doc.openapi} is newer than the recognized 3.${MAX_KNOWN_OPENAPI_MINOR}.x range; it was accepted and imported at OpenAPI 3.1 fidelity. Some newer features may not be fully represented.`,
+        path: 'openapi',
+        severity: 'medium'
+      });
+    } else if (!isThreeX) {
+      // Non-3.x (e.g. 4.0.0): unsupported.
+      warnings.push({
+        type: 'warning',
+        message: `OpenAPI ${doc.openapi} is not supported. Please use OpenAPI 3.0.x, 3.1.x, or 3.2.x.`,
         path: 'openapi',
         severity: 'high'
       });

--- a/objectified-ui/tests/openapi-3.2-accept.test.ts
+++ b/objectified-ui/tests/openapi-3.2-accept.test.ts
@@ -1,0 +1,134 @@
+/**
+ * OA1 (#3498) — Accept OpenAPI 3.2.0 documents.
+ *
+ * Verifies the version gate was lifted so 3.2.0 documents are accepted and routed to the
+ * importer (importing at least at 3.1 fidelity), that the analyzer reports them as supported,
+ * and that unknown future 3.x minors degrade to a non-blocking warning instead of a hard error.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { parseOpenAPISpec } from '../src/app/utils/openapi-import';
+import {
+  analyzeSpecification,
+  classifyOpenAPIVersion,
+  MAX_KNOWN_OPENAPI_MINOR,
+} from '../src/app/utils/openapi-analyzer';
+
+const examplePath = path.join(__dirname, '../examples/openapi/32-openapi-3.2.0-minimal.yaml');
+const example32 = fs.readFileSync(examplePath, 'utf-8');
+
+describe('classifyOpenAPIVersion (OA1 #3498)', () => {
+  it('classifies 3.0.x as a known 3.x minor 0', () => {
+    expect(classifyOpenAPIVersion('3.0.0')).toEqual({ minor: 0, isThreeX: true, isKnownMinor: true });
+    expect(classifyOpenAPIVersion('3.0.3')).toEqual({ minor: 0, isThreeX: true, isKnownMinor: true });
+  });
+
+  it('classifies 3.1.x as a known 3.x minor 1', () => {
+    expect(classifyOpenAPIVersion('3.1.0')).toEqual({ minor: 1, isThreeX: true, isKnownMinor: true });
+  });
+
+  it('classifies 3.2.0 as a known 3.x minor 2', () => {
+    expect(classifyOpenAPIVersion('3.2.0')).toEqual({ minor: 2, isThreeX: true, isKnownMinor: true });
+  });
+
+  it('classifies an unknown future 3.x minor as 3.x but not a known minor', () => {
+    expect(classifyOpenAPIVersion('3.9.0')).toEqual({ minor: 9, isThreeX: true, isKnownMinor: false });
+    expect(classifyOpenAPIVersion(`3.${MAX_KNOWN_OPENAPI_MINOR + 1}.0`)).toEqual({
+      minor: MAX_KNOWN_OPENAPI_MINOR + 1,
+      isThreeX: true,
+      isKnownMinor: false,
+    });
+  });
+
+  it('classifies non-3.x and malformed versions as not 3.x', () => {
+    expect(classifyOpenAPIVersion('4.0.0')).toEqual({ minor: null, isThreeX: false, isKnownMinor: false });
+    expect(classifyOpenAPIVersion('2.0')).toEqual({ minor: null, isThreeX: false, isKnownMinor: false });
+    expect(classifyOpenAPIVersion('')).toEqual({ minor: null, isThreeX: false, isKnownMinor: false });
+    // @ts-expect-error exercising malformed (non-string) input is intentional
+    expect(classifyOpenAPIVersion(undefined)).toEqual({ minor: null, isThreeX: false, isKnownMinor: false });
+  });
+});
+
+describe('analyzeSpecification version gate (OA1 #3498)', () => {
+  function docWith(version: string) {
+    return JSON.stringify({
+      openapi: version,
+      info: { title: 'T', version: '1.0.0' },
+      paths: {},
+      components: { schemas: { Foo: { type: 'object', properties: { a: { type: 'string' } } } } },
+    });
+  }
+
+  it('reports 3.2.0 as a supported OpenAPI format with a display name noting 3.2.0', async () => {
+    const result = await analyzeSpecification(docWith('3.2.0'), 'openapi-3.2.json');
+    expect(result.format).toBe('openapi');
+    expect(result.formatSupported).toBe(true);
+    expect(result.version).toBe('3.2.0');
+    expect(result.formatDisplayName).toContain('3.2.0');
+  });
+
+  it('does not emit a high-severity "not supported" warning for 3.2.0', async () => {
+    const result = await analyzeSpecification(docWith('3.2.0'), 'openapi-3.2.json');
+    const blocking = result.warnings.filter(
+      (w) => w.path === 'openapi' && w.severity === 'high',
+    );
+    expect(blocking).toHaveLength(0);
+    // It should instead carry a low-severity "normalized for import" note.
+    const note = result.warnings.find((w) => w.path === 'openapi');
+    expect(note?.severity).toBe('low');
+    expect(note?.message.toLowerCase()).toContain('normalized');
+  });
+
+  it.each(['3.0.0', '3.1.0', '3.2.0'])('treats %s as supported', async (version) => {
+    const result = await analyzeSpecification(docWith(version), 'openapi.json');
+    expect(result.formatSupported).toBe(true);
+  });
+
+  it('degrades an unknown future 3.x version to a non-blocking warning, not a hard error', async () => {
+    const result = await analyzeSpecification(docWith('3.9.0'), 'openapi-3.9.json');
+    expect(result.format).toBe('openapi');
+    // Accepted (not hard-rejected at the format gate).
+    expect(result.formatSupported).toBe(true);
+    // No critical errors introduced by the version.
+    const versionErrors = result.errors.filter((e) => e.severity === 'critical');
+    expect(versionErrors).toHaveLength(0);
+    // Non-blocking warning is present and is not high severity.
+    const note = result.warnings.find((w) => w.path === 'openapi');
+    expect(note).toBeDefined();
+    expect(note?.severity).not.toBe('high');
+  });
+
+  it('still flags a non-3.x version (e.g. 4.0.0) as unsupported', async () => {
+    const result = await analyzeSpecification(docWith('4.0.0'), 'openapi-4.json');
+    expect(result.formatSupported).toBe(false);
+    const note = result.warnings.find((w) => w.path === 'openapi');
+    expect(note?.severity).toBe('high');
+  });
+});
+
+describe('parseOpenAPISpec routes 3.2.0 through the importer (OA1 #3498)', () => {
+  it('imports the minimal 3.2.0 example successfully (not the JSON-Schema fallback)', () => {
+    const result = parseOpenAPISpec(example32);
+    expect(result.success).toBe(true);
+    expect(result.error).toBeUndefined();
+
+    const widget = result.classes.find((c) => c.name === 'Widget');
+    expect(widget).toBeDefined();
+    const propNames = widget?.properties.map((p) => p.name) ?? [];
+    expect(propNames).toEqual(expect.arrayContaining(['id', 'name', 'quantity']));
+
+    // Operations/paths and security schemes survive (would be lost via the JSON-Schema bag fallback).
+    expect(result.paths?.length).toBeGreaterThan(0);
+    expect(result.securitySchemes?.some((s) => s.scheme_name === 'apiKey')).toBe(true);
+  });
+
+  it('produces the same classes/properties as the 3.1 equivalent', () => {
+    const result32 = parseOpenAPISpec(example32);
+    const result31 = parseOpenAPISpec(example32.replace('openapi: 3.2.0', 'openapi: 3.1.0'));
+
+    const classes32 = result32.classes.map((c) => ({ name: c.name, props: c.properties.map((p) => p.name).sort() }));
+    const classes31 = result31.classes.map((c) => ({ name: c.name, props: c.properties.map((p) => p.name).sort() }));
+    expect(classes32).toEqual(classes31);
+  });
+});


### PR DESCRIPTION
## What & why (OA1, epic #3497)

OpenAPI **3.2.0** documents were hard-rejected before reaching the importer: the analyzer only treated a version as supported when it started with `3.0` or `3.1`. This lifts the version gate so any OpenAPI **3.x** document is accepted and routed to the importer, importing at least at 3.1 fidelity. Transforming the new 3.2 keywords is intentionally **out of scope** (OA2–OA6); this only guarantees a 3.2.0 doc is accepted and routed.

### Changes
- **`openapi-analyzer.ts`**
  - New `MAX_KNOWN_OPENAPI_MINOR` constant + exported `classifyOpenAPIVersion()` helper (single source of truth for the version tier).
  - `detectFormat()`: any 3.x is `supported: true`. 3.0 → "will be converted"; 3.2 → native; unknown future 3.x → display name notes 3.1-fidelity import; non-3.x → unsupported.
  - `findWarnings()`: 3.0 = low (converted), 3.2 = low (normalized for import, informational), unknown future 3.x = medium (non-blocking), non-3.x = high (unsupported). 3.1 emits no version warning.
- **Routing** — verified unchanged and already version-agnostic: `openapi-import.ts` routes any 3.x through `parseOpenAPISpecInternal` (a 3.2 doc never hits the JSON-Schema fallback because `isJsonSchema()` returns false for any doc with an `openapi` field); `mapSourceKind()` already maps `openapi-3`/`openapi` regardless of version.
- **REST scanner** — `detected_kind_from_path()` is filename-based, so 3.2 files already classify as `openapi-candidate`; pinned with a test (no code change).
- New 3.2.0 example fixture; semver patch bumps for `objectified-ui` and `objectified-rest`.

## How to test
- **`cd objectified-ui && yarn jest openapi --no-coverage`** — 170+ tests pass, including the new `tests/openapi-3.2-accept.test.ts` (14 tests covering the 3.0/3.1/3.2/unknown-3.x/non-3.x boundaries, supported flags, warning severities, and a 3.2-vs-3.1 class/property equivalence check).
- **`cd objectified-rest && .venv/bin/python -m pytest tests/test_detected_kind_openapi_3_2.py -q`** — scanner classification test passes.
- Manually: analyze/import `objectified-ui/examples/openapi/32-openapi-3.2.0-minimal.yaml` — imports the `Widget` class (`id`, `name`, `quantity`), paths, and the `apiKey` security scheme; analyzer reports `format: openapi`, `supported: true`, display name noting `3.2.0`.

## Risk / notes
- Low risk: version-predicate widening only; non-3.x specs still reported unsupported; 3.1 behavior unchanged.
- No new lint errors (pre-existing `no-explicit-any` count unchanged) and `tsc --noEmit` is clean.
- Acceptance criteria for 3.2 keyword transformation are deferred to OA2–OA6 per the issue scope.

Closes #3498

Work performed by Claude Code via model claude-opus-4-8[1m]