### PR TITLE
Fix #3499 - OpenAPI 3.2.0 → 3.1.x normalization layer for import (OA2)

### DIFF
--- a/objectified-ui/package.json
+++ b/objectified-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "objectified-ui",
-  "version": "0.11.135",
+  "version": "0.11.136",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/objectified-ui/src/app/utils/openapi-analyzer.ts
+++ b/objectified-ui/src/app/utils/openapi-analyzer.ts
@@ -8,6 +8,7 @@ import { convertSwaggerToOpenAPI, isSwagger2 } from './swagger-converter';
 import { convertJsonSchemaToOpenAPI, isJsonSchema } from './jsonschema-converter';
 import { convertGraphQLToOpenAPI, isGraphQL, isGraphQLIntrospection, convertGraphQLIntrospectionToOpenAPI } from './graphql-converter';
 import { convertOpenAPI30ToOpenAPI31, isOpenAPI30 } from './openapi30-converter';
+import { convertOpenAPI32ToOpenAPI31, isOpenAPI32, OpenAPI32UnsupportedConstruct } from './openapi32-converter';
 import { convertAsyncAPIToOpenAPI, isAsyncAPI } from './asyncapi-converter';
 import { convertRAMLToOpenAPI, isRAML } from './raml-converter';
 import { convertProtobufToOpenAPI, isProtobuf } from './protobuf-converter';
@@ -1465,6 +1466,20 @@ function identifyDeprecatedConstructs(doc: any): UnsupportedFeature[] {
 }
 
 /**
+ * Map a carried-forward OpenAPI 3.2 construct (OA2, #3499) to the analyzer's
+ * unsupported-feature shape for the pre-import compatibility check.
+ */
+function toUnsupportedFeature(construct: OpenAPI32UnsupportedConstruct): UnsupportedFeature {
+  return {
+    id: `openapi32-${construct.id}`,
+    label: construct.label,
+    description: construct.description,
+    count: construct.count,
+    severity: construct.severity
+  };
+}
+
+/**
  * Identify features in the specification that are not or only partially supported by the import.
  * Used for pre-import compatibility check (#573).
  */
@@ -1683,6 +1698,9 @@ export async function analyzeSpecification(fileContent: string, fileName: string
 
   let doc = parseResult.data;
   let conversionWarnings: AnalysisIssue[] = [];
+  // 3.2-only constructs carried forward by the OA2 normalization layer (#3499),
+  // surfaced as unsupported features for the pre-import compatibility check.
+  let openapi32Constructs: UnsupportedFeature[] = [];
 
   // Convert Swagger 2.x to OpenAPI 3.1.x if needed
   if (isSwagger2(doc)) {
@@ -1779,6 +1797,25 @@ export async function analyzeSpecification(fileContent: string, fileName: string
         severity: 'low' as const
       }))
     ];
+  }
+
+  // Normalize OpenAPI 3.2.0 for the pre-import compatibility check (OA2, #3499).
+  // The doc is left as-is (so the version display and OA1 version note are preserved);
+  // the converter is run only to collect the 3.2-only constructs it would carry forward,
+  // which are surfaced below as unsupported features.
+  if (isOpenAPI32(doc)) {
+    const conversionResult = convertOpenAPI32ToOpenAPI31(doc);
+    if (conversionResult.success) {
+      openapi32Constructs = conversionResult.unsupportedConstructs.map(toUnsupportedFeature);
+      conversionWarnings = [
+        ...conversionWarnings,
+        ...conversionResult.warnings.map(warning => ({
+          type: 'warning' as const,
+          message: warning,
+          severity: 'low' as const
+        }))
+      ];
+    }
   }
 
   // Convert Apache Avro (.avsc) to OpenAPI 3.1–like document for import (#239) — before JSON Schema so Avro records are not mistaken for JSON Schema
@@ -2211,7 +2248,8 @@ export async function analyzeSpecification(fileContent: string, fileName: string
   const allWarnings = [...conversionWarnings, ...warnings];
 
   // Identify unsupported features for import compatibility (#573)
-  const unsupportedFeatures = identifyUnsupportedFeatures(doc);
+  // Append any 3.2-only constructs carried forward by the OA2 normalization layer (#3499).
+  const unsupportedFeatures = [...identifyUnsupportedFeatures(doc), ...openapi32Constructs];
 
   return {
     isValid: validation.valid,

--- a/objectified-ui/src/app/utils/openapi-import.ts
+++ b/objectified-ui/src/app/utils/openapi-import.ts
@@ -11,6 +11,7 @@ import { convertSwaggerToOpenAPI, isSwagger2 } from './swagger-converter';
 import { convertJsonSchemaToOpenAPI, isJsonSchema } from './jsonschema-converter';
 import { convertGraphQLToOpenAPI, isGraphQL, isGraphQLIntrospection, convertGraphQLIntrospectionToOpenAPI } from './graphql-converter';
 import { convertOpenAPI30ToOpenAPI31, isOpenAPI30 } from './openapi30-converter';
+import { convertOpenAPI32ToOpenAPI31, isOpenAPI32 } from './openapi32-converter';
 import { convertRAMLToOpenAPI, isRAML } from './raml-converter';
 import { convertProtobufToOpenAPI, isProtobuf } from './protobuf-converter';
 import { convertAvroToOpenAPI, isAvroSchemaObject } from './avro-converter';
@@ -483,6 +484,39 @@ export function parseOpenAPISpec(specContent: string): OpenAPIParseResult {
         : [`Successfully converted from OpenAPI ${originalVersion} to OpenAPI 3.1.x`];
 
       // Continue with the converted spec
+      return parseOpenAPISpecInternal(spec, globalWarnings);
+    }
+
+    // Check for OpenAPI 3.2.0 and normalize to 3.1.x if needed (OA2, #3499).
+    // Runs after the OA1 routing decision (3.2.x is accepted) so 3.2-only constructs
+    // are transformed/stashed rather than silently dropped by the 3.1 importer.
+    if (isOpenAPI32(spec)) {
+      const originalVersion = spec.openapi || '3.2.0';
+      const conversionResult = convertOpenAPI32ToOpenAPI31(spec);
+
+      if (!conversionResult.success) {
+        return {
+          success: false,
+          classes: [],
+          warnings: conversionResult.warnings,
+          error: `OpenAPI 3.2 conversion failed: ${conversionResult.error}`
+        };
+      }
+
+      // Use the normalized spec.
+      spec = conversionResult.document;
+
+      // Surface conversion notes plus any carried-forward 3.2-only constructs.
+      const constructNotes = conversionResult.unsupportedConstructs.map(
+        (c) => `${c.label}: ${c.description} (${c.count} occurrence${c.count === 1 ? '' : 's'})`
+      );
+      const globalWarnings = [
+        `Normalized OpenAPI ${originalVersion} to OpenAPI 3.1.x for import`,
+        ...conversionResult.warnings,
+        ...constructNotes
+      ];
+
+      // Continue with the normalized spec.
       return parseOpenAPISpecInternal(spec, globalWarnings);
     }
 

--- a/objectified-ui/src/app/utils/openapi32-converter.ts
+++ b/objectified-ui/src/app/utils/openapi32-converter.ts
@@ -1,0 +1,622 @@
+/**
+ * OpenAPI 3.2.0 to OpenAPI 3.1.x Normalization Layer (OA2, #3499)
+ *
+ * Converts OpenAPI 3.2.0 specifications into a 3.1.x-shaped document that the
+ * existing 3.1 importer/analyzer can consume without re-parsing, mirroring the
+ * contract of {@link ./openapi30-converter.ts}.
+ *
+ * The converter does three things with 3.2-only / changed constructs:
+ *
+ *  1. **Transform (safe / lossless)** — normalizations that the 3.1 importer can
+ *     consume directly:
+ *       - `example` (deprecated on Media Type / Parameter in 3.2) folded into the
+ *         `examples` map; the deprecation is surfaced as an informational warning.
+ *       - XML Object `nodeType` (which replaces the legacy boolean `attribute`)
+ *         mapped back to the legacy `attribute` field where there is an equivalent.
+ *
+ *  2. **Preserve (lossless, already valid in 3.1)** — constructs that are valid in
+ *     3.1 and simply carried through:
+ *       - `summary` / `description` siblings on a `$ref` (Reference Object metadata,
+ *         added in 3.1). Recorded for OA6 so it can attach them to resolved nodes.
+ *
+ *  3. **Stash (owned by OA3–OA6)** — 3.2-only constructs that the importer does not
+ *     understand yet. Instead of being silently dropped they are carried forward on
+ *     `x-objectified-*` extensions (or left in place where harmless) and reported in
+ *     {@link OpenAPI32ConversionResult.unsupportedConstructs} so the downstream
+ *     issues can light them up incrementally without re-parsing:
+ *       - `additionalOperations` and the `QUERY` HTTP method (OA4).
+ *       - sequential media types / `itemSchema` (OA3).
+ *       - `tags[].summary` / `parent` / `kind` (OA5).
+ *
+ * The emitted document carries `openapi: '3.1.0'` so the downstream importer treats
+ * it natively as 3.1.
+ */
+
+/**
+ * The roadmap issue that owns the follow-up handling for a carried-forward construct.
+ */
+export type OpenAPI32ConstructOwner = 'OA3' | 'OA4' | 'OA5' | 'OA6';
+
+/**
+ * A 3.2-only construct that was carried forward (transformed, preserved, or stashed)
+ * rather than silently dropped, so a downstream issue can act on it later.
+ */
+export interface OpenAPI32UnsupportedConstruct {
+  /** Stable identifier (e.g. `additional-operations`). */
+  id: string;
+  /** Short human-readable label. */
+  label: string;
+  /** Explanation of what was carried forward and how. */
+  description: string;
+  /** Roadmap issue that owns the follow-up handling. */
+  ownedBy: OpenAPI32ConstructOwner;
+  /** Number of occurrences found in the document. */
+  count: number;
+  /** Severity for surfacing in the analyzer's unsupported-features list. */
+  severity: 'warning' | 'info';
+}
+
+/**
+ * Result of an OpenAPI 3.2.0 to 3.1.x conversion.
+ */
+export interface OpenAPI32ConversionResult {
+  /** Whether the conversion succeeded. */
+  success: boolean;
+  /** The converted 3.1.x-shaped document (null on failure). */
+  document: any;
+  /** Error message when {@link success} is false. */
+  error?: string;
+  /** Informational/transformation notes (e.g. deprecation notices). */
+  warnings: string[];
+  /** 3.2-only constructs carried forward for downstream issues (OA3–OA6). */
+  unsupportedConstructs: OpenAPI32UnsupportedConstruct[];
+}
+
+/**
+ * Mutable bookkeeping passed through the recursive walk so warnings and
+ * carried-forward constructs accumulate in one place.
+ */
+interface ConversionContext {
+  warnings: string[];
+  /** Carried-forward constructs keyed by id so counts aggregate. */
+  constructs: Map<string, OpenAPI32UnsupportedConstruct>;
+}
+
+/** HTTP methods recognized as operations by the 3.1 importer. */
+const KNOWN_OPERATIONS = ['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace'] as const;
+
+/**
+ * Check if a document is OpenAPI 3.2.x.
+ *
+ * @param doc - the parsed document to inspect.
+ * @returns true when the document declares an `openapi` version in the 3.2 line.
+ */
+export function isOpenAPI32(doc: any): boolean {
+  if (!doc || typeof doc !== 'object') {
+    return false;
+  }
+  if (!doc.openapi || typeof doc.openapi !== 'string') {
+    return false;
+  }
+  return doc.openapi.startsWith('3.2');
+}
+
+/**
+ * Record a carried-forward construct, aggregating the occurrence count when the
+ * same construct id is seen more than once.
+ */
+function recordConstruct(
+  ctx: ConversionContext,
+  construct: Omit<OpenAPI32UnsupportedConstruct, 'count'> & { count?: number }
+): void {
+  const increment = construct.count ?? 1;
+  const existing = ctx.constructs.get(construct.id);
+  if (existing) {
+    existing.count += increment;
+    return;
+  }
+  ctx.constructs.set(construct.id, {
+    id: construct.id,
+    label: construct.label,
+    description: construct.description,
+    ownedBy: construct.ownedBy,
+    severity: construct.severity,
+    count: increment
+  });
+}
+
+/**
+ * Converts an OpenAPI 3.2.0 specification to OpenAPI 3.1.x format.
+ *
+ * @param openapi32Doc - the parsed OpenAPI 3.2.0 document.
+ * @returns the converted 3.1.x document plus conversion warnings and the list of
+ *   3.2-only constructs carried forward for downstream issues.
+ */
+export function convertOpenAPI32ToOpenAPI31(openapi32Doc: any): OpenAPI32ConversionResult {
+  const ctx: ConversionContext = { warnings: [], constructs: new Map() };
+
+  try {
+    // Validate input.
+    if (!openapi32Doc || typeof openapi32Doc !== 'object') {
+      return {
+        success: false,
+        document: null,
+        error: 'Invalid OpenAPI document: expected an object',
+        warnings: [],
+        unsupportedConstructs: []
+      };
+    }
+
+    if (!isOpenAPI32(openapi32Doc)) {
+      return {
+        success: false,
+        document: null,
+        error: `Invalid OpenAPI version: expected 3.2.x, got ${openapi32Doc.openapi}`,
+        warnings: [],
+        unsupportedConstructs: []
+      };
+    }
+
+    // Deep clone so the original document is never mutated.
+    const doc = JSON.parse(JSON.stringify(openapi32Doc));
+
+    // Downstream importer treats this as a native 3.1 document.
+    doc.openapi = '3.1.0';
+
+    // Tag metadata additions (summary/parent/kind) are owned by OA5.
+    if (Array.isArray(doc.tags)) {
+      convertTags(doc.tags, ctx);
+    }
+
+    // components.* objects.
+    if (doc.components?.schemas) {
+      doc.components.schemas = convertSchemaMap(doc.components.schemas, ctx, 'components.schemas');
+    }
+    if (doc.components?.parameters) {
+      doc.components.parameters = convertNamedMap(doc.components.parameters, ctx, 'components.parameters', convertParameter);
+    }
+    if (doc.components?.requestBodies) {
+      doc.components.requestBodies = convertNamedMap(doc.components.requestBodies, ctx, 'components.requestBodies', convertRequestBody);
+    }
+    if (doc.components?.responses) {
+      doc.components.responses = convertNamedMap(doc.components.responses, ctx, 'components.responses', convertResponse);
+    }
+    if (doc.components?.headers) {
+      doc.components.headers = convertNamedMap(doc.components.headers, ctx, 'components.headers', convertHeader);
+    }
+
+    // Paths.
+    if (doc.paths) {
+      doc.paths = convertPaths(doc.paths, ctx);
+    }
+
+    return {
+      success: true,
+      document: doc,
+      warnings: ctx.warnings,
+      unsupportedConstructs: Array.from(ctx.constructs.values())
+    };
+  } catch (error) {
+    return {
+      success: false,
+      document: null,
+      error: `Conversion failed: ${error instanceof Error ? error.message : String(error)}`,
+      warnings: ctx.warnings,
+      unsupportedConstructs: Array.from(ctx.constructs.values())
+    };
+  }
+}
+
+/**
+ * Normalize the `tags` array. The 3.2-only `summary`, `parent`, and `kind` fields
+ * are valid extra keys (the 3.1 importer ignores them) so they are preserved in
+ * place and reported for OA5 rather than dropped.
+ */
+function convertTags(tags: any[], ctx: ConversionContext): void {
+  let count = 0;
+  for (const tag of tags) {
+    if (!tag || typeof tag !== 'object') continue;
+    if (tag.summary !== undefined || tag.parent !== undefined || tag.kind !== undefined) {
+      count++;
+    }
+  }
+  if (count > 0) {
+    recordConstruct(ctx, {
+      id: 'tag-metadata',
+      label: 'Tag metadata (summary/parent/kind)',
+      description:
+        'OpenAPI 3.2 tag fields summary/parent/kind are preserved on the tag objects and carried forward for hierarchical tag support (OA5).',
+      ownedBy: 'OA5',
+      count,
+      severity: 'info'
+    });
+  }
+}
+
+/**
+ * Convert a `{ name: schema }` map of schemas.
+ */
+function convertSchemaMap(schemas: any, ctx: ConversionContext, path: string): any {
+  const result: any = {};
+  for (const [name, schema] of Object.entries<any>(schemas)) {
+    result[name] = convertSchema(schema, ctx, `${path}.${name}`);
+  }
+  return result;
+}
+
+/**
+ * Convert a `{ name: object }` map using the supplied per-entry converter.
+ */
+function convertNamedMap(
+  map: any,
+  ctx: ConversionContext,
+  path: string,
+  convertEntry: (entry: any, ctx: ConversionContext, path: string) => any
+): any {
+  const result: any = {};
+  for (const [name, entry] of Object.entries<any>(map)) {
+    result[name] = convertEntry(entry, ctx, `${path}.${name}`);
+  }
+  return result;
+}
+
+/**
+ * Convert a single schema. Recurses through nested schemas and maps the XML
+ * Object `nodeType` field. `$ref` nodes are passed through (their 3.1-valid
+ * summary/description siblings are preserved and recorded for OA6).
+ */
+function convertSchema(schema: any, ctx: ConversionContext, path: string): any {
+  if (!schema || typeof schema !== 'object') {
+    return schema;
+  }
+
+  // $ref node: preserve as-is. Reference Object summary/description siblings are
+  // valid in 3.1; record them so OA6 can attach them to the resolved node.
+  if (schema.$ref) {
+    if (schema.summary !== undefined || schema.description !== undefined) {
+      recordConstruct(ctx, {
+        id: 'ref-sibling-metadata',
+        label: '$ref sibling metadata (summary/description)',
+        description:
+          'summary/description siblings on a $ref are preserved and carried forward to be attached to the resolved node (OA6).',
+        ownedBy: 'OA6',
+        severity: 'info'
+      });
+    }
+    return { ...schema };
+  }
+
+  const converted: any = { ...schema };
+
+  // Map XML Object nodeType (3.2) back to the legacy boolean attribute (3.0/3.1).
+  if (converted.xml && typeof converted.xml === 'object') {
+    converted.xml = convertXmlObject(converted.xml, ctx, `${path}.xml`);
+  }
+
+  // Recurse into nested schemas.
+  if (converted.properties && typeof converted.properties === 'object') {
+    const props: any = {};
+    for (const [propName, propSchema] of Object.entries<any>(converted.properties)) {
+      props[propName] = convertSchema(propSchema, ctx, `${path}.properties.${propName}`);
+    }
+    converted.properties = props;
+  }
+
+  if (converted.items) {
+    converted.items = convertSchema(converted.items, ctx, `${path}.items`);
+  }
+
+  if (Array.isArray(converted.prefixItems)) {
+    converted.prefixItems = converted.prefixItems.map((s: any, i: number) =>
+      convertSchema(s, ctx, `${path}.prefixItems[${i}]`)
+    );
+  }
+
+  if (converted.additionalProperties && typeof converted.additionalProperties === 'object') {
+    converted.additionalProperties = convertSchema(
+      converted.additionalProperties,
+      ctx,
+      `${path}.additionalProperties`
+    );
+  }
+
+  for (const key of ['allOf', 'oneOf', 'anyOf'] as const) {
+    if (Array.isArray(converted[key])) {
+      converted[key] = converted[key].map((s: any, i: number) =>
+        convertSchema(s, ctx, `${path}.${key}[${i}]`)
+      );
+    }
+  }
+
+  if (converted.not) {
+    converted.not = convertSchema(converted.not, ctx, `${path}.not`);
+  }
+
+  return converted;
+}
+
+/**
+ * Map an XML Object's 3.2 `nodeType` back to legacy fields.
+ *
+ * 3.2 replaces the boolean `attribute` with a `nodeType` enum
+ * (`element` | `attribute` | `text` | `cdata` | `none`). `element` and
+ * `attribute` have legacy equivalents; the remaining values have none, so they
+ * are stashed on `x-objectified-xml-node-type` and reported for OA6.
+ */
+function convertXmlObject(xml: any, ctx: ConversionContext, path: string): any {
+  if (!xml || typeof xml !== 'object' || xml.nodeType === undefined) {
+    return xml;
+  }
+
+  const converted = { ...xml };
+  const nodeType = converted.nodeType;
+  delete converted.nodeType;
+
+  if (nodeType === 'attribute') {
+    converted.attribute = true;
+    ctx.warnings.push(`Mapped XML nodeType "attribute" to the legacy "attribute: true" field at ${path}.`);
+  } else if (nodeType === 'element') {
+    // `element` is the default; no legacy field needed.
+    ctx.warnings.push(`Mapped XML nodeType "element" to the default element representation at ${path}.`);
+  } else {
+    // text/cdata/none: no legacy equivalent. Stash so OA6 can act on it later.
+    converted['x-objectified-xml-node-type'] = nodeType;
+    recordConstruct(ctx, {
+      id: 'xml-node-type',
+      label: 'XML nodeType without a legacy equivalent',
+      description:
+        'XML Object nodeType values text/cdata/none have no OpenAPI 3.1 equivalent; they are stashed on x-objectified-xml-node-type and carried forward (OA6).',
+      ownedBy: 'OA6',
+      severity: 'info'
+    });
+  }
+
+  return converted;
+}
+
+/**
+ * Convert a Parameter Object: fold a deprecated singular `example` into the
+ * `examples` map and normalize its schema/content.
+ */
+function convertParameter(parameter: any, ctx: ConversionContext, path: string): any {
+  if (!parameter || typeof parameter !== 'object') {
+    return parameter;
+  }
+
+  const converted = { ...parameter };
+
+  foldExampleToExamples(converted, ctx, path);
+
+  if (converted.schema) {
+    converted.schema = convertSchema(converted.schema, ctx, `${path}.schema`);
+  }
+  if (converted.content) {
+    converted.content = convertContent(converted.content, ctx, `${path}.content`);
+  }
+
+  return converted;
+}
+
+/**
+ * Convert a Request Body Object.
+ */
+function convertRequestBody(requestBody: any, ctx: ConversionContext, path: string): any {
+  if (!requestBody || typeof requestBody !== 'object') {
+    return requestBody;
+  }
+  const converted = { ...requestBody };
+  if (converted.content) {
+    converted.content = convertContent(converted.content, ctx, `${path}.content`);
+  }
+  return converted;
+}
+
+/**
+ * Convert a Response Object.
+ */
+function convertResponse(response: any, ctx: ConversionContext, path: string): any {
+  if (!response || typeof response !== 'object') {
+    return response;
+  }
+  const converted = { ...response };
+  if (converted.content) {
+    converted.content = convertContent(converted.content, ctx, `${path}.content`);
+  }
+  if (converted.headers && typeof converted.headers === 'object') {
+    converted.headers = convertNamedMap(converted.headers, ctx, `${path}.headers`, convertHeader);
+  }
+  return converted;
+}
+
+/**
+ * Convert a Header Object: fold a deprecated singular `example` and normalize
+ * its schema/content.
+ */
+function convertHeader(header: any, ctx: ConversionContext, path: string): any {
+  if (!header || typeof header !== 'object') {
+    return header;
+  }
+  const converted = { ...header };
+  foldExampleToExamples(converted, ctx, path);
+  if (converted.schema) {
+    converted.schema = convertSchema(converted.schema, ctx, `${path}.schema`);
+  }
+  if (converted.content) {
+    converted.content = convertContent(converted.content, ctx, `${path}.content`);
+  }
+  return converted;
+}
+
+/**
+ * Convert a Content map (`{ mediaType: mediaTypeObject }`). Each Media Type Object
+ * has its deprecated `example` folded into `examples`, its schema normalized, and
+ * any `itemSchema` (sequential media types / streaming, OA3) stashed.
+ */
+function convertContent(content: any, ctx: ConversionContext, path: string): any {
+  if (!content || typeof content !== 'object') {
+    return content;
+  }
+
+  const result: any = {};
+  for (const [mediaType, mediaTypeObject] of Object.entries<any>(content)) {
+    if (!mediaTypeObject || typeof mediaTypeObject !== 'object') {
+      result[mediaType] = mediaTypeObject;
+      continue;
+    }
+
+    const mtPath = `${path}['${mediaType}']`;
+    const converted = { ...mediaTypeObject };
+
+    foldExampleToExamples(converted, ctx, mtPath);
+
+    if (converted.schema) {
+      converted.schema = convertSchema(converted.schema, ctx, `${mtPath}.schema`);
+    }
+
+    // itemSchema (3.2 sequential/streaming media types) — owned by OA3.
+    if (converted.itemSchema !== undefined) {
+      converted['x-objectified-item-schema'] = converted.itemSchema;
+      delete converted.itemSchema;
+      recordConstruct(ctx, {
+        id: 'item-schema',
+        label: 'Sequential media type itemSchema',
+        description:
+          'Media Type itemSchema (streaming / sequential media types) is stashed on x-objectified-item-schema and carried forward (OA3).',
+        ownedBy: 'OA3',
+        severity: 'warning'
+      });
+    }
+
+    result[mediaType] = converted;
+  }
+
+  return result;
+}
+
+/**
+ * Fold a deprecated singular `example` into the `examples` map on a Media Type,
+ * Parameter, or Header Object. A pre-existing `examples` map is left untouched
+ * (the singular `example` is simply removed). The deprecation is surfaced as an
+ * informational warning.
+ *
+ * Mutates `obj` in place.
+ */
+function foldExampleToExamples(obj: any, ctx: ConversionContext, path: string): void {
+  if (obj.example === undefined) {
+    return;
+  }
+
+  const exampleValue = obj.example;
+  delete obj.example;
+
+  if (obj.examples && typeof obj.examples === 'object') {
+    // Keep the richer examples map; just drop the redundant singular form.
+    ctx.warnings.push(
+      `The deprecated singular "example" at ${path} was dropped in favor of the existing "examples" map (OpenAPI 3.2).`
+    );
+    return;
+  }
+
+  obj.examples = { default: { value: exampleValue } };
+  ctx.warnings.push(
+    `Folded the deprecated singular "example" at ${path} into the "examples" map (OpenAPI 3.2).`
+  );
+}
+
+/**
+ * Convert the Paths Object.
+ */
+function convertPaths(paths: any, ctx: ConversionContext): any {
+  const result: any = {};
+  for (const [pathName, pathItem] of Object.entries<any>(paths)) {
+    result[pathName] = convertPathItem(pathItem, ctx, `paths['${pathName}']`);
+  }
+  return result;
+}
+
+/**
+ * Convert a Path Item Object. Standard operations are normalized in place; the
+ * 3.2-only `additionalOperations` map and the `QUERY` HTTP method are stashed on
+ * `x-objectified-*` extensions and carried forward for OA4.
+ */
+function convertPathItem(pathItem: any, ctx: ConversionContext, path: string): any {
+  if (!pathItem || typeof pathItem !== 'object') {
+    return pathItem;
+  }
+
+  const converted = { ...pathItem };
+
+  if (Array.isArray(converted.parameters)) {
+    converted.parameters = converted.parameters.map((param: any, i: number) =>
+      convertParameter(param, ctx, `${path}.parameters[${i}]`)
+    );
+  }
+
+  for (const op of KNOWN_OPERATIONS) {
+    if (converted[op]) {
+      converted[op] = convertOperation(converted[op], ctx, `${path}.${op}`);
+    }
+  }
+
+  // QUERY method (3.2) — not a known 3.1 operation key. Stash for OA4.
+  if (converted.query && typeof converted.query === 'object') {
+    converted['x-objectified-query-operation'] = convertOperation(converted.query, ctx, `${path}.query`);
+    delete converted.query;
+    recordConstruct(ctx, {
+      id: 'query-method',
+      label: 'QUERY HTTP method',
+      description:
+        'The OpenAPI 3.2 QUERY operation is stashed on x-objectified-query-operation and carried forward (OA4).',
+      ownedBy: 'OA4',
+      severity: 'warning'
+    });
+  }
+
+  // additionalOperations (3.2) — custom HTTP methods map. Stash for OA4.
+  if (converted.additionalOperations && typeof converted.additionalOperations === 'object') {
+    const additional: any = {};
+    for (const [method, operation] of Object.entries<any>(converted.additionalOperations)) {
+      additional[method] = convertOperation(operation, ctx, `${path}.additionalOperations.${method}`);
+    }
+    converted['x-objectified-additional-operations'] = additional;
+    delete converted.additionalOperations;
+    recordConstruct(ctx, {
+      id: 'additional-operations',
+      label: 'additionalOperations (custom HTTP methods)',
+      description:
+        'The OpenAPI 3.2 additionalOperations map is stashed on x-objectified-additional-operations and carried forward (OA4).',
+      ownedBy: 'OA4',
+      count: Object.keys(converted['x-objectified-additional-operations']).length,
+      severity: 'warning'
+    });
+  }
+
+  return converted;
+}
+
+/**
+ * Convert an Operation Object: parameters, request body, and responses.
+ */
+function convertOperation(operation: any, ctx: ConversionContext, path: string): any {
+  if (!operation || typeof operation !== 'object') {
+    return operation;
+  }
+
+  const converted = { ...operation };
+
+  if (Array.isArray(converted.parameters)) {
+    converted.parameters = converted.parameters.map((param: any, i: number) =>
+      convertParameter(param, ctx, `${path}.parameters[${i}]`)
+    );
+  }
+
+  if (converted.requestBody) {
+    converted.requestBody = convertRequestBody(converted.requestBody, ctx, `${path}.requestBody`);
+  }
+
+  if (converted.responses && typeof converted.responses === 'object') {
+    converted.responses = convertNamedMap(converted.responses, ctx, `${path}.responses`, convertResponse);
+  }
+
+  return converted;
+}

--- a/objectified-ui/tests/openapi32-converter.test.ts
+++ b/objectified-ui/tests/openapi32-converter.test.ts
@@ -1,0 +1,336 @@
+/**
+ * Tests for the OpenAPI 3.2.0 to 3.1.x normalization layer (OA2, #3499).
+ */
+
+import {
+  convertOpenAPI32ToOpenAPI31,
+  isOpenAPI32,
+  OpenAPI32ConversionResult
+} from '../src/app/utils/openapi32-converter';
+
+/** Minimal valid 3.2.0 envelope with the supplied body merged in. */
+function doc(body: Record<string, any>): any {
+  return {
+    openapi: '3.2.0',
+    info: { title: 'Test API', version: '1.0.0' },
+    ...body
+  };
+}
+
+describe('OpenAPI 3.2 to 3.1 normalization layer', () => {
+  describe('isOpenAPI32', () => {
+    it('detects 3.2.0', () => {
+      expect(isOpenAPI32({ openapi: '3.2.0' })).toBe(true);
+    });
+
+    it('detects 3.2.x minors', () => {
+      expect(isOpenAPI32({ openapi: '3.2.5' })).toBe(true);
+    });
+
+    it('does not detect 3.0.x / 3.1.x', () => {
+      expect(isOpenAPI32({ openapi: '3.0.0' })).toBe(false);
+      expect(isOpenAPI32({ openapi: '3.1.0' })).toBe(false);
+    });
+
+    it('does not detect Swagger or invalid documents', () => {
+      expect(isOpenAPI32({ swagger: '2.0' })).toBe(false);
+      expect(isOpenAPI32(null)).toBe(false);
+      expect(isOpenAPI32({})).toBe(false);
+    });
+  });
+
+  describe('convertOpenAPI32ToOpenAPI31 — guard rails', () => {
+    it('rewrites the version to 3.1.0', () => {
+      const result = convertOpenAPI32ToOpenAPI31(doc({ components: { schemas: {} } }));
+      expect(result.success).toBe(true);
+      expect(result.document.openapi).toBe('3.1.0');
+    });
+
+    it('rejects non-3.2 versions', () => {
+      const result = convertOpenAPI32ToOpenAPI31({ openapi: '3.1.0', info: { title: 'T', version: '1' } });
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('3.2.x');
+    });
+
+    it('rejects invalid input', () => {
+      const result = convertOpenAPI32ToOpenAPI31(null);
+      expect(result.success).toBe(false);
+      expect(result.error).toBeDefined();
+    });
+
+    it('does not mutate the input document', () => {
+      const input = doc({
+        paths: { '/a': { query: { responses: { '200': { description: 'ok' } } } } }
+      });
+      const snapshot = JSON.stringify(input);
+      convertOpenAPI32ToOpenAPI31(input);
+      expect(JSON.stringify(input)).toBe(snapshot);
+    });
+  });
+
+  describe('example -> examples normalization', () => {
+    it('folds a singular media type example into the examples map', () => {
+      const result = convertOpenAPI32ToOpenAPI31(
+        doc({
+          paths: {
+            '/pets': {
+              get: {
+                responses: {
+                  '200': {
+                    description: 'ok',
+                    content: {
+                      'application/json': {
+                        schema: { type: 'object' },
+                        example: { id: 1 }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        })
+      );
+
+      expect(result.success).toBe(true);
+      const media = result.document.paths['/pets'].get.responses['200'].content['application/json'];
+      expect(media.example).toBeUndefined();
+      expect(media.examples).toEqual({ default: { value: { id: 1 } } });
+      expect(result.warnings.some((w) => w.toLowerCase().includes('example'))).toBe(true);
+    });
+
+    it('folds a singular parameter example into the examples map', () => {
+      const result = convertOpenAPI32ToOpenAPI31(
+        doc({
+          components: {
+            parameters: {
+              Limit: { name: 'limit', in: 'query', schema: { type: 'integer' }, example: 10 }
+            }
+          }
+        })
+      );
+
+      const param = result.document.components.parameters.Limit;
+      expect(param.example).toBeUndefined();
+      expect(param.examples).toEqual({ default: { value: 10 } });
+    });
+
+    it('drops a redundant singular example when an examples map already exists', () => {
+      const result = convertOpenAPI32ToOpenAPI31(
+        doc({
+          components: {
+            parameters: {
+              Limit: {
+                name: 'limit',
+                in: 'query',
+                schema: { type: 'integer' },
+                example: 10,
+                examples: { ten: { value: 10 }, twenty: { value: 20 } }
+              }
+            }
+          }
+        })
+      );
+
+      const param = result.document.components.parameters.Limit;
+      expect(param.example).toBeUndefined();
+      expect(param.examples).toEqual({ ten: { value: 10 }, twenty: { value: 20 } });
+    });
+  });
+
+  describe('XML nodeType mapping', () => {
+    it('maps nodeType "attribute" to the legacy attribute: true field', () => {
+      const result = convertOpenAPI32ToOpenAPI31(
+        doc({
+          components: {
+            schemas: {
+              Pet: {
+                type: 'object',
+                properties: {
+                  id: { type: 'string', xml: { nodeType: 'attribute' } }
+                }
+              }
+            }
+          }
+        })
+      );
+
+      const xml = result.document.components.schemas.Pet.properties.id.xml;
+      expect(xml.nodeType).toBeUndefined();
+      expect(xml.attribute).toBe(true);
+    });
+
+    it('stashes nodeType values without a legacy equivalent and reports them for OA6', () => {
+      const result = convertOpenAPI32ToOpenAPI31(
+        doc({
+          components: {
+            schemas: {
+              Pet: {
+                type: 'object',
+                properties: {
+                  note: { type: 'string', xml: { nodeType: 'cdata' } }
+                }
+              }
+            }
+          }
+        })
+      );
+
+      const xml = result.document.components.schemas.Pet.properties.note.xml;
+      expect(xml.nodeType).toBeUndefined();
+      expect(xml['x-objectified-xml-node-type']).toBe('cdata');
+      const construct = result.unsupportedConstructs.find((c) => c.id === 'xml-node-type');
+      expect(construct).toBeDefined();
+      expect(construct?.ownedBy).toBe('OA6');
+    });
+  });
+
+  describe('$ref sibling metadata (OA6)', () => {
+    it('preserves summary/description siblings on a $ref and reports them', () => {
+      const result = convertOpenAPI32ToOpenAPI31(
+        doc({
+          components: {
+            schemas: {
+              Pet: {
+                type: 'object',
+                properties: {
+                  category: {
+                    $ref: '#/components/schemas/Category',
+                    summary: 'The pet category',
+                    description: 'A reference with metadata'
+                  }
+                }
+              }
+            }
+          }
+        })
+      );
+
+      const category = result.document.components.schemas.Pet.properties.category;
+      expect(category.$ref).toBe('#/components/schemas/Category');
+      expect(category.summary).toBe('The pet category');
+      expect(category.description).toBe('A reference with metadata');
+      expect(result.unsupportedConstructs.find((c) => c.id === 'ref-sibling-metadata')?.ownedBy).toBe('OA6');
+    });
+  });
+
+  describe('OA4 — additionalOperations and QUERY method', () => {
+    it('stashes additionalOperations on an extension and reports the count', () => {
+      const result = convertOpenAPI32ToOpenAPI31(
+        doc({
+          paths: {
+            '/pets': {
+              get: { responses: { '200': { description: 'ok' } } },
+              additionalOperations: {
+                PURGE: { responses: { '204': { description: 'purged' } } }
+              }
+            }
+          }
+        })
+      );
+
+      const pathItem = result.document.paths['/pets'];
+      expect(pathItem.additionalOperations).toBeUndefined();
+      expect(pathItem['x-objectified-additional-operations'].PURGE).toBeDefined();
+      const construct = result.unsupportedConstructs.find((c) => c.id === 'additional-operations');
+      expect(construct?.ownedBy).toBe('OA4');
+      expect(construct?.count).toBe(1);
+    });
+
+    it('stashes a QUERY operation on an extension and reports it', () => {
+      const result = convertOpenAPI32ToOpenAPI31(
+        doc({
+          paths: {
+            '/search': {
+              query: { responses: { '200': { description: 'results' } } }
+            }
+          }
+        })
+      );
+
+      const pathItem = result.document.paths['/search'];
+      expect(pathItem.query).toBeUndefined();
+      expect(pathItem['x-objectified-query-operation']).toBeDefined();
+      expect(result.unsupportedConstructs.find((c) => c.id === 'query-method')?.ownedBy).toBe('OA4');
+    });
+  });
+
+  describe('OA3 — sequential media types / itemSchema', () => {
+    it('stashes itemSchema on an extension and reports it', () => {
+      const result = convertOpenAPI32ToOpenAPI31(
+        doc({
+          paths: {
+            '/events': {
+              get: {
+                responses: {
+                  '200': {
+                    description: 'stream',
+                    content: {
+                      'text/event-stream': {
+                        itemSchema: { type: 'object', properties: { data: { type: 'string' } } }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        })
+      );
+
+      const media = result.document.paths['/events'].get.responses['200'].content['text/event-stream'];
+      expect(media.itemSchema).toBeUndefined();
+      expect(media['x-objectified-item-schema']).toBeDefined();
+      expect(result.unsupportedConstructs.find((c) => c.id === 'item-schema')?.ownedBy).toBe('OA3');
+    });
+  });
+
+  describe('OA5 — tag metadata', () => {
+    it('preserves summary/parent/kind on tags and reports them', () => {
+      const result = convertOpenAPI32ToOpenAPI31(
+        doc({
+          tags: [
+            { name: 'pets', summary: 'Pet operations', parent: 'store', kind: 'nav' },
+            { name: 'store' }
+          ]
+        })
+      );
+
+      const petsTag = result.document.tags.find((t: any) => t.name === 'pets');
+      expect(petsTag.summary).toBe('Pet operations');
+      expect(petsTag.parent).toBe('store');
+      expect(petsTag.kind).toBe('nav');
+      const construct = result.unsupportedConstructs.find((c) => c.id === 'tag-metadata');
+      expect(construct?.ownedBy).toBe('OA5');
+      expect(construct?.count).toBe(1);
+    });
+  });
+
+  describe('lossless pass-through', () => {
+    it('leaves a plain 3.1-compatible 3.2 document structurally identical (besides version)', () => {
+      const input = doc({
+        components: {
+          schemas: {
+            Widget: {
+              type: 'object',
+              required: ['id'],
+              properties: {
+                id: { type: 'string' },
+                tags: { type: 'array', items: { $ref: '#/components/schemas/Tag' } }
+              }
+            },
+            Tag: { type: 'object', properties: { name: { type: 'string' } } }
+          }
+        }
+      });
+
+      const result = convertOpenAPI32ToOpenAPI31(input);
+      expect(result.success).toBe(true);
+      expect(result.unsupportedConstructs).toHaveLength(0);
+
+      const expected = JSON.parse(JSON.stringify(input));
+      expected.openapi = '3.1.0';
+      expect(result.document).toEqual(expected);
+    });
+  });
+});

--- a/objectified-ui/tests/openapi32-import-integration.test.ts
+++ b/objectified-ui/tests/openapi32-import-integration.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Integration tests for the OpenAPI 3.2.0 normalization layer (OA2, #3499).
+ *
+ * Verifies a 3.2.0 document carrying 3.2-only constructs is normalized and imported
+ * successfully, that the carried-forward constructs are surfaced (never silently
+ * dropped), and that a 3.2.0 doc and its hand-written 3.1 equivalent produce identical
+ * imported classes/properties.
+ */
+
+import { parseOpenAPISpec } from '../src/app/utils/openapi-import';
+import { analyzeSpecification } from '../src/app/utils/openapi-analyzer';
+
+/** A 3.2.0 document exercising the OA3–OA6 constructs plus the safe normalizations. */
+const SPEC_32 = JSON.stringify({
+  openapi: '3.2.0',
+  info: { title: 'Constructs API', version: '1.0.0', description: 'Exercises 3.2-only constructs.' },
+  servers: [{ url: 'https://api.example.com' }],
+  tags: [
+    { name: 'pets', summary: 'Pet operations', parent: 'store', kind: 'nav' },
+    { name: 'store' }
+  ],
+  paths: {
+    '/pets': {
+      get: {
+        operationId: 'listPets',
+        tags: ['pets'],
+        responses: {
+          '200': {
+            description: 'A list of pets',
+            content: {
+              'application/json': {
+                schema: { type: 'array', items: { $ref: '#/components/schemas/Pet' } },
+                example: [{ id: '1', name: 'Rex' }]
+              }
+            }
+          }
+        }
+      },
+      // OA4: custom HTTP methods map.
+      additionalOperations: {
+        PURGE: { operationId: 'purgePets', responses: { '204': { description: 'purged' } } }
+      }
+    },
+    // OA4: the QUERY HTTP method.
+    '/pets/search': {
+      query: {
+        operationId: 'searchPets',
+        responses: { '200': { description: 'results' } }
+      }
+    },
+    // OA3: sequential media types / itemSchema.
+    '/pets/events': {
+      get: {
+        operationId: 'streamPets',
+        responses: {
+          '200': {
+            description: 'event stream',
+            content: {
+              'text/event-stream': {
+                itemSchema: { $ref: '#/components/schemas/Pet' }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  components: {
+    securitySchemes: {
+      apiKey: { type: 'apiKey', in: 'header', name: 'X-API-Key' }
+    },
+    schemas: {
+      Pet: {
+        type: 'object',
+        description: 'A pet.',
+        required: ['id', 'name'],
+        properties: {
+          id: { type: 'string', description: 'Identifier.', xml: { nodeType: 'attribute' } },
+          name: { type: 'string', description: 'Name.' },
+          // OA6: $ref sibling metadata.
+          category: { $ref: '#/components/schemas/Category', description: 'The pet category.' }
+        }
+      },
+      Category: {
+        type: 'object',
+        description: 'A category.',
+        properties: {
+          name: { type: 'string', description: 'Category name.' }
+        }
+      }
+    }
+  }
+});
+
+/** The hand-written 3.1 equivalent: same schemas, no 3.2-only constructs. */
+const SPEC_31 = JSON.stringify({
+  openapi: '3.1.0',
+  info: { title: 'Constructs API', version: '1.0.0', description: 'Exercises 3.2-only constructs.' },
+  servers: [{ url: 'https://api.example.com' }],
+  paths: {
+    '/pets': {
+      get: {
+        operationId: 'listPets',
+        responses: {
+          '200': {
+            description: 'A list of pets',
+            content: {
+              'application/json': {
+                schema: { type: 'array', items: { $ref: '#/components/schemas/Pet' } }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  components: {
+    securitySchemes: {
+      apiKey: { type: 'apiKey', in: 'header', name: 'X-API-Key' }
+    },
+    schemas: {
+      Pet: {
+        type: 'object',
+        description: 'A pet.',
+        required: ['id', 'name'],
+        properties: {
+          id: { type: 'string', description: 'Identifier.', xml: { attribute: true } },
+          name: { type: 'string', description: 'Name.' },
+          category: { $ref: '#/components/schemas/Category', description: 'The pet category.' }
+        }
+      },
+      Category: {
+        type: 'object',
+        description: 'A category.',
+        properties: {
+          name: { type: 'string', description: 'Category name.' }
+        }
+      }
+    }
+  }
+});
+
+describe('OpenAPI 3.2 import integration (OA2 #3499)', () => {
+  it('imports a 3.2.0 document with 3.2-only constructs successfully', () => {
+    const result = parseOpenAPISpec(SPEC_32);
+
+    expect(result.success).toBe(true);
+    expect(result.error).toBeUndefined();
+
+    const pet = result.classes.find((c) => c.name === 'Pet');
+    expect(pet).toBeDefined();
+    const propNames = pet?.properties.map((p) => p.name) ?? [];
+    expect(propNames).toEqual(expect.arrayContaining(['id', 'name', 'category']));
+
+    expect(result.classes.find((c) => c.name === 'Category')).toBeDefined();
+  });
+
+  it('surfaces carried-forward constructs in the import warnings (never silently dropped)', () => {
+    const result = parseOpenAPISpec(SPEC_32);
+    const joined = result.warnings.join('\n');
+    expect(joined).toMatch(/Normalized OpenAPI 3\.2/);
+    expect(joined).toMatch(/additionalOperations/i);
+    expect(joined).toMatch(/QUERY/i);
+    expect(joined).toMatch(/itemSchema/i);
+  });
+
+  it('produces the same classes/properties as the hand-written 3.1 equivalent (round-trip)', () => {
+    const result32 = parseOpenAPISpec(SPEC_32);
+    const result31 = parseOpenAPISpec(SPEC_31);
+
+    const shape = (r: ReturnType<typeof parseOpenAPISpec>) =>
+      r.classes
+        .map((c) => ({ name: c.name, props: c.properties.map((p) => p.name).sort() }))
+        .sort((a, b) => a.name.localeCompare(b.name));
+
+    expect(shape(result32)).toEqual(shape(result31));
+  });
+
+  it('analyzer keeps the 3.2.0 version display and surfaces 3.2 constructs as unsupported features', async () => {
+    const analysis = await analyzeSpecification(SPEC_32, 'constructs-3.2.json');
+
+    // OA1 behavior preserved: still reported as 3.2.0.
+    expect(analysis.version).toBe('3.2.0');
+    expect(analysis.formatDisplayName).toContain('3.2.0');
+
+    // 3.2-only constructs are surfaced for the pre-import compatibility check.
+    const ids = analysis.unsupportedFeatures.map((f) => f.id);
+    expect(ids).toEqual(
+      expect.arrayContaining([
+        'openapi32-additional-operations',
+        'openapi32-query-method',
+        'openapi32-item-schema',
+        'openapi32-tag-metadata'
+      ])
+    );
+  });
+});


### PR DESCRIPTION
## What & why

The importer had a dedicated 3.0.x → 3.1.x normalizer but **no equivalent for 3.2.0**. After OA1 (#3498) let 3.2.0 documents in, the 3.1 importer would encounter 3.2-only constructs it doesn't understand and silently drop or mis-handle them.

This adds `openapi32-converter.ts`, mirroring the 30-converter contract: it takes a 3.2.0 document and emits a 3.1.x-shaped document the existing importer consumes, plus an `unsupportedConstructs[]` list so 3.2-only constructs are surfaced rather than silently dropped.

### Handling per construct
- **Transform (safe / lossless):**
  - Fold the deprecated singular `example` into the `examples` map on Media Type / Parameter / Header objects (deprecation surfaced as an info warning).
  - Map XML Object `nodeType` back to the legacy `attribute` field; values with no legacy equivalent (`text`/`cdata`/`none`) are stashed on `x-objectified-xml-node-type`.
- **Preserve (valid in 3.1):** `summary`/`description` siblings on a `$ref` are kept and recorded for OA6.
- **Stash (carried on `x-objectified-*` extensions, never dropped, each reported):**
  - `additionalOperations` and the `QUERY` HTTP method → OA4
  - sequential media types / `itemSchema` → OA3
  - `tags[].summary`/`parent`/`kind` → OA5

### Wiring
- `openapi-import.ts`: after the OA1 routing decision, 3.2.0 specs are normalized to 3.1.x and routed through the existing importer; carried constructs are added to the import warnings.
- `openapi-analyzer.ts`: the converter runs non-destructively to surface the carried constructs in the pre-import `unsupportedFeatures` list, while preserving the OA1 behavior (3.2.0 version display + low-severity "normalized" note).

## How to test
- `cd objectified-ui && yarn jest tests/openapi32-converter.test.ts tests/openapi32-import-integration.test.ts tests/openapi-3.2-accept.test.ts`
- Unit tests cover each transform/stash path; the integration test imports a 3.2.0 doc carrying all OA3–OA6 constructs, verifies they surface in warnings, and asserts a **round-trip**: the 3.2.0 doc and its hand-written 3.1 equivalent produce identical imported classes/properties.
- Full suite: `yarn jest` (1264 tests pass), `yarn build` succeeds, `npx tsc --noEmit` clean.

## Risk / notes
- The converter deep-clones its input (no mutation) and is purely additive in the pipeline. The minimal 3.2.0 example (no 3.2-only constructs) is unchanged besides the `openapi` version, so OA1 behavior is preserved.
- `any` usage matches the existing converter files (`openapi30-converter.ts`); the project does not gate the build on `no-explicit-any`.

Closes #3499

Work performed by Claude Code via model claude-opus-4-8[1m]